### PR TITLE
fix #715: workaround to fix the progress bar animation on gingerbread

### DIFF
--- a/res/layout/create_blog_fragment.xml
+++ b/res/layout/create_blog_fragment.xml
@@ -128,14 +128,19 @@
                     android:padding="8dp"
                     android:enabled="false"/>
 
-                <ProgressBar
+                <RelativeLayout
                     android:id="@+id/nux_sign_in_progress_bar"
+                    style="@style/WordPress.NUXPrimaryButton"
                     android:layout_width="fill_parent"
                     android:layout_height="40dp"
-                    style="@style/WordPress.NUXPrimaryButton"
-                    android:enabled="false"
-                    android:visibility="gone" />
+                    android:visibility="gone"
+                    android:enabled="false">
 
+                    <ProgressBar
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_centerHorizontal="true" />
+                </RelativeLayout>
             </RelativeLayout>
 
             <org.wordpress.android.widgets.WPTextView

--- a/res/layout/new_account_user_fragment_screen.xml
+++ b/res/layout/new_account_user_fragment_screen.xml
@@ -191,13 +191,19 @@
                     android:padding="8dp"
                     android:enabled="false"/>
 
-                <ProgressBar
+                <RelativeLayout
                     android:id="@+id/nux_sign_in_progress_bar"
+                    style="@style/WordPress.NUXPrimaryButton"
                     android:layout_width="fill_parent"
                     android:layout_height="40dp"
-                    style="@style/WordPress.NUXPrimaryButton"
-                    android:enabled="false"
-                    android:visibility="gone" />
+                    android:visibility="gone"
+                    android:enabled="false">
+
+                    <ProgressBar
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_centerHorizontal="true" />
+                </RelativeLayout>
 
             </RelativeLayout>
 

--- a/src/org/wordpress/android/ui/accounts/NewAccountAbstractPageFragment.java
+++ b/src/org/wordpress/android/ui/accounts/NewAccountAbstractPageFragment.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.accounts;
 
-import android.app.ProgressDialog;
 import android.content.Context;
 import android.net.ConnectivityManager;
 import android.os.Bundle;
@@ -33,7 +32,6 @@ import org.wordpress.android.util.WPRestClient;
  */
 public abstract class NewAccountAbstractPageFragment extends SherlockFragment {
     protected ConnectivityManager mSystemService;
-    protected ProgressDialog mProgressDialog;
     protected static RequestQueue requestQueue = null;
     protected static WPRestClient restClient = null;
     protected boolean mPasswordVisible;

--- a/src/org/wordpress/android/ui/accounts/NewBlogFragment.java
+++ b/src/org/wordpress/android/ui/accounts/NewBlogFragment.java
@@ -13,7 +13,7 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.EditText;
-import android.widget.ProgressBar;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import org.json.JSONException;
@@ -33,7 +33,7 @@ public class NewBlogFragment extends NewAccountAbstractPageFragment implements T
     private WPTextView mSignupButton;
     private WPTextView mProgressTextSignIn;
     private WPTextView mCancelButton;
-    private ProgressBar mProgressBarSignIn;
+    private RelativeLayout mProgressBarSignIn;
     private boolean mSignoutOnCancelMode;
 
     public NewBlogFragment() {
@@ -163,8 +163,11 @@ public class NewBlogFragment extends NewAccountAbstractPageFragment implements T
         if (!checkUserData())
             return;
 
-        if (View.VISIBLE==mProgressBarSignIn.getVisibility()) //prevent double tapping of the "done" btn in keyboard for those clients that don't dismiss the keyboard. Samsung S4 for example
+        // prevent double tapping of the "done" btn in keyboard for those clients that don't dismiss the keyboard.
+        // Samsung S4 for example
+        if (View.VISIBLE == mProgressBarSignIn.getVisibility()) {
             return;
+        }
 
         startProgress(getString(R.string.validating_site_data));
 
@@ -235,7 +238,7 @@ public class NewBlogFragment extends NewAccountAbstractPageFragment implements T
         mCancelButton.setOnClickListener(cancelClickListener);
 
         mProgressTextSignIn = (WPTextView) rootView.findViewById(R.id.nux_sign_in_progress_text);
-        mProgressBarSignIn = (ProgressBar) rootView.findViewById(R.id.nux_sign_in_progress_bar);
+        mProgressBarSignIn = (RelativeLayout) rootView.findViewById(R.id.nux_sign_in_progress_bar);
 
         mSiteTitleTextField = (EditText) rootView.findViewById(R.id.site_title);
         mSiteUrlTextField = (EditText) rootView.findViewById(R.id.site_url);

--- a/src/org/wordpress/android/ui/accounts/NewUserPageFragment.java
+++ b/src/org/wordpress/android/ui/accounts/NewUserPageFragment.java
@@ -14,7 +14,7 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.EditText;
-import android.widget.ProgressBar;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import org.json.JSONObject;
@@ -35,7 +35,7 @@ public class NewUserPageFragment extends NewAccountAbstractPageFragment implemen
     private EditText mUsernameTextField;
     private WPTextView mSignupButton;
     private WPTextView mProgressTextSignIn;
-    private ProgressBar mProgressBarSignIn;
+    private RelativeLayout mProgressBarSignIn;
 
     private EmailChecker mEmailChecker;
     private boolean mEmailAutoCorrected;
@@ -304,7 +304,7 @@ public class NewUserPageFragment extends NewAccountAbstractPageFragment implemen
         mSignupButton.setEnabled(false);
 
         mProgressTextSignIn = (WPTextView) rootView.findViewById(R.id.nux_sign_in_progress_text);
-        mProgressBarSignIn = (ProgressBar) rootView.findViewById(R.id.nux_sign_in_progress_bar);
+        mProgressBarSignIn = (RelativeLayout) rootView.findViewById(R.id.nux_sign_in_progress_bar);
 
         mEmailTextField = (EditText) rootView.findViewById(R.id.email_address);
         mEmailTextField.setText(UserEmail.getPrimaryEmail(getActivity()));


### PR DESCRIPTION
Fixed for new account and new blog screens.
