### PR TITLE
Fix #312: Clear comment selection when comment delete is successful

### DIFF
--- a/src/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/src/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -601,7 +601,11 @@ public class CommentsListFragment extends ListFragment {
             getBulkCheck().setOnClickListener(new OnClickListener() {
 
                 public void onClick(View arg0) {
-                    selectedCommentPositions.add(position);
+                    if (getBulkCheck().isChecked()) {
+                        selectedCommentPositions.add(position);
+                    } else {
+                        selectedCommentPositions.remove(position);
+                    }
                     showOrHideModerationBar();
                 }
             });


### PR DESCRIPTION
Fix #312 
