### PR TITLE
Reader empty blog preview message

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -14,8 +14,8 @@ public class ReaderTag implements Serializable {
     private String endpoint;
     public ReaderTagType tagType;
 
-    public static String TAG_ID_FOLLOWING = "following";
-    public static String TAG_ID_LIKED = "liked";
+    public static final String TAG_ID_FOLLOWING = "following";
+    public static final String TAG_ID_LIKED = "liked";
 
     // these are the default tag names, which aren't localized in the /read/menu/ response
     public static final String TAG_NAME_LIKED = "Posts I Like";

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -567,7 +567,7 @@ public class ReaderPostListFragment extends Fragment {
     }
 
     /*
-     * box/pages animation that appears when loading an empty list should only appear for tags
+     * box/pages animation that appears when loading an empty list (only appears for tags)
      */
     private boolean shouldShowBoxAndPagesAnimation() {
         return getPostListType().isTagType();
@@ -596,8 +596,6 @@ public class ReaderPostListFragment extends Fragment {
 
         if (isUpdating()) {
             titleResId = R.string.reader_empty_posts_in_tag_updating;
-        } else if (!NetworkUtils.isNetworkAvailable(getActivity())) {
-            titleResId = R.string.connection_error;
         } else if (getPostListType() == ReaderPostListType.BLOG_PREVIEW) {
             titleResId = R.string.reader_empty_posts_in_blog;
         } else if (getPostListType() == ReaderPostListType.TAG_FOLLOWED && getSpinnerAdapter() != null) {
@@ -621,15 +619,14 @@ public class ReaderPostListFragment extends Fragment {
                     titleResId = R.string.reader_empty_posts_in_tag;
                     break;
             }
-        } else if (getPostListType().isTagType()) {
-            titleResId = R.string.reader_empty_posts_in_tag;
         } else {
-            return;
+            titleResId = R.string.reader_empty_posts_in_tag;
         }
 
         TextView titleView = (TextView) mEmptyView.findViewById(R.id.title_empty);
-        TextView descriptionView = (TextView) mEmptyView.findViewById(R.id.description_empty);
         titleView.setText(getString(titleResId));
+
+        TextView descriptionView = (TextView) mEmptyView.findViewById(R.id.description_empty);
         if (descriptionResId == 0) {
             descriptionView.setVisibility(View.INVISIBLE);
         } else {
@@ -644,14 +641,15 @@ public class ReaderPostListFragment extends Fragment {
     private final ReaderInterfaces.DataLoadedListener mDataLoadedListener = new ReaderInterfaces.DataLoadedListener() {
         @Override
         public void onDataLoaded(boolean isEmpty) {
-            if (!isAdded())
+            if (!isAdded()) {
                 return;
+            }
             if (isEmpty) {
+                setEmptyTitleAndDescription();
+                mEmptyView.setVisibility(View.VISIBLE);
                 if (shouldShowBoxAndPagesAnimation()) {
                     startBoxAndPagesAnimation();
                 }
-                setEmptyTitleAndDescription();
-                mEmptyView.setVisibility(View.VISIBLE);
             } else {
                 mEmptyView.setVisibility(View.GONE);
                 if (mRestorePosition > 0) {
@@ -709,7 +707,6 @@ public class ReaderPostListFragment extends Fragment {
     private ReaderPostAdapter getPostAdapter() {
         if (mPostAdapter == null) {
             AppLog.d(T.READER, "reader post list > creating post adapter");
-
             Context context = WPActivityUtils.getThemedContext(getActivity());
             mPostAdapter = new ReaderPostAdapter(context, getPostListType());
             mPostAdapter.setOnPostSelectedListener(mPostSelectedListener);

--- a/WordPress/src/main/res/layout/reader_empty_view.xml
+++ b/WordPress/src/main/res/layout/reader_empty_view.xml
@@ -11,6 +11,7 @@
 
     <RelativeLayout
         android:layout_width="wrap_content"
+        android:id="@+id/layout_empty_images"
         android:layout_height="100dp"
         android:layout_marginBottom="8dp">
 

--- a/WordPress/src/main/res/layout/reader_empty_view.xml
+++ b/WordPress/src/main/res/layout/reader_empty_view.xml
@@ -10,8 +10,8 @@
     tools:visibility="visible">
 
     <RelativeLayout
+        android:id="@+id/layout_box_images"
         android:layout_width="wrap_content"
-        android:id="@+id/layout_empty_images"
         android:layout_height="100dp"
         android:layout_marginBottom="8dp">
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -727,6 +727,7 @@
     <string name="reader_empty_followed_blogs_description">But don\'t worry, just tap the tag icon to start exploring!</string>
     <string name="reader_empty_posts_liked">You haven\'t liked any posts</string>
     <string name="reader_empty_comments">No comments yet</string>
+    <string name="reader_empty_posts_in_blog">This blog is empty</string>
 
     <!-- layout tags - do not translate -->
     <string name="fragment_tag_comment_list" translatable="false">fragment_comment_list</string>


### PR DESCRIPTION
Fix #2181 - blog preview now shows an empty message for blogs that have no posts. Also cleaned up a lot of the "empty" logic while I was at it, including the animated boxes/pages which should only appear when updating posts with a specific tag.