### PR TITLE
fix #2023: mGridAdapter was called before creation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
@@ -75,6 +75,10 @@ public class MediaGalleryPickerActivity extends Activity
         mGridView = (GridView) findViewById(R.id.media_gallery_picker_gridview);
         mGridView.setMultiChoiceModeListener(this);
         mGridView.setOnItemClickListener(this);
+        mGridAdapter = new MediaGridAdapter(this, null, 0, MediaImageLoader.getInstance());
+        mGridAdapter.setSelectedItems(selectedItems);
+        mGridAdapter.setCallback(this);
+        mGridView.setAdapter(mGridAdapter);
         if (mIsSelectOneItem) {
             setTitle(R.string.select_from_media_library);
             ActionBar actionBar = getActionBar();
@@ -86,10 +90,6 @@ public class MediaGalleryPickerActivity extends Activity
             mActionMode.setTitle(String.format(getString(R.string.cab_selected),
                     mGridAdapter.getSelectedItems().size()));
         }
-        mGridAdapter = new MediaGridAdapter(this, null, 0, MediaImageLoader.getInstance());
-        mGridAdapter.setSelectedItems(selectedItems);
-        mGridAdapter.setCallback(this);
-        mGridView.setAdapter(mGridAdapter);
     }
 
     @Override


### PR DESCRIPTION
fix #2023: mGridAdapter was called before creation

To reproduce the issue before the fix:
1. Create a gallery from the media library
1. Tap the plus button to add another image to the gallery: crash
