### PR TITLE
issue/2489 error placeholder image

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
@@ -354,8 +354,8 @@ public class WPNetworkImageView extends ImageView {
                 setImageResource(R.drawable.gravatar_placeholder);
                 break;
             default :
-                // medium grey box for all others
-                setImageDrawable(new ColorDrawable(getColorRes(R.color.grey_darken_10)));
+                // grey box for all others
+                setImageDrawable(new ColorDrawable(getColorRes(R.color.grey_lighten_30)));
                 break;
         }
     }


### PR DESCRIPTION
Fix #2489 by lightening the error placeholder drawable. Before/after screens below.

![placeholder](https://cloud.githubusercontent.com/assets/3903757/6952991/483296e6-d894-11e4-866e-f99687bffa47.png)
