### PR TITLE
Back in black

### DIFF
--- a/WordPress/src/main/res/layout-sw600dp-port/theme_details_fragment.xml
+++ b/WordPress/src/main/res/layout-sw600dp-port/theme_details_fragment.xml
@@ -154,7 +154,7 @@
             android:layout_marginLeft="15dp"
             android:layout_marginTop="18dp"
             android:text="@string/themes_details_label"
-            android:textColor="@color/black"
+            android:textColor="@color/grey_dark"
             android:textSize="16sp" />
 
         <TextView
@@ -165,7 +165,7 @@
             android:layout_marginLeft="15dp"
             android:layout_marginRight="15dp"
             android:fontFamily="sans-serif-light"
-            android:textColor="@color/black"
+            android:textColor="@color/grey_dark"
             android:textSize="16sp"
             android:textStyle="normal" />
 
@@ -178,7 +178,7 @@
             android:layout_marginLeft="16dp"
             android:layout_marginTop="18dp"
             android:text="@string/themes_features_label"
-            android:textColor="@color/black"
+            android:textColor="@color/grey_dark"
             android:textSize="16sp" />
 
         <LinearLayout

--- a/WordPress/src/main/res/layout-sw600dp/theme_details_fragment.xml
+++ b/WordPress/src/main/res/layout-sw600dp/theme_details_fragment.xml
@@ -150,7 +150,7 @@
                 android:layout_marginLeft="15dp"
                 android:layout_marginTop="18dp"
                 android:text="@string/themes_details_label"
-                android:textColor="@color/black"
+                android:textColor="@color/grey_dark"
                 android:textSize="16sp" />
 
             <TextView
@@ -161,7 +161,7 @@
                 android:layout_marginLeft="15dp"
                 android:layout_marginRight="15dp"
                 android:fontFamily="sans-serif-light"
-                android:textColor="@color/black"
+                android:textColor="@color/grey_dark"
                 android:textSize="16sp"
                 android:textStyle="normal" />
 
@@ -174,7 +174,7 @@
                 android:layout_marginLeft="16dp"
                 android:layout_marginTop="18dp"
                 android:text="@string/themes_features_label"
-                android:textColor="@color/black"
+                android:textColor="@color/grey_dark"
                 android:textSize="16sp" />
 
             <LinearLayout

--- a/WordPress/src/main/res/layout-sw720dp/theme_details_fragment.xml
+++ b/WordPress/src/main/res/layout-sw720dp/theme_details_fragment.xml
@@ -151,7 +151,7 @@
                 android:layout_marginLeft="15dp"
                 android:layout_marginTop="18dp"
                 android:text="@string/themes_details_label"
-                android:textColor="@color/black"
+                android:textColor="@color/grey_dark"
                 android:textSize="16sp" />
 
             <TextView
@@ -162,7 +162,7 @@
                 android:layout_marginLeft="15dp"
                 android:layout_marginRight="15dp"
                 android:fontFamily="sans-serif-light"
-                android:textColor="@color/black"
+                android:textColor="@color/grey_dark"
                 android:textSize="16sp"
                 android:textStyle="normal" />
 
@@ -175,7 +175,7 @@
                 android:layout_marginLeft="16dp"
                 android:layout_marginTop="18dp"
                 android:text="@string/themes_features_label"
-                android:textColor="@color/black"
+                android:textColor="@color/grey_dark"
                 android:textSize="16sp" />
 
             <LinearLayout

--- a/WordPress/src/main/res/layout/fragment_edit_post_settings.xml
+++ b/WordPress/src/main/res/layout/fragment_edit_post_settings.xml
@@ -40,7 +40,7 @@
             android:layout_marginRight="@dimen/margin_large"
             android:background="@drawable/selectable_background_wordpress"
             android:text="@string/immediately"
-            android:textColor="@color/black"
+            android:textColor="@color/grey_dark"
             android:textSize="@dimen/text_sz_large" />
 
         <TextView

--- a/WordPress/src/main/res/layout/theme_details_fragment.xml
+++ b/WordPress/src/main/res/layout/theme_details_fragment.xml
@@ -159,7 +159,7 @@
             android:layout_marginLeft="16dp"
             android:layout_marginTop="18dp"
             android:text="@string/themes_details_label"
-            android:textColor="@color/black"
+            android:textColor="@color/grey_dark"
             android:textSize="16sp" />
 
         <TextView
@@ -170,7 +170,7 @@
             android:layout_marginLeft="16dp"
             android:layout_marginRight="16dp"
             android:fontFamily="sans-serif-light"
-            android:textColor="@color/black"
+            android:textColor="@color/grey_dark"
             android:textSize="16sp"
             android:textStyle="normal" />
 
@@ -183,7 +183,7 @@
             android:layout_marginLeft="16dp"
             android:layout_marginTop="18dp"
             android:text="@string/themes_features_label"
-            android:textColor="@color/black"
+            android:textColor="@color/grey_dark"
             android:textSize="16sp" />
 
         <LinearLayout

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -23,7 +23,8 @@
     <color name="light_gray">@color/grey_lighten_30</color>
     <color name="gray">@color/grey_lighten_20</color>
     <color name="white">#FFFFFF</color>
-    <color name="black">@color/grey_dark</color>
+    <!-- note that black should NOT be used for text - use grey_dark instead -->
+    <color name="black">#000000</color>
     <color name="default_background">@color/grey_lighten_30</color>
 
     <!-- ==================================== -->
@@ -87,7 +88,7 @@
     <color name="media_gallery_option_default">@color/grey_lighten_30</color>
 
     <!-- Theme Details -->
-    <color name="theme_details_name">@color/black</color>
+    <color name="theme_details_name">@color/grey_dark</color>
     <color name="theme_details_button">@color/white</color>
     <color name="theme_details_premium">@color/orange_jazzy</color>
     <color name="theme_feature_text">@color/grey_dark</color>


### PR DESCRIPTION
Fix #2400 - Changed `black` back to #000000 in `colors.xml` and changed all `textColor` references that used `black` to use `grey_dark` instead.

cc: @drw158 