### PR TITLE
Like icon now reverses its rotation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderAnim.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderAnim.java
@@ -211,6 +211,8 @@ public class ReaderAnim {
                 // rotate like button +/- 72 degrees (72 = 360/5, 5 is the number of points in the star)
                 float endRotate = (button == ReaderButton.LIKE_ON ? 72f : -72f);
                 ObjectAnimator animRotate = ObjectAnimator.ofFloat(target, View.ROTATION, 0f, endRotate);
+                animRotate.setRepeatMode(ValueAnimator.REVERSE);
+                animRotate.setRepeatCount(1);
                 set.play(animX).with(animY).with(animRotate);
                 // on Android 4.4.3 the rotation animation may cause the drawable to fade out unless
                 // we set the layer type - https://code.google.com/p/android/issues/detail?id=70914


### PR DESCRIPTION
Fix #1817 - the like icon now reverses the rotation, which resolves the problem with the icon appearing to shift to the left. Note that this is for the 3.2 milestone, since it's needed by #1802 (another 3.2 PR).
