### PR TITLE
fix #1463: Remove unused isNew() method

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/Post.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Post.java
@@ -473,11 +473,11 @@ public class Post implements Serializable {
         return postContent;
     }
 
-    public boolean isNew() {
-        return getLocalTablePostId() >= 0;
+    public boolean isPublished() {
+        return !getRemotePostId().isEmpty();
     }
 
     public boolean isPublishable() {
-        return !(isNew() && getContent().isEmpty() && getPostExcerpt().isEmpty() && getTitle().isEmpty());
+        return !(getContent().isEmpty() && getPostExcerpt().isEmpty() && getTitle().isEmpty());
     }
 }


### PR DESCRIPTION
fix #1463: Remove unused isNew() method

Replaced `isNew()` by `isPublished()` and removed the test in `isPublishable()` since server will reply with a 500 error if we try to update a post with empty title and content.
