### PR TITLE
Fix #905 - ArrayIndexOutOfBoundsException in notification settings

### DIFF
--- a/src/org/wordpress/android/ui/prefs/PreferencesActivity.java
+++ b/src/org/wordpress/android/ui/prefs/PreferencesActivity.java
@@ -90,7 +90,7 @@ public class PreferencesActivity extends SherlockPreferenceActivity {
         OnPreferenceChangeListener preferenceChangeListener = new OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
-                if (newValue != null) { // cancelled dismiss keyoard
+                if (newValue != null) { // cancelled dismiss keyboard
                     preference.setSummary(newValue.toString());
                 }
                 InputMethodManager imm = (InputMethodManager)getSystemService(Context.INPUT_METHOD_SERVICE);
@@ -580,6 +580,8 @@ public class PreferencesActivity extends SherlockPreferenceActivity {
     };
 
     private void loadNotifications() {
+        AppLog.d(T.NOTIFS, "Preferences > loading notification settings");
+
         // Add notifications group back in case it was previously removed from being logged out
         PreferenceScreen rootScreen = (PreferenceScreen)findPreference("wp_pref_root");
         rootScreen.addPreference(mNotificationsGroup);
@@ -625,6 +627,9 @@ public class PreferencesActivity extends SherlockPreferenceActivity {
                     blogPreference.setChecked(!MapUtils.getMapBool(blogMap, "value"));
                     blogPreference.setTitle(StringUtils.unescapeHTML(blogName));
                     blogPreference.setOnPreferenceChangeListener(mMuteBlogChangeListener);
+                    // set the order here so it matches the key in mMutedBlogsList since
+                    // mMuteBlogChangeListener uses the order to locate the clicked blog
+                    blogPreference.setOrder(i);
                     selectBlogsCategory.addPreference(blogPreference);
                 }
 


### PR DESCRIPTION
Fix #905 by setting the order of each "muted" blog preference
