### PR TITLE
issue/1927-motion-event-illegal-argument

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerActivity.java
@@ -12,10 +12,11 @@ import android.view.Window;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
-import org.wordpress.android.ui.reader.views.ReaderPhotoView.PhotoViewListener;
 import org.wordpress.android.ui.reader.ReaderViewPagerTransformer.TransformType;
 import org.wordpress.android.ui.reader.models.ReaderImageList;
 import org.wordpress.android.ui.reader.utils.ReaderImageScanner;
+import org.wordpress.android.ui.reader.views.ReaderPhotoView.PhotoViewListener;
+import org.wordpress.android.ui.reader.views.ReaderViewPager;
 import org.wordpress.android.util.AppLog;
 
 import javax.annotation.Nonnull;
@@ -30,7 +31,7 @@ public class ReaderPhotoViewerActivity extends Activity
     private String mInitialImageUrl;
     private boolean mIsPrivate;
     private String mContent;
-    private ViewPager mViewPager;
+    private ReaderViewPager mViewPager;
     private TextView mTxtTitle;
     private boolean mIsTitleVisible;
 
@@ -41,7 +42,7 @@ public class ReaderPhotoViewerActivity extends Activity
         requestWindowFeature(Window.FEATURE_NO_TITLE);
         setContentView(R.layout.reader_activity_photo_viewer);
 
-        mViewPager = (ViewPager) findViewById(R.id.viewpager);
+        mViewPager = (ReaderViewPager) findViewById(R.id.viewpager);
         mTxtTitle = (TextView) findViewById(R.id.text_title);
 
         // title is hidden until we know we can show it

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -36,6 +36,7 @@ import org.wordpress.android.ui.reader.actions.ReaderBlogActions.BlockedBlogResu
 import org.wordpress.android.ui.reader.actions.ReaderPostActions;
 import org.wordpress.android.ui.reader.models.ReaderBlogIdPostId;
 import org.wordpress.android.ui.reader.models.ReaderBlogIdPostIdList;
+import org.wordpress.android.ui.reader.views.ReaderViewPager;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -51,7 +52,7 @@ public class ReaderPostPagerActivity extends Activity
         implements ReaderInterfaces.FullScreenListener,
                    ReaderInterfaces.OnPostPopupListener {
 
-    private ViewPager mViewPager;
+    private ReaderViewPager mViewPager;
 
     private ReaderTag mCurrentTag;
     private long mCurrentBlogId;
@@ -78,7 +79,7 @@ public class ReaderPostPagerActivity extends Activity
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
 
-        mViewPager = (ViewPager) findViewById(R.id.viewpager);
+        mViewPager = (ReaderViewPager) findViewById(R.id.viewpager);
 
         final String title;
         final long blogId;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderViewPager.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderViewPager.java
@@ -1,0 +1,47 @@
+package org.wordpress.android.ui.reader.views;
+
+import android.content.Context;
+import android.support.v4.view.ViewPager;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+
+import org.wordpress.android.util.AppLog;
+
+/*
+ * custom ViewPager which resolves the "pointer index out of range" bug in the compatibility library
+ * https://code.google.com/p/android/issues/detail?id=16836
+ * https://code.google.com/p/android/issues/detail?id=18990
+ * https://github.com/chrisbanes/PhotoView/issues/31
+ *
+ */
+
+public class ReaderViewPager extends ViewPager {
+
+    public ReaderViewPager(Context context) {
+        super(context);
+    }
+
+    public ReaderViewPager(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent ev) {
+        try {
+            return super.onInterceptTouchEvent(ev);
+        } catch (IllegalArgumentException e) {
+            AppLog.e(AppLog.T.READER, e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent ev) {
+        try {
+            return super.onTouchEvent(ev);
+        } catch (IllegalArgumentException e) {
+            AppLog.e(AppLog.T.READER, e);
+            return false;
+        }
+    }
+}

--- a/WordPress/src/main/res/layout/reader_activity_photo_viewer.xml
+++ b/WordPress/src/main/res/layout/reader_activity_photo_viewer.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     android:background="@color/grey_extra_dark">
 
-    <android.support.v4.view.ViewPager
+    <org.wordpress.android.ui.reader.views.ReaderViewPager
         android:id="@+id/viewpager"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />

--- a/WordPress/src/main/res/layout/reader_activity_post_pager.xml
+++ b/WordPress/src/main/res/layout/reader_activity_post_pager.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.view.ViewPager xmlns:android="http://schemas.android.com/apk/res/android"
+<org.wordpress.android.ui.reader.views.ReaderViewPager
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/viewpager"
     android:layout_width="match_parent"
     android:layout_height="wrap_content" />


### PR DESCRIPTION
Fix #1927 - I could never reproduce the problem, but I'm pretty sure this bug is the same as the one [described here](https://github.com/chrisbanes/PhotoView/issues/31) which would impact the ReaderPhotoViewerActivity. Resolved the problem by having that activity and ReaderPostPagerActivity use a custom ViewPager which catches the IllegalArgumentException. 
