### PR TITLE
issue/1393-html-in-recommended-blogs

### DIFF
--- a/src/org/wordpress/android/models/ReaderRecommendedBlog.java
+++ b/src/org/wordpress/android/models/ReaderRecommendedBlog.java
@@ -30,7 +30,7 @@ public class ReaderRecommendedBlog {
 
         blog.setTitle(JSONUtil.getString(json, "title"));
         blog.setImageUrl(JSONUtil.getString(json, "image"));
-        blog.setReason(JSONUtil.getString(json, "reason"));
+        blog.setReason(JSONUtil.getStringDecoded(json, "reason"));
 
         // the "url" field points to an API endpoint, "blog_domain" contains the actual url
         blog.setBlogUrl(JSONUtil.getString(json, "blog_domain"));


### PR DESCRIPTION
Fix #1393 - Reason (description) in recommended blogs is now unescaped.
