### PR TITLE
fix #2336 NPE in LogEntry

### DIFF
--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -113,22 +113,31 @@ public class AppLog {
     }
 
     private static class LogEntry {
-        LogLevel logLevel;
-        String logText;
-        T logTag;
+        LogLevel mLogLevel;
+        String mLogText;
+        T mLogTag;
+
+        public LogEntry(LogLevel logLevel, String logText, T logTag) {
+            mLogLevel = logLevel;
+            mLogText = logText;
+            if (mLogText == null) {
+                mLogText = "null";
+            }
+            mLogTag = logTag;
+        }
 
         private String toHtml() {
-            StringBuilder sb = new StringBuilder()
-                    .append("<font color=\"")
-                    .append(logLevel.toHtmlColor())
-                    .append("\">")
-                    .append("[")
-                    .append(logTag.name())
-                    .append("] ")
-                    .append(logLevel.name())
-                    .append(": ")
-                    .append(TextUtils.htmlEncode(logText).replace("\n", "<br />"))
-                    .append("</font>");
+            StringBuilder sb = new StringBuilder();
+            sb.append("<font color=\"");
+            sb.append(mLogLevel.toHtmlColor());
+            sb.append("\">");
+            sb.append("[");
+            sb.append(mLogTag.name());
+            sb.append("] ");
+            sb.append(mLogLevel.name());
+            sb.append(": ");
+            sb.append(TextUtils.htmlEncode(mLogText).replace("\n", "<br />"));
+            sb.append("</font>");
             return sb.toString();
         }
     }
@@ -155,12 +164,10 @@ public class AppLog {
 
     private static void addEntry(T tag, LogLevel level, String text) {
         // skip if recording is disabled (default)
-        if (!mEnableRecording)
+        if (!mEnableRecording) {
             return;
-        LogEntry entry = new LogEntry();
-        entry.logLevel = level;
-        entry.logText = text;
-        entry.logTag = tag;
+        }
+        LogEntry entry = new LogEntry(level, text, tag);
         mLogEntries.addEntry(entry);
     }
 
@@ -169,7 +176,6 @@ public class AppLog {
         throwable.printStackTrace(new PrintWriter(errors));
         return errors.toString();
     }
-
 
     /*
      * returns entire log as html for display (see AppLogViewerActivity)
@@ -188,7 +194,6 @@ public class AppLog {
         return items;
     }
 
-
     /*
      * returns entire log as plain text
      */
@@ -203,7 +208,7 @@ public class AppLog {
         int lineNum = 1;
         while (it.hasNext()) {
               sb.append(String.format("%02d - ", lineNum))
-              .append(it.next().logText)
+              .append(it.next().mLogText)
               .append("\n");
             lineNum++;
         }


### PR DESCRIPTION
fix #2336 NPE in LogEntry

We recently added checks against null messages here:
https://github.com/wordpress-mobile/WordPress-Android/blob/72a7a51def66338b873beb3f622623a23ca2b932/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java#L66

But actually an exception message can be null, so a NPE can come from:
https://github.com/wordpress-mobile/WordPress-Android/blob/72a7a51def66338b873beb3f622623a23ca2b932/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java#L74