### PR TITLE
issue/2062-drawer-scrolling

### DIFF
--- a/WordPress/src/main/res/layout/drawer.xml
+++ b/WordPress/src/main/res/layout/drawer.xml
@@ -24,7 +24,7 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_above="@+id/layout_drawer_footer"
-        android:layout_marginBottom="@dimen/drawer_divider_margin"
+        android:layout_marginBottom="@dimen/margin_small"
         android:layout_marginTop="@dimen/margin_extra_small"
         android:background="@color/drawer_divider" />
 
@@ -33,7 +33,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
-        android:layout_marginBottom="@dimen/drawer_divider_margin"
+        android:layout_marginBottom="@dimen/margin_small"
         android:orientation="vertical">
 
         <RelativeLayout

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -24,12 +24,12 @@
     <dimen name="drawer_row_height">40dp</dimen>
     <dimen name="drawer_icon_size">24dp</dimen>
     <dimen name="drawer_badge_size">24dp</dimen>
-    <dimen name="drawer_divider_margin">8dp</dimen>
-    <dimen name="drawer_header_size">@dimen/drawer_header_size_normal</dimen>
-    <dimen name="drawer_header_size_normal">96dp</dimen>
-    <dimen name="drawer_header_size_tablet">128dp</dimen>
+    <dimen name="drawer_divider_margin">6dp</dimen>
     <dimen name="drawer_text_keyline">72dp</dimen>
     <dimen name="drawer_row_keyline">16dp</dimen>
+    <dimen name="drawer_header_size">@dimen/drawer_header_size_normal</dimen>
+    <dimen name="drawer_header_size_normal">88dp</dimen>
+    <dimen name="drawer_header_size_tablet">128dp</dimen>
 
 	<dimen name="media_grid_local_image_width">160dp</dimen>
 	<dimen name="media_grid_progress_height">50dp</dimen>


### PR DESCRIPTION
Fix #2062 - reduced the header size and the size of margins around dividers to decrease the likelihood of needing to scroll the drawer.

@roundhill This should remove the need to scroll the drawer when using larger displays like the N5.
