### PR TITLE
Fix #222: Stop showing quotes in dialog text when deleting untitled draft

### DIFF
--- a/src/org/wordpress/android/ui/posts/PostsActivity.java
+++ b/src/org/wordpress/android/ui/posts/PostsActivity.java
@@ -500,9 +500,14 @@ public class PostsActivity extends WPActionBarActivity
                         PostsActivity.this);
                 dialogBuilder.setTitle(getResources().getText(
                         R.string.delete_draft));
-                dialogBuilder.setMessage(getResources().getText(
-                        R.string.delete_sure)
-                        + " '" + post.getTitle() + "'?");
+
+                String deleteDraftMessage = getResources().getText(R.string.delete_sure).toString();
+                if (!post.getTitle().isEmpty()) {
+                    String postTitleEnclosedByQuotes = "'" + post.getTitle() + "'";
+                    deleteDraftMessage += " " + postTitleEnclosedByQuotes;
+                }
+
+                dialogBuilder.setMessage(deleteDraftMessage + "?");
                 dialogBuilder.setPositiveButton(
                         getResources().getText(R.string.yes),
                         new DialogInterface.OnClickListener() {


### PR DESCRIPTION
Fix #222. Check if draft to be deleted has a non-empty title before
showing quotes and the title name in the dialog text.
