### PR TITLE
Fixed malformed stats pseudo-tabs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
@@ -91,7 +91,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         for (int i = 0; i < overviewItems.length; i++) {
             CheckedTextView rb = (CheckedTextView) inflater.inflate(R.layout.stats_visitors_and_views_button, container, false);
             LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(RadioGroup.LayoutParams.MATCH_PARENT,
-                    RadioGroup.LayoutParams.WRAP_CONTENT);
+                    RadioGroup.LayoutParams.MATCH_PARENT);
             params.weight = 1;
             rb.setTypeface((TypefaceCache.getTypeface(view.getContext())));
             params.setMargins(0, 0, 0, 0);


### PR DESCRIPTION
Fix #2230 by matching the parent height.

It's a quick fix for 3.6, a real solution for this problem will be introduced in https://github.com/wordpress-mobile/WordPress-Android/issues/2208 where the top area will be re-designed.