### PR TITLE
fix #739: text too long - settings -> signature checkbox 

### DIFF
--- a/res-zbetagroup/xml/preferences.xml
+++ b/res-zbetagroup/xml/preferences.xml
@@ -51,11 +51,12 @@
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="wp_pref_signature_enabled"
-            android:title="@string/add_tagline"/>
+            android:title="@string/post_signature"
+            android:summary="@string/add_tagline"/>
 
         <org.wordpress.android.util.WPEditTextPreference
             android:key="wp_pref_post_signature"
-            android:title="@string/post_signature"/>
+            android:title="@string/your_signature"/>
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -251,6 +251,7 @@
     <string name="page_not_published">Page status isn\'t published</string>
     <string name="view_in_browser">View in browser</string>
     <string name="post_signature">Post signature</string>
+    <string name="your_signature">Your signature:</string>
     <string name="add_tagline">Add a signature to new posts</string>
     <string name="posted_from">Posted from WordPress for Android</string>
     <string name="preview">Preview</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -51,11 +51,12 @@
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="wp_pref_signature_enabled"
-            android:title="@string/add_tagline"/>
+            android:title="@string/post_signature"
+            android:summary="@string/add_tagline"/>
 
         <org.wordpress.android.util.WPEditTextPreference
             android:key="wp_pref_post_signature"
-            android:title="@string/post_signature"/>
+            android:title="@string/your_signature"/>
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
fix #739: text too long - settings -> signature checkbox 
