### PR TITLE
Issue/adjust incorrect properties in mixpanel

### DIFF
--- a/src/org/wordpress/android/util/stats/AnalyticsTrackerMixpanel.java
+++ b/src/org/wordpress/android/util/stats/AnalyticsTrackerMixpanel.java
@@ -231,7 +231,7 @@ public class AnalyticsTrackerMixpanel implements AnalyticsTracker.Tracker {
             case READER_COMMENTED_ON_ARTICLE:
                 instructions = AnalyticsTrackerMixpanelInstructionsForStat.
                         mixpanelInstructionsForEventName("Reader - Commented on Article");
-                instructions.setSuperPropertyAndPeoplePropertyToIncrement("number_of_times_commented_on_article");
+                instructions.setSuperPropertyAndPeoplePropertyToIncrement("number_of_times_commented_on_reader_article");
                 break;
             case READER_FOLLOWED_SITE:
                 instructions = AnalyticsTrackerMixpanelInstructionsForStat.


### PR DESCRIPTION
While doing a deep dive into our updated Mixpanel Implementation(https://github.com/wordpress-mobile/WordPress-Android/pull/1264), I noticed a few of the properties in Android weren't matching the properties in iOS(https://github.com/wordpress-mobile/WordPress-iOS/blob/21ff398e6cb17831b150a6409637755def4d5646/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerMixpanel.m). I've adjusted them here on Android so they line up with the iOS project so going forward we can analyze this data more clearly.

Changes:
- number_of_times_commented_on_article -> number_of_times_commented_on_reader_article
- number_of_published_posts_with_photos -> number_of_posts_published_with_photos
- number_of_published_posts_with_videos -> number_of_posts_published_with_videos
- number_of_published_posts_with_categories -> number_of_posts_published_with_categories
- number_of_published_posts_with_tags -> number_of_posts_published_with_tags
