### PR TITLE
Adds Better Transitions Between Fragments on Lollipop

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -8,7 +8,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.v7.app.ActionBar;
-import android.view.MenuItem;
 
 import com.cocosw.undobar.UndoBarController;
 
@@ -24,6 +23,7 @@ import org.wordpress.android.ui.notifications.NotificationFragment;
 import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.TransitionUtils;
 
 import javax.annotation.Nonnull;
 
@@ -155,10 +155,12 @@ public class CommentsActivity extends WPDrawerActivity
         FragmentTransaction ft = fm.beginTransaction();
         String tagForFragment = getString(R.string.fragment_tag_reader_post_detail);
         ft.add(R.id.layout_fragment_container, fragment, tagForFragment)
-          .addToBackStack(tagForFragment)
-          .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE);
-        if (hasDetailFragment())
+          .addToBackStack(tagForFragment);
+        TransitionUtils.setFragmentTransition(ft, fragment);
+        if (hasDetailFragment()) {
             ft.hide(getDetailFragment());
+        }
+
         ft.commit();
     }
 
@@ -179,8 +181,8 @@ public class CommentsActivity extends WPDrawerActivity
         String tagForFragment = getString(R.string.fragment_tag_comment_detail);
         CommentDetailFragment detailFragment = CommentDetailFragment.newInstance(WordPress.getCurrentLocalTableBlogId(),
                 commentId);
-        ft.add(R.id.layout_fragment_container, detailFragment, tagForFragment).addToBackStack(tagForFragment)
-          .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE);
+        ft.add(R.id.layout_fragment_container, detailFragment, tagForFragment).addToBackStack(tagForFragment);
+        TransitionUtils.setFragmentTransition(ft, detailFragment);
         if (listFragment != null) {
             ft.hide(listFragment);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -36,6 +36,7 @@ import org.wordpress.android.ui.media.MediaGridFragment.Filter;
 import org.wordpress.android.ui.media.MediaGridFragment.MediaGridListener;
 import org.wordpress.android.ui.media.MediaItemFragment.MediaItemFragmentCallback;
 import org.wordpress.android.ui.media.services.MediaDeleteService;
+import org.wordpress.android.util.TransitionUtils;
 import org.wordpress.android.widgets.WPAlertDialogFragment;
 import org.xmlrpc.android.ApiHelper;
 import org.xmlrpc.android.ApiHelper.GetFeatures.Callback;
@@ -299,6 +300,7 @@ public class MediaBrowserActivity extends WPDrawerActivity implements MediaGridL
             setupBaseLayout();
             mMediaItemFragment = MediaItemFragment.newInstance(mediaId);
             ft.add(R.id.media_browser_container, mMediaItemFragment, MediaItemFragment.TAG);
+            TransitionUtils.setFragmentTransition(ft, mMediaItemFragment);
             ft.addToBackStack(null);
             ft.commit();
         }
@@ -359,6 +361,7 @@ public class MediaBrowserActivity extends WPDrawerActivity implements MediaGridL
 
                 mMediaEditFragment = MediaEditFragment.newInstance(mediaId);
                 ft.add(R.id.media_browser_container, mMediaEditFragment, MediaEditFragment.TAG);
+                TransitionUtils.setFragmentTransition(ft, mMediaEditFragment);
                 ft.addToBackStack(null);
                 ft.commit();
                 if (getDrawerToggle() != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsActivity.java
@@ -5,11 +5,13 @@ import android.app.FragmentManager;
 import android.app.FragmentTransaction;
 import android.app.NotificationManager;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.v7.app.ActionBar;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
+import android.transition.AutoTransition;
 import android.view.MenuItem;
 
 import com.cocosw.undobar.UndoBarController;
@@ -35,6 +37,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.AuthenticationDialogUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.TransitionUtils;
 
 import javax.annotation.Nonnull;
 
@@ -246,10 +249,9 @@ public class NotificationsActivity extends WPDrawerActivity implements CommentAc
 
         FragmentManager fm = getFragmentManager();
         FragmentTransaction ft = fm.beginTransaction();
-        ft.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE);
+        TransitionUtils.setFragmentTransition(ft, mDetailFragment);
         ft.hide(mNotesListFragment);
         ft.add(R.id.layout_fragment_container, mDetailFragment);
-        //mMenuDrawer.setDrawerIndicatorEnabled(false);
         ft.addToBackStack(null);
         ft.commitAllowingStateLoss();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsActivity.java
@@ -5,14 +5,11 @@ import android.app.FragmentManager;
 import android.app.FragmentTransaction;
 import android.app.NotificationManager;
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.v7.app.ActionBar;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
-import android.transition.AutoTransition;
-import android.view.MenuItem;
 
 import com.cocosw.undobar.UndoBarController;
 import com.simperium.client.Bucket;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
@@ -13,7 +13,6 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.text.TextUtils;
-import android.view.MenuItem;
 import android.widget.Toast;
 
 import org.wordpress.android.R;
@@ -29,6 +28,7 @@ import org.wordpress.android.util.AlertUtil;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.ProfilingUtils;
+import org.wordpress.android.util.TransitionUtils;
 import org.wordpress.android.util.WPMeShortlinks;
 import org.wordpress.android.widgets.WPAlertDialogFragment;
 import org.wordpress.passcodelock.AppLockManager;
@@ -254,7 +254,7 @@ public class PostsActivity extends WPDrawerActivity
                 ft.hide(mPostList);
                 viewPostFragment = new ViewPostFragment();
                 ft.add(R.id.postDetailFragmentContainer, viewPostFragment);
-                ft.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE);
+                TransitionUtils.setFragmentTransition(ft, viewPostFragment);
                 ft.addToBackStack(null);
                 ft.commitAllowingStateLoss();
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/util/TransitionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/TransitionUtils.java
@@ -1,0 +1,21 @@
+package org.wordpress.android.util;
+
+import android.app.Fragment;
+import android.app.FragmentTransaction;
+import android.os.Build;
+import android.transition.AutoTransition;
+
+public class TransitionUtils {
+
+    // Set a lollipop or higher AutoTransition, otherwise use a fade
+    public static void setFragmentTransition(FragmentTransaction transaction, Fragment fragment) {
+        if (transaction == null || fragment == null) return;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            fragment.setEnterTransition(new AutoTransition());
+        } else {
+            transaction.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE);
+        }
+    }
+
+}

--- a/WordPress/src/main/res/layout/notifications_fragment_detail_list.xml
+++ b/WordPress/src/main/res/layout/notifications_fragment_detail_list.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@color/calypso_blue_light">
 
     <!-- this container is needed in order to center the content of 'badge' notification types. -->
     <LinearLayout


### PR DESCRIPTION
Master -> Detail fragment transactions now use an `AutoTransition` on lollipop or higher, which is essentially a better fade.