### PR TITLE
Fix #300 by checking if the activity is in FG before displaying the alert about Jetpack needed.

### DIFF
--- a/src/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/src/org/wordpress/android/ui/stats/StatsActivity.java
@@ -73,7 +73,7 @@ public class StatsActivity extends WPActionBarActivity implements StatsNavDialog
     private MenuItem mRefreshMenuItem;
     private int mResultCode = -1;
     private boolean mIsRestoredFromState = false, mIsTablet;
-    private boolean isInFront;
+    private boolean mIsInFront;
 
     // Used for tablet UI
     private static final int TABLET_720DP = 720;
@@ -142,7 +142,7 @@ public class StatsActivity extends WPActionBarActivity implements StatsNavDialog
     @Override
     protected void onResume() {
         super.onResume();
-        isInFront = true;
+        mIsInFront = true;
         
         LocalBroadcastManager lbm = LocalBroadcastManager.getInstance(this);
         lbm.registerReceiver(mReceiver, new IntentFilter(StatsRestHelper.REFRESH_VIEW_TYPE));
@@ -172,7 +172,7 @@ public class StatsActivity extends WPActionBarActivity implements StatsNavDialog
     protected void onPause() {
         super.onPause();
 
-        isInFront = false;
+        mIsInFront = false;
         LocalBroadcastManager lbm = LocalBroadcastManager.getInstance(this);
         lbm.unregisterReceiver(mReceiver);
         
@@ -390,7 +390,7 @@ public class StatsActivity extends WPActionBarActivity implements StatsNavDialog
        
         @Override
         public void onSuccess() {
-            if (statsActivityWeakRef.get() == null || statsActivityWeakRef.get().isFinishing() || statsActivityWeakRef.get().isInFront == false) {
+            if (statsActivityWeakRef.get() == null || statsActivityWeakRef.get().isFinishing() || statsActivityWeakRef.get().mIsInFront == false) {
                 return;
             }
             


### PR DESCRIPTION
Not sure if this is the best implementation, but for sure it also fixes an issue where the alert about JP was shown 2/3 times, when you left the app quickly.
