### PR TITLE
Use a circular shape drawable as the background of the moderating progress view

### DIFF
--- a/WordPress/src/main/res/drawable/shape_oval_translucent.xml
+++ b/WordPress/src/main/res/drawable/shape_oval_translucent.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval" >
+    <solid android:color="@color/translucent" />
+</shape>

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -84,7 +84,7 @@
                     android:layout_width="@dimen/avatar_sz_medium"
                     android:layout_height="@dimen/avatar_sz_medium"
                     android:layout_marginTop="@dimen/margin_small"
-                    android:background="@color/translucent"
+                    android:background="@drawable/shape_oval_translucent"
                     android:gravity="center"
                     android:padding="@dimen/margin_large"
                     android:visibility="gone"


### PR DESCRIPTION
![screen shot 2014-12-05 at 1 38 08 pm](https://cloud.githubusercontent.com/assets/789137/5323373/399646e4-7c84-11e4-92e0-055fef258771.png)

Fixes #2078
