### PR TITLE
Fixes #474 - CDATA in comments

### DIFF
--- a/src/org/wordpress/android/models/Comment.java
+++ b/src/org/wordpress/android/models/Comment.java
@@ -5,6 +5,7 @@ import android.text.TextUtils;
 import org.json.JSONObject;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.util.DateTimeUtils;
+import org.wordpress.android.util.HtmlUtils;
 import org.wordpress.android.util.JSONUtil;
 import org.xmlrpc.android.ApiHelper;
 
@@ -60,7 +61,11 @@ public class Comment {
 
         this.commentID = json.optInt("ID");
         this.status = JSONUtil.getString(json, "status");
-        this.comment = JSONUtil.getString(json, "content"); // contains html
+
+        // note that the content often contains html, and on rare occasions may contain
+        // script blocks that need to be removed (only seen with blogs that use the
+        // sociable plugin)
+        this.comment = HtmlUtils.stripScript(JSONUtil.getString(json, "content"));
 
         java.util.Date date = DateTimeUtils.iso8601ToJavaDate(JSONUtil.getString(json, "date"));
         if (date != null)

--- a/src/org/wordpress/android/models/ReaderComment.java
+++ b/src/org/wordpress/android/models/ReaderComment.java
@@ -4,6 +4,7 @@ import android.text.TextUtils;
 
 import org.json.JSONObject;
 import org.wordpress.android.util.DateTimeUtils;
+import org.wordpress.android.util.HtmlUtils;
 import org.wordpress.android.util.JSONUtil;
 import org.wordpress.android.util.StringUtils;
 
@@ -41,7 +42,7 @@ public class ReaderComment {
         comment.status = JSONUtil.getString(json, "status");
 
         // note that content may contain html, adapter needs to handle it
-        comment.text = stripScript(JSONUtil.getString(json, "content"));
+        comment.text = HtmlUtils.stripScript(JSONUtil.getString(json, "content"));
 
         comment.published = JSONUtil.getString(json, "date");
         comment.timestamp = DateTimeUtils.iso8601ToTimestamp(comment.published);
@@ -63,26 +64,6 @@ public class ReaderComment {
             comment.parentId = jsonParent.optLong("ID");
 
         return comment;
-    }
-
-    // comments on posts that use the "Sociable" plugin ( http://wordpress.org/plugins/sociable/ )
-    // may have a script block which contains <!--//--> followed by a CDATA section followed by <!]]>,
-    // all of which will show up if we don't strip it here (example: http://cl.ly/image/0J0N3z3h1i04 )
-    // first seen at http://houseofgeekery.com/2013/11/03/13-terrible-x-men-we-wont-see-in-the-movies/
-    // TODO: move this to a utility class
-    private static String stripScript(final String text) {
-        StringBuilder sb = new StringBuilder(text);
-        int start = sb.indexOf("<script");
-
-        while (start > -1) {
-            int end = sb.indexOf("</script>", start);
-            if (end == -1)
-                return sb.toString();
-            sb.delete(start, end+9);
-            start = sb.indexOf("<script", start);
-        }
-
-        return sb.toString();
     }
 
     public String getAuthorName() {

--- a/src/org/wordpress/android/util/HtmlUtils.java
+++ b/src/org/wordpress/android/util/HtmlUtils.java
@@ -42,7 +42,6 @@ public class HtmlUtils {
         return fastUnescapeHtml(text.replaceAll("<(.|\n)*?>", "").trim());
     }
 
-
     /*
      * convert html entities to actual Unicode characters - relies on commons apache lang
      */
@@ -61,6 +60,31 @@ public class HtmlUtils {
         } catch (Resources.NotFoundException e) {
             return "#000000";
         }
+    }
+
+    /*
+     * remove <script>..</script> blocks from the passed string - added to project after noticing
+     * comments on posts that use the "Sociable" plugin ( http://wordpress.org/plugins/sociable/ )
+     * may have a script block which contains <!--//--> followed by a CDATA section followed by <!]]>,
+     * all of which will show up if we don't strip it here (example: http://cl.ly/image/0J0N3z3h1i04 )
+     * first seen at http://houseofgeekery.com/2013/11/03/13-terrible-x-men-we-wont-see-in-the-movies/
+     */
+    public static String stripScript(final String text) {
+        if (text == null)
+            return null;
+
+        StringBuilder sb = new StringBuilder(text);
+        int start = sb.indexOf("<script");
+
+        while (start > -1) {
+            int end = sb.indexOf("</script>", start);
+            if (end == -1)
+                return sb.toString();
+            sb.delete(start, end+9);
+            start = sb.indexOf("<script", start);
+        }
+
+        return sb.toString();
     }
 
 }


### PR DESCRIPTION
Fixes #474 - script blocks are now stripped from comments after downloading, which corrects the display of CDATA sections. Note that you may need to sign out and sign back in before testing this.
