### PR TITLE
Feature/reader autohide toolbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderAnim.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderAnim.java
@@ -12,7 +12,9 @@ import android.view.animation.AccelerateDecelerateInterpolator;
 import android.view.animation.AccelerateInterpolator;
 import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
+import android.view.animation.DecelerateInterpolator;
 import android.view.animation.LinearInterpolator;
+import android.view.animation.TranslateAnimation;
 import android.widget.ListView;
 import android.widget.TextView;
 
@@ -307,6 +309,50 @@ public class ReaderAnim {
         }
 
         listItem.startAnimation(animation);
+    }
+
+    /*
+     * used when animating a toolbar in/out
+     */
+    public static void animateTopBar(View view, boolean show) {
+        animateBar(view, show, true);
+    }
+    public static void animateBottomBar(View view, boolean show) {
+        animateBar(view, show, false);
+    }
+    private static void animateBar(View view, boolean show, boolean isTopBar) {
+        int newVisibility = (show ? View.VISIBLE : View.GONE);
+        if (view == null || view.getVisibility() == newVisibility) {
+            return;
+        }
+
+        float fromY;
+        float toY;
+        if (isTopBar) {
+            fromY = (show ? -1f : 0f);
+            toY   = (show ? 0f : -1f);
+        } else {
+            fromY = (show ? 1f : 0f);
+            toY   = (show ? 0f : 1f);
+        }
+        Animation animation = new TranslateAnimation(
+                Animation.RELATIVE_TO_SELF, 0.0f,
+                Animation.RELATIVE_TO_SELF, 0.0f,
+                Animation.RELATIVE_TO_SELF, fromY,
+                Animation.RELATIVE_TO_SELF, toY);
+
+        long durationMillis = Duration.MEDIUM.toMillis(view.getContext());
+        animation.setDuration(durationMillis);
+
+        if (show) {
+            animation.setInterpolator(new DecelerateInterpolator());
+        } else {
+            animation.setInterpolator(new AccelerateInterpolator());
+        }
+
+        view.clearAnimation();
+        view.startAnimation(animation);
+        view.setVisibility(newVisibility);
     }
 
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderAnim.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderAnim.java
@@ -11,14 +11,11 @@ import android.view.View;
 import android.view.animation.AccelerateDecelerateInterpolator;
 import android.view.animation.AccelerateInterpolator;
 import android.view.animation.Animation;
-import android.view.animation.AnimationUtils;
 import android.view.animation.DecelerateInterpolator;
 import android.view.animation.LinearInterpolator;
 import android.view.animation.TranslateAnimation;
-import android.widget.ListView;
 import android.widget.TextView;
 
-import org.wordpress.android.R;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 
 public class ReaderAnim {
@@ -84,22 +81,6 @@ public class ReaderAnim {
         getFadeOutAnim(target, duration).start();
     }
 
-    public static void fadeInFadeOut(final View target, Duration duration) {
-        if (target == null || duration == null) {
-            return;
-        }
-
-        ObjectAnimator fadeIn = getFadeInAnim(target, duration);
-        ObjectAnimator fadeOut = getFadeOutAnim(target, duration);
-
-        // keep view visible for passed duration before fading it out
-        fadeOut.setStartDelay(duration.toMillis(target.getContext()));
-
-        AnimatorSet set = new AnimatorSet();
-        set.play(fadeOut).after(fadeIn);
-        set.start();
-    }
-
     public static void scaleIn(final View target, Duration duration) {
         if (target == null || duration == null) {
             return;
@@ -148,35 +129,6 @@ public class ReaderAnim {
         });
 
         animator.start();
-    }
-
-    public static void scaleInScaleOut(final View target, Duration duration) {
-        if (target == null || duration == null) {
-            return;
-        }
-
-        ObjectAnimator animX = ObjectAnimator.ofFloat(target, View.SCALE_X, 0f, 1f);
-        animX.setRepeatMode(ValueAnimator.REVERSE);
-        animX.setRepeatCount(1);
-        ObjectAnimator animY = ObjectAnimator.ofFloat(target, View.SCALE_Y, 0f, 1f);
-        animY.setRepeatMode(ValueAnimator.REVERSE);
-        animY.setRepeatCount(1);
-
-        AnimatorSet set = new AnimatorSet();
-        set.play(animX).with(animY);
-        set.setDuration(duration.toMillis(target.getContext()));
-        set.setInterpolator(new AccelerateDecelerateInterpolator());
-        set.addListener(new AnimatorListenerAdapter() {
-            @Override
-            public void onAnimationStart(Animator animation) {
-                target.setVisibility(View.VISIBLE);
-            }
-            @Override
-            public void onAnimationEnd(Animator animation) {
-                target.setVisibility(View.GONE);
-            }
-        });
-        set.start();
     }
 
     /*
@@ -260,55 +212,6 @@ public class ReaderAnim {
         set.setInterpolator(new AccelerateDecelerateInterpolator());
 
         set.start();
-    }
-
-    /*
-     * called when adding or removing an item from a listView
-     */
-    public static enum AnimateListItemStyle {
-        ADD,
-        REMOVE,
-        SHRINK }
-    public static void animateListItem(ListView listView,
-                                       int positionAbsolute,
-                                       AnimateListItemStyle style,
-                                       Animation.AnimationListener listener) {
-        if (listView == null) {
-            return;
-        }
-
-        // passed value is the absolute position of this item, convert to relative or else we'll
-        // remove the wrong item if list is scrolled
-        int firstVisible = listView.getFirstVisiblePosition();
-        int positionRelative = positionAbsolute - firstVisible;
-
-        View listItem = listView.getChildAt(positionRelative);
-        if (listItem == null) {
-            return;
-        }
-
-        final int animResId;
-        switch (style) {
-            case ADD:
-                animResId = R.anim.reader_listitem_add;
-                break;
-            case REMOVE:
-                animResId = R.anim.reader_listitem_remove;
-                break;
-            case SHRINK:
-                animResId = R.anim.reader_listitem_shrink;
-                break;
-            default:
-                return;
-        }
-
-        Animation animation = AnimationUtils.loadAnimation(listView.getContext(), animResId);
-
-        if (listener != null) {
-            animation.setAnimationListener(listener);
-        }
-
-        listItem.startAnimation(animation);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
@@ -15,6 +15,13 @@ public class ReaderInterfaces {
     }
 
     /*
+     * called from post detail fragment so toolbar can animate in/out when scrolling
+     */
+    public static interface AutoHideToolbarListener {
+        public void onShowHideToolbar(boolean show);
+    }
+
+    /*
      * called when user taps the dropdown arrow next to a post to show the popup menu
      */
     public static interface OnPostPopupListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -281,15 +281,7 @@ public class ReaderPostDetailFragment extends Fragment
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-
         setHasOptionsMenu(true);
-
-        ActionBar actionBar = getActionBar();
-        if (actionBar != null) {
-            actionBar.setDisplayShowTitleEnabled(true);
-            actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_STANDARD);
-        }
-
         restoreState(savedInstanceState);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -14,7 +14,9 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.animation.AccelerateInterpolator;
 import android.view.animation.Animation;
+import android.view.animation.DecelerateInterpolator;
 import android.view.animation.TranslateAnimation;
 import android.webkit.WebView;
 import android.widget.Button;
@@ -166,14 +168,14 @@ public class ReaderPostDetailFragment extends Fragment
 
     @Override
     public void onScrollUp() {
-        animateIconBar(true);
+        showIconBar(true);
         showToolbar(true);
     }
 
     @Override
     public void onScrollDown() {
         if (mScrollView.canScrollDown() && mScrollView.canScrollUp()) {
-            animateIconBar(false);
+            showIconBar(false);
             showToolbar(false);
         }
     }
@@ -181,7 +183,7 @@ public class ReaderPostDetailFragment extends Fragment
     @Override
     public void onScrollCompleted() {
         if (!mScrollView.canScrollDown()) {
-            animateIconBar(true);
+            showIconBar(true);
         }
     }
 
@@ -239,30 +241,33 @@ public class ReaderPostDetailFragment extends Fragment
     /*
      * animate in/out the layout containing the reblog/comment/like icons
      */
-    private void animateIconBar(boolean isAnimatingIn) {
-        if (isAnimatingIn && mLayoutIcons.getVisibility() == View.VISIBLE) {
-            return;
-        }
-        if (!isAnimatingIn && mLayoutIcons.getVisibility() != View.VISIBLE) {
+    private void showIconBar(boolean show) {
+        if (!isAdded()) return;
+
+        int newVisibility = (show ? View.VISIBLE : View.GONE);
+        if (mLayoutIcons == null || mLayoutIcons.getVisibility() == newVisibility) {
             return;
         }
 
-        final Animation animation;
-        if (isAnimatingIn) {
-            animation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 0.0f,
-                    Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF,
-                    1.0f, Animation.RELATIVE_TO_SELF, 0.0f);
-        } else {
-            animation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 0.0f,
-                    Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF,
-                    0.0f, Animation.RELATIVE_TO_SELF, 1.0f);
-        }
+        float fromY = (show ? 1f : 0f);
+        float toY   = (show ? 0f : 1f);
+        Animation animation = new TranslateAnimation(
+                Animation.RELATIVE_TO_SELF, 0.0f,
+                Animation.RELATIVE_TO_SELF, 0.0f,
+                Animation.RELATIVE_TO_SELF, fromY,
+                Animation.RELATIVE_TO_SELF, toY);
 
         animation.setDuration(mResourceVars.mediumAnimTime);
 
+        if (show) {
+            animation.setInterpolator(new DecelerateInterpolator());
+        } else {
+            animation.setInterpolator(new AccelerateInterpolator());
+        }
+
         mLayoutIcons.clearAnimation();
         mLayoutIcons.startAnimation(animation);
-        mLayoutIcons.setVisibility(isAnimatingIn ? View.VISIBLE : View.GONE);
+        mLayoutIcons.setVisibility(newVisibility);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -147,6 +147,11 @@ public class ReaderPostDetailFragment extends Fragment
         mScrollView.setVisibility(View.INVISIBLE);
         mLayoutIcons.setVisibility(View.INVISIBLE);
 
+        // spacer that's set to the same height as the toolbar needs to be visible if fragment is
+        // in an activity that supports toolbar auto-hiding (e.g. ReaderPostPagerActivity)
+        View spacer = view.findViewById(R.id.spacer_autohide_toolbar);
+        spacer.setVisibility(mAutoHideToolbarListener != null ? View.VISIBLE : View.GONE);
+
         return view;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -73,6 +73,7 @@ public class ReaderPostDetailFragment extends Fragment
     private boolean mIsBlockBlogDisabled;
 
     private ReaderInterfaces.OnPostPopupListener mOnPopupListener;
+    private ReaderInterfaces.AutoHideToolbarListener mAutoHideToolbarListener;
 
     private ReaderResourceVars mResourceVars;
 
@@ -120,6 +121,9 @@ public class ReaderPostDetailFragment extends Fragment
         if (activity instanceof ReaderInterfaces.OnPostPopupListener) {
             mOnPopupListener = (ReaderInterfaces.OnPostPopupListener) activity;
         }
+        if (activity instanceof ReaderInterfaces.AutoHideToolbarListener) {
+            mAutoHideToolbarListener = (ReaderInterfaces.AutoHideToolbarListener) activity;
+        }
     }
 
     @Override
@@ -154,15 +158,18 @@ public class ReaderPostDetailFragment extends Fragment
         }
     }
 
+
     @Override
     public void onScrollUp() {
         animateIconBar(true);
+        showToolbar(true);
     }
 
     @Override
     public void onScrollDown() {
         if (mScrollView.canScrollDown() && mScrollView.canScrollUp()) {
             animateIconBar(false);
+            showToolbar(false);
         }
     }
 
@@ -170,6 +177,12 @@ public class ReaderPostDetailFragment extends Fragment
     public void onScrollCompleted() {
         if (!mScrollView.canScrollDown()) {
             animateIconBar(true);
+        }
+    }
+
+    private void showToolbar(boolean show) {
+        if (mAutoHideToolbarListener != null) {
+            mAutoHideToolbarListener.onShowHideToolbar(show);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -14,10 +14,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.animation.AccelerateInterpolator;
-import android.view.animation.Animation;
-import android.view.animation.DecelerateInterpolator;
-import android.view.animation.TranslateAnimation;
 import android.webkit.WebView;
 import android.widget.Button;
 import android.widget.ImageView;
@@ -242,32 +238,9 @@ public class ReaderPostDetailFragment extends Fragment
      * animate in/out the layout containing the reblog/comment/like icons
      */
     private void showIconBar(boolean show) {
-        if (!isAdded()) return;
-
-        int newVisibility = (show ? View.VISIBLE : View.GONE);
-        if (mLayoutIcons == null || mLayoutIcons.getVisibility() == newVisibility) {
-            return;
+        if (isAdded()) {
+            ReaderAnim.animateBottomBar(mLayoutIcons, show);
         }
-
-        float fromY = (show ? 1f : 0f);
-        float toY   = (show ? 0f : 1f);
-        Animation animation = new TranslateAnimation(
-                Animation.RELATIVE_TO_SELF, 0.0f,
-                Animation.RELATIVE_TO_SELF, 0.0f,
-                Animation.RELATIVE_TO_SELF, fromY,
-                Animation.RELATIVE_TO_SELF, toY);
-
-        animation.setDuration(mResourceVars.mediumAnimTime);
-
-        if (show) {
-            animation.setInterpolator(new DecelerateInterpolator());
-        } else {
-            animation.setInterpolator(new AccelerateInterpolator());
-        }
-
-        mLayoutIcons.clearAnimation();
-        mLayoutIcons.startAnimation(animation);
-        mLayoutIcons.setVisibility(newVisibility);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -15,10 +15,6 @@ import android.util.SparseArray;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.animation.AccelerateInterpolator;
-import android.view.animation.Animation;
-import android.view.animation.DecelerateInterpolator;
-import android.view.animation.TranslateAnimation;
 import android.widget.PopupMenu;
 import android.widget.ProgressBar;
 
@@ -398,31 +394,9 @@ public class ReaderPostPagerActivity extends ActionBarActivity
      */
     @Override
     public void onShowHideToolbar(boolean show) {
-        int newVisibility = (show ? View.VISIBLE : View.GONE);
-        if (isFinishing() || mToolbar == null || mToolbar.getVisibility() == newVisibility) {
-            return;
+        if (!isFinishing()) {
+            ReaderAnim.animateTopBar(mToolbar, show);
         }
-
-        float fromY = (show ? -1f : 0f);
-        float toY   = (show ? 0f : -1f);
-        Animation animation = new TranslateAnimation(
-                Animation.RELATIVE_TO_SELF, 0.0f,
-                Animation.RELATIVE_TO_SELF, 0.0f,
-                Animation.RELATIVE_TO_SELF, fromY,
-                Animation.RELATIVE_TO_SELF, toY);
-
-        long duration = getResources().getInteger(android.R.integer.config_mediumAnimTime);
-        animation.setDuration(duration);
-
-        if (show) {
-            animation.setInterpolator(new DecelerateInterpolator());
-        } else {
-            animation.setInterpolator(new AccelerateInterpolator());
-        }
-
-        mToolbar.clearAnimation();
-        mToolbar.startAnimation(animation);
-        mToolbar.setVisibility(newVisibility);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -15,6 +15,8 @@ import android.util.SparseArray;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.animation.Animation;
+import android.view.animation.TranslateAnimation;
 import android.widget.PopupMenu;
 import android.widget.ProgressBar;
 
@@ -47,7 +49,8 @@ import javax.annotation.Nonnull;
  * post detail
  */
 public class ReaderPostPagerActivity extends ActionBarActivity
-        implements ReaderInterfaces.OnPostPopupListener {
+        implements ReaderInterfaces.OnPostPopupListener,
+                   ReaderInterfaces.AutoHideToolbarListener {
 
     private Toolbar mToolbar;
     private ReaderViewPager mViewPager;
@@ -65,7 +68,6 @@ public class ReaderPostPagerActivity extends ActionBarActivity
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        // TODO: investigate setHideOnContentScrollEnabled
         super.onCreate(savedInstanceState);
         setContentView(R.layout.reader_activity_post_pager);
 
@@ -121,6 +123,7 @@ public class ReaderPostPagerActivity extends ActionBarActivity
             public void onPageSelected(int position) {
                 super.onPageSelected(position);
                 AnalyticsTracker.track(AnalyticsTracker.Stat.READER_OPENED_ARTICLE);
+                onShowHideToolbar(true);
             }
 
             @Override
@@ -386,6 +389,32 @@ public class ReaderPostPagerActivity extends ActionBarActivity
         if (!isFinishing()) {
             UndoBarController.clear(this);
         }
+    }
+
+    @Override
+    public void onShowHideToolbar(boolean show) {
+        int newVisibility = (show ? View.VISIBLE : View.GONE);
+        if (mToolbar == null || mToolbar.getVisibility() == newVisibility) {
+            return;
+        }
+
+        final Animation animation;
+        if (show) {
+            animation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 0.0f,
+                    Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF,
+                    -1.0f, Animation.RELATIVE_TO_SELF, 0.0f);
+        } else {
+            animation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 0.0f,
+                    Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF,
+                    0.0f, Animation.RELATIVE_TO_SELF, -1.0f);
+        }
+
+        long duration = getResources().getInteger(android.R.integer.config_mediumAnimTime);
+        animation.setDuration(duration);
+
+        mToolbar.clearAnimation();
+        mToolbar.startAnimation(animation);
+        mToolbar.setVisibility(newVisibility);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -15,6 +15,7 @@ import android.util.SparseArray;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.animation.AccelerateInterpolator;
 import android.view.animation.Animation;
 import android.view.animation.TranslateAnimation;
 import android.widget.PopupMenu;
@@ -396,21 +397,21 @@ public class ReaderPostPagerActivity extends ActionBarActivity
      */
     @Override
     public void onShowHideToolbar(boolean show) {
+        if (isFinishing()) {
+            return;
+        }
         int newVisibility = (show ? View.VISIBLE : View.GONE);
         if (mToolbar == null || mToolbar.getVisibility() == newVisibility) {
             return;
         }
 
-        final Animation animation;
-        if (show) {
-            animation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 0.0f,
-                    Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF,
-                    -1.0f, Animation.RELATIVE_TO_SELF, 0.0f);
-        } else {
-            animation = new TranslateAnimation(Animation.RELATIVE_TO_SELF, 0.0f,
-                    Animation.RELATIVE_TO_SELF, 0.0f, Animation.RELATIVE_TO_SELF,
-                    0.0f, Animation.RELATIVE_TO_SELF, -1.0f);
-        }
+        float fromY = (show ? -1f : 0f);
+        float toY   = (show ? 0f : -1f);
+        Animation animation = new TranslateAnimation(
+                Animation.RELATIVE_TO_SELF, 0.0f,
+                Animation.RELATIVE_TO_SELF, 0.0f,
+                Animation.RELATIVE_TO_SELF, fromY,
+                Animation.RELATIVE_TO_SELF, toY);
 
         long duration = getResources().getInteger(android.R.integer.config_mediumAnimTime);
         animation.setDuration(duration);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -17,6 +17,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.AccelerateInterpolator;
 import android.view.animation.Animation;
+import android.view.animation.DecelerateInterpolator;
 import android.view.animation.TranslateAnimation;
 import android.widget.PopupMenu;
 import android.widget.ProgressBar;
@@ -397,11 +398,8 @@ public class ReaderPostPagerActivity extends ActionBarActivity
      */
     @Override
     public void onShowHideToolbar(boolean show) {
-        if (isFinishing()) {
-            return;
-        }
         int newVisibility = (show ? View.VISIBLE : View.GONE);
-        if (mToolbar == null || mToolbar.getVisibility() == newVisibility) {
+        if (isFinishing() || mToolbar == null || mToolbar.getVisibility() == newVisibility) {
             return;
         }
 
@@ -415,6 +413,12 @@ public class ReaderPostPagerActivity extends ActionBarActivity
 
         long duration = getResources().getInteger(android.R.integer.config_mediumAnimTime);
         animation.setDuration(duration);
+
+        if (show) {
+            animation.setInterpolator(new DecelerateInterpolator());
+        } else {
+            animation.setInterpolator(new AccelerateInterpolator());
+        }
 
         mToolbar.clearAnimation();
         mToolbar.startAnimation(animation);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -391,6 +391,9 @@ public class ReaderPostPagerActivity extends ActionBarActivity
         }
     }
 
+    /*
+     * called by detail fragment to show/hide the toolbar when user scrolls
+     */
     @Override
     public void onShowHideToolbar(boolean show) {
         int newVisibility = (show ? View.VISIBLE : View.GONE);
@@ -429,7 +432,7 @@ public class ReaderPostPagerActivity extends ActionBarActivity
         // built-in way to do this - note that destroyItem() removes fragments
         // from this map when they're removed from the adapter, so this doesn't
         // retain *every* fragment
-        private final SparseArray<Fragment> mFragmentMap = new SparseArray<Fragment>();
+        private final SparseArray<Fragment> mFragmentMap = new SparseArray<>();
 
         PostPagerAdapter(FragmentManager fm, ReaderBlogIdPostIdList ids) {
             super(fm);

--- a/WordPress/src/main/res/layout/reader_activity_post_pager.xml
+++ b/WordPress/src/main/res/layout/reader_activity_post_pager.xml
@@ -5,15 +5,10 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <include
-        android:id="@+id/toolbar"
-        layout="@layout/toolbar" />
-
     <org.wordpress.android.ui.reader.views.ReaderViewPager
         android:id="@+id/viewpager"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/toolbar" />
+        android:layout_height="wrap_content" />
 
     <ProgressBar
         android:id="@+id/progress_loading"
@@ -22,5 +17,9 @@
         android:layout_centerInParent="true"
         android:visibility="gone"
         tools:visibility="visible" />
+
+    <include
+        android:id="@+id/toolbar"
+        layout="@layout/toolbar" />
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -22,6 +22,7 @@
                 layout="@layout/reader_include_post_detail"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
+            
         </org.wordpress.android.widgets.WPScrollView>
 
         <RelativeLayout

--- a/WordPress/src/main/res/layout/reader_include_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail.xml
@@ -13,6 +13,13 @@
     android:paddingRight="@dimen/reader_card_content_padding"
     android:paddingTop="@dimen/margin_large">
 
+    <View
+        android:id="@+id/spacer_autohide_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
     <LinearLayout
         android:id="@+id/layout_detail_header"
         android:layout_width="match_parent"


### PR DESCRIPTION
This PR returns the "auto-hide" toolbar to the Reader detail view, which hides the toolbar when scrolling down and re-displays it when scrolling up. [Here's a demo video](https://cloudup.com/cqzfsAT0WtA).