### PR TITLE
issue/1527-tags-shown-in-post-titles

### DIFF
--- a/src/org/wordpress/android/models/ReaderPost.java
+++ b/src/org/wordpress/android/models/ReaderPost.java
@@ -143,6 +143,11 @@ public class ReaderPost {
             post.title = extractTitle(post.excerpt, 50);
         }
 
+        // remove html from title (rare, but does happen)
+        if (post.hasTitle() && post.title.contains("<") && post.title.contains(">")) {
+            post.title = HtmlUtils.stripHtml(post.title);
+        }
+
         // parse the tags section
         assignTagsFromJson(post, json.optJSONObject("tags"));
 


### PR DESCRIPTION
Fix #1527 by removing HTML from post titles
