### PR TITLE
Fix #895 - loading indicator never goes away

### DIFF
--- a/src/org/wordpress/android/ui/notifications/NotificationsActivity.java
+++ b/src/org/wordpress/android/ui/notifications/NotificationsActivity.java
@@ -496,8 +496,13 @@ public class NotificationsActivity extends WPActionBarActivity implements Commen
 
     private class NoteProvider implements NotificationsListFragment.NoteProvider {
         @Override
+        public boolean canRequestMore() {
+            return mFirstLoadComplete && !mLoadingMore;
+        }
+
+        @Override
         public void onRequestMoreNotifications(ListView notesList, ListAdapter notesAdapter){
-            if (mFirstLoadComplete && !mLoadingMore) {
+            if (canRequestMore()) {
                 NotificationsListFragment.NotesAdapter adapter = mNotesList.getNotesAdapter();
                 if (adapter.getCount() > 0) {
                     Note lastNote = adapter.getItem(adapter.getCount()-1);


### PR DESCRIPTION
Fix #895 - Problem was due to "Loading" message being shown even when the NoteProvider couldn't load more notes.
