### PR TITLE
fix #1827 post stuck in uploading state

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
@@ -939,8 +939,7 @@ public class PostUploadService extends Service {
                     + ": " + mErrorMessage);
             notificationBuilder.setContentIntent(pendingIntent);
             notificationBuilder.setAutoCancel(true);
-            mNotificationId += (new Random()).nextInt();
-            mNotificationManager.notify(mNotificationId, notificationBuilder.build());
+            mNotificationManager.notify(mNotificationId + (new Random()).nextInt(), notificationBuilder.build());
         }
 
         public void updateNotificationProgress(float progress) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
@@ -88,7 +88,17 @@ public class PostUploadService extends Service {
     }
 
     @Override
-    public void onStart(Intent intent, int startId) {
+    public void onDestroy() {
+        super.onDestroy();
+        // Cancel current task, it will reset post from "uploading" to "local draft"
+        if (mCurrentTask != null) {
+            AppLog.d(T.API, "cancelling current upload task");
+            mCurrentTask.cancel(true);
+        }
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
         synchronized (mPostsList) {
             if (mPostsList.size() == 0 || mContext == null) {
                 this.stopSelf();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
@@ -849,6 +849,7 @@ public class PostUploadService extends Service {
         private final NotificationCompat.Builder mNotificationBuilder;
 
         private final int mNotificationId;
+        private int mNotificationErrorId = 0;
         private int mTotalMediaItems;
         private int mCurrentMediaItem;
         private float mItemProgressSize;
@@ -939,7 +940,10 @@ public class PostUploadService extends Service {
                     + ": " + mErrorMessage);
             notificationBuilder.setContentIntent(pendingIntent);
             notificationBuilder.setAutoCancel(true);
-            mNotificationManager.notify(mNotificationId + (new Random()).nextInt(), notificationBuilder.build());
+            if (mNotificationErrorId == 0) {
+                mNotificationErrorId = mNotificationId + (new Random()).nextInt();
+            }
+            mNotificationManager.notify(mNotificationErrorId, notificationBuilder.build());
         }
 
         public void updateNotificationProgress(float progress) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
@@ -855,25 +855,27 @@ public class PostUploadService extends Service {
 
         public PostUploadNotifier(Post post) {
             // add the uploader to the notification bar
-            mNotificationManager = (NotificationManager) SystemServiceFactory.get(mContext, Context.NOTIFICATION_SERVICE);
+            mNotificationManager = (NotificationManager) SystemServiceFactory.get(mContext,
+                    Context.NOTIFICATION_SERVICE);
 
-            mNotificationBuilder =
-                    new NotificationCompat.Builder(getApplicationContext())
-                            .setSmallIcon(android.R.drawable.stat_sys_upload);
+            mNotificationBuilder = new NotificationCompat.Builder(getApplicationContext());
+            mNotificationBuilder.setSmallIcon(android.R.drawable.stat_sys_upload);
 
             Intent notificationIntent = new Intent(mContext, post.isPage() ? PagesActivity.class : PostsActivity.class);
-            notificationIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP
-                    | Intent.FLAG_ACTIVITY_NEW_TASK
+            notificationIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK
                     | IntentCompat.FLAG_ACTIVITY_CLEAR_TASK);
             notificationIntent.setAction(Intent.ACTION_MAIN);
             notificationIntent.addCategory(Intent.CATEGORY_LAUNCHER);
-            notificationIntent.setData((Uri.parse("custom://wordpressNotificationIntent" + post.getLocalTableBlogId())));
+            notificationIntent.setData((Uri.parse("custom://wordpressNotificationIntent"
+                    + post.getLocalTableBlogId())));
             notificationIntent.putExtra(PostsActivity.EXTRA_VIEW_PAGES, post.isPage());
-            PendingIntent pendingIntent = PendingIntent.getActivity(mContext, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+            PendingIntent pendingIntent = PendingIntent.getActivity(mContext, 0, notificationIntent,
+                    PendingIntent.FLAG_UPDATE_CURRENT);
 
             mNotificationBuilder.setContentIntent(pendingIntent);
 
             mNotificationId = (new Random()).nextInt() + post.getLocalTableBlogId();
+            startForeground(mNotificationId, mNotificationBuilder.build());
         }
 
 
@@ -901,9 +903,13 @@ public class PostUploadService extends Service {
             mNotificationManager.cancel(mNotificationId);
         }
 
-        public void updateNotificationWithError(String mErrorMessage, boolean isMediaError, boolean isPage, boolean isVideoPressError) {
-            String postOrPage = (String) (isPage ? mContext.getResources().getText(R.string.page_id) : mContext.getResources()
-                    .getText(R.string.post_id));
+        public void updateNotificationWithError(String mErrorMessage, boolean isMediaError, boolean isPage,
+                                                boolean isVideoPressError) {
+            AppLog.d(T.POSTS, "updateNotificationWithError: " + mErrorMessage);
+
+            Builder notificationBuilder = new NotificationCompat.Builder(getApplicationContext());
+            String postOrPage = (String) (isPage ? mContext.getResources().getText(R.string.page_id)
+                    : mContext.getResources().getText(R.string.post_id));
             Intent notificationIntent = new Intent(mContext, isPage ? PagesActivity.class : PostsActivity.class);
             notificationIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP
                     | Intent.FLAG_ACTIVITY_NEW_TASK

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
@@ -101,12 +101,14 @@ public class PostUploadService extends Service {
     public int onStartCommand(Intent intent, int flags, int startId) {
         synchronized (mPostsList) {
             if (mPostsList.size() == 0 || mContext == null) {
-                this.stopSelf();
-                return;
+                stopSelf();
+                return START_NOT_STICKY;
             }
         }
 
         uploadNextPost();
+        // We want this service to continue running until it is explicitly stopped, so return sticky.
+        return START_STICKY;
     }
 
     private FeatureSet synchronousGetFeatureSet() {
@@ -130,7 +132,7 @@ public class PostUploadService extends Service {
                     mCurrentTask = new UploadPostTask();
                     mCurrentTask.execute(mCurrentUploadingPost);
                 } else {
-                    this.stopSelf();
+                    stopSelf();
                 }
             }
         }
@@ -142,11 +144,6 @@ public class PostUploadService extends Service {
             mCurrentUploadingPost = null;
         }
         uploadNextPost();
-    }
-
-    public static boolean isUploading(Post post) {
-        return mCurrentUploadingPost != null && mCurrentUploadingPost.equals(post) ||
-                mPostsList.size() > 0 && mPostsList.contains(post);
     }
 
     private class UploadPostTask extends AsyncTask<Post, Boolean, Boolean> {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.posts;
 
+import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
@@ -17,6 +18,7 @@ import android.preference.PreferenceManager;
 import android.provider.MediaStore.Images;
 import android.provider.MediaStore.Video;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.app.NotificationCompat.Builder;
 import android.support.v4.content.IntentCompat;
 import android.text.TextUtils;
 import android.webkit.MimeTypeMap;
@@ -172,10 +174,19 @@ public class PostUploadService extends Service {
                 WordPress.wpDB.deleteMediaFilesForPost(mPost);
             } else {
                 WordPress.postUploadFailed(mPost.getLocalTableBlogId());
-                mPostUploadNotifier.updateNotificationWithError(mErrorMessage, mIsMediaError, mPost.isPage(), mErrorUnavailableVideoPress);
+                mPostUploadNotifier.updateNotificationWithError(mErrorMessage, mIsMediaError, mPost.isPage(),
+                        mErrorUnavailableVideoPress);
             }
 
             postUploaded();
+        }
+
+        @Override
+        protected void onCancelled(Boolean aBoolean) {
+            super.onCancelled(aBoolean);
+            mPostUploadNotifier.updateNotificationWithError(mErrorMessage, mIsMediaError, mPost.isPage(),
+                    mErrorUnavailableVideoPress);
+            WordPress.postUploadFailed(mPost.getLocalTableBlogId());
         }
 
         @Override
@@ -601,7 +612,8 @@ public class PostUploadService extends Service {
             }
 
             String fullSizeUrl = null;
-            // Upload the full size picture if "Original Size" is selected in settings, or if 'link to full size' is checked.
+            // Upload the full size picture if "Original Size" is selected in settings,
+            // or if 'link to full size' is checked.
             if (!shouldUploadResizedVersion || mBlog.isFullSizeImage()) {
                 Map<String, Object> parameters = new HashMap<String, Object>();
                 parameters.put("name", fileName);
@@ -639,7 +651,8 @@ public class PostUploadService extends Service {
             String mimeType = "", xRes = "", yRes = "";
 
             if (videoUri.toString().contains("content:")) {
-                String[] projection = new String[]{Video.Media._ID, Video.Media.DATA, Video.Media.MIME_TYPE, Video.Media.RESOLUTION};
+                String[] projection = new String[]{Video.Media._ID, Video.Media.DATA, Video.Media.MIME_TYPE,
+                        Video.Media.RESOLUTION};
                 Cursor cur = mContext.getContentResolver().query(videoUri, projection, null, null, null);
 
                 if (cur != null && cur.moveToFirst()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.posts;
 
-import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
@@ -54,6 +53,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -496,7 +496,7 @@ public class PostUploadService extends Service {
         }
 
         private String uploadImage(MediaFile mediaFile) {
-            AppLog.d(T.POSTS, "uploadImage: " + mediaFile);
+            AppLog.d(T.POSTS, "uploadImage: " + mediaFile.getFilePath());
 
             if (mediaFile.getFilePath() == null) {
                 return null;
@@ -759,8 +759,6 @@ public class PostUploadService extends Service {
         }
 
         private String uploadImageFile(Map<String, Object> pictureParams, MediaFile mf, Blog blog) {
-            AppLog.d(T.POSTS, "uploadImageFile: " + pictureParams);
-
             // create temporary upload file
             File tempFile;
             try {
@@ -798,7 +796,7 @@ public class PostUploadService extends Service {
         }
 
         private Object uploadFileHelper(Object[] params, final File tempFile) {
-            AppLog.w(T.POSTS, "uploadFileHelper: " + params);
+            AppLog.d(T.POSTS, "uploadFileHelper: " + Arrays.toString(params));
 
             // Create listener for tracking upload progress in the notification
             if (mClient instanceof XMLRPCClient) {
@@ -816,7 +814,6 @@ public class PostUploadService extends Service {
             }
 
             try {
-                AppLog.i(T.API, "wp.uploadFile: " + params);
                 return mClient.call("wp.uploadFile", params, tempFile);
             } catch (XMLRPCException e) {
                 AppLog.e(T.API, e);

--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
@@ -605,10 +605,8 @@ public class XMLRPCClient implements XMLRPCClientInterface {
      */
     private boolean checkXMLRPCErrorMessage(Exception exception) {
         String errorMessage = exception.getMessage().toLowerCase();
-        if ((errorMessage.contains("code: 503") || errorMessage.contains("code 503"))//TODO Not sure 503 is the correct error code returned by wpcom
-                &&
-            (errorMessage.contains("limit reached") || errorMessage.contains("login limit")))
-        {
+        if ((errorMessage.contains("code: 503") || errorMessage.contains("code 503")) &&
+            (errorMessage.contains("limit reached") || errorMessage.contains("login limit"))) {
             broadcastAction(WordPress.BROADCAST_ACTION_XMLRPC_LOGIN_LIMIT);
             return true;
         }

--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
@@ -14,7 +14,6 @@ import org.apache.http.entity.FileEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.params.CoreConnectionPNames;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.params.HttpProtocolParams;
@@ -150,7 +149,6 @@ public class XMLRPCClient implements XMLRPCClientInterface {
             }
         }
 
-        // This is probably superfluous, since we're setting the timeouts in the method parameters. See preparePostMethod
         HttpConnectionParams.setConnectionTimeout(client.getParams(), DEFAULT_CONNECTION_TIMEOUT);
         HttpConnectionParams.setSoTimeout(client.getParams(), DEFAULT_SOCKET_TIMEOUT);
 
@@ -399,12 +397,6 @@ public class XMLRPCClient implements XMLRPCClientInterface {
             HttpEntity entity = new StringEntity(bodyWriter.toString());
             mPostMethod.setEntity(entity);
         }
-
-        //set timeout to 30 seconds, does it need to be set for both mClient and method?
-        mClient.getParams().setParameter(CoreConnectionPNames.CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT);
-        mClient.getParams().setParameter(CoreConnectionPNames.SO_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
-        mPostMethod.getParams().setParameter(CoreConnectionPNames.CONNECTION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT);
-        mPostMethod.getParams().setParameter(CoreConnectionPNames.SO_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
     }
 
     /**

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -15,7 +15,8 @@ import java.util.NoSuchElementException;
  */
 public class AppLog {
     // T for Tag
-    public enum T {READER, EDITOR, MEDIA, NUX, API, STATS, UTILS, NOTIFS, DB, POSTS, COMMENTS, THEMES, TESTS, PROFILING, SIMPERIUM, SUGGESTION}
+    public enum T {READER, EDITOR, MEDIA, NUX, API, STATS, UTILS, NOTIFS, DB, POSTS, COMMENTS, THEMES, TESTS, PROFILING,
+        SIMPERIUM, SUGGESTION}
     public static final String TAG = "WordPress";
     public static final int HEADER_LINE_COUNT = 2;
 


### PR DESCRIPTION
fix #1827 post stuck in uploading state

* start PostUploadService as a foreground service (ongoing notification)
* reset post state when PostUploadService is destroyed
* make PostUploadService sticky (stop it when we decide, ie. when the post is uploaded or when an error occured)
* remove unnecessary timeout settings
* new debug log