### PR TITLE
Fix #1319: tag post list items as 'Uploading'

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -344,6 +344,8 @@ public class WordPress extends Application {
 
     public interface OnPostUploadedListener {
         public abstract void OnPostUploaded(int localBlogId, String postId, boolean isPage);
+
+        public abstract void OnPostUploadFailed(int localBlogId);
     }
 
     public static void setOnPostUploadedListener(OnPostUploadedListener listener) {
@@ -354,6 +356,19 @@ public class WordPress extends Application {
         if (onPostUploadedListener != null) {
             try {
                 onPostUploadedListener.OnPostUploaded(localBlogId, postId, isPage);
+            } catch (Exception e) {
+                postsShouldRefresh = true;
+            }
+        } else {
+            postsShouldRefresh = true;
+        }
+
+    }
+
+    public static void postUploadFailed(int localBlogId) {
+        if (onPostUploadedListener != null) {
+            try {
+                onPostUploadedListener.OnPostUploadFailed(localBlogId);
             } catch (Exception e) {
                 postsShouldRefresh = true;
             }

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -1069,7 +1069,7 @@ public class WordPressDB {
                 }
 
                 post.setLocalDraft(SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("localDraft"))));
-            post.setUploading(SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("isUploading"))));
+                post.setUploading(SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("isUploading"))));
                 post.setUploaded(SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("uploaded"))));
                 post.setIsPage(SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("isPage"))));
                 post.setPageParentId(c.getString(c.getColumnIndex("wp_page_parent_id")));

--- a/WordPress/src/main/java/org/wordpress/android/models/Post.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Post.java
@@ -43,6 +43,7 @@ public class Post implements Serializable {
     private String slug;
     private boolean localDraft;
     private boolean uploaded;
+    private boolean mIsUploading;
     private boolean mChangedFromLocalDraftToPublished;
     private boolean isPage;
     private String pageParentId;
@@ -365,6 +366,14 @@ public class Post implements Serializable {
 
     public void setPageParentTitle(String wp_page_parent_title) {
         this.pageParentTitle = wp_page_parent_title;
+    }
+
+    public boolean isUploading() {
+        return mIsUploading;
+    }
+
+    public void setUploading(boolean uploading) {
+        this.mIsUploading = uploading;
     }
 
     public boolean isUploaded() {

--- a/WordPress/src/main/java/org/wordpress/android/models/PostsListPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/PostsListPost.java
@@ -17,8 +17,10 @@ public class PostsListPost {
     private String status;
     private boolean isLocalDraft;
     private boolean hasLocalChanges;
+    private boolean mIsUploading;
 
-    public PostsListPost(int postId, int blogId, String title, long dateCreatedGmt, String status, boolean localDraft, boolean localChanges) {
+    public PostsListPost(int postId, int blogId, String title, long dateCreatedGmt, String status, boolean localDraft,
+                         boolean localChanges, boolean uploading) {
         setPostId(postId);
         setBlogId(blogId);
         setTitle(title);
@@ -26,6 +28,7 @@ public class PostsListPost {
         setStatus(status);
         setLocalDraft(localDraft);
         setHasLocalChanges(localChanges);
+        setIsUploading(uploading);
     }
 
     public int getPostId() {
@@ -90,5 +93,13 @@ public class PostsListPost {
 
     public void setHasLocalChanges(boolean localChanges) {
         this.hasLocalChanges = localChanges;
+    }
+
+    public boolean isUploading() {
+        return mIsUploading;
+    }
+
+    public void setIsUploading(boolean uploading) {
+        this.mIsUploading = uploading;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
@@ -70,6 +70,9 @@ public class PostUploadService extends Service {
     public static void addPostToUpload(Post currentPost) {
         synchronized (mPostsList) {
             mPostsList.add(currentPost);
+            // Enable 'isUploading' flag for post
+            currentPost.setUploading(true);
+            WordPress.wpDB.updatePost(currentPost);
         }
     }
 
@@ -152,11 +155,16 @@ public class PostUploadService extends Service {
 
         @Override
         protected void onPostExecute(Boolean postUploadedSuccessfully) {
+            // Update the 'isUploading' flag for post
+            mPost.setUploading(false);
+            WordPress.wpDB.updatePost(mPost);
+
             if (postUploadedSuccessfully) {
                 WordPress.postUploaded(mPost.getLocalTableBlogId(), mPost.getRemotePostId(), mPost.isPage());
                 mPostUploadNotifier.cancelNotification();
                 WordPress.wpDB.deleteMediaFilesForPost(mPost);
             } else {
+                WordPress.postUploadFailed(mPost.getLocalTableBlogId());
                 mPostUploadNotifier.updateNotificationWithError(mErrorMessage, mIsMediaError, mPost.isPage(), mErrorUnavailableVideoPress);
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -456,6 +456,29 @@ public class PostsListFragment extends ListFragment
         }
     }
 
+    @Override
+    public void OnPostUploadFailed(int localBlogId) {
+        mSwipeToRefreshHelper.setRefreshing(true);
+
+        if (!isAdded()) {
+            return;
+        }
+
+        // If the user switched to a different blog while uploading his post, don't reload posts and refresh the view
+        if (WordPress.getCurrentBlog() == null || WordPress.getCurrentBlog().getLocalTableBlogId() != localBlogId) {
+            return;
+        }
+
+        if (!NetworkUtils.checkConnection(getActivity())) {
+            mSwipeToRefreshHelper.setRefreshing(false);
+            return;
+        }
+
+        mSwipeToRefreshHelper.setRefreshing(false);
+        // Refresh the posts list to revert post status back to local draft or local changes
+        getPostListAdapter().loadPosts();
+    }
+
     public void onBlogChanged() {
         if (mCurrentFetchPostsTask != null) {
             mCurrentFetchPostsTask.cancel(true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -102,7 +102,9 @@ public class PostsListAdapter extends BaseAdapter {
             wrapper.getStatus().setVisibility(View.GONE);
         } else {
             wrapper.getStatus().setVisibility(View.VISIBLE);
-            if (post.isLocalDraft()) {
+            if (post.isUploading()) {
+                formattedStatus = mContext.getResources().getString(R.string.post_uploading);
+            } else if (post.isLocalDraft()) {
                 formattedStatus = mContext.getResources().getString(R.string.local_draft);
             } else if (post.hasLocalChanges()) {
                 formattedStatus = mContext.getResources().getString(R.string.local_changes);
@@ -126,7 +128,8 @@ public class PostsListAdapter extends BaseAdapter {
             }
 
             // Set post status TextView color
-            if (post.isLocalDraft() || post.getStatusEnum() == PostStatus.DRAFT || post.hasLocalChanges()) {
+            if (post.isLocalDraft() || post.getStatusEnum() == PostStatus.DRAFT || post.hasLocalChanges() ||
+                    post.isUploading()) {
                 wrapper.getStatus().setTextColor(mContext.getResources().getColor(R.color.orange_dark));
             } else {
                 wrapper.getStatus().setTextColor(mContext.getResources().getColor(R.color.grey_medium));
@@ -235,6 +238,8 @@ public class PostsListAdapter extends BaseAdapter {
             if (newPost.getDateCreatedGmt() != currentPost.getDateCreatedGmt())
                 return false;
             if (!newPost.getOriginalStatus().equals(currentPost.getOriginalStatus()))
+                return false;
+            if (newPost.isUploading() != currentPost.isUploading())
                 return false;
             if (newPost.isLocalDraft() != currentPost.isLocalDraft())
                 return false;

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -166,6 +166,7 @@
     <!-- posts tab -->
     <string name="untitled">Untitled</string>
     <string name="local_draft">Local draft</string>
+    <string name="post_uploading">Uploading</string>
     <string name="posts_empty_list">No posts yet. Why not create one?</string>
     <string name="empty_list_default">This list is empty</string>
 


### PR DESCRIPTION
Fixes [#1319](https://github.com/wordpress-mobile/WordPress-Android/issues/1319). While a post (or page) is being uploaded, changes its status in the post list to `Uploading`.

- This works for `Local Draft` as well as `Local Changes`.
- If the upload fails, the post's status is changed back to `Local Draft` or `Local Changes`.