### PR TITLE
issue/1006-npe-on-select-item

### DIFF
--- a/src/org/wordpress/android/ui/WPActionBarActivity.java
+++ b/src/org/wordpress/android/ui/WPActionBarActivity.java
@@ -785,6 +785,8 @@ public abstract class WPActionBarActivity extends SherlockFragmentActivity {
         }
         @Override
         public void onSelectItem(){
+            if (WordPress.getCurrentBlog() == null)
+                return;
             if (!(WPActionBarActivity.this instanceof PagesActivity))
                 mShouldFinish = true;
             Intent intent = new Intent(WPActionBarActivity.this, PagesActivity.class);
@@ -810,6 +812,8 @@ public abstract class WPActionBarActivity extends SherlockFragmentActivity {
         }
         @Override
         public void onSelectItem(){
+            if (WordPress.getCurrentBlog() == null)
+                return;
             if (!(WPActionBarActivity.this instanceof CommentsActivity))
                 mShouldFinish = true;
             Intent intent = new Intent(WPActionBarActivity.this, CommentsActivity.class);
@@ -874,6 +878,8 @@ public abstract class WPActionBarActivity extends SherlockFragmentActivity {
         }
         @Override
         public void onSelectItem(){
+            if (WordPress.getCurrentBlog() == null)
+                return;
             if (!isSelected())
                 mShouldFinish = true;
 


### PR DESCRIPTION
Fix #1006 - NPE selecting item from  drawer when current blog is null
