### PR TITLE
Fix #284 (NPE while adding a site on SSL with errors in the SSL certificate)

### DIFF
--- a/src/org/xmlrpc/android/ApiHelper.java
+++ b/src/org/xmlrpc/android/ApiHelper.java
@@ -860,10 +860,13 @@ public class ApiHelper {
     public static InputStream getResponseStream(String urlString) {
         HttpRequest request = getHttpRequest(urlString);
         if (request != null) {
-            return request.buffer();
-        } else {
-            return null;
+            try {
+                return request.buffer();
+            } catch (HttpRequestException e) {
+                Log.e( "ApiHelper", "Cannot setup an InputStream on " + urlString, e );
+            }
         }
+        return null;
     }
 
     /**
@@ -879,6 +882,7 @@ public class ApiHelper {
                 String body = request.body();
                 return body;
             } catch (HttpRequestException e) {
+                Log.e( "ApiHelper", "Cannot load the content of " + urlString, e );
                 return null;
             }
         } else {


### PR DESCRIPTION
Actually the error was happening when the user was trying to add a site that uses HTTPS, and the classic way of appending '/xmlrpc.php" at the end of the URL did not worked fine.
The error was inside the XML-RPC endpoint discovery procedure. That code were reached by a minority of of users.
