### PR TITLE
issue/2222 theme preview title

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemePreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemePreviewFragment.java
@@ -134,8 +134,11 @@ public class ThemePreviewFragment extends Fragment {
         mWebView.getSettings().setUserAgentString(DESKTOP_UA);
         mWebView.setScrollBarStyle(View.SCROLLBARS_INSIDE_OVERLAY);
 
-        mWebView.setWebChromeClient(new WPWebChromeClient(getActivity(), (ProgressBar) view.findViewById(
-                R.id.progress_bar)));
+        mWebView.setWebChromeClient(
+                new WPWebChromeClient(
+                        getActivity(),
+                        (ProgressBar) view.findViewById(R.id.progress_bar),
+                        false));
 
         mWebView.setWebViewClient(new WPWebViewClient(mBlog));
 

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/WPWebChromeClient.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/WPWebChromeClient.java
@@ -7,23 +7,35 @@ import android.webkit.WebView;
 import android.widget.ProgressBar;
 
 public class WPWebChromeClient extends WebChromeClient {
-    private ProgressBar mProgressBar;
-    private Activity mActivity;
+    private final ProgressBar mProgressBar;
+    private final Activity mActivity;
+    private final boolean mAutoUpdateActivityTitle;
 
     public WPWebChromeClient(Activity activity, ProgressBar progressBar) {
-        mProgressBar = progressBar;
         mActivity = activity;
+        mProgressBar = progressBar;
+        mAutoUpdateActivityTitle = true;
+    }
+
+    public WPWebChromeClient(Activity activity,
+                             ProgressBar progressBar,
+                             boolean autoUpdateActivityTitle) {
+        mActivity = activity;
+        mProgressBar = progressBar;
+        mAutoUpdateActivityTitle = autoUpdateActivityTitle;
     }
 
     public void onProgressChanged(WebView webView, int progress) {
-        if (!mActivity.isFinishing()) {
+        if (mActivity != null && !mActivity.isFinishing() && mAutoUpdateActivityTitle) {
             mActivity.setTitle(webView.getTitle());
         }
-        if (progress == 100) {
-            mProgressBar.setVisibility(View.GONE);
-        } else {
-            mProgressBar.setVisibility(View.VISIBLE);
-            mProgressBar.setProgress(progress);
+        if (mProgressBar != null) {
+            if (progress == 100) {
+                mProgressBar.setVisibility(View.GONE);
+            } else {
+                mProgressBar.setVisibility(View.VISIBLE);
+                mProgressBar.setProgress(progress);
+            }
         }
     }
 }


### PR DESCRIPTION
Fix #2222 - previewing a theme no longer changes the activity title. This was done by adding a param to WPWebChromeClient's constructor that tells it not to set the activity title in its progress change event.