### PR TITLE
Using CalypsoTheme for some Activities that didn't have it set.

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -155,7 +155,9 @@
         </activity>
 
         <!-- Theme Activities -->
-        <activity android:name=".ui.themes.ThemeBrowserActivity" >
+        <activity
+            android:name=".ui.themes.ThemeBrowserActivity"
+            android:theme="@style/CalypsoTheme" >
         </activity>
 
         <!-- Deep Linking Activity -->


### PR DESCRIPTION
Without the CalypsoTheme applied overflow menus were inconsistent between Activities. I've done a side-by-side comparison of all the activities and didn't notice anything else changing substantially.
