### PR TITLE
Fix #2462: replace the old crashlytics dependency with the updated Twitter-Fabric crashlytics dependency

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -1,24 +1,24 @@
 buildscript {
     repositories {
         mavenCentral()
-        maven { url 'http://download.crashlytics.com/maven' }
+        maven { url 'https://maven.fabric.io/repo' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.0.0'
         classpath 'com.github.nrudenko:gradle-android-cq-plugin:0.1+'
-        classpath 'com.crashlytics.tools.gradle:crashlytics-gradle:+'
+        classpath 'io.fabric.tools:gradle:1.+'
     }
 }
 
 repositories {
     mavenCentral()
     maven { url 'http://wordpress-mobile.github.io/WordPress-Android' }
-    maven { url 'http://download.crashlytics.com/maven' }
+    maven { url 'https://maven.fabric.io/repo' }
 }
 
 apply plugin: 'com.android.application'
 apply plugin: 'android-cq'
-apply plugin: 'crashlytics'
+apply plugin: 'io.fabric'
 
 android {
     packagingOptions {
@@ -58,12 +58,13 @@ android {
 
         debug {
             buildConfigField "String", "APP_PN_KEY", "\"org.wordpress.android.debug.build\""
+            ext.enableCrashlytics = false
         }
     }
 }
 
 dependencies {
-    compile 'com.crashlytics.android:crashlytics:+'
+    compile 'com.crashlytics.sdk.android:crashlytics:2.2.2'
 
     // Provided by maven central
     compile 'org.wordpress:mediapicker:1.1.4'

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -72,6 +72,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import de.greenrobot.event.EventBus;
+import io.fabric.sdk.android.Fabric;
 
 public class WordPress extends Application {
     public static final String ACCESS_TOKEN_PREFERENCE="wp_pref_wpcom_access_token";
@@ -143,8 +144,9 @@ public class WordPress extends Application {
         // Enable log recording
         AppLog.enableRecording(true);
         if (!PackageUtils.isDebugBuild()) {
-            Crashlytics.start(this);
+            Fabric.with(this, new Crashlytics());
         }
+
         versionName = PackageUtils.getVersionName(this);
         HelpshiftHelper.init(this);
         initWpDb();


### PR DESCRIPTION
Fix #2462: replace the old crashlytics dependency with the updated Twitter-Fabric crashlytics dependency