### PR TITLE
Fix #644 - message bar animation bug

### DIFF
--- a/res/layout/reader_activity_tags.xml
+++ b/res/layout/reader_activity_tags.xml
@@ -29,6 +29,7 @@
         android:paddingBottom="@dimen/margin_large"
         android:paddingTop="@dimen/margin_large"
         android:text="@string/reader_empty_followed_tags"
+        android:textColor="@color/grey_medium"
         android:visibility="gone" />
 
     <ListView
@@ -41,7 +42,8 @@
     <include
         android:id="@+id/text_message_bar"
         layout="@layout/message_bar_include"
-        android:layout_alignBottom="@id/android:list"
+        android:layout_above="@+id/layout_add_topic"
+        android:layout_alignWithParentIfMissing="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 


### PR DESCRIPTION
Fix #644 - message bar animation now stops above "Enter a tag" when the last tag is removed
