### PR TITLE
Issue/2398 reader color tweaks

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
@@ -70,7 +70,7 @@ class CommentAdapter extends BaseAdapter {
 
         mStatusColorSpam = context.getResources().getColor(R.color.comment_status_spam);
         mStatusColorUnapproved = context.getResources().getColor(R.color.comment_status_unapproved);
-        mSelectionColor = context.getResources().getColor(R.color.blue_light);
+        mSelectionColor = context.getResources().getColor(R.color.semi_transparent_blue_light);
 
         mStatusTextSpam = context.getResources().getString(R.string.comment_status_spam);
         mStatusTextUnapproved = context.getResources().getString(R.string.comment_status_unapproved);

--- a/WordPress/src/main/res/drawable-v21/reader_follow_button_selector.xml
+++ b/WordPress/src/main/res/drawable-v21/reader_follow_button_selector.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?android:attr/colorControlHighlight">
+    <item>
+        <selector>
+            <item
+                android:drawable="@drawable/reader_follow_button_pressed"
+                android:state_pressed="true" />
+            <item android:drawable="@drawable/reader_follow_button" />
+        </selector>
+    </item>
+</ripple>

--- a/WordPress/src/main/res/drawable/reader_follow_button.xml
+++ b/WordPress/src/main/res/drawable/reader_follow_button.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <stroke
+        android:width="1dp"
+        android:color="@color/grey_lighten_20" />
+    <solid android:color="@color/grey_light" />
+    <corners android:radius="2dp" />
+</shape>

--- a/WordPress/src/main/res/drawable/reader_follow_button.xml
+++ b/WordPress/src/main/res/drawable/reader_follow_button.xml
@@ -4,6 +4,6 @@
     <stroke
         android:width="1dp"
         android:color="@color/grey_lighten_20" />
-    <solid android:color="@color/grey_light" />
+    <solid android:color="@color/white" />
     <corners android:radius="2dp" />
 </shape>

--- a/WordPress/src/main/res/drawable/reader_follow_button_pressed.xml
+++ b/WordPress/src/main/res/drawable/reader_follow_button_pressed.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <stroke
+        android:width="1dp"
+        android:color="@color/grey_lighten_30" />
+    <solid android:color="@color/color_control_highlight" />
+    <corners android:radius="2dp" />
+</shape>

--- a/WordPress/src/main/res/drawable/reader_follow_button_pressed.xml
+++ b/WordPress/src/main/res/drawable/reader_follow_button_pressed.xml
@@ -4,6 +4,6 @@
     <stroke
         android:width="1dp"
         android:color="@color/grey_lighten_30" />
-    <solid android:color="@color/color_control_highlight" />
+    <solid android:color="@color/grey_lighten_20" />
     <corners android:radius="2dp" />
 </shape>

--- a/WordPress/src/main/res/drawable/reader_follow_button_selector.xml
+++ b/WordPress/src/main/res/drawable/reader_follow_button_selector.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@color/grey_lighten_30" android:state_pressed="true" />
-    <item android:drawable="@color/grey_light" />
+    <item android:drawable="@drawable/reader_follow_button_pressed" android:state_pressed="true" />
+    <item android:drawable="@drawable/reader_follow_button" />
 </selector>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -12,7 +12,7 @@
     <color name="color_primary_dark">@color/status_bar_tint</color>
     <color name="color_accent">@color/orange_jazzy</color>
     <color name="color_control_activated">@color/blue_light</color>
-    <color name="color_control_highlight">@color/blue_light</color>
+    <color name="color_control_highlight">@color/pressed_wordpress</color>
 
     <color name="fab_color">@color/color_accent</color>
     <color name="list_selected">@color/semi_transparent_blue_light</color>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -9,7 +9,7 @@
         <item name="colorControlActivated">@color/color_control_activated</item>
         <item name="colorControlHighlight">@color/color_control_highlight</item>
 
-        <item name="android:windowBackground">@color/grey_light</item>
+        <item name="android:windowBackground">@color/grey_lighten_30</item>
         <item name="android:actionBarItemBackground">@drawable/selectable_background_wordpress</item>
         <item name="android:popupMenuStyle">@style/PopupMenu.WordPress</item>
         <item name="android:dropDownListViewStyle">@style/DropDownListView.Dark.WordPress</item>


### PR DESCRIPTION
Fix #2398 - Made the following tweaks to the color changes added in #2185:
* Default selection color has been lightened
* Follow button now has a border and ripple effect to make it stand out better
* Default window background has been slightly darkened so that white listViews stand out better

Before (left) and after (right) comparison below:

![color-before-and-after](https://cloud.githubusercontent.com/assets/3903757/6516812/2c99a0dc-c363-11e4-9bdf-b8c99d7725f0.png)
