### PR TITLE
Fix #2258 by adding getCount() Override

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NoteBlockAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NoteBlockAdapter.java
@@ -32,6 +32,11 @@ public class NoteBlockAdapter extends ArrayAdapter<NoteBlock> {
     }
 
     @Override
+    public int getCount() {
+        return mNoteBlockList == null ? 0 : mNoteBlockList.size();
+    }
+
+    @Override
     public View getView(int position, View convertView, ViewGroup parent) {
         NoteBlock noteBlock = mNoteBlockList.get(position);
 


### PR DESCRIPTION
Adapter needed an override of `getCount()`. 

Fixes #2258.