### PR TITLE
Track Mixpanel analytics event "stats scrolling to bottom"

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/ScrollViewExt.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/ScrollViewExt.java
@@ -1,0 +1,38 @@
+package org.wordpress.android.ui.stats;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.ScrollView;
+
+public class ScrollViewExt extends ScrollView {
+    private ScrollViewListener mScrollViewListener = null;
+    public ScrollViewExt(Context context) {
+        super(context);
+    }
+
+    public ScrollViewExt(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    public ScrollViewExt(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public void setScrollViewListener(ScrollViewListener scrollViewListener) {
+        this.mScrollViewListener = scrollViewListener;
+    }
+
+    @Override
+    protected void onScrollChanged(int l, int t, int oldl, int oldt) {
+        super.onScrollChanged(l, t, oldl, oldt);
+        if (mScrollViewListener != null) {
+            mScrollViewListener.onScrollChanged(this, l, t, oldl, oldt);
+        }
+    }
+
+    public interface ScrollViewListener {
+        void onScrollChanged(ScrollViewExt scrollView,
+                             int x, int y, int oldx, int oldy);
+    }
+}
+

--- a/WordPress/src/main/res/layout/stats_activity.xml
+++ b/WordPress/src/main/res/layout/stats_activity.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    <org.wordpress.android.ui.stats.ScrollViewExt xmlns:android="http://schemas.android.com/apk/res/android"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:id="@+id/scroll_view_stats"
@@ -127,5 +127,5 @@
                 android:layout_marginRight="@dimen/margin_medium" /> -->
 
         </LinearLayout>
-    </ScrollView>
+    </org.wordpress.android.ui.stats.ScrollViewExt>
 </uk.co.senab.actionbarpulltorefresh.library.PullToRefreshLayout>


### PR DESCRIPTION
Fix #1714 by tracking the scrolling state of the main ScrollView used in Stats screen.

Unfortunately there is not an obvious way to do this without extending ScrollView.
also used a limited task with a guard of 2 secs, otherwise multiple bottom reached events can be tracked at the same time.

/cc @sendhil 
