### PR TITLE
issue/1310-webview-user-agent

### DIFF
--- a/src/org/wordpress/android/ui/WebViewActivity.java
+++ b/src/org/wordpress/android/ui/WebViewActivity.java
@@ -41,8 +41,10 @@ public class WebViewActivity extends WPActionBarActivity {
         ab.setDisplayShowTitleEnabled(true);
         ab.setDisplayHomeAsUpEnabled(true);
 
+        // note: do NOT call mWebView.getSettings().setUserAgentString(WordPress.getUserAgent())
+        // here since it causes problems with the browser-sniffing that some sites rely on to
+        // format the page for mobile display
         mWebView = (WebView) findViewById(R.id.webView);
-        mWebView.getSettings().setUserAgentString(WordPress.getUserAgent());
         mWebView.getSettings().setBuiltInZoomControls(true);
         mWebView.setScrollBarStyle(View.SCROLLBARS_INSIDE_OVERLAY);
 

--- a/src/org/wordpress/android/ui/notifications/NotificationsWebViewActivity.java
+++ b/src/org/wordpress/android/ui/notifications/NotificationsWebViewActivity.java
@@ -31,7 +31,6 @@ public class NotificationsWebViewActivity extends AuthenticatedWebViewActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         mWebView.getSettings().setJavaScriptEnabled(true);
-        mWebView.getSettings().setUserAgentString(WordPress.getUserAgent());
         if (android.os.Build.VERSION.SDK_INT >= 11) {
             mWebView.getSettings().setDisplayZoomControls(false);
         }


### PR DESCRIPTION
Fix #1310 - Removed setUserAgentString from webViews that display external content. This is necessary so external sites which rely on browser-sniffing will work correctly.
