### PR TITLE
Fixes nav drawer button

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
@@ -330,7 +330,7 @@ public abstract class WPDrawerActivity extends ActionBarActivity {
         }
     }
 
-    protected void toggleDrawer() {
+    private void toggleDrawer() {
         if (mDrawerLayout != null) {
             if (mDrawerLayout.isDrawerOpen(GravityCompat.START)) {
                 closeDrawer();

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
@@ -271,6 +271,10 @@ public abstract class WPDrawerActivity extends ActionBarActivity {
         initBlogSpinner();
         updateMenuDrawer();
 
+        setToolbarClickListener();
+    }
+
+    protected void setToolbarClickListener() {
         // Set navigation listener, which ensures menu button works on all devices (#2157)
         getToolbar().setNavigationOnClickListener(new View.OnClickListener() {
             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
@@ -4,6 +4,7 @@ package org.wordpress.android.ui;
 import android.animation.ObjectAnimator;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
+import android.app.FragmentManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -19,7 +20,6 @@ import android.support.v7.app.ActionBarActivity;
 import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.AccelerateInterpolator;
@@ -227,7 +227,7 @@ public abstract class WPDrawerActivity extends ActionBarActivity {
             mDrawerToggle = new ActionBarDrawerToggle(
                     this,
                     mDrawerLayout,
-                    mToolbar,
+                    getToolbar(),
                     R.string.open_drawer,
                     R.string.close_drawer
             ) {
@@ -270,6 +270,21 @@ public abstract class WPDrawerActivity extends ActionBarActivity {
 
         initBlogSpinner();
         updateMenuDrawer();
+
+        // Set navigation listener, which ensures menu button works on all devices (#2157)
+        getToolbar().setNavigationOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (isFinishing()) return;
+
+                FragmentManager fm = getFragmentManager();
+                if (fm.getBackStackEntryCount() > 0) {
+                    fm.popBackStack();
+                } else {
+                    toggleDrawer();
+                }
+            }
+        });
     }
 
     /*
@@ -311,7 +326,7 @@ public abstract class WPDrawerActivity extends ActionBarActivity {
         }
     }
 
-    private void toggleDrawer() {
+    protected void toggleDrawer() {
         if (mDrawerLayout != null) {
             if (mDrawerLayout.isDrawerOpen(GravityCompat.START)) {
                 closeDrawer();
@@ -675,13 +690,6 @@ public abstract class WPDrawerActivity extends ActionBarActivity {
         public void onNothingSelected(AdapterView<?> parent) {
         }
     };
-
-    public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == android.R.id.home && mDrawerLayout != null) {
-            toggleDrawer();
-        }
-        return super.onOptionsItemSelected(item);
-    }
 
     private void refreshCurrentBlogContent() {
         if (WordPress.getCurrentBlog() != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -42,7 +42,6 @@ public class CommentsActivity extends WPDrawerActivity
         super.onCreate(null);
 
         createMenuDrawer(R.layout.comment_activity);
-        setSupportActionBar(getToolbar());
 
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
@@ -99,20 +98,6 @@ public class CommentsActivity extends WPDrawerActivity
         if (hasDetailFragment()) {
             getDetailFragment().clear();
         }
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                    FragmentManager fm = getFragmentManager();
-                    if (fm.getBackStackEntryCount() > 0) {
-                        fm.popBackStack();
-                    return true;
-                }
-                break;
-        }
-        return super.onOptionsItemSelected(item);
     }
 
     private final FragmentManager.OnBackStackChangedListener mOnBackStackChangedListener =

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -71,7 +71,6 @@ public class MediaBrowserActivity extends WPDrawerActivity implements MediaGridL
         super.onCreate(savedInstanceState);
 
         createMenuDrawer(R.layout.media_browser_activity);
-        setSupportActionBar(getToolbar());
 
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
@@ -319,14 +318,7 @@ public class MediaBrowserActivity extends WPDrawerActivity implements MediaGridL
     public boolean onOptionsItemSelected(MenuItem item) {
         int itemId = item.getItemId();
 
-        if (itemId == android.R.id.home) {
-            FragmentManager fm = getFragmentManager();
-            if (fm.getBackStackEntryCount() > 0) {
-                fm.popBackStack();
-                setupBaseLayout();
-                return true;
-            }
-        } else if (itemId == R.id.menu_new_media) {
+        if (itemId == R.id.menu_new_media) {
             View view = findViewById(R.id.menu_new_media);
             if (view != null) {
                 int y_offset = getResources().getDimensionPixelSize(R.dimen.action_bar_spinner_y_offset);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsActivity.java
@@ -63,7 +63,6 @@ public class NotificationsActivity extends WPDrawerActivity implements CommentAc
         super.onCreate(null);
         AppLog.i(T.NOTIFS, "Creating NotificationsActivity");
         createMenuDrawer(R.layout.notifications_activity);
-        setSupportActionBar(getToolbar());
 
         if (savedInstanceState == null) {
             AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATIONS_ACCESSED);
@@ -136,29 +135,14 @@ public class NotificationsActivity extends WPDrawerActivity implements CommentAc
         }
     }
 
-    @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                FragmentManager fm = getFragmentManager();
-                if (fm.getBackStackEntryCount() > 0) {
-                    mRestoredReplyText = getCommentReplyText();
-                    popNoteDetail();
-                    return true;
-                } else {
-                    return super.onOptionsItemSelected(item);
-                }
-            default:
-                return super.onOptionsItemSelected(item);
-        }
-    }
-
     private final FragmentManager.OnBackStackChangedListener mOnBackStackChangedListener =
             new FragmentManager.OnBackStackChangedListener() {
                 public void onBackStackChanged() {
                     int backStackEntryCount = getFragmentManager().getBackStackEntryCount();
                     if (getSupportActionBar() != null && backStackEntryCount == 0) {
                         getSupportActionBar().setTitle(R.string.notifications);
+                    } else {
+                        mRestoredReplyText = getCommentReplyText();
                     }
                     if (getDrawerToggle() != null) {
                         getDrawerToggle().setDrawerIndicatorEnabled(backStackEntryCount == 0);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
@@ -63,7 +63,6 @@ public class PostsActivity extends WPDrawerActivity
         ProfilingUtils.dump();
 
         createMenuDrawer(R.layout.posts);
-        setSupportActionBar(getToolbar());
 
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
@@ -218,19 +217,6 @@ public class PostsActivity extends WPDrawerActivity
         i.putExtra(EditPostActivity.EXTRA_IS_PAGE, mIsPage);
         i.putExtra(EditPostActivity.EXTRA_IS_NEW_POST, true);
         startActivityForResult(i, ACTIVITY_EDIT_POST);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
-        if (item.getItemId() == android.R.id.home) {
-            FragmentManager fm = getFragmentManager();
-            if (fm.getBackStackEntryCount() > 0) {
-                popPostDetail();
-                return true;
-            }
-        }
-
-        return super.onOptionsItemSelected(item);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -79,6 +79,12 @@ public class ReaderCommentListActivity extends ActionBarActivity {
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
+        toolbar.setNavigationOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                onBackPressed();
+            }
+        });
         getSupportActionBar().setDisplayShowTitleEnabled(true);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
@@ -236,17 +242,6 @@ public class ReaderCommentListActivity extends ActionBarActivity {
     public void finish() {
         super.finish();
         overridePendingTransition(R.anim.reader_activity_scale_in, R.anim.reader_flyout);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                onBackPressed();
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
-        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -163,9 +163,6 @@ public class ReaderPostListActivity extends WPDrawerActivity
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         switch (item.getItemId()) {
-            case android.R.id.home:
-                onBackPressed();
-                return true;
             case R.id.menu_tags:
                 ReaderActivityLauncher.showReaderSubsForResult(this);
                 return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -71,7 +71,7 @@ public class ReaderPostListActivity extends WPDrawerActivity
         // hide drawer toggle and enable back arrow click if this is blog preview or tag preview
         if (mPostListType.isPreviewType() && getDrawerToggle() != null) {
             getDrawerToggle().setDrawerIndicatorEnabled(false);
-            getDrawerToggle().setToolbarNavigationClickListener(new View.OnClickListener() {
+            getToolbar().setNavigationOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     onBackPressed();
@@ -156,6 +156,7 @@ public class ReaderPostListActivity extends WPDrawerActivity
     public void onBackPressed() {
         ReaderPostListFragment fragment = getListFragment();
         if (fragment == null || !fragment.goBackInTagHistory()) {
+            setToolbarClickListener();
             super.onBackPressed();
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -71,6 +71,12 @@ public class ReaderPostPagerActivity extends ActionBarActivity
 
         mToolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(mToolbar);
+        mToolbar.setNavigationOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                onBackPressed();
+            }
+        });
         getSupportActionBar().setDisplayShowTitleEnabled(true);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
@@ -176,17 +182,6 @@ public class ReaderPostPagerActivity extends ActionBarActivity
         }
 
         super.onSaveInstanceState(outState);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                onBackPressed();
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
-        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderReblogActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderReblogActivity.java
@@ -63,6 +63,12 @@ public class ReaderReblogActivity extends ActionBarActivity {
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
+        toolbar.setNavigationOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                onBackPressed();
+            }
+        });
         getSupportActionBar().setDisplayShowTitleEnabled(false);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
@@ -152,9 +158,6 @@ public class ReaderReblogActivity extends ActionBarActivity {
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         switch (item.getItemId()) {
-            case android.R.id.home:
-                onBackPressed();
-                return true;
             case R.id.menu_publish:
                 submitReblog();
                 return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -100,6 +100,12 @@ public class ReaderSubsActivity extends ActionBarActivity
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
+        toolbar.setNavigationOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                onBackPressed();
+            }
+        });
         getSupportActionBar().setDisplayShowTitleEnabled(true);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
@@ -240,17 +246,6 @@ public class ReaderSubsActivity extends ActionBarActivity
         }
 
         super.onBackPressed();
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                onBackPressed();
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
-        }
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderUserListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderUserListActivity.java
@@ -5,6 +5,7 @@ import android.support.v7.app.ActionBarActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
+import android.view.View;
 
 import org.wordpress.android.R;
 import org.wordpress.android.datasets.ReaderCommentTable;
@@ -34,6 +35,12 @@ public class ReaderUserListActivity extends ActionBarActivity {
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
+        toolbar.setNavigationOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                onBackPressed();
+            }
+        });
         getSupportActionBar().setDisplayShowTitleEnabled(true);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
@@ -76,17 +83,6 @@ public class ReaderUserListActivity extends ActionBarActivity {
             mRecyclerView.setAdapter(mAdapter);
         }
         return mAdapter;
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                onBackPressed();
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
-        }
     }
 
     private void loadUsers(final long blogId,

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -78,7 +78,6 @@ public class ThemeBrowserActivity extends WPDrawerActivity implements
         setTitle(R.string.themes);
 
         createMenuDrawer(R.layout.theme_browser_activity);
-        setSupportActionBar(getToolbar());
 
         mThemePagerAdapter = new ThemePagerAdapter(getFragmentManager());
 
@@ -254,14 +253,7 @@ public class ThemeBrowserActivity extends WPDrawerActivity implements
     public boolean onOptionsItemSelected(MenuItem item) {
         int itemId = item.getItemId();
 
-        if (itemId == android.R.id.home) {
-            FragmentManager fm = getFragmentManager();
-            if (fm.getBackStackEntryCount() > 0) {
-                fm.popBackStack();
-                setupBaseLayout();
-                return true;
-            }
-        } else if (itemId == R.id.menu_search) {
+        if (itemId == R.id.menu_search) {
             FragmentTransaction ft = getFragmentManager().beginTransaction();
             if (mSearchFragment == null) {
                 mSearchFragment = ThemeSearchFragment.newInstance();


### PR DESCRIPTION
Changes anywhere we used `setSupportActionBar()` to use `Toolbar.setNavigationClickListener()` to manage the opening/closing of the drawer and popping fragments off of the stack, instead of using `onOptionsItemSelected()` which was not being fired on the LG F6 and other devices running a customized version of Android.