### PR TITLE
issue/1328-reader-blockquote-border

### DIFF
--- a/src/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/src/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -1101,6 +1101,11 @@ public class ReaderPostDetailFragment extends Fragment
               .append("        background-color: ").append(greyExtraLight).append("; ")
               .append("        padding: ").append(marginSmall).append("px; }");
 
+        // add a left border to blockquotes
+        sbHtml.append("  blockquote { margin-left: ").append(marginSmall).append("px; ")
+              .append("               padding-left: ").append(marginSmall).append("px; ")
+              .append("               border-left: 3px solid ").append(greyLight).append("; }");
+
         // make sure links don't overflow and are shown in the same color they are elsewhere in the app
         sbHtml.append("  a { word-wrap: break-word; text-decoration: none; color: ").append(linkColor).append("; }");
 


### PR DESCRIPTION
Fix #1328 - Added blockquote styling to ReaderPostDetailFragment

![blockquote](https://cloud.githubusercontent.com/assets/3903757/2988200/0989b1ac-dc57-11e3-9e88-318d13c87559.png)
