### PR TITLE
Issue/952 posts illegal state failure

### DIFF
--- a/src/org/wordpress/android/ui/posts/PostsActivity.java
+++ b/src/org/wordpress/android/ui/posts/PostsActivity.java
@@ -90,7 +90,8 @@ public class PostsActivity extends WPActionBarActivity implements OnPostSelected
 
                 @Override
                 public void onFailure(ApiHelper.ErrorType errorType, String errorMessage, Throwable throwable) {
-                    ToastUtils.showToastOrAuthAlert(PostsActivity.this, errorMessage, getString(R.string.error_generic));
+                    if (!isFinishing())
+                        ToastUtils.showToastOrAuthAlert(PostsActivity.this, errorMessage, getString(R.string.error_generic));
                 }
             }).execute(false);
 


### PR DESCRIPTION
Fix #952 - added isFinishing() check before showing toast message when RefreshBlogContentTask fails.
