### PR TITLE
issue/1546-reader-list-illegal-state-exception

### DIFF
--- a/src/org/wordpress/android/ui/reader/ReaderBlogFragment.java
+++ b/src/org/wordpress/android/ui/reader/ReaderBlogFragment.java
@@ -89,9 +89,9 @@ public class ReaderBlogFragment extends Fragment
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
         outState.putSerializable(ARG_BLOG_TYPE, getBlogType());
         outState.putBoolean(ReaderConstants.KEY_WAS_PAUSED, mWasPaused);
+        super.onSaveInstanceState(outState);
     }
 
     private void restoreState(Bundle args) {

--- a/src/org/wordpress/android/ui/reader/ReaderPhotoViewerActivity.java
+++ b/src/org/wordpress/android/ui/reader/ReaderPhotoViewerActivity.java
@@ -45,9 +45,9 @@ public class ReaderPhotoViewerActivity extends Activity {
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
         outState.putString(ReaderConstants.ARG_IMAGE_URL, mImageUrl);
         outState.putBoolean(ReaderConstants.ARG_IS_PRIVATE, mIsPrivate);
+        super.onSaveInstanceState(outState);
     }
 
     private void loadImage(String imageUrl) {

--- a/src/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/src/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -356,8 +356,6 @@ public class ReaderPostDetailFragment extends Fragment
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-
         outState.putLong(ReaderConstants.ARG_BLOG_ID, mBlogId);
         outState.putLong(ReaderConstants.ARG_POST_ID, mPostId);
 
@@ -378,6 +376,8 @@ public class ReaderPostDetailFragment extends Fragment
         } else {
             mListState = null;
         }
+
+        super.onSaveInstanceState(outState);
     }
 
     @Override

--- a/src/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/src/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -213,7 +213,6 @@ public class ReaderPostListFragment extends Fragment
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
         AppLog.d(T.READER, "reader post list > saving instance state");
 
         if (mCurrentTag != null) {
@@ -233,6 +232,8 @@ public class ReaderPostListFragment extends Fragment
         if (mListView != null && mListView.getFirstVisiblePosition() > 0) {
             outState.putParcelable(ReaderConstants.KEY_LIST_STATE, mListView.onSaveInstanceState());
         }
+
+        super.onSaveInstanceState(outState);
     }
 
     @Override

--- a/src/org/wordpress/android/ui/reader/ReaderReblogActivity.java
+++ b/src/org/wordpress/android/ui/reader/ReaderReblogActivity.java
@@ -111,10 +111,10 @@ public class ReaderReblogActivity extends Activity {
 
     @Override
     protected void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
         if (mDestinationBlogId != 0) {
             outState.putLong(KEY_DESTINATION_BLOG_ID, mDestinationBlogId);
         }
+        super.onSaveInstanceState(outState);
     }
 
     @Override

--- a/src/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/src/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -173,13 +173,13 @@ public class ReaderSubsActivity extends Activity
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
         outState.putBoolean(KEY_TAGS_CHANGED, mTagsChanged);
         outState.putBoolean(KEY_BLOGS_CHANGED, mBlogsChanged);
         outState.putBoolean(ReaderConstants.KEY_ALREADY_UPDATED, mHasPerformedUpdate);
         if (mLastAddedTagName != null) {
             outState.putString(KEY_LAST_ADDED_TAG_NAME, mLastAddedTagName);
         }
+        super.onSaveInstanceState(outState);
     }
 
     @Override

--- a/src/org/wordpress/android/ui/reader/ReaderTagFragment.java
+++ b/src/org/wordpress/android/ui/reader/ReaderTagFragment.java
@@ -92,8 +92,8 @@ public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagA
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
         outState.putSerializable(ARG_TAG_TYPE, getTagType());
+        super.onSaveInstanceState(outState);
     }
 
     private void scrollToTagName(String tagName) {

--- a/src/org/wordpress/android/ui/reader/ReaderUserListActivity.java
+++ b/src/org/wordpress/android/ui/reader/ReaderUserListActivity.java
@@ -85,10 +85,10 @@ public class ReaderUserListActivity extends Activity {
 
     @Override
     protected void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
         if (getListView().getFirstVisiblePosition() > 0) {
             outState.putParcelable(LIST_STATE, getListView().onSaveInstanceState());
         }
+        super.onSaveInstanceState(outState);
     }
 
     private void loadUsers(final long blogId, final long postId) {


### PR DESCRIPTION
Fix #1546 - Super() is now called at the end of onSaveInstanceState() in all reader fragments/activities that use it. Google seems to favor [calling it last](http://developer.android.com/training/basics/activity-lifecycle/recreating.html#SaveState), and more importantly it fixes https://code.google.com/p/android/issues/detail?id=19917#c8 (which is known to cause the dreaded "Can not perform this action after onSaveInstanceState" exception).
