### PR TITLE
Stats - Fix illegalStateException in Stats activity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -299,7 +299,6 @@ public class StatsActivity extends WPDrawerActivity implements ScrollViewExt.Scr
         }
         FragmentManager fm = getFragmentManager();
         FragmentTransaction ft = fm.beginTransaction();
-        //ft.setCustomAnimations(R.anim.stats_fragment_in, R.anim.stats_fragment_out);
 
         StatsAbstractFragment fragment;
 
@@ -362,7 +361,7 @@ public class StatsActivity extends WPDrawerActivity implements ScrollViewExt.Scr
             }
         }
 
-        ft.commit();
+        ft.commitAllowingStateLoss();
     }
 
     // AuthorsFragment should be dismissed when 0 or 1 author.

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -200,7 +200,9 @@ public class StatsActivity extends WPDrawerActivity implements ScrollViewExt.Scr
                 mSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
                     @Override
                     public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-
+                        if (isFinishing() || isActivityDestroyed()) {
+                            return;
+                        }
                         final StatsTimeframe selectedTimeframe =  (StatsTimeframe) mTimeframeSpinnerAdapter.getItem(position);
 
                         if (mCurrentTimeframe == selectedTimeframe) {
@@ -292,6 +294,9 @@ public class StatsActivity extends WPDrawerActivity implements ScrollViewExt.Scr
     }
 
     private void loadStatsFragments(boolean forceRecreationOfFragments, boolean loadGraphFragment, boolean loadAlltimeFragmets) {
+        if (isFinishing() || isActivityDestroyed()) {
+            return;
+        }
         FragmentManager fm = getFragmentManager();
         FragmentTransaction ft = fm.beginTransaction();
         //ft.setCustomAnimations(R.anim.stats_fragment_in, R.anim.stats_fragment_out);
@@ -603,6 +608,9 @@ public class StatsActivity extends WPDrawerActivity implements ScrollViewExt.Scr
     // StatsVisitorsAndViewsFragment calls this when the user taps on a bar in the graph
     @Override
     public void onDateChanged(String blogID, StatsTimeframe timeframe, String date) {
+        if (isFinishing() || isActivityDestroyed()) {
+            return;
+        }
         mRequestedDate = date;
         refreshStats(timeframe, date, false, false);
         emptyDataModelInFragments(false, false);


### PR DESCRIPTION
Fix #2239 by making sure the activity is still running before executing callbacks code.