### PR TITLE
Issue/2461 reader detail lag

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -12,18 +12,15 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.CookieManager;
 import android.webkit.WebChromeClient;
-import android.webkit.WebResourceRequest;
 import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.UrlUtils;
 
 import java.io.IOException;
@@ -36,19 +33,19 @@ import java.io.InputStream;
 public class ReaderWebView extends WebView {
 
     public interface ReaderWebViewUrlClickListener {
-        public boolean onUrlClick(String url);
-        public boolean onImageUrlClick(String imageUrl, View view, int x, int y);
+        boolean onUrlClick(String url);
+        boolean onImageUrlClick(String imageUrl, View view, int x, int y);
     }
 
     public interface ReaderCustomViewListener {
-        public void onCustomViewShown();
-        public void onCustomViewHidden();
-        public ViewGroup onRequestCustomView();
-        public ViewGroup onRequestContentView();
+        void onCustomViewShown();
+        void onCustomViewHidden();
+        ViewGroup onRequestCustomView();
+        ViewGroup onRequestContentView();
     }
 
     public interface ReaderWebViewPageFinishedListener {
-        public void onPageFinished(WebView view, String url);
+        void onPageFinished(WebView view, String url);
     }
 
     private ReaderWebChromeClient mReaderChromeClient;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -17,11 +17,24 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
 import org.apache.http.HttpResponse;
+import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.params.ConnManagerParams;
+import org.apache.http.conn.params.ConnPerRouteBean;
+import org.apache.http.conn.scheme.PlainSocketFactory;
+import org.apache.http.conn.scheme.Scheme;
+import org.apache.http.conn.scheme.SchemeRegistry;
+import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.HttpConnectionParams;
+import org.apache.http.params.HttpParams;
+import org.apache.http.params.HttpProtocolParams;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.UrlUtils;
+import org.wordpress.android.util.WPRestClient;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -214,7 +227,20 @@ public class ReaderWebView extends WebView {
         private static DefaultHttpClient mHttpClient;
         private static synchronized DefaultHttpClient getHttpClient() {
             if (mHttpClient ==  null) {
-                mHttpClient = new DefaultHttpClient();
+                SchemeRegistry schemeRegistry = new SchemeRegistry();
+                schemeRegistry.register(new Scheme("http", PlainSocketFactory.getSocketFactory(), 80));
+                schemeRegistry.register(new Scheme("https", SSLSocketFactory.getSocketFactory(), 443));
+
+                HttpParams params = new BasicHttpParams();
+                HttpConnectionParams.setTcpNoDelay(params, true);
+                HttpConnectionParams.setConnectionTimeout(params, WPRestClient.REST_TIMEOUT_MS);
+                HttpProtocolParams.setUserAgent(params, WordPress.getUserAgent());
+                HttpProtocolParams.setVersion(params, HttpVersion.HTTP_1_1);
+                ConnManagerParams.setMaxConnectionsPerRoute(params, new ConnPerRouteBean(100));
+                ConnManagerParams.setMaxTotalConnections(params, 100);
+
+                ThreadSafeClientConnManager manager = new ThreadSafeClientConnManager(params, schemeRegistry);
+                mHttpClient = new DefaultHttpClient(manager, params);
             }
             return mHttpClient;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -211,15 +211,22 @@ public class ReaderWebView extends WebView {
             }
         }
 
+        private static DefaultHttpClient mHttpClient;
+        private static synchronized DefaultHttpClient getHttpClient() {
+            if (mHttpClient ==  null) {
+                mHttpClient = new DefaultHttpClient();
+            }
+            return mHttpClient;
+        }
+
         @Override
         public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
             // Intercept requests for private images and add the WP.com authorization header
             if (mIsPrivatePost && !TextUtils.isEmpty(mToken) && UrlUtils.isImageUrl(url)) {
-                DefaultHttpClient client = new DefaultHttpClient();
                 HttpGet httpGet = new HttpGet(url);
                 httpGet.setHeader("Authorization", "Bearer " + mToken);
                 try {
-                    HttpResponse httpResponse = client.execute(httpGet);
+                    HttpResponse httpResponse = getHttpClient().execute(httpGet);
                     InputStream responseInputStream = httpResponse.getEntity().getContent();
                     return new WebResourceResponse(httpResponse.getEntity().getContentType().toString(), "UTF-8", responseInputStream);
                 } catch (IOException e) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -21,7 +21,9 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPRestClient;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -219,11 +221,13 @@ public class ReaderWebView extends WebView {
                     HttpURLConnection conn = (HttpURLConnection) imageUrl.openConnection();
                     conn.setReadTimeout(WPRestClient.REST_TIMEOUT_MS);
                     conn.setConnectTimeout(WPRestClient.REST_TIMEOUT_MS);
-                    conn.setRequestMethod("GET");
                     conn.setRequestProperty("Authorization", "Bearer " + mToken);
                     conn.setRequestProperty("User-Agent", WordPress.getUserAgent());
                     conn.connect();
-                    return new WebResourceResponse(conn.getContentType(), "UTF-8", conn.getInputStream());
+                    if (conn.getResponseCode() == HttpURLConnection.HTTP_OK) {
+                        InputStream inputStream = new BufferedInputStream(conn.getInputStream());
+                        return new WebResourceResponse(conn.getContentType(), "UTF-8", inputStream);
+                    }
                 } catch (IOException e) {
                     AppLog.e(AppLog.T.READER, e);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -223,6 +223,7 @@ public class ReaderWebView extends WebView {
                     conn.setConnectTimeout(WPRestClient.REST_TIMEOUT_MS);
                     conn.setRequestProperty("Authorization", "Bearer " + mToken);
                     conn.setRequestProperty("User-Agent", WordPress.getUserAgent());
+                    conn.setRequestProperty("Connection", "Keep-Alive");
                     conn.connect();
                     if (conn.getResponseCode() == HttpURLConnection.HTTP_OK) {
                         InputStream inputStream = new BufferedInputStream(conn.getInputStream());
@@ -233,7 +234,7 @@ public class ReaderWebView extends WebView {
                 }
             }
 
-            return super.shouldInterceptRequest(view, url);
+            return null;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -16,19 +16,6 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
-import org.apache.http.HttpVersion;
-import org.apache.http.conn.params.ConnManagerParams;
-import org.apache.http.conn.params.ConnPerRouteBean;
-import org.apache.http.conn.scheme.PlainSocketFactory;
-import org.apache.http.conn.scheme.Scheme;
-import org.apache.http.conn.scheme.SchemeRegistry;
-import org.apache.http.conn.ssl.SSLSocketFactory;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.impl.conn.tsccm.ThreadSafeClientConnManager;
-import org.apache.http.params.BasicHttpParams;
-import org.apache.http.params.HttpConnectionParams;
-import org.apache.http.params.HttpParams;
-import org.apache.http.params.HttpProtocolParams;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.UrlUtils;
@@ -221,29 +208,6 @@ public class ReaderWebView extends WebView {
             } else {
                 return false;
             }
-        }
-
-        private static DefaultHttpClient mHttpClient;
-        private static synchronized DefaultHttpClient getHttpClient() {
-            if (mHttpClient ==  null) {
-                SchemeRegistry schemeRegistry = new SchemeRegistry();
-                schemeRegistry.register(new Scheme("http", PlainSocketFactory.getSocketFactory(), 80));
-                schemeRegistry.register(new Scheme("https", SSLSocketFactory.getSocketFactory(), 443));
-
-                HttpParams params = new BasicHttpParams();
-                HttpConnectionParams.setTcpNoDelay(params, true);
-                HttpConnectionParams.setConnectionTimeout(params, WPRestClient.REST_TIMEOUT_MS);
-
-                HttpProtocolParams.setUserAgent(params, WordPress.getUserAgent());
-                HttpProtocolParams.setVersion(params, HttpVersion.HTTP_1_1);
-
-                ConnManagerParams.setMaxConnectionsPerRoute(params, new ConnPerRouteBean(100));
-                ConnManagerParams.setMaxTotalConnections(params, 100);
-
-                ThreadSafeClientConnManager manager = new ThreadSafeClientConnManager(params, schemeRegistry);
-                mHttpClient = new DefaultHttpClient(manager, params);
-            }
-            return mHttpClient;
         }
 
         @Override


### PR DESCRIPTION
Alleviates #2461 - testing shows that the lag caused by loading private images [here](https://github.com/wordpress-mobile/WordPress-Android/blob/17c21cd85975cd4872c9d7f53af1e7183cb428de/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java#L221-L229) can't be completely resolved - it appears that the webView won't render content until `shouldInterceptRequest` completes.

I was, however, able to improve the performance of these image requests by switching from `HttpClient` to `HttpUrlConnection` as recommended [here](http://android-developers.blogspot.com/2011/09/androids-http-clients.html) and adding a response cache for `HttpUrlConnection`. 

Note: I attempted to re-use the DefaultHttpClient and employ a ThreadSafeClientConnManager as suggested in [the issue](https://github.com/wordpress-mobile/WordPress-Android/issues/2461) but these changes didn't appear to make any difference.