### PR TITLE
Removed left/right margin from comment box

### DIFF
--- a/WordPress/src/main/res/layout/reader_activity_comment_list.xml
+++ b/WordPress/src/main/res/layout/reader_activity_comment_list.xml
@@ -46,9 +46,7 @@
         android:id="@+id/layout_bottom"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_marginLeft="@dimen/reader_detail_margin"
-        android:layout_marginRight="@dimen/reader_detail_margin">
+        android:layout_alignParentBottom="true">
 
         <include
             android:id="@+id/layout_comment_box"


### PR DESCRIPTION
Fix #2051 - removed the left/right margin from the comment box
