### PR TITLE
issue/1181-reader-endless-back

### DIFF
--- a/src/org/wordpress/android/ui/WPActionBarActivity.java
+++ b/src/org/wordpress/android/ui/WPActionBarActivity.java
@@ -503,10 +503,16 @@ public abstract class WPActionBarActivity extends SherlockFragmentActivity {
         startActivity(intent);
     }
 
-    protected void showReaderIfNoBlog() {
-        // If logged in without blog, redirect to the Reader view
+    /*
+     * redirect to the Reader if there aren't any visible blogs
+     * returns true if redirected, false otherwise
+     */
+    protected boolean showReaderIfNoBlog() {
         if (WordPress.wpDB.getNumVisibleAccounts() == 0) {
             showReader();
+            return true;
+        } else {
+            return false;
         }
     }
 

--- a/src/org/wordpress/android/ui/posts/PostsActivity.java
+++ b/src/org/wordpress/android/ui/posts/PostsActivity.java
@@ -264,9 +264,15 @@ public class PostsActivity extends WPActionBarActivity
     @Override
     protected void onResume() {
         super.onResume();
+
+        // posts can't be shown if there aren't any visible blogs, so redirect to the reader and
+        // exit the post list in this situation
         if (WordPress.isSignedIn(PostsActivity.this)) {
-            showReaderIfNoBlog();
+            if (showReaderIfNoBlog()) {
+                finish();
+            }
         }
+
         if (WordPress.postsShouldRefresh) {
             checkForLocalChanges(false);
             mPostList.setRefreshing(true);


### PR DESCRIPTION
Fix #1181 - PostsActivity now finishes if reader is displayed due to no visible blogs
