### PR TITLE
Re-add support for Self hosted sites that share one SSL certificate

### DIFF
--- a/src/org/wordpress/android/networking/SelfSignedSSLCertsManager.java
+++ b/src/org/wordpress/android/networking/SelfSignedSSLCertsManager.java
@@ -244,6 +244,10 @@ public class SelfSignedSSLCertsManager {
             }
         }
 
+        return isCertificateTrusted(x509Certificate);
+    }
+
+    public boolean isCertificateTrusted(X509Certificate x509Certificate){
         if (x509Certificate==null)
             return false;
 

--- a/src/org/wordpress/android/ui/accounts/SetupBlog.java
+++ b/src/org/wordpress/android/ui/accounts/SetupBlog.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLPeerUnverifiedException;
 
 public class SetupBlog {
     private static final String DEFAULT_IMAGE_SIZE = "2000";
@@ -217,6 +218,18 @@ public class SetupBlog {
             if (isHTTPAuthErrorMessage(e)) {
                 return null;
             }
+        } catch (SSLHandshakeException e) {
+            if (!UrlUtils.getDomainFromUrl(baseUrl).endsWith("wordpress.com")) {
+                mErroneousSslCertificate = true;
+            }
+            AppLog.w(T.NUX, "SSLHandshakeException failed. Erroneous SSL certificate detected.");
+            return null;
+        } catch (SSLPeerUnverifiedException e) {
+            if (!UrlUtils.getDomainFromUrl(baseUrl).endsWith("wordpress.com")) {
+                mErroneousSslCertificate = true;
+            }
+            AppLog.w(T.NUX, "SSLPeerUnverifiedException failed. Erroneous SSL certificate detected.");
+            return null;
         } catch (IOException e) {
             AppLog.i(T.NUX, "system.listMethods failed on: " + baseUrl);
             if (isHTTPAuthErrorMessage(e)) {
@@ -243,6 +256,18 @@ public class SetupBlog {
             return xmlRpcUrl;
         } catch (XMLRPCException e) {
             AppLog.e(T.NUX, "system.listMethods failed on: " + guessURL, e);
+        } catch (SSLHandshakeException e) {
+            if (!UrlUtils.getDomainFromUrl(baseUrl).endsWith("wordpress.com")) {
+                mErroneousSslCertificate = true;
+            }
+            AppLog.w(T.NUX, "SSLHandshakeException failed. Erroneous SSL certificate detected.");
+            return null;
+        } catch (SSLPeerUnverifiedException e) {
+            if (!UrlUtils.getDomainFromUrl(baseUrl).endsWith("wordpress.com")) {
+                mErroneousSslCertificate = true;
+            }
+            AppLog.w(T.NUX, "SSLPeerUnverifiedException failed. Erroneous SSL certificate detected.");
+            return null;
         } catch (IOException e) {
             AppLog.e(T.NUX, "system.listMethods failed on: " + guessURL, e);
         } catch (XmlPullParserException e) {
@@ -298,6 +323,7 @@ public class SetupBlog {
             AppLog.w(T.NUX, "SSLHandshakeException failed. Erroneous SSL certificate detected.");
             return null;
         }
+
         return xmlrpcUrl;
     }
 

--- a/src/org/xmlrpc/android/XMLRPCClient.java
+++ b/src/org/xmlrpc/android/XMLRPCClient.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLPeerUnverifiedException;
 
 /**
  * A WordPress XMLRPC Client.
@@ -542,6 +543,14 @@ public class XMLRPCClient implements XMLRPCClientInterface {
                     AppLog.e(T.NUX, "SSLHandshakeException failed. Erroneous SSL certificate detected on wordpress.com");
                 } else {
                     AppLog.w(T.NUX, "SSLHandshakeException failed. Erroneous SSL certificate detected.");
+                    broadcastAction(WordPress.BROADCAST_ACTION_XMLRPC_INVALID_SSL_CERTIFICATE);
+                }
+                throw e;
+            } catch (SSLPeerUnverifiedException e) {
+                if (mIsWpcom) {
+                    AppLog.e(T.NUX, "SSLPeerUnverifiedException failed. Erroneous SSL certificate detected on wordpress.com");
+                } else {
+                    AppLog.w(T.NUX, "SSLPeerUnverifiedException failed. Erroneous SSL certificate detected.");
                     broadcastAction(WordPress.BROADCAST_ACTION_XMLRPC_INVALID_SSL_CERTIFICATE);
                 }
                 throw e;


### PR DESCRIPTION
Fix #1487

This PR includes the following changes:
- SSL certs host name verifier: Switched to BrowserCompatHostnameVerifier that is the host name verifier that works the same way as Curl and Firefox.
- Includes a fix for #1487 - When a certificate fails the host name verification we need to check it against our SSLTrust store. The certificate could be added to the trusted certificates pool. If it's not added we need tho show the "Trust this cert" details screen.

With this patch merged in the code, the app works fine with the following configurations:
- Self-signed SSL cert
- Shared SSL cert
- Self-signed shared SSL cert
- SNI
