### PR TITLE
Added elevation to tabs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/FloatingActionButton.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/FloatingActionButton.java
@@ -40,7 +40,8 @@ public class FloatingActionButton extends ImageButton {
     void init(Context context) {
         mIsLollipop = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP);
         if (mIsLollipop) {
-            setElevation(DisplayUtils.dpToPx(context, 4));
+            int elevation = context.getResources().getDimensionPixelSize(R.dimen.fab_elevation);
+            setElevation(elevation);
         }
 
         int fabColor = context.getResources().getColor(R.color.fab_color);

--- a/WordPress/src/main/res/layout/reader_activity_subs.xml
+++ b/WordPress/src/main/res/layout/reader_activity_subs.xml
@@ -23,6 +23,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="top"
             android:background="@color/tab_background"
+            android:elevation="@dimen/tabs_elevation"
             android:paddingBottom="@dimen/margin_large"
             android:paddingTop="@dimen/margin_large"
             android:textAppearance="@style/ReaderTabStripTextAppearance" />

--- a/WordPress/src/main/res/layout/theme_browser_activity.xml
+++ b/WordPress/src/main/res/layout/theme_browser_activity.xml
@@ -9,7 +9,8 @@
         android:id="@+id/sliding_tabs"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/tab_background" />
+        android:background="@color/tab_background"
+        android:elevation="@dimen/tabs_elevation" />
 
     <android.support.v4.view.ViewPager
         android:id="@+id/theme_browser_pager"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -15,7 +15,7 @@
     <dimen name="fab_elevation">8dp</dimen>
 
     <dimen name="card_elevation">2dp</dimen>
-    <dimen name="card_elevation_pressed">4dp</dimen>
+    <dimen name="card_elevation_pressed">8dp</dimen>
 
     <dimen name="message_bar_elevation">2dp</dimen>
     <dimen name="tabs_elevation">4dp</dimen>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -14,7 +14,7 @@
     <dimen name="fab_margin_tablet">24dp</dimen>
     <dimen name="fab_elevation">8dp</dimen>
 
-    <dimen name="card_elevation">1dp</dimen>
+    <dimen name="card_elevation">2dp</dimen>
     <dimen name="card_elevation_pressed">4dp</dimen>
 
     <dimen name="message_bar_elevation">2dp</dimen>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -12,6 +12,7 @@
     <dimen name="fab_margin">@dimen/fab_margin_default</dimen>
     <dimen name="fab_margin_default">16dp</dimen>
     <dimen name="fab_margin_tablet">24dp</dimen>
+    <dimen name="fab_elevation">8dp</dimen>
 
     <dimen name="card_elevation">1dp</dimen>
     <dimen name="card_elevation_pressed">4dp</dimen>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -17,6 +17,7 @@
     <dimen name="card_elevation_pressed">4dp</dimen>
 
     <dimen name="message_bar_elevation">2dp</dimen>
+    <dimen name="tabs_elevation">4dp</dimen>
 
     <dimen name="drawer_width_static">300dp</dimen>
     <dimen name="drawer_row_height">40dp</dimen>


### PR DESCRIPTION
Fix #2391 - added a 4dp drop-shadow to the tab strips on the reader subs and themes activities. Note that I couldn't find any guidelines on the elevation size, but 4dp seems to be what Google's apps use and it's the elevation [used in iosched](https://github.com/google/iosched/blob/master/android/src/main/res/values/dimens.xml#L123).