### PR TITLE
Issue/2420 Update xmlrpc mocks

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/mocks/XMLRPCClientEmptyMock.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/mocks/XMLRPCClientEmptyMock.java
@@ -36,4 +36,8 @@ public class XMLRPCClientEmptyMock implements XMLRPCClientInterface {
     public long callAsync(XMLRPCCallback listener, String methodName, Object[] params, File tempFile) {
         return 0;
     }
+
+    public String getResponse() {
+        return null;
+    }
 }


### PR DESCRIPTION
I have updated the xmlrpc mocks so that they now implement ```getResponse``` in the updated ```XMLRPCClientInterface```.
The new methods mimic the behavior of ```XMLRPCClient``` ```getResponse``` as much as possible 

Fixes wordpress-mobile/WordPress-Android#2420