### PR TITLE
fix AppLogViewerActivity when a log message is null

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -650,7 +650,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                 endProgress();
                 return;
             } else {
-                AppLog.e(T.NUX, clientResponse);
+                AppLog.e(T.NUX, "Server response: " + clientResponse);
                 // create a 3 buttons dialog ("Contact us", "Read Application Logs" and "Cancel")
                 nuxAlert = SignInDialogFragment.newInstance(getString(org.wordpress.android.R.string.nux_cannot_log_in),
                         getString(messageId),

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -33,31 +33,37 @@ public class AppLog {
     }
 
     public static void v(T tag, String message) {
+        message = StringUtils.notNullStr(message);
         Log.v(TAG + "-" + tag.toString(), message);
         addEntry(tag, LogLevel.v, message);
     }
 
     public static void d(T tag, String message) {
+        message = StringUtils.notNullStr(message);
         Log.d(TAG + "-" + tag.toString(), message);
         addEntry(tag, LogLevel.d, message);
     }
 
     public static void i(T tag, String message) {
+        message = StringUtils.notNullStr(message);
         Log.i(TAG + "-" + tag.toString(), message);
         addEntry(tag, LogLevel.i, message);
     }
 
     public static void w(T tag, String message) {
+        message = StringUtils.notNullStr(message);
         Log.w(TAG + "-" + tag.toString(), message);
         addEntry(tag, LogLevel.w, message);
     }
 
     public static void e(T tag, String message) {
+        message = StringUtils.notNullStr(message);
         Log.e(TAG + "-" + tag.toString(), message);
         addEntry(tag, LogLevel.e, message);
     }
 
     public static void e(T tag, String message, Throwable tr) {
+        message = StringUtils.notNullStr(message);
         Log.e(TAG + "-" + tag.toString(), message, tr);
         addEntry(tag, LogLevel.e, message + " - exception: " + tr.getMessage());
         addEntry(tag, LogLevel.e, "StackTrace: " + getStringStackTrace(tr));


### PR DESCRIPTION
First occurence of this issue, it might come from https://github.com/wordpress-mobile/WordPress-Android/blob/bbb70997dbd9bc8c686155ae136680214da11c41/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java#L653 introduced in 3.7