### PR TITLE
fix #1473: disable crashlytics logging of all caught exceptions

### DIFF
--- a/src/org/wordpress/android/WordPress.java
+++ b/src/org/wordpress/android/WordPress.java
@@ -107,7 +107,6 @@ public class WordPress extends Application {
         AppLog.enableRecording(true);
         if (!Utils.isDebugBuild()) {
             Crashlytics.start(this);
-            AppLog.enableCrashlytics(true);
         }
         versionName = getVersionName(this);
         initWpDb();

--- a/src/org/wordpress/android/util/AppLog.java
+++ b/src/org/wordpress/android/util/AppLog.java
@@ -40,7 +40,7 @@ public class AppLog {
         mEnableCrashlytics = enable;
     }
 
-    public static void crashlyticsLog(T tag, Throwable throwable, String message) {
+    private static void crashlyticsLog(T tag, Throwable throwable, String message) {
         if (mEnableCrashlytics) {
             CrashlyticsUtils.logException(throwable, ExceptionType.USUAL, tag, message);
         }


### PR DESCRIPTION
fix #1473: disable crashlytics logging of all caught exceptions
