### PR TITLE
Issue/delete untitled remote post dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
@@ -426,15 +426,20 @@ public class PostsActivity extends WPDrawerActivity
                     dialogBuilder.create().show();
                 }
             } else {
+                String deletePostMessage = getResources().getText(
+                        (post.isPage()) ? R.string.delete_page
+                                : R.string.delete_post).toString();
+                if (!post.getTitle().isEmpty()) {
+                    String postTitleEnclosedByQuotes = "'" + post.getTitle() + "'";
+                    deletePostMessage += " " + postTitleEnclosedByQuotes;
+                }
+
                 AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(
                         PostsActivity.this);
                 dialogBuilder.setTitle(getResources().getText(
                         (post.isPage()) ? R.string.delete_page
                                 : R.string.delete_post));
-                dialogBuilder.setMessage(getResources().getText(
-                        (post.isPage()) ? R.string.delete_sure_page
-                                : R.string.delete_sure_post)
-                        + " '" + post.getTitle() + "'?");
+                dialogBuilder.setMessage(deletePostMessage + "?");
                 dialogBuilder.setPositiveButton(
                         getResources().getText(R.string.yes),
                         new DialogInterface.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
@@ -427,8 +427,8 @@ public class PostsActivity extends WPDrawerActivity
                 }
             } else {
                 String deletePostMessage = getResources().getText(
-                        (post.isPage()) ? R.string.delete_page
-                                : R.string.delete_post).toString();
+                        (post.isPage()) ? R.string.delete_sure_page
+                                : R.string.delete_sure_post).toString();
                 if (!post.getTitle().isEmpty()) {
                     String postTitleEnclosedByQuotes = "'" + post.getTitle() + "'";
                     deletePostMessage += " " + postTitleEnclosedByQuotes;


### PR DESCRIPTION
The message in the confirmation dialog for deleting an untitled remote post was displaying empty quotes for untitled posts. Strangely enough, this was working fine for deleting local drafts, so I copied the style from there.

Before:
<img src="https://cloud.githubusercontent.com/assets/5845439/5994453/b9c18b68-aa41-11e4-96b6-591f9427b263.png" width="200" >

After:
<img src="https://cloud.githubusercontent.com/assets/5845439/5994454/c549fa42-aa41-11e4-88ea-7e3e55c6a737.png" width="200" >
