### PR TITLE
Issue/2245 reader reveal exception

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -22,6 +22,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewAnimationUtils;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
 import android.view.animation.AccelerateDecelerateInterpolator;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
@@ -361,23 +362,33 @@ public class ReaderPostListFragment extends Fragment {
         if (!isAdded()) {
             return;
         }
-        ViewGroup header = (ViewGroup) getView().findViewById(R.id.frame_header);
-        if (header == null || header.getVisibility() == View.VISIBLE) {
+
+        final ViewGroup header = (ViewGroup) getView().findViewById(R.id.frame_header);
+        if (header == null) {
             return;
         }
-        header.setVisibility(View.VISIBLE);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            Animator animator = ViewAnimationUtils.createCircularReveal(
-                    header,
-                    header.getWidth() / 2,
-                    0,
-                    0,
-                    (float) Math.hypot(header.getWidth(), header.getHeight()));
-            animator.setInterpolator(new AccelerateDecelerateInterpolator());
-            animator.start();
-        } else {
-            AniUtils.startAnimation(header, R.anim.reader_top_bar_in);
-        }
+
+        // must wait for header to be fully laid out before animation or else we risk
+        // "IllegalStateException: Cannot start this animator on a detached view"
+        header.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+            @Override
+            public void onGlobalLayout() {
+                header.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                header.setVisibility(View.VISIBLE);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    Animator animator = ViewAnimationUtils.createCircularReveal(
+                            header,
+                            header.getWidth() / 2,
+                            0,
+                            0,
+                            (float) Math.hypot(header.getWidth(), header.getHeight()));
+                    animator.setInterpolator(new AccelerateDecelerateInterpolator());
+                    animator.start();
+                } else {
+                    AniUtils.startAnimation(header, R.anim.reader_top_bar_in);
+                }
+            }
+        });
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -355,7 +355,7 @@ public class ReaderPostListFragment extends Fragment {
     }
 
     /*
-     * animate in the blog/tag info header
+     * animate in the blog/tag info header after a brief delay
      */
     @SuppressLint("NewApi")
     private void animateHeader() {
@@ -364,29 +364,35 @@ public class ReaderPostListFragment extends Fragment {
         }
 
         final ViewGroup header = (ViewGroup) getView().findViewById(R.id.frame_header);
-        if (header == null) {
+        if (header == null || header.getVisibility() == View.VISIBLE) {
             return;
         }
 
-        // must wait for header to be fully laid out before animation or else we risk
+        // must wait for header to be fully laid out (ie: measured) or else we risk
         // "IllegalStateException: Cannot start this animator on a detached view"
         header.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
             @Override
             public void onGlobalLayout() {
                 header.getViewTreeObserver().removeOnGlobalLayoutListener(this);
-                header.setVisibility(View.VISIBLE);
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                    Animator animator = ViewAnimationUtils.createCircularReveal(
-                            header,
-                            header.getWidth() / 2,
-                            0,
-                            0,
-                            (float) Math.hypot(header.getWidth(), header.getHeight()));
-                    animator.setInterpolator(new AccelerateDecelerateInterpolator());
-                    animator.start();
-                } else {
-                    AniUtils.startAnimation(header, R.anim.reader_top_bar_in);
-                }
+                new Handler().postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (!isAdded()) return;
+                        header.setVisibility(View.VISIBLE);
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                            Animator animator = ViewAnimationUtils.createCircularReveal(
+                                    header,
+                                    header.getWidth() / 2,
+                                    0,
+                                    0,
+                                    (float) Math.hypot(header.getWidth(), header.getHeight()));
+                            animator.setInterpolator(new AccelerateDecelerateInterpolator());
+                            animator.start();
+                        } else {
+                            AniUtils.startAnimation(header, R.anim.reader_top_bar_in);
+                        }
+                    }
+                }, 250);
             }
         });
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -354,31 +354,30 @@ public class ReaderPostListFragment extends Fragment {
     }
 
     /*
-     * animate in the blog/tag info header after a brief delay
+     * animate in the blog/tag info header
      */
     @SuppressLint("NewApi")
     private void animateHeader() {
-        new Handler().postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                if (isAdded()) {
-                    ViewGroup header = (ViewGroup) getView().findViewById(R.id.frame_header);
-                    header.setVisibility(View.VISIBLE);
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                        Animator animator = ViewAnimationUtils.createCircularReveal(
-                                header,
-                                header.getWidth() / 2,
-                                0,
-                                0,
-                                (float) Math.hypot(header.getWidth(), header.getHeight()));
-                        animator.setInterpolator(new AccelerateDecelerateInterpolator());
-                        animator.start();
-                    } else {
-                        AniUtils.startAnimation(header, R.anim.reader_top_bar_in);
-                    }
-                }
-            }
-        }, 250);
+        if (!isAdded()) {
+            return;
+        }
+        ViewGroup header = (ViewGroup) getView().findViewById(R.id.frame_header);
+        if (header == null || header.getVisibility() == View.VISIBLE) {
+            return;
+        }
+        header.setVisibility(View.VISIBLE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            Animator animator = ViewAnimationUtils.createCircularReveal(
+                    header,
+                    header.getWidth() / 2,
+                    0,
+                    0,
+                    (float) Math.hypot(header.getWidth(), header.getHeight()));
+            animator.setInterpolator(new AccelerateDecelerateInterpolator());
+            animator.start();
+        } else {
+            AniUtils.startAnimation(header, R.anim.reader_top_bar_in);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fix #2245 - prevent IllegalStateException "Cannot start this animator on a detached view" by using a global layout listener to start the animation after the view has been measured.