### PR TITLE
fix #721: unescape blog name in EditPostActivity

### DIFF
--- a/src/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/src/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -22,10 +22,10 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.models.Post;
-import org.wordpress.android.models.PostStatus;
 import org.wordpress.android.util.PostUploadService;
-import org.wordpress.android.util.stats.AnalyticsTracker;
+import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.WPViewPager;
+import org.wordpress.android.util.stats.AnalyticsTracker;
 
 public class EditPostActivity extends SherlockFragmentActivity {
 
@@ -138,7 +138,7 @@ public class EditPostActivity extends SherlockFragmentActivity {
             return;
         }
 
-        setTitle(WordPress.getCurrentBlog().getBlogName());
+        setTitle(StringUtils.unescapeHTML(WordPress.getCurrentBlog().getBlogName()));
 
         mSectionsPagerAdapter = new SectionsPagerAdapter(getSupportFragmentManager());
 


### PR DESCRIPTION
fix #721: unescape blog name in EditPostActivity
