### PR TITLE
fix #1148: check if blogId correspond to the current selected blog in PostUploaded callback

### DIFF
--- a/src/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/src/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -346,9 +346,16 @@ public class PostsListFragment extends ListFragment implements WordPress.OnPostU
     }
 
     @Override
-    public void OnPostUploaded(String postId) {
-        if (!hasActivity())
+    public void OnPostUploaded(int localBlogId, String postId, boolean isPage) {
+        if (!hasActivity()) {
             return;
+        }
+
+        // If the user switched to a different blog while uploading his post, don't reload posts and refresh the view
+        boolean sameBlogId = true;
+        if (WordPress.getCurrentBlog() == null || WordPress.getCurrentBlog().getLocalTableBlogId() != localBlogId) {
+            sameBlogId = false;
+        }
 
         if (!NetworkUtils.checkConnection(getActivity())) {
             mPullToRefreshHelper.setRefreshing(false);
@@ -357,17 +364,19 @@ public class PostsListFragment extends ListFragment implements WordPress.OnPostU
 
         // Fetch the newly uploaded post
         if (!TextUtils.isEmpty(postId)) {
+            final boolean reloadPosts = sameBlogId;
             List<Object> apiArgs = new Vector<Object>();
-            apiArgs.add(WordPress.getCurrentBlog());
+            apiArgs.add(WordPress.wpDB.instantiateBlogByLocalId(localBlogId));
             apiArgs.add(postId);
-            apiArgs.add(mIsPage);
+            apiArgs.add(isPage);
 
-            mCurrentFetchSinglePostTask = new ApiHelper.FetchSinglePostTask(new ApiHelper.FetchSinglePostTask.Callback() {
+            mCurrentFetchSinglePostTask = new ApiHelper.FetchSinglePostTask(
+                    new ApiHelper.FetchSinglePostTask.Callback() {
                 @Override
                 public void onSuccess() {
                     mCurrentFetchSinglePostTask = null;
                     mIsFetchingPosts = false;
-                    if (!hasActivity()) {
+                    if (!hasActivity() || !reloadPosts) {
                         return;
                     }
                     mPullToRefreshHelper.setRefreshing(false);
@@ -379,7 +388,7 @@ public class PostsListFragment extends ListFragment implements WordPress.OnPostU
                 public void onFailure(ApiHelper.ErrorType errorType, String errorMessage, Throwable throwable) {
                     mCurrentFetchSinglePostTask = null;
                     mIsFetchingPosts = false;
-                    if (!hasActivity()) {
+                    if (!hasActivity() || !reloadPosts) {
                         return;
                     }
                     if (errorType != ErrorType.TASK_CANCELLED) {

--- a/src/org/wordpress/android/util/PostUploadService.java
+++ b/src/org/wordpress/android/util/PostUploadService.java
@@ -140,7 +140,7 @@ public class PostUploadService extends Service {
         @Override
         protected void onPostExecute(Boolean postUploadedSuccessfully) {
             if (postUploadedSuccessfully) {
-                WordPress.postUploaded(post.getRemotePostId());
+                WordPress.postUploaded(post.getLocalTableBlogId(), post.getRemotePostId(), post.isPage());
                 nm.cancel(notificationID);
                 WordPress.wpDB.deleteMediaFilesForPost(post);
             } else {


### PR DESCRIPTION
fix #1148:

In PostUploaded callback, if blogId correspond to the current selected blog, then fetch the new post/page and refresh the view else only fetch the new post/page.
