### PR TITLE
fix #2127: fix status bar color on landscape xlarge tablet (static drawer)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
@@ -97,7 +97,9 @@ public abstract class WPDrawerActivity extends ActionBarActivity {
 
         if (isStaticMenuDrawer()) {
             setContentView(R.layout.activity_drawer_static);
-            getWindow().setStatusBarColor(getResources().getColor(R.color.color_primary_dark));
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                getWindow().setStatusBarColor(getResources().getColor(R.color.color_primary_dark));
+            }
         } else {
             setContentView(R.layout.activity_drawer);
         }


### PR DESCRIPTION
fix #2127: fix status bar color on landscape xlarge tablet (static drawer)
