### PR TITLE
fix #1897: null check mBucket onResume/onPause

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -105,7 +105,7 @@ public class NotificationsListFragment extends ListFragment implements Bucket.Li
         }
 
         mFauxPullToRefreshHelper.unregisterReceiver(getActivity());
-        super.onDestroyView();
+        super.onDestroy();
     }
 
     private void initPullToRefreshHelper() {


### PR DESCRIPTION
fix #1897: null check mBucket onResume/onPause
