### PR TITLE
Issue/1377 blank reader

### DIFF
--- a/src/org/wordpress/android/ui/reader/ReaderActivity.java
+++ b/src/org/wordpress/android/ui/reader/ReaderActivity.java
@@ -19,6 +19,7 @@ import org.wordpress.android.datasets.ReaderTagTable;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.ui.WPActionBarActivity;
+import org.wordpress.android.ui.accounts.WPComLoginActivity;
 import org.wordpress.android.ui.prefs.UserPrefs;
 import org.wordpress.android.ui.reader.ReaderPostListFragment.OnPostSelectedListener;
 import org.wordpress.android.ui.reader.ReaderPostListFragment.OnTagSelectedListener;
@@ -265,13 +266,25 @@ public class ReaderActivity extends WPActionBarActivity
                         detailFragment.reloadPost();
                 }
                 break;
+
+            // user just returned from the login dialog, need to perform initial update again
+            // since creds have changed
+            case WPComLoginActivity.REQUEST_CODE:
+                if (isResultOK) {
+                    removeFragments();
+                    mHasPerformedInitialUpdate = false;
+                    performInitialUpdate();
+                }
+                break;
         }
     }
 
     @Override
     public void onSignout() {
         super.onSignout();
+
         mHasPerformedInitialUpdate = false;
+        AppLog.i(T.READER, "user signed out");
 
         // reader database will have been cleared by the time this is called, but the fragments must
         // be removed or else they will continue to show the same articles - onResume() will take care

--- a/src/org/wordpress/android/util/AuthErrorDialogFragment.java
+++ b/src/org/wordpress/android/util/AuthErrorDialogFragment.java
@@ -44,7 +44,7 @@ public class AuthErrorDialogFragment extends DialogFragment {
                     Intent authIntent = new Intent(getActivity(), WPComLoginActivity.class);
                     authIntent.putExtra("wpcom", true);
                     authIntent.putExtra("auth-only", true);
-                    getActivity().startActivity(authIntent);
+                    getActivity().startActivityForResult(authIntent, WPComLoginActivity.REQUEST_CODE);
                 }
             });
         } else {


### PR DESCRIPTION
Fix #1377 - changing password and returning to the app no longer results in an empty Reader.

Note: you can test this without changing your password by revoking the application-specific password and adding a new one at https://wordpress.com/settings/security/
