### PR TITLE
Issue/2257 blog preview tablet

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
@@ -324,7 +324,7 @@ public abstract class WPDrawerActivity extends ActionBarActivity {
         }
     }
 
-    private void closeDrawer() {
+    void closeDrawer() {
         if (mDrawerLayout != null) {
             mDrawerLayout.closeDrawer(GravityCompat.START);
         }
@@ -333,6 +333,13 @@ public abstract class WPDrawerActivity extends ActionBarActivity {
     private void openDrawer() {
         if (mDrawerLayout != null) {
             mDrawerLayout.openDrawer(GravityCompat.START);
+        }
+    }
+
+    protected void hideStaticDrawer() {
+        View drawer = findViewById(R.id.left_drawer);
+        if (drawer != null) {
+            drawer.setVisibility(View.GONE);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
@@ -336,7 +336,7 @@ public abstract class WPDrawerActivity extends ActionBarActivity {
         }
     }
 
-    protected void hideStaticDrawer() {
+    protected void hideDrawer() {
         View drawer = findViewById(R.id.left_drawer);
         if (drawer != null) {
             drawer.setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPDrawerActivity.java
@@ -288,6 +288,8 @@ public abstract class WPDrawerActivity extends ActionBarActivity {
                 FragmentManager fm = getFragmentManager();
                 if (fm.getBackStackEntryCount() > 0) {
                     fm.popBackStack();
+                } else if (isStaticMenuDrawer()) {
+                    finish();
                 } else {
                     toggleDrawer();
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -132,6 +132,11 @@ public class ReaderPostListActivity extends WPDrawerActivity
             default:
                 break;
         }
+
+        // hide the static drawer for blog/tag preview
+        if (isStaticMenuDrawer() && mPostListType.isPreviewType()) {
+            hideStaticDrawer();
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -135,7 +135,7 @@ public class ReaderPostListActivity extends WPDrawerActivity
 
         // hide the static drawer for blog/tag preview
         if (isStaticMenuDrawer() && mPostListType.isPreviewType()) {
-            hideStaticDrawer();
+            hideDrawer();
         }
     }
 

--- a/WordPress/src/main/res/layout/activity_drawer_static.xml
+++ b/WordPress/src/main/res/layout/activity_drawer_static.xml
@@ -14,13 +14,13 @@
         <include
             layout="@layout/drawer"
             android:layout_width="@dimen/drawer_width_static"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            android:layout_marginRight="@dimen/margin_extra_small" />
 
         <LinearLayout
             android:id="@+id/activity_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginLeft="@dimen/margin_extra_small"
             android:orientation="vertical" />
     </LinearLayout>
 


### PR DESCRIPTION
Fix #2257 - When blog preview is shown and there's a static drawer, the drawer is now hidden so the preview appears "modal." The back arrow navigation now works as well.

Note that I'm not totally happy with this solution - I think showing blog preview as a fragment rather than an activity would be cleaner, but that's a much more involved solution, and one that would be tossed out in the upcoming redesign.