### PR TITLE
fix #2270: login screen, show a "no network" error instead of a generic

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -51,6 +51,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.GenericCallback;
+import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.widgets.WPTextView;
 import org.wordpress.emailchecker.EmailChecker;
@@ -631,7 +632,12 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         AnalyticsTracker.track(Stat.LOGIN_FAILED);
         FragmentTransaction ft = getFragmentManager().beginTransaction();
         SignInDialogFragment nuxAlert;
-        if (messageId == org.wordpress.android.R.string.account_two_step_auth_enabled) {
+        if (!NetworkUtils.isNetworkAvailable(getActivity())) {
+            nuxAlert = SignInDialogFragment.newInstance(getString(R.string.no_network_title),
+                    getString(R.string.no_network_message),
+                    R.drawable.noticon_alert_big,
+                    getString(R.string.cancel));
+        } else if (messageId == org.wordpress.android.R.string.account_two_step_auth_enabled) {
             nuxAlert = SignInDialogFragment.newInstance(getString(org.wordpress.android.R.string.nux_cannot_log_in),
                     getString(messageId), org.wordpress.android.R.drawable.noticon_alert_big, 2, getString(
                             org.wordpress.android.R.string.cancel), getString(
@@ -641,26 +647,20 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             bundle.putString(SignInDialogFragment.ARG_OPEN_URL_PARAM,
                     "https://wordpress.com/settings/security/?ssl=forced");
             nuxAlert.setArguments(bundle);
+        } else if (messageId == org.wordpress.android.R.string.username_or_password_incorrect) {
+            handleInvalidUsernameOrPassword(messageId);
+            return;
+        } else if (messageId == org.wordpress.android.R.string.invalid_url_message) {
+            showUrlError(messageId);
+            endProgress();
+            return;
         } else {
-            if (messageId == org.wordpress.android.R.string.username_or_password_incorrect) {
-                handleInvalidUsernameOrPassword(messageId);
-                return;
-            } else if (messageId == org.wordpress.android.R.string.invalid_url_message) {
-                showUrlError(messageId);
-                endProgress();
-                return;
-            } else {
-                AppLog.e(T.NUX, clientResponse);
-                // create a 3 buttons dialog ("Contact us", "Read Application Logs" and "Cancel")
-                nuxAlert = SignInDialogFragment.newInstance(getString(org.wordpress.android.R.string.nux_cannot_log_in),
-                        getString(messageId),
-                        R.drawable.noticon_alert_big, 3,
-                        getString(R.string.cancel),
-                        getString(R.string.contact_us),
-                        getString(R.string.reader_title_applog),
-                        SignInDialogFragment.ACTION_OPEN_SUPPORT_CHAT,
-                        SignInDialogFragment.ACTION_OPEN_APPLICATION_LOG);
-            }
+            AppLog.e(T.NUX, clientResponse);
+            nuxAlert = SignInDialogFragment.newInstance(getString(org.wordpress.android.R.string.nux_cannot_log_in),
+                    getString(messageId), R.drawable.noticon_alert_big, 3,
+                    getString(R.string.cancel), getString(R.string.contact_us), getString(R.string.reader_title_applog),
+                    SignInDialogFragment.ACTION_OPEN_SUPPORT_CHAT,
+                    SignInDialogFragment.ACTION_OPEN_APPLICATION_LOG);
         }
         ft.add(nuxAlert, "alert");
         ft.commitAllowingStateLoss();

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -409,10 +409,30 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         fetchBlogListWPOrg.execute(mFecthBlogListCallback);
     }
 
+    private boolean checkNetworkConnectivity() {
+        if (!NetworkUtils.isNetworkAvailable(getActivity())) {
+            FragmentTransaction ft = getFragmentManager().beginTransaction();
+            SignInDialogFragment nuxAlert;
+            nuxAlert = SignInDialogFragment.newInstance(getString(R.string.no_network_title),
+                    getString(R.string.no_network_message),
+                    R.drawable.noticon_alert_big,
+                    getString(R.string.cancel));
+            ft.add(nuxAlert, "alert");
+            ft.commitAllowingStateLoss();
+            return true;
+        }
+        return false;
+    }
+
     private void signIn() {
         if (!isUserDataValid()) {
             return;
         }
+
+        if (checkNetworkConnectivity()) {
+            return;
+        }
+
         mUsername = EditTextUtils.getText(mUsernameEditText).trim();
         mPassword = EditTextUtils.getText(mPasswordEditText).trim();
         if (isWPComLogin()) {
@@ -632,12 +652,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         AnalyticsTracker.track(Stat.LOGIN_FAILED);
         FragmentTransaction ft = getFragmentManager().beginTransaction();
         SignInDialogFragment nuxAlert;
-        if (!NetworkUtils.isNetworkAvailable(getActivity())) {
-            nuxAlert = SignInDialogFragment.newInstance(getString(R.string.no_network_title),
-                    getString(R.string.no_network_message),
-                    R.drawable.noticon_alert_big,
-                    getString(R.string.cancel));
-        } else if (messageId == org.wordpress.android.R.string.account_two_step_auth_enabled) {
+        if (messageId == org.wordpress.android.R.string.account_two_step_auth_enabled) {
             nuxAlert = SignInDialogFragment.newInstance(getString(org.wordpress.android.R.string.nux_cannot_log_in),
                     getString(messageId), org.wordpress.android.R.drawable.noticon_alert_big, 2, getString(
                             org.wordpress.android.R.string.cancel), getString(

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -419,9 +419,9 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                     getString(R.string.cancel));
             ft.add(nuxAlert, "alert");
             ft.commitAllowingStateLoss();
-            return true;
+            return false;
         }
-        return false;
+        return true;
     }
 
     private void signIn() {
@@ -429,7 +429,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             return;
         }
 
-        if (checkNetworkConnectivity()) {
+        if (!checkNetworkConnectivity()) {
             return;
         }
 


### PR DESCRIPTION
fix #2270: login screen, show a "no network" error instead of a generic