### PR TITLE
Check if notifications bucket is null in NotificationsListFragment 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -82,13 +82,13 @@ public class NotificationsListFragment extends ListFragment implements Bucket.Li
         refreshNotes();
 
         // start listening to bucket change events
-        mBucket.addListener(this);
+        if (mBucket != null) mBucket.addListener(this);
     }
 
     @Override
     public void onPause() {
         // unregister the listener
-        mBucket.removeListener(this);
+       if (mBucket != null) mBucket.removeListener(this);
 
         super.onPause();
     }


### PR DESCRIPTION
When WordPress is built with the example `gradle.properties` Simperium is not configured so the bucket instance is `null`.

Results in an empty list view.

Fixes #1865
