### PR TITLE
Fix #878 - reader backstack issue

### DIFF
--- a/src/org/wordpress/android/ui/WPActionBarActivity.java
+++ b/src/org/wordpress/android/ui/WPActionBarActivity.java
@@ -700,7 +700,6 @@ public abstract class WPActionBarActivity extends SherlockFragmentActivity {
     }
 
     private class ReaderMenuItem extends MenuDrawerItem {
-
         ReaderMenuItem(){
             super(READER_ACTIVITY, R.string.reader, R.drawable.dashboard_icon_subs);
         }
@@ -716,6 +715,8 @@ public abstract class WPActionBarActivity extends SherlockFragmentActivity {
         }
         @Override
         public void onSelectItem(){
+            if (!isSelected())
+                mShouldFinish = true;
             Intent intent;
             intent = new Intent(WPActionBarActivity.this, ReaderActivity.class);
             intent.setFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);


### PR DESCRIPTION
Fix #878 - app now returns to Android home after tapping back from the Reader.
