### PR TITLE
issue/2018-drawer-shadow

### DIFF
--- a/WordPress/src/main/res/layout/activity_drawer_static.xml
+++ b/WordPress/src/main/res/layout/activity_drawer_static.xml
@@ -5,26 +5,23 @@
 
     <include layout="@layout/toolbar" />
 
-    <include
-        layout="@layout/menu_drawer"
-        android:layout_width="@dimen/menu_drawer_width"
-        android:layout_height="match_parent"
-        android:layout_below="@+id/toolbar" />
-
-    <ImageView
-        android:id="@+id/image_drawer_shadow"
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_below="@+id/toolbar"
-        android:layout_toRightOf="@+id/left_drawer"
-        android:src="@drawable/drawer_shadow" />
+        android:orientation="horizontal">
 
-    <LinearLayout
-        android:id="@+id/activity_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_below="@+id/toolbar"
-        android:layout_toRightOf="@+id/image_drawer_shadow"
-        android:orientation="vertical" />
+        <include
+            layout="@layout/menu_drawer"
+            android:layout_width="@dimen/menu_drawer_width"
+            android:layout_height="match_parent" />
+
+        <LinearLayout
+            android:id="@+id/activity_container"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginLeft="@dimen/margin_extra_small"
+            android:orientation="vertical" />
+    </LinearLayout>
 
 </RelativeLayout>


### PR DESCRIPTION
Fix #2018 - removed the shadow image from the static drawer, added a small margin between the drawer and the activity container.
