### PR TITLE
Issue/1002 npe media file name

### DIFF
--- a/src/org/wordpress/android/util/PostUploadService.java
+++ b/src/org/wordpress/android/util/PostUploadService.java
@@ -782,9 +782,9 @@ public class PostUploadService extends Service {
             
             if (!TextUtils.isEmpty(mimeType)) { //try to get the extension from mimeType
                 MimeTypeMap mimeTypeMap = MimeTypeMap.getSingleton();
-                String fileExtensionFromMimeType = mimeTypeMap.getExtensionFromMimeType(mimeType).toLowerCase();
+                String fileExtensionFromMimeType = mimeTypeMap.getExtensionFromMimeType(mimeType);
                 if (!TextUtils.isEmpty(fileExtensionFromMimeType)) {
-                    originalFileName += "." + fileExtensionFromMimeType;
+                    originalFileName += "." + fileExtensionFromMimeType.toLowerCase();
                 } else {
                     //We're still without an extension - split the mime type and retrieve it
                    String[] split = mimeType.split("/");


### PR DESCRIPTION
Fix #1002 - fixed NPE in getMediaFileName() due to calling toLowerCase() on null fileExtensionFromMimeType 
