### PR TITLE
Add initial IDN support

### DIFF
--- a/src/org/wordpress/android/ui/accounts/SetupBlog.java
+++ b/src/org/wordpress/android/ui/accounts/SetupBlog.java
@@ -144,14 +144,16 @@ public class SetupBlog {
     private String getSelfHostedXmlrpcUrl(String url) {
         String xmlrpcUrl = null;
 
-		// Convert IDN names to punycode if necessary
+        // Convert IDN names to punycode if necessary
         if (!Charset.forName("US-ASCII").newEncoder().canEncode(url)) {
-			if (url.toLowerCase().startsWith("http://")) {
-				url = "http://" + IDN.toASCII(url.substring(7));
-			} else if (url.toLowerCase().startsWith("https://")) {
-				url = "https://" + IDN.toASCII(url.substring(8));
-			}
-		}
+            if (url.toLowerCase().startsWith("http://")) {
+                url = "http://" + IDN.toASCII(url.substring(7));
+            } else if (url.toLowerCase().startsWith("https://")) {
+                url = "https://" + IDN.toASCII(url.substring(8));
+            } else {
+                url = IDN.toASCII(url);
+            }
+        }
 
         // Add http to the beginning of the URL if needed
         if (!(url.toLowerCase().startsWith("http://")) && !(url.toLowerCase().startsWith("https://"))) {


### PR DESCRIPTION
The `org.wordpress.android.ui.accounts.SetupBlog.getSelfHostedXmlrpcUrl` method does not accept IDN names.
Punycode, however, is accepted. While `URLUtil.isValidUrl` says that it's a completely valid URL, the `ApiHelper.getRSDMetaTagHrefRegEx` method does not like it at all.
So I'm proposing the use of `java.net.IDN` to convert non-ASCII URLs to valid ASCII punycode for custom blogs.

If you'd like access to an IDN domain, I have one in production, and I'll be happy to give out credentials for testing.
