### PR TITLE
Show the current WordPress.com account name in the error dialog

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -551,7 +551,7 @@
     <string name="jetpack_message_not_admin">The Jetpack plugin is required for stats. Contact the site administrator.</string>
     <string name="jetpack_not_found">Jetpack plugin not found</string>
     <string name="jetpack_stats_unauthorized">Can\'t access stats</string>
-    <string name="jetpack_stats_switch_user">This WordPress.com account doesn\'t have access to the stats for this blog. Would you like to sign in to a different account?</string>
+    <string name="jetpack_stats_switch_user">The current WordPress.com account (%s) doesn\'t have access to the stats for this blog. Would you like to sign in to a different account?</string>
 
     <!--
        ****

--- a/src/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/src/org/wordpress/android/ui/stats/StatsActivity.java
@@ -553,9 +553,12 @@ public class StatsActivity extends WPActionBarActivity {
 
                         if (error.networkResponse != null && error.networkResponse.statusCode == 403) {
                             // This site has the wrong WP.com credentials
+                            SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(StatsActivity.this);
+                            String username = settings.getString(WordPress.WPCOM_USERNAME_PREFERENCE, "");
+                            
                             AlertDialog.Builder builder = new AlertDialog.Builder(StatsActivity.this);
                             builder.setTitle(getString(R.string.jetpack_stats_unauthorized))
-                                    .setMessage(getString(R.string.jetpack_stats_switch_user));
+                                    .setMessage(getString(R.string.jetpack_stats_switch_user, username));
                             builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
                                 public void onClick(DialogInterface dialog, int id) {
                                     startWPComLoginActivity();


### PR DESCRIPTION
Fix #873 
