### PR TITLE
Fix #887 - ArrayIndexOutOfBoundsException opening stats

### DIFF
--- a/src/org/wordpress/android/ui/stats/StatsAbsPagedViewFragment.java
+++ b/src/org/wordpress/android/ui/stats/StatsAbsPagedViewFragment.java
@@ -19,6 +19,7 @@ import android.widget.RadioGroup.OnCheckedChangeListener;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
+import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StatUtils;
 import org.wordpress.android.util.Utils;
 
@@ -95,24 +96,42 @@ public abstract class StatsAbsPagedViewFragment extends StatsAbsViewFragment imp
             if (i == mSelectedButtonIndex)
                 rb.setChecked(true);
         }
-        
+
         loadFragmentIndex(mSelectedButtonIndex);
     }
 
     @Override
     public void onCheckedChanged(RadioGroup group, int checkedId) {
-        mSelectedButtonIndex  = group.indexOfChild(group.findViewById(checkedId));
+        // checkedId will be -1 when the selection is cleared
+        if (checkedId == -1) {
+            AppLog.w(AppLog.T.STATS, "checkedId is -1");
+            return;
+        }
+
+        int index  = group.indexOfChild(group.findViewById(checkedId));
+        if (index == -1) {
+            AppLog.w(AppLog.T.STATS, "invalid checkedId");
+            return;
+        }
+
+        mSelectedButtonIndex = index;
         loadFragmentIndex(mSelectedButtonIndex);
     }
-    
+
     private void loadFragmentIndex(int index) {
-        if (getChildFragmentManager().findFragmentByTag(CHILD_TAG + ":" + index) == null) {
+        if (index == -1) {
+            AppLog.w(AppLog.T.STATS, "invalid fragment index");
+            return;
+        }
+
+        String childTag = CHILD_TAG + ":" + index;
+        if (getChildFragmentManager().findFragmentByTag(childTag) == null) {
             //set minimum height for container, so we don't get a janky fragment transaction
             mFragmentContainer.setMinimumHeight(mFragmentContainer.getHeight());
             Fragment fragment = getFragment(index);
             FragmentTransaction ft = getChildFragmentManager().beginTransaction();
             ft.setCustomAnimations(R.anim.stats_fade_in, R.anim.stats_fade_out);
-            ft.replace(R.id.stats_pager_container, fragment, CHILD_TAG + ":" + index);
+            ft.replace(R.id.stats_pager_container, fragment, childTag);
             ft.commit();
         }
     }

--- a/src/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/src/org/wordpress/android/ui/stats/StatsActivity.java
@@ -35,6 +35,7 @@ import org.wordpress.android.ui.AuthenticatedWebViewActivity;
 import org.wordpress.android.ui.WPActionBarActivity;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StatsRestHelper;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.Utils;
@@ -400,7 +401,9 @@ public class StatsActivity extends WPActionBarActivity {
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.menu_refresh) {
-            refreshStats();
+            // make sure we have a connection before proceeding (will alert user if not)
+            if (NetworkUtils.checkConnection(this))
+                refreshStats();
             return true;
         } else if (item.getItemId() == R.id.menu_view_stats_full_site) {
             startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("http://wordpress.com/my-stats")));
@@ -455,6 +458,8 @@ public class StatsActivity extends WPActionBarActivity {
 
     private void refreshStats() {
         if (WordPress.getCurrentBlog() == null)
+            return;
+        if (!NetworkUtils.isNetworkAvailable(this))
             return;
         
         String blogId;


### PR DESCRIPTION
Fix #887 - I was unable to reproduce this bug on any device other than the Genymotion 2.3.7 emulator, but I went ahead and added some safety checks to prevent the exception. Also added connectivity checks before refreshing stats.
