### PR TITLE
issue/2063-reader-restore-position

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -30,5 +30,6 @@ public class ReaderConstants {
     static final String KEY_ALREADY_UPDATED   = "already_updated";
     static final String KEY_ALREADY_REQUESTED = "already_requested";
     static final String KEY_LIST_STATE        = "list_state";
+    static final String KEY_RESTORE_POSITION  = "restore_position";
     static final String KEY_WAS_PAUSED        = "was_paused";
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.ActionBarActivity;
+import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.Toolbar;
 import android.text.Html;
 import android.text.TextUtils;
@@ -88,6 +89,7 @@ public class ReaderPostListFragment extends Fragment {
     private long mCurrentBlogId;
     private String mCurrentBlogUrl;
     private ReaderPostListType mPostListType;
+    private int mRestorePosition;
 
     private boolean mIsUpdating;
     private boolean mWasPaused;
@@ -191,6 +193,7 @@ public class ReaderPostListFragment extends Fragment {
             if (getPostListType() == ReaderPostListType.TAG_PREVIEW) {
                 mTagPreviewHistory.restoreInstance(savedInstanceState);
             }
+            mRestorePosition = savedInstanceState.getInt(ReaderConstants.KEY_RESTORE_POSITION);
             mWasPaused = savedInstanceState.getBoolean(ReaderConstants.KEY_WAS_PAUSED);
         }
     }
@@ -238,9 +241,18 @@ public class ReaderPostListFragment extends Fragment {
         outState.putLong(ReaderConstants.ARG_BLOG_ID, mCurrentBlogId);
         outState.putString(ReaderConstants.ARG_BLOG_URL, mCurrentBlogUrl);
         outState.putBoolean(ReaderConstants.KEY_WAS_PAUSED, mWasPaused);
+        outState.putInt(ReaderConstants.KEY_RESTORE_POSITION, getCurrentPosition());
         outState.putSerializable(ReaderConstants.ARG_POST_LIST_TYPE, getPostListType());
 
         super.onSaveInstanceState(outState);
+    }
+
+    private int getCurrentPosition() {
+        if (mRecyclerView != null && hasPostRecycler()) {
+            return ((LinearLayoutManager) mRecyclerView.getLayoutManager()).findFirstVisibleItemPosition();
+        } else {
+            return 0;
+        }
     }
 
     @Override
@@ -602,7 +614,11 @@ public class ReaderPostListFragment extends Fragment {
                 mEmptyView.setVisibility(View.VISIBLE);
             } else {
                 mEmptyView.setVisibility(View.GONE);
+                if (mRestorePosition > 0) {
+                    mRecyclerView.scrollToPosition(mRestorePosition);
+                }
             }
+            mRestorePosition = 0;
         }
     };
 


### PR DESCRIPTION
Fix #2063 - reader list view now restores its position after rotation.
