### PR TITLE
Fixes notification header post link color

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/Note.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Note.java
@@ -135,7 +135,7 @@ public class Note extends Syncable {
     }
 
     public Spannable getFormattedSubject() {
-        return NotificationsUtils.getSpannableContentFromIndices(getSubject(), null, null);
+        return NotificationsUtils.getSpannableContentForRanges(getSubject(), null, null);
     }
 
     public String getTitle() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
@@ -84,10 +84,10 @@ public class CommentUserNoteBlock extends UserNoteBlock {
         }
 
         noteBlockHolder.commentTextView.setText(
-                NotificationsUtils.getSpannableContentFromIndices(
-                    getNoteData().optJSONObject("comment_text"),
-                    noteBlockHolder.commentTextView,
-                    getOnNoteBlockTextClickListener())
+                NotificationsUtils.getSpannableContentForRanges(
+                        getNoteData().optJSONObject("comment_text"),
+                        noteBlockHolder.commentTextView,
+                        getOnNoteBlockTextClickListener())
         );
 
         // Change display based on comment status and type:

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/HeaderUserNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/HeaderUserNoteBlock.java
@@ -51,7 +51,7 @@ public class HeaderUserNoteBlock extends NoteBlock {
     public View configureView(View view) {
         final NoteHeaderBlockHolder noteBlockHolder = (NoteHeaderBlockHolder)view.getTag();
 
-        Spannable spannable = NotificationsUtils.getSpannableContentFromIndices(
+        Spannable spannable = NotificationsUtils.getSpannableContentForRanges(
                 mHeaderArray.optJSONObject(0),
                 null,
                 null);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
@@ -68,7 +68,7 @@ public class NoteBlock {
     }
 
     Spannable getNoteText() {
-        return NotificationsUtils.getSpannableContentFromIndices(mNoteData, null, mOnNoteBlockTextClickListener);
+        return NotificationsUtils.getSpannableContentForRanges(mNoteData, null, mOnNoteBlockTextClickListener);
     }
 
     public String getMetaHomeTitle() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlockClickableSpan.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlockClickableSpan.java
@@ -56,12 +56,12 @@ public class NoteBlockClickableSpan extends ClickableSpan {
                 mIndices[1] = indicesArray.optInt(1);
             }
 
-            // Don't link ranges that we don't know the type of, unless we have a URL
-            mShouldLink = mShouldLink && (mRangeType != NoteBlockRangeType.UNKNOWN || !TextUtils.isEmpty(mUrl));
+            // Don't link certain range types, or unknown ones, unless we have a URL
+            mShouldLink = mShouldLink && mRangeType != NoteBlockRangeType.BLOCKQUOTE &&
+                    (mRangeType != NoteBlockRangeType.UNKNOWN || !TextUtils.isEmpty(mUrl));
 
-            // Apply different coloring for blockquotes
-            if (getRangeType() == NoteBlockRangeType.BLOCKQUOTE) {
-                mShouldLink = false;
+            // Apply grey color to some types
+            if (getRangeType() == NoteBlockRangeType.BLOCKQUOTE || getRangeType() == NoteBlockRangeType.POST) {
                 mTextColor = mContext.getResources().getColor(R.color.grey);
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -221,8 +221,9 @@ public class NotificationsUtils {
         return "org.wordpress.android.playstore";
     }
 
-    public static Spannable getSpannableContentFromIndices(JSONObject subject, TextView textView,
-                                                           final NoteBlock.OnNoteBlockTextClickListener onNoteBlockTextClickListener) {
+    // Builds a Spannable with range objects found in the note JSON
+    public static Spannable getSpannableContentForRanges(JSONObject subject, TextView textView,
+                                                         final NoteBlock.OnNoteBlockTextClickListener onNoteBlockTextClickListener) {
         if (subject == null) {
             return new SpannableStringBuilder();
         }


### PR DESCRIPTION
Applies grey coloring to `POST` range types.

Before:
![screen shot 2015-03-18 at 3 49 56 pm](https://cloud.githubusercontent.com/assets/789137/6736713/b38a4a86-ce23-11e4-8d8d-3f9c83b0707d.png)

After:
![screen shot 2015-03-18 at 3 40 03 pm](https://cloud.githubusercontent.com/assets/789137/6736715/b864e1ba-ce23-11e4-9f11-21b03e9b5a13.png)

I also renamed a method.

Fixes #2378 