### PR TITLE
Fixes tab divider color on v14 or higher devices. Fixes #1360

### DIFF
--- a/res/drawable/tab_divider_wordpress.xml
+++ b/res/drawable/tab_divider_wordpress.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/grey_medium_dark" />
+    <size android:width="1px" />
+</shape>

--- a/res/values-v14/styles.xml
+++ b/res/values-v14/styles.xml
@@ -15,6 +15,7 @@
         <item name="android:actionModeSplitBackground">@drawable/cab_background_bottom_wordpress</item>
         <item name="android:actionModeCloseButtonStyle">@style/ActionButton.CloseMode.WordPress</item>
         <item name="android:actionBarTabTextStyle">@style/TabTextStyle.WordPress</item>
+        <item name="android:actionBarTabBarStyle">@style/TabBarStyle.WordPress</item>
 
         <!-- Light.DarkActionBar specific -->
         <item name="android:actionBarWidgetTheme">@style/Theme.WordPress.Widget</item>
@@ -42,6 +43,11 @@
     <style name="Theme.WordPress.Widget" parent="@style/Theme.Sherlock">
         <item name="android:popupMenuStyle">@style/PopupMenu.WordPress</item>
         <item name="android:dropDownListViewStyle">@style/DropDownListView.WordPress</item>
+    </style>
+
+    <style name="TabBarStyle.WordPress" parent="@android:style/Widget.Holo.ActionBar.TabBar">
+        <item name="android:showDividers">middle</item>
+        <item name="android:divider">@drawable/tab_divider_wordpress</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Here's how it looks now:
![screen shot 2014-05-06 at 3 06 21 pm](https://cloud.githubusercontent.com/assets/789137/2896268/b9f9e8ca-d56a-11e3-9562-f8ef5851b3b5.png)
