### PR TITLE
Reverted to XMLRPC for moderating comments

### DIFF
--- a/src/org/wordpress/android/models/Blog.java
+++ b/src/org/wordpress/android/models/Blog.java
@@ -8,13 +8,13 @@ import com.google.gson.Gson;
 import com.google.gson.internal.StringMap;
 import com.google.gson.reflect.TypeToken;
 
-import java.lang.reflect.Type;
-import java.util.List;
-import java.util.Map;
-
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.WordPress;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
 
 public class Blog {
 

--- a/src/org/wordpress/android/models/CommentStatus.java
+++ b/src/org/wordpress/android/models/CommentStatus.java
@@ -10,41 +10,39 @@ public enum CommentStatus {
     TRASH,
     SPAM;
 
-    // XMLRPC and REST use different strings - consider XMLRPC the default, since that's the format
-    // the app has stored the comment status as since the start
-    public static String toString(CommentStatus status, ApiFormat format) {
-        switch (format) {
-            case XMLRPC:
-                switch (status) {
-                    case UNAPPROVED:
-                        return "hold";
-                    case APPROVED:
-                        return "approve";
-                    case SPAM:
-                        return "spam";
-                    default:
-                        return "";
-                }
-
-            case REST:
-                switch (status) {
-                    case UNAPPROVED:
-                        return "unapproved";
-                    case APPROVED:
-                        return "approved";
-                    case SPAM:
-                        return "spam";
-                    case TRASH:
-                        return "trash";
-                    default:
-                        return "";
-                }
-
+    /*
+     * returns the string representation of the passed status, as used by the XMLRPC API
+     */
+    public static String toString(CommentStatus status) {
+        switch (status) {
+            case UNAPPROVED:
+                return "hold";
+            case APPROVED:
+                return "approve";
+            case SPAM:
+                return "spam";
             default:
                 return "";
         }
+
+        /* for future reference, REST API uses these strings:
+        switch (status) {
+            case UNAPPROVED:
+                return "unapproved";
+            case APPROVED:
+                return "approved";
+            case SPAM:
+                return "spam";
+            case TRASH:
+                return "trash";
+            default:
+                return "";
+        } */
     };
 
+    /*
+     * returns the status associated with the passed strings - handles both XMLRPC and REST
+     */
     public static CommentStatus fromString(String value) {
         if (value == null)
             return CommentStatus.UNKNOWN;
@@ -58,6 +56,4 @@ public enum CommentStatus {
             return TRASH;
         return CommentStatus.UNKNOWN;
     }
-
-    public static enum ApiFormat {XMLRPC, REST}
 };

--- a/src/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/src/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -214,7 +214,9 @@ public class CommentsActivity extends WPActionBarActivity
              * fire background action to delete this comment
              */
             showDialog(ID_DIALOG_DELETING);
-            CommentActions.deleteComment(WordPress.currentBlog,
+            CommentActions.deleteComment(
+                    WordPress.currentBlog,
+                    WordPress.getCurrentBlogId(),
                     WordPress.currentComment,
                     new CommentActions.CommentActionListener() {
                         @Override


### PR DESCRIPTION
Resolves issue #339 (Comment unification currently relies on the REST API, which will break for non-Jetpack .org users)
