### PR TITLE
fix #1533: call gradle clean after th gradle test build

### DIFF
--- a/tools/release-checks.sh
+++ b/tools/release-checks.sh
@@ -38,6 +38,7 @@ function checkENStrings() {
 	rm -f res/values-??/strings.xml
 	/bin/echo -n "Check for missing strings (slow)..."
 	./gradlew build > /dev/null 2>&1 && pOk || (pFail; ./gradlew build)
+	./gradlew clean
 	git checkout -- res/
 
 	# restore local changes


### PR DESCRIPTION
fix #1533: call gradle clean after th gradle test build
