### PR TITLE
issue/1871-reader-detail-illegal-state

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -19,7 +19,7 @@ import java.io.OutputStream;
  */
 public class ReaderDatabase extends SQLiteOpenHelper {
     protected static final String DB_NAME = "wpreader.db";
-    private static final int DB_VERSION = 92;
+    private static final int DB_VERSION = 93;
 
     /*
      * version history
@@ -44,6 +44,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      *   85 - removed tbl_attachments, added attachments_json to tbl_posts
      *   90 - added default values for all INTEGER columns that were missing them (hotfix 3.1.1)
      *   92 - added default values for all INTEGER columns that were missing them (3.2)
+     *   93 - tbl_posts text is now truncated to a max length (3.3)
      */
 
     /*

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -649,6 +649,7 @@
     <string name="reader_label_tag_preview">Posts tagged %s</string>
     <string name="reader_label_reached_last_post">You\'ve reached the end</string>
     <string name="reader_label_tap_to_dismiss">Tap to dismiss</string>
+    <string name="reader_label_view_original">View original article</string>
 
     <!-- like counts liking users activity-->
     <string name="reader_label_like">Like</string>


### PR DESCRIPTION
Fix #1871 - in rare cases, storing very large text columns could result in an IllegalStateException when the row was read due to the 2MB size limit for Android's CursorWindow ( see [here](https://github.com/android/platform_frameworks_base/blob/master/core/res/res/values/config.xml#L946) and [here](https://github.com/android/platform_frameworks_base/blob/3bdbf644d61f46b531838558fabbd5b990fc4913/core/java/android/database/CursorWindow.java#L103) ).

This PR works around the problem by limiting the size of the string stored in the text column.
