### PR TITLE
Issue/2425 npe getmd5inthash

### DIFF
--- a/libs/utils/WordPressUtils/src/androidTest/java/org/wordpress/android/util/UrlUtilsTest.java
+++ b/libs/utils/WordPressUtils/src/androidTest/java/org/wordpress/android/util/UrlUtilsTest.java
@@ -1,0 +1,20 @@
+package org.wordpress.android.util;
+
+import android.test.InstrumentationTestCase;
+
+public class UrlUtilsTest extends InstrumentationTestCase {
+    public void testGetDomainFromUrlWithEmptyStringDoesNotReturnNull() {
+        assertNotNull(UrlUtils.getDomainFromUrl(""));
+    }
+
+    public void testGetDomainFromUrlWithNoHostDoesNotReturnNull() {
+        assertNotNull(UrlUtils.getDomainFromUrl("wordpress"));
+    }
+
+    public void testGetDomainFromUrlWithHostReturnsHost() {
+        String url = "http://www.wordpress.com";
+        String host = UrlUtils.getDomainFromUrl(url);
+
+        assertTrue(host.equals("www.wordpress.com"));
+    }
+}

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
@@ -33,11 +33,14 @@ public class UrlUtils {
     }
 
     public static String getDomainFromUrl(final String urlString) {
-        if (urlString == null) {
-            return "";
+        if (urlString != null) {
+            Uri uri = Uri.parse(urlString);
+            if (uri.getHost() != null) {
+                return uri.getHost();
+            }
         }
-        Uri uri = Uri.parse(urlString);
-        return uri.getHost();
+
+        return "";
     }
 
     /**

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
@@ -32,6 +32,11 @@ public class UrlUtils {
         }
     }
 
+    /**
+     *
+     * @param urlString url to get domain from
+     * @return domain of uri if available. Empty string otherwise.
+     */
     public static String getDomainFromUrl(final String urlString) {
         if (urlString != null) {
             Uri uri = Uri.parse(urlString);


### PR DESCRIPTION
Resolves issue #2452

The problem was that if `urlString` wasn't a RFC 2396-compliant URI, `uri.getHost()` would return null.

I've added tests, but I have to admit that I don't know if it was in the right place. They all run, but I don't know if they'll run in Travis. Help with where to put them would be appreciated.