### PR TITLE
Use the same progress bar style in webviews and in PTR views

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ android {
         compile 'com.google.code.gson:gson:2.2.2'
         compile 'org.ccil.cowan.tagsoup:tagsoup:1.2.1'
         compile 'com.android.support:support-v4:19.0.+'
-        compile 'com.github.castorflex.smoothprogressbar:library:0.3.3'
+        compile 'com.github.castorflex.smoothprogressbar:library:0.4.0'
 
         androidTestCompile 'com.jayway.android.robotium:robotium-solo:5.+'
         androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.0'

--- a/res/drawable/progressbar_horizontal.xml
+++ b/res/drawable/progressbar_horizontal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@android:id/progress">
+        <clip>
+            <shape>
+                <solid
+                    android:color="@color/blue_dark" />
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/res/layout/webview.xml
+++ b/res/layout/webview.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/webview_wrapper"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -7,15 +8,15 @@
     <WebView
         android:id="@+id/webView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"/>
 
     <ProgressBar
-        android:id="@+id/progressBar"
-        style="?android:attr/progressBarStyleLarge"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        android:layout_centerHorizontal="true"
-        android:layout_centerVertical="true" />
+        android:id="@+id/progress_bar"
+        style="@android:style/Widget.ProgressBar.Horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/progress_bar_height"
+        android:indeterminate="false"
+        android:layout_alignTop="@+id/webView"
+        android:progressDrawable="@drawable/progressbar_horizontal"/>
 
 </RelativeLayout>

--- a/res/values/dimens.xml
+++ b/res/values/dimens.xml
@@ -97,5 +97,6 @@
     <dimen name="note_icon_sz">20dp</dimen>
     <dimen name="note_avatar_sz">48dp</dimen>
 
+    <dimen name="progress_bar_height">3dp</dimen>
     <dimen name="ptr_tip_margin_top">8dp</dimen>
 </resources>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -320,7 +320,7 @@
     <!-- Pull to refresh -->
     <style name="Widget.Custom.PtrHeader" parent="android:Widget">
         <item name="ptrProgressBarColor">@color/blue_dark</item>
-        <item name="ptrProgressBarHeight">3dp</item>
+        <item name="ptrProgressBarHeight">@dimen/progress_bar_height</item>
     </style>
 
     <!-- On top message -->

--- a/src/org/wordpress/android/ui/AuthenticatedWebViewActivity.java
+++ b/src/org/wordpress/android/ui/AuthenticatedWebViewActivity.java
@@ -1,13 +1,11 @@
 
 package org.wordpress.android.ui;
 
-import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
-import android.webkit.WebView;
+import android.widget.ProgressBar;
 import android.widget.Toast;
 
 import com.actionbarsherlock.view.Menu;
@@ -21,6 +19,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.WPWebChromeClient;
 import org.wordpress.android.util.WPWebViewClient;
 import org.wordpress.passcodelock.AppLockManager;
 
@@ -63,6 +62,7 @@ public class AuthenticatedWebViewActivity extends WebViewActivity {
             String authUrl = extras.getString(LOAD_AUTHENTICATED_URL);
             loadAuthenticatedUrl(authUrl);
         }
+        mWebView.setWebChromeClient(new WPWebChromeClient(this, (ProgressBar) findViewById(R.id.progress_bar)));
     }
 
     /**
@@ -106,28 +106,6 @@ public class AuthenticatedWebViewActivity extends WebViewActivity {
             mWebView.postUrl(getLoginUrl(), postData.getBytes());
         } catch (UnsupportedEncodingException e) {
             AppLog.e(T.UTILS, e);
-        }
-    }
-
-    /**
-     * WebChromeClient that displays "Loading..." title until the content of the webview is fully
-     * loaded.
-     */
-    protected class WordPressWebChromeClient extends WebChromeClient {
-        private Context context;
-
-        public WordPressWebChromeClient(Context context) {
-            this.context = context;
-        }
-
-        public void onProgressChanged(WebView webView, int progress) {
-            AuthenticatedWebViewActivity.this.setTitle(
-                    context.getResources().getText(R.string.loading));
-            AuthenticatedWebViewActivity.this.setSupportProgress(progress * 100);
-
-            if (progress == 100) {
-                setTitle(webView.getTitle());
-            }
         }
     }
 

--- a/src/org/wordpress/android/ui/DashboardActivity.java
+++ b/src/org/wordpress/android/ui/DashboardActivity.java
@@ -1,14 +1,13 @@
 
 package org.wordpress.android.ui;
 
-import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
-import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
+import android.widget.ProgressBar;
 import android.widget.Toast;
 
 import com.actionbarsherlock.app.ActionBar;
@@ -23,6 +22,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.WPWebChromeClient;
 import org.wordpress.android.util.WPWebViewClient;
 import org.wordpress.passcodelock.AppLockManager;
 
@@ -80,7 +80,7 @@ public class DashboardActivity extends SherlockActivity {
         }
 
         mWebView.setWebViewClient(new WPWebViewClient(mBlog));
-        mWebView.setWebChromeClient(new WordPressWebChromeClient(this));
+        mWebView.setWebChromeClient(new WPWebChromeClient(this, (ProgressBar) findViewById(R.id.progress_bar)));
 
         mWebView.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
         mWebView.getSettings().setSavePassword(false);
@@ -139,28 +139,6 @@ public class DashboardActivity extends SherlockActivity {
             mWebView.postUrl(getLoginUrl(), postData.getBytes());
         } catch (UnsupportedEncodingException e) {
             AppLog.e(T.POSTS, e);
-        }
-    }
-
-    /**
-     * WebChromeClient that displays "Loading..." title until the content of the webview is fully
-     * loaded.
-     */
-    protected class WordPressWebChromeClient extends WebChromeClient {
-        private Context context;
-
-        public WordPressWebChromeClient(Context context) {
-            this.context = context;
-        }
-
-        public void onProgressChanged(WebView webView, int progress) {
-            setTitle(
-                    context.getResources().getText(R.string.loading));
-            setSupportProgress(progress * 100);
-
-            if (progress == 100) {
-                setTitle(webView.getTitle());
-            }
         }
     }
 

--- a/src/org/wordpress/android/ui/ViewSiteActivity.java
+++ b/src/org/wordpress/android/ui/ViewSiteActivity.java
@@ -1,9 +1,6 @@
 
 package org.wordpress.android.ui;
 
-import java.lang.reflect.Type;
-import java.util.Map;
-
 import android.os.Bundle;
 
 import com.actionbarsherlock.view.MenuItem;
@@ -12,6 +9,9 @@ import com.google.gson.reflect.TypeToken;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+
+import java.lang.reflect.Type;
+import java.util.Map;
 
 /**
  * Activity to view the WordPress blog in a WebView
@@ -27,7 +27,6 @@ public class ViewSiteActivity extends AuthenticatedWebViewActivity {
         this.setTitle(getResources().getText(R.string.view_site));
 
         // configure webview
-        mWebView.setWebChromeClient(new WordPressWebChromeClient(this));
         mWebView.getSettings().setJavaScriptEnabled(true);
         mWebView.getSettings().setDomStorageEnabled(true);
 
@@ -52,7 +51,7 @@ public class ViewSiteActivity extends AuthenticatedWebViewActivity {
         }
         loadAuthenticatedUrl(siteURL);
     }
-    
+
     @Override
     public void onBlogChanged() {
         super.onBlogChanged();

--- a/src/org/wordpress/android/ui/notifications/NotificationsWebViewActivity.java
+++ b/src/org/wordpress/android/ui/notifications/NotificationsWebViewActivity.java
@@ -16,7 +16,6 @@ import org.wordpress.android.ui.AuthenticatedWebViewActivity;
 
 @SuppressLint("SetJavaScriptEnabled")
 public class NotificationsWebViewActivity extends AuthenticatedWebViewActivity {
-    
     private static final String URL_TO_LOAD = "external_url";
 
     public static void openUrl(Context context, String url) {
@@ -33,21 +32,19 @@ public class NotificationsWebViewActivity extends AuthenticatedWebViewActivity {
         super.onCreate(savedInstanceState);
         mWebView.getSettings().setJavaScriptEnabled(true);
         mWebView.getSettings().setUserAgentString(WordPress.getUserAgent());
-        if (android.os.Build.VERSION.SDK_INT >= 11) { 
+        if (android.os.Build.VERSION.SDK_INT >= 11) {
             mWebView.getSettings().setDisplayZoomControls(false);
         }
-        mWebView.setWebChromeClient(new WordPressWebChromeClient(this));
-     
         ActionBar actionBar = getSupportActionBar();
         actionBar.setDisplayHomeAsUpEnabled(true);
-        
+
         // load URL if one was provided in the intent
         String url = getIntent().getStringExtra(URL_TO_LOAD);
         if (!TextUtils.isEmpty(url)) {
             loadUrl(url);
         }
     }
-    
+
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
@@ -55,17 +52,14 @@ public class NotificationsWebViewActivity extends AuthenticatedWebViewActivity {
         menu.findItem(R.id.menu_settings).setVisible(false);
         return true;
     }
-    
-    
+
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-
         int itemID = item.getItemId();
         if (itemID == android.R.id.home) {
             finish();
             return true;
         }
-
         return super.onOptionsItemSelected(item);
     }
 }

--- a/src/org/wordpress/android/ui/posts/PreviewPostActivity.java
+++ b/src/org/wordpress/android/ui/posts/PreviewPostActivity.java
@@ -1,7 +1,5 @@
 package org.wordpress.android.ui.posts;
 
-import java.util.Date;
-
 import android.os.Bundle;
 import android.widget.Toast;
 
@@ -12,6 +10,8 @@ import org.wordpress.android.models.PostStatus;
 import org.wordpress.android.ui.AuthenticatedWebViewActivity;
 import org.wordpress.android.util.StringUtils;
 
+import java.util.Date;
+
 /**
  * Activity for previewing a post or page in a webview.
  */
@@ -21,7 +21,7 @@ public class PreviewPostActivity extends AuthenticatedWebViewActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Bundle extras = getIntent().getExtras();
-        
+
         boolean isPage = getIntent().getBooleanExtra("isPage", false);
         if (isPage) {
             this.setTitle(StringUtils.unescapeHTML(WordPress.getCurrentBlog().getBlogName())
@@ -31,9 +31,8 @@ public class PreviewPostActivity extends AuthenticatedWebViewActivity {
                     + " - " + getResources().getText(R.string.preview_post));
         }
 
-        mWebView.setWebChromeClient(new WordPressWebChromeClient(this));
         mWebView.getSettings().setJavaScriptEnabled(true);
-        
+
         if (extras != null) {
             long mPostID = extras.getLong("postID");
 
@@ -54,16 +53,16 @@ public class PreviewPostActivity extends AuthenticatedWebViewActivity {
      * Load the post preview. If the post is in a non-public state (e.g. draft status, part of a
      * non-public blog, etc), load the preview as an authenticated URL. Otherwise, just load the
      * preview normally.
-     * 
+     *
      * @param post Post to load the preview for.
      */
     private void loadPostPreview(Post post) {
         if (post != null) {
             String url = post.getPermaLink();
-            
-            Date d = new Date();           
+
+            Date d = new Date();
             if ( WordPress.getCurrentBlog().isPrivate() //blog private
-                    || post.isLocalDraft() 
+                    || post.isLocalDraft()
                     || post.isLocalChange()
                     || post.getDate_created_gmt() > d.getTime() //Scheduled
                     || post.getStatusEnum() != PostStatus.PUBLISHED) {

--- a/src/org/wordpress/android/ui/themes/ThemePreviewFragment.java
+++ b/src/org/wordpress/android/ui/themes/ThemePreviewFragment.java
@@ -6,7 +6,6 @@ import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
@@ -21,6 +20,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.WPWebChromeClient;
 import org.wordpress.android.util.WPWebViewClient;
 
 import java.io.UnsupportedEncodingException;
@@ -136,27 +136,14 @@ public class ThemePreviewFragment extends SherlockFragment {
         View view = inflater.inflate(R.layout.webview, container, false);
 
         mWebView = (WebView) view.findViewById(R.id.webView);
-        mProgressBar = (ProgressBar) view.findViewById(R.id.progressBar);
         mWebView.getSettings().setUserAgentString(DESKTOP_UA);
         mWebView.getSettings().setBuiltInZoomControls(true);
         mWebView.setScrollBarStyle(View.SCROLLBARS_INSIDE_OVERLAY);
 
-        mWebView.setWebChromeClient(new WebChromeClient() {
-            @Override
-            public void onProgressChanged(WebView view, int newProgress) {
-                super.onProgressChanged(view, newProgress);
-                if(newProgress < 100 && !mProgressBar.isShown()){
-                    mProgressBar.setVisibility(ProgressBar.VISIBLE);
-                }
-                mProgressBar.setProgress(newProgress);
+        mWebView.setWebChromeClient(new WPWebChromeClient(getActivity(), (ProgressBar) view.findViewById(
+                R.id.progress_bar)));
 
-                if(newProgress == 100) {
-                    mProgressBar.setVisibility(ProgressBar.GONE);
-                }
-            }
-        });
-
-        mWebView.setWebViewClient(new WordPressWebViewClient(mBlog));
+        mWebView.setWebViewClient(new WPWebViewClient(mBlog));
 
         mWebView.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
         mWebView.getSettings().setSavePassword(false);
@@ -185,27 +172,6 @@ public class ThemePreviewFragment extends SherlockFragment {
             mWebView.postUrl(WordPress.getLoginUrl(mBlog), postData.getBytes());
         } catch (UnsupportedEncodingException e) {
             AppLog.e(T.THEMES, e);
-        }
-    }
-
-    /**
-     * WebViewClient that is capable of handling HTTP authentication requests using the HTTP
-     * username and password of the blog configured for this activity.
-     */
-    private class WordPressWebViewClient extends WPWebViewClient {
-        WordPressWebViewClient(Blog blog) {
-            super(blog);
-        }
-
-        @Override
-        public boolean shouldOverrideUrlLoading(WebView view, String url) {
-            view.loadUrl(url);
-            return true;
-        }
-
-        @Override
-        public void onPageFinished(WebView view, String url) {
-            mProgressBar.setVisibility(ProgressBar.GONE);
         }
     }
 

--- a/src/org/wordpress/android/util/WPWebChromeClient.java
+++ b/src/org/wordpress/android/util/WPWebChromeClient.java
@@ -1,0 +1,29 @@
+package org.wordpress.android.util;
+
+import android.app.Activity;
+import android.view.View;
+import android.webkit.WebChromeClient;
+import android.webkit.WebView;
+import android.widget.ProgressBar;
+
+public class WPWebChromeClient extends WebChromeClient {
+    private ProgressBar mProgressBar;
+    private Activity mActivity;
+
+    public WPWebChromeClient(Activity activity, ProgressBar progressBar) {
+        mProgressBar = progressBar;
+        mActivity = activity;
+    }
+
+    public void onProgressChanged(WebView webView, int progress) {
+        if (!mActivity.isFinishing()) {
+            mActivity.setTitle(webView.getTitle());
+        }
+        if (progress == 100) {
+            mProgressBar.setVisibility(View.GONE);
+        } else {
+            mProgressBar.setVisibility(View.VISIBLE);
+            mProgressBar.setProgress(progress);
+        }
+    }
+}


### PR DESCRIPTION
fix #1074 

I tested PTR on webviews, it felt weird and added unnecessary complexity (centered progress bar + undetermined progress bar + left centered determined progress bar).

So I just unified progress bar styling on all webviews by using the same 3dp dark blue rect bar.
