### PR TITLE
fix #1590: delete post dialog crash

### DIFF
--- a/src/org/wordpress/android/ui/posts/PostsActivity.java
+++ b/src/org/wordpress/android/ui/posts/PostsActivity.java
@@ -391,7 +391,6 @@ public class PostsActivity extends WPActionBarActivity
             mLoadingDialog.setCancelable(false);
             return mLoadingDialog;
         }
-
         return super.onCreateDialog(id);
     }
 
@@ -407,6 +406,12 @@ public class PostsActivity extends WPActionBarActivity
 
         @Override
         protected void onPostExecute(Boolean result) {
+            if (result) {
+                WordPress.wpDB.deletePost(post);
+            }
+            if (mLoadingDialog == null || isActivityDestroyed() || isFinishing()) {
+                return;
+            }
             dismissDialog(ID_DIALOG_DELETING);
             attemptToSelectPost();
             if (result) {
@@ -414,7 +419,6 @@ public class PostsActivity extends WPActionBarActivity
                         R.string.page_deleted : R.string.post_deleted),
                         Toast.LENGTH_SHORT).show();
                 checkForLocalChanges(false);
-                WordPress.wpDB.deletePost(post);
                 mPostList.requestPosts(false);
                 mPostList.setRefreshing(true);
             } else {


### PR DESCRIPTION
This code is going to die with the new editor, so IMO, we should only assure minimum maintenance.

Note: we should remove all progress dialogs and replace them with in place progress bar / animation.
