### PR TITLE
Post detail toolbar improvements

### DIFF
--- a/res/layout/viewpost.xml
+++ b/res/layout/viewpost.xml
@@ -116,7 +116,6 @@
                 android:background="@drawable/selectable_background_wordpress"
                 android:scaleType="fitCenter"
                 android:padding="9dp"
-                android:tint="#3f3f3f"
                 android:src="@drawable/dashboard_icon_comments"
                 android:contentDescription="@string/add_comment" />
             

--- a/src/org/wordpress/android/ui/posts/ViewPostFragment.java
+++ b/src/org/wordpress/android/ui/posts/ViewPostFragment.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.posts;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v4.app.Fragment;
@@ -123,6 +124,8 @@ public class ViewPostFragment extends Fragment {
         });
 
         mAddCommentButton = (ImageButton) v.findViewById(R.id.addComment);
+        // Tint the comment icon to match the other icons in the toolbar
+        mAddCommentButton.setColorFilter(Color.argb(255, 132, 132, 132));
         mAddCommentButton.setOnClickListener(new ImageButton.OnClickListener() {
             public void onClick(View v) {
                 if (!parentActivity.mIsRefreshing) {


### PR DESCRIPTION
This is a small PR that updates a few things in the post detail view toolbar:
- Changed the touch targets to be 48x48dp.
- Fixed ugly orange background color when a toolbar button was tapped.
- Fixed tint of comment button.

Before:
![cool](https://f.cloud.github.com/assets/789137/2465235/3064ee9c-afa0-11e3-833a-5dfe33b1be9d.jpg)
After:
![cool2](https://f.cloud.github.com/assets/789137/2465237/357e23ee-afa0-11e3-9eca-f1f20bf43941.jpg)
