### PR TITLE
issue/1899-illegal-state-reader-pager

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -343,12 +343,16 @@ public class ReaderPostPagerActivity extends Activity
         return true;
     }
 
-    private ReaderPostDetailFragment getActiveDetailFragment() {
-        if (!hasPagerAdapter()) {
+    private Fragment getActivePagerFragment() {
+        if (hasPagerAdapter()) {
+            return getPagerAdapter().getActiveFragment();
+        } else {
             return null;
         }
+    }
 
-        Fragment fragment = getPagerAdapter().getActiveFragment();
+    private ReaderPostDetailFragment getActiveDetailFragment() {
+        Fragment fragment = getActivePagerFragment();
         if (fragment instanceof ReaderPostDetailFragment) {
             return (ReaderPostDetailFragment) fragment;
         } else {
@@ -385,7 +389,7 @@ public class ReaderPostPagerActivity extends Activity
             return;
         }
 
-        Fragment fragment = getPagerAdapter().getActiveFragment();
+        Fragment fragment = getActivePagerFragment();
         if (fragment == null) {
             return;
         }
@@ -444,7 +448,7 @@ public class ReaderPostPagerActivity extends Activity
 
         // reload the adapter and move to the best post not in the blocked blog
         int position = mViewPager.getCurrentItem();
-        ReaderBlogIdPostId newId = getPagerAdapter().getBestIdNotInBlog(position, blogId);
+        ReaderBlogIdPostId newId = (hasPagerAdapter() ? getPagerAdapter().getBestIdNotInBlog(position, blogId) : null);
         long newBlogId = (newId != null ? newId.getBlogId() : 0);
         long newPostId = (newId != null ? newId.getPostId() : 0);
         loadPosts(newBlogId, newPostId, false);


### PR DESCRIPTION
Fix #1899 - exception appeared to be caused by re-using the same adapter (mPagerAdapter) that was already assigned to the ViewPager, resulting in potential problems when attempting to restore the adapter's state. This PR prevents the problem by creating a new adapter when necessary, and  null-ing the previous adapter if one is assigned.
