### PR TITLE
issue/1578-blog-preview-empty-title

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -571,7 +571,7 @@
     <!-- timespan shown for posts/comments published within the past 60 seconds -->
     <string name="reader_timespan_now">now</string>
 
-    <!-- title shown for untitled posts -->
+    <!-- title shown for untitled posts and blogs -->
     <string name="reader_untitled_post">(Untitled)</string>
 
     <!-- activity titles -->

--- a/src/org/wordpress/android/ui/reader/ReaderBlogInfoView.java
+++ b/src/org/wordpress/android/ui/reader/ReaderBlogInfoView.java
@@ -107,6 +107,10 @@ class ReaderBlogInfoView extends FrameLayout {
 
         if (blogInfo.hasName()) {
             txtBlogName.setText(blogInfo.getName());
+        } else if (blogInfo.hasUrl()) {
+            txtBlogName.setText(UrlUtils.getDomainFromUrl(blogInfo.getUrl()));
+        } else {
+            txtBlogName.setText(getContext().getString(R.string.reader_untitled_post));
         }
 
         if (blogInfo.hasDescription()) {


### PR DESCRIPTION
Fix #1578 - Blog preview now shows the blog's domain if the blog name is empty
