### PR TITLE
fix #1285 npe in setupblog

### DIFF
--- a/src/org/wordpress/android/ui/accounts/SetupBlog.java
+++ b/src/org/wordpress/android/ui/accounts/SetupBlog.java
@@ -197,7 +197,7 @@ public class SetupBlog {
 
     private String getmXmlrpcByUserEnteredPath(String baseUrl) {
         String xmlRpcUrl = null;
-        if (!UrlUtils.isValidUrl(baseUrl)) {
+        if (!UrlUtils.isValidUrlAndHostNotNull(baseUrl)) {
             AppLog.e(T.NUX, "invalid URL: " + baseUrl);
             mErrorMsgId = R.string.invalid_url_message;
             return null;

--- a/src/org/wordpress/android/util/UrlUtils.java
+++ b/src/org/wordpress/android/util/UrlUtils.java
@@ -151,7 +151,7 @@ public class UrlUtils {
     /**
      * returns false if the url is not valid or if the url host is null, else true
      */
-    public static boolean isValidUrl(String url) {
+    public static boolean isValidUrlAndHostNotNull(String url) {
         try {
             URI uri = URI.create(url);
             if (uri.getHost() == null) {


### PR DESCRIPTION
fix #1285 null host setupblog

App was crashing when null host uri were entered like `http:///example.com`
