### PR TITLE
Notifications: Proper retrieval of note comment actions object

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/Note.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Note.java
@@ -222,7 +222,7 @@ public class Note extends Syncable {
                 return mNoteJSON.getJSONArray("body");
             }
         } catch (JSONException e) {
-            return null;
+            return new JSONArray();
         }
     }
 
@@ -231,9 +231,23 @@ public class Note extends Syncable {
         return queryJSON("noticon", "");
     }
 
-    JSONObject getCommentActions() {
+    private JSONObject getCommentActions() {
         if (mActions == null) {
-            mActions = queryJSON("body[last].actions", new JSONObject());
+            // Find comment block that matches the root note comment id
+            long commentId = getCommentId();
+            JSONArray bodyArray = getBody();
+            for (int i = 0; i < bodyArray.length(); i++) {
+                try {
+                    JSONObject bodyItem = bodyArray.getJSONObject(i);
+                    if (bodyItem.has("type") && bodyItem.optString("type").equals("comment")
+                            && commentId == JSONUtil.queryJSON(bodyItem, "meta.ids.comment", 0)) {
+                        mActions = JSONUtil.queryJSON(bodyItem, "actions", new JSONObject());
+                        break;
+                    }
+                } catch (JSONException e) {
+                    break;
+                }
+            }
         }
 
         return mActions;

--- a/WordPress/src/main/java/org/wordpress/android/models/Note.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Note.java
@@ -248,6 +248,10 @@ public class Note extends Syncable {
                     break;
                 }
             }
+
+            if (mActions == null) {
+                mActions = new JSONObject();
+            }
         }
 
         return mActions;


### PR DESCRIPTION
Get the note comment actions by looping through the note body. Match is found when the note meta comment id equals the meta id of the body item.

Note to PR reviewer: To test that this works properly, look for actions on a comment notification ('Like', 'Approve', etc)

Fixes #2322