### PR TITLE
Fix for issue #170 "Edit Page always asks to save changes".

### DIFF
--- a/src/org/wordpress/android/models/Post.java
+++ b/src/org/wordpress/android/models/Post.java
@@ -429,6 +429,27 @@ public class Post {
         return quickPostType;
     }
 
+    /**
+     * Checks if this post currently has data differing from another post.
+     *
+     * @param otherPost The post to compare to this post's editable data.
+     * @return True if this post's data differs from otherPost's data, False otherwise.
+     */
+    public boolean hasChanges(Post otherPost) {
+        return(!(this.title.equals(otherPost.title) &&
+                this.description.equals(otherPost.description) &&
+                this.mt_excerpt.equals(otherPost.mt_excerpt) &&
+                this.date_created_gmt == otherPost.date_created_gmt &&
+                this.categories.equals(otherPost.categories) &&
+                this.mt_keywords.equals(otherPost.mt_keywords) &&
+                this.post_status.equals(otherPost.post_status) &&
+                this.wp_password.equals(otherPost.wp_password) &&
+                this.wp_post_format.equals(otherPost.wp_post_format) &&
+                this.latitude == otherPost.latitude &&
+                this.longitude == otherPost.longitude)
+        );
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;

--- a/src/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/src/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -975,6 +975,18 @@ public class EditPostActivity extends SherlockFragmentActivity implements OnClic
             return;
         }
 
+        // Save the current Post
+        savePost(false, true);
+
+        // Compare the current Post to the original and if no changes have been made,
+        // set the Post back to the original and go back to the previous view
+        if (mOriginalPost != null && !mPost.hasChanges(mOriginalPost)) {
+            mOriginalPost.update();
+            WordPress.currentPost = mOriginalPost;
+            finish();
+            return;
+        }
+
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(EditPostActivity.this);
         dialogBuilder.setTitle(getString((mIsPage) ? R.string.edit_page : R.string.edit_post));
         dialogBuilder.setMessage(getString(R.string.prompt_save_changes));


### PR DESCRIPTION
The save dialog will no longer pop when post/page content is not modified.
