### PR TITLE
fix #2293: remove leading double slash in URLs returned by wporg servers

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/FetchBlogListWPOrg.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/FetchBlogListWPOrg.java
@@ -120,9 +120,8 @@ public class FetchBlogListWPOrg extends FetchBlogListAbstract {
         // Validate the URL found before calling the client. Prevent a crash that can occur
         // during the setup of self-hosted sites.
         URI xmlrpcUri;
-            xmlrpcUri = URI.create(xmlrpcUrl);
-            getBlogList(xmlrpcUri, callback);
-
+        xmlrpcUri = URI.create(xmlrpcUrl);
+        getBlogList(xmlrpcUri, callback);
     }
 
     private String getRsdUrl(String baseUrl) throws SSLHandshakeException {
@@ -243,7 +242,7 @@ public class FetchBlogListWPOrg extends FetchBlogListAbstract {
         // Attempt to get the XMLRPC URL via RSD
         String rsdUrl;
         try {
-            rsdUrl = getRsdUrl(url);
+            rsdUrl = UrlUtils.addUrlSchemeIfNeeded(getRsdUrl(url), false);
         } catch (SSLHandshakeException e) {
             if (!UrlUtils.getDomainFromUrl(url).endsWith("wordpress.com")) {
                 mErroneousSslCertificate = true;
@@ -254,12 +253,12 @@ public class FetchBlogListWPOrg extends FetchBlogListAbstract {
 
         try {
             if (rsdUrl != null) {
-                xmlrpcUrl = ApiHelper.getXMLRPCUrl(rsdUrl);
+                xmlrpcUrl = UrlUtils.addUrlSchemeIfNeeded(ApiHelper.getXMLRPCUrl(rsdUrl), false);
                 if (xmlrpcUrl == null) {
-                    xmlrpcUrl = rsdUrl.replace("?rsd", "");
+                    xmlrpcUrl = UrlUtils.addUrlSchemeIfNeeded(rsdUrl.replace("?rsd", ""), false);
                 }
             } else {
-                xmlrpcUrl = getXmlrpcByUserEnteredPath(url);
+                xmlrpcUrl = UrlUtils.addUrlSchemeIfNeeded(getXmlrpcByUserEnteredPath(url), false);
             }
         } catch (SSLHandshakeException e) {
             if (!UrlUtils.getDomainFromUrl(url).endsWith("wordpress.com")) {

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
@@ -4,9 +4,12 @@ import android.net.Uri;
 import android.webkit.MimeTypeMap;
 import android.webkit.URLUtil;
 
+import org.wordpress.android.util.AppLog.T;
+
 import java.io.UnsupportedEncodingException;
 import java.net.IDN;
 import java.net.URI;
+import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
@@ -52,10 +55,29 @@ public class UrlUtils {
         return url;
     }
 
+    /**
+     * Remove leading double slash, and inherit protocol scheme
+     */
+    public static String removeLeadingDoubleSlash(String url, String scheme) {
+        if (url != null && url.startsWith("//")) {
+            url = url.substring(2);
+            if (scheme != null) {
+                if (scheme.endsWith("://")){
+                    url = scheme + url;
+                } else {
+                    AppLog.e(T.UTILS, "Invalid scheme used: " + scheme);
+                }
+            }
+        }
+        return url;
+    }
+
     public static String addUrlSchemeIfNeeded(String url, boolean isHTTPS) {
         if (url == null) {
             return null;
         }
+
+        url = removeLeadingDoubleSlash(url, (isHTTPS ? "https" : "http") + "://");
 
         if (!URLUtil.isValidUrl(url)) {
             if (!(url.toLowerCase().startsWith("http://")) && !(url.toLowerCase().startsWith("https://"))) {
@@ -78,7 +100,8 @@ public class UrlUtils {
         // this routine is called from some performance-critical code and creating a URI from a string
         // is slow, so skip it when possible - if we know it's not a relative path (and 99.9% of the
         // time it won't be for our purposes) then we can normalize it without java.net.URI.normalize()
-        if (urlString.startsWith("http") && !urlString.contains("build/intermediates/exploded-aar/org.wordpress/graphview/3.1.1")) {
+        if (urlString.startsWith("http") &&
+                !urlString.contains("build/intermediates/exploded-aar/org.wordpress/graphview/3.1.1")) {
             // return without a trailing slash
             if (urlString.endsWith("/")) {
                 return urlString.substring(0, urlString.length() - 1);


### PR DESCRIPTION
fix #2293: remove leading double slash in URLs returned by wporg servers