### PR TITLE
Fixes #501. 

### DIFF
--- a/src/org/wordpress/android/WordPressDB.java
+++ b/src/org/wordpress/android/WordPressDB.java
@@ -778,18 +778,11 @@ public class WordPressDB {
     }
 
     public boolean deletePost(Post post) {
+        int result = db.delete(POSTS_TABLE,
+                "blogID=? AND id=?",
+                new String[]{String.valueOf(post.getBlogID()), String.valueOf(post.getId())});
 
-        boolean returnValue = false;
-
-        int result = 0;
-        result = db.delete(POSTS_TABLE, "blogID=" + post.getBlogID()
-                + " AND id=" + post.getId(), null);
-
-        if (result == 1) {
-            returnValue = true;
-        }
-
-        return returnValue;
+        return (result == 1);
     }
 
     public boolean savePosts(List<?> postValues, int blogID, boolean isPage) {

--- a/src/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/src/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -346,7 +346,7 @@ public class EditPostActivity extends SherlockFragmentActivity {
         dialogBuilder.setNeutralButton(getString(R.string.discard), new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int whichButton) {
                 // When discard option is chosen, restore existing post or delete new post if it was autosaved.
-                if (mOriginalPost != null) {
+                if (mOriginalPost != null && !mIsNewPost) {
                     mOriginalPost.update();
                     WordPress.currentPost = mOriginalPost;
                 } else if (mPost != null && mIsNewPost) {


### PR DESCRIPTION
Don’t update the original post if the user chose to discard a brand new post. Also improved the readability of the WordPressDB.deletePost() method.
