### PR TITLE
Added isAdded() check to restoreListScrollPosition()

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -200,7 +200,7 @@ public class NotificationsListFragment extends ListFragment implements Bucket.Li
     }
 
     private void restoreListScrollPosition() {
-        if (getListView() != null && mRestoredListPosition != ListView.INVALID_POSITION
+        if (isAdded() && getListView() != null && mRestoredListPosition != ListView.INVALID_POSITION
                 && mRestoredListPosition < mNotesAdapter.getCount()) {
             // Restore scroll position in list
             getListView().setSelectionFromTop(mRestoredListPosition, 0);


### PR DESCRIPTION
There's a chance this will fix #1928, but can't know for sure until after the 3.3. release.
