### PR TITLE
Moved notes list cursor close to `onDestroy` of `NotificationsActivity`.

### DIFF
--- a/src/org/wordpress/android/ui/notifications/NotificationsActivity.java
+++ b/src/org/wordpress/android/ui/notifications/NotificationsActivity.java
@@ -112,6 +112,15 @@ public class NotificationsActivity extends WPActionBarActivity
         notificationManager.cancel(GCMIntentService.PUSH_NOTIFICATION_ID);
     }
 
+    @Override
+    protected void onDestroy() {
+        if (mNotesList != null) {
+            mNotesList.closeAdapterCursor();
+        }
+
+        super.onDestroy();
+    }
+
     private final FragmentManager.OnBackStackChangedListener mOnBackStackChangedListener =
             new FragmentManager.OnBackStackChangedListener() {
                 public void onBackStackChanged() {

--- a/src/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/src/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -99,9 +99,6 @@ public class NotificationsListFragment extends ListFragment implements Bucket.Li
 
     @Override
     public void onDestroyView() {
-        if (mNotesAdapter != null) {
-            mNotesAdapter.closeCursor();
-        }
         mFauxPullToRefreshHelper.unregisterReceiver(getActivity());
         super.onDestroyView();
     }
@@ -114,6 +111,12 @@ public class NotificationsListFragment extends ListFragment implements Bucket.Li
         // so we have to re-init the layout, via the helper here
         initPullToRefreshHelper();
         mFauxPullToRefreshHelper.setRefreshing(isRefreshing);
+    }
+
+    public void closeAdapterCursor() {
+        if (mNotesAdapter != null) {
+            mNotesAdapter.closeCursor();
+        }
     }
 
     private void initPullToRefreshHelper() {


### PR DESCRIPTION
'onDestroyView' is called when a fragment is replaced which is what caused the exception. Fixes #1553
