### PR TITLE
Don't pass the savedInstanceState to super in NotificationsActivity

### DIFF
--- a/src/org/wordpress/android/ui/notifications/NotificationsActivity.java
+++ b/src/org/wordpress/android/ui/notifications/NotificationsActivity.java
@@ -56,14 +56,13 @@ public class NotificationsActivity extends WPActionBarActivity
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
+        super.onCreate(null);
+        createMenuDrawer(R.layout.notifications);
         // savedInstanceState will be non-null if activity is being re-created
         if (savedInstanceState == null) {
             AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATIONS_ACCESSED);
         }
 
-        createMenuDrawer(R.layout.notifications);
         View fragmentContainer = findViewById(R.id.layout_fragment_container);
         mDualPane = fragmentContainer != null && getString(R.string.dual_pane_mode).equals(fragmentContainer.getTag());
 


### PR DESCRIPTION
Now works the same way as `CommentsActivity` does rotation. Fixes #1519

Note: I have rotation working in a better way in the upcoming notifications redesign PR that doesn't require the entire layout to be set up again. But in the meantime this will fix the crash for 3.0.
