### PR TITLE
Use rest v1.1 for all Reader calls

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -85,17 +85,24 @@ public class ReaderPost {
         post.shortUrl = JSONUtil.getString(json, "short_URL");
         post.setBlogUrl(JSONUtil.getString(json, "site_URL"));
 
-        post.numReplies = json.optInt("comment_count");
         post.numLikes = json.optInt("like_count");
         post.isLikedByCurrentUser = JSONUtil.getBool(json, "i_like");
         post.isFollowedByCurrentUser = JSONUtil.getBool(json, "is_following");
         post.isRebloggedByCurrentUser = JSONUtil.getBool(json, "is_reblogged");
-        post.isCommentsOpen = JSONUtil.getBool(json, "comments_open");
         post.isExternal = JSONUtil.getBool(json, "is_external");
         post.isPrivate = JSONUtil.getBool(json, "site_is_private");
 
         post.isLikesEnabled = JSONUtil.getBool(json, "likes_enabled");
         post.isSharingEnabled = JSONUtil.getBool(json, "sharing_enabled");
+
+        JSONObject jsonDiscussion = json.optJSONObject("discussion");
+        if (jsonDiscussion != null) {
+            post.isCommentsOpen = JSONUtil.getBool(jsonDiscussion, "comments_open");
+            post.numReplies = jsonDiscussion.optInt("comment_count");
+        } else {
+            post.isCommentsOpen = JSONUtil.getBool(json, "comments_open");
+            post.numReplies = json.optInt("comment_count");
+        }
 
         // parse the author section
         assignAuthorFromJson(post, json.optJSONObject("author"));

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -82,7 +82,7 @@ public class ReaderBlogActions {
                 }
             }
         };
-        WordPress.getRestClientUtils().post(path, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
 
         return true;
     }
@@ -200,7 +200,7 @@ public class ReaderBlogActions {
                 }
             }
         };
-        WordPress.getRestClientUtils().post(path, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
 
         return true;
     }
@@ -432,7 +432,7 @@ public class ReaderBlogActions {
 
         AppLog.i(T.READER, "blocking blog " + blogId);
         String path = "/me/block/sites/" + Long.toString(blogId) + "/new";
-        WordPress.getRestClientUtils().post(path, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
 
         return blockResult;
     }
@@ -467,6 +467,6 @@ public class ReaderBlogActions {
 
         AppLog.i(T.READER, "unblocking blog " + blockResult.blogId);
         String path = "/me/block/sites/" + Long.toString(blockResult.blogId) + "/delete";
-        WordPress.getRestClientUtils().post(path, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -54,7 +54,7 @@ public class ReaderBlogActions {
         }
 
         final String actionName = (isAskingToFollow ? "follow" : "unfollow");
-        final String path = "/sites/" + blogId + "/follows/" + (isAskingToFollow ? "new" : "mine/delete");
+        final String path = "sites/" + blogId + "/follows/" + (isAskingToFollow ? "new" : "mine/delete");
 
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
@@ -170,7 +170,7 @@ public class ReaderBlogActions {
         }
 
         final String actionName = (isAskingToFollow ? "follow" : "unfollow");
-        final String path = "/read/following/mine/"
+        final String path = "read/following/mine/"
                 + (isAskingToFollow ? "new" : "delete")
                 + "?url=" + UrlUtils.urlEncode(feedUrl);
 
@@ -307,9 +307,9 @@ public class ReaderBlogActions {
         };
 
         if (hasBlogId) {
-            WordPress.getRestClientUtilsV1_1().get("/sites/" + blogId, listener, errorListener);
+            WordPress.getRestClientUtilsV1_1().get("sites/" + blogId, listener, errorListener);
         } else {
-            WordPress.getRestClientUtilsV1_1().get("/sites/" + UrlUtils.urlEncode(UrlUtils.getDomainFromUrl(blogUrl)), listener, errorListener);
+            WordPress.getRestClientUtilsV1_1().get("sites/" + UrlUtils.urlEncode(UrlUtils.getDomainFromUrl(blogUrl)), listener, errorListener);
         }
     }
     public static void updateFeedInfo(long feedId, String feedUrl, final UpdateBlogInfoListener infoListener) {
@@ -330,9 +330,9 @@ public class ReaderBlogActions {
         };
         String path;
         if (feedId != 0) {
-            path = "/read/feed/" + feedId;
+            path = "read/feed/" + feedId;
         } else {
-            path = "/read/feed/" + UrlUtils.urlEncode(feedUrl);
+            path = "read/feed/" + UrlUtils.urlEncode(feedUrl);
         }
         WordPress.getRestClientUtilsV1_1().get(path, listener, errorListener);
     }
@@ -431,7 +431,7 @@ public class ReaderBlogActions {
         };
 
         AppLog.i(T.READER, "blocking blog " + blogId);
-        String path = "/me/block/sites/" + Long.toString(blogId) + "/new";
+        String path = "me/block/sites/" + Long.toString(blogId) + "/new";
         WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
 
         return blockResult;
@@ -466,7 +466,7 @@ public class ReaderBlogActions {
         };
 
         AppLog.i(T.READER, "unblocking blog " + blockResult.blogId);
-        String path = "/me/block/sites/" + Long.toString(blockResult.blogId) + "/delete";
+        String path = "me/block/sites/" + Long.toString(blockResult.blogId) + "/delete";
         WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
@@ -35,7 +35,7 @@ public class ReaderCommentActions {
     public static void updateCommentsForPost(final ReaderPost post,
                                              final int pageNumber,
                                              final ReaderActions.UpdateResultListener resultListener) {
-        String path = "sites/" + post.blogId + "/posts/" + post.postId + "/replies/"
+        String path = "/sites/" + post.blogId + "/posts/" + post.postId + "/replies/"
                     + "?number=" + Integer.toString(ReaderConstants.READER_MAX_COMMENTS_TO_REQUEST)
                     + "&meta=likes"
                     + "&hierarchical=true"
@@ -178,9 +178,9 @@ public class ReaderCommentActions {
         // different endpoint depending on whether the new comment is a reply to another comment
         final String path;
         if (replyToCommentId == 0) {
-            path = "sites/" + post.blogId + "/posts/" + post.postId + "/replies/new";
+            path = "/sites/" + post.blogId + "/posts/" + post.postId + "/replies/new";
         } else {
-            path = "sites/" + post.blogId + "/comments/" + Long.toString(replyToCommentId) + "/replies/new";
+            path = "/sites/" + post.blogId + "/comments/" + Long.toString(replyToCommentId) + "/replies/new";
         }
 
         Map<String, String> params = new HashMap<String, String>();
@@ -239,7 +239,7 @@ public class ReaderCommentActions {
 
         // sites/$site/comments/$comment_ID/likes/new
         final String actionName = isAskingToLike ? "like" : "unlike";
-        String path = "sites/" + comment.blogId + "/comments/" + comment.commentId + "/likes/";
+        String path = "/sites/" + comment.blogId + "/comments/" + comment.commentId + "/likes/";
         if (isAskingToLike) {
             path += "new";
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
@@ -58,7 +58,7 @@ public class ReaderCommentActions {
             }
         };
         AppLog.d(T.READER, "updating comments");
-        WordPress.getRestClientUtils().get(path, null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().get(path, null, null, listener, errorListener);
     }
     private static void handleUpdateCommentsResponse(final JSONObject jsonObject,
                                                      final long blogId,
@@ -212,7 +212,7 @@ public class ReaderCommentActions {
         };
 
         AppLog.i(T.READER, "submitting comment");
-        WordPress.getRestClientUtils().post(path, params, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().post(path, params, null, listener, errorListener);
 
         return newComment;
     }
@@ -275,7 +275,7 @@ public class ReaderCommentActions {
             }
         };
 
-        WordPress.getRestClientUtils().post(path, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
         return true;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
@@ -35,7 +35,7 @@ public class ReaderCommentActions {
     public static void updateCommentsForPost(final ReaderPost post,
                                              final int pageNumber,
                                              final ReaderActions.UpdateResultListener resultListener) {
-        String path = "/sites/" + post.blogId + "/posts/" + post.postId + "/replies/"
+        String path = "sites/" + post.blogId + "/posts/" + post.postId + "/replies/"
                     + "?number=" + Integer.toString(ReaderConstants.READER_MAX_COMMENTS_TO_REQUEST)
                     + "&meta=likes"
                     + "&hierarchical=true"
@@ -178,9 +178,9 @@ public class ReaderCommentActions {
         // different endpoint depending on whether the new comment is a reply to another comment
         final String path;
         if (replyToCommentId == 0) {
-            path = "/sites/" + post.blogId + "/posts/" + post.postId + "/replies/new";
+            path = "sites/" + post.blogId + "/posts/" + post.postId + "/replies/new";
         } else {
-            path = "/sites/" + post.blogId + "/comments/" + Long.toString(replyToCommentId) + "/replies/new";
+            path = "sites/" + post.blogId + "/comments/" + Long.toString(replyToCommentId) + "/replies/new";
         }
 
         Map<String, String> params = new HashMap<String, String>();
@@ -239,7 +239,7 @@ public class ReaderCommentActions {
 
         // sites/$site/comments/$comment_ID/likes/new
         final String actionName = isAskingToLike ? "like" : "unlike";
-        String path = "/sites/" + comment.blogId + "/comments/" + comment.commentId + "/likes/";
+        String path = "sites/" + comment.blogId + "/comments/" + comment.commentId + "/likes/";
         if (isAskingToLike) {
             path += "new";
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -86,7 +86,7 @@ public class ReaderPostActions {
             }
         };
 
-        WordPress.getRestClientUtils().post(path, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
         return true;
     }
 
@@ -137,7 +137,7 @@ public class ReaderPostActions {
         String path = "/sites/" + post.blogId
                     + "/posts/" + post.postId
                     + "/reblogs/new";
-        WordPress.getRestClientUtils().post(path, params, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().post(path, params, null, listener, errorListener);
     }
 
     /*
@@ -164,7 +164,7 @@ public class ReaderPostActions {
             }
         };
         AppLog.d(T.READER, "updating post");
-        WordPress.getRestClientUtils().get(path, null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().get(path, null, null, listener, errorListener);
     }
 
     private static void handleUpdatePostResponse(final ReaderPost originalPost,
@@ -284,7 +284,7 @@ public class ReaderPostActions {
             }
         };
         AppLog.d(T.READER, "requesting post");
-        WordPress.getRestClientUtils().get(path, null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().get(path, null, null, listener, errorListener);
     }
 
     /*
@@ -338,7 +338,7 @@ public class ReaderPostActions {
             }
         };
 
-        WordPress.getRestClientUtils().get(sb.toString(), null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().get(sb.toString(), null, null, listener, errorListener);
     }
 
     /*
@@ -372,7 +372,7 @@ public class ReaderPostActions {
             }
         };
         AppLog.d(T.READER, "updating posts in blog " + blogId);
-        WordPress.getRestClientUtils().get(path, null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().get(path, null, null, listener, errorListener);
     }
 
     public static void requestPostsForFeed(final long feedId,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -58,7 +58,7 @@ public class ReaderPostActions {
         ReaderLikeTable.setCurrentUserLikesPost(post, isAskingToLike);
 
         final String actionName = isAskingToLike ? "like" : "unlike";
-        String path = "/sites/" + post.blogId + "/posts/" + post.postId + "/likes/";
+        String path = "sites/" + post.blogId + "/posts/" + post.postId + "/likes/";
         if (isAskingToLike) {
             path += "new";
         } else {
@@ -135,7 +135,7 @@ public class ReaderPostActions {
             }
         };
 
-        String path = "/sites/" + post.blogId
+        String path = "sites/" + post.blogId
                     + "/posts/" + post.postId
                     + "/reblogs/new";
         WordPress.getRestClientUtilsV1_1().post(path, params, null, listener, errorListener);
@@ -147,7 +147,7 @@ public class ReaderPostActions {
      */
     public static void updatePost(final ReaderPost originalPost,
                                   final UpdateResultListener resultListener) {
-        String path = "/sites/" + originalPost.blogId + "/posts/" + originalPost.postId + "/?meta=site,likes";
+        String path = "sites/" + originalPost.blogId + "/posts/" + originalPost.postId + "/?meta=site,likes";
 
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
@@ -259,7 +259,7 @@ public class ReaderPostActions {
      * similar to updatePost, but used when post doesn't already exist in local db
      **/
     public static void requestPost(final long blogId, final long postId, final ActionListener actionListener) {
-        String path = "/sites/" + blogId + "/posts/" + postId + "/?meta=site,likes";
+        String path = "sites/" + blogId + "/posts/" + postId + "/?meta=site,likes";
 
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
@@ -348,7 +348,7 @@ public class ReaderPostActions {
     public static void requestPostsForBlog(final long blogId,
                                            final RequestDataAction updateAction,
                                            final UpdateResultListener resultListener) {
-        String path = "/sites/" + blogId + "/posts/?meta=site,likes";
+        String path = "sites/" + blogId + "/posts/?meta=site,likes";
 
         // append the date of the oldest cached post in this blog when requesting older posts
         if (updateAction == RequestDataAction.LOAD_OLDER) {
@@ -379,7 +379,7 @@ public class ReaderPostActions {
     public static void requestPostsForFeed(final long feedId,
                                            final RequestDataAction updateAction,
                                            final UpdateResultListener resultListener) {
-        String path = "/read/feed/" + feedId + "/posts/?meta=site,likes";
+        String path = "read/feed/" + feedId + "/posts/?meta=site,likes";
         if (updateAction == RequestDataAction.LOAD_OLDER) {
             String dateOldest = ReaderPostTable.getOldestPubDateInFeed(feedId);
             if (!TextUtils.isEmpty(dateOldest)) {
@@ -468,7 +468,7 @@ public class ReaderPostActions {
             return null;
         }
 
-        return String.format("/read/tags/%s/posts", ReaderUtils.sanitizeWithDashes(tag.getTagName()));
+        return String.format("read/tags/%s/posts", ReaderUtils.sanitizeWithDashes(tag.getTagName()));
     }
 
     /*
@@ -478,17 +478,17 @@ public class ReaderPostActions {
      * between API versions (as it did when we moved from v1 to v1.1)
      *
      * ex: https://public-api.wordpress.com/rest/v1/read/tags/fitness/posts
-     *     becomes just                            /read/tags/fitness/posts
+     *     becomes just                             read/tags/fitness/posts
      */
     private static String getRelativeEndpoint(final String endpoint) {
         if (endpoint != null && endpoint.startsWith("http")) {
             int pos = endpoint.indexOf("/read/");
             if (pos > -1) {
-                return endpoint.substring(pos, endpoint.length());
+                return endpoint.substring(pos + 1, endpoint.length());
             }
             pos = endpoint.indexOf("/v1/");
             if (pos > -1) {
-                return endpoint.substring(pos + 3, endpoint.length());
+                return endpoint.substring(pos + 4, endpoint.length());
             }
         }
         return StringUtils.notNullStr(endpoint);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -57,7 +57,7 @@ public class ReaderPostActions {
         ReaderLikeTable.setCurrentUserLikesPost(post, isAskingToLike);
 
         final String actionName = isAskingToLike ? "like" : "unlike";
-        String path = "sites/" + post.blogId + "/posts/" + post.postId + "/likes/";
+        String path = "/sites/" + post.blogId + "/posts/" + post.postId + "/likes/";
         if (isAskingToLike) {
             path += "new";
         } else {
@@ -146,7 +146,7 @@ public class ReaderPostActions {
      */
     public static void updatePost(final ReaderPost originalPost,
                                   final UpdateResultListener resultListener) {
-        String path = "sites/" + originalPost.blogId + "/posts/" + originalPost.postId + "/?meta=site,likes";
+        String path = "/sites/" + originalPost.blogId + "/posts/" + originalPost.postId + "/?meta=site,likes";
 
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
@@ -258,7 +258,7 @@ public class ReaderPostActions {
      * similar to updatePost, but used when post doesn't already exist in local db
      **/
     public static void requestPost(final long blogId, final long postId, final ActionListener actionListener) {
-        String path = "sites/" + blogId + "/posts/" + postId + "/?meta=site,likes";
+        String path = "/sites/" + blogId + "/posts/" + postId + "/?meta=site,likes";
 
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
@@ -347,7 +347,7 @@ public class ReaderPostActions {
     public static void requestPostsForBlog(final long blogId,
                                            final RequestDataAction updateAction,
                                            final UpdateResultListener resultListener) {
-        String path = "sites/" + blogId + "/posts/?meta=site,likes";
+        String path = "/sites/" + blogId + "/posts/?meta=site,likes";
 
         // append the date of the oldest cached post in this blog when requesting older posts
         if (updateAction == RequestDataAction.LOAD_OLDER) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
@@ -112,7 +112,7 @@ public class ReaderTagActions {
                 }
             }
         };
-        WordPress.getRestClientUtils().post(path, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
 
         return true;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
@@ -51,14 +51,14 @@ public class ReaderTagActions {
                 // delete tag & all related posts
                 ReaderTagTable.deleteTag(tag);
                 ReaderPostTable.deletePostsWithTag(tag);
-                path = "/read/tags/" + tagNameForApi + "/mine/delete";
+                path = "read/tags/" + tagNameForApi + "/mine/delete";
                 break;
 
             case ADD :
                 String endpoint = "/read/tags/" + tagNameForApi + "/posts";
                 ReaderTag newTopic = new ReaderTag(tag.getTagName(), endpoint, ReaderTagType.FOLLOWED);
                 ReaderTagTable.addOrUpdateTag(newTopic);
-                path = "/read/tags/" + tagNameForApi + "/mine/new";
+                path = "read/tags/" + tagNameForApi + "/mine/new";
                 break;
 
             default :

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
@@ -51,14 +51,14 @@ public class ReaderTagActions {
                 // delete tag & all related posts
                 ReaderTagTable.deleteTag(tag);
                 ReaderPostTable.deletePostsWithTag(tag);
-                path = "read/tags/" + tagNameForApi + "/mine/delete";
+                path = "/read/tags/" + tagNameForApi + "/mine/delete";
                 break;
 
             case ADD :
                 String endpoint = "/read/tags/" + tagNameForApi + "/posts";
                 ReaderTag newTopic = new ReaderTag(tag.getTagName(), endpoint, ReaderTagType.FOLLOWED);
                 ReaderTagTable.addOrUpdateTag(newTopic);
-                path = "read/tags/" + tagNameForApi + "/mine/new";
+                path = "/read/tags/" + tagNameForApi + "/mine/new";
                 break;
 
             default :

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderUserActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderUserActions.java
@@ -49,7 +49,7 @@ public class ReaderUserActions {
             }
         };
 
-        WordPress.getRestClientUtils().get("me", listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().get("me", listener, errorListener);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderUserActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderUserActions.java
@@ -49,7 +49,7 @@ public class ReaderUserActions {
             }
         };
 
-        WordPress.getRestClientUtilsV1_1().get("/me", listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().get("me", listener, errorListener);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderUserActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderUserActions.java
@@ -49,7 +49,7 @@ public class ReaderUserActions {
             }
         };
 
-        WordPress.getRestClientUtilsV1_1().get("me", listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().get("/me", listener, errorListener);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -130,7 +130,7 @@ public class ReaderUpdateService extends Service {
             }
         };
         AppLog.d(AppLog.T.READER, "reader service > updating tags");
-        WordPress.getRestClientUtilsV1_1().get("/read/menu", null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().get("read/menu", null, null, listener, errorListener);
     }
 
     private void handleUpdateTagsResponse(final JSONObject jsonObject) {
@@ -240,7 +240,7 @@ public class ReaderUpdateService extends Service {
 
         AppLog.d(AppLog.T.READER, "reader service > updating followed blogs");
         // request using ?meta=site,feed to get extra info
-        WordPress.getRestClientUtilsV1_1().get("/read/following/mine?meta=site%2Cfeed", listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().get("read/following/mine?meta=site%2Cfeed", listener, errorListener);
     }
     private void handleFollowedBlogsResponse(final JSONObject jsonObject) {
         new Thread() {
@@ -279,7 +279,7 @@ public class ReaderUpdateService extends Service {
         };
 
         AppLog.d(AppLog.T.READER, "reader service > updating recommended blogs");
-        String path = "/read/recommendations/mine/"
+        String path = "read/recommendations/mine/"
                     + "?source=mobile"
                     + "&number=" + Integer.toString(ReaderConstants.READER_MAX_RECOMMENDED_TO_REQUEST);
         WordPress.getRestClientUtilsV1_1().get(path, listener, errorListener);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -130,7 +130,7 @@ public class ReaderUpdateService extends Service {
             }
         };
         AppLog.d(AppLog.T.READER, "reader service > updating tags");
-        WordPress.getRestClientUtils().get("read/menu", null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().get("read/menu", null, null, listener, errorListener);
     }
 
     private void handleUpdateTagsResponse(final JSONObject jsonObject) {
@@ -240,7 +240,7 @@ public class ReaderUpdateService extends Service {
 
         AppLog.d(AppLog.T.READER, "reader service > updating followed blogs");
         // request using ?meta=site,feed to get extra info
-        WordPress.getRestClientUtils().get("/read/following/mine?meta=site%2Cfeed", listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().get("/read/following/mine?meta=site%2Cfeed", listener, errorListener);
     }
     private void handleFollowedBlogsResponse(final JSONObject jsonObject) {
         new Thread() {
@@ -282,7 +282,7 @@ public class ReaderUpdateService extends Service {
         String path = "/read/recommendations/mine/"
                 + "?source=mobile"
                 + "&number=" + Integer.toString(ReaderConstants.READER_MAX_RECOMMENDED_TO_REQUEST);
-        WordPress.getRestClientUtils().get(path, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().get(path, listener, errorListener);
     }
     private void handleRecommendedBlogsResponse(final JSONObject jsonObject) {
         new Thread() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -130,7 +130,7 @@ public class ReaderUpdateService extends Service {
             }
         };
         AppLog.d(AppLog.T.READER, "reader service > updating tags");
-        WordPress.getRestClientUtilsV1_1().get("read/menu", null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().get("/read/menu", null, null, listener, errorListener);
     }
 
     private void handleUpdateTagsResponse(final JSONObject jsonObject) {
@@ -280,8 +280,8 @@ public class ReaderUpdateService extends Service {
 
         AppLog.d(AppLog.T.READER, "reader service > updating recommended blogs");
         String path = "/read/recommendations/mine/"
-                + "?source=mobile"
-                + "&number=" + Integer.toString(ReaderConstants.READER_MAX_RECOMMENDED_TO_REQUEST);
+                    + "?source=mobile"
+                    + "&number=" + Integer.toString(ReaderConstants.READER_MAX_RECOMMENDED_TO_REQUEST);
         WordPress.getRestClientUtilsV1_1().get(path, listener, errorListener);
     }
     private void handleRecommendedBlogsResponse(final JSONObject jsonObject) {


### PR DESCRIPTION
Fix #2359 - updated the Reader to use v1.1 REST endpoints for all actions.