### PR TITLE
Native reader: tapping a comment now enables replying to it

### DIFF
--- a/res/layout/reader_listitem_comment.xml
+++ b/res/layout/reader_listitem_comment.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/grey_extra_light"
+    android:descendantFocusability="blocksDescendants"
     android:paddingBottom="@dimen/reader_margin_medium"
     android:paddingLeft="@dimen/reader_margin_large"
     android:paddingRight="@dimen/reader_margin_large"
@@ -49,14 +50,16 @@
         android:layout_alignLeft="@+id/text_comment_title"
         android:layout_below="@+id/text_comment_title"
         android:layout_marginTop="@dimen/reader_margin_small"
+        android:focusable="false"
+        android:focusableInTouchMode="false"
         android:text="text_comment_text" />
 
     <ProgressBar
+        android:id="@+id/progress"
         style="@style/ReaderProgressBar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
-        android:visibility="gone"
-        android:id="@+id/progress"/>
+        android:visibility="gone" />
 </RelativeLayout>

--- a/src/org/wordpress/android/ui/reader_native/ReaderPostDetailActivity.java
+++ b/src/org/wordpress/android/ui/reader_native/ReaderPostDetailActivity.java
@@ -5,7 +5,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v4.app.FragmentActivity;
@@ -88,23 +87,14 @@ public class ReaderPostDetailActivity extends FragmentActivity {
         if (mListView==null) {
             mListView = (ListView) findViewById(android.R.id.list);
 
-            // enable replying to an individual comment when the user long clicks it - this is done
-            // instead of setting an OnItemClickListener for two reasons:
-            //   1. OnItemClickListener won't fire for comments that contain links (due
-            //      to the comment text using autoLink="web")
-            //   2. It's too easy to accidentally cause OnItemClickListener to fire while
-            //      scrolling/flinging through the list, whereas OnItemLongClickListener
-            //      is a more deliberate action
-            mListView.setOnItemLongClickListener(new AdapterView.OnItemLongClickListener() {
+            // enable replying to an individual comment when the user taps it
+            mListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
                 @Override
-                public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
-                    // id will be the id of the tapped comment - note that it will be -1 when the
-                    // post detail header is long clicked, which we want to ignore
+                public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                    // id is the commentId of the tapped comment - note that it will be -1 when the
+                    // post detail header is tapped, which we want to ignore
                     if (id > 0) {
                         showAddCommentBox(id);
-                        return true;
-                    } else {
-                        return false;
                     }
                 }
             });


### PR DESCRIPTION
Previously required a long-press, which wasn't obvious. Addresses #376.
