### PR TITLE
fix #1155: re init pull to refresh layout onConfigurationChange on ListFragment

### DIFF
--- a/src/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/src/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.notifications;
 
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.v4.app.ListFragment;
 import android.view.LayoutInflater;
@@ -18,7 +19,6 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.NetworkUtils;
 
 import uk.co.senab.actionbarpulltorefresh.extras.actionbarsherlock.PullToRefreshLayout;
-
 
 public class NotificationsListFragment extends ListFragment implements NotesAdapter.DataLoadedListener {
     private static final int LOAD_MORE_WITHIN_X_ROWS = 5;
@@ -73,8 +73,20 @@ public class NotificationsListFragment extends ListFragment implements NotesAdap
         if (textview != null) {
             textview.setText(getText(R.string.notifications_empty_list));
         }
+        initPullToRefreshHelper();
+    }
 
-        // pull to refresh setup
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        boolean isRefreshing = mPullToRefreshHelper.isRefreshing();
+        super.onConfigurationChanged(newConfig);
+        // Pull to refresh layout is destroyed onDetachedFromWindow,
+        // so we have to re-init the layout, via the helper here
+        initPullToRefreshHelper();
+        mPullToRefreshHelper.setRefreshing(isRefreshing);
+    }
+
+    private void initPullToRefreshHelper() {
         mPullToRefreshHelper = new PullToRefreshHelper(getActivity(),
                 (PullToRefreshLayout) getActivity().findViewById(R.id.ptr_layout),
                 new RefreshListener() {
@@ -167,6 +179,7 @@ public class NotificationsListFragment extends ListFragment implements NotesAdap
         if (mProgressFooterView != null)
             mProgressFooterView.setVisibility(View.VISIBLE);
     }
+
     private void hideProgressFooter() {
         if (mProgressFooterView != null)
             mProgressFooterView.setVisibility(View.GONE);

--- a/src/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/src/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.posts;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.app.ListFragment;
@@ -38,7 +39,6 @@ import java.util.Vector;
 import uk.co.senab.actionbarpulltorefresh.extras.actionbarsherlock.PullToRefreshLayout;
 
 public class PostsListFragment extends ListFragment implements WordPress.OnPostUploadedListener {
-
     public static final int POSTS_REQUEST_COUNT = 20;
 
     private PullToRefreshHelper mPullToRefreshHelper;
@@ -61,13 +61,24 @@ public class PostsListFragment extends ListFragment implements WordPress.OnPostU
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        View view = inflater.inflate(R.layout.post_listview, container, false);
+    public void onConfigurationChanged(Configuration newConfig) {
+        boolean isRefreshing = mPullToRefreshHelper.isRefreshing();
+        super.onConfigurationChanged(newConfig);
+        // Pull to refresh layout is destroyed onDetachedFromWindow,
+        // so we have to re-init the layout, via the helper here
+        initPullToRefreshHelper();
+        mPullToRefreshHelper.setRefreshing(isRefreshing);
+    }
 
-        // pull to refresh setup
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.post_listview, container, false);
+    }
+
+    private void initPullToRefreshHelper() {
         mPullToRefreshHelper = new PullToRefreshHelper(
                 getActivity(),
-                (PullToRefreshLayout) view.findViewById(R.id.ptr_layout),
+                (PullToRefreshLayout) getActivity().findViewById(R.id.ptr_layout),
                 new RefreshListener() {
                     @Override
                     public void onRefreshStarted(View view) {
@@ -78,7 +89,6 @@ public class PostsListFragment extends ListFragment implements WordPress.OnPostU
                         refreshPosts((PostsActivity) getActivity());
                     }
                 }, LinearLayout.class);
-        return view;
     }
 
     private void refreshPosts(PostsActivity postsActivity) {
@@ -190,7 +200,7 @@ public class PostsListFragment extends ListFragment implements WordPress.OnPostU
                 textView.setText(getText(R.string.posts_empty_list));
             }
         }
-
+        initPullToRefreshHelper();
         WordPress.setOnPostUploadedListener(this);
     }
 


### PR DESCRIPTION
This is a Fragment specific issue caused by the removing of PTR layout onDetachedFromWindow. PTR layout is removed here to avoid layout leak later on fragment destroy.
