### PR TITLE
Blogs comparator handles empty titles properly

### DIFF
--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/BlogUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/BlogUtils.java
@@ -10,12 +10,10 @@ public class BlogUtils {
             Map<Object, Object> blogMap2 = (Map<Object, Object>) blog2;
 
             String blogName1 = MapUtils.getMapStr(blogMap1, "blogName");
-            if (blogName1.length() == 0) {
-                blogName1 = MapUtils.getMapStr(blogMap1, "url");
-            }
-
             String blogName2 = MapUtils.getMapStr(blogMap2, "blogName");
-            if (blogName2.length() == 0) {
+
+            if (blogName2.length() == 0 && blogName1.length() == 0) {
+                blogName1 = MapUtils.getMapStr(blogMap1, "url");
                 blogName2 = MapUtils.getMapStr(blogMap2, "url");
             }
 


### PR DESCRIPTION
Fixes #2328. The comparator used the url to compare blogs with no titles to blogs with titles. This results in blogs with no title being put in the 'h' section (for 'http://...') in a sorted list. I changed it to only use the url for comparing two blogs if both blogs don't have a title.