### PR TITLE
Fix #646 - comment icon appears in post list even when post doesn't allow comments

### DIFF
--- a/src/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/src/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -342,11 +342,13 @@ public class ReaderPostAdapter extends BaseAdapter {
         if (post.numReplies > 0) {
             holder.txtCommentCount.setText(FormatUtils.formatInt(post.numReplies));
             holder.txtCommentCount.setVisibility(View.VISIBLE);
+            // note that the comment icon is shown here even if comments are now closed since
+            // the post has existing comments
+            holder.imgBtnComment.setVisibility(View.VISIBLE);
         } else {
             holder.txtCommentCount.setVisibility(View.GONE);
+            holder.imgBtnComment.setVisibility(post.isCommentsOpen ? View.VISIBLE : View.GONE);
         }
-
-        holder.imgBtnComment.setVisibility(post.isCommentsOpen ? View.VISIBLE : View.GONE);
     }
 
     /*


### PR DESCRIPTION
Fix #646 - comment icon now only appears when post allows comments
