### PR TITLE
First pass at fixing #273.

### DIFF
--- a/res/layout/notifications_matcher.xml
+++ b/res/layout/notifications_matcher.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:background="#FFFFFF"
+    android:orientation="vertical" >
+
+    <LinearLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+        
+        <include
+            android:id="@+id/header"
+            layout="@layout/notifications_detail_header" />
+        
+        <com.android.volley.toolbox.NetworkImageView
+            android:id="@+id/gravatar"
+            android:layout_width="96dp"
+            android:layout_height="96dp"
+            android:minWidth="96dp"
+            android:minHeight="96dp"
+            android:scaleType="fitCenter"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp" />
+
+        <TextView
+            android:id="@+id/body"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1.0"
+            android:fontFamily="sans-serif-light"
+            android:linksClickable="true"
+            android:paddingLeft="8dp"
+            android:paddingRight="8dp"
+            android:textSize="18sp" />
+
+        <ImageView
+            android:layout_width="fill_parent"
+            android:layout_height="1px"
+            android:scaleType="fitXY"
+            android:src="@drawable/list_divider" />
+        
+         <include
+           android:id="@+id/footer"
+           layout="@layout/notifications_detail_header" />
+        
+    </LinearLayout>
+
+</ScrollView>

--- a/src/org/wordpress/android/models/Note.java
+++ b/src/org/wordpress/android/models/Note.java
@@ -28,7 +28,7 @@ public class Note {
     protected static final String COMMENT_TYPE="comment";
     protected static final String COMMENT_LIKE_TYPE="comment_like";
     //protected static final String LIKE_TYPE="like";
-    //protected static final String MATCHER_TYPE = "automattcher";
+    protected static final String MATCHER_TYPE = "automattcher";
 
     // Notes have different types of "templates" for displaying differently
     // this is not a canonical list but covers all the types currently in use
@@ -139,6 +139,9 @@ public class Note {
     }
     public Boolean isCommentLikeType(){
         return isType(COMMENT_LIKE_TYPE);
+    }
+    public Boolean isAutomattcherType(){
+        return isType(MATCHER_TYPE);
     }
     public String getSubject(){
         if (mSubject==null) {

--- a/src/org/wordpress/android/ui/notifications/NoteMatcherFragment.java
+++ b/src/org/wordpress/android/ui/notifications/NoteMatcherFragment.java
@@ -1,0 +1,77 @@
+package org.wordpress.android.ui.notifications;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.text.Html;
+import android.text.method.LinkMovementMethod;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import com.android.volley.toolbox.NetworkImageView;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.models.Note;
+import org.wordpress.android.util.JSONUtil;
+
+public class NoteMatcherFragment extends Fragment implements NotificationFragment {
+    private Note mNote;
+    
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup parent, Bundle state){
+        View view = inflater.inflate(R.layout.notifications_matcher, parent, false);
+
+        // No note? No service.
+        if (getNote() == null)
+            return view;        
+
+        JSONObject noteBody = getNote().queryJSON("body", new JSONObject());
+        JSONArray noteBodyItems = getNote().queryJSON("body.items", new JSONArray());
+        JSONObject noteBodyItemAtPositionZero = JSONUtil.queryJSON(noteBodyItems, String.format("[%d]", 0), new JSONObject());
+        
+        DetailHeader noteHeader = (DetailHeader) view.findViewById(R.id.header);
+        JSONObject subject = getNote().queryJSON("subject", new JSONObject());
+        String headerText = JSONUtil.getStringDecoded(subject, "text");
+        noteHeader.setText(headerText);
+        noteHeader.setBackgroundColor(getResources().getColor(R.color.light_gray));
+        noteHeader.getTextView().setGravity(Gravity.CENTER_HORIZONTAL);
+        noteHeader.setClickable(false);
+        
+        String gravURL = JSONUtil.queryJSON(noteBodyItemAtPositionZero, "icon", "");
+        if (!gravURL.equals("")) {
+            NetworkImageView mBadgeImageView = (NetworkImageView) view.findViewById(R.id.gravatar);
+            mBadgeImageView.setImageUrl(gravURL, WordPress.imageLoader);
+        }
+
+        TextView bodyTextView = (TextView) view.findViewById(R.id.body);
+        bodyTextView.setMovementMethod(LinkMovementMethod.getInstance());
+        String noteHTML = JSONUtil.getString(noteBodyItemAtPositionZero, "html");
+        bodyTextView.setText(Html.fromHtml(noteHTML));
+
+        //setup the footer
+        DetailHeader noteFooter = (DetailHeader) view.findViewById(R.id.footer);
+        String footerText = JSONUtil.getStringDecoded(noteBody, "header_text");
+        noteFooter.setText(footerText);
+        JSONObject bodyObject =  getNote().queryJSON("body", new JSONObject());
+        String itemURL = JSONUtil.getString(bodyObject, "header_link");
+        if (!itemURL.equals("")) {
+            noteFooter.setUrl(itemURL);
+        }            
+        
+        return view;
+    }
+    
+    public void setNote(Note note){
+        mNote = note;
+    }
+    public Note getNote(){
+        return mNote;
+    }
+    
+}

--- a/src/org/wordpress/android/ui/notifications/NotificationsActivity.java
+++ b/src/org/wordpress/android/ui/notifications/NotificationsActivity.java
@@ -95,8 +95,12 @@ public class NotificationsActivity extends WPActionBarActivity {
         fragmentDetectors.add(new FragmentDetector() {
             @Override
             public Fragment getFragment(Note note) {
-                if (note.isMultiLineListTemplate() && note.isCommentLikeType()) {
-                    Fragment fragment = new NoteCommentLikeFragment();
+                if (note.isMultiLineListTemplate()){
+                    Fragment fragment = null;
+                    if (note.isCommentLikeType())
+                        fragment = new NoteCommentLikeFragment();
+                    else if (note.isAutomattcherType())
+                        fragment = new NoteMatcherFragment();
                     return fragment;
                 }
                 return null;


### PR DESCRIPTION
 It would be nice to add the reply field at the bottom of the notifications screen,  without opening the web-browser, or the near to be implemented in the native reader, the AuthenticatedWebView (#175).
This is probably something we can do later, when comments unification is completely done. Also, this feature is only available for a small group of lucky people, I don't think we no need to spent more time on this at the moment.
