### PR TITLE
Added mixpanel.getPeople().identify to mark user as opted in to People tracking

### DIFF
--- a/src/org/wordpress/android/util/WPMobileStatsUtil.java
+++ b/src/org/wordpress/android/util/WPMobileStatsUtil.java
@@ -131,6 +131,7 @@ public class WPMobileStatsUtil {
         if (connected) {
             String username = preferences.getString(WordPress.WPCOM_USERNAME_PREFERENCE, null);
             mixpanel.identify(username);
+            mixpanel.getPeople().identify(username);
             mixpanel.getPeople().increment("Application Opened", 1);
 
             try {


### PR DESCRIPTION
Is it possible that these identify calls need to be wrapped in an if statement? I didn't dive in to the command but I was worried that

```
preferences.getString(WordPress.WPCOM_USERNAME_PREFERENCE, null);
```

might return 'null' as a value and identify non-logged in users with the same identifier.

If that's not a concern then this change should lead to profiles being pushed!
