### PR TITLE
issue/2265 theme preview illegal state

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -478,7 +478,8 @@ public class ThemeBrowserActivity extends WPDrawerActivity implements
                 ft.hide(mDetailsFragment);
             }
         }
-        ft.add(R.id.theme_browser_container, mPreviewFragment, ThemePreviewFragment.TAG);
+
+        ft.replace(R.id.theme_browser_container, mPreviewFragment, ThemePreviewFragment.TAG);
         ft.addToBackStack(null);
         ft.commit();
         setupBaseLayout();


### PR DESCRIPTION
Fix #2265 by using "replace" rather than "add" with the theme preview fragment. This will replace the existing fragment, and if there isn't one it will simply add it, resolving the problem.