### PR TITLE
Featured image is now retained after updating post in detail view

### DIFF
--- a/src/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/src/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -237,6 +237,13 @@ public class ReaderPostActions {
 
                 if (hasChanges) {
                     AppLog.d("post updated");
+                    // the endpoint for requesting a single post doesn't always support featured images,
+                    // so if the original post had a featured image and the updated post doesn't, set
+                    // the featured image for the updated post to that of the original post
+                    if (post.hasFeaturedImage() && !updatedPost.hasFeaturedImage()) {
+                        AppLog.i("restored featured image after updating post");
+                        updatedPost.setFeaturedImage(post.getFeaturedImage());
+                    }
                     ReaderPostTable.addOrUpdatePost(updatedPost);
                 }
 


### PR DESCRIPTION
Fix #634 - featured image disappears after returning from reader post detail to reader post list
