### PR TITLE
fix #1399: auto login after account creation

### DIFF
--- a/src/org/wordpress/android/ui/accounts/NewUserPageFragment.java
+++ b/src/org/wordpress/android/ui/accounts/NewUserPageFragment.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.accounts;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -173,13 +174,13 @@ public class NewUserPageFragment extends NewAccountAbstractPageFragment implemen
     }
 
     private void finishThisStuff(String username) {
-        final NewAccountActivity act = (NewAccountActivity) getActivity();
-        Bundle bundle = new Bundle();
-        bundle.putString("username", username);
-        Intent intent = new Intent();
-        intent.putExtras(bundle);
-        act.setResult(NewAccountActivity.RESULT_OK, intent);
-        act.finish();
+        final Activity activity = getActivity();
+        if (activity != null) {
+            Intent intent = new Intent();
+            intent.putExtra("username", username);
+            activity.setResult(NewAccountActivity.RESULT_OK, intent);
+            activity.finish();
+        }
     }
 
     protected boolean specificShowError(int messageId) {

--- a/src/org/wordpress/android/ui/accounts/WelcomeActivity.java
+++ b/src/org/wordpress/android/ui/accounts/WelcomeActivity.java
@@ -54,7 +54,6 @@ public class WelcomeActivity extends Activity {
             if (username != null) {
                 mWelcomeFragmentSignIn.signInDotComUser();
             }
-
         }
     }
 }

--- a/src/org/wordpress/android/ui/accounts/WelcomeFragmentSignIn.java
+++ b/src/org/wordpress/android/ui/accounts/WelcomeFragmentSignIn.java
@@ -201,7 +201,10 @@ public class WelcomeFragmentSignIn extends NewAccountAbstractPageFragment implem
         @Override
         public void onClick(View v) {
             Intent newAccountIntent = new Intent(getActivity(), NewAccountActivity.class);
-            startActivityForResult(newAccountIntent, WelcomeActivity.CREATE_ACCOUNT_REQUEST);
+            Activity activity = getActivity();
+            if (activity != null) {
+                activity.startActivityForResult(newAccountIntent, WelcomeActivity.CREATE_ACCOUNT_REQUEST);
+            }
         }
     };
 


### PR DESCRIPTION
fix #1399: use getActivity().startActivityForResult() from WelcomeFragmentSignIn fragment instead of startActivityForResult()
