### PR TITLE
fix #1447: manually restore the activity - because of the dualpane <-> singlepane code (7 inches tablet)

### DIFF
--- a/src/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/src/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -37,7 +37,7 @@ public class CommentsActivity extends WPActionBarActivity
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+        super.onCreate(null);
         createMenuDrawer(R.layout.comment_activity);
         View detailView = findViewById(R.id.fragment_comment_detail);
         mDualPane = detailView != null && detailView.getVisibility() == View.VISIBLE;


### PR DESCRIPTION
fix #1447: manually restore the activity - because of the dualpane <-> singlepane code (7 inches tablet)
