### PR TITLE
fix #1935: move EDITOR_CREATED_POST tracking and add a source property

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
@@ -20,7 +20,6 @@ import android.widget.Toast;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
-import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.models.Post;
 import org.wordpress.android.models.PostStatus;
@@ -267,7 +266,6 @@ public class PostsActivity extends WPActionBarActivity
     }
 
     public void newPost() {
-        AnalyticsTracker.track(AnalyticsTracker.Stat.EDITOR_CREATED_POST);
         if (WordPress.getCurrentBlog() == null) {
             if (!isFinishing())
                 Toast.makeText(this, R.string.blog_not_found, Toast.LENGTH_SHORT).show();


### PR DESCRIPTION
fix #1935 

There are actually 5 ways to create a post from the Android app:
1. from the Post List
2. from the Media Library
3. from QuickPress
4. from QuickPhoto or QuickVideo
5. from an external app (using the "Share with..." Android feature)

cc @sendhil 
