### PR TITLE
Fix #652 - In comments with emoticons, URLs are not clickable

### DIFF
--- a/src/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/src/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -4,7 +4,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.text.Html;
-import android.text.SpannableStringBuilder;
+import android.text.Spanned;
 import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -215,22 +215,21 @@ public class ReaderCommentAdapter extends BaseAdapter {
         if (content==null || textView==null)
             return;
 
-        // convert emoticons first (otherwise they'll be downloaded)
-        if (content.contains("icon_"))
-            content = Emoticons.replaceEmoticonsWithEmoji((SpannableStringBuilder) Html.fromHtml(content)).toString().trim();
-
         // skip performance hit of html conversion if content doesn't contain html
-        if (!content.contains("<") && !content.contains("&")) {
+        if (!content.contains("<") && content.contains("&")) {
             textView.setText(content.trim());
             return;
         }
 
+        // convert emoticons first (otherwise they'll be downloaded)
+        content = Emoticons.replaceEmoticonsWithEmoji(content);
+
         // now convert to HTML with an image getter that enforces a max image size
-        final SpannableStringBuilder html;
+        final Spanned html;
         if (content.contains("<img")) {
-            html = (SpannableStringBuilder) Html.fromHtml(content, new WPImageGetter(textView.getContext(), textView, mMaxImageSz), null);
+            html = Html.fromHtml(content, new WPImageGetter(textView.getContext(), textView, mMaxImageSz), null);
         } else {
-            html = (SpannableStringBuilder) Html.fromHtml(content);
+            html = Html.fromHtml(content);
         }
 
         // remove extra \n\n added by Html.convert()

--- a/src/org/wordpress/android/util/Emoticons.java
+++ b/src/org/wordpress/android/util/Emoticons.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.util;
 
+import android.text.Html;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.style.ForegroundColorSpan;
@@ -15,8 +16,8 @@ import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES;
 
 public class Emoticons {
-    public static final int EMOTICON_COLOR=0xFF21759B;
-    private static final boolean HAS_EMOJI=SDK_INT >= VERSION_CODES.JELLY_BEAN;
+    public static final int EMOTICON_COLOR = 0xFF21759B;
+    private static final boolean HAS_EMOJI = SDK_INT >= VERSION_CODES.JELLY_BEAN;
     private static final Map<String, String> wpSmilies;
     static {
         Map<String, String> smilies = new HashMap<String, String>();
@@ -70,5 +71,14 @@ public class Emoticons {
             }
         }
         return html;
+    }
+    public static String replaceEmoticonsWithEmoji(final String text) {
+        if (text != null && text.contains("icon_")) {
+            final SpannableStringBuilder html = (SpannableStringBuilder)replaceEmoticonsWithEmoji((SpannableStringBuilder) Html.fromHtml(text));
+            // Html.toHtml() is used here rather than toString() since the latter strips html
+            return Html.toHtml(html);
+        } else {
+            return text;
+        }
     }
 }


### PR DESCRIPTION
Fix #652 by preserving html after converting emoticons. Before & after shot below.

![emoticons](https://f.cloud.github.com/assets/3903757/1872440/37d682fc-78a6-11e3-83b2-945d26b5ba74.png)
