### PR TITLE
Fixes vertical centering of 'badge' notification types.

### DIFF
--- a/WordPress/src/main/res/layout/notifications_fragment_detail_list.xml
+++ b/WordPress/src/main/res/layout/notifications_fragment_detail_list.xml
@@ -1,15 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/notifications_list_root"
-    android:orientation="vertical"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ListView
-        android:id="@id/android:list"
+    <!-- this container is needed in order to center the content of 'badge' notification types. -->
+    <LinearLayout
+        android:id="@+id/notifications_list_root"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:listSelector="@android:color/transparent" />
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-</LinearLayout>
+        <ListView
+            android:id="@id/android:list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:listSelector="@android:color/transparent" />
+
+    </LinearLayout>
+
+</RelativeLayout>


### PR DESCRIPTION
The linear layout that applies the centering gravity needed to be a child of a root layout element.

Fixes #2037 
