### PR TITLE
Fix #2282: Prevent posts from being opened if uploading

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
@@ -29,6 +29,7 @@ import org.wordpress.android.util.AlertUtil;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.ProfilingUtils;
+import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPMeShortlinks;
 import org.wordpress.android.widgets.WPAlertDialogFragment;
 import org.wordpress.passcodelock.AppLockManager;
@@ -249,6 +250,7 @@ public class PostsActivity extends WPDrawerActivity
 
         if (post != null) {
             if (post.isUploading()){
+                ToastUtils.showToast(this, "Unable to open this post", ToastUtils.Duration.SHORT);
                 return;
             }
             WordPress.currentPost = post;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
@@ -250,7 +250,7 @@ public class PostsActivity extends WPDrawerActivity
 
         if (post != null) {
             if (post.isUploading()){
-                ToastUtils.showToast(this, "Unable to open this post", ToastUtils.Duration.SHORT);
+                ToastUtils.showToast(this, R.string.toast_err_post_uploading, ToastUtils.Duration.SHORT);
                 return;
             }
             WordPress.currentPost = post;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
@@ -248,6 +248,9 @@ public class PostsActivity extends WPDrawerActivity
         ViewPostFragment viewPostFragment = (ViewPostFragment) fm.findFragmentById(R.id.postDetail);
 
         if (post != null) {
+            if (post.isUploading()){
+                return;
+            }
             WordPress.currentPost = post;
             if (viewPostFragment == null || !viewPostFragment.isInLayout()) {
                 FragmentTransaction ft = fm.beginTransaction();

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -189,6 +189,7 @@
     <string name="share_url">Share URL</string>
     <string name="loading_posts">Loading posts…</string>
     <string name="loading_pages">Loading pages…</string>
+    <string name="toast_err_post_uploading">Unable to open this post while it's uploading</string>
 
     <!-- reload drop down -->
     <string name="loading">Loading…</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -189,7 +189,7 @@
     <string name="share_url">Share URL</string>
     <string name="loading_posts">Loading posts…</string>
     <string name="loading_pages">Loading pages…</string>
-    <string name="toast_err_post_uploading">Unable to open this post while it's uploading</string>
+    <string name="toast_err_post_uploading">Unable to open this post while it\'s uploading</string>
 
     <!-- reload drop down -->
     <string name="loading">Loading…</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -189,7 +189,7 @@
     <string name="share_url">Share URL</string>
     <string name="loading_posts">Loading posts…</string>
     <string name="loading_pages">Loading pages…</string>
-    <string name="toast_err_post_uploading">Unable to open this post while it\'s uploading</string>
+    <string name="toast_err_post_uploading">Unable to open post while it\'s uploading</string>
 
     <!-- reload drop down -->
     <string name="loading">Loading…</string>


### PR DESCRIPTION
Followed @maxme's recommendation and made posts unable to be opened if they are uploading.