### PR TITLE
fix #499: show an error message and close the picker activity if there is no media after refreshing from server

### DIFF
--- a/src/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
+++ b/src/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.media;
 import android.content.Intent;
 import android.database.Cursor;
 import android.os.Bundle;
+import android.os.Handler;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.Toast;
@@ -17,6 +18,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.ui.MultiSelectGridView;
 import org.wordpress.android.ui.MultiSelectGridView.MultiSelectListener;
+import org.wordpress.android.util.ToastUtils;
 import org.xmlrpc.android.ApiHelper;
 import org.xmlrpc.android.ApiHelper.SyncMediaLibraryTask;
 
@@ -105,9 +107,7 @@ public class MediaGalleryPickerActivity extends SherlockActivity implements Mult
     private void refereshViews() {
         if (WordPress.getCurrentBlog() == null)
             return;
-        
         final String blogId = String.valueOf(WordPress.getCurrentBlog().getBlogId());
-        
         Cursor cursor = WordPress.wpDB.getMediaImagesForBlog(blogId, mFilteredItems);
         if (cursor.getCount() == 0) {
             refreshMediaFromServer(0);
@@ -180,16 +180,24 @@ public class MediaGalleryPickerActivity extends SherlockActivity implements Mult
         return false;
     }
 
+    private void noMediaFinish() {
+        ToastUtils.showToast(this, R.string.media_empty_list, ToastUtils.Duration.LONG);
+        // Delay activity finish
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                finish();
+            }
+        }, 1500);
+    }
+
     public void refreshMediaFromServer(int offset) {
-
-        if(offset == 0 || !mIsRefreshing) {
-
+        if (offset == 0 || !mIsRefreshing) {
             if (offset == mOldMediaSyncOffset) {
                 // we're pulling the same data again for some reason. Pull from the beginning.
                 offset = 0;
             }
             mOldMediaSyncOffset = offset;
-
             mIsRefreshing = true;
             mGridAdapter.setRefreshing(true);
 
@@ -206,7 +214,11 @@ public class MediaGalleryPickerActivity extends SherlockActivity implements Mult
                     MediaGridAdapter adapter = (MediaGridAdapter) mGridView.getAdapter();
                     mHasRetrievedAllMedia = (count == 0);
                     adapter.setHasRetrieviedAll(mHasRetrievedAllMedia);
-
+                    String blogId = String.valueOf(WordPress.getCurrentBlog().getBlogId());
+                    if (WordPress.wpDB.getMediaCountAll(blogId) == 0 && count == 0) {
+                        // There is no media at all
+                        noMediaFinish();
+                    }
                     mIsRefreshing = false;
 
                     // the activity may be gone by the time this finishes, so check for it
@@ -228,7 +240,6 @@ public class MediaGalleryPickerActivity extends SherlockActivity implements Mult
 
                 @Override
                 public void onFailure(int errorCode) {
-
                     if ( errorCode == ApiHelper.SyncMediaLibraryTask.NO_UPLOAD_FILES_CAP || errorCode == SyncMediaLibraryTask.UNKNOWN_ERROR ) {
                         String errorMessage = errorCode == SyncMediaLibraryTask.NO_UPLOAD_FILES_CAP ? "You do not have permission to view the media library" : "Something went wrong while refreshing the media library. Try again later.";
                         Toast.makeText(MediaGalleryPickerActivity.this, errorMessage, Toast.LENGTH_SHORT).show();


### PR DESCRIPTION
fix #499 
