### PR TITLE
Autocomplete suggestions for tags

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/Tag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Tag.java
@@ -1,0 +1,51 @@
+package org.wordpress.android.models;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.wordpress.android.util.JSONUtil;
+import org.wordpress.android.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Tag {
+    public long siteID;
+
+    private String tag;
+
+    public Tag(long siteID,
+               String tag) {
+        this.siteID = siteID;
+        this.tag = tag;
+    }
+
+    public static Tag fromJSON(JSONObject json, long siteID) {
+        if (json == null) {
+            return null;
+        }
+
+        String tag = JSONUtil.getString(json, "name");
+
+        // the api currently doesn't return a taxonomy field but we want to be ready for when it does
+        return new Tag(siteID, tag);
+    }
+
+    public static List<Tag> tagListFromJSON(JSONArray jsonArray, long siteID) {
+        if (jsonArray == null) {
+            return null;
+        }
+
+        ArrayList<Tag> suggestions = new ArrayList<Tag>(jsonArray.length());
+
+        for (int i = 0; i < jsonArray.length(); i++) {
+            Tag suggestion = Tag.fromJSON(jsonArray.optJSONObject(i), siteID);
+            suggestions.add(suggestion);
+        }
+
+        return suggestions;
+    }
+
+    public String getTag() {
+        return StringUtils.notNullStr(tag);
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -26,6 +26,10 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
+import org.wordpress.android.ui.suggestion.adapters.SuggestionAdapter;
+import org.wordpress.android.ui.suggestion.util.SuggestionServiceConnectionManager;
+import org.wordpress.android.ui.suggestion.util.SuggestionUtils;
+import org.wordpress.android.widgets.SuggestionAutoCompleteText;
 import org.wordpress.android.widgets.WPViewPager;
 
 import java.util.HashMap;
@@ -66,10 +70,14 @@ public class EditPostActivity extends ActionBarActivity {
 
     private Post mPost;
     private Post mOriginalPost;
+    private SuggestionAdapter mSuggestionAdapter;
+    private SuggestionServiceConnectionManager mSuggestionServiceConnectionManager;
+    private int remoteBlogId;
 
     private EditPostContentFragment mEditPostContentFragment;
     private EditPostSettingsFragment mEditPostSettingsFragment;
     private EditPostPreviewFragment mEditPostPreviewFragment;
+    private SuggestionAutoCompleteText mTags;
 
     private boolean mIsNewPost;
 
@@ -220,6 +228,18 @@ public class EditPostActivity extends ActionBarActivity {
         super.onCreateOptionsMenu(menu);
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.edit_post, menu);
+
+        mTags = (SuggestionAutoCompleteText) findViewById(R.id.tags);
+        mTags.setTokenizer(new SuggestionAutoCompleteText.CommaTokenizer());
+        mTags.setThreshold(1);
+
+        remoteBlogId = WordPress.getCurrentRemoteBlogId();
+        mSuggestionServiceConnectionManager = new SuggestionServiceConnectionManager(this, remoteBlogId);
+        mSuggestionAdapter = SuggestionUtils.setupSuggestions(remoteBlogId, this, mSuggestionServiceConnectionManager);
+        if (mSuggestionAdapter != null) {
+            mTags.setAdapter(mSuggestionAdapter);
+        }
+
         return true;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -26,7 +26,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
-import org.wordpress.android.ui.suggestion.adapters.SuggestionAdapter;
+import org.wordpress.android.ui.suggestion.adapters.TagSuggestionAdapter;
 import org.wordpress.android.ui.suggestion.util.SuggestionServiceConnectionManager;
 import org.wordpress.android.ui.suggestion.util.SuggestionUtils;
 import org.wordpress.android.widgets.SuggestionAutoCompleteText;
@@ -70,7 +70,7 @@ public class EditPostActivity extends ActionBarActivity {
 
     private Post mPost;
     private Post mOriginalPost;
-    private SuggestionAdapter mSuggestionAdapter;
+    private TagSuggestionAdapter mTagSuggestionAdapter;
     private SuggestionServiceConnectionManager mSuggestionServiceConnectionManager;
     private int remoteBlogId;
 
@@ -231,13 +231,12 @@ public class EditPostActivity extends ActionBarActivity {
 
         mTags = (SuggestionAutoCompleteText) findViewById(R.id.tags);
         mTags.setTokenizer(new SuggestionAutoCompleteText.CommaTokenizer());
-        mTags.setThreshold(1);
 
         remoteBlogId = WordPress.getCurrentRemoteBlogId();
         mSuggestionServiceConnectionManager = new SuggestionServiceConnectionManager(this, remoteBlogId);
-        mSuggestionAdapter = SuggestionUtils.setupSuggestions(remoteBlogId, this, mSuggestionServiceConnectionManager);
-        if (mSuggestionAdapter != null) {
-            mTags.setAdapter(mSuggestionAdapter);
+        mTagSuggestionAdapter = SuggestionUtils.setupTagSuggestions(remoteBlogId, this, mSuggestionServiceConnectionManager);
+        if (mTagSuggestionAdapter != null) {
+            mTags.setAdapter(mTagSuggestionAdapter);
         }
 
         return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -212,6 +212,10 @@ public class EditPostActivity extends ActionBarActivity {
     protected void onDestroy() {
         super.onDestroy();
         AnalyticsTracker.track(AnalyticsTracker.Stat.EDITOR_CLOSED_POST);
+
+        if (mSuggestionServiceConnectionManager != null) {
+            mSuggestionServiceConnectionManager.unbindFromService();
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/adapters/TagSuggestionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/adapters/TagSuggestionAdapter.java
@@ -1,0 +1,138 @@
+package org.wordpress.android.ui.suggestion.adapters;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.Filter;
+import android.widget.Filterable;
+import android.widget.TextView;
+
+import org.wordpress.android.R;
+import org.wordpress.android.models.Tag;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TagSuggestionAdapter extends BaseAdapter implements Filterable {
+    private final LayoutInflater mInflater;
+    private Filter mTagFilter;
+    private List<Tag> mTagList;
+    private List<Tag> mOrigTagList;
+
+    public TagSuggestionAdapter(Context context) {
+        mInflater = LayoutInflater.from(context);
+    }
+
+    public void setTagList(List<Tag> tagList) {
+        mOrigTagList = tagList;
+    }
+
+    @Override
+    public int getCount() {
+        if (mTagList == null) {
+            return 0;
+        }
+        return mTagList.size();
+    }
+
+    @Override
+    public Tag getItem(int position) {
+        if (mTagList == null) {
+            return null;
+        }
+        return mTagList.get(position);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return position;
+    }
+
+    @Override
+    public View getView(int position, View convertView, ViewGroup parent) {
+        final TagViewHolder holder;
+
+        if (convertView == null || convertView.getTag() == null) {
+            convertView = mInflater.inflate(R.layout.tag_list_row, parent, false);
+            holder = new TagViewHolder(convertView);
+            convertView.setTag(holder);
+        } else {
+            holder = (TagViewHolder) convertView.getTag();
+        }
+
+        Tag tag = getItem(position);
+
+        if (tag != null) {
+            holder.txtTag.setText(tag.getTag());
+        }
+
+        return convertView;
+    }
+
+    @Override
+    public Filter getFilter() {
+        if (mTagFilter == null) {
+            mTagFilter = new TagFilter();
+        }
+
+        return mTagFilter;
+    }
+
+    private class TagViewHolder {
+        private final TextView txtTag;
+
+        TagViewHolder(View row) {
+            txtTag = (TextView) row.findViewById(R.id.tag_list_row_tag_label);
+        }
+    }
+
+    private class TagFilter extends Filter {
+        @Override
+        protected FilterResults performFiltering(CharSequence constraint) {
+            FilterResults results = new FilterResults();
+
+            if (mOrigTagList == null) {
+                results.values = null;
+                results.count = 0;
+            }
+            else if (constraint == null || constraint.length() == 0) {
+                results.values = mOrigTagList;
+                results.count = mOrigTagList.size();
+            }
+            else {
+                List<Tag> nTagList = new ArrayList<Tag>();
+
+                for (Tag tag : mOrigTagList) {
+                    String lowerCaseConstraint = constraint.toString().toLowerCase();
+                    if (tag.getTag().toLowerCase().startsWith(lowerCaseConstraint)
+                            || tag.getTag().toLowerCase().contains(" " + lowerCaseConstraint))
+                        nTagList.add(tag);
+                }
+
+                results.values = nTagList;
+                results.count = nTagList.size();
+            }
+            return results;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        protected void publishResults(CharSequence constraint,
+                                      FilterResults results) {
+            if (results.count == 0)
+                notifyDataSetInvalidated();
+            else {
+                mTagList = (List<Tag>) results.values;
+                notifyDataSetChanged();
+            }
+        }
+
+        @Override
+        public CharSequence convertResultToString (Object resultValue) {
+            Tag tag = (Tag) resultValue;
+            return tag.getTag();
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/util/SuggestionServiceConnectionManager.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/util/SuggestionServiceConnectionManager.java
@@ -42,6 +42,7 @@ public class SuggestionServiceConnectionManager implements ServiceConnection {
         SuggestionService suggestionService = b.getService();
 
         suggestionService.updateSuggestions(mRemoteBlogId);
+        suggestionService.updateTags(mRemoteBlogId);
 
         mAttemptingToBind = false;
         mBound = true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/util/SuggestionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/util/SuggestionUtils.java
@@ -6,7 +6,9 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.SuggestionTable;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.models.Suggestion;
+import org.wordpress.android.models.Tag;
 import org.wordpress.android.ui.suggestion.adapters.SuggestionAdapter;
+import org.wordpress.android.ui.suggestion.adapters.TagSuggestionAdapter;
 
 import java.util.List;
 
@@ -33,5 +35,28 @@ public class SuggestionUtils {
         }
         suggestionAdapter.setSuggestionList(suggestions);
         return suggestionAdapter;
+    }
+
+    public static TagSuggestionAdapter setupTagSuggestions(final int remoteBlogId, Context context, SuggestionServiceConnectionManager serviceConnectionManager) {
+        Blog blog = WordPress.wpDB.getBlogForDotComBlogId(Integer.toString(remoteBlogId));
+        boolean isDotComFlag = (blog != null && blog.isDotcomFlag());
+
+        return SuggestionUtils.setupTagSuggestions(remoteBlogId, context, serviceConnectionManager, isDotComFlag);
+    }
+
+    public static TagSuggestionAdapter setupTagSuggestions(final int remoteBlogId, Context context, SuggestionServiceConnectionManager serviceConnectionManager, boolean isDotcomFlag) {
+        if (!isDotcomFlag) {
+            return null;
+        }
+
+        TagSuggestionAdapter tagSuggestionAdapter = new TagSuggestionAdapter(context);
+
+        List<Tag> tags = SuggestionTable.getTagsForSite(remoteBlogId);
+        // if the tags are not stored yet, we want to trigger an update for it
+        if (tags.isEmpty()) {
+            serviceConnectionManager.bindToService();
+        }
+        tagSuggestionAdapter.setTagList(tags);
+        return tagSuggestionAdapter;
     }
 }

--- a/WordPress/src/main/res/layout/fragment_edit_post_settings.xml
+++ b/WordPress/src/main/res/layout/fragment_edit_post_settings.xml
@@ -77,7 +77,7 @@
                 android:layout_height="wrap_content"
                 android:paddingLeft="@dimen/margin_medium" />
 
-            <EditText
+            <org.wordpress.android.widgets.SuggestionAutoCompleteText
                 android:id="@+id/tags"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/tag_list_row.xml
+++ b/WordPress/src/main/res/layout/tag_list_row.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:padding="@dimen/margin_large">
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/tag_list_row_tag_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/margin_medium"
+        android:layout_weight="1"
+        android:ellipsize="end"
+        android:gravity="center_vertical"
+        android:maxLines="1"
+        android:textColor="@color/grey_dark"
+        android:textSize="@dimen/text_sz_medium"
+        tools:text="tag_name" />
+
+</LinearLayout>


### PR DESCRIPTION
This addresses #1999. I got this first running using a simple array adapter instead of the WordPress suggestions:

    String[] test = {"Test 1","Test 2","Test 3", "A Test","B Test","C Test"};
    ArrayAdapter<String> adapter = new ArrayAdapter<>(this, android.R.layout.simple_dropdown_item_1line, test);
    mTags.setAdapter(adapter);

After adding suggestions using SuggestionUtils, I wasn't sure about how the suggestions list works. Is there just one suggestions list per blog and it is the list that should be used for tag recommendations in this case? And are tags submitted ever added to this suggestion list? When running it on my test blog it seemed like the only thing in the suggestion list was my username.
