### PR TITLE
Stats - Authors module always available and be in par with web

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -47,9 +47,9 @@ import org.wordpress.android.util.RateLimitedTask;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
+import org.wordpress.android.util.ptr.CustomSwipeRefreshLayout;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper.RefreshListener;
-import org.wordpress.android.util.ptr.CustomSwipeRefreshLayout;
 import org.xmlrpc.android.ApiHelper;
 import org.xmlrpc.android.XMLRPCCallback;
 import org.xmlrpc.android.XMLRPCClientInterface;
@@ -67,7 +67,6 @@ import java.util.Map;
  * </p>
  */
 public class StatsActivity extends WPDrawerActivity implements ScrollViewExt.ScrollViewListener,
-        StatsAuthorsFragment.OnAuthorsSectionChangeListener,
         StatsVisitorsAndViewsFragment.OnDateChangeListener,
         StatsAbstractListFragment.OnRequestDataListener,
         StatsAbstractFragment.TimeframeDateProvider {
@@ -366,14 +365,6 @@ public class StatsActivity extends WPDrawerActivity implements ScrollViewExt.Scr
         }
 
         ft.commitAllowingStateLoss();
-    }
-
-    // AuthorsFragment should be dismissed when 0 or 1 author.
-    public void onAuthorsVisibilityChange(boolean isEmpty) {
-        View authorsContainer = this.findViewById(R.id.stats_top_authors_container);
-        if (authorsContainer != null) {
-            authorsContainer.setVisibility(isEmpty ? View.GONE : View.VISIBLE);
-        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAuthorsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAuthorsFragment.java
@@ -20,22 +20,6 @@ import java.util.List;
 
 public class StatsAuthorsFragment extends StatsAbstractListFragment {
     public static final String TAG = StatsAuthorsFragment.class.getSimpleName();
-    private OnAuthorsSectionChangeListener mListener;
-
-    // Container Activity must implement this interface
-    public interface OnAuthorsSectionChangeListener {
-        public void onAuthorsVisibilityChange(boolean isEmpty);
-    }
-
-    @Override
-    public void onAttach(Activity activity) {
-        super.onAttach(activity);
-        try {
-            mListener = (OnAuthorsSectionChangeListener) activity;
-        } catch (ClassCastException e) {
-            throw new ClassCastException(activity.toString() + " must implement OnAuthorsSectionChangeListener");
-        }
-    }
 
     @Override
     protected void updateUI() {
@@ -50,22 +34,18 @@ public class StatsAuthorsFragment extends StatsAbstractListFragment {
 
         if (isDataEmpty()) {
             showHideNoResultsUI(true);
-            mListener.onAuthorsVisibilityChange(true); // Hide the authors section if completely empty
             return;
         }
 
         List<AuthorModel> authors = ((AuthorsModel) mDatamodels[0]).getAuthors();
-        // Do not show the authors section if there is one author only
-        if (authors == null || authors.size() <= 1) {
+        if (authors == null || authors.size() == 0) {
             showHideNoResultsUI(true);
-            mListener.onAuthorsVisibilityChange(true);
             return;
         }
 
         BaseExpandableListAdapter adapter = new MyExpandableListAdapter(getActivity(), authors);
         StatsUIHelper.reloadGroupViews(getActivity(), adapter, mGroupIdToExpandedMap, mList, getMaxNumberOfItemsToShowInList());
         showHideNoResultsUI(false);
-        mListener.onAuthorsVisibilityChange(false);
     }
 
     @Override
@@ -97,7 +77,7 @@ public class StatsAuthorsFragment extends StatsAbstractListFragment {
     }
     @Override
     protected int getEmptyLabelTitleResId() {
-        return R.string.stats_empty_top_authors;
+        return R.string.stats_empty_top_posts_title;
     }
     @Override
     protected int getEmptyLabelDescResId() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSinglePostDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSinglePostDetailsActivity.java
@@ -36,8 +36,8 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.ptr.SwipeToRefreshHelper;
 import org.wordpress.android.util.ptr.CustomSwipeRefreshLayout;
+import org.wordpress.android.util.ptr.SwipeToRefreshHelper;
 
 import java.lang.ref.WeakReference;
 import java.util.List;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
@@ -11,7 +11,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
-import org.wordpress.android.WordPressDB;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
@@ -26,8 +26,8 @@ import org.wordpress.android.ui.stats.service.StatsService;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.ptr.SwipeToRefreshHelper;
 import org.wordpress.android.util.ptr.CustomSwipeRefreshLayout;
+import org.wordpress.android.util.ptr.SwipeToRefreshHelper;
 
 import java.io.Serializable;
 import java.lang.ref.WeakReference;
@@ -43,8 +43,7 @@ import java.util.concurrent.ThreadPoolExecutor;
  *  Single item details activity.
  */
 public class StatsViewAllActivity extends ActionBarActivity
-        implements StatsAuthorsFragment.OnAuthorsSectionChangeListener,
-        StatsAbstractListFragment.OnRequestDataListener,
+        implements StatsAbstractListFragment.OnRequestDataListener,
         StatsAbstractFragment.TimeframeDateProvider {
 
     private boolean mIsInFront;
@@ -381,11 +380,6 @@ public class StatsViewAllActivity extends ActionBarActivity
                 refreshStats();
             }
         }, 75L);
-    }
-
-    @Override
-    public void onAuthorsVisibilityChange(boolean isEmpty) {
-        // Nothing to do here, since the section must not disappear here.
     }
 
     private class RestListener implements RestRequest.Listener, RestRequest.ErrorListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewHolder.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewHolder.java
@@ -14,7 +14,6 @@ import android.widget.TextView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
-import org.wordpress.android.WordPressDB;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.stats.models.PostModel;
 import org.wordpress.android.util.AppLog;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
@@ -8,14 +8,12 @@ import android.content.IntentFilter;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.v4.content.LocalBroadcastManager;
-import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckedTextView;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.RadioGroup;
 import android.widget.TextView;
 
 import com.android.volley.VolleyError;
@@ -35,7 +33,6 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StringUtils;
-import org.wordpress.android.widgets.TypefaceCache;
 
 import java.io.Serializable;
 import java.text.ParseException;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWPLinkMovementMethod.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWPLinkMovementMethod.java
@@ -9,7 +9,6 @@ import android.view.MotionEvent;
 import android.widget.TextView;
 
 import org.wordpress.android.WordPress;
-import org.wordpress.android.WordPressDB;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.UrlUtils;

--- a/WordPress/src/main/res/layout/stats_activity.xml
+++ b/WordPress/src/main/res/layout/stats_activity.xml
@@ -82,6 +82,15 @@
                 android:layout_marginRight="@dimen/margin_medium"/>
 
             <FrameLayout
+                android:id="@+id/stats_top_authors_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_large"
+                android:layout_marginLeft="@dimen/margin_medium"
+                android:layout_marginRight="@dimen/margin_medium"
+                />
+
+            <FrameLayout
                 android:id="@+id/stats_geoviews_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -91,15 +100,6 @@
 
             <FrameLayout
                 android:id="@+id/stats_search_terms_container"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_large"
-                android:layout_marginLeft="@dimen/margin_medium"
-                android:layout_marginRight="@dimen/margin_medium"
-                />
-
-            <FrameLayout
-                android:id="@+id/stats_top_authors_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_large"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -433,7 +433,6 @@
     <string name="stats_empty_clicks_desc">When your content includes links to other sites, you’ll see which ones your visitors click on the most.</string>
     <string name="stats_empty_search_engine_terms_title">No search terms</string>
     <string name="stats_empty_search_engine_terms_desc">Search terms are words or phrases users find you with when they search.</string>
-    <string name="stats_empty_top_authors">No posts viewed</string>
     <string name="stats_empty_top_authors_desc">Track the views on each contributor\'s posts, and zoom in to discover the most popular content by each author.</string>
     <string name="stats_empty_tags_and_categories">No tagged posts or pages viewed</string>
     <string name="stats_empty_tags_and_categories_desc">Get an overview of the most popular topics on your site, as reflected in your top posts from the past week.</string>


### PR DESCRIPTION
We had a custom logic that hid the Authors module when there was 0 or 1 author in the selected timeperiod.

Better to have it always visible on the screen to address issues where there are no authors in the selected timeperiod. Web version of Stats already fixed this issue.