### PR TITLE
fix #772: npe in create account page with a certain timing

### DIFF
--- a/src/org/wordpress/android/ui/accounts/NewUserPageFragment.java
+++ b/src/org/wordpress/android/ui/accounts/NewUserPageFragment.java
@@ -266,13 +266,17 @@ public class NewUserPageFragment extends NewAccountAbstractPageFragment implemen
                     @Override
                     public void onSuccess(JSONObject createSiteResponse) {
                         endProgress();
-                        finishThisStuff(username);
+                        if (hasActivity()) {
+                            finishThisStuff(username);
+                        }
                     }
 
                     @Override
                     public void onError(int messageId) {
                         endProgress();
-                        showError(getString(messageId));
+                        if (hasActivity()) {
+                            showError(getString(messageId));
+                        }
                     }
                 });
         createUserAndBlog.startCreateUserAndBlogProcess();


### PR DESCRIPTION
fix #772: npe in create account page with a certain timing, when a user create an account and hit back just before completion
