### PR TITLE
Using forked build of AndroidAsync

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -97,8 +97,13 @@ dependencies {
     compile 'org.wordpress:android-passcodelock:0.0.6'
     compile 'org.wordpress:emailchecker:0.3'
 
+    // Patched version of AndroidAsync see simperium/simperium-android issue #156
+    compile 'org.wordpress:androidasync:1.3.9-SNAPSHOT@aar'
     // Simperium
-    compile('com.simperium.android:simperium:0.5.0')
+    compile('com.simperium.android:simperium:0.5.0') {
+        exclude group: 'com.koushikdutta.async', module: 'androidasync'
+    }
+
 
     releaseCompile project(path:':libs:utils:WordPressUtils', configuration: 'release')
     debugCompile project(path:':libs:utils:WordPressUtils', configuration: 'debug')


### PR DESCRIPTION
Excludes the AndroidAsync dependency in Simperium and uses the forked build that fixes Simperium/Simperium-Android#156

The build includes fix for https://github.com/koush/AndroidAsync/issues/237
