### PR TITLE
issue/1941-reader-illegal-state-onbackpressed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -4,7 +4,6 @@ import android.app.ActionBar;
 import android.app.Activity;
 import android.app.Fragment;
 import android.os.Bundle;
-import android.os.Handler;
 import android.os.Parcelable;
 import android.text.Html;
 import android.text.TextUtils;
@@ -1243,16 +1242,7 @@ public class ReaderPostListFragment extends Fragment
                         @Override
                         public void onBlogInfoFailed() {
                             if (isAdded()) {
-                                // blog couldn't be shown, alert user then back out after a brief delay
-                                ToastUtils.showToast(getActivity(), R.string.reader_toast_err_get_blog_info);
-                                new Handler().postDelayed(new Runnable() {
-                                    @Override
-                                    public void run() {
-                                        if (isAdded()) {
-                                            getActivity().onBackPressed();
-                                        }
-                                    }
-                                }, 1000);
+                                ToastUtils.showToast(getActivity(), R.string.reader_toast_err_get_blog_info, ToastUtils.Duration.LONG);
                             }
                         }
                     }


### PR DESCRIPTION
Fix #1941 by no longer closing the activity (via onBackPressed) when blog info fails to load.
