### PR TITLE
Use dimensions of ContentEditText when resizing the picture

### DIFF
--- a/src/org/wordpress/android/ui/posts/EditPostContentFragment.java
+++ b/src/org/wordpress/android/ui/posts/EditPostContentFragment.java
@@ -883,6 +883,10 @@ public class EditPostContentFragment extends SherlockFragment implements TextWat
 
             @Override
             public void onResponse(ImageLoader.ImageContainer container, boolean arg1) {
+                if (!hasActivity()) {
+                    return;
+                }
+
                 Bitmap downloadedBitmap = container.getBitmap();
                 if (downloadedBitmap == null) {
                     //no bitmap downloaded from the server.


### PR DESCRIPTION
Fix #1317 
