### PR TITLE
Fixes #782 NPE

### DIFF
--- a/src/org/wordpress/android/ui/media/MediaUtils.java
+++ b/src/org/wordpress/android/ui/media/MediaUtils.java
@@ -343,7 +343,11 @@ public class MediaUtils {
     }
 
     public static Uri downloadExternalMedia(Context context, Uri imageUri) {
+        if (context == null || imageUri == null)
+            return null;
+
         File cacheDir;
+
         String mimeType = context.getContentResolver().getType(imageUri);
         boolean isVideo = (mimeType != null && mimeType.contains("video"));
 


### PR DESCRIPTION
Don’t proceed with downloading external media if the method arguments are null. Most likely the cause of this was that the activity had finished.
