### PR TITLE
fix #889: hide keyboard when form action is called on: login/new account/new blog/otp screens

### DIFF
--- a/src/org/wordpress/android/ui/accounts/NewAccountAbstractPageFragment.java
+++ b/src/org/wordpress/android/ui/accounts/NewAccountAbstractPageFragment.java
@@ -9,6 +9,7 @@ import android.view.KeyEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 import android.widget.ImageView;
 
@@ -68,6 +69,16 @@ public abstract class NewAccountAbstractPageFragment extends SherlockFragment {
             if (!isUserDataValid()) {
                 return true;
             }
+
+            // hide keyboard before calling the done action
+            InputMethodManager inputManager = (InputMethodManager) getActivity().getSystemService(
+                    Context.INPUT_METHOD_SERVICE);
+            View view = getActivity().getCurrentFocus();
+            if (view != null) {
+                inputManager.hideSoftInputFromWindow(view.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
+            }
+
+            // call child action
             onDoneAction();
             return true;
         }


### PR DESCRIPTION
fix #889: hide keyboard when form action is called on: login/new account/new blog/otp screens
