### PR TITLE
Check Bucket.ChangeType in Simperium Bucket Listeners

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -353,6 +353,9 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
 
     @Override
     public void onChange(Bucket<Note> noteBucket, Bucket.ChangeType changeType, String noteId) {
+        // We're not interested in INDEX events here
+        if (changeType == Bucket.ChangeType.INDEX) return;
+
         // Refresh content if we receive a change for the Note
         if (mNote != null && mNote.getId().equals(noteId)) {
             // If the note was removed, pop the back stack to return to the notes list

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -245,15 +245,17 @@ public class NotificationsListFragment extends ListFragment implements Bucket.Li
 
     @Override
     public void onChange(Bucket<Note> bucket, Bucket.ChangeType type, String key) {
-        // Reset the note's local status when a change is received
-        try {
-            Note note = bucket.get(key);
-            if (note.isCommentType()) {
-                note.setLocalStatus(null);
-                note.save();
+        if (type == Bucket.ChangeType.MODIFY) {
+            // Reset the note's local status when a change is received
+            try {
+                Note note = bucket.get(key);
+                if (note.isCommentType()) {
+                    note.setLocalStatus(null);
+                    note.save();
+                }
+            } catch (BucketObjectMissingException e) {
+                AppLog.e(AppLog.T.NOTIFS, "Could not create note after receiving change.");
             }
-        } catch (BucketObjectMissingException e) {
-            AppLog.e(AppLog.T.NOTIFS, "Could not create note after receiving change.");
         }
 
         refreshNotes();


### PR DESCRIPTION
Ignore `INDEX` changes in the bucket listener in `NotificationsDetailListFragment`.

Change local status of note only when we receive a `MODIFY` type from simperium in `NotificationsListFragment`.

Fixes #2000.
