### PR TITLE
fix #2373: new CustomSwipeRefreshLayout with a workaround to catch onTouchEvent IllegalArgumentException

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/ManageBlogsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/ManageBlogsActivity.java
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.accounts;
 
 import android.content.Context;
 import android.os.Bundle;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBarActivity;
 import android.view.LayoutInflater;
@@ -28,6 +27,7 @@ import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper.RefreshListener;
+import org.wordpress.android.util.ptr.CustomSwipeRefreshLayout;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.util.List;
@@ -59,7 +59,7 @@ public class ManageBlogsActivity extends ActionBarActivity {
         }
 
         // swipe to refresh setup
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(this, (SwipeRefreshLayout) findViewById(R.id.ptr_layout),
+        mSwipeToRefreshHelper = new SwipeToRefreshHelper(this, (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
                 new RefreshListener() {
                     @Override
                     public void onRefreshStarted() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -7,7 +7,6 @@ import android.content.DialogInterface;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.view.ActionMode;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -33,6 +32,7 @@ import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper.RefreshListener;
+import org.wordpress.android.util.ptr.CustomSwipeRefreshLayout;
 import org.xmlrpc.android.ApiHelper;
 import org.xmlrpc.android.ApiHelper.ErrorType;
 import org.xmlrpc.android.XMLRPCFault;
@@ -198,7 +198,7 @@ public class CommentsListFragment extends Fragment {
 
         // swipe to refresh setup
         mSwipeToRefreshHelper = new SwipeToRefreshHelper(getActivity(),
-                (SwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
+                (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
                 new RefreshListener() {
                     @Override
                     public void onRefreshStarted() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -9,7 +9,6 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.os.Bundle;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.view.ActionMode;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -47,6 +46,7 @@ import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper.RefreshListener;
+import org.wordpress.android.util.ptr.CustomSwipeRefreshLayout;
 import org.xmlrpc.android.ApiHelper;
 import org.xmlrpc.android.ApiHelper.SyncMediaLibraryTask.Callback;
 
@@ -179,7 +179,7 @@ public class MediaGridFragment extends Fragment
 
         // swipe to refresh setup
         mSwipeToRefreshHelper = new SwipeToRefreshHelper(getActivity(),
-                (SwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
+                (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
                 new RefreshListener() {
                     @Override
                     public void onRefreshStarted() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -9,7 +9,6 @@ import android.os.Handler;
 import android.os.Parcelable;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.ActivityOptionsCompat;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -37,6 +36,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper;
+import org.wordpress.android.util.ptr.CustomSwipeRefreshLayout;
 
 import javax.annotation.Nonnull;
 
@@ -174,7 +174,7 @@ public class NotificationsListFragment extends Fragment implements Bucket.Listen
     private void initSwipeToRefreshHelper() {
         mFauxSwipeToRefreshHelper = new SwipeToRefreshHelper(
                 getActivity(),
-                (SwipeRefreshLayout) getActivity().findViewById(R.id.ptr_layout),
+                (CustomSwipeRefreshLayout) getActivity().findViewById(R.id.ptr_layout),
                 new SwipeToRefreshHelper.RefreshListener() {
                     @Override
                     public void onRefreshStarted() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -7,7 +7,6 @@ import android.app.ListFragment;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -30,6 +29,7 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper.RefreshListener;
+import org.wordpress.android.util.ptr.CustomSwipeRefreshLayout;
 import org.wordpress.android.widgets.FloatingActionButton;
 import org.wordpress.android.widgets.WPAlertDialogFragment;
 import org.xmlrpc.android.ApiHelper;
@@ -86,7 +86,7 @@ public class PostsListFragment extends ListFragment
     private void initSwipeToRefreshHelper() {
         mSwipeToRefreshHelper = new SwipeToRefreshHelper(
                 getActivity(),
-                (SwipeRefreshLayout) getView().findViewById(R.id.ptr_layout),
+                (CustomSwipeRefreshLayout) getView().findViewById(R.id.ptr_layout),
                 new RefreshListener() {
                     @Override
                     public void onRefreshStarted() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
@@ -2,10 +2,8 @@ package org.wordpress.android.ui.posts;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.os.Bundle;
 import android.os.Handler;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBarActivity;
 import android.util.SparseBooleanArray;
@@ -21,14 +19,15 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.models.CategoryNode;
-import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ListScrollPositionManager;
+import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper.RefreshListener;
+import org.wordpress.android.util.ptr.CustomSwipeRefreshLayout;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlrpc.android.XMLRPCClientInterface;
 import org.xmlrpc.android.XMLRPCException;
@@ -104,7 +103,7 @@ public class SelectCategoriesActivity extends ActionBarActivity {
         }
 
         // swipe to refresh setup
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(this, (SwipeRefreshLayout) findViewById(R.id.ptr_layout),
+        mSwipeToRefreshHelper = new SwipeToRefreshHelper(this, (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
                 new RefreshListener() {
                     @Override
                     public void onRefreshStarted() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -9,7 +9,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Parcelable;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.ActionBarActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.Toolbar;
@@ -68,6 +67,7 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper.RefreshListener;
+import org.wordpress.android.util.ptr.CustomSwipeRefreshLayout;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -328,7 +328,7 @@ public class ReaderPostListFragment extends Fragment {
 
         // swipe to refresh setup
         mSwipeToRefreshHelper = new SwipeToRefreshHelper(getActivity(),
-                (SwipeRefreshLayout) rootView.findViewById(R.id.ptr_layout),
+                (CustomSwipeRefreshLayout) rootView.findViewById(R.id.ptr_layout),
                 new RefreshListener() {
                     @Override
                     public void onRefreshStarted() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -14,7 +14,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.support.v4.content.LocalBroadcastManager;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.ActionBar;
 import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
@@ -51,6 +50,7 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper.RefreshListener;
+import org.wordpress.android.util.ptr.CustomSwipeRefreshLayout;
 import org.xmlrpc.android.ApiHelper;
 import org.xmlrpc.android.XMLRPCCallback;
 import org.xmlrpc.android.XMLRPCClientInterface;
@@ -129,7 +129,7 @@ public class StatsActivity extends WPDrawerActivity implements ScrollViewExt.Scr
             });
         }
 
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(this, (SwipeRefreshLayout) findViewById(R.id.ptr_layout),
+        mSwipeToRefreshHelper = new SwipeToRefreshHelper(this, (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
                 new RefreshListener() {
                     @Override
                     public void onRefreshStarted() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSinglePostDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSinglePostDetailsActivity.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.os.Handler;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBarActivity;
 import android.util.SparseBooleanArray;
@@ -38,6 +37,7 @@ import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper;
+import org.wordpress.android.util.ptr.CustomSwipeRefreshLayout;
 
 import java.lang.ref.WeakReference;
 import java.util.List;
@@ -99,7 +99,7 @@ public class StatsSinglePostDetailsActivity extends ActionBarActivity
         }
 
         // pull to refresh setup
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(this, (SwipeRefreshLayout) findViewById(R.id.ptr_layout),
+        mSwipeToRefreshHelper = new SwipeToRefreshHelper(this, (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
                 new SwipeToRefreshHelper.RefreshListener() {
                     @Override
                     public void onRefreshStarted() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
@@ -7,7 +7,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v4.content.LocalBroadcastManager;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBarActivity;
 import android.view.MenuItem;
@@ -28,6 +27,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper;
+import org.wordpress.android.util.ptr.CustomSwipeRefreshLayout;
 
 import java.io.Serializable;
 import java.lang.ref.WeakReference;
@@ -85,7 +85,7 @@ public class StatsViewAllActivity extends ActionBarActivity
         }
 
         // pull to refresh setup
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(this, (SwipeRefreshLayout) findViewById(R.id.ptr_layout),
+        mSwipeToRefreshHelper = new SwipeToRefreshHelper(this, (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
                 new SwipeToRefreshHelper.RefreshListener() {
                     @Override
                     public void onRefreshStarted() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeTabFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeTabFragment.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.app.Fragment;
 import android.database.Cursor;
 import android.os.Bundle;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -25,6 +24,7 @@ import org.wordpress.android.ui.themes.ThemeTabAdapter.ScreenshotHolder;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper.RefreshListener;
+import org.wordpress.android.util.ptr.CustomSwipeRefreshLayout;
 
 /**
  * A fragment display the themes on a grid view.
@@ -103,7 +103,7 @@ public class ThemeTabFragment extends Fragment implements OnItemClickListener, R
 
         // swipe to refresh setup but not for the search view
         if (!(this instanceof ThemeSearchFragment)) {
-            mSwipeToRefreshHelper = new SwipeToRefreshHelper(getActivity(), (SwipeRefreshLayout) view.findViewById(
+            mSwipeToRefreshHelper = new SwipeToRefreshHelper(getActivity(), (CustomSwipeRefreshLayout) view.findViewById(
                     R.id.ptr_layout), new RefreshListener() {
                 @Override
                 public void onRefreshStarted() {

--- a/WordPress/src/main/res/layout/comment_list_fragment.xml
+++ b/WordPress/src/main/res/layout/comment_list_fragment.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.v4.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <org.wordpress.android.util.ptr.CustomSwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/ptr_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -20,7 +20,7 @@
             android:dividerHeight="1dp"
             android:scrollingCache="true"
             tools:listitem="@layout/comment_listitem" />
-    </android.support.v4.widget.SwipeRefreshLayout>
+    </org.wordpress.android.util.ptr.CustomSwipeRefreshLayout>
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/empty_view"

--- a/WordPress/src/main/res/layout/empty_listview.xml
+++ b/WordPress/src/main/res/layout/empty_listview.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     android:background="@color/background_grey">
 
-    <android.support.v4.widget.SwipeRefreshLayout
+    <org.wordpress.android.util.ptr.CustomSwipeRefreshLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/ptr_layout"
         android:layout_width="match_parent"
@@ -28,5 +28,5 @@
             android:layout_marginLeft="@dimen/empty_list_title_side_margin"
             android:layout_marginRight="@dimen/empty_list_title_side_margin"
             android:text="@string/empty_list_default" />
-    </android.support.v4.widget.SwipeRefreshLayout>
+    </org.wordpress.android.util.ptr.CustomSwipeRefreshLayout>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/media_grid_fragment.xml
+++ b/WordPress/src/main/res/layout/media_grid_fragment.xml
@@ -31,7 +31,7 @@
         android:padding="8dp"
         android:visibility="gone" />
 
-    <android.support.v4.widget.SwipeRefreshLayout
+    <org.wordpress.android.util.ptr.CustomSwipeRefreshLayout
         android:id="@+id/ptr_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -49,7 +49,7 @@
             android:scrollbarStyle="outsideOverlay"
             android:stretchMode="columnWidth"
             android:verticalSpacing="@dimen/margin_small" />
-    </android.support.v4.widget.SwipeRefreshLayout>
+    </org.wordpress.android.util.ptr.CustomSwipeRefreshLayout>
 
     <LinearLayout
         android:id="@+id/empty_view"

--- a/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
+++ b/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <android.support.v4.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <org.wordpress.android.util.ptr.CustomSwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/ptr_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -16,7 +16,7 @@
             android:layout_height="fill_parent"
             android:scrollbars="vertical" />
 
-    </android.support.v4.widget.SwipeRefreshLayout>
+    </org.wordpress.android.util.ptr.CustomSwipeRefreshLayout>
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/empty_view"

--- a/WordPress/src/main/res/layout/post_listview.xml
+++ b/WordPress/src/main/res/layout/post_listview.xml
@@ -49,7 +49,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <android.support.v4.widget.SwipeRefreshLayout
+        <org.wordpress.android.util.ptr.CustomSwipeRefreshLayout
             android:id="@+id/ptr_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
@@ -60,7 +60,7 @@
                 android:layout_height="match_parent"
                 android:drawSelectorOnTop="false"
                 tools:listitem="@layout/post_list_row" />
-        </android.support.v4.widget.SwipeRefreshLayout>
+        </org.wordpress.android.util.ptr.CustomSwipeRefreshLayout>
 
         <org.wordpress.android.widgets.FloatingActionButton
             android:id="@+id/fab_button"

--- a/WordPress/src/main/res/layout/reader_fragment_post_cards.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_cards.xml
@@ -11,7 +11,7 @@
         android:layout_height="wrap_content"
         android:visibility="gone" />
 
-    <android.support.v4.widget.SwipeRefreshLayout
+    <org.wordpress.android.util.ptr.CustomSwipeRefreshLayout
         android:id="@+id/ptr_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -23,7 +23,7 @@
             android:layout_height="match_parent"
             android:scrollbars="vertical" />
 
-    </android.support.v4.widget.SwipeRefreshLayout>
+    </org.wordpress.android.util.ptr.CustomSwipeRefreshLayout>
 
     <include
         android:id="@+id/empty_view"

--- a/WordPress/src/main/res/layout/select_categories.xml
+++ b/WordPress/src/main/res/layout/select_categories.xml
@@ -6,7 +6,7 @@
     android:padding="0px"
     android:orientation="vertical">
 
-    <android.support.v4.widget.SwipeRefreshLayout
+    <org.wordpress.android.util.ptr.CustomSwipeRefreshLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:id="@+id/ptr_layout"
         android:layout_width="match_parent"
@@ -22,5 +22,5 @@
             android:cacheColorHint="#00000000">
         </ListView>
 
-    </android.support.v4.widget.SwipeRefreshLayout>
+    </org.wordpress.android.util.ptr.CustomSwipeRefreshLayout>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/stats_activity.xml
+++ b/WordPress/src/main/res/layout/stats_activity.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.widget.SwipeRefreshLayout
+<org.wordpress.android.util.ptr.CustomSwipeRefreshLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/ptr_layout"
     android:layout_width="match_parent"
@@ -163,4 +163,4 @@
 
         </LinearLayout>
     </org.wordpress.android.ui.stats.ScrollViewExt>
-</android.support.v4.widget.SwipeRefreshLayout>
+</org.wordpress.android.util.ptr.CustomSwipeRefreshLayout>

--- a/WordPress/src/main/res/layout/stats_activity_single_post_details.xml
+++ b/WordPress/src/main/res/layout/stats_activity_single_post_details.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<org.wordpress.android.util.ptr.CustomSwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/ptr_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -249,4 +249,4 @@
 
         </LinearLayout>
     </org.wordpress.android.ui.stats.ScrollViewExt>
-</android.support.v4.widget.SwipeRefreshLayout>
+</org.wordpress.android.util.ptr.CustomSwipeRefreshLayout>

--- a/WordPress/src/main/res/layout/stats_activity_view_all.xml
+++ b/WordPress/src/main/res/layout/stats_activity_view_all.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.widget.SwipeRefreshLayout
+<org.wordpress.android.util.ptr.CustomSwipeRefreshLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/ptr_layout"
     android:layout_width="match_parent"
@@ -38,4 +38,4 @@
 
         </LinearLayout>
     </org.wordpress.android.ui.stats.ScrollViewExt>
-</android.support.v4.widget.SwipeRefreshLayout>
+</org.wordpress.android.util.ptr.CustomSwipeRefreshLayout>

--- a/WordPress/src/main/res/layout/theme_tab_fragment.xml
+++ b/WordPress/src/main/res/layout/theme_tab_fragment.xml
@@ -13,8 +13,7 @@
         android:visibility="gone"
         android:layout_margin="16dp"/>
 
-    <android.support.v4.widget.SwipeRefreshLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
+    <org.wordpress.android.util.ptr.CustomSwipeRefreshLayout
         android:id="@+id/ptr_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -32,7 +31,7 @@
             android:stretchMode="columnWidth"
             android:layout_below="@id/theme_no_search_result_text">
         </GridView>
-    </android.support.v4.widget.SwipeRefreshLayout>
+    </org.wordpress.android.util.ptr.CustomSwipeRefreshLayout>
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/text_empty"

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ptr/CustomSwipeRefreshLayout.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ptr/CustomSwipeRefreshLayout.java
@@ -22,6 +22,10 @@ public class CustomSwipeRefreshLayout extends SwipeRefreshLayout {
         try{
             return super.onTouchEvent(event);
         } catch(IllegalArgumentException e) {
+            // Fix for https://github.com/wordpress-mobile/WordPress-Android/issues/2373
+            // Catch IllegalArgumentException which can be fired by the underlying SwipeRefreshLayout.onTouchEvent()
+            // method.
+            // When android support-v4 fixes it, we'll have to remove that custom layout completely.
             AppLog.e(T.UTILS, e);
             return true;
         }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ptr/CustomSwipeRefreshLayout.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ptr/CustomSwipeRefreshLayout.java
@@ -1,0 +1,29 @@
+package org.wordpress.android.util.ptr;
+
+import android.content.Context;
+import android.support.v4.widget.SwipeRefreshLayout;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+
+public class CustomSwipeRefreshLayout extends SwipeRefreshLayout {
+    public CustomSwipeRefreshLayout(Context context) {
+        super(context);
+    }
+
+    public CustomSwipeRefreshLayout(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        try{
+            return super.onTouchEvent(event);
+        } catch(IllegalArgumentException e) {
+            AppLog.e(T.UTILS, e);
+            return true;
+        }
+    }
+}

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ptr/SwipeToRefreshHelper.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ptr/SwipeToRefreshHelper.java
@@ -3,14 +3,13 @@ package org.wordpress.android.util.ptr;
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v4.widget.SwipeRefreshLayout.OnRefreshListener;
 import android.util.TypedValue;
 
 import org.wordpress.android.util.R;
 
 public class SwipeToRefreshHelper implements OnRefreshListener {
-    private SwipeRefreshLayout mSwipeRefreshLayout;
+    private CustomSwipeRefreshLayout mSwipeRefreshLayout;
     private RefreshListener mRefreshListener;
     private boolean mRefreshing;
 
@@ -18,11 +17,11 @@ public class SwipeToRefreshHelper implements OnRefreshListener {
         public void onRefreshStarted();
     }
 
-    public SwipeToRefreshHelper(Activity activity, SwipeRefreshLayout swipeRefreshLayout, RefreshListener listener) {
+    public SwipeToRefreshHelper(Activity activity, CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener) {
         init(activity, swipeRefreshLayout, listener);
     }
 
-    public void init(Activity activity, SwipeRefreshLayout swipeRefreshLayout, RefreshListener listener) {
+    public void init(Activity activity, CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener) {
         mRefreshListener = listener;
         mSwipeRefreshLayout = swipeRefreshLayout;
         mSwipeRefreshLayout.setOnRefreshListener(this);


### PR DESCRIPTION
fix #2373: new CustomSwipeRefreshLayout with a workaround to catch onTouchEvent IllegalArgumentException

I don't like that solution much (I don't want to maintain a custom `SwipeRefreshLayout`) but I don't see any better workaround for this crash.