### PR TITLE
Stats - Don't pass ordinal of StatsViewType

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -170,7 +170,7 @@ public class NotificationsDetailActivity extends ActionBarActivity implements
         Intent intent;
         if (rangeType == NoteBlockRangeType.FOLLOW) {
             intent = new Intent(this, StatsViewAllActivity.class);
-            intent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, StatsViewType.FOLLOWERS.ordinal());
+            intent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, StatsViewType.FOLLOWERS);
             intent.putExtra(StatsAbstractFragment.ARGS_TIMEFRAME, StatsTimeframe.DAY);
         } else {
             intent = new Intent(this, StatsActivity.class);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
@@ -77,7 +77,7 @@ public abstract class StatsAbstractFragment extends Fragment {
         }
 
         Bundle args = new Bundle();
-        args.putInt(ARGS_VIEW_TYPE, viewType.ordinal());
+        args.putSerializable(ARGS_VIEW_TYPE, viewType);
         args.putInt(StatsActivity.ARG_LOCAL_TABLE_BLOG_ID, localTableBlogID);
         fragment.setArguments(args);
 
@@ -101,8 +101,7 @@ public abstract class StatsAbstractFragment extends Fragment {
     }
 
     protected StatsViewType getViewType() {
-        int ordinal = getArguments().getInt(ARGS_VIEW_TYPE);
-        return StatsViewType.values()[ordinal];
+        return (StatsViewType) getArguments().getSerializable(ARGS_VIEW_TYPE);
     }
 
     protected int getLocalTableBlogID() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractListFragment.java
@@ -329,7 +329,7 @@ public abstract class StatsAbstractListFragment extends StatsAbstractFragment {
                 Intent viewAllIntent = new Intent(getActivity(), StatsViewAllActivity.class);
                 viewAllIntent.putExtra(StatsActivity.ARG_LOCAL_TABLE_BLOG_ID, getLocalTableBlogID());
                 viewAllIntent.putExtra(StatsAbstractFragment.ARGS_TIMEFRAME, getTimeframe());
-                viewAllIntent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, getViewType().ordinal());
+                viewAllIntent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, getViewType());
                 viewAllIntent.putExtra(StatsAbstractFragment.ARGS_START_DATE, getStartDate());
                 viewAllIntent.putExtra(ARGS_IS_SINGLE_VIEW, true);
                 if (mTopPagerContainer.getVisibility() == View.VISIBLE) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
@@ -113,7 +113,7 @@ public class StatsViewAllActivity extends ActionBarActivity
             mTimeframe = (StatsTimeframe) extras.getSerializable(StatsAbstractFragment.ARGS_TIMEFRAME);
             mDate = extras.getString(StatsAbstractFragment.ARGS_START_DATE);
             mStatsViewType = (StatsViewType) extras.getSerializable(StatsAbstractFragment.ARGS_VIEW_TYPE);
-            if (mStatsViewType == null) {
+            if (mStatsViewType == null || mTimeframe == null || mDate == null) {
                 Toast.makeText(this, getResources().getText(R.string.stats_generic_error),
                         Toast.LENGTH_SHORT).show();
                 finish();

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
@@ -113,12 +113,13 @@ public class StatsViewAllActivity extends ActionBarActivity
             mTimeframe = (StatsTimeframe) extras.getSerializable(StatsAbstractFragment.ARGS_TIMEFRAME);
             mDate = extras.getString(StatsAbstractFragment.ARGS_START_DATE);
             mStatsViewType = (StatsViewType) extras.getSerializable(StatsAbstractFragment.ARGS_VIEW_TYPE);
-            if (mStatsViewType == null || mTimeframe == null || mDate == null) {
-                Toast.makeText(this, getResources().getText(R.string.stats_generic_error),
-                        Toast.LENGTH_SHORT).show();
-                finish();
-            }
             mOuterPagerSelectedButtonIndex = extras.getInt(StatsAbstractListFragment.ARGS_TOP_PAGER_SELECTED_BUTTON_INDEX, 0);
+        }
+
+        if (mStatsViewType == null || mTimeframe == null || mDate == null) {
+            Toast.makeText(this, getResources().getText(R.string.stats_generic_error),
+                    Toast.LENGTH_SHORT).show();
+            finish();
         }
 
         // Setup the top date label. It's available on those fragments that are affected by the top date selector.

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
@@ -104,16 +104,14 @@ public class StatsViewAllActivity extends ActionBarActivity
             }
             mTimeframe = (StatsTimeframe) savedInstanceState.getSerializable(StatsAbstractFragment.ARGS_TIMEFRAME);
             mDate = savedInstanceState.getString(StatsAbstractFragment.ARGS_START_DATE);
-            int ordinal = savedInstanceState.getInt(StatsAbstractFragment.ARGS_VIEW_TYPE, 0);
-            mStatsViewType = StatsViewType.values()[ordinal];
+            mStatsViewType = (StatsViewType) savedInstanceState.getSerializable(StatsAbstractFragment.ARGS_VIEW_TYPE);
             mOuterPagerSelectedButtonIndex = savedInstanceState.getInt(StatsAbstractListFragment.ARGS_TOP_PAGER_SELECTED_BUTTON_INDEX, 0);
         } else if (getIntent() != null) {
             Bundle extras = getIntent().getExtras();
             mLocalBlogID = extras.getInt(StatsActivity.ARG_LOCAL_TABLE_BLOG_ID, -1);
             mTimeframe = (StatsTimeframe) extras.getSerializable(StatsAbstractFragment.ARGS_TIMEFRAME);
             mDate = extras.getString(StatsAbstractFragment.ARGS_START_DATE);
-            int ordinal = extras.getInt(StatsAbstractFragment.ARGS_VIEW_TYPE, 0);
-            mStatsViewType = StatsViewType.values()[ordinal];
+            mStatsViewType = (StatsViewType) extras.getSerializable(StatsAbstractFragment.ARGS_VIEW_TYPE);
             mOuterPagerSelectedButtonIndex = extras.getInt(StatsAbstractListFragment.ARGS_TOP_PAGER_SELECTED_BUTTON_INDEX, 0);
         }
 
@@ -151,7 +149,8 @@ public class StatsViewAllActivity extends ActionBarActivity
         String prefix = getString(R.string.stats_for);
         switch (timeframe) {
             case DAY:
-                return String.format(prefix, StatsUtils.parseDate(date, StatsConstants.STATS_INPUT_DATE_FORMAT, "MMMM d"));
+                return String.format(prefix, StatsUtils.parseDate(date, StatsConstants.STATS_INPUT_DATE_FORMAT,
+                        StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_DAY_SHORT_FORMAT));
             case WEEK:
                 try {
                     SimpleDateFormat sdf = new SimpleDateFormat(StatsConstants.STATS_INPUT_DATE_FORMAT);
@@ -215,7 +214,7 @@ public class StatsViewAllActivity extends ActionBarActivity
 
         Bundle args = new Bundle();
         args.putInt(StatsActivity.ARG_LOCAL_TABLE_BLOG_ID, mLocalBlogID);
-        args.putInt(StatsAbstractFragment.ARGS_VIEW_TYPE, mStatsViewType.ordinal());
+        args.putSerializable(StatsAbstractFragment.ARGS_VIEW_TYPE, mStatsViewType);
         args.putSerializable(StatsAbstractFragment.ARGS_TIMEFRAME, mTimeframe);
         args.putBoolean(StatsAbstractListFragment.ARGS_IS_SINGLE_VIEW, true); // Always true here
         args.putString(StatsAbstractFragment.ARGS_START_DATE, mDate);
@@ -231,7 +230,7 @@ public class StatsViewAllActivity extends ActionBarActivity
         outState.putSerializable(StatsAbstractFragment.ARG_REST_RESPONSE, mRestResponse);
         outState.putSerializable(StatsAbstractFragment.ARGS_TIMEFRAME, mTimeframe);
         outState.putString(StatsAbstractFragment.ARGS_START_DATE, mDate);
-        outState.putInt(StatsAbstractFragment.ARGS_VIEW_TYPE, mStatsViewType.ordinal());
+        outState.putSerializable(StatsAbstractFragment.ARGS_VIEW_TYPE, mStatsViewType);
         outState.putInt(StatsAbstractListFragment.ARGS_TOP_PAGER_SELECTED_BUTTON_INDEX, mOuterPagerSelectedButtonIndex);
         super.onSaveInstanceState(outState);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
@@ -10,6 +10,7 @@ import android.support.v7.app.ActionBarActivity;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
@@ -112,6 +113,11 @@ public class StatsViewAllActivity extends ActionBarActivity
             mTimeframe = (StatsTimeframe) extras.getSerializable(StatsAbstractFragment.ARGS_TIMEFRAME);
             mDate = extras.getString(StatsAbstractFragment.ARGS_START_DATE);
             mStatsViewType = (StatsViewType) extras.getSerializable(StatsAbstractFragment.ARGS_VIEW_TYPE);
+            if (mStatsViewType == null) {
+                Toast.makeText(this, getResources().getText(R.string.stats_generic_error),
+                        Toast.LENGTH_SHORT).show();
+                finish();
+            }
             mOuterPagerSelectedButtonIndex = extras.getInt(StatsAbstractListFragment.ARGS_TOP_PAGER_SELECTED_BUTTON_INDEX, 0);
         }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -400,13 +400,16 @@
     <string name="stats">Stats</string>
     <string name="stats_for">Stats for %s</string>
     <string name="stats_other_recent_stats_label">Other Recent Stats</string>
-    <string name="stats_no_blog">Stats couldn\'t be loaded for the required blog</string>
     <string name="view_stats_full_site">View full site</string>
     <string name="stats_view_all">View all</string>
     <string name="stats_view">View</string>
     <string name="stats_follow">Follow</string>
     <string name="stats_unfollow">Unfollow</string>
     <string name="stats_pagination_label">Page %1$s of %2$s</string>
+
+    <!-- stats: errors -->
+    <string name="stats_no_blog">Stats couldn\'t be loaded for the required blog</string>
+    <string name="stats_generic_error">Required Stats couldn\'t be loaded</string>
 
     <!-- stats: labels for timeframes -->
     <string name="stats_timeframe_today">Today</string>


### PR DESCRIPTION
Fix  #2469 - StatsViewType is an Enum, and enums are serializable. Don't need to pass ordinals.

//cc @roundhill 