### PR TITLE
fix #559: don't display the share view with one blog and text

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -306,6 +306,7 @@
     <string name="share_action_post">New Post</string>
     <string name="share_action_media">Media Gallery</string>
     <string name="share_action">Share</string>
+    <string name="cant_share_no_visible_blog">You can\'t share to WordPress without a visible blog</string>
     <string name="no_account">No WordPress account found, please add an account and try again.</string>
 
     <!-- file errors -->

--- a/src/org/wordpress/android/WordPress.java
+++ b/src/org/wordpress/android/WordPress.java
@@ -319,11 +319,14 @@ public class WordPress extends Application {
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
         String username = settings.getString(WPCOM_USERNAME_PREFERENCE, null);
         String password = settings.getString(WPCOM_PASSWORD_PREFERENCE, null);
+        return username != null && password != null;
+    }
 
-        if (username != null && password != null)
+    public static boolean isSignedIn(Context context) {
+        if (WordPress.hasValidWPComCredentials(context)) {
             return true;
-        else
-            return false;
+        }
+        return WordPress.wpDB.getNumVisibleAccounts() != 0;
     }
 
     /**

--- a/src/org/wordpress/android/ui/WPActionBarActivity.java
+++ b/src/org/wordpress/android/ui/WPActionBarActivity.java
@@ -466,19 +466,8 @@ public abstract class WPActionBarActivity extends SherlockFragmentActivity {
         return blogNames;
     }
 
-    private int getNumVisibleAccounts() {
-        return WordPress.wpDB.getNumVisibleAccounts();
-    }
-
-    protected boolean isSignedIn() {
-        if (WordPress.hasValidWPComCredentials(WPActionBarActivity.this)) {
-            return true;
-        }
-        return getNumVisibleAccounts() != 0;
-    }
-
     private boolean askToSignInIfNot() {
-        if (!isSignedIn()) {
+        if (!WordPress.isSignedIn(WPActionBarActivity.this)) {
             Log.d(TAG, "No accounts configured.  Sending user to set up an account");
             mShouldFinish = false;
             Intent intent = new Intent(this, WelcomeActivity.class);
@@ -507,7 +496,7 @@ public abstract class WPActionBarActivity extends SherlockFragmentActivity {
 
     protected void showReaderIfNoBlog() {
         // If logged in without blog, redirect to the Reader view
-        if (getNumVisibleAccounts() == 0) {
+        if (WordPress.wpDB.getNumVisibleAccounts() == 0) {
             showReader();
         }
     }
@@ -747,7 +736,7 @@ public abstract class WPActionBarActivity extends SherlockFragmentActivity {
         }
         @Override
         public Boolean isVisible() {
-            return getNumVisibleAccounts() != 0;
+            return WordPress.wpDB.getNumVisibleAccounts() != 0;
         }
     }
 
@@ -769,7 +758,7 @@ public abstract class WPActionBarActivity extends SherlockFragmentActivity {
         }
         @Override
         public Boolean isVisible() {
-            return getNumVisibleAccounts() != 0;
+            return WordPress.wpDB.getNumVisibleAccounts() != 0;
         }
     }
     
@@ -794,7 +783,7 @@ public abstract class WPActionBarActivity extends SherlockFragmentActivity {
         }
         @Override
         public Boolean isVisible() {
-            return getNumVisibleAccounts() != 0;
+            return WordPress.wpDB.getNumVisibleAccounts() != 0;
         }
     }
 
@@ -833,7 +822,7 @@ public abstract class WPActionBarActivity extends SherlockFragmentActivity {
         }
         @Override
         public Boolean isVisible() {
-            return getNumVisibleAccounts() != 0;
+            return WordPress.wpDB.getNumVisibleAccounts() != 0;
         }
     }
     
@@ -884,7 +873,7 @@ public abstract class WPActionBarActivity extends SherlockFragmentActivity {
         }
         @Override
         public Boolean isVisible() {
-            return getNumVisibleAccounts() != 0;
+            return WordPress.wpDB.getNumVisibleAccounts() != 0;
         }
     }
 
@@ -904,7 +893,7 @@ public abstract class WPActionBarActivity extends SherlockFragmentActivity {
         }
         @Override
         public Boolean isVisible() {
-            return getNumVisibleAccounts() != 0;
+            return WordPress.wpDB.getNumVisibleAccounts() != 0;
         }
     }
 
@@ -924,7 +913,7 @@ public abstract class WPActionBarActivity extends SherlockFragmentActivity {
         }
         @Override
         public Boolean isVisible() {
-            return getNumVisibleAccounts() != 0;
+            return WordPress.wpDB.getNumVisibleAccounts() != 0;
         }
     }
 
@@ -946,7 +935,7 @@ public abstract class WPActionBarActivity extends SherlockFragmentActivity {
         }
         @Override
         public Boolean isVisible() {
-            return getNumVisibleAccounts() != 0;
+            return WordPress.wpDB.getNumVisibleAccounts() != 0;
         }
     }
 

--- a/src/org/wordpress/android/ui/posts/PostsActivity.java
+++ b/src/org/wordpress/android/ui/posts/PostsActivity.java
@@ -272,7 +272,7 @@ public class PostsActivity extends WPActionBarActivity implements OnPostSelected
     @Override
     protected void onResume() {
         super.onResume();
-        if (isSignedIn()) {
+        if (WordPress.isSignedIn(PostsActivity.this)) {
             showReaderIfNoBlog();
         }
         if (postList.getListView().getCount() == 0)


### PR DESCRIPTION
fix #559: don't display the share view with one blog and text
- fix a NPE when user doesn't have visible blog
- if the user isn't signed in, redirect it to the login screen, if he's signed and have no visible blog, display a toast error and finish the share activity
- move isSignedIn to Worpress.java
