### PR TITLE
Remove setOngoing() flag from the post upload notification.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
@@ -819,8 +819,7 @@ public class PostUploadService extends Service {
 
             mNotificationBuilder =
                     new NotificationCompat.Builder(getApplicationContext())
-                            .setSmallIcon(android.R.drawable.stat_sys_upload)
-                            .setOngoing(true);
+                            .setSmallIcon(android.R.drawable.stat_sys_upload);
 
             Intent notificationIntent = new Intent(mContext, post.isPage() ? PagesActivity.class : PostsActivity.class);
             notificationIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP


### PR DESCRIPTION
I couldn't get to the root cause of what causes the HTTP client to die when switching networks (ref #1827).

For now I removed the `ongoing` flag so if the post upload does get stuck, at least the user can swipe away the notification. The drawback is that if you swipe while the upload is happening, it reappears again as soon as the progress updates. But I figured that annoyance was smaller than having a notification that you can't get rid of without force closing the app entirely.
