### PR TITLE
Fix #927 - IllegalStateException in notifications

### DIFF
--- a/src/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/src/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -91,6 +91,10 @@ public class NotificationsListFragment extends ListFragment {
         }
     }
 
+    private boolean hasActivity() {
+        return (getActivity() != null && !isRemoving());
+    }
+
     public NotesAdapter getNotesAdapter() {
         return mNotesAdapter;
     }
@@ -104,7 +108,7 @@ public class NotificationsListFragment extends ListFragment {
     }
 
     private void requestMoreNotifications() {
-        if (mNoteProvider != null && mNoteProvider.canRequestMore()) {
+        if (mNoteProvider != null && mNoteProvider.canRequestMore() && hasActivity()) {
             showProgressFooter();
             mNoteProvider.onRequestMoreNotifications(getListView(), getListAdapter());
         }


### PR DESCRIPTION
Fix #927 - I'm pretty certain this was already fixed in v2.6.1, but I added a hasActivity() check just to be safe.
