### PR TITLE
fix #1843: remove static fields from AuthErrorDialogFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/AuthenticationDialogUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AuthenticationDialogUtils.java
@@ -80,12 +80,14 @@ public class AuthenticationDialogUtils {
         }
         FragmentTransaction ft = activity.getFragmentManager().beginTransaction();
         AuthErrorDialogFragment authAlert;
-        if (WordPress.getCurrentBlog() == null) {
-            // No blogs found, so the user is logged in wpcom and doesn't own any blog
-            authAlert = AuthErrorDialogFragment.newInstance(true, titleResId, messageResId);
-        } else {
-            authAlert = AuthErrorDialogFragment.newInstance(WordPress.getCurrentBlog().isDotcomFlag(), titleResId, messageResId);
+        // Default to isDotCom (If WordPress.getCurrentBlog() == null: no blogs found,
+        // so the user is logged in wpcom and doesn't own any blog
+        boolean isDotCom = true;
+        if (WordPress.getCurrentBlog() != null) {
+            isDotCom = WordPress.getCurrentBlog().isDotcomFlag();
         }
+        authAlert = new AuthErrorDialogFragment();
+        authAlert.setWPComTitleMessage(isDotCom, titleResId, messageResId);
         ft.add(authAlert, ALERT_TAG);
         ft.commitAllowingStateLoss();
     }

--- a/WordPress/src/main/java/org/wordpress/android/widgets/AuthErrorDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/AuthErrorDialogFragment.java
@@ -18,11 +18,11 @@ import org.wordpress.android.ui.prefs.BlogPreferencesActivity;
 public class AuthErrorDialogFragment extends DialogFragment {
     public static int DEFAULT_RESOURCE_ID = -1;
 
-    private static boolean mIsWPCom;
-    private static int mMessageId;
-    private static int mTitleId;
+    private boolean mIsWPCom;
+    private int mMessageId = R.string.incorrect_credentials;
+    private int mTitleId = R.string.connection_error;
 
-    public static AuthErrorDialogFragment newInstance(boolean isWPCom, int titleResourceId, int messageResourceId) {
+    public void setWPComTitleMessage(boolean isWPCom, int titleResourceId, int messageResourceId) {
         mIsWPCom = isWPCom;
 
         if (titleResourceId != DEFAULT_RESOURCE_ID) {
@@ -38,7 +38,6 @@ public class AuthErrorDialogFragment extends DialogFragment {
         } else {
             mMessageId = R.string.incorrect_credentials;
         }
-        return new AuthErrorDialogFragment();
     }
 
     @Override


### PR DESCRIPTION
fix #1843: remove static fields from AuthErrorDialogFragment
