### PR TITLE
Fixes #780 (OutOfIndex).

### DIFF
--- a/src/org/wordpress/android/ui/posts/EditPostContentFragment.java
+++ b/src/org/wordpress/android/ui/posts/EditPostContentFragment.java
@@ -1095,8 +1095,11 @@ public class EditPostContentFragment extends SherlockFragment implements TextWat
             } else if (id == R.id.more) {
                 mSelectionEnd = mContentEditText.getSelectionEnd();
                 Editable str = mContentEditText.getText();
-                if (str != null)
+                if (str != null) {
+                    if (mSelectionEnd > str.length())
+                        mSelectionEnd = str.length();
                     str.insert(mSelectionEnd, "\n<!--more-->\n");
+                }
                 trackFormatButtonClick(WPMobileStatsUtil.StatsPropertyPostDetailClickedKeyboardToolbarMoreButton);
             } else if (id == R.id.link) {
                 mSelectionStart = mContentEditText.getSelectionStart();


### PR DESCRIPTION
Ensure we aren’t inserting a string outside of the length of the content editable string.
