### PR TITLE
fix #900: use HtmlUtils.fromHtml instead of Html.fromHtml for BigBadgeNotes

### DIFF
--- a/src/org/wordpress/android/ui/notifications/BigBadgeFragment.java
+++ b/src/org/wordpress/android/ui/notifications/BigBadgeFragment.java
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.notifications;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
-import android.text.Html;
 import android.text.Spanned;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -16,6 +15,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Note;
 import org.wordpress.android.ui.stats.StatsActivity;
+import org.wordpress.android.util.HtmlUtils;
 import org.wordpress.android.util.JSONUtil;
 import org.wordpress.android.util.WPLinkMovementMethod;
 
@@ -26,15 +26,16 @@ public class BigBadgeFragment extends Fragment implements NotificationFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup parent, Bundle state){
         View view = inflater.inflate(R.layout.notifications_big_badge, parent, false);
         NetworkImageView badgeImageView = (NetworkImageView) view.findViewById(R.id.badge);
-        
+
         TextView bodyTextView = (TextView) view.findViewById(R.id.body);
         bodyTextView.setMovementMethod(WPLinkMovementMethod.getInstance());
 
         if (getNote() != null) {
             String noteHTML = JSONUtil.queryJSON(getNote().toJSONObject(), "body.html", "");
-            if (noteHTML.equals(""))
+            if (noteHTML.equals("")) {
                 noteHTML = getNote().getSubject();
-            Spanned html = Html.fromHtml(noteHTML);
+            }
+            Spanned html = HtmlUtils.fromHtml(noteHTML);
             bodyTextView.setText(html);
 
             // Get the badge
@@ -60,7 +61,7 @@ public class BigBadgeFragment extends Fragment implements NotificationFragment {
                 }
             }
         }
-        
+
         return view;
     }
 

--- a/tests/java/org/wordpress/android/ui/notifications/NotesParseTest.java
+++ b/tests/java/org/wordpress/android/ui/notifications/NotesParseTest.java
@@ -4,12 +4,12 @@ import android.text.SpannableStringBuilder;
 
 import junit.framework.TestCase;
 
-import org.wordpress.android.models.Note;
+import org.wordpress.android.util.HtmlUtils;
 
 public class NotesParseTest extends TestCase {
     public void testParagraphInListItem1() {
         String text = "<li><p>Paragraph in li</p></li>";
-        SpannableStringBuilder html = Note.prepareHtml(text);
+        SpannableStringBuilder html = HtmlUtils.fromHtml(text);
         // if this didn't throw a RuntimeException we're ok
         assertNotNull(html);
     }
@@ -17,13 +17,13 @@ public class NotesParseTest extends TestCase {
     // Trying to reproduce https://github.com/wordpress-mobile/WordPress-Android/issues/900
     public void testSpanInListItem1() {
         String text = "<ul><li><span>Current Record: </span><span>20</span></li><li><span>Old Record: </span><span>1</span></li></ul>";
-        SpannableStringBuilder ssb = Note.prepareHtml(text);
+        SpannableStringBuilder ssb = HtmlUtils.fromHtml(text);
         assertEquals("Current Record: 20\nOld Record: 1\n", ssb.toString());
     }
 
     public void testSpanInListItemFullTest() {
         String text = "<p>Au Mercredi 18 septembre 2013 vous avez pulvérisé votre précédent record de follows enregistrés en un seul jour, sur votre blog <a href=\"http://taliwutblog.wordpress.com\" title=\"taliwut &amp; blog\" target=\"_blank\" notes-data-click=\"best_period_ever_feat\">taliwut &amp; blog</a>. Super!</p><ul><li><span  class=\"wpn-feat-current-record-title\">Current Record: </span><span class=\"wpn-feat-new-record-count\">20</span></li><li><span  class=\"wpn-feat-old-record-title\">Old Record: </span><span class=\"wpn-feat-old-record-count\">1</span></li></ul>";
-        SpannableStringBuilder ssb = Note.prepareHtml(text);
+        SpannableStringBuilder ssb = HtmlUtils.fromHtml(text);
         assertTrue(ssb.toString().contains("Current Record: 20\nOld Record: 1\n"));
     }
 }


### PR DESCRIPTION
fix #900: use HtmlUtils.fromHtml instead of Html.fromHtml for BigBadgeNotes
