### PR TITLE
fix #2252: fix npe when opening stats from notifications on 10" landscape tablets

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
@@ -43,6 +43,7 @@ import org.wordpress.android.ui.notifications.utils.SimperiumUtils;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.prefs.SettingsActivity;
 import org.wordpress.android.ui.reader.ReaderPostListActivity;
+import org.wordpress.android.ui.stats.StatsActivity;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.AuthenticationDialogUtils;
@@ -98,8 +99,11 @@ public abstract class WPDrawerActivity extends ActionBarActivity {
     @SuppressLint("NewApi")
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        if (isStaticMenuDrawer()) {
+        boolean menuDrawerDisabled = false;
+        if (getIntent() != null) {
+            menuDrawerDisabled = getIntent().getBooleanExtra(StatsActivity.ARG_NO_MENU_DRAWER, false);
+        }
+        if (isStaticMenuDrawer() && !menuDrawerDisabled) {
             setContentView(R.layout.activity_drawer_static);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 getWindow().setStatusBarColor(getResources().getColor(R.color.color_primary_dark));


### PR DESCRIPTION
fix #2252: fix npe when opening stats from notifications on 10" landscape tablets

I don't like that solution (still a bandaid), we should have 2 separates activities (one descending from WPDrawerActivity and another one descending from ActionBarActivity when the Stats screen open as a modal view).
