### PR TITLE
Fix #890 - media stays empty after selecting invalid custom dates

### DIFF
--- a/src/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/src/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -474,13 +474,14 @@ public class MediaGridFragment extends Fragment implements OnItemClickListener,
 
         if (cursor != null && cursor.moveToFirst()) {
             mResultView.setVisibility(View.VISIBLE);
+            setEmptyViewVisible(false);
 
             SimpleDateFormat fmt = new SimpleDateFormat("dd-MMM-yyyy");
             fmt.setCalendar(startDate);
             String formattedStart = fmt.format(startDate.getTime());
             String formattedEnd = fmt.format(endDate.getTime());
 
-            mResultView.setVisibility(View.VISIBLE);
+            // TODO: replace hard-coded text with string resource
             mResultView.setText("Displaying media from " + formattedStart + " to " + formattedEnd);
             return cursor;
         } else {


### PR DESCRIPTION
Fix #890 - problem was caused by failing to hide the "empty view" when a valid date range was chosen, now corrected.
