### PR TITLE
fix #1820: theme detail crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeDetailsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeDetailsFragment.java
@@ -292,27 +292,24 @@ public class ThemeDetailsFragment extends DialogFragment {
      * @param context
      * @author Karim Varela
      **/
-    private void populateViews(LinearLayout linearLayout, View[] views, Context context)
-    {
-        RelativeLayout.LayoutParams llParams = (android.widget.RelativeLayout.LayoutParams) linearLayout.getLayoutParams();
+    private void populateViews(LinearLayout linearLayout, View[] views, Context context) {
+        RelativeLayout.LayoutParams llParams =
+                (android.widget.RelativeLayout.LayoutParams) linearLayout.getLayoutParams();
 
         Display display = getActivity().getWindowManager().getDefaultDisplay();
         linearLayout.removeAllViews();
 
-        int maxWidth = display.getWidth() - llParams.leftMargin - llParams.rightMargin - mParentView.getPaddingLeft() - mParentView.getPaddingRight();
-
+        int maxWidth = display.getWidth() - llParams.leftMargin - llParams.rightMargin - mParentView.getPaddingLeft()
+                - mParentView.getPaddingRight();
 
         if (DisplayUtils.isXLarge(getActivity())) {
             int minDialogWidth = getResources().getDimensionPixelSize(R.dimen.theme_details_dialog_min_width);
             int dialogWidth = Math.max((int) (display.getWidth() * 0.6), minDialogWidth);
             maxWidth = dialogWidth / 2 - llParams.leftMargin - llParams.rightMargin;
-
-        } else if (DisplayUtils.isTablet(getActivity()) && mLeftContainer != null) {
+        } else if (mLeftContainer != null && mLeftContainer.getLayoutParams() instanceof LinearLayout.LayoutParams) {
             int spec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED);
             mLeftContainer.measure(spec, spec);
-
             LinearLayout.LayoutParams params = (LayoutParams) mLeftContainer.getLayoutParams();
-
             maxWidth -= mLeftContainer.getMeasuredWidth() + params.rightMargin + params.leftMargin;
         }
 

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/DisplayUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/DisplayUtils.java
@@ -52,6 +52,10 @@ public class DisplayUtils {
         return (int) ((px/displayMetrics.density)+0.5);
     }
 
+    /**
+     * Deprecated method, returns true on some phones.
+     */
+    @Deprecated
     public static boolean isTablet(Context context) {
         // http://stackoverflow.com/a/8427523/1673548
         if (context == null)


### PR DESCRIPTION
Other isTablet() calls seem harmless, so I filled this https://github.com/wordpress-mobile/WordPress-Android/issues/1821 for 3.3
