### PR TITLE
Fix #193. Add connection check before posting/uploading

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaAddFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaAddFragment.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.database.Cursor;
 import android.graphics.BitmapFactory;
+import android.net.ConnectivityManager;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -24,9 +25,10 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.models.MediaFile;
-import org.wordpress.android.ui.media.services.MediaUploadService;
 import org.wordpress.android.ui.media.MediaUtils.LaunchCameraCallback;
 import org.wordpress.android.ui.media.MediaUtils.RequestCode;
+import org.wordpress.android.ui.media.services.MediaUploadService;
+import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 
 import java.io.File;
@@ -74,13 +76,24 @@ public class MediaAddFragment extends Fragment implements LaunchCameraCallback {
     }
 
     @Override
+    public void onStart() {
+        super.onStart();
+
+        // register context for change in connection status
+        getActivity().registerReceiver(mReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
+    }
+
+    @Override
+    public void onStop() {
+        getActivity().unregisterReceiver(mReceiver);
+        super.onStop();
+    }
+
+    @Override
     public void onResume() {
         super.onResume();
 
-        LocalBroadcastManager lbm = LocalBroadcastManager.getInstance(getActivity());
-        lbm.registerReceiver(mReceiver, new IntentFilter(MediaUploadService.MEDIA_UPLOAD_INTENT_NOTIFICATION));
-
-        startMediaUploadService();
+        resumeMediaUploadService();
     }
 
     @Override
@@ -102,6 +115,9 @@ public class MediaAddFragment extends Fragment implements LaunchCameraCallback {
                     ToastUtils.showToast(context, errorMessage, ToastUtils.Duration.SHORT);
                 }
                 mCallback.onMediaAdded(mediaId);
+            } else if (ConnectivityManager.CONNECTIVITY_ACTION.equals(action)) {
+                // Coming from zero connection. Re-register upload intent.
+                resumeMediaUploadService();
             }
         }
     };
@@ -224,7 +240,16 @@ public class MediaAddFragment extends Fragment implements LaunchCameraCallback {
     }
 
     private void startMediaUploadService() {
-        getActivity().startService(new Intent(getActivity(), MediaUploadService.class));
+        if (NetworkUtils.isNetworkAvailable(getActivity())) {
+            getActivity().startService(new Intent(getActivity(), MediaUploadService.class));
+        }
+    }
+
+    private void resumeMediaUploadService() {
+        LocalBroadcastManager lbm = LocalBroadcastManager.getInstance(getActivity());
+        lbm.registerReceiver(mReceiver, new IntentFilter(MediaUploadService.MEDIA_UPLOAD_INTENT_NOTIFICATION));
+
+        startMediaUploadService();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -23,6 +23,7 @@ import org.wordpress.android.models.Post;
 import org.wordpress.android.models.PostStatus;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
@@ -304,8 +305,15 @@ public class EditPostActivity extends ActionBarActivity {
                 ToastUtils.showToast(this, R.string.error_publish_empty_post, Duration.SHORT);
                 return false;
             }
+
             savePost(false, false);
             trackSavePostAnalytics();
+
+            if (!NetworkUtils.isNetworkAvailable(this)) {
+                ToastUtils.showToast(this, R.string.error_publish_no_network, Duration.SHORT);
+                return false;
+            }
+
             PostUploadService.addPostToUpload(mPost);
             startService(new Intent(this, PostUploadService.class));
             Intent i = new Intent();

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -613,6 +613,7 @@
     <string name="error_moderate_comment">An error occurred while moderating</string>
     <string name="error_edit_comment">An error occurred while editing the comment</string>
     <string name="error_publish_empty_post">Can\'t publish an empty post</string>
+    <string name="error_publish_no_network">Can\'t publish while there is no connection. Saved as draft.</string>
     <string name="error_upload">An error occurred while uploading the %s</string>
     <string name="error_media_upload">An error occurred while uploading media</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>


### PR DESCRIPTION
Alert users that the post can't be published due to
a complete lack of connection.
Also, when there is no connection, adding media (video/photo) will only be queued
without trying to upload it. Upload will continue once a connection is
established.