### PR TITLE
fix #1681: NPE in CommentsListFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -514,7 +514,7 @@ public class CommentsListFragment extends Fragment {
                         return;
                 }
             }
-            if (comments != null && comments.size() > 0) {
+            if (!getActivity().isFinishing() && comments != null && comments.size() > 0) {
                 getCommentAdapter().loadComments();
             }
         }


### PR DESCRIPTION
bug introduced in 3.1 by this https://github.com/wordpress-mobile/WordPress-Android/pull/1656
