### PR TITLE
Fix for #338 (clear reader on signout)

### DIFF
--- a/src/org/wordpress/android/WordPress.java
+++ b/src/org/wordpress/android/WordPress.java
@@ -3,6 +3,7 @@ package org.wordpress.android;
 import android.annotation.SuppressLint;
 import android.app.Application;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
@@ -30,6 +31,8 @@ import com.wordpress.rest.Oauth;
 import org.apache.http.HttpResponse;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.wordpress.android.datasets.ReaderDatabase;
+import org.wordpress.android.ui.prefs.ReaderPrefs;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.passcodelock.AppLockManager;
 import org.xmlrpc.android.WPComXMLRPCApi;
@@ -74,6 +77,7 @@ public class WordPress extends Application {
     private static Context mContext;
 
     public static final String TAG = "WordPress";
+    public static final String BROADCAST_ACTION_SIGNOUT = "wp-signout";
 
     @Override
     public void onCreate() {
@@ -440,6 +444,17 @@ public class WordPress extends Application {
         wpDB.deactivateAccounts();
         wpDB.updateLastBlogId(-1);
         currentBlog = null;
+
+        // reset all reader-related prefs & data
+        ReaderPrefs.reset();
+        ReaderDatabase.reset();
+
+        // send broadcast that user is signing out - this is received by WPActionBarActivity
+        // descendants
+        Intent broadcastIntent = new Intent();
+        broadcastIntent.setAction(BROADCAST_ACTION_SIGNOUT);
+        context.sendBroadcast(broadcastIntent);
+
     }
 
     public static String getLoginUrl(Blog blog) {

--- a/src/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/src/org/wordpress/android/datasets/ReaderDatabase.java
@@ -41,6 +41,16 @@ public class ReaderDatabase extends SQLiteOpenHelper {
     }
 
     /*
+     * resets (clears) the reader database
+     */
+    public static void reset() {
+        // note that we must call getWritableDb() before getDatabase() in case the database
+        // object hasn't been created yet
+        SQLiteDatabase db = getWritableDb();
+        getDatabase().reset(db);
+    }
+
+    /*
      * used during development to copy database to SD card so we can access it via DDMS
      * MUST be commented out in release
      */

--- a/src/org/wordpress/android/ui/prefs/ReaderPrefs.java
+++ b/src/org/wordpress/android/ui/prefs/ReaderPrefs.java
@@ -17,6 +17,17 @@ public class ReaderPrefs {
         return PreferenceManager.getDefaultSharedPreferences(WordPress.getContext());
     }
 
+    /*
+     * remove all reader-related preferences
+     */
+    public static void reset() {
+        SharedPreferences.Editor editor = prefs().edit();
+        editor.remove(PREFKEY_USER_ID);
+        editor.remove(PREFKEY_READER_TAG);
+        editor.commit();
+    }
+
+
     private static String getString(String key) {
         return getString(key, "");
     }

--- a/src/org/wordpress/android/ui/reader_native/NativeReaderActivity.java
+++ b/src/org/wordpress/android/ui/reader_native/NativeReaderActivity.java
@@ -95,12 +95,17 @@ public class NativeReaderActivity extends WPActionBarActivity implements ReaderP
             });
         }
 
-        if (savedInstanceState==null) {
-            showPostListFragment();
-        } else {
+        if (savedInstanceState != null) {
             mHasPerformedInitialUpdate = savedInstanceState.getBoolean(KEY_INITIAL_UPDATE);
             mHasPerformedPurge = savedInstanceState.getBoolean(KEY_HAS_PURGED);
         }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (getPostListFragment() == null)
+            showPostListFragment();
     }
 
     @Override
@@ -232,6 +237,15 @@ public class NativeReaderActivity extends WPActionBarActivity implements ReaderP
         }
 
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void onSignout() {
+        super.onSignout();
+        // reader database will have been cleared by the time this is called, but the fragment must
+        // be removed or else it will continue to show the same articles - onResume() will take care
+        // of re-displaying the fragment if necessary
+        removePostListFragment();
     }
 
     /*

--- a/src/org/wordpress/android/ui/reader_native/ReaderPostListFragment.java
+++ b/src/org/wordpress/android/ui/reader_native/ReaderPostListFragment.java
@@ -666,6 +666,9 @@ public class ReaderPostListFragment extends Fragment implements AbsListView.OnSc
         return mActionBarAdapter;
     }
 
+    private boolean hasActionBarAdapter() {
+        return (mActionBarAdapter != null);
+    }
     /*
      * refresh the list of tags shown in the ActionBar
      */


### PR DESCRIPTION
App now sends a broadcast upon signout which is received by WPActionBarActivity.

WPActionBarActivity calls onSignout() when this broadcast is received, so descendants can do activity-specific cleanup when the user signs out.

NativeReaderActivity relies on this to clear the post fragment when the user signs out (otherwise, the previously displayed posts will continue to show if the user logs back in)
