### PR TITLE
fix #692: disable EditText and Button on NUX screens when request in progress

### DIFF
--- a/src/org/wordpress/android/ui/accounts/NewBlogFragment.java
+++ b/src/org/wordpress/android/ui/accounts/NewBlogFragment.java
@@ -92,6 +92,8 @@ public class NewBlogFragment extends NewAccountAbstractPageFragment implements T
         mSignupButton.setVisibility(View.GONE);
         mProgressBarSignIn.setEnabled(false);
         mProgressTextSignIn.setText(message);
+        mSiteTitleTextField.setEnabled(false);
+        mSiteUrlTextField.setEnabled(false);
     }
 
     protected void updateProgress(String message) {
@@ -102,6 +104,8 @@ public class NewBlogFragment extends NewAccountAbstractPageFragment implements T
         mProgressBarSignIn.setVisibility(View.GONE);
         mProgressTextSignIn.setVisibility(View.GONE);
         mSignupButton.setVisibility(View.VISIBLE);
+        mSiteTitleTextField.setEnabled(true);
+        mSiteUrlTextField.setEnabled(true);
     }
 
     private void showSiteUrlError(int messageId) {
@@ -161,7 +165,7 @@ public class NewBlogFragment extends NewAccountAbstractPageFragment implements T
 
         if (View.VISIBLE==mProgressBarSignIn.getVisibility()) //prevent double tapping of the "done" btn in keyboard for those clients that don't dismiss the keyboard. Samsung S4 for example
             return;
-        
+
         startProgress(getString(R.string.validating_site_data));
 
         final String siteUrl = mSiteUrlTextField.getText().toString().trim();

--- a/src/org/wordpress/android/ui/accounts/NewUserPageFragment.java
+++ b/src/org/wordpress/android/ui/accounts/NewUserPageFragment.java
@@ -74,6 +74,10 @@ public class NewUserPageFragment extends NewAccountAbstractPageFragment implemen
         mSignupButton.setVisibility(View.GONE);
         mProgressBarSignIn.setEnabled(false);
         mProgressTextSignIn.setText(message);
+        mEmailTextField.setEnabled(false);
+        mPasswordTextField.setEnabled(false);
+        mUsernameTextField.setEnabled(false);
+        mSiteUrlTextField.setEnabled(false);
     }
 
     protected void updateProgress(String message) {
@@ -84,6 +88,10 @@ public class NewUserPageFragment extends NewAccountAbstractPageFragment implemen
         mProgressBarSignIn.setVisibility(View.GONE);
         mProgressTextSignIn.setVisibility(View.GONE);
         mSignupButton.setVisibility(View.VISIBLE);
+        mEmailTextField.setEnabled(true);
+        mPasswordTextField.setEnabled(true);
+        mUsernameTextField.setEnabled(true);
+        mSiteUrlTextField.setEnabled(true);
     }
 
     private boolean checkUserData() {
@@ -213,7 +221,7 @@ public class NewUserPageFragment extends NewAccountAbstractPageFragment implemen
 
         if (View.VISIBLE==mProgressBarSignIn.getVisibility()) //prevent double tapping of the "done" btn in keyboard for those clients that don't dismiss the keyboard. Samsung S4 for example
             return;
-        
+
         startProgress(getString(R.string.validating_user_data));
 
         final String siteUrl = mSiteUrlTextField.getText().toString().trim();

--- a/src/org/wordpress/android/ui/accounts/WelcomeFragmentSignIn.java
+++ b/src/org/wordpress/android/ui/accounts/WelcomeFragmentSignIn.java
@@ -227,7 +227,8 @@ public class WelcomeFragmentSignIn extends NewAccountAbstractPageFragment implem
     }
 
     public void signInDotComUser() {
-        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getActivity().getApplicationContext());
+        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(
+                getActivity().getApplicationContext());
         String username = settings.getString(WordPress.WPCOM_USERNAME_PREFERENCE, null);
         String password = WordPressDB.decryptPassword(settings.getString(WordPress.WPCOM_PASSWORD_PREFERENCE, null));
         if (username != null && password != null) {
@@ -243,12 +244,22 @@ public class WelcomeFragmentSignIn extends NewAccountAbstractPageFragment implem
         mSignInButton.setVisibility(View.GONE);
         mProgressBarSignIn.setEnabled(false);
         mProgressTextSignIn.setText(message);
+        mUsernameEditText.setEnabled(false);
+        mPasswordEditText.setEnabled(false);
+        mUrlEditText.setEnabled(false);
+        mAddSelfHostedButton.setEnabled(false);
+        mCreateAccountButton.setEnabled(false);
     }
 
     protected void endProgress() {
         mProgressBarSignIn.setVisibility(View.GONE);
         mProgressTextSignIn.setVisibility(View.GONE);
         mSignInButton.setVisibility(View.VISIBLE);
+        mUsernameEditText.setEnabled(true);
+        mPasswordEditText.setEnabled(true);
+        mUrlEditText.setEnabled(true);
+        mAddSelfHostedButton.setEnabled(true);
+        mCreateAccountButton.setEnabled(true);
     }
 
     private class SetupBlogTask extends AsyncTask<Void, Void, List<Object>> {


### PR DESCRIPTION
fix #692: disable EditText and Button on NUX screens when a request is in progress
