### PR TITLE
Check for a valid `comment` before moderating.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -737,29 +737,24 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         if (!isAdded() || !hasComment())
             return;
 
-        final CommentStatus newStatus;  // status to apply when moderation button is tapped
         final int statusTextResId;      // string resource id for status text
         final int statusColor;          // color for status text
 
         switch (mComment.getStatusEnum()) {
             case APPROVED:
-                newStatus = CommentStatus.UNAPPROVED;
                 statusTextResId = R.string.comment_status_approved;
                 statusColor = getActivity().getResources().getColor(R.color.calypso_orange_dark);
                 break;
             case UNAPPROVED:
-                newStatus = CommentStatus.APPROVED;
                 statusTextResId = R.string.comment_status_unapproved;
                 statusColor = getActivity().getResources().getColor(R.color.calypso_orange_dark);
                 break;
             case SPAM:
-                newStatus = CommentStatus.APPROVED;
                 statusTextResId = R.string.comment_status_spam;
                 statusColor = getActivity().getResources().getColor(R.color.comment_status_spam);
                 break;
             case TRASH:
             default:
-                newStatus = CommentStatus.APPROVED;
                 statusTextResId = R.string.comment_status_trash;
                 statusColor = getActivity().getResources().getColor(R.color.comment_status_spam);
                 break;
@@ -796,6 +791,11 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
                 @Override
                 public void onClick(View v) {
                     if (!hasComment()) return;
+
+                    CommentStatus newStatus = CommentStatus.APPROVED;
+                    if (mComment.getStatusEnum() == CommentStatus.APPROVED) {
+                        newStatus = CommentStatus.UNAPPROVED;
+                    }
 
                     mComment.setStatus(newStatus.toString());
                     setModerateButtonForStatus(newStatus);


### PR DESCRIPTION
Hard to reproduce, but I think this could have happened if the button click event was triggered after `onPause()`.

Fixes #1900
