### PR TITLE
issue/1038-tag-adapter-in-post-detail

### DIFF
--- a/src/org/wordpress/android/ui/reader/ReaderActivity.java
+++ b/src/org/wordpress/android/ui/reader/ReaderActivity.java
@@ -240,15 +240,16 @@ public class ReaderActivity extends WPActionBarActivity
         String tagForFragment = getString(R.string.fragment_tag_reader_post_detail);
         Fragment fragment = ReaderPostDetailFragment.newInstance(blogId, postId);
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
-        ft.add(R.id.fragment_container, fragment, tagForFragment);
 
-        // add to backstack if there's already a list fragment
+        // if list fragment exists, replace it with the detail and add to backstack
         if (hasListFragment()) {
+            ft.replace(R.id.fragment_container, fragment, tagForFragment);
             ft.addToBackStack(tagForFragment);
-            ft.hide(getListFragment());
-            ft.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE);
+        } else {
+            ft.add(R.id.fragment_container, fragment, tagForFragment);
         }
 
+        ft.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE);
         ft.commit();
     }
 


### PR DESCRIPTION
Fix #1038 - Tag adapter no longer appears in post detail after rotation
