### PR TITLE
fix #2166: remove handbook and dev blog reference, add OAuth2 infos, replace IRC with Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ account.
 
 Read more about [OAuth2][6] and the [WordPress.com REST endpoint][7].
 
+## How we work ##
+
+You can read more about [Code Style Guidelines](CODESTYLE.md) we adopted, and
+how we're organizing branches in our repository in the
+[Contribution Guide](CONTRIBUTING.md).
+
 ## Need help to build or hack? ##
 
 Say hello on our [Slack][4] channel: `#mobile`.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ our example:
     $ echo "sdk.dir=YOUR_SDK_DIR" > local.properties
     $ cp ./WordPress/gradle.properties-example ./WordPress/gradle.properties
 
+Note: this is the default `./WordPress/gradle.properties` file, if you
+want to use WordPress.com functions (login to a WordPress.com account,
+access the Reader and Stats for example), you'll have to get a WordPress.com
+OAuth2 id and secret. Please read the
+[OAuth2 Authentication](#oauth2-authentication) section.
+
 Previous command create a `libs/` directory and clone all dependencies needed
 by the main WordPress for Android project. You can now build, install and
 test the project:
@@ -42,10 +48,25 @@ You can use [Android Studio][3] by importing the project as a Gradle project.
             |-- vanilla         # vanilla variant specific manifest
             `-- zbetagroup      # beta variant specific resources and manifest
 
+## OAuth2 Authentication ##
+
+In order to use WordPress.com functions you will need a client id, and
+a client secret key. These details will be used to authenticate your
+application and verify that the API calls being made are valid. You can
+create an application or view details for your existing applications with
+our [WordPress.com applications manager][5].
+
+Once you created your application in the [applications manager][5], you'll
+need to edit the `./WordPress/gradle.properties` file and change the
+`WP.OAUTH.APP.ID` and `WP.OAUTH.APP.SECRET` fields. Then you can compile and
+run the app on a device or an emulator and try to login with a WordPress.com
+account.
+
+Read more about [OAuth2][6] and the [WordPress.com REST endpoint][7].
+
 ## Need help to build or hack? ##
 
-Say hello on our IRC channel: `#WordPress-Mobile` (freenode). Read our
-[Developer Handbook][4] and [Development Blog][5].
+Say hello on our [Slack][4] channel: `#mobile`.
 
 ## License
 
@@ -57,7 +78,7 @@ be covered by a different license compatible with the GPLv2.
 [1]: https://play.google.com/store/apps/details?id=org.wordpress.android
 [2]: http://tools.android.com/tech-docs/new-build-system/user-guide
 [3]: http://developer.android.com/sdk/installing/studio.html
-[4]: http://make.wordpress.org/mobile/handbook/
-[5]: http://make.wordpress.org/mobile/
-
-
+[4]: https://make.wordpress.org/chat/
+[5]: https://developer.wordpress.com/apps/
+[6]: https://developer.wordpress.com/docs/oauth2/
+[7]: https://developer.wordpress.com/docs/api/


### PR DESCRIPTION
fix #2166: remove handbook and dev blog reference, add OAuth2 infos, replace IRC with Slack