### PR TITLE
fix #1789: remove call to invalidate in onScroll callback

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPActionBarActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPActionBarActivity.java
@@ -308,17 +308,6 @@ public abstract class WPActionBarActivity extends Activity {
                 // if we have an intent, start the new activity
             }
         });
-        mListView.setOnScrollListener(new AbsListView.OnScrollListener() {
-            @Override
-            public void onScrollStateChanged(AbsListView view, int scrollState) {
-            }
-
-            @Override
-            public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount,
-                    int totalItemCount) {
-                mMenuDrawer.invalidate();
-            }
-        });
 
         mMenuDrawer.setMenuView(mListView);
         mListView.setAdapter(mAdapter);


### PR DESCRIPTION
fix #1789: remove call to invalidate in onScroll callback
