### PR TITLE
Fixes low res avatar in reader post detail

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -1127,7 +1127,7 @@ public class ReaderPostDetailFragment extends Fragment
 
             if (mPost.hasPostAvatar()) {
                 imgAvatar.setImageUrl(mPost.getPostAvatarForDisplay(
-                        mResourceVars.likeAvatarSizePx), WPNetworkImageView.ImageType.AVATAR);
+                        mResourceVars.headerAvatarSizePx), WPNetworkImageView.ImageType.AVATAR);
                 imgAvatar.setVisibility(View.VISIBLE);
             } else {
                 imgAvatar.setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderResourceVars.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderResourceVars.java
@@ -15,6 +15,7 @@ class ReaderResourceVars {
     final int displayWidthPx;
     final int actionBarHeightPx;
     final int likeAvatarSizePx;
+    final int headerAvatarSizePx;
 
     final int marginLargePx;
     final int marginSmallPx;
@@ -41,6 +42,7 @@ class ReaderResourceVars {
         displayWidthPx = DisplayUtils.getDisplayPixelWidth(context);
         actionBarHeightPx = DisplayUtils.getActionBarHeight(context);
         likeAvatarSizePx = resources.getDimensionPixelSize(R.dimen.avatar_sz_small);
+        headerAvatarSizePx = resources.getDimensionPixelSize(R.dimen.avatar_sz_medium);
         featuredImageHeightPx = resources.getDimensionPixelSize(R.dimen.reader_featured_image_height);
 
         marginLargePx = resources.getDimensionPixelSize(R.dimen.margin_large);


### PR DESCRIPTION
Add an additional avatar size to `ReaderResourceVars`.

Fixes #1856
