### PR TITLE
fix #1260: null context crashed getThumbnailForWPImageSpan

### DIFF
--- a/src/org/wordpress/android/util/ImageHelper.java
+++ b/src/org/wordpress/android/util/ImageHelper.java
@@ -327,7 +327,7 @@ public class ImageHelper {
      * @return resized bitmap
      */
     public Bitmap getThumbnailForWPImageSpan(Context context, String filePath, int targetWidth) {
-        if (filePath == null) {
+        if (filePath == null || context == null) {
             return null;
         }
         int width = getThumbnailWidth(context, targetWidth);


### PR DESCRIPTION
fix #1260: null context crashed getThumbnailForWPImageSpan
