### PR TITLE
Stats - Do not serialize VolleyErrors

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractListFragment.java
@@ -131,6 +131,16 @@ public abstract class StatsAbstractListFragment extends StatsAbstractFragment {
     @Override
     public void onSaveInstanceState(Bundle outState) {
         //AppLog.d(AppLog.T.STATS, this.getTag() + " > saving instance state");
+
+        // Do not serialize VolleyError. FIX for https://github.com/wordpress-mobile/WordPress-Android/issues/2228
+        if (mDatamodels != null) {
+            for (int i=0; i < mDatamodels.length; i++) {
+                if (mDatamodels[i] instanceof VolleyError) {
+                    mDatamodels[i] = null;
+                }
+            }
+        }
+
         outState.putSerializable(ARG_REST_RESPONSE, mDatamodels);
         super.onSaveInstanceState(outState);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
@@ -4,12 +4,15 @@ import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
+import com.android.volley.VolleyError;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.WordPressDB;
 import org.wordpress.android.models.Blog;
+import org.wordpress.android.ui.stats.exceptions.StatsError;
 import org.wordpress.android.ui.stats.models.AuthorsModel;
 import org.wordpress.android.ui.stats.models.ClicksModel;
 import org.wordpress.android.ui.stats.models.CommentFollowersModel;
@@ -335,6 +338,24 @@ public class StatsUtils {
                 break;
         }
         return model;
+    }
+
+    /*
+     * This function rewrites a VolleyError into a simple Stats Error by getting the error message.
+     * This is a FIX for https://github.com/wordpress-mobile/WordPress-Android/issues/2228 where
+     * VolleyErrors cannot be serializable.
+     */
+    public static StatsError rewriteVolleyError(VolleyError volleyError, String defaultErrorString) {
+        if (volleyError != null && volleyError.getMessage() != null) {
+            return new StatsError(volleyError.getMessage());
+        }
+
+        if (defaultErrorString != null) {
+            return new StatsError(defaultErrorString);
+        }
+
+        // Error string should be localized here, but don't want to pass a context
+        return new StatsError("Stats couldn't be refreshed at this time");
     }
 
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
@@ -22,6 +22,7 @@ import com.jjoe64.graphview.GraphViewSeries;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.ui.stats.exceptions.StatsError;
 import org.wordpress.android.ui.stats.models.VisitModel;
 import org.wordpress.android.ui.stats.models.VisitsModel;
 import org.wordpress.android.ui.stats.service.StatsService;
@@ -166,6 +167,11 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
     public void onSaveInstanceState(Bundle outState) {
         //AppLog.d(T.STATS, "StatsVisitorsAndViewsFragment > saving instance state");
 
+        // FIX for https://github.com/wordpress-mobile/WordPress-Android/issues/2228
+        if (mVisitsData != null && mVisitsData instanceof VolleyError) {
+            VolleyError currentVolleyError = (VolleyError) mVisitsData;
+            mVisitsData = StatsUtils.rewriteVolleyError(currentVolleyError, getString(R.string.error_refresh_stats));
+        }
         outState.putSerializable(ARG_REST_RESPONSE, mVisitsData);
         outState.putInt(ARG_SELECTED_GRAPH_BAR, mSelectedBarGraphBarIndex);
         outState.putInt(ARG_SELECTED_OVERVIEW_ITEM, mSelectedOverviewItemIndex);
@@ -214,7 +220,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
             return;
         }
 
-        if (mVisitsData instanceof VolleyError) {
+        if (mVisitsData instanceof VolleyError || mVisitsData instanceof StatsError) {
             setupNoResultsUI(false);
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/exceptions/StatsError.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/exceptions/StatsError.java
@@ -1,0 +1,9 @@
+package org.wordpress.android.ui.stats.exceptions;
+
+import java.io.Serializable;
+
+public class StatsError extends Exception implements Serializable {
+    public StatsError(String errorMessage) {
+        super(errorMessage);
+    }
+}


### PR DESCRIPTION
Fix #2228 by not serializing VolleyErrors as-is, but rewrite them into simple Exceptions (StatsError) before saving them.