### PR TITLE
fix #2437: clear uploading posts state if the PostUploadService is not running during PostList creation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -408,7 +408,7 @@ public class WordPressDB {
     public boolean isDotComAccountVisible(int blogId) {
         String[] args = {Integer.toString(blogId)};
         return SqlUtils.boolForQuery(db, "SELECT 1 FROM " + SETTINGS_TABLE +
-                                         " WHERE isHidden = 0 AND blogId=?", args);
+                " WHERE isHidden = 0 AND blogId=?", args);
     }
 
     public boolean isBlogInDatabase(int blogId, String xmlRpcUrl) {
@@ -892,6 +892,16 @@ public class WordPressDB {
         c.close();
 
         return posts;
+    }
+
+    public int clearAllUploadingPosts(int localTableBlogId, boolean isPage) {
+        ContentValues values = new ContentValues();
+        values.put("isUploading", 0);
+        return db.update(POSTS_TABLE, values, "blogID=? AND isPage=? AND isUploading=1",
+                new String[]{
+                        String.valueOf(localTableBlogId),
+                        String.valueOf(SqlUtils.boolToSql(isPage))
+                });
     }
 
     public long savePost(Post post) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.EmptyViewAnimationHandler;
 import org.wordpress.android.ui.EmptyViewMessageType;
 import org.wordpress.android.ui.posts.adapters.PostsListAdapter;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.ServiceUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.ptr.SwipeToRefreshHelper;
@@ -70,6 +71,11 @@ public class PostsListFragment extends ListFragment
             Bundle extras = getActivity().getIntent().getExtras();
             if (extras != null) {
                 mIsPage = extras.getBoolean(PostsActivity.EXTRA_VIEW_PAGES);
+            }
+            // If PostUploadService is not running, check for posts stuck with an uploading state
+            Blog currentBlog = WordPress.getCurrentBlog();
+            if (!ServiceUtils.isServiceRunning(getActivity(), PostUploadService.class) && currentBlog != null) {
+                WordPress.wpDB.clearAllUploadingPosts(currentBlog.getLocalTableBlogId(), mIsPage);
             }
         }
     }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ServiceUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ServiceUtils.java
@@ -1,0 +1,16 @@
+package org.wordpress.android.util;
+
+import android.app.ActivityManager;
+import android.content.Context;
+
+public class ServiceUtils {
+    public static boolean isServiceRunning(Context context, Class<?> serviceClass) {
+        ActivityManager manager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+        for (ActivityManager.RunningServiceInfo service : manager.getRunningServices(Integer.MAX_VALUE)) {
+            if (serviceClass.getName().equals(service.service.getClassName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
fix #2437: clear uploading posts state if the PostUploadService is not running during PostList creation