### PR TITLE
Fix issue/957-npe-reader-share

### DIFF
--- a/src/org/wordpress/android/ui/reader/ReaderPostDetailActivity.java
+++ b/src/org/wordpress/android/ui/reader/ReaderPostDetailActivity.java
@@ -549,6 +549,8 @@ public class ReaderPostDetailActivity extends WPActionBarActivity {
      * display the standard Android share chooser to share a link to this post
      */
     private void sharePage() {
+        if (!hasPost())
+            return;
         Intent intent = new Intent(Intent.ACTION_SEND);
         intent.setType("text/plain");
         intent.putExtra(Intent.EXTRA_TEXT, mPost.getUrl());


### PR DESCRIPTION
Fix #957 - prevents NPE by checking for valid post before sharing
