### PR TITLE
Fixes #1019 

### DIFF
--- a/src/org/wordpress/android/ui/notifications/NotificationsActivity.java
+++ b/src/org/wordpress/android/ui/notifications/NotificationsActivity.java
@@ -436,6 +436,7 @@ public class NotificationsActivity extends WPActionBarActivity
             @Override
             public void onNotes(final List<Note> notes) {
                 mFirstLoadComplete = true;
+                mNotesList.setAllNotesLoaded(false);
                 // nbradbury - saving notes can be slow, so do it in the background
                 new Thread() {
                     @Override

--- a/src/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/src/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -121,6 +121,10 @@ public class NotificationsListFragment extends ListFragment {
         }
     }
 
+    public void setAllNotesLoaded(boolean allNotesLoaded) {
+        mAllNotesLoaded = allNotesLoaded;
+    }
+
     private boolean hasActivity() {
         return (getActivity() != null && !isRemoving());
     }


### PR DESCRIPTION
Added a setter for mAllNotesLoaded in NotificationsListFragment, so we can set it back to false after refreshing the notifications list. 
