### PR TITLE
Proper site id retrieval for SITE notification types

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlockClickableSpan.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlockClickableSpan.java
@@ -128,8 +128,4 @@ public class NoteBlockClickableSpan extends ClickableSpan {
     public String getUrl() {
         return mUrl;
     }
-
-    public boolean shouldShowBlogPreview() {
-        return mRangeType == NoteBlockRangeType.USER || mRangeType == NoteBlockRangeType.SITE;
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -385,31 +385,40 @@ public class NotificationsUtils {
     }
 
     public static void handleNoteBlockSpanClick(NotificationsDetailActivity activity, NoteBlockClickableSpan clickedSpan) {
-        if (clickedSpan.shouldShowBlogPreview()) {
-            // Show blog preview
-            activity.showBlogPreviewActivity(clickedSpan.getSiteId());
-        } else if (clickedSpan.getRangeType() == NoteBlockRangeType.POST) {
-            // Show post detail
-            activity.showPostActivity(clickedSpan.getSiteId(), clickedSpan.getId());
-        } else if (clickedSpan.getRangeType() == NoteBlockRangeType.COMMENT) {
-            // For now, show post detail for comments
-            activity.showPostActivity(clickedSpan.getSiteId(), clickedSpan.getPostId());
-        } else if (clickedSpan.getRangeType() == NoteBlockRangeType.STAT) {
-            // We can open native stats, but only if the site is stored in the app locally.
-            int localTableSiteId = WordPress.wpDB.getLocalTableBlogIdForRemoteBlogId(
-                    (int)clickedSpan.getSiteId()
-            );
+        switch (clickedSpan.getRangeType()) {
+            case SITE:
+                // Show blog preview
+                activity.showBlogPreviewActivity(clickedSpan.getId());
+                break;
+            case USER:
+                // Show blog preview
+                activity.showBlogPreviewActivity(clickedSpan.getSiteId());
+                break;
+            case POST:
+                // Show post detail
+                activity.showPostActivity(clickedSpan.getSiteId(), clickedSpan.getId());
+                break;
+            case COMMENT:
+                // For now, show post detail for comments
+                activity.showPostActivity(clickedSpan.getSiteId(), clickedSpan.getPostId());
+                break;
+            case STAT:
+                // We can open native stats, but only if the site is stored in the app locally.
+                int localTableSiteId = WordPress.wpDB.getLocalTableBlogIdForRemoteBlogId(
+                        (int) clickedSpan.getSiteId()
+                );
 
-            if (localTableSiteId > 0) {
-                activity.showStatsActivityForSite(localTableSiteId);
-            } else if (!TextUtils.isEmpty(clickedSpan.getUrl())) {
-                activity.showWebViewActivityForUrl(clickedSpan.getUrl());
-            }
-        } else {
-            // We don't know what type of id this is, let's see if it has a URL and push a webview
-            if (!TextUtils.isEmpty(clickedSpan.getUrl())) {
-                activity.showWebViewActivityForUrl(clickedSpan.getUrl());
-            }
+                if (localTableSiteId > 0) {
+                    activity.showStatsActivityForSite(localTableSiteId);
+                } else if (!TextUtils.isEmpty(clickedSpan.getUrl())) {
+                    activity.showWebViewActivityForUrl(clickedSpan.getUrl());
+                }
+                break;
+            default:
+                // We don't know what type of id this is, let's see if it has a URL and push a webview
+                if (!TextUtils.isEmpty(clickedSpan.getUrl())) {
+                    activity.showWebViewActivityForUrl(clickedSpan.getUrl());
+                }
         }
     }
 


### PR DESCRIPTION
Use `getId()` when getting the site id for a `SITE` note block type instead of `getSiteId()`.

Also changed the `handleNoteBlockSpanClick()` method to use a switch statement so it's easier to read.

Fixes #2348 