### PR TITLE
issue/1004-npe-followrow-issiteid

### DIFF
--- a/src/org/wordpress/android/ui/notifications/FollowRow.java
+++ b/src/org/wordpress/android/ui/notifications/FollowRow.java
@@ -131,7 +131,8 @@ public class FollowRow extends LinearLayout {
         getTextView().setText(resourceId);
     }
     public boolean isSiteId(String siteId){
-        return getSiteId().equals(siteId);
+        String thisSiteId = getSiteId();
+        return (thisSiteId != null && thisSiteId.equals(siteId));
     }
     public void setFollowing(boolean following){
         if (hasParams()) {


### PR DESCRIPTION
Fix #1004 - fixed NPE caused by calling equals() on null result from getSiteId()
