### PR TITLE
fix #2151: proguard workaround for Samsung 4.2.2 devices

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -59,6 +59,11 @@ android {
     }
 
     buildTypes {
+        release {
+            minifyEnabled true
+            proguardFile 'proguard.cfg'
+        }
+
         debug {
             buildConfigField "String", "APP_PN_KEY", "\"org.wordpress.android.debug.build\""
         }
@@ -81,6 +86,8 @@ dependencies {
     compile 'com.cocosw:undobar:1.6@aar'
 
     compile('org.apache.httpcomponents:httpmime:4.1.+') {
+        exclude module: 'httpcore'
+        exclude module: 'httpclient'
         exclude group: 'commons-logging', module: 'commons-logging'
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -60,6 +60,8 @@ android {
 
     buildTypes {
         release {
+            // Proguard is only used to fix an issue with some Samsung device
+            // https://github.com/wordpress-mobile/WordPress-Android/issues/2151
             minifyEnabled true
             proguardFile 'proguard.cfg'
         }

--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -1,4 +1,5 @@
 -keepattributes **
+# Used as a workaround for some Samsung devices on 4.2.2 - https://github.com/wordpress-mobile/WordPress-Android/issues/2151
 -keep class !android.support.v7.internal.view.menu.**,** {*;}
 -dontpreverify
 -dontoptimize

--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -1,0 +1,5 @@
+-keepattributes **
+-keep class !android.support.v7.internal.view.menu.**,** {*;}
+-dontpreverify
+-dontoptimize
+-dontshrink


### PR DESCRIPTION
I can't test on a Samsung 4.2.2 device, but I've checked the problematic class `android.support.v7.internal.view.menu.MenuBuilder` was renamed in the apk:

```
$ apktool decode -f WordPress-vanilla-release.apk
$ l WordPress-vanilla-release/smali/android/support/v7/internal/view/menu/
total 484K
-rw-r--r--+ 1 max 4.7K Jan  6 13:43 ActionMenuItemView$a.smali
-rw-r--r--+ 1 max  699 Jan  6 13:43 ActionMenuItemView$b.smali
-rw-r--r--+ 1 max  27K Jan  6 13:43 ActionMenuItemView.smali
-rw-r--r--+ 1 max 5.3K Jan  6 13:43 ExpandedMenuView.smali
-rw-r--r--+ 1 max  25K Jan  6 13:43 ListMenuItemView.smali
-rw-r--r--+ 1 max  17K Jan  6 13:43 a.smali
-rw-r--r--+ 1 max  15K Jan  6 13:43 b.smali
-rw-r--r--+ 1 max 9.3K Jan  6 13:43 c.smali
-rw-r--r--+ 1 max 1.8K Jan  6 13:43 d.smali
-rw-r--r--+ 1 max 8.2K Jan  6 13:43 e$a.smali
-rw-r--r--+ 1 max  16K Jan  6 13:43 e.smali
-rw-r--r--+ 1 max  616 Jan  6 13:43 f$a.smali
-rw-r--r--+ 1 max  487 Jan  6 13:43 f$b.smali
-rw-r--r--+ 1 max  98K Jan  6 13:43 f.smali
-rw-r--r--+ 1 max  14K Jan  6 13:43 g.smali
-rw-r--r--+ 1 max 1.7K Jan  6 13:43 h$1.smali
-rw-r--r--+ 1 max  45K Jan  6 13:43 h.smali
-rw-r--r--+ 1 max 2.8K Jan  6 13:43 i$a.smali
-rw-r--r--+ 1 max 2.1K Jan  6 13:43 i$b.smali
-rw-r--r--+ 1 max 2.8K Jan  6 13:43 i$c.smali
-rw-r--r--+ 1 max 2.0K Jan  6 13:43 i$d.smali
-rw-r--r--+ 1 max  26K Jan  6 13:43 i.smali
-rw-r--r--+ 1 max 3.9K Jan  6 13:43 j$a.smali
-rw-r--r--+ 1 max 1.4K Jan  6 13:43 j.smali
-rw-r--r--+ 1 max  11K Jan  6 13:43 k$a.smali
-rw-r--r--+ 1 max  30K Jan  6 13:43 k.smali
-rw-r--r--+ 1 max  586 Jan  6 13:43 l$a.smali
-rw-r--r--+ 1 max 1.5K Jan  6 13:43 l.smali
-rw-r--r--+ 1 max  968 Jan  6 13:43 m$a.smali
-rw-r--r--+ 1 max  453 Jan  6 13:43 m.smali
-rw-r--r--+ 1 max 3.0K Jan  6 13:43 n.smali
-rw-r--r--+ 1 max  15K Jan  6 13:43 o.smali
-rw-r--r--+ 1 max 9.5K Jan  6 13:43 p.smali
-rw-r--r--+ 1 max 5.3K Jan  6 13:43 q.smali
```