### PR TITLE
fix #2226 - create a menu drawer even when stats are shown as modal

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
@@ -143,7 +143,9 @@ public abstract class WPDrawerActivity extends ActionBarActivity {
             overridePendingTransition(0, 0);
             finish();
         }
-        mScrollPositionManager.saveToPreferences(this, SCROLL_POSITION_ID);
+        if (mScrollPositionManager != null) {
+            mScrollPositionManager.saveToPreferences(this, SCROLL_POSITION_ID);
+        }
     }
 
     @Override
@@ -155,7 +157,9 @@ public abstract class WPDrawerActivity extends ActionBarActivity {
             // Sync the toggle state after onRestoreInstanceState has occurred.
             mDrawerToggle.syncState();
         }
-        mScrollPositionManager.restoreFromPreferences(this, SCROLL_POSITION_ID);
+        if (mScrollPositionManager != null) {
+            mScrollPositionManager.restoreFromPreferences(this, SCROLL_POSITION_ID);
+        }
     }
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -548,10 +548,8 @@ public class StatsActivity extends WPDrawerActivity implements ScrollViewExt.Scr
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
-        if (!mNoMenuDrawer) {
-            MenuInflater inflater = getMenuInflater();
-            inflater.inflate(R.menu.stats, menu);
-        }
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.stats, menu);
         return true;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -119,7 +119,7 @@ public class StatsActivity extends WPDrawerActivity implements ScrollViewExt.Scr
         ActionBar actionBar = getSupportActionBar();
         createMenuDrawer(R.layout.stats_activity);
         if (mNoMenuDrawer) {
-            actionBar.setDisplayHomeAsUpEnabled(true);
+            getDrawerToggle().setDrawerIndicatorEnabled(false);
             // Override the default NavigationOnClickListener
             getToolbar().setNavigationOnClickListener(new View.OnClickListener() {
                 @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -117,13 +117,16 @@ public class StatsActivity extends WPDrawerActivity implements ScrollViewExt.Scr
 
         mNoMenuDrawer = getIntent().getBooleanExtra(ARG_NO_MENU_DRAWER, false);
         ActionBar actionBar = getSupportActionBar();
+        createMenuDrawer(R.layout.stats_activity);
         if (mNoMenuDrawer) {
-            setContentView(R.layout.stats_activity);
-            if (actionBar != null) {
-                actionBar.setDisplayHomeAsUpEnabled(true);
-            }
-        } else {
-            createMenuDrawer(R.layout.stats_activity);
+            actionBar.setDisplayHomeAsUpEnabled(true);
+            // Override the default NavigationOnClickListener
+            getToolbar().setNavigationOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    onBackPressed();
+                }
+            });
         }
 
         mSwipeToRefreshHelper = new SwipeToRefreshHelper(this, (SwipeRefreshLayout) findViewById(R.id.ptr_layout),
@@ -183,7 +186,7 @@ public class StatsActivity extends WPDrawerActivity implements ScrollViewExt.Scr
         }
 
         if (!mNoMenuDrawer && actionBar != null && mSpinner == null) {
-            final Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+            final Toolbar toolbar = getToolbar();
             if (toolbar != null) {
                 View view = View.inflate(this, R.layout.reader_spinner, toolbar);
                 mSpinner = (Spinner) view.findViewById(R.id.action_bar_spinner);
@@ -545,8 +548,10 @@ public class StatsActivity extends WPDrawerActivity implements ScrollViewExt.Scr
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
-        MenuInflater inflater = getMenuInflater();
-        inflater.inflate(R.menu.stats, menu);
+        if (!mNoMenuDrawer) {
+            MenuInflater inflater = getMenuInflater();
+            inflater.inflate(R.menu.stats, menu);
+        }
         return true;
     }
 
@@ -572,9 +577,6 @@ public class StatsActivity extends WPDrawerActivity implements ScrollViewExt.Scr
             WPWebViewActivity.openUrlByUsingWPCOMCredentials(this, addressToLoad, statsAuthenticatedUser,
                     statsAuthenticatedPassword);
             AnalyticsTracker.track(AnalyticsTracker.Stat.STATS_OPENED_WEB_VERSION);
-            return true;
-        } else if (mNoMenuDrawer && item.getItemId() == android.R.id.home) {
-            onBackPressed();
             return true;
         }
         return super.onOptionsItemSelected(item);


### PR DESCRIPTION
fix #2226 - create a menu drawer even when stats are shown as modal (opened from a Notification for instance).