### PR TITLE
Fix #213. Update counter after media deletion/addition

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -136,6 +136,11 @@ public class MediaBrowserActivity extends WPDrawerActivity implements MediaGridL
 
     private final FragmentManager.OnBackStackChangedListener mOnBackStackChangedListener = new FragmentManager.OnBackStackChangedListener() {
         public void onBackStackChanged() {
+            FragmentManager manager = getFragmentManager();
+            MediaGridFragment mediaGridFragment = (MediaGridFragment)manager.findFragmentById(R.id.mediaGridFragment);
+            if (mediaGridFragment.isVisible()) {
+                mediaGridFragment.refreshSpinnerAdapter();
+            }
             setupBaseLayout();
         }
     };


### PR DESCRIPTION
Simply update the counter whenever MediaGridFragment is visible after a backstack change.