### PR TITLE
Fix #794 - RuntimeException in ReaderPostTable

### DIFF
--- a/src/org/wordpress/android/datasets/ReaderCommentTable.java
+++ b/src/org/wordpress/android/datasets/ReaderCommentTable.java
@@ -72,7 +72,6 @@ public class ReaderCommentTable {
         try {
             ReaderCommentList comments = new ReaderCommentList();
             if (c.moveToFirst()) {
-                resetColumnIndexes(c);
                 do {
                     comments.add(getCommentFromCursor(c));
                 } while (c.moveToNext());
@@ -157,52 +156,25 @@ public class ReaderCommentTable {
         ReaderDatabase.getWritableDb().delete("tbl_comments", "blog_id=? AND post_id=? AND comment_id=?", args);
     }
 
-    private static int COL_COMMENT_ID;
-    private static int COL_BLOG_ID;
-    private static int COL_POST_ID;
-    private static int COL_PARENT_ID;
-    private static int COL_STATUS;
-    private static int COL_PUBLISHED;
-    private static int COL_TIMESTAMP;
-    private static int COL_AUTHOR_AVATAR;
-    private static int COL_AUTHOR_NAME;
-    private static int COL_AUTHOR_URL;
-    private static int COL_TEXT;
-
-    // see comment in ReaderPostTable.java for purpose
-    private static void resetColumnIndexes(Cursor c) {
-        COL_COMMENT_ID = c.getColumnIndex("comment_id");
-        COL_BLOG_ID = c.getColumnIndex("blog_id");
-        COL_POST_ID = c.getColumnIndex("post_id");
-        COL_PARENT_ID = c.getColumnIndex("parent_id");
-        COL_PUBLISHED = c.getColumnIndex("published");
-        COL_TIMESTAMP = c.getColumnIndex("timestamp");
-        COL_AUTHOR_AVATAR = c.getColumnIndex("author_avatar");
-        COL_AUTHOR_NAME = c.getColumnIndex("author_name");
-        COL_AUTHOR_URL = c.getColumnIndex("author_url");
-        COL_STATUS = c.getColumnIndex("status");
-        COL_TEXT = c.getColumnIndex("text");
-    }
-
     public static ReaderComment getCommentFromCursor(Cursor c) {
         if (c==null)
             throw new IllegalArgumentException("null comment cursor");
 
         ReaderComment comment = new ReaderComment();
 
-        comment.commentId = c.getLong(COL_COMMENT_ID);
-        comment.blogId = c.getLong(COL_BLOG_ID);
-        comment.postId = c.getLong(COL_POST_ID);
-        comment.parentId = c.getLong(COL_PARENT_ID);
+        comment.commentId = c.getLong(c.getColumnIndex("comment_id"));
+        comment.blogId = c.getLong(c.getColumnIndex("blog_id"));
+        comment.postId = c.getLong(c.getColumnIndex("post_id"));
+        comment.parentId = c.getLong(c.getColumnIndex("parent_id"));
 
-        comment.setPublished(c.getString(COL_PUBLISHED));
-        comment.timestamp = c.getLong(COL_TIMESTAMP);
+        comment.setPublished(c.getString(c.getColumnIndex("published")));
+        comment.timestamp = c.getLong(c.getColumnIndex("timestamp"));
 
-        comment.setAuthorAvatar(c.getString(COL_AUTHOR_AVATAR));
-        comment.setAuthorName(c.getString(COL_AUTHOR_NAME));
-        comment.setAuthorUrl(c.getString(COL_AUTHOR_URL));
-        comment.setStatus(c.getString(COL_STATUS));
-        comment.setText(c.getString(COL_TEXT));
+        comment.setAuthorAvatar(c.getString(c.getColumnIndex("author_avatar")));
+        comment.setAuthorName(c.getString(c.getColumnIndex("author_name")));
+        comment.setAuthorUrl(c.getString(c.getColumnIndex("author_url")));
+        comment.setStatus(c.getString(c.getColumnIndex("status")));
+        comment.setText(c.getString(c.getColumnIndex("text")));
 
         return comment;
     }

--- a/src/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/src/org/wordpress/android/datasets/ReaderPostTable.java
@@ -143,7 +143,6 @@ public class ReaderPostTable {
         try {
             if (!c.moveToFirst())
                 return null;
-            resetColumnIndexes(c);
             return getPostFromCursor(c);
         } finally {
             SqlUtils.closeCursor(c);
@@ -377,7 +376,6 @@ public class ReaderPostTable {
             if (cursor==null || !cursor.moveToFirst())
                 return posts;
 
-            resetColumnIndexes(cursor);
             do {
                 posts.add(getPostFromCursor(cursor));
             } while (cursor.moveToNext());
@@ -398,104 +396,43 @@ public class ReaderPostTable {
         ReaderDatabase.getWritableDb().execSQL(sql, args);
     }
 
-    private static int COL_POST_ID;
-    private static int COL_BLOG_ID;
-    private static int COL_PSEUDO_ID;
-    private static int COL_AUTHOR_NAME;
-    private static int COL_BLOG_NAME;
-    private static int COL_BLOG_URL;
-    private static int COL_EXCERPT;
-    private static int COL_FEATURED_IMAGE;
-    private static int COL_FEATURED_VIDEO;
-    private static int COL_TITLE;
-    private static int COL_TEXT;
-    private static int COL_URL;
-    private static int COL_POST_AVATAR;
-    private static int COL_TIMESTAMP;
-    private static int COL_PUBLISHED;
-    private static int COL_NUM_REPLIES;
-    private static int COL_NUM_LIKES;
-    private static int COL_IS_LIKED;
-    private static int COL_IS_FOLLOWED;
-    private static int COL_IS_COMMENTS_OPEN;
-    private static int COL_IS_REBLOGGED;
-    private static int COL_IS_EXTERNAL;
-    private static int COL_IS_PRIVATE;
-    private static int COL_IS_VIDEOPRESS;
-    private static int COL_TAGLIST;
-
-    /*
-     * should be called whenever a cursor is returned above so that column indexes are known - this avoids
-     * calling getColumnIndex() in getPostFromCursor() for each column every time that function is called
-     */
-    private static void resetColumnIndexes(Cursor c) {
-        COL_POST_ID = c.getColumnIndex("post_id");
-        COL_BLOG_ID = c.getColumnIndex("blog_id");
-        COL_PSEUDO_ID = c.getColumnIndex("pseudo_id");
-        COL_AUTHOR_NAME = c.getColumnIndex("author_name");
-        COL_BLOG_NAME = c.getColumnIndex("blog_name");
-        COL_BLOG_URL = c.getColumnIndex("blog_url");
-        COL_EXCERPT = c.getColumnIndex("excerpt");
-        COL_FEATURED_IMAGE = c.getColumnIndex("featured_image");
-        COL_FEATURED_VIDEO = c.getColumnIndex("featured_video");
-        COL_TITLE = c.getColumnIndex("title");
-        COL_TEXT = c.getColumnIndex("text");
-        COL_URL = c.getColumnIndex("url");
-        COL_POST_AVATAR = c.getColumnIndex("post_avatar");
-        COL_TIMESTAMP = c.getColumnIndex("timestamp");
-        COL_PUBLISHED = c.getColumnIndex("published");
-        COL_NUM_REPLIES = c.getColumnIndex("num_replies");
-        COL_NUM_LIKES = c.getColumnIndex("num_likes");
-        COL_IS_LIKED = c.getColumnIndex("is_liked");
-        COL_IS_FOLLOWED = c.getColumnIndex("is_followed");
-        COL_IS_COMMENTS_OPEN = c.getColumnIndex("is_comments_open");
-        COL_IS_REBLOGGED = c.getColumnIndex("is_reblogged");
-        COL_IS_EXTERNAL = c.getColumnIndex("is_external");
-        COL_IS_PRIVATE = c.getColumnIndex("is_private");
-        COL_IS_VIDEOPRESS = c.getColumnIndex("is_videopress");
-        COL_TAGLIST = c.getColumnIndex("tag_list");
-    }
-
-    /*
-     * resetColumnIndexes() MUST be called before this is called for the first time
-     */
     private static ReaderPost getPostFromCursor(Cursor c) {
         if (c==null)
             throw new IllegalArgumentException("null post cursor");
 
         ReaderPost post = new ReaderPost();
 
-        post.postId = c.getLong(COL_POST_ID);
-        post.blogId = c.getLong(COL_BLOG_ID);
-        post.setPseudoId(c.getString(COL_PSEUDO_ID));
+        post.postId = c.getLong(c.getColumnIndex("post_id"));
+        post.blogId = c.getLong(c.getColumnIndex("blog_id"));
+        post.setPseudoId(c.getString(c.getColumnIndex("pseudo_id")));
 
-        post.setAuthorName(c.getString(COL_AUTHOR_NAME));
-        post.setBlogName(c.getString(COL_BLOG_NAME));
-        post.setBlogUrl(c.getString(COL_BLOG_URL));
-        post.setExcerpt(c.getString(COL_EXCERPT));
-        post.setFeaturedImage(c.getString(COL_FEATURED_IMAGE));
-        post.setFeaturedVideo(c.getString(COL_FEATURED_VIDEO));
+        post.setAuthorName(c.getString(c.getColumnIndex("author_name")));
+        post.setBlogName(c.getString(c.getColumnIndex("blog_name")));
+        post.setBlogUrl(c.getString(c.getColumnIndex("blog_url")));
+        post.setExcerpt(c.getString(c.getColumnIndex("excerpt")));
+        post.setFeaturedImage(c.getString(c.getColumnIndex("featured_image")));
+        post.setFeaturedVideo(c.getString(c.getColumnIndex("featured_video")));
 
-        post.setTitle(c.getString(COL_TITLE));
-        post.setText(c.getString(COL_TEXT));
-        post.setUrl(c.getString(COL_URL));
-        post.setPostAvatar(c.getString(COL_POST_AVATAR));
+        post.setTitle(c.getString(c.getColumnIndex("title")));
+        post.setText(c.getString(c.getColumnIndex("text")));
+        post.setUrl(c.getString(c.getColumnIndex("url")));
+        post.setPostAvatar(c.getString(c.getColumnIndex("post_avatar")));
 
-        post.timestamp = c.getLong(COL_TIMESTAMP);
-        post.setPublished(c.getString(COL_PUBLISHED));
+        post.timestamp = c.getLong(c.getColumnIndex("timestamp"));
+        post.setPublished(c.getString(c.getColumnIndex("published")));
 
-        post.numReplies = c.getInt(COL_NUM_REPLIES);
-        post.numLikes = c.getInt(COL_NUM_LIKES);
+        post.numReplies = c.getInt(c.getColumnIndex("num_replies"));
+        post.numLikes = c.getInt(c.getColumnIndex("num_likes"));
 
-        post.isLikedByCurrentUser = SqlUtils.sqlToBool(c.getInt(COL_IS_LIKED));
-        post.isFollowedByCurrentUser = SqlUtils.sqlToBool(c.getInt(COL_IS_FOLLOWED));
-        post.isCommentsOpen = SqlUtils.sqlToBool(c.getInt(COL_IS_COMMENTS_OPEN));
-        post.isRebloggedByCurrentUser = SqlUtils.sqlToBool(c.getInt(COL_IS_REBLOGGED));
-        post.isExternal = SqlUtils.sqlToBool(c.getInt(COL_IS_EXTERNAL));
-        post.isPrivate = SqlUtils.sqlToBool(c.getInt(COL_IS_PRIVATE));
-        post.isVideoPress = SqlUtils.sqlToBool(c.getInt(COL_IS_VIDEOPRESS));
+        post.isLikedByCurrentUser = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_liked")));
+        post.isFollowedByCurrentUser = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_followed")));
+        post.isCommentsOpen = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_comments_open")));
+        post.isRebloggedByCurrentUser = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_reblogged")));
+        post.isExternal = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_external")));
+        post.isPrivate = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_private")));
+        post.isVideoPress = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_videopress")));
 
-        post.setTags(c.getString(COL_TAGLIST));
+        post.setTags(c.getString(c.getColumnIndex("tag_list")));
 
         return post;
     }


### PR DESCRIPTION
Fix #794 - I believe this was caused by the way I cached column indexes before accessing a cursor. If one cursor was being loaded using the cached column indexes, and a second cursor called from a different thread reloaded those indexes, the indexes could be invalid to the first cursor.

Fix was to remove the caching, both from ReaderPostTable and ReaderCommentTable.
