### PR TITLE
Fix #381: Use setError instead of modal when user enter wrong credentials in sign in screen enhancement NUX

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -796,7 +796,7 @@
     <string name="username_invalid">Invalid username</string>
     <string name="unknown_error">Unknown error</string>
     <string name="limit_reached">Limit reached. You can try again in 1 minute. Trying again before that will only increase the time you have to wait before the ban is lifted. If you think this is in error, contact support.</string>
-    <string name="update_credentials">Wrong username or password. Update your credentials and try again.</string>
+    <string name="username_or_password_incorrect">The username or password you entered is incorrect.</string>
     <string name="nux_tap_continue">Continue</string>
     <string name="nux_tap_learn_more">Learn More</string>
     <string name="nux_cannot_log_in">Sorry, we can\'t log you in.</string>

--- a/src/org/wordpress/android/ui/accounts/SetupBlog.java
+++ b/src/org/wordpress/android/ui/accounts/SetupBlog.java
@@ -105,7 +105,7 @@ public class SetupBlog {
         } catch (XMLRPCException e) {
             String message = e.getMessage();
             if (message.contains("code 403"))
-                mErrorMsgId = R.string.update_credentials;
+                mErrorMsgId = R.string.username_or_password_incorrect;
             else if (message.contains("404"))
                 mErrorMsgId = R.string.xmlrpc_error;
             else if (message.contains("425"))

--- a/src/org/wordpress/android/ui/accounts/WelcomeFragmentSignIn.java
+++ b/src/org/wordpress/android/ui/accounts/WelcomeFragmentSignIn.java
@@ -301,7 +301,7 @@ public class WelcomeFragmentSignIn extends NewAccountAbstractPageFragment implem
                             NUXDialogFragment.ACTION_OPEN_URL,
                             "https://wordpress.com/settings/security/?ssl=forced");
                 } else {
-                    if (mErrorMsgId == R.string.update_credentials) {
+                    if (mErrorMsgId == R.string.username_or_password_incorrect) {
                         showUsernameError(mErrorMsgId);
                         showPasswordError(mErrorMsgId);
                         mErrorMsgId = 0;


### PR DESCRIPTION
Fix #381
![screen shot 2013-11-28 at 16 21 07](https://f.cloud.github.com/assets/40213/1640700/c163e130-5840-11e3-99af-b652f27cd7e9.png)
