### PR TITLE
Issue/2255 photon quality

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -113,10 +113,17 @@ public class ReaderUtils {
     }
 
     public static String getResizedImageUrl(final String imageUrl, int width, int height, boolean isPrivate) {
+        return getResizedImageUrl(imageUrl, width, height, isPrivate, PhotonUtils.Quality.MEDIUM);
+    }
+    public static String getResizedImageUrl(final String imageUrl,
+                                            int width,
+                                            int height,
+                                            boolean isPrivate,
+                                            PhotonUtils.Quality quality) {
         if (isPrivate) {
             return getPrivateImageForDisplay(imageUrl, width, height);
         } else {
-            return PhotonUtils.getPhotonImageUrl(imageUrl, width, height);
+            return PhotonUtils.getPhotonImageUrl(imageUrl, width, height, quality);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -1,21 +1,12 @@
 package org.wordpress.android.ui.reader.utils;
 
 import android.content.Context;
-import android.graphics.Bitmap;
-import android.net.Uri;
 import android.text.TextUtils;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.AbsListView;
-import android.widget.ListView;
-import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.util.UrlUtils;
-
-import java.util.List;
 
 public class ReaderUtils {
 
@@ -30,86 +21,6 @@ public class ReaderUtils {
         }
         txtFollow.setText(txtFollow.getContext().getString(isFollowed ? R.string.reader_btn_unfollow : R.string.reader_btn_follow));
         txtFollow.setSelected(isFollowed);
-    }
-
-    /*
-     * return the path to use for the /batch/ endpoint from the list of request urls
-     * https://developer.wordpress.com/docs/api/1/get/batch/
-     */
-    public static String getBatchEndpointForRequests(List<String> requestUrls) {
-        StringBuilder sbBatch = new StringBuilder("/batch/");
-        if (requestUrls != null) {
-            boolean isFirst = true;
-            for (String url : requestUrls) {
-                if (!TextUtils.isEmpty(url)) {
-                    if (isFirst) {
-                        isFirst = false;
-                        sbBatch.append("?");
-                    } else {
-                        sbBatch.append("&");
-                    }
-                    sbBatch.append("urls%5B%5D=").append(Uri.encode(url));
-                }
-            }
-        }
-        return sbBatch.toString();
-    }
-
-    /*
-     * adds a transparent header to the passed listView
-     */
-    public static View addListViewHeader(ListView listView, int height) {
-        if (listView == null) {
-            return null;
-        }
-        RelativeLayout header = new RelativeLayout(listView.getContext());
-        header.setLayoutParams(new AbsListView.LayoutParams(
-                AbsListView.LayoutParams.MATCH_PARENT,
-                height));
-        listView.addHeaderView(header, null, false);
-        return header;
-    }
-
-    /*
-     * adds a rule which tells the view with targetId to be placed below layoutBelowId - only
-     * works if viewParent is a RelativeLayout
-     */
-    public static void layoutBelow(ViewGroup viewParent, int targetId, int layoutBelowId) {
-        if (viewParent == null || !(viewParent instanceof RelativeLayout)) {
-            return;
-        }
-
-        View target = viewParent.findViewById(targetId);
-        if (target == null) {
-            return;
-        }
-
-        if (target.getLayoutParams() instanceof RelativeLayout.LayoutParams) {
-            RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams) target.getLayoutParams();
-            params.addRule(RelativeLayout.BELOW, layoutBelowId);
-        }
-    }
-
-    /*
-     * returns a bitmap of the passed view - note that the view must have layout for this to work
-     */
-    public static Bitmap createBitmapFromView(View view) {
-        if (view == null) {
-            return null;
-        }
-
-        view.buildDrawingCache();
-        try {
-            Bitmap bmp = view.getDrawingCache();
-            if (bmp == null) {
-                return null;
-            }
-            // return a copy of this bitmap since original will be destroyed when the
-            // cache is destroyed
-            return bmp.copy(Bitmap.Config.ARGB_8888, false);
-        } finally {
-            view.destroyDrawingCache();
-        }
     }
 
     public static String getResizedImageUrl(final String imageUrl, int width, int height, boolean isPrivate) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPhotoView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPhotoView.java
@@ -21,6 +21,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DisplayUtils;
+import org.wordpress.android.util.PhotonUtils;
 
 import uk.co.senab.photoview.PhotoViewAttacher;
 
@@ -76,8 +77,8 @@ public class ReaderPhotoView extends RelativeLayout {
                             boolean isPrivate,
                             PhotoViewListener listener) {
         int loResWidth = (int) (hiResWidth * 0.10f);
-        mLoResImageUrl = ReaderUtils.getResizedImageUrl(imageUrl, loResWidth, 0, isPrivate);
-        mHiResImageUrl = ReaderUtils.getResizedImageUrl(imageUrl, hiResWidth, 0, isPrivate);
+        mLoResImageUrl = ReaderUtils.getResizedImageUrl(imageUrl, loResWidth, 0, isPrivate, PhotonUtils.Quality.LOW);
+        mHiResImageUrl = ReaderUtils.getResizedImageUrl(imageUrl, hiResWidth, 0, isPrivate, PhotonUtils.Quality.MEDIUM);
 
         mPhotoViewListener = listener;
         loadLoResImage();

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
@@ -37,6 +37,7 @@ public class PhotonUtils {
     /*
      * returns a photon url for the passed image with the resize query set to the passed dimensions
      */
+    private static final String QUALITY_PARAM = "quality=65";
     public static String getPhotonImageUrl(String imageUrl, int width, int height) {
         if (TextUtils.isEmpty(imageUrl)) {
             return "";
@@ -68,16 +69,16 @@ public class PhotonUtils {
         }
 
         // if both width & height are passed use the "resize" param, use only "w" or "h" if just
-        // one of them is set, otherwise no query string
+        // one of them is set - note that the passed quality parameter will only affect JPEGs
         final String query;
         if (width > 0 && height > 0) {
-            query = "?resize=" + width + "," + height;
+            query = "?resize=" + width + "," + height + "&" + QUALITY_PARAM;
         } else if (width > 0) {
-            query = "?w=" + width;
+            query = "?w=" + width + "&" + QUALITY_PARAM;
         } else if (height > 0) {
-            query = "?h=" + height;
+            query = "?h=" + height + "&" + QUALITY_PARAM;
         } else {
-            query = "";
+            query = "?" + QUALITY_PARAM;
         }
 
         // return passed url+query if it's already a photon url

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
@@ -20,8 +20,9 @@ public class PhotonUtils {
             return "";
 
         // if this isn't a gravatar image, return as resized photon image url
-        if (!imageUrl.contains("gravatar.com"))
+        if (!imageUrl.contains("gravatar.com")) {
             return getPhotonImageUrl(imageUrl, avatarSz, avatarSz);
+        }
 
         // remove all other params, then add query string for size and "mystery man" default
         return UrlUtils.removeQuery(imageUrl) + "?s=" + avatarSz + "&d=mm";
@@ -35,12 +36,13 @@ public class PhotonUtils {
     }
 
     /*
-     * returns a photon url for the passed image with the resize query set to the passed dimensions
+     * returns a photon url for the passed image with the resize query set to the passed
+     * dimensions - note that the passed quality parameter will only affect JPEGs
      */
     public static enum Quality {
         HIGH,
         MEDIUM,
-        LOW,
+        LOW
     }
     public static String getPhotonImageUrl(String imageUrl, int width, int height) {
         return getPhotonImageUrl(imageUrl, width, height, Quality.MEDIUM);
@@ -85,7 +87,7 @@ public class PhotonUtils {
         }
 
         // if both width & height are passed use the "resize" param, use only "w" or "h" if just
-        // one of them is set - note that the passed quality parameter will only affect JPEGs
+        // one of them is set
         final String query;
         if (width > 0 && height > 0) {
             query = "?resize=" + width + "," + height + "&" + qualityParam;

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
@@ -62,15 +62,11 @@ public class PhotonUtils {
         // don't use with GIFs - photon breaks animated GIFs, and sometimes returns a GIF that
         // can't be read by BitmapFactory.decodeByteArray (used by Volley in ImageRequest.java
         // to decode the downloaded image)
-        // ex: http://i0.wp.com/lusianne.files.wordpress.com/2013/08/193.gif?resize=768,320
         if (imageUrl.endsWith(".gif")) {
             return imageUrl;
         }
 
         // if this is an "mshots" url, skip photon and return it with a query that sets the width/height
-        // (these are screenshots of the blog that often appear in freshly pressed posts)
-        // see http://wp.tutsplus.com/tutorials/how-to-generate-website-screenshots-for-your-wordpress-site/
-        // ex: http://s.wordpress.com/mshots/v1/http%3A%2F%2Fnickbradbury.com?w=600
         if (isMshotsUrl(imageUrl)) {
             return imageUrl + "?w=" + width + "&h=" + height;
         }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
@@ -37,8 +37,15 @@ public class PhotonUtils {
     /*
      * returns a photon url for the passed image with the resize query set to the passed dimensions
      */
-    private static final String QUALITY_PARAM = "quality=65";
+    public static enum Quality {
+        HIGH,
+        MEDIUM,
+        LOW,
+    }
     public static String getPhotonImageUrl(String imageUrl, int width, int height) {
+        return getPhotonImageUrl(imageUrl, width, height, Quality.MEDIUM);
+    }
+    public static String getPhotonImageUrl(String imageUrl, int width, int height, Quality quality) {
         if (TextUtils.isEmpty(imageUrl)) {
             return "";
         }
@@ -68,17 +75,30 @@ public class PhotonUtils {
             return imageUrl + "?w=" + width + "&h=" + height;
         }
 
+        final String qualityParam;
+        switch (quality) {
+            case HIGH:
+                qualityParam = "quality=100";
+                break;
+            case LOW:
+                qualityParam = "quality=35";
+                break;
+            default: // medium
+                qualityParam = "quality=65";
+                break;
+        }
+
         // if both width & height are passed use the "resize" param, use only "w" or "h" if just
         // one of them is set - note that the passed quality parameter will only affect JPEGs
         final String query;
         if (width > 0 && height > 0) {
-            query = "?resize=" + width + "," + height + "&" + QUALITY_PARAM;
+            query = "?resize=" + width + "," + height + "&" + qualityParam;
         } else if (width > 0) {
-            query = "?w=" + width + "&" + QUALITY_PARAM;
+            query = "?w=" + width + "&" + qualityParam;
         } else if (height > 0) {
-            query = "?h=" + height + "&" + QUALITY_PARAM;
+            query = "?h=" + height + "&" + qualityParam;
         } else {
-            query = "?" + QUALITY_PARAM;
+            query = "?" + qualityParam;
         }
 
         // return passed url+query if it's already a photon url


### PR DESCRIPTION
Fix #2255 - adds a "quality" parameter to Photon requests, significantly reducing the file size of JPEG images. This primarily impacts the reader, where large featured images are often JPEGs. Note that I chose a default quality of 65, which seems to offer the best compression without much loss of fidelity.