### PR TITLE
fix #1452: unhighlight comment rows on single pane comment list

### DIFF
--- a/src/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/src/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -168,6 +168,9 @@ public class CommentsActivity extends WPActionBarActivity
                             }
                             break;
                         case 0:
+                            if (!mDualPane) {
+                                getListFragment().setHighlightedCommentId(-1);
+                            }
                             mMenuDrawer.setDrawerIndicatorEnabled(true);
                             mSelectedCommentId = 0;
                             mSelectedReaderPost = null;


### PR DESCRIPTION
fix #1452: unhighlight comment rows on single pane comment list
