### PR TITLE
fix #2160: removed unnecessary configChanges

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -84,7 +84,6 @@
             android:theme="@style/Theme.AppCompat.NoActionBar"/>
         <activity
             android:name=".ui.prefs.BlogPreferencesActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize"
             android:windowSoftInputMode="stateHidden"/>
         <activity
             android:name=".ui.prefs.LicensesActivity"/>
@@ -109,7 +108,6 @@
         <!-- Posts activities -->
         <activity
             android:name=".ui.posts.AddCategoryActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="@string/add_new_category"
             android:theme="@style/WordPress.Dialog" />
         <activity
@@ -131,7 +129,6 @@
         </activity>
         <activity
             android:name=".ui.posts.PostsActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize"
             android:theme="@style/WordPress.DrawerActivity" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -139,11 +136,9 @@
         </activity>
         <activity
             android:name=".ui.posts.PagesActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize"
             android:theme="@style/WordPress.DrawerActivity" />
         <activity
-            android:name=".ui.posts.SelectCategoriesActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize" />
+            android:name=".ui.posts.SelectCategoriesActivity" />
         <activity android:name=".ui.posts.ViewPostActivity" />
 
         <!-- Stats Activities -->
@@ -251,13 +246,10 @@
             </intent-filter>
         </activity>
         <activity
-            android:name=".ui.DashboardActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize" />
+            android:name=".ui.DashboardActivity" />
         <activity
             android:name=".ui.ViewSiteActivity"
-            android:theme="@style/WordPress.DrawerActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize" >
-        </activity>
+            android:theme="@style/WordPress.DrawerActivity" />
 
         <!-- Notifications activities -->
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/AddCategoryActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/AddCategoryActivity.java
@@ -109,10 +109,4 @@ public class AddCategoryActivity extends ActionBarActivity {
             sCategories.setAdapter(categoryAdapter);
         }
     }
-
-    @Override
-    public void onConfigurationChanged(Configuration newConfig) {
-        //ignore orientation change
-        super.onConfigurationChanged(newConfig);
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostContentFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostContentFragment.java
@@ -614,7 +614,6 @@ public class EditPostContentFragment extends Fragment implements TextWatcher,
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
-
         mFullViewBottom = mRootView.getBottom();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -64,16 +64,6 @@ public class PostsListFragment extends ListFragment
     }
 
     @Override
-    public void onConfigurationChanged(Configuration newConfig) {
-        boolean isRefreshing = mSwipeToRefreshHelper.isRefreshing();
-        super.onConfigurationChanged(newConfig);
-        // Swipe to refresh layout is destroyed onDetachedFromWindow,
-        // so we have to re-init the layout, via the helper here
-        initSwipeToRefreshHelper();
-        mSwipeToRefreshHelper.setRefreshing(isRefreshing);
-    }
-
-    @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         return inflater.inflate(R.layout.post_listview, container, false);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
@@ -363,12 +363,6 @@ public class SelectCategoriesActivity extends ActionBarActivity {
     }
 
     @Override
-    public void onConfigurationChanged(Configuration newConfig) {
-        // ignore orientation change
-        super.onConfigurationChanged(newConfig);
-    }
-
-    @Override
     public void onBackPressed() {
         saveAndFinish();
         super.onBackPressed();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.prefs;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBarActivity;
@@ -35,7 +34,7 @@ import java.util.Locale;
 public class BlogPreferencesActivity extends ActionBarActivity {
     private boolean mIsViewingAdmin;
 
-    /** The blog this activity is managing settings for. */
+    // The blog this activity is managing settings for.
     private Blog blog;
     private boolean mBlogDeleted;
     private EditText mUsernameET;
@@ -140,17 +139,9 @@ public class BlogPreferencesActivity extends ActionBarActivity {
 
         WordPress.wpDB.saveBlog(blog);
 
-        if (WordPress.getCurrentBlog().getLocalTableBlogId() == blog.getLocalTableBlogId())
+        if (WordPress.getCurrentBlog().getLocalTableBlogId() == blog.getLocalTableBlogId()) {
             WordPress.currentBlog = blog;
-
-        // exit settings screen
-        Bundle bundle = new Bundle();
-
-        bundle.putString("returnStatus", "SAVE");
-        Intent mIntent = new Intent();
-        mIntent.putExtras(bundle);
-        setResult(RESULT_OK, mIntent);
-        finish();
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
@@ -268,12 +268,6 @@ public class BlogPreferencesActivity extends ActionBarActivity {
         et.setVisibility(show ? View.VISIBLE : View.GONE);
     }
 
-    @Override
-    public void onConfigurationChanged(Configuration newConfig) {
-        // ignore orientation change
-        super.onConfigurationChanged(newConfig);
-    }
-
     /**
      * Remove the blog this activity is managing settings for.
      */

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
@@ -78,7 +78,7 @@ public class BlogPreferencesActivity extends ActionBarActivity {
 
         if (blog.isDotcomFlag()) {
             // Hide credentials section
-            RelativeLayout credentialsRL = (RelativeLayout)findViewById(R.id.sectionContent);
+            RelativeLayout credentialsRL = (RelativeLayout) findViewById(R.id.sectionContent);
             credentialsRL.setVisibility(View.GONE);
             removeBlogButton.setVisibility(View.GONE);
         }
@@ -95,8 +95,9 @@ public class BlogPreferencesActivity extends ActionBarActivity {
     protected void onPause() {
         super.onPause();
 
-        if (mBlogDeleted || mIsViewingAdmin)
+        if (mBlogDeleted || mIsViewingAdmin) {
             return;
+        }
 
         blog.setUsername(mUsernameET.getText().toString());
         blog.setPassword(mPasswordET.getText().toString());
@@ -116,8 +117,9 @@ public class BlogPreferencesActivity extends ActionBarActivity {
                 error = true;
             }
 
-            if (width == 0)
+            if (width == 0) {
                 error = true;
+            }
 
             if (error) {
                 AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(BlogPreferencesActivity.this);
@@ -157,27 +159,33 @@ public class BlogPreferencesActivity extends ActionBarActivity {
 
     private void loadSettingsForBlog() {
         // Set header labels to upper case
-        ((TextView) findViewById(R.id.l_section1)).setText(getResources().getString(R.string.account_details).toUpperCase(Locale.getDefault()));
-        ((TextView) findViewById(R.id.l_section2)).setText(getResources().getString(R.string.media).toUpperCase(Locale.getDefault()));
-        ((TextView) findViewById(R.id.l_maxImageWidth)).setText(getResources().getString(R.string.max_thumbnail_px_width).toUpperCase(Locale.getDefault()));
-        ((TextView) findViewById(R.id.l_httpuser)).setText(getResources().getString(R.string.http_credentials).toUpperCase(Locale.getDefault()));
+        ((TextView) findViewById(R.id.l_section1))
+                .setText(getResources().getString(R.string.account_details).toUpperCase(Locale.getDefault()));
+        ((TextView) findViewById(R.id.l_section2))
+                .setText(getResources().getString(R.string.media).toUpperCase(Locale.getDefault()));
+        ((TextView) findViewById(R.id.l_maxImageWidth))
+                .setText(getResources().getString(R.string.max_thumbnail_px_width).toUpperCase(Locale.getDefault()));
+        ((TextView) findViewById(R.id.l_httpuser))
+                .setText(getResources().getString(R.string.http_credentials).toUpperCase(Locale.getDefault()));
 
         ArrayAdapter<Object> spinnerArrayAdapter = new ArrayAdapter<Object>(this,
-                R.layout.spinner_textview, new String[] {
-                        "Original Size", "100", "200", "300", "400", "500", "600", "700", "800",
-                        "900", "1000", "1100", "1200", "1300", "1400", "1500", "1600", "1700",
-                        "1800", "1900", "2000"
-                });
+                R.layout.spinner_textview, new String[]{
+                "Original Size", "100", "200", "300", "400", "500", "600", "700", "800",
+                "900", "1000", "1100", "1200", "1300", "1400", "1500", "1600", "1700",
+                "1800", "1900", "2000"
+        });
         spinnerArrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         mImageWidthSpinner.setAdapter(spinnerArrayAdapter);
         mImageWidthSpinner.setOnItemSelectedListener(new OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-               CheckBox fullSizeImageCheckBox = (CheckBox)findViewById(R.id.fullSizeImage);
-               if(id == 0) //Original size selected. Do not show the link to full image.
-                   fullSizeImageCheckBox.setVisibility(View.GONE);
-               else
-                   fullSizeImageCheckBox.setVisibility(View.VISIBLE);
+                CheckBox fullSizeImageCheckBox = (CheckBox) findViewById(R.id.fullSizeImage);
+                // Original size selected. Do not show the link to full image.
+                if (id == 0) {
+                    fullSizeImageCheckBox.setVisibility(View.GONE);
+                } else {
+                    fullSizeImageCheckBox.setVisibility(View.VISIBLE);
+                }
             }
 
             @Override
@@ -185,12 +193,11 @@ public class BlogPreferencesActivity extends ActionBarActivity {
             }
         });
 
-
         mUsernameET.setText(blog.getUsername());
         mPasswordET.setText(blog.getPassword());
         mHttpUsernameET.setText(blog.getHttpuser());
         mHttpPasswordET.setText(blog.getHttppassword());
-        TextView httpUserLabel = (TextView)findViewById(R.id.l_httpuser);
+        TextView httpUserLabel = (TextView) findViewById(R.id.l_httpuser);
         if (blog.isDotcomFlag()) {
             mHttpUsernameET.setVisibility(View.GONE);
             mHttpPasswordET.setVisibility(View.GONE);
@@ -224,7 +231,7 @@ public class BlogPreferencesActivity extends ActionBarActivity {
             }
         });*/
         // sets up a state listener for the fullsize checkbox
-        CheckBox fullSizeImageCheckBox = (CheckBox)findViewById(R.id.fullSizeImage);
+        CheckBox fullSizeImageCheckBox = (CheckBox) findViewById(R.id.fullSizeImage);
         fullSizeImageCheckBox.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -241,10 +248,13 @@ public class BlogPreferencesActivity extends ActionBarActivity {
 
         int imageWidthPosition = spinnerArrayAdapter.getPosition(blog.getMaxImageWidth());
         mImageWidthSpinner.setSelection((imageWidthPosition >= 0) ? imageWidthPosition : 0);
-        if (mImageWidthSpinner.getSelectedItemPosition() == 0) //Original size selected. Do not show the link to full image.
+        if (mImageWidthSpinner.getSelectedItemPosition() ==
+                0) //Original size selected. Do not show the link to full image.
+        {
             fullSizeImageCheckBox.setVisibility(View.GONE);
-        else
+        } else {
             fullSizeImageCheckBox.setVisibility(View.VISIBLE);
+        }
     }
 
     /**
@@ -269,10 +279,12 @@ public class BlogPreferencesActivity extends ActionBarActivity {
         dialogBuilder.setMessage(getResources().getText(R.string.sure_to_remove_account));
         dialogBuilder.setPositiveButton(getResources().getText(R.string.yes), new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int whichButton) {
-                boolean deleteSuccess = WordPress.wpDB.deleteAccount(BlogPreferencesActivity.this, blog.getLocalTableBlogId());
+                boolean deleteSuccess =
+                        WordPress.wpDB.deleteAccount(BlogPreferencesActivity.this, blog.getLocalTableBlogId());
                 if (deleteSuccess) {
                     AnalyticsTracker.refreshMetadata();
-                    Toast.makeText(activity, getResources().getText(R.string.blog_removed_successfully), Toast.LENGTH_SHORT)
+                    Toast.makeText(activity, getResources().getText(R.string.blog_removed_successfully),
+                            Toast.LENGTH_SHORT)
                             .show();
                     WordPress.wpDB.deleteLastBlogId();
                     WordPress.currentBlog = null;


### PR DESCRIPTION
I kept in SignIn/NewAccount acitivities cause we're moving buttons on
rotation (we could remove it and use a different layout) and EditPost
activity to keep the keyboard opened after rotation.