### PR TITLE
fix #1238: remove left gravity in edit comment text box

### DIFF
--- a/res/layout/comment_edit_activity.xml
+++ b/res/layout/comment_edit_activity.xml
@@ -45,7 +45,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:inputType="textCapSentences|textAutoCorrect|textMultiLine"
-            android:gravity="top|left"
+            android:gravity="top"
             android:minLines="4"
             android:hint="@string/hint_comment_content"
             android:textColorLink="@color/reader_hyperlink" />


### PR DESCRIPTION
fix #1238: remove left gravity in edit comment text box

Before:
![screencap-2014-06-19t12-33-39 0200](https://cloud.githubusercontent.com/assets/40213/3326405/52576170-f79d-11e3-9235-884b72e17fa4.png)

After:
![screencap-2014-06-19t12-34-06 0200](https://cloud.githubusercontent.com/assets/40213/3326404/525529f0-f79d-11e3-82f4-94c34f4fe991.png)
