### PR TITLE
Fix #796 - NPE in reader post list fragment

### DIFF
--- a/src/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/src/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -237,6 +237,8 @@ public class ReaderPostListFragment extends Fragment implements AbsListView.OnSc
     private ReaderActions.DataLoadedListener mDataLoadedListener = new ReaderActions.DataLoadedListener() {
         @Override
         public void onDataLoaded(boolean isEmpty) {
+            if (!hasActivity())
+                return;
             if (isEmpty) {
                 startBoxAndPagesAnimation();
                 setEmptyTitleAndDecriptionForCurrentTag();


### PR DESCRIPTION
Fix #796 - now checking whether activity is valid after adapter finishes loading data
