### PR TITLE
fix #943: add default dimens for theme dialog

### DIFF
--- a/res/values/dimens.xml
+++ b/res/values/dimens.xml
@@ -20,6 +20,9 @@
     <dimen name="theme_details_fragment_width">650dp</dimen>
     <dimen name="theme_details_fragment_height">450dp</dimen>
 
+    <dimen name="theme_details_dialog_min_width">650dp</dimen>
+    <dimen name="theme_details_dialog_height">450dp</dimen>
+
     <dimen name="action_bar_spinner_width">312dp</dimen>
     <dimen name="action_bar_spinner_y_offset">-8dp</dimen>
     <dimen name="graph_font_size">8sp</dimen>


### PR DESCRIPTION
fix #943: add default dimens for theme dialog in case Utils.isXLarge() returns true even if the device width is < 720dp

Note: I couldn't reproduce the error but I suppose this specific device (Picasso) is returning a wrong screen configuration and then load the wrong dimens.xml file
