### PR TITLE
Removed WordPress.currentComment

### DIFF
--- a/src/org/wordpress/android/WordPress.java
+++ b/src/org/wordpress/android/WordPress.java
@@ -68,7 +68,6 @@ public class WordPress extends Application {
 
     public static String versionName;
     public static Blog currentBlog;
-    public static Comment currentComment;
     public static Post currentPost;
     public static WordPressDB wpDB;
     public static WordPressStatsDB wpStatsDB;

--- a/src/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/src/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -40,8 +40,6 @@ public class CommentsActivity extends WPActionBarActivity
         fm.addOnBackStackChangedListener(mOnBackStackChangedListener);
         mCommentListFragment = (CommentsListFragment) fm.findFragmentById(R.id.commentList);
 
-        WordPress.currentComment = null;
-
         if (savedInstanceState != null)
             popCommentDetail();
     }
@@ -135,7 +133,6 @@ public class CommentsActivity extends WPActionBarActivity
 
         if (comment != null && fm.getBackStackEntryCount() == 0) {
             if (f == null || !f.isInLayout()) {
-                WordPress.currentComment = comment;
                 FragmentTransaction ft = fm.beginTransaction();
                 ft.hide(mCommentListFragment);
                 f = CommentDetailFragment.newInstance(WordPress.getCurrentLocalTableBlogId(), comment.commentID);


### PR DESCRIPTION
Fix #935 - global comment has been removed
