### PR TITLE
issue/1834-npe-reader-detail

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -1247,7 +1247,7 @@ public class ReaderPostDetailFragment extends Fragment
             imgFeatured = (WPNetworkImageView) container.findViewById(R.id.image_featured);
 
             imgBtnReblog = (ImageView) mLayoutIcons.findViewById(R.id.image_reblog_btn);
-            imgBtnLike = (ImageView) getView().findViewById(R.id.image_like_btn);
+            imgBtnLike = (ImageView) container.findViewById(R.id.image_like_btn);
             imgBtnComment = (ImageView) mLayoutIcons.findViewById(R.id.image_comment_btn);
 
             layoutDetailHeader = (ViewGroup) container.findViewById(R.id.layout_detail_header);


### PR DESCRIPTION
Fix #1834 - fixed NPE caused by incorrect use of getView() - note that this fix is intended for 3.1.2
