### PR TITLE
issue/1049-notifications-unfriendly-toast

### DIFF
--- a/src/org/wordpress/android/ui/notifications/NotificationsActivity.java
+++ b/src/org/wordpress/android/ui/notifications/NotificationsActivity.java
@@ -37,6 +37,7 @@ import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
 import org.wordpress.android.ui.reader.actions.ReaderAuthActions;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 
 import java.util.ArrayList;
@@ -429,6 +430,9 @@ public class NotificationsActivity extends WPActionBarActivity
     }
 
     private void refreshNotes(){
+        if (!NetworkUtils.checkConnection(this))
+            return;
+
         mFirstLoadComplete = false;
         mShouldAnimateRefreshButton = true;
         startAnimatingRefreshButton(mRefreshMenuItem);


### PR DESCRIPTION
Fix #1049 - Added connection check before refreshing notes
