### PR TITLE
Stats - improve the Referrers parsing code, and UI

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsReferrersFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsReferrersFragment.java
@@ -114,7 +114,7 @@ public class StatsReferrersFragment extends StatsAbstractListFragment {
         public View getChildView(int groupPosition, final int childPosition,
                                  boolean isLastChild, View convertView, ViewGroup parent) {
 
-            final ReferrerResultModel children = (ReferrerResultModel) getChild(groupPosition, childPosition);
+            final ReferrerResultModel currentReferrerResult = (ReferrerResultModel) getChild(groupPosition, childPosition);
 
             if (convertView == null) {
                 convertView = inflater.inflate(R.layout.stats_list_cell, parent, false);
@@ -125,26 +125,26 @@ public class StatsReferrersFragment extends StatsAbstractListFragment {
 
             final StatsViewHolder holder = (StatsViewHolder) convertView.getTag();
 
-            String name = children.getName();
-            int total = children.getViews();
+            String name = currentReferrerResult.getName();
+            int views = currentReferrerResult.getViews();
 
             // The link icon
             holder.showLinkIcon();
 
             // name, url
-            List<SingleItemModel> thirdLevelChildren = children.getChildren();
+            List<SingleItemModel> thirdLevelChildren = currentReferrerResult.getChildren();
             if (thirdLevelChildren != null && thirdLevelChildren.size() > 0 ) {
                 holder.setEntryTextOrLink(thirdLevelChildren.get(0).getUrl(), name);
             } else {
-                holder.setEntryTextOrLink(children.getUrl(), name);
+                holder.setEntryTextOrLink(currentReferrerResult.getUrl(), name);
             }
 
             // totals
-            holder.totalsTextView.setText(FormatUtils.formatDecimal(total));
+            holder.totalsTextView.setText(FormatUtils.formatDecimal(views));
 
-            if (!TextUtils.isEmpty(children.getIcon())) {
+            if (!TextUtils.isEmpty(currentReferrerResult.getIcon())) {
                 holder.networkImageView.setImageUrl(
-                        GravatarUtils.fixGravatarUrl(children.getIcon(), mResourceVars.headerAvatarSizePx),
+                        GravatarUtils.fixGravatarUrl(currentReferrerResult.getIcon(), mResourceVars.headerAvatarSizePx),
                         WPNetworkImageView.ImageType.BLAVATAR);
                 holder.networkImageView.setVisibility(View.VISIBLE);
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsReferrersFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsReferrersFragment.java
@@ -93,7 +93,7 @@ public class StatsReferrersFragment extends StatsAbstractListFragment {
     private class MyExpandableListAdapter extends BaseExpandableListAdapter {
         public final LayoutInflater inflater;
         private final List<ReferrerGroupModel> groups;
-        private final List<List<MyChildModel>> childs;
+        private final List<List<MyChildModel>> children;
 
         public MyExpandableListAdapter(Context context, List<ReferrerGroupModel> groups) {
             this.groups = groups;
@@ -101,10 +101,10 @@ public class StatsReferrersFragment extends StatsAbstractListFragment {
 
             // The code below flattens the 3-levels tree of children to a 2-levels structure
             // that will be used later to populate the UI
-            this.childs = new ArrayList<>(groups.size());
+            this.children = new ArrayList<>(groups.size());
             // pre-populate the structure with null values
             for (int i = 0; i < groups.size(); i++) {
-                this.childs.add(null);
+                this.children.add(null);
             }
             for (int i = 0; i < groups.size(); i++) {
                 ReferrerGroupModel currentGroup = groups.get(i);
@@ -112,7 +112,7 @@ public class StatsReferrersFragment extends StatsAbstractListFragment {
                 if (referrals != null) {
                     // Children available for the current group
                     // Children could be a 2-levels or a 3-levels structure
-                    List<MyChildModel> currentGroupChilds = new ArrayList<>();
+                    List<MyChildModel> currentGroupChildren = new ArrayList<>();
                     for (ReferrerResultModel refResult : referrals) {
                         List<SingleItemModel> thirdLevelChildren = refResult.getChildren();
                         if (thirdLevelChildren != null && thirdLevelChildren.size() > 0 ) {
@@ -126,7 +126,7 @@ public class StatsReferrersFragment extends StatsAbstractListFragment {
                                 myChild.url = currentThirdLevelChild.getUrl();
                                 myChild.name = currentThirdLevelChild.getTitle();
                                 myChild.views = currentThirdLevelChild.getTotals();
-                                currentGroupChilds.add(myChild);
+                                currentGroupChildren.add(myChild);
                             }
                         } else {
                             MyChildModel myChild = new MyChildModel();
@@ -134,10 +134,10 @@ public class StatsReferrersFragment extends StatsAbstractListFragment {
                             myChild.url = refResult.getUrl();
                             myChild.name = refResult.getName();
                             myChild.views = refResult.getViews();
-                            currentGroupChilds.add(myChild);
+                            currentGroupChildren.add(myChild);
                         }
                     }
-                    this.childs.set(i, currentGroupChilds);
+                    this.children.set(i, currentGroupChildren);
                 }
             }
         }
@@ -151,8 +151,8 @@ public class StatsReferrersFragment extends StatsAbstractListFragment {
 
         @Override
         public Object getChild(int groupPosition, int childPosition) {
-            List<MyChildModel> currentGroupChilds = childs.get(groupPosition);
-            return currentGroupChilds.get(childPosition);
+            List<MyChildModel> currentGroupChildren = children.get(groupPosition);
+            return currentGroupChildren.get(childPosition);
         }
 
         @Override
@@ -204,11 +204,11 @@ public class StatsReferrersFragment extends StatsAbstractListFragment {
 
         @Override
         public int getChildrenCount(int groupPosition) {
-            List<MyChildModel> currentGroupChilds = childs.get(groupPosition);
-            if (currentGroupChilds == null) {
+            List<MyChildModel> currentGroupChildren = children.get(groupPosition);
+            if (currentGroupChildren == null) {
                 return 0;
             } else {
-                return currentGroupChilds.size();
+                return currentGroupChildren.size();
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/models/ReferrerGroupModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/models/ReferrerGroupModel.java
@@ -35,14 +35,18 @@ public class ReferrerGroupModel implements Serializable {
         setName(groupJSON.getString("name"));
         setTotal(groupJSON.getInt("total"));
         setIcon(JSONUtils.getString(groupJSON, "icon"));
-        // if URL is set in the response there is one result only. No need to unfold "results"
+
+        // if URL is set in the response there is one result only.
         if (!TextUtils.isEmpty(JSONUtils.getString(groupJSON, "url"))) {
             setUrl(JSONUtils.getString(groupJSON, "url"));
-        } else {
+        }
+
+        // results is an array when there are results, otherwise it's an object.
+        JSONArray resultsArray = groupJSON.optJSONArray("results");
+        if (resultsArray != null) {
             mResults = new ArrayList<>();
-            JSONArray resultsJSON = groupJSON.getJSONArray("results");
-            for (int i = 0; i < resultsJSON.length(); i++) {
-                JSONObject currentResultJSON = resultsJSON.getJSONObject(i);
+            for (int i = 0; i < resultsArray.length(); i++) {
+                JSONObject currentResultJSON = resultsArray.getJSONObject(i);
                 ReferrerResultModel currentResultModel = new ReferrerResultModel(blogId,
                         date, currentResultJSON);
                 mResults.add(currentResultModel);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/models/ReferrerResultModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/models/ReferrerResultModel.java
@@ -59,7 +59,7 @@ public class ReferrerResultModel implements Serializable {
     private SingleItemModel getChildren(String blogId, String date, JSONObject child) throws JSONException {
         String name = child.getString("name");
         int totals = child.getInt("views");
-        String icon = child.optString("icon");
+        String icon = JSONUtils.getString(child, "icon");
         String url = child.optString("url");
         return new SingleItemModel(blogId, date, null, name, totals, url, icon);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/models/ReferrerResultModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/models/ReferrerResultModel.java
@@ -46,7 +46,7 @@ public class ReferrerResultModel implements Serializable {
                 mChildren.add(getChildren(blogId, date, currentChild));
             }
 
-            //Sort the childs by views.
+            //Sort the children by views.
             Collections.sort(mChildren, new java.util.Comparator<SingleItemModel>() {
                 public int compare(SingleItemModel o1, SingleItemModel o2) {
                     // descending order

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/models/ReferrerResultModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/models/ReferrerResultModel.java
@@ -14,7 +14,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * A model to represent a referrer group stat
+ * A model to represent a referrer result in stat
  */
 public class ReferrerResultModel implements Serializable {
     private String mBlogId;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/models/ReferrerResultModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/models/ReferrerResultModel.java
@@ -1,0 +1,116 @@
+package org.wordpress.android.ui.stats.models;
+
+import android.text.TextUtils;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.wordpress.android.ui.stats.StatsUtils;
+import org.wordpress.android.util.JSONUtils;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A model to represent a referrer group stat
+ */
+public class ReferrerResultModel implements Serializable {
+    private String mBlogId;
+    private long mDate;
+
+    private String mName;
+    private String mIcon;
+    private int mViews;
+    private String mUrl;
+    private List<SingleItemModel> mChildren;
+
+    public ReferrerResultModel(String blogId, String date, JSONObject resultJSON) throws JSONException {
+        setBlogId(blogId);
+        setDate(StatsUtils.toMs(date));
+
+        setName(resultJSON.getString("name"));
+        setViews(resultJSON.getInt("views"));
+        setIcon(JSONUtils.getString(resultJSON, "icon"));
+
+        if (!TextUtils.isEmpty(JSONUtils.getString(resultJSON, "url"))) {
+            setUrl(JSONUtils.getString(resultJSON, "url"));
+        }
+
+        if (resultJSON.has("children")) {
+            JSONArray childrenJSON = resultJSON.getJSONArray("children");
+            mChildren = new ArrayList<>();
+            for (int i = 0; i < childrenJSON.length(); i++) {
+                JSONObject currentChild = childrenJSON.getJSONObject(i);
+                mChildren.add(getChildren(blogId, date, currentChild));
+            }
+
+            //Sort the childs by views.
+            Collections.sort(mChildren, new java.util.Comparator<SingleItemModel>() {
+                public int compare(SingleItemModel o1, SingleItemModel o2) {
+                    // descending order
+                    return o2.getTotals() - o1.getTotals();
+                }
+            });
+        }
+    }
+
+    private SingleItemModel getChildren(String blogId, String date, JSONObject child) throws JSONException {
+        String name = child.getString("name");
+        int totals = child.getInt("views");
+        String icon = child.optString("icon");
+        String url = child.optString("url");
+        return new SingleItemModel(blogId, date, null, name, totals, url, icon);
+    }
+
+    public String getBlogId() {
+        return mBlogId;
+    }
+
+    public void setBlogId(String blogId) {
+        this.mBlogId = blogId;
+    }
+
+    public long getDate() {
+        return mDate;
+    }
+
+    public void setDate(long date) {
+        this.mDate = date;
+    }
+
+    public String getName() {
+        return mName;
+    }
+
+    public void setName(String name) {
+        this.mName = name;
+    }
+
+    public int getViews() {
+        return mViews;
+    }
+
+    public void setViews(int total) {
+        this.mViews = total;
+    }
+
+    public String getIcon() {
+        return mIcon;
+    }
+
+    public void setIcon(String icon) {
+        this.mIcon = icon;
+    }
+
+    public String getUrl() {
+        return mUrl;
+    }
+
+    public void setUrl(String url) {
+        this.mUrl = url;
+    }
+
+    public List<SingleItemModel> getChildren() { return mChildren; }
+}


### PR DESCRIPTION
This PR introduced a couple of changes in the Referrers module:
- The parsing code now uses a 3-levels model that maps the JSON response better. In the previous version we "flattenized" the 3-levels structure to a 2-levels structure at parsing time.
- The UI (the list adapter) now transforms the 3-levels model to a 2-levels, and displays it. It also adds icons on children where available.

These changes are required for a future improvement (not yet scheduled) where a 3-levels UI will be introduced on lists.