### PR TITLE
With android:largeHeap=true, Application process should be created with a larger Dalvik heap

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -48,6 +48,7 @@
         android:icon="@drawable/app_icon"
         android:label="@string/app_name"
         android:theme="@style/WordPress"
+        android:largeHeap="true"
         tools:replace="allowBackup, icon">
 
         <activity


### PR DESCRIPTION
With android:largeHeap=true, Application process should be created with a larger Dalvik heap.

To be tested in 3.7 beta.