### PR TITLE
Added thousands-separators to like/comments counts

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -615,10 +615,10 @@
 
     <!-- like counts liking users activity-->
     <string name="reader_likes_one">One person likes this</string>
-    <string name="reader_likes_multi">%d people like this</string>
+    <string name="reader_likes_multi">%,d people like this</string>
     <string name="reader_likes_only_you">You like this</string>
     <string name="reader_likes_you_and_one">You and one other like this</string>
-    <string name="reader_likes_you_and_multi">You and %d others like this</string>
+    <string name="reader_likes_you_and_multi">You and %,d others like this</string>
 
     <!-- toast messages -->
     <string name="reader_toast_reblog_success">Post has been reblogged</string>

--- a/src/org/wordpress/android/ui/reader_native/adapters/ReaderPostAdapter.java
+++ b/src/org/wordpress/android/ui/reader_native/adapters/ReaderPostAdapter.java
@@ -26,10 +26,14 @@ import org.wordpress.android.ui.reader_native.actions.ReaderActions;
 import org.wordpress.android.ui.reader_native.actions.ReaderPostActions;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DisplayUtils;
+import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.ReaderAniUtils;
 import org.wordpress.android.util.ReaderLog;
+import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.SysUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
+
+import java.text.NumberFormat;
 
 /**
  * Created by nbradbury on 6/27/13.
@@ -331,14 +335,14 @@ public class ReaderPostAdapter extends BaseAdapter {
      */
     private void showCounts(final PostViewHolder holder, final ReaderPost post) {
         if (post.numLikes > 0) {
-            holder.txtLikeCount.setText(Integer.toString(post.numLikes));
+            holder.txtLikeCount.setText(FormatUtils.formatInt(post.numLikes));
             holder.txtLikeCount.setVisibility(View.VISIBLE);
         } else {
             holder.txtLikeCount.setVisibility(View.GONE);
         }
 
         if (post.numReplies > 0) {
-            holder.txtCommentCount.setText(Integer.toString(post.numReplies));
+            holder.txtCommentCount.setText(FormatUtils.formatInt(post.numReplies));
             holder.txtCommentCount.setVisibility(View.VISIBLE);
         } else {
             holder.txtCommentCount.setVisibility(View.GONE);

--- a/src/org/wordpress/android/util/FormatUtils.java
+++ b/src/org/wordpress/android/util/FormatUtils.java
@@ -1,0 +1,27 @@
+package org.wordpress.android.util;
+
+import java.text.NumberFormat;
+
+/**
+ * Created by nbradbury on 1/3/14.
+ */
+public class FormatUtils {
+
+    /*
+     * NumberFormat isn't synchronized, so a separate instance must be created for each thread
+     * http://developer.android.com/reference/java/text/NumberFormat.html
+     */
+    private static final ThreadLocal<NumberFormat> IntegerFormat = new ThreadLocal<NumberFormat>() {
+        @Override
+        protected NumberFormat initialValue() {
+            return NumberFormat.getIntegerInstance();
+        }
+    };
+
+    /*
+     * returns the passed integer formatted with thousands-separators based on the current locale
+     */
+    public static final String formatInt(int value) {
+        return IntegerFormat.get().format(value).toString();
+    }
+}


### PR DESCRIPTION
Fix #620 - like/comment counts in post list now show thousands-separators, as do like counts in post detail and liking users.
