### PR TITLE
Feature/reader services

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -300,6 +300,9 @@
         <service android:name=".ui.reader.services.ReaderUpdateService"
             android:label="Reader Update Service"
             android:exported="false"/>
+        <service android:name=".ui.reader.services.ReaderPostService"
+            android:label="Reader Post Service"
+            android:exported="false"/>
 
         <service android:name="org.wordpress.android.GCMIntentService"/>
 

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -303,6 +303,9 @@
         <service android:name=".ui.reader.services.ReaderPostService"
             android:label="Reader Post Service"
             android:exported="false"/>
+        <service android:name=".ui.reader.services.ReaderCommentService"
+            android:label="Reader Comment Service"
+            android:exported="false"/>
 
         <service android:name="org.wordpress.android.GCMIntentService"/>
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -14,18 +14,12 @@ import android.view.View;
 
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
-import org.wordpress.android.datasets.ReaderBlogTable;
-import org.wordpress.android.models.ReaderBlog;
 import org.wordpress.android.models.ReaderComment;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
-import org.wordpress.android.ui.reader.actions.ReaderActions;
-import org.wordpress.android.ui.reader.actions.ReaderBlogActions;
 import org.wordpress.android.util.ToastUtils;
-
-import java.lang.ref.WeakReference;
 
 public class ReaderActivityLauncher {
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
@@ -21,7 +21,7 @@ public class ReaderEvents {
     public static class HasPerformedInitialUpdate {}
 
     public static class UpdatedFollowedTagsAndBlogs {
-        private Date mUpdateDate;
+        private final Date mUpdateDate;
         public UpdatedFollowedTagsAndBlogs() {
             mUpdateDate = new Date();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
@@ -67,4 +67,15 @@ public class ReaderEvents {
             return mAction;
         }
     }
+
+    public static class UpdateCommentsStarted {}
+    public static class UpdateCommentsEnded {
+        private final ReaderActions.UpdateResult mResult;
+        public UpdateCommentsEnded(ReaderActions.UpdateResult result) {
+            mResult = result;
+        }
+        public ReaderActions.UpdateResult getResult() {
+            return mResult;
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
@@ -1,5 +1,8 @@
 package org.wordpress.android.ui.reader;
 
+import org.wordpress.android.models.ReaderTag;
+import org.wordpress.android.ui.reader.actions.ReaderActions;
+import org.wordpress.android.ui.reader.services.ReaderPostService;
 import org.wordpress.android.util.DateTimeUtils;
 
 import java.util.Date;
@@ -24,6 +27,44 @@ public class ReaderEvents {
         }
         public int minutesSinceLastUpdate() {
             return DateTimeUtils.minutesBetween(mUpdateDate, new Date());
+        }
+    }
+
+    public static class UpdatePostsStarted {
+        private final ReaderPostService.UpdateAction mAction;
+        public UpdatePostsStarted(ReaderPostService.UpdateAction action) {
+            mAction = action;
+        }
+        public ReaderPostService.UpdateAction getAction() {
+            return mAction;
+        }
+    }
+
+    public static class UpdatePostsEnded {
+        private final ReaderTag mReaderTag;
+        private final ReaderActions.UpdateResult mResult;
+        private final ReaderPostService.UpdateAction mAction;
+        public UpdatePostsEnded(ReaderActions.UpdateResult result,
+                                ReaderPostService.UpdateAction action) {
+            mResult = result;
+            mAction = action;
+            mReaderTag = null;
+        }
+        public UpdatePostsEnded(ReaderTag readerTag,
+                                ReaderActions.UpdateResult result,
+                                ReaderPostService.UpdateAction action) {
+            mReaderTag = readerTag;
+            mResult = result;
+            mAction = action;
+        }
+        public ReaderTag getReaderTag() {
+            return mReaderTag;
+        }
+        public ReaderActions.UpdateResult getResult() {
+            return mResult;
+        }
+        public ReaderPostService.UpdateAction getAction() {
+            return mAction;
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -50,14 +50,14 @@ import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
-import org.wordpress.android.ui.reader.actions.ReaderActions.RequestDataAction;
 import org.wordpress.android.ui.reader.actions.ReaderAuthActions;
 import org.wordpress.android.ui.reader.actions.ReaderBlogActions;
-import org.wordpress.android.ui.reader.actions.ReaderPostActions;
 import org.wordpress.android.ui.reader.actions.ReaderTagActions;
 import org.wordpress.android.ui.reader.actions.ReaderUserActions;
 import org.wordpress.android.ui.reader.adapters.ReaderPostAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderTagSpinnerAdapter;
+import org.wordpress.android.ui.reader.services.ReaderPostService;
+import org.wordpress.android.ui.reader.services.ReaderPostService.UpdateAction;
 import org.wordpress.android.ui.reader.services.ReaderUpdateService;
 import org.wordpress.android.ui.reader.views.ReaderBlogInfoView;
 import org.wordpress.android.ui.reader.views.ReaderFollowButton;
@@ -254,7 +254,7 @@ public class ReaderPostListFragment extends Fragment
                     && getPostListType() == ReaderPostListType.TAG_FOLLOWED
                     && ReaderTagTable.shouldAutoUpdateTag(mCurrentTag)) {
                 AppLog.i(T.READER, "reader post list > auto-updating current tag after resume");
-                updatePostsWithTag(getCurrentTag(), RequestDataAction.LOAD_NEWER);
+                updatePostsWithTag(getCurrentTag(), UpdateAction.REQUEST_NEWER);
             }
         }
     }
@@ -391,10 +391,10 @@ public class ReaderPostListFragment extends Fragment
                         switch (getPostListType()) {
                             case TAG_FOLLOWED:
                             case TAG_PREVIEW:
-                                updatePostsWithTag(getCurrentTag(), RequestDataAction.LOAD_NEWER);
+                                updatePostsWithTag(getCurrentTag(), UpdateAction.REQUEST_NEWER);
                                 break;
                             case BLOG_PREVIEW:
-                                updatePostsInCurrentBlogOrFeed(RequestDataAction.LOAD_NEWER);
+                                updatePostsInCurrentBlogOrFeed(UpdateAction.REQUEST_NEWER);
                                 break;
                         }
                         // make sure swipe-to-refresh progress shows since this is a manual refresh
@@ -468,7 +468,7 @@ public class ReaderPostListFragment extends Fragment
             boolean isRecreated = (savedInstanceState != null);
             getPostAdapter().setCurrentTag(mCurrentTag);
             if (!isRecreated && ReaderTagTable.shouldAutoUpdateTag(mCurrentTag)) {
-                updatePostsWithTag(getCurrentTag(), RequestDataAction.LOAD_NEWER);
+                updatePostsWithTag(getCurrentTag(), UpdateAction.REQUEST_NEWER);
             }
         }
 
@@ -792,7 +792,7 @@ public class ReaderPostListFragment extends Fragment
                 case TAG_PREVIEW:
                     if (ReaderPostTable.getNumPostsWithTag(mCurrentTag) < ReaderConstants.READER_MAX_POSTS_TO_DISPLAY) {
                         // request older posts
-                        updatePostsWithTag(getCurrentTag(), RequestDataAction.LOAD_OLDER);
+                        updatePostsWithTag(getCurrentTag(), UpdateAction.REQUEST_OLDER);
                         AnalyticsTracker.track(AnalyticsTracker.Stat.READER_INFINITE_SCROLL);
                     }
                     break;
@@ -805,7 +805,7 @@ public class ReaderPostListFragment extends Fragment
                         numPosts = ReaderPostTable.getNumPostsInBlog(mCurrentBlogId);
                     }
                     if (numPosts < ReaderConstants.READER_MAX_POSTS_TO_DISPLAY) {
-                        updatePostsInCurrentBlogOrFeed(RequestDataAction.LOAD_OLDER);
+                        updatePostsInCurrentBlogOrFeed(UpdateAction.REQUEST_OLDER);
                         AnalyticsTracker.track(AnalyticsTracker.Stat.READER_INFINITE_SCROLL);
                     }
                     break;
@@ -905,7 +905,7 @@ public class ReaderPostListFragment extends Fragment
 
         // update posts in this tag if it's time to do so
         if (allowAutoUpdate && ReaderTagTable.shouldAutoUpdateTag(tag)) {
-            updatePostsWithTag(tag, RequestDataAction.LOAD_NEWER);
+            updatePostsWithTag(tag, UpdateAction.REQUEST_NEWER);
         }
     }
 
@@ -971,104 +971,62 @@ public class ReaderPostListFragment extends Fragment
     /*
      * get posts for the current blog from the server
      */
-    void updatePostsInCurrentBlogOrFeed(final RequestDataAction updateAction) {
+    void updatePostsInCurrentBlogOrFeed(final UpdateAction updateAction) {
         if (!NetworkUtils.isNetworkAvailable(getActivity())) {
             AppLog.i(T.READER, "reader post list > network unavailable, canceled blog update");
             return;
         }
-
-        setIsUpdating(true, updateAction);
-
-        ReaderActions.UpdateResultListener resultListener = new ReaderActions.UpdateResultListener() {
-            @Override
-            public void onUpdateResult(ReaderActions.UpdateResult result) {
-                if (!isAdded()) {
-                    return;
-                }
-                setIsUpdating(false, updateAction);
-                if (result.isNewOrChanged()) {
-                    refreshPosts();
-                } else if (isPostAdapterEmpty()) {
-                    boolean requestFailed = (result == ReaderActions.UpdateResult.FAILED);
-                    setEmptyTitleAndDescription(requestFailed);
-                }
-            }
-        };
         if (mCurrentFeedId != 0) {
-            ReaderPostActions.requestPostsForFeed(mCurrentFeedId, updateAction, resultListener);
+            ReaderPostService.startServiceForFeed(getActivity(), mCurrentFeedId, updateAction);
         } else {
-            ReaderPostActions.requestPostsForBlog(mCurrentBlogId, updateAction, resultListener);
+            ReaderPostService.startServiceForBlog(getActivity(), mCurrentBlogId, updateAction);
         }
     }
 
-    void updateCurrentTag() {
-        updatePostsWithTag(getCurrentTag(), RequestDataAction.LOAD_NEWER);
+    @SuppressWarnings("unused")
+    public void onEventMainThread(ReaderEvents.UpdatePostsStarted event) {
+        if (!isAdded()) return;
+
+        setIsUpdating(true, event.getAction());
+        setEmptyTitleAndDescription(false);
+    }
+
+    @SuppressWarnings("unused")
+    public void onEventMainThread(ReaderEvents.UpdatePostsEnded event) {
+        if (!isAdded()) return;
+
+        setIsUpdating(false, event.getAction());
+        if (event.getReaderTag() != null && !isCurrentTag(event.getReaderTag())) {
+            return;
+        }
+
+        if (event.getResult() == ReaderActions.UpdateResult.HAS_NEW
+                && !isPostAdapterEmpty()
+                && event.getAction() == UpdateAction.REQUEST_NEWER
+                && getPostListType() == ReaderPostListType.TAG_FOLLOWED) {
+            showNewPostsBar();
+            refreshPosts();
+        } else if (event.getResult().isNewOrChanged()) {
+            refreshPosts();
+        } else {
+            boolean requestFailed = (event.getResult() == ReaderActions.UpdateResult.FAILED);
+            setEmptyTitleAndDescription(requestFailed);
+        }
     }
 
     /*
      * get latest posts for this tag from the server
      */
-    void updatePostsWithTag(final ReaderTag tag,
-                            final RequestDataAction updateAction) {
-        if (tag == null) {
-            return;
-        }
-
+    void updatePostsWithTag(ReaderTag tag, UpdateAction updateAction) {
         if (!NetworkUtils.isNetworkAvailable(getActivity())) {
-            AppLog.i(T.READER, "reader post list > network unavailable, canceled update");
+            AppLog.i(T.READER, "reader post list > network unavailable, canceled tag update");
             return;
         }
+        ReaderPostService.startServiceForTag(getActivity(), tag, updateAction);
+    }
 
-        setIsUpdating(true, updateAction);
-        setEmptyTitleAndDescription(false);
-
-        // go no further if we're viewing a followed tag and the tag table is empty - this will
-        // occur when the Reader is accessed for the first time (ie: fresh install) - note that
-        // this check is purposely done after the "Refreshing" message is shown since we want
-        // that to appear in this situation - ReaderActivity will take of re-issuing this
-        // update request once tag data has been populated
-        if (getPostListType() == ReaderPostListType.TAG_FOLLOWED && ReaderTagTable.isEmpty()) {
-            AppLog.d(T.READER, "reader post list > empty followed tags, canceled update");
-            return;
-        }
-
-        ReaderActions.UpdateResultListener resultListener = new ReaderActions.UpdateResultListener() {
-            @Override
-            public void onUpdateResult(ReaderActions.UpdateResult result) {
-                if (!isAdded()) {
-                    AppLog.w(T.READER, "reader post list > posts updated when fragment has no activity");
-                    return;
-                }
-
-                setIsUpdating(false, updateAction);
-
-                // make sure this is still the current tag (user may have switched tags during the update)
-                if (!isCurrentTag(tag)) {
-                    return;
-                }
-
-                // show "new posts" bar only if there are new posts and the list isn't empty
-                if (result == ReaderActions.UpdateResult.HAS_NEW
-                        && !isPostAdapterEmpty()
-                        && updateAction == RequestDataAction.LOAD_NEWER) {
-                    showNewPostsBar();
-                    refreshPosts();
-                } else if (result.isNewOrChanged()) {
-                    refreshPosts();
-                } else {
-                    boolean requestFailed = (result == ReaderActions.UpdateResult.FAILED);
-                    setEmptyTitleAndDescription(requestFailed);
-                    // refresh if this is "Posts I Like" or "Blogs I Follow" so posts that
-                    // were unliked/unfollowed no longer appear
-                    if (updateAction == RequestDataAction.LOAD_NEWER
-                            && (tag.isPostsILike() || tag.isBlogsIFollow())) {
-                        refreshPosts();
-                    }
-                }
-            }
-        };
-
-        ReaderPostActions.updatePostsInTag(tag, updateAction, resultListener);
+    void updateCurrentTag() {
+        updatePostsWithTag(getCurrentTag(), UpdateAction.REQUEST_NEWER);
     }
 
     boolean isUpdating() {
@@ -1095,12 +1053,12 @@ public class ReaderPostListFragment extends Fragment
         }
     }
 
-    void setIsUpdating(boolean isUpdating, RequestDataAction updateAction) {
+    void setIsUpdating(boolean isUpdating, UpdateAction updateAction) {
         if (!isAdded() || mIsUpdating == isUpdating) {
             return;
         }
 
-        if (updateAction == RequestDataAction.LOAD_OLDER) {
+        if (updateAction == UpdateAction.REQUEST_OLDER) {
             // show/hide progress bar at bottom if these are older posts
             showLoadingProgress(isUpdating);
         } else if (isUpdating && isPostAdapterEmpty()) {
@@ -1254,7 +1212,7 @@ public class ReaderPostListFragment extends Fragment
                         mCurrentFeedId = blogInfo.feedId;
                         if (isPostAdapterEmpty()) {
                             getPostAdapter().setCurrentBlog(mCurrentBlogId);
-                            updatePostsInCurrentBlogOrFeed(RequestDataAction.LOAD_NEWER);
+                            updatePostsInCurrentBlogOrFeed(UpdateAction.REQUEST_NEWER);
                         }
                         if (mFollowButton != null) {
                             mFollowButton.setIsFollowed(blogInfo.isFollowing);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -51,7 +51,7 @@ class ReaderPostRenderer {
         }
 
         mPost = post;
-        mWeakWebView = new WeakReference<ReaderWebView>(webView);
+        mWeakWebView = new WeakReference<>(webView);
         mResourceVars = new ReaderResourceVars(webView.getContext());
 
         mMinFullSizeWidthDp = pxToDp(mResourceVars.fullSizeImageWidthPx / 3);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderUserListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderUserListActivity.java
@@ -4,7 +4,6 @@ import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.Toolbar;
-import android.view.MenuItem;
 import android.view.View;
 
 import org.wordpress.android.R;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderActions.java
@@ -59,7 +59,6 @@ public class ReaderActions {
     /*
      * used by adapters to notify when more data should be loaded
      */
-    public static enum RequestDataAction {LOAD_NEWER, LOAD_OLDER}
     public interface DataRequestedListener {
         public void onRequestData();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
@@ -83,7 +83,7 @@ public class ReaderCommentActions {
             path = "sites/" + post.blogId + "/comments/" + Long.toString(replyToCommentId) + "/replies/new";
         }
 
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         params.put("content", commentText);
 
         RestRequest.Listener listener = new RestRequest.Listener() {
@@ -112,7 +112,7 @@ public class ReaderCommentActions {
         };
 
         AppLog.i(T.READER, "submitting comment");
-        WordPress.getRestClientUtils().post(path, params, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().post(path, params, null, listener, errorListener);
 
         return newComment;
     }
@@ -175,7 +175,7 @@ public class ReaderCommentActions {
             }
         };
 
-        WordPress.getRestClientUtils().post(path, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
         return true;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
@@ -1,24 +1,18 @@
 package org.wordpress.android.ui.reader.actions;
 
-import android.os.Handler;
 import android.text.TextUtils;
 
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
 
-import org.json.JSONArray;
 import org.json.JSONObject;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.ReaderCommentTable;
-import org.wordpress.android.datasets.ReaderDatabase;
 import org.wordpress.android.datasets.ReaderLikeTable;
 import org.wordpress.android.datasets.ReaderUserTable;
 import org.wordpress.android.models.ReaderComment;
-import org.wordpress.android.models.ReaderCommentList;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderUser;
-import org.wordpress.android.models.ReaderUserList;
-import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
@@ -29,100 +23,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class ReaderCommentActions {
-    /**
-     * get the latest comments for this post
-     **/
-    public static void updateCommentsForPost(final ReaderPost post,
-                                             final int pageNumber,
-                                             final ReaderActions.UpdateResultListener resultListener) {
-        String path = "sites/" + post.blogId + "/posts/" + post.postId + "/replies/"
-                    + "?number=" + Integer.toString(ReaderConstants.READER_MAX_COMMENTS_TO_REQUEST)
-                    + "&meta=likes"
-                    + "&hierarchical=true"
-                    + "&order=ASC"
-                    + "&page=" + pageNumber;
-
-        RestRequest.Listener listener = new RestRequest.Listener() {
-            @Override
-            public void onResponse(JSONObject jsonObject) {
-                handleUpdateCommentsResponse(jsonObject, post.blogId, pageNumber, resultListener);
-            }
-        };
-        RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError volleyError) {
-                AppLog.e(T.READER, volleyError);
-                if (resultListener != null) {
-                    resultListener.onUpdateResult(ReaderActions.UpdateResult.FAILED);
-                }
-            }
-        };
-        AppLog.d(T.READER, "updating comments");
-        WordPress.getRestClientUtils().get(path, null, null, listener, errorListener);
-    }
-    private static void handleUpdateCommentsResponse(final JSONObject jsonObject,
-                                                     final long blogId,
-                                                     final int pageNumber,
-                                                     final ReaderActions.UpdateResultListener resultListener) {
-        if (jsonObject == null) {
-            if (resultListener != null) {
-                resultListener.onUpdateResult(ReaderActions.UpdateResult.FAILED);
-            }
-            return;
-        }
-
-        final Handler handler = new Handler();
-
-        new Thread() {
-            @Override
-            public void run() {
-                final boolean hasNewComments;
-
-                ReaderDatabase.getWritableDb().beginTransaction();
-                try {
-                    ReaderCommentList serverComments = new ReaderCommentList();
-                    JSONArray jsonCommentList = jsonObject.optJSONArray("comments");
-                    if (jsonCommentList != null) {
-                        for (int i = 0; i < jsonCommentList.length(); i++) {
-                            JSONObject jsonComment = jsonCommentList.optJSONObject(i);
-
-                            // extract this comment and add it to the list
-                            ReaderComment comment = ReaderComment.fromJson(jsonComment, blogId);
-                            comment.pageNumber = pageNumber;
-                            serverComments.add(comment);
-
-                            // extract and save likes for this comment
-                            JSONObject jsonLikes = JSONUtil.getJSONChild(jsonComment, "meta/data/likes");
-                            if (jsonLikes != null) {
-                                ReaderUserList likingUsers = ReaderUserList.fromJsonLikes(jsonLikes);
-                                ReaderUserTable.addOrUpdateUsers(likingUsers);
-                                ReaderLikeTable.setLikesForComment(comment, likingUsers.getUserIds());
-                            }
-                        }
-                    }
-
-                    hasNewComments = (serverComments.size() > 0);
-
-                    // save to db regardless of whether any are new so changes to likes are stored
-                    ReaderCommentTable.addOrUpdateComments(serverComments);
-                    ReaderDatabase.getWritableDb().setTransactionSuccessful();
-                } finally {
-                    ReaderDatabase.getWritableDb().endTransaction();
-                }
-
-                if (resultListener != null) {
-                    handler.post(new Runnable() {
-                        public void run() {
-                            ReaderActions.UpdateResult result =
-                                    (hasNewComments ? ReaderActions.UpdateResult.HAS_NEW
-                                                    : ReaderActions.UpdateResult.UNCHANGED);
-                            resultListener.onUpdateResult(result);
-                        }
-                    });
-                }
-            }
-        }.start();
-    }
 
     /*
      * used by post detail to generate a temporary "fake" comment id (see below)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -10,24 +10,16 @@ import org.json.JSONObject;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.ReaderLikeTable;
 import org.wordpress.android.datasets.ReaderPostTable;
-import org.wordpress.android.datasets.ReaderTagTable;
 import org.wordpress.android.datasets.ReaderUserTable;
 import org.wordpress.android.models.ReaderPost;
-import org.wordpress.android.models.ReaderPostList;
-import org.wordpress.android.models.ReaderTag;
-import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.models.ReaderUserIdList;
 import org.wordpress.android.models.ReaderUserList;
-import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.ui.reader.actions.ReaderActions.ActionListener;
-import org.wordpress.android.ui.reader.actions.ReaderActions.RequestDataAction;
 import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResult;
 import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResultListener;
-import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.JSONUtil;
-import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.VolleyUtils;
 
 import java.util.HashMap;
@@ -105,7 +97,7 @@ public class ReaderPostActions {
             return;
         }
 
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         params.put("destination_site_id", Long.toString(destinationBlogId));
         if (!TextUtils.isEmpty(optionalComment)) {
             params.put("note", optionalComment);
@@ -286,188 +278,4 @@ public class ReaderPostActions {
         AppLog.d(T.READER, "requesting post");
         WordPress.getRestClientUtils().get(path, null, null, listener, errorListener);
     }
-
-    /*
-     * get the latest posts in the passed topic - note that this uses an UpdateResultAndCountListener
-     * so the caller can be told how many new posts were added
-     */
-    public static void updatePostsInTag(final ReaderTag tag,
-                                        final RequestDataAction updateAction,
-                                        final UpdateResultListener resultListener) {
-        String endpoint = getEndpointForTag(tag);
-        if (TextUtils.isEmpty(endpoint)) {
-            if (resultListener != null) {
-                resultListener.onUpdateResult(UpdateResult.FAILED);
-            }
-            return;
-        }
-
-        StringBuilder sb = new StringBuilder(endpoint);
-
-        // append #posts to retrieve
-        sb.append("?number=").append(ReaderConstants.READER_MAX_POSTS_TO_REQUEST);
-
-        // return newest posts first (this is the default, but make it explicit since it's important)
-        sb.append("&order=DESC");
-
-        // if older posts are being requested, add the &before param based on the oldest existing post
-        if (updateAction == RequestDataAction.LOAD_OLDER) {
-            String dateOldest = ReaderPostTable.getOldestPubDateWithTag(tag);
-            if (!TextUtils.isEmpty(dateOldest)) {
-                sb.append("&before=").append(UrlUtils.urlEncode(dateOldest));
-            }
-        }
-
-        com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
-            @Override
-            public void onResponse(JSONObject jsonObject) {
-                // remember when this tag was updated if newer posts were requested
-                if (updateAction == RequestDataAction.LOAD_NEWER) {
-                    ReaderTagTable.setTagLastUpdated(tag);
-                }
-                handleUpdatePostsResponse(tag, jsonObject, resultListener);
-            }
-        };
-        RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError volleyError) {
-                AppLog.e(T.READER, volleyError);
-                if (resultListener != null) {
-                    resultListener.onUpdateResult(UpdateResult.FAILED);
-                }
-            }
-        };
-
-        WordPress.getRestClientUtils().get(sb.toString(), null, null, listener, errorListener);
-    }
-
-    /*
-     * get the latest posts in the passed blog
-     */
-    public static void requestPostsForBlog(final long blogId,
-                                           final RequestDataAction updateAction,
-                                           final UpdateResultListener resultListener) {
-        String path = "sites/" + blogId + "/posts/?meta=site,likes";
-
-        // append the date of the oldest cached post in this blog when requesting older posts
-        if (updateAction == RequestDataAction.LOAD_OLDER) {
-            String dateOldest = ReaderPostTable.getOldestPubDateInBlog(blogId);
-            if (!TextUtils.isEmpty(dateOldest)) {
-                path += "&before=" + UrlUtils.urlEncode(dateOldest);
-            }
-        }
-        com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
-            @Override
-            public void onResponse(JSONObject jsonObject) {
-                handleUpdatePostsResponse(null, jsonObject, resultListener);
-            }
-        };
-        RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError volleyError) {
-                AppLog.e(T.READER, volleyError);
-                if (resultListener != null) {
-                    resultListener.onUpdateResult(UpdateResult.FAILED);
-                }
-            }
-        };
-        AppLog.d(T.READER, "updating posts in blog " + blogId);
-        WordPress.getRestClientUtils().get(path, null, null, listener, errorListener);
-    }
-
-    public static void requestPostsForFeed(final long feedId,
-                                           final RequestDataAction updateAction,
-                                           final UpdateResultListener resultListener) {
-        String path = "/read/feed/" + feedId + "/posts/?meta=site,likes";
-        if (updateAction == RequestDataAction.LOAD_OLDER) {
-            String dateOldest = ReaderPostTable.getOldestPubDateInFeed(feedId);
-            if (!TextUtils.isEmpty(dateOldest)) {
-                path += "&before=" + UrlUtils.urlEncode(dateOldest);
-            }
-        }
-
-        com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
-            @Override
-            public void onResponse(JSONObject jsonObject) {
-                handleUpdatePostsResponse(null, jsonObject, resultListener);
-            }
-        };
-        RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError volleyError) {
-                AppLog.e(T.READER, volleyError);
-                if (resultListener != null) {
-                    resultListener.onUpdateResult(UpdateResult.FAILED);
-                }
-            }
-        };
-
-        AppLog.d(T.READER, "updating posts in feed " + feedId);
-        WordPress.getRestClientUtilsV1_1().get(path, null, null, listener, errorListener);
-    }
-
-    /*
-     * called after requesting posts with a specific tag or in a specific blog
-     */
-    private static void handleUpdatePostsResponse(final ReaderTag tag,
-                                                  final JSONObject jsonObject,
-                                                  final UpdateResultListener resultListener) {
-        if (jsonObject == null) {
-            if (resultListener != null) {
-                resultListener.onUpdateResult(UpdateResult.FAILED);
-            }
-            return;
-        }
-
-        final Handler handler = new Handler();
-        new Thread() {
-            @Override
-            public void run() {
-                ReaderPostList serverPosts = ReaderPostList.fromJson(jsonObject);
-                final UpdateResult updateResult = ReaderPostTable.comparePosts(serverPosts);
-                if (updateResult.isNewOrChanged()) {
-                    ReaderPostTable.addOrUpdatePosts(tag, serverPosts);
-                }
-                AppLog.d(T.READER, "requested posts response = " + updateResult.toString());
-
-                if (resultListener != null) {
-                    handler.post(new Runnable() {
-                        public void run() {
-                            resultListener.onUpdateResult(updateResult);
-                        }
-                    });
-                }
-            }
-        }.start();
-    }
-
-    /*
-     * returns the endpoint to use for the passed tag - first gets it from local db, if not
-     * there it generates it "by hand"
-     */
-    private static String getEndpointForTag(ReaderTag tag) {
-        if (tag == null) {
-            return null;
-        }
-
-        // if passed tag has an assigned endpoint, return it and be done
-        if (!TextUtils.isEmpty(tag.getEndpoint())) {
-            return tag.getEndpoint();
-        }
-
-        // check the db for the endpoint
-        String endpoint = ReaderTagTable.getEndpointForTag(tag);
-        if (!TextUtils.isEmpty(endpoint)) {
-            return endpoint;
-        }
-
-        // never hand craft the endpoint for default tags, since these MUST be updated
-        // using their stored endpoints
-        if (tag.tagType == ReaderTagType.DEFAULT) {
-            return null;
-        }
-
-        return String.format("/read/tags/%s/posts", ReaderUtils.sanitizeWithDashes(tag.getTagName()));
-    }
-
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -78,7 +78,7 @@ public class ReaderPostActions {
             }
         };
 
-        WordPress.getRestClientUtils().post(path, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
         return true;
     }
 
@@ -126,10 +126,10 @@ public class ReaderPostActions {
             }
         };
 
-        String path = "/sites/" + post.blogId
+        String path = "sites/" + post.blogId
                     + "/posts/" + post.postId
                     + "/reblogs/new";
-        WordPress.getRestClientUtils().post(path, params, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().post(path, params, null, listener, errorListener);
     }
 
     /*
@@ -156,7 +156,7 @@ public class ReaderPostActions {
             }
         };
         AppLog.d(T.READER, "updating post");
-        WordPress.getRestClientUtils().get(path, null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().get(path, null, null, listener, errorListener);
     }
 
     private static void handleUpdatePostResponse(final ReaderPost originalPost,
@@ -276,6 +276,6 @@ public class ReaderPostActions {
             }
         };
         AppLog.d(T.READER, "requesting post");
-        WordPress.getRestClientUtils().get(path, null, null, listener, errorListener);
+        WordPress.getRestClientUtilsV1_1().get(path, null, null, listener, errorListener);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderCommentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderCommentService.java
@@ -95,7 +95,7 @@ public class ReaderCommentService extends Service {
                                               final long postId,
                                               final int pageNumber,
                                               final ReaderActions.UpdateResultListener resultListener) {
-        String path = "/sites/" + blogId + "/posts/" + postId + "/replies/"
+        String path = "sites/" + blogId + "/posts/" + postId + "/replies/"
                     + "?number=" + Integer.toString(ReaderConstants.READER_MAX_COMMENTS_TO_REQUEST)
                     + "&meta=likes"
                     + "&hierarchical=true"

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderCommentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderCommentService.java
@@ -1,0 +1,173 @@
+package org.wordpress.android.ui.reader.services;
+
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.IBinder;
+
+import com.android.volley.VolleyError;
+import com.wordpress.rest.RestRequest;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.datasets.ReaderCommentTable;
+import org.wordpress.android.datasets.ReaderDatabase;
+import org.wordpress.android.datasets.ReaderLikeTable;
+import org.wordpress.android.datasets.ReaderUserTable;
+import org.wordpress.android.models.ReaderComment;
+import org.wordpress.android.models.ReaderCommentList;
+import org.wordpress.android.models.ReaderPost;
+import org.wordpress.android.models.ReaderUserList;
+import org.wordpress.android.ui.reader.ReaderConstants;
+import org.wordpress.android.ui.reader.ReaderEvents;
+import org.wordpress.android.ui.reader.actions.ReaderActions;
+import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResult;
+import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResultListener;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.JSONUtil;
+
+import de.greenrobot.event.EventBus;
+
+public class ReaderCommentService extends Service {
+
+    private static final String ARG_POST_ID   = "post_id";
+    private static final String ARG_BLOG_ID   = "blog_id";
+    private static final String ARG_NEXT_PAGE = "next_page";
+
+    public static void startService(Context context, ReaderPost post, boolean requestNextPage) {
+        Intent intent = new Intent(context, ReaderCommentService.class);
+        intent.putExtra(ARG_BLOG_ID, post.blogId);
+        intent.putExtra(ARG_POST_ID, post.postId);
+        intent.putExtra(ARG_NEXT_PAGE, requestNextPage);
+        context.startService(intent);
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        AppLog.i(AppLog.T.READER, "reader comment service > created");
+    }
+
+    @Override
+    public void onDestroy() {
+        AppLog.i(AppLog.T.READER, "reader comment service > destroyed");
+        super.onDestroy();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent == null) {
+            return START_NOT_STICKY;
+        }
+
+        EventBus.getDefault().post(new ReaderEvents.UpdateCommentsStarted());
+
+        long blogId = intent.getLongExtra(ARG_BLOG_ID, 0);
+        long postId = intent.getLongExtra(ARG_POST_ID, 0);
+        boolean requestNextPage = intent.getBooleanExtra(ARG_NEXT_PAGE, false);
+
+        int pageNumber;
+        if (requestNextPage) {
+            int prevPage = ReaderCommentTable.getLastPageNumberForPost(blogId, postId);
+            pageNumber = prevPage + 1;
+        } else {
+            pageNumber = 1;
+        }
+
+        updateCommentsForPost(blogId, postId, pageNumber, new UpdateResultListener() {
+            @Override
+            public void onUpdateResult(UpdateResult result) {
+                EventBus.getDefault().post(new ReaderEvents.UpdateCommentsEnded(result));
+                stopSelf();
+            }
+        });
+
+        return START_NOT_STICKY;
+    }
+
+    private static void updateCommentsForPost(final long blogId,
+                                              final long postId,
+                                              final int pageNumber,
+                                              final ReaderActions.UpdateResultListener resultListener) {
+        String path = "/sites/" + blogId + "/posts/" + postId + "/replies/"
+                    + "?number=" + Integer.toString(ReaderConstants.READER_MAX_COMMENTS_TO_REQUEST)
+                    + "&meta=likes"
+                    + "&hierarchical=true"
+                    + "&order=ASC"
+                    + "&page=" + pageNumber;
+
+        RestRequest.Listener listener = new RestRequest.Listener() {
+            @Override
+            public void onResponse(JSONObject jsonObject) {
+                handleUpdateCommentsResponse(jsonObject, blogId, pageNumber, resultListener);
+            }
+        };
+        RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
+            @Override
+            public void onErrorResponse(VolleyError volleyError) {
+                AppLog.e(AppLog.T.READER, volleyError);
+                resultListener.onUpdateResult(ReaderActions.UpdateResult.FAILED);
+            }
+        };
+        AppLog.d(AppLog.T.READER, "updating comments");
+        WordPress.getRestClientUtilsV1_1().get(path, null, null, listener, errorListener);
+    }
+    private static void handleUpdateCommentsResponse(final JSONObject jsonObject,
+                                                     final long blogId,
+                                                     final int pageNumber,
+                                                     final ReaderActions.UpdateResultListener resultListener) {
+        if (jsonObject == null) {
+            resultListener.onUpdateResult(ReaderActions.UpdateResult.FAILED);
+            return;
+        }
+
+        new Thread() {
+            @Override
+            public void run() {
+                final boolean hasNewComments;
+
+                ReaderDatabase.getWritableDb().beginTransaction();
+                try {
+                    ReaderCommentList serverComments = new ReaderCommentList();
+                    JSONArray jsonCommentList = jsonObject.optJSONArray("comments");
+                    if (jsonCommentList != null) {
+                        for (int i = 0; i < jsonCommentList.length(); i++) {
+                            JSONObject jsonComment = jsonCommentList.optJSONObject(i);
+
+                            // extract this comment and add it to the list
+                            ReaderComment comment = ReaderComment.fromJson(jsonComment, blogId);
+                            comment.pageNumber = pageNumber;
+                            serverComments.add(comment);
+
+                            // extract and save likes for this comment
+                            JSONObject jsonLikes = JSONUtil.getJSONChild(jsonComment, "meta/data/likes");
+                            if (jsonLikes != null) {
+                                ReaderUserList likingUsers = ReaderUserList.fromJsonLikes(jsonLikes);
+                                ReaderUserTable.addOrUpdateUsers(likingUsers);
+                                ReaderLikeTable.setLikesForComment(comment, likingUsers.getUserIds());
+                            }
+                        }
+                    }
+
+                    hasNewComments = (serverComments.size() > 0);
+
+                    // save to db regardless of whether any are new so changes to likes are stored
+                    ReaderCommentTable.addOrUpdateComments(serverComments);
+                    ReaderDatabase.getWritableDb().setTransactionSuccessful();
+                } finally {
+                    ReaderDatabase.getWritableDb().endTransaction();
+                }
+
+                ReaderActions.UpdateResult result =
+                        (hasNewComments ? ReaderActions.UpdateResult.HAS_NEW : ReaderActions.UpdateResult.UNCHANGED);
+                resultListener.onUpdateResult(result);
+            }
+        }.start();
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderPostService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderPostService.java
@@ -1,0 +1,336 @@
+package org.wordpress.android.ui.reader.services;
+
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.IBinder;
+import android.text.TextUtils;
+
+import com.android.volley.VolleyError;
+import com.wordpress.rest.RestRequest;
+
+import org.json.JSONObject;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.datasets.ReaderPostTable;
+import org.wordpress.android.datasets.ReaderTagTable;
+import org.wordpress.android.models.ReaderPostList;
+import org.wordpress.android.models.ReaderTag;
+import org.wordpress.android.models.ReaderTagType;
+import org.wordpress.android.ui.reader.ReaderConstants;
+import org.wordpress.android.ui.reader.ReaderEvents;
+import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResult;
+import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResultListener;
+import org.wordpress.android.ui.reader.utils.ReaderUtils;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.UrlUtils;
+
+import de.greenrobot.event.EventBus;
+
+/**
+ * service which updates posts with specific tags or in specific blogs/feeds - relies on
+ * EventBus to alert of update status
+ */
+
+public class ReaderPostService extends Service {
+
+    private static final String ARG_TAG     = "tag";
+    private static final String ARG_ACTION  = "action";
+    private static final String ARG_BLOG_ID = "blog_id";
+    private static final String ARG_FEED_ID = "feed_id";
+
+    public static enum UpdateAction {REQUEST_NEWER, REQUEST_OLDER}
+
+    /*
+     * update posts with the passed tag
+     */
+    public static void startServiceForTag(Context context, ReaderTag tag, UpdateAction action) {
+        Intent intent = new Intent(context, ReaderPostService.class);
+        intent.putExtra(ARG_TAG, tag);
+        intent.putExtra(ARG_ACTION, action);
+        context.startService(intent);
+    }
+
+    /*
+     * update posts in the passed blog
+     */
+    public static void startServiceForBlog(Context context, long blogId, UpdateAction action) {
+        Intent intent = new Intent(context, ReaderPostService.class);
+        intent.putExtra(ARG_BLOG_ID, blogId);
+        intent.putExtra(ARG_ACTION, action);
+        context.startService(intent);
+    }
+
+    /*
+     * update posts in the passed feed
+     */
+    public static void startServiceForFeed(Context context, long feedId, UpdateAction action) {
+        Intent intent = new Intent(context, ReaderPostService.class);
+        intent.putExtra(ARG_FEED_ID, feedId);
+        intent.putExtra(ARG_ACTION, action);
+        context.startService(intent);
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        AppLog.i(AppLog.T.READER, "reader post service > created");
+    }
+
+    @Override
+    public void onDestroy() {
+        AppLog.i(AppLog.T.READER, "reader post service > destroyed");
+        super.onDestroy();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent == null) {
+            return START_NOT_STICKY;
+        }
+
+        UpdateAction action;
+        if (intent.hasExtra(ARG_ACTION)) {
+            action = (UpdateAction) intent.getSerializableExtra(ARG_ACTION);
+        } else {
+            action = UpdateAction.REQUEST_NEWER;
+        }
+
+        if (intent.hasExtra(ARG_TAG)) {
+            ReaderTag tag = (ReaderTag) intent.getSerializableExtra(ARG_TAG);
+            updatePostsWithTag(tag, action);
+        } else if (intent.hasExtra(ARG_BLOG_ID)) {
+            long blogId = intent.getLongExtra(ARG_BLOG_ID, 0);
+            updatePostsInBlog(blogId, action);
+        } else if (intent.hasExtra(ARG_FEED_ID)) {
+            long feedId = intent.getLongExtra(ARG_FEED_ID, 0);
+            updatePostsInFeed(feedId, action);
+        }
+
+        return START_NOT_STICKY;
+    }
+
+    void updatePostsWithTag(final ReaderTag tag, final UpdateAction action) {
+        requestPostsWithTag(
+                tag,
+                action,
+                new UpdateResultListener() {
+                    @Override
+                    public void onUpdateResult(UpdateResult result) {
+                        EventBus.getDefault().post(new ReaderEvents.UpdatePostsEnded(tag, result, action));
+                        stopSelf();
+                    }
+                });
+        EventBus.getDefault().post(new ReaderEvents.UpdatePostsStarted(action));
+    }
+
+    void updatePostsInBlog(long blogId, final UpdateAction action) {
+        UpdateResultListener listener = new UpdateResultListener() {
+            @Override
+            public void onUpdateResult(UpdateResult result) {
+                EventBus.getDefault().post(new ReaderEvents.UpdatePostsEnded(result, action));
+                stopSelf();
+            }
+        };
+        requestPostsForBlog(blogId, action, listener);
+    }
+
+    void updatePostsInFeed(long feedId, final UpdateAction action) {
+        UpdateResultListener listener = new UpdateResultListener() {
+            @Override
+            public void onUpdateResult(UpdateResult result) {
+                EventBus.getDefault().post(new ReaderEvents.UpdatePostsEnded(result, action));
+                stopSelf();
+            }
+        };
+        requestPostsForFeed(feedId, action, listener);
+    }
+
+    private static void requestPostsWithTag(final ReaderTag tag,
+                                            final UpdateAction updateAction,
+                                            final UpdateResultListener resultListener) {
+        String endpoint = getEndpointForTag(tag);
+        if (TextUtils.isEmpty(endpoint)) {
+            resultListener.onUpdateResult(UpdateResult.FAILED);
+            return;
+        }
+
+        StringBuilder sb = new StringBuilder(endpoint);
+
+        // append #posts to retrieve
+        sb.append("?number=").append(ReaderConstants.READER_MAX_POSTS_TO_REQUEST);
+
+        // return newest posts first (this is the default, but make it explicit since it's important)
+        sb.append("&order=DESC");
+
+        // if older posts are being requested, add the &before param based on the oldest existing post
+        if (updateAction == UpdateAction.REQUEST_OLDER) {
+            String dateOldest = ReaderPostTable.getOldestPubDateWithTag(tag);
+            if (!TextUtils.isEmpty(dateOldest)) {
+                sb.append("&before=").append(UrlUtils.urlEncode(dateOldest));
+            }
+        }
+
+        com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
+            @Override
+            public void onResponse(JSONObject jsonObject) {
+                // remember when this tag was updated if newer posts were requested
+                if (updateAction == UpdateAction.REQUEST_NEWER) {
+                    ReaderTagTable.setTagLastUpdated(tag);
+                }
+                handleUpdatePostsResponse(tag, jsonObject, resultListener);
+            }
+        };
+        RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
+            @Override
+            public void onErrorResponse(VolleyError volleyError) {
+                AppLog.e(AppLog.T.READER, volleyError);
+                resultListener.onUpdateResult(UpdateResult.FAILED);
+            }
+        };
+
+        WordPress.getRestClientUtilsV1_1().get(sb.toString(), null, null, listener, errorListener);
+    }
+
+
+    private static void requestPostsForBlog(final long blogId,
+                                            final UpdateAction updateAction,
+                                            final UpdateResultListener resultListener) {
+        String path = "/sites/" + blogId + "/posts/?meta=site,likes";
+
+        // append the date of the oldest cached post in this blog when requesting older posts
+        if (updateAction == UpdateAction.REQUEST_OLDER) {
+            String dateOldest = ReaderPostTable.getOldestPubDateInBlog(blogId);
+            if (!TextUtils.isEmpty(dateOldest)) {
+                path += "&before=" + UrlUtils.urlEncode(dateOldest);
+            }
+        }
+
+        com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
+            @Override
+            public void onResponse(JSONObject jsonObject) {
+                handleUpdatePostsResponse(null, jsonObject, resultListener);
+            }
+        };
+        RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
+            @Override
+            public void onErrorResponse(VolleyError volleyError) {
+                AppLog.e(AppLog.T.READER, volleyError);
+                resultListener.onUpdateResult(UpdateResult.FAILED);
+            }
+        };
+        AppLog.d(AppLog.T.READER, "updating posts in blog " + blogId);
+        WordPress.getRestClientUtilsV1_1().get(path, null, null, listener, errorListener);
+    }
+
+    private static void requestPostsForFeed(final long feedId,
+                                            final UpdateAction updateAction,
+                                            final UpdateResultListener resultListener) {
+        String path = "/read/feed/" + feedId + "/posts/?meta=site,likes";
+        if (updateAction == UpdateAction.REQUEST_OLDER) {
+            String dateOldest = ReaderPostTable.getOldestPubDateInFeed(feedId);
+            if (!TextUtils.isEmpty(dateOldest)) {
+                path += "&before=" + UrlUtils.urlEncode(dateOldest);
+            }
+        }
+
+        com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
+            @Override
+            public void onResponse(JSONObject jsonObject) {
+                handleUpdatePostsResponse(null, jsonObject, resultListener);
+            }
+        };
+        RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
+            @Override
+            public void onErrorResponse(VolleyError volleyError) {
+                AppLog.e(AppLog.T.READER, volleyError);
+                resultListener.onUpdateResult(UpdateResult.FAILED);
+            }
+        };
+
+        AppLog.d(AppLog.T.READER, "updating posts in feed " + feedId);
+        WordPress.getRestClientUtilsV1_1().get(path, null, null, listener, errorListener);
+    }
+
+    /*
+     * called after requesting posts with a specific tag or in a specific blog
+     */
+    private static void handleUpdatePostsResponse(final ReaderTag tag,
+                                                  final JSONObject jsonObject,
+                                                  final UpdateResultListener resultListener) {
+        if (jsonObject == null) {
+            resultListener.onUpdateResult(UpdateResult.FAILED);
+            return;
+        }
+
+        new Thread() {
+            @Override
+            public void run() {
+                ReaderPostList serverPosts = ReaderPostList.fromJson(jsonObject);
+                UpdateResult updateResult = ReaderPostTable.comparePosts(serverPosts);
+                if (updateResult.isNewOrChanged()) {
+                    ReaderPostTable.addOrUpdatePosts(tag, serverPosts);
+                }
+                AppLog.d(AppLog.T.READER, "requested posts response = " + updateResult.toString());
+                resultListener.onUpdateResult(updateResult);
+            }
+        }.start();
+    }
+
+    /*
+     * returns the endpoint to use when requesting posts with the passed tag
+     */
+    private static String getEndpointForTag(ReaderTag tag) {
+        if (tag == null) {
+            return null;
+        }
+
+        // if passed tag has an assigned endpoint, return it and be done
+        if (!TextUtils.isEmpty(tag.getEndpoint())) {
+            return getRelativeEndpoint(tag.getEndpoint());
+        }
+
+        // check the db for the endpoint
+        String endpoint = ReaderTagTable.getEndpointForTag(tag);
+        if (!TextUtils.isEmpty(endpoint)) {
+            return getRelativeEndpoint(endpoint);
+        }
+
+        // never hand craft the endpoint for default tags, since these MUST be updated
+        // using their stored endpoints
+        if (tag.tagType == ReaderTagType.DEFAULT) {
+            return null;
+        }
+
+        return String.format("/read/tags/%s/posts", ReaderUtils.sanitizeWithDashes(tag.getTagName()));
+    }
+
+    /*
+     * returns the passed endpoint without the unnecessary path - this is
+     * needed because as of 20-Feb-2015 the /read/menu/ call returns the
+     * full path but we don't want to use the full path since it may change
+     * between API versions (as it did when we moved from v1 to v1.1)
+     *
+     * ex: https://public-api.wordpress.com/rest/v1/read/tags/fitness/posts
+     *     becomes just                            /read/tags/fitness/posts
+     */
+    private static String getRelativeEndpoint(final String endpoint) {
+        if (endpoint != null && endpoint.startsWith("http")) {
+            int pos = endpoint.indexOf("/read/");
+            if (pos > -1) {
+                return endpoint.substring(pos, endpoint.length());
+            }
+            pos = endpoint.indexOf("/v1/");
+            if (pos > -1) {
+                return endpoint.substring(pos + 3, endpoint.length());
+            }
+        }
+        return StringUtils.notNullStr(endpoint);
+    }
+
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderPostService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderPostService.java
@@ -202,7 +202,7 @@ public class ReaderPostService extends Service {
     private static void requestPostsForBlog(final long blogId,
                                             final UpdateAction updateAction,
                                             final UpdateResultListener resultListener) {
-        String path = "/sites/" + blogId + "/posts/?meta=site,likes";
+        String path = "sites/" + blogId + "/posts/?meta=site,likes";
 
         // append the date of the oldest cached post in this blog when requesting older posts
         if (updateAction == UpdateAction.REQUEST_OLDER) {
@@ -232,7 +232,7 @@ public class ReaderPostService extends Service {
     private static void requestPostsForFeed(final long feedId,
                                             final UpdateAction updateAction,
                                             final UpdateResultListener resultListener) {
-        String path = "/read/feed/" + feedId + "/posts/?meta=site,likes";
+        String path = "read/feed/" + feedId + "/posts/?meta=site,likes";
         if (updateAction == UpdateAction.REQUEST_OLDER) {
             String dateOldest = ReaderPostTable.getOldestPubDateInFeed(feedId);
             if (!TextUtils.isEmpty(dateOldest)) {
@@ -308,7 +308,7 @@ public class ReaderPostService extends Service {
             return null;
         }
 
-        return String.format("/read/tags/%s/posts", ReaderUtils.sanitizeWithDashes(tag.getTagName()));
+        return String.format("read/tags/%s/posts", ReaderUtils.sanitizeWithDashes(tag.getTagName()));
     }
 
     /*
@@ -318,17 +318,17 @@ public class ReaderPostService extends Service {
      * between API versions (as it did when we moved from v1 to v1.1)
      *
      * ex: https://public-api.wordpress.com/rest/v1/read/tags/fitness/posts
-     *     becomes just                            /read/tags/fitness/posts
+     *     becomes just                             read/tags/fitness/posts
      */
     private static String getRelativeEndpoint(final String endpoint) {
         if (endpoint != null && endpoint.startsWith("http")) {
             int pos = endpoint.indexOf("/read/");
             if (pos > -1) {
-                return endpoint.substring(pos, endpoint.length());
+                return endpoint.substring(pos + 1, endpoint.length());
             }
             pos = endpoint.indexOf("/v1/");
             if (pos > -1) {
-                return endpoint.substring(pos + 3, endpoint.length());
+                return endpoint.substring(pos + 4, endpoint.length());
             }
         }
         return StringUtils.notNullStr(endpoint);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderPostService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderPostService.java
@@ -101,6 +101,8 @@ public class ReaderPostService extends Service {
             action = UpdateAction.REQUEST_NEWER;
         }
 
+        EventBus.getDefault().post(new ReaderEvents.UpdatePostsStarted(action));
+
         if (intent.hasExtra(ARG_TAG)) {
             ReaderTag tag = (ReaderTag) intent.getSerializableExtra(ARG_TAG);
             updatePostsWithTag(tag, action);
@@ -126,7 +128,6 @@ public class ReaderPostService extends Service {
                         stopSelf();
                     }
                 });
-        EventBus.getDefault().post(new ReaderEvents.UpdatePostsStarted(action));
     }
 
     void updatePostsInBlog(long blogId, final UpdateAction action) {


### PR DESCRIPTION
Fix #2369 - Replaced existing methods of updating posts & comments with [ReaderPostService](https://github.com/wordpress-mobile/WordPress-Android/blob/feature/reader-services/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderPostService.java) and [ReaderCommentService](https://github.com/wordpress-mobile/WordPress-Android/blob/feature/reader-services/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderCommentService.java), both of which rely on an EventBus to notify of changes.

Note that the majority of the logic for updating posts & comments is unchanged from previous builds - this simply moves the same logic to services.