### PR TITLE
Changed to removeGlobalOnLayoutListener()

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.reader;
 
 import android.animation.Animator;
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Fragment;
 import android.content.Context;
@@ -357,7 +356,6 @@ public class ReaderPostListFragment extends Fragment {
     /*
      * animate in the blog/tag info header after a brief delay
      */
-    @SuppressLint("NewApi")
     private void animateHeader() {
         if (!isAdded()) {
             return;
@@ -373,7 +371,7 @@ public class ReaderPostListFragment extends Fragment {
         header.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
             @Override
             public void onGlobalLayout() {
-                header.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                header.getViewTreeObserver().removeGlobalOnLayoutListener(this);
                 new Handler().postDelayed(new Runnable() {
                     @Override
                     public void run() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.reader;
 
 import android.animation.Animator;
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Fragment;
 import android.content.Context;
@@ -356,6 +357,7 @@ public class ReaderPostListFragment extends Fragment {
     /*
      * animate in the blog/tag info header after a brief delay
      */
+    @SuppressLint("NewApi")
     private void animateHeader() {
         if (!isAdded()) {
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -357,8 +357,7 @@ public class ReaderPostListFragment extends Fragment {
     /*
      * animate in the blog/tag info header after a brief delay
      */
-    @SuppressLint("NewApi")
-    private void animateHeader() {
+    private void animateHeaderDelayed() {
         if (!isAdded()) {
             return;
         }
@@ -377,9 +376,12 @@ public class ReaderPostListFragment extends Fragment {
                 new Handler().postDelayed(new Runnable() {
                     @Override
                     public void run() {
-                        if (!isAdded()) return;
+                        if (!isAdded()) {
+                            return;
+                        }
                         header.setVisibility(View.VISIBLE);
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                            @SuppressLint({"NewApi", "LocalSuppress"})
                             Animator animator = ViewAnimationUtils.createCircularReveal(
                                     header,
                                     header.getWidth() / 2,
@@ -425,11 +427,11 @@ public class ReaderPostListFragment extends Fragment {
         switch (getPostListType()) {
             case BLOG_PREVIEW:
                 loadBlogInfo();
-                animateHeader();
+                animateHeaderDelayed();
                 break;
             case TAG_PREVIEW:
                 updateTagPreviewHeader();
-                animateHeader();
+                animateHeaderDelayed();
                 break;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -357,6 +357,7 @@ public class ReaderPostListFragment extends Fragment {
     /*
      * animate in the blog/tag info header after a brief delay
      */
+    @SuppressLint("NewApi")
     private void animateHeaderDelayed() {
         if (!isAdded()) {
             return;
@@ -381,7 +382,6 @@ public class ReaderPostListFragment extends Fragment {
                         }
                         header.setVisibility(View.VISIBLE);
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                            @SuppressLint({"NewApi", "LocalSuppress"})
                             Animator animator = ViewAnimationUtils.createCircularReveal(
                                     header,
                                     header.getWidth() / 2,


### PR DESCRIPTION
Fix #2341 - NoSuchMethod exception resolved by using the deprecated `removeGlobalOnLayoutListener()` instead of `removeOnGlobalLayoutListener()` (which requires API 16).