### PR TITLE
fix #1591: fix db initialization by forcing DB deletion in case current DB is invalid

### DIFF
--- a/src/org/wordpress/android/WordPress.java
+++ b/src/org/wordpress/android/WordPress.java
@@ -222,8 +222,9 @@ public class WordPress extends Application {
             editor.commit();
             if (wpDB != null) {
                 wpDB.updateLastBlogId(-1);
-                wpDB.deleteDatabase(this);
             }
+            // Force DB deletion
+            WordPressDB.deleteDatabase(this);
             wpDB = new WordPressDB(this);
         }
     }

--- a/src/org/wordpress/android/WordPressDB.java
+++ b/src/org/wordpress/android/WordPressDB.java
@@ -252,7 +252,7 @@ public class WordPressDB {
         return db;
     }
 
-    public void deleteDatabase(Context ctx) {
+    public static void deleteDatabase(Context ctx) {
         ctx.deleteDatabase(DATABASE_NAME);
     }
 


### PR DESCRIPTION
It's tricky to test this, one method:
1. Checkout `issue/1591-wpdb-init-exception`and  apply this patch

```
--- a/src/org/wordpress/android/WordPressDB.java
+++ b/src/org/wordpress/android/WordPressDB.java
@@ -163,6 +163,7 @@ public class WordPressDB {
             case 0:
                 // New install
                 currentVersion++;
+                db.execSQL(ADD_BLOGID);
             case 1:
                 // Add columns that were added in very early releases, then move on to version 9
                 db.execSQL(ADD_BLOGID);
@@ -245,14 +246,14 @@ public class WordPressDB {
                 db.execSQL("DROP TABLE IF EXISTS notes;");
                 currentVersion++;
         }
-        db.setVersion(DATABASE_VERSION);
+        db.setVersion(0);
     }
```
1. Delete the app
2. Install and run the app with previous patch (it's going to crash on startup)
3. Reverse previous patch
4. Install `issue/1591-wpdb-init-exception` version on top of current app -> that should work even if following case is going to be executed

```
case 1:
                 // Add columns that were added in very early releases, then move on to version 9
                 db.execSQL(ADD_BLOGID);
```

If you run the same steps on `release/3.0` branch, it's going to crash on startup.
