### PR TITLE
fix #1100: start the progress bar when add category action is called

### DIFF
--- a/src/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
+++ b/src/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
@@ -300,6 +300,7 @@ public class SelectCategoriesActivity extends SherlockListActivity {
 
                     // Check if the category name already exists
                     if (!mCategoryNames.keySet().contains(category_name)) {
+                        mPullToRefreshHelper.setRefreshing(true);
                         Thread th = new Thread() {
                             public void run() {
                                 finalResult = addCategory(category_name, category_slug, category_desc, parent_id);


### PR DESCRIPTION
fix #1100: start the progress bar when add category action is called
