### PR TITLE
Fall back to previewing site in web view if no site id is provided in Notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -173,11 +173,15 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
 
     private final UserNoteBlock.OnGravatarClickedListener mOnGravatarClickedListener = new UserNoteBlock.OnGravatarClickedListener() {
         @Override
-        public void onGravatarClicked(long siteId, long userId) {
+        public void onGravatarClicked(long siteId, long userId, String siteUrl) {
             if (!isAdded()) return;
 
             NotificationsActivity notificationsActivity = (NotificationsActivity)getActivity();
-            notificationsActivity.showBlogPreviewActivity(siteId, null);
+            if (siteId == 0 && !TextUtils.isEmpty(siteUrl)) {
+                notificationsActivity.showWebViewActivityForUrl(siteUrl);
+            } else {
+                notificationsActivity.showBlogPreviewActivity(siteId, siteUrl);
+            }
         }
     };
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/HeaderUserNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/HeaderUserNoteBlock.java
@@ -144,8 +144,9 @@ public class HeaderUserNoteBlock extends NoteBlock {
                     // In the future we can use this to load a 'profile view' (currently in R&D)
                     long siteId = Long.valueOf(JSONUtil.queryJSON(mHeaderArray, "[0].ranges[0].site_id", 0));
                     long userId = Long.valueOf(JSONUtil.queryJSON(mHeaderArray, "[0].ranges[0].id", 0));
+                    String siteUrl = getUserUrl();
                     if (siteId > 0 && userId > 0) {
-                        mGravatarClickedListener.onGravatarClicked(siteId, userId);
+                        mGravatarClickedListener.onGravatarClicked(siteId, userId, siteUrl);
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/UserNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/UserNoteBlock.java
@@ -24,7 +24,7 @@ public class UserNoteBlock extends NoteBlock {
 
     public interface OnGravatarClickedListener {
         // userId is currently unused, but will be handy once a profile view is added to the app
-        public void onGravatarClicked(long siteId, long userId);
+        public void onGravatarClicked(long siteId, long userId, String siteUrl);
     }
 
     public UserNoteBlock(
@@ -191,8 +191,9 @@ public class UserNoteBlock extends NoteBlock {
     private void showBlogPreview() {
         long siteId = Long.valueOf(JSONUtil.queryJSON(getNoteData(), "meta.ids.site", 0));
         long userId = Long.valueOf(JSONUtil.queryJSON(getNoteData(), "meta.ids.user", 0));
-        if (mGravatarClickedListener != null && siteId > 0 && userId > 0) {
-            mGravatarClickedListener.onGravatarClicked(siteId, userId);
+        String siteUrl = getUserUrl();
+        if (mGravatarClickedListener != null) {
+            mGravatarClickedListener.onGravatarClicked(siteId, userId, siteUrl);
         }
     }
 }


### PR DESCRIPTION
* Show blog preview if we have a siteId or no siteUrl (if we don't have either at least the user will see an error message).
* Show web view if we have no siteId, but do have a siteUrl.

Fixes #2169