### PR TITLE
Comment notification HTML can crash HTML.fromHTML

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,10 +60,7 @@ android {
             assets.srcDirs = ['assets']
         }
 
-        instrumentTest {
-            java.srcDirs = ['tests/src']
-            assets.srcDirs = ['tests/assets'];
-        }
+        instrumentTest.setRoot('tests')
     }
 
 }


### PR DESCRIPTION
In this particular instance a `<p>` inside an `<li>` throws a RuntimeException.

Reproduces wordpress-mobile/WordPress-Android#334
