### PR TITLE
Added default values for all INTEGER columns that were missing them

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -19,7 +19,7 @@ import java.io.OutputStream;
  */
 public class ReaderDatabase extends SQLiteOpenHelper {
     protected static final String DB_NAME = "wpreader.db";
-    private static final int DB_VERSION = 81;
+    private static final int DB_VERSION = 90;
 
     /*
      * version history
@@ -38,6 +38,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      *   79 - added is_likes_enabled and is_sharing_enabled to tbl_posts
      *   80 - added tbl_comment_likes in ReaderLikeTable, added num_likes to tbl_comments
      *   81 - added image_url to tbl_blog_info
+     *   90 - added default values for all INTEGER columns that were missing them (hotfix 3.1.1)
      */
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderLikeTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderLikeTable.java
@@ -17,15 +17,15 @@ import org.wordpress.android.util.SqlUtils;
 public class ReaderLikeTable {
     protected static void createTables(SQLiteDatabase db) {
         db.execSQL("CREATE TABLE tbl_post_likes ("
-                + " post_id        INTEGER,"
-                + " blog_id        INTEGER,"
-                + " user_id        INTEGER,"
+                + " post_id        INTEGER DEFAULT 0,"
+                + " blog_id        INTEGER DEFAULT 0,"
+                + " user_id        INTEGER DEFAULT 0,"
                 + " PRIMARY KEY (blog_id, post_id, user_id))");
 
         db.execSQL("CREATE TABLE tbl_comment_likes ("
-                + " comment_id     INTEGER,"
-                + " blog_id        INTEGER,"
-                + " user_id        INTEGER,"
+                + " comment_id     INTEGER DEFAULT 0,"
+                + " blog_id        INTEGER DEFAULT 0,"
+                + " user_id        INTEGER DEFAULT 0,"
                 + " PRIMARY KEY (blog_id, comment_id, user_id))");
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -53,8 +53,8 @@ public class ReaderPostTable {
 
     protected static void createTables(SQLiteDatabase db) {
         db.execSQL("CREATE TABLE tbl_posts ("
-                + "	post_id		        INTEGER,"       // post_id for WP blogs, feed_item_id for non-WP blogs
-                + " blog_id             INTEGER,"       // blog_id for WP blogs, feed_id for non-WP blogs
+                + "	post_id		        INTEGER DEFAULT 0,"   // post_id for WP blogs, feed_item_id for non-WP blogs
+                + " blog_id             INTEGER DEFAULT 0,"   // blog_id for WP blogs, feed_id for non-WP blogs
                 + " pseudo_id           TEXT NOT NULL,"
                 + "	author_name	        TEXT,"
                 + " author_id           INTEGER DEFAULT 0,"
@@ -87,8 +87,8 @@ public class ReaderPostTable {
                 + ")");
 
         db.execSQL("CREATE TABLE tbl_post_tags ("
-                + "   post_id     INTEGER NOT NULL,"
-                + "   blog_id     INTEGER NOT NULL,"
+                + "   post_id     INTEGER DEFAULT 0,"
+                + "   blog_id     INTEGER DEFAULT 0,"
                 + "   pseudo_id   TEXT NOT NULL,"
                 + "   tag_name    TEXT NOT NULL COLLATE NOCASE,"
                 + "   tag_type    INTEGER DEFAULT 0,"

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderThumbnailTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderThumbnailTable.java
@@ -15,7 +15,7 @@ public class ReaderThumbnailTable {
         db.execSQL("CREATE TABLE tbl_thumbnails ("
                 + "	full_url	  TEXT COLLATE NOCASE PRIMARY KEY,"
                 + " thumbnail_url TEXT NOT NULL,"
-                + " post_id       INTEGER)");
+                + " post_id       INTEGER DEFAULT 0)");
     }
 
     protected static void dropTables(SQLiteDatabase db) {


### PR DESCRIPTION
Fix #1812 - **This is for the hotfix/3.1.1 branch - a separate PR for this issue will be filed for 3.2** - Added default values for all INTEGER columns that were missing them - [see explanation](http://blog.tapreason.com/2014/03/02/how-to-resolve-java-lang-illegalstateexception-couldnt-read-row-0-col-y-from-cursorwindow-make-sure-the-cursor-is-initialized-correctly-before-accessing-data-from-it/)
