### PR TITLE
fix #1215 prevent a crash if fragment hasn't attached activity

### DIFF
--- a/src/org/wordpress/android/ui/accounts/NewUserPageFragment.java
+++ b/src/org/wordpress/android/ui/accounts/NewUserPageFragment.java
@@ -247,6 +247,9 @@ public class NewUserPageFragment extends NewAccountAbstractPageFragment implemen
                 new CreateUserAndBlog.Callback() {
                     @Override
                     public void onStepFinished(CreateUserAndBlog.Step step) {
+                        if (!hasActivity()) {
+                            return;
+                        }
                         switch (step) {
                             case VALIDATE_USER:
                                 updateProgress(getString(R.string.validating_site_data));


### PR DESCRIPTION
fix #1215 
