### PR TITLE
Fix #904 - handle empty tag names returned by API

### DIFF
--- a/src/org/wordpress/android/datasets/ReaderTagTable.java
+++ b/src/org/wordpress/android/datasets/ReaderTagTable.java
@@ -9,12 +9,12 @@ import android.text.TextUtils;
 
 import org.wordpress.android.Constants;
 import org.wordpress.android.models.ReaderTag;
+import org.wordpress.android.models.ReaderTag.ReaderTagType;
 import org.wordpress.android.models.ReaderTagList;
+import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
-import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.SqlUtils;
-
 
 import java.util.Date;
 
@@ -130,16 +130,14 @@ public class ReaderTagTable {
     }
 
     private static ReaderTag getTagFromCursor(Cursor c) {
-        if (c==null)
+        if (c == null)
             throw new IllegalArgumentException("null topic cursor");
 
-        ReaderTag tag = new ReaderTag();
+        String tagName = c.getString(c.getColumnIndex("tag_name"));
+        String endpoint = c.getString(c.getColumnIndex("endpoint"));
+        ReaderTagType tagType = ReaderTag.ReaderTagType.fromInt(c.getInt(c.getColumnIndex("topic_type")));
 
-        tag.setTagName(c.getString(c.getColumnIndex("tag_name")));
-        tag.setEndpoint(c.getString(c.getColumnIndex("endpoint")));
-        tag.tagType = ReaderTag.ReaderTagType.fromInt(c.getInt(c.getColumnIndex("topic_type")));
-
-        return tag;
+        return new ReaderTag(tagName, endpoint, tagType);
     }
 
     public static ReaderTag getTag(String tagName) {

--- a/src/org/wordpress/android/models/ReaderTag.java
+++ b/src/org/wordpress/android/models/ReaderTag.java
@@ -18,10 +18,10 @@ public class ReaderTag {
     public static String TAG_ID_LIKED = "liked";
 
     // these are the default tag names, which aren't localized in the /read/menu/ response
-    public static String TAG_NAME_LIKED = "Posts I Like";
-    public static String TAG_NAME_FOLLOWING = "Blogs I Follow";
-    public static String TAG_NAME_FRESHLY_PRESSED = "Freshly Pressed";
-    public static String TAG_NAME_DEFAULT = TAG_NAME_FRESHLY_PRESSED;
+    public static final String TAG_NAME_LIKED = "Posts I Like";
+    public static final String TAG_NAME_FOLLOWING = "Blogs I Follow";
+    public static final String TAG_NAME_FRESHLY_PRESSED = "Freshly Pressed";
+    public static final String TAG_NAME_DEFAULT = TAG_NAME_FRESHLY_PRESSED;
 
     public static enum ReaderTagType {SUBSCRIBED,
                                       DEFAULT,
@@ -51,6 +51,16 @@ public class ReaderTag {
     private String tagName;
     private String endpoint;
     public ReaderTagType tagType;
+
+    public ReaderTag(String tagName, String endpoint, ReaderTagType tagType) {
+        if (TextUtils.isEmpty(tagName)) {
+            this.setTagName(getTagNameFromEndpoint(endpoint));
+        } else {
+            this.setTagName(tagName);
+        }
+        this.setEndpoint(endpoint);
+        this.tagType = tagType;
+    }
 
     public String getEndpoint() {
         return StringUtils.notNullStr(endpoint);
@@ -82,7 +92,7 @@ public class ReaderTag {
         this.tagName = StringUtils.notNullStr(name);
     }
     public String getCapitalizedTagName() {
-        if (tagName ==null)
+        if (tagName == null)
             return "";
         // HACK to allow iPhone, iPad, iEverything else
         if (tagName.startsWith("iP"))
@@ -100,5 +110,28 @@ public class ReaderTag {
         if (INVALID_CHARS.matcher(tagName).matches())
             return false;
         return true;
+    }
+
+    /*
+     * extracts the tag name from a valid read/tags/[tagName]/posts endpoint
+     */
+    private static String getTagNameFromEndpoint(final String endpoint) {
+        if (TextUtils.isEmpty(endpoint))
+            return "";
+
+        // make sure passed endpoint is valid
+        if (!endpoint.endsWith("/posts"))
+            return "";
+        int start = endpoint.indexOf("/read/tags/");
+        if (start == -1)
+            return "";
+
+        // skip "/read/tags/" then find the next "/"
+        start += 11;
+        int end = endpoint.indexOf("/", start);
+        if (end == -1)
+            return "";
+
+        return endpoint.substring(start, end);
     }
 }

--- a/src/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
+++ b/src/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
@@ -12,6 +12,7 @@ import org.wordpress.android.datasets.ReaderDatabase;
 import org.wordpress.android.datasets.ReaderPostTable;
 import org.wordpress.android.datasets.ReaderTagTable;
 import org.wordpress.android.models.ReaderTag;
+import org.wordpress.android.models.ReaderTag.ReaderTagType;
 import org.wordpress.android.models.ReaderTagList;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -61,10 +62,8 @@ public class ReaderTagActions {
 
             case ADD :
                 originalTopic = null; // prevent compiler warning
-                ReaderTag newTopic = new ReaderTag();
-                newTopic.setTagName(tagName);
-                newTopic.tagType = ReaderTag.ReaderTagType.SUBSCRIBED;
-                newTopic.setEndpoint("/read/tags/" + tagNameForApi + "/posts");
+                String endpoint = "/read/tags/" + tagNameForApi + "/posts";
+                ReaderTag newTopic = new ReaderTag(tagName, endpoint, ReaderTagType.SUBSCRIBED);
                 ReaderTagTable.addOrUpdateTag(newTopic);
                 path = "read/tags/" + tagNameForApi + "/mine/new";
                 break;
@@ -235,11 +234,9 @@ public class ReaderTagActions {
             String internalName = it.next();
             JSONObject jsonTopic = jsonTopics.optJSONObject(internalName);
             if (jsonTopic!=null) {
-                ReaderTag topic = new ReaderTag();
-                topic.tagType = topicType;
-                topic.setTagName(JSONUtil.getStringDecoded(jsonTopic, "title"));
-                topic.setEndpoint(JSONUtil.getString(jsonTopic, "URL"));
-                topics.add(topic);
+                String tagName = JSONUtil.getStringDecoded(jsonTopic, "title");
+                String endpoint = JSONUtil.getString(jsonTopic, "URL");
+                topics.add(new ReaderTag(tagName, endpoint, topicType));
             }
         }
 


### PR DESCRIPTION
Fix #904 - added code to handle the rare case that an empty tag name is returned by the endpoint
