### PR TITLE
Update AuthenticatedWebViewActivity.java

### DIFF
--- a/src/org/wordpress/android/ui/AuthenticatedWebViewActivity.java
+++ b/src/org/wordpress/android/ui/AuthenticatedWebViewActivity.java
@@ -1,4 +1,3 @@
-
 package org.wordpress.android.ui;
 
 import java.io.UnsupportedEncodingException;
@@ -171,7 +170,8 @@ public class AuthenticatedWebViewActivity extends WebViewActivity {
         
         int itemID = item.getItemId();
         if (itemID == R.id.menu_refresh) {
-            mWebView.reload();
+            loadAuthenticatedUrl(mWebView.getUrl()); 
+            //mWebView.reload();
             return true;
         } else if (itemID == R.id.menu_share) {
             Intent share = new Intent(Intent.ACTION_SEND);


### PR DESCRIPTION
I found this bug:
In View Site mode, disable your internet connection. Try to refresh (you get 404). Enable your internet, hit refresh, and you are redirected to login page.
This way, you login again and load the last url.
