### PR TITLE
Fix #2512 - Updating to MediaPicker v1.2.0 and updating MediaSources.

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -66,7 +66,9 @@ dependencies {
     compile 'com.crashlytics.android:crashlytics:+'
 
     // Provided by maven central
-    compile 'org.wordpress:mediapicker:1.1.4'
+    compile ('org.wordpress:mediapicker:1.2.0') {
+        exclude group:'com.android.support'
+    }
     compile 'com.google.code.gson:gson:2.2.2'
     compile 'org.ccil.cowan.tagsoup:tagsoup:1.2.1'
     compile 'com.android.support:support-v13:21.0.+'

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPickerActivity.java
@@ -244,8 +244,12 @@ public class MediaPickerActivity extends ActionBarActivity
     }
 
     @Override
-    public void onGalleryCreated(ArrayList<MediaItem> mediaContent) {
-        finishWithResults(mediaContent, ACTIVITY_RESULT_CODE_GALLERY_CREATED);
+     public boolean onMenuItemSelected(MenuItem menuItem, ArrayList<MediaItem> selectedContent) {
+        if (menuItem.getItemId() == R.id.menu_media_content_selection_gallery) {
+            finishWithResults(selectedContent, ACTIVITY_RESULT_CODE_GALLERY_CREATED);
+        }
+
+        return false;
     }
 
     @Override
@@ -358,10 +362,30 @@ public class MediaPickerActivity extends ActionBarActivity
         if (mViewPager != null) {
             mViewPager.setPagingEnabled(true);
 
-            mMediaPickerAdapter.addTab(mMediaSources[0] != null ? mMediaSources[0] : new ArrayList<MediaSource>(), getResources().getString(R.string.tab_title_device_images));
-            mMediaPickerAdapter.addTab(mMediaSources[1] != null ? mMediaSources[1] : new ArrayList<MediaSource>(), getResources().getString(R.string.tab_title_device_videos));
-            mMediaPickerAdapter.addTab(mMediaSources[2] != null ? mMediaSources[2] : new ArrayList<MediaSource>(), getResources().getString(R.string.tab_title_site_images));
-            mMediaPickerAdapter.addTab(mMediaSources[3] != null ? mMediaSources[3] : new ArrayList<MediaSource>(), getResources().getString(R.string.tab_title_site_videos));
+            mMediaPickerAdapter.addTab(mMediaSources[0] != null ? mMediaSources[0] :
+                            new ArrayList<MediaSource>(),
+                    getString(R.string.tab_title_device_images),
+                    getString(R.string.loading_images),
+                    getString(R.string.error_loading_images),
+                    getString(R.string.no_device_images));
+            mMediaPickerAdapter.addTab(mMediaSources[1] != null ? mMediaSources[1] :
+                            new ArrayList<MediaSource>(),
+                    getString(R.string.tab_title_device_videos),
+                    getString(R.string.loading_videos),
+                    getString(R.string.error_loading_videos),
+                    getString(R.string.no_device_videos));
+            mMediaPickerAdapter.addTab(mMediaSources[2] != null ? mMediaSources[2] :
+                            new ArrayList<MediaSource>(),
+                    getString(R.string.tab_title_site_images),
+                    getString(R.string.loading_blog_images),
+                    getString(R.string.error_loading_blog_images),
+                    getString(R.string.no_blog_images));
+            mMediaPickerAdapter.addTab(mMediaSources[3] != null ? mMediaSources[3] :
+                            new ArrayList<MediaSource>(),
+                    getString(R.string.tab_title_site_videos),
+                    getString(R.string.loading_blog_videos),
+                    getString(R.string.error_loading_blog_videos),
+                    getString(R.string.no_blog_videos));
 
             mViewPager.setAdapter(mMediaPickerAdapter);
 
@@ -452,10 +476,16 @@ public class MediaPickerActivity extends ActionBarActivity
      */
     public class MediaPickerAdapter extends FragmentPagerAdapter {
         private class MediaPicker {
+            public String loadingText;
+            public String errorText;
+            public String emptyText;
             public String pickerTitle;
             public ArrayList<MediaSource> mediaSources;
 
-            public MediaPicker(String name, ArrayList<MediaSource> sources) {
+            public MediaPicker(String name, String loading, String error, String empty, ArrayList<MediaSource> sources) {
+                loadingText = loading;
+                errorText = error;
+                emptyText = empty;
                 pickerTitle = name;
                 mediaSources = sources;
             }
@@ -474,6 +504,10 @@ public class MediaPickerActivity extends ActionBarActivity
             if (position < mMediaPickers.size()) {
                 MediaPicker mediaPicker = mMediaPickers.get(position);
                 MediaPickerFragment fragment = new MediaPickerFragment();
+                fragment.setLoadingText(mediaPicker.loadingText);
+                fragment.setErrorText(mediaPicker.errorText);
+                fragment.setEmptyText(mediaPicker.emptyText);
+                fragment.setActionModeMenu(R.menu.menu_media_picker_action_mode);
                 fragment.setMediaSources(mediaPicker.mediaSources);
 
                 return fragment;
@@ -492,8 +526,8 @@ public class MediaPickerActivity extends ActionBarActivity
             return mMediaPickers.get(position).pickerTitle;
         }
 
-        public void addTab(ArrayList<MediaSource> mediaSources, String tabName) {
-            mMediaPickers.add(new MediaPicker(tabName, mediaSources));
+        public void addTab(ArrayList<MediaSource> mediaSources, String tabName, String loading, String error, String empty) {
+            mMediaPickers.add(new MediaPicker(tabName, loading, error, empty, mediaSources));
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSourceWPImages.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSourceWPImages.java
@@ -1,10 +1,12 @@
 package org.wordpress.android.ui.media;
 
+import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Parcel;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -21,7 +23,6 @@ import org.wordpress.mediapicker.source.MediaSource;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,18 +31,39 @@ public class MediaSourceWPImages implements MediaSource {
     private final List<MediaItem> mVerifiedItems = new ArrayList<>();
     private final List<MediaItem> mMediaItems = new ArrayList<>();
 
-    private boolean mLoading;
     private OnMediaChange mListener;
 
     public MediaSourceWPImages() {
-        fetchImageData();
+    }
+
+    @Override
+    public void gather(Context context) {
+        mMediaItems.clear();
+
+        Blog blog = WordPress.getCurrentBlog();
+
+        if (blog != null) {
+            Cursor imageCursor = MediaUtils.getWordPressMediaImages(String.valueOf(blog.getLocalTableBlogId()));
+
+            if (imageCursor != null) {
+                addWordPressImagesFromCursor(imageCursor);
+                imageCursor.close();
+            } else if (mListener != null){
+                mListener.onMediaLoaded(false);
+            }
+        } else if (mListener != null){
+            mListener.onMediaLoaded(false);
+        }
+    }
+
+    @Override
+    public void cleanup() {
+        mMediaItems.clear();
     }
 
     @Override
     public void setListener(OnMediaChange listener) {
         mListener = listener;
-
-        notifyLoadingStatus();
     }
 
     @Override
@@ -75,7 +97,7 @@ public class MediaSourceWPImages implements MediaSource {
                         imageView.setImageResource(R.color.grey_darken_10);
                         MediaUtils.BackgroundDownloadWebImage bgDownload = new MediaUtils.BackgroundDownloadWebImage(imageView);
                         imageView.setTag(bgDownload);
-                        bgDownload.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, mediaItem.getPreviewSource());
+                        bgDownload.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR, mediaItem.getPreviewSource());
                     } else {
                         imageView.setImageBitmap(imageBitmap);
                     }
@@ -92,42 +114,6 @@ public class MediaSourceWPImages implements MediaSource {
     @Override
     public boolean onMediaItemSelected(MediaItem mediaItem, boolean selected) {
         return !selected;
-    }
-
-    public static final Creator<MediaSourceWPImages> CREATOR =
-            new Creator<MediaSourceWPImages>() {
-                public MediaSourceWPImages createFromParcel(Parcel in) {
-                    return new MediaSourceWPImages();
-                }
-
-                public MediaSourceWPImages[] newArray(int size) {
-                    return new MediaSourceWPImages[size];
-                }
-            };
-
-    @Override
-    public int describeContents() {
-        return 0;
-    }
-
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-    }
-
-    private void fetchImageData() {
-        Blog blog = WordPress.getCurrentBlog();
-
-        if (blog != null) {
-            mLoading = true;
-            notifyLoadingStatus();
-
-            Cursor imageCursor = MediaUtils.getWordPressMediaImages(String.valueOf(blog.getLocalTableBlogId()));
-
-            if (imageCursor != null) {
-                addWordPressImagesFromCursor(imageCursor);
-                imageCursor.close();
-            }
-        }
     }
 
     private void addWordPressImagesFromCursor(Cursor cursor) {
@@ -174,54 +160,80 @@ public class MediaSourceWPImages implements MediaSource {
             } while (cursor.moveToNext());
 
             removeDeletedEntries();
-        } else {
-            mLoading = false;
-            notifyLoadingStatus();
+        } else if (mListener != null) {
+            mListener.onMediaLoaded(true);
         }
     }
 
     private void removeDeletedEntries() {
-        AsyncTask<List<MediaItem>, Void, Void> backgroundCheck = new AsyncTask<List<MediaItem>, Void, Void>() {
-            @Override
-            protected Void doInBackground(List<MediaItem>[] params) {
-                for (MediaItem mediaItem : params[0]) {
+        List<MediaItem> existingItems = new ArrayList<>(mMediaItems);
+
+        for (MediaItem mediaItem : existingItems) {
+            final boolean callLoaded = existingItems.indexOf(mediaItem) == existingItems.size() - 1;
+
+            AsyncTask<MediaItem, Void, MediaItem> backgroundCheck = new AsyncTask<MediaItem, Void, MediaItem>() {
+                int responseCode;
+
+                @Override
+                protected MediaItem doInBackground(MediaItem[] params) {
+                    MediaItem mediaItem = params[0];
                     try {
                         URL mediaUrl = new URL(mediaItem.getSource().toString());
                         HttpURLConnection connection = (HttpURLConnection) mediaUrl.openConnection();
                         connection.setRequestMethod("GET");
                         connection.connect();
-                        int responseCode = connection.getResponseCode();
+                        responseCode = connection.getResponseCode();
 
-                        if (responseCode == 200) {
-                            mVerifiedItems.add(mediaItem);
-                        }
-                    } catch (MalformedURLException e) {
                     } catch (IOException ioException) {
+                        Log.e("", "Error reading from " + mediaItem.getSource() + "\nexception:" + ioException);
+
+                        return null;
                     }
 
-                    Thread.yield();
+                    return mediaItem;
                 }
 
-                return null;
-            }
+                @Override
+                public void onPostExecute(MediaItem result) {
+                    if (mListener != null && result != null) {
+                        List<MediaItem> resultList = new ArrayList<>();
+                        resultList.add(result);
+                        if (responseCode == 200) {
+                            mVerifiedItems.add(result);
+                            mListener.onMediaAdded(MediaSourceWPImages.this, resultList);
+                        }
 
-            @Override
-            public void onPostExecute(Void result) {
-                mLoading = false;
-                notifyLoadingStatus();
-                if (mVerifiedItems.size() > 0 && mListener != null) {
-                    mListener.onMediaAdded(MediaSourceWPImages.this, mVerifiedItems);
+                        if (callLoaded) {
+                            mListener.onMediaLoaded(true);
+                        }
+                    }
                 }
-            }
-        };
-
-        List<MediaItem> existingItems = new ArrayList<>(mMediaItems);
-        backgroundCheck.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, existingItems);
+            };
+            backgroundCheck.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, mediaItem);
+        }
     }
 
-    private void notifyLoadingStatus() {
-        if (mListener != null) {
-            mListener.onMediaLoading(this, !mLoading);
-        }
+    /**
+     * {@link android.os.Parcelable} interface
+     */
+
+    public static final Creator<MediaSourceWPImages> CREATOR =
+            new Creator<MediaSourceWPImages>() {
+                public MediaSourceWPImages createFromParcel(Parcel in) {
+                    return new MediaSourceWPImages();
+                }
+
+                public MediaSourceWPImages[] newArray(int size) {
+                    return new MediaSourceWPImages[size];
+                }
+            };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSourceWPVideos.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSourceWPVideos.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.media;
 
+import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.net.Uri;
@@ -25,19 +26,38 @@ public class MediaSourceWPVideos implements MediaSource {
     private static final String VIDEO_PRESS_HOST = "https://videos.files.wordpress.com/";
     private static final String VIDEO_PRESS_THUMBNAIL_APPEND = "_hd.thumbnail.jpg";
 
-    private boolean mLoading;
     private OnMediaChange mListener;
     private List<MediaItem> mMediaItems = new ArrayList<>();
 
     public MediaSourceWPVideos() {
-        fetchVideoData();
+    }
+
+    @Override
+    public void gather(Context context) {
+        Blog blog = WordPress.getCurrentBlog();
+
+        if (blog != null) {
+            Cursor videoCursor = MediaUtils.getWordPressMediaVideos(String.valueOf(blog.getLocalTableBlogId()));
+
+            if (videoCursor != null) {
+                addWordPressVideosFromCursor(videoCursor);
+                videoCursor.close();
+            } else if (mListener != null){
+                mListener.onMediaLoaded(false);
+            }
+        } else if (mListener != null){
+            mListener.onMediaLoaded(false);
+        }
+    }
+
+    @Override
+    public void cleanup() {
+        mMediaItems.clear();
     }
 
     @Override
     public void setListener(OnMediaChange listener) {
         mListener = listener;
-
-        notifyLoadingStatus();
     }
 
     @Override
@@ -70,7 +90,8 @@ public class MediaSourceWPVideos implements MediaSource {
                     imageView.setScaleType(ImageView.ScaleType.CENTER_CROP);
                     if (imageBitmap == null) {
                         imageView.setImageResource(R.color.grey_darken_10);
-                        MediaUtils.BackgroundDownloadWebImage bgDownload = new MediaUtils.BackgroundDownloadWebImage(imageView);
+                        MediaUtils.BackgroundDownloadWebImage bgDownload =
+                                new MediaUtils.BackgroundDownloadWebImage(imageView);
                         imageView.setTag(bgDownload);
                         bgDownload.execute(mediaItem.getPreviewSource());
                     } else {
@@ -105,45 +126,6 @@ public class MediaSourceWPVideos implements MediaSource {
         cursorEntry = cursorEntry.substring(0, cursorEntry.length() - 1);
 
         return cursorEntry;
-    }
-
-    /*
-        Parcelable interface
-     */
-
-    public static final Creator<MediaSourceWPVideos> CREATOR =
-            new Creator<MediaSourceWPVideos>() {
-                public MediaSourceWPVideos createFromParcel(Parcel in) {
-                    return new MediaSourceWPVideos();
-                }
-
-                public MediaSourceWPVideos[] newArray(int size) {
-                    return new MediaSourceWPVideos[size];
-                }
-            };
-
-    @Override
-    public int describeContents() {
-        return 0;
-    }
-
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-    }
-
-    private void fetchVideoData() {
-        Blog blog = WordPress.getCurrentBlog();
-
-        if (blog != null) {
-            mLoading = true;
-            notifyLoadingStatus();
-            Cursor videoCursor = MediaUtils.getWordPressMediaVideos(String.valueOf(blog.getLocalTableBlogId()));
-
-            if (videoCursor != null) {
-                addWordPressVideosFromCursor(videoCursor);
-                videoCursor.close();
-            }
-        }
     }
 
     private void addWordPressVideosFromCursor(Cursor cursor) {
@@ -186,13 +168,32 @@ public class MediaSourceWPVideos implements MediaSource {
             } while (cursor.moveToNext());
         }
 
-        mLoading = false;
-        notifyLoadingStatus();
+        if (mListener != null) {
+            mListener.onMediaLoaded(true);
+        }
     }
 
-    private void notifyLoadingStatus() {
-        if (mListener != null) {
-            mListener.onMediaLoading(this, !mLoading);
-        }
+    /**
+     * {@link android.os.Parcelable} interface
+     */
+
+    public static final Creator<MediaSourceWPVideos> CREATOR =
+            new Creator<MediaSourceWPVideos>() {
+                public MediaSourceWPVideos createFromParcel(Parcel in) {
+                    return new MediaSourceWPVideos();
+                }
+
+                public MediaSourceWPVideos[] newArray(int size) {
+                    return new MediaSourceWPVideos[size];
+                }
+            };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostContentFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostContentFragment.java
@@ -1638,7 +1638,7 @@ public class EditPostContentFragment extends Fragment implements TextWatcher,
      */
     private ArrayList<MediaSource> imageMediaSelectionSources() {
         ArrayList<MediaSource> imageMediaSources = new ArrayList<>();
-        imageMediaSources.add(new MediaSourceDeviceImages(getActivity().getContentResolver()));
+        imageMediaSources.add(new MediaSourceDeviceImages());
 
         return imageMediaSources;
     }
@@ -1665,7 +1665,7 @@ public class EditPostContentFragment extends Fragment implements TextWatcher,
      */
     private ArrayList<MediaSource> videoMediaSelectionSources() {
         ArrayList<MediaSource> videoMediaSources = new ArrayList<>();
-        videoMediaSources.add(new MediaSourceDeviceVideos(getActivity().getContentResolver()));
+        videoMediaSources.add(new MediaSourceDeviceVideos());
 
         return videoMediaSources;
     }

--- a/WordPress/src/main/res/layout/media_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/media_picker_fragment.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:gravity="center_vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/media_empty_view"
+        style="@style/WordPress.EmptyList.Title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginBottom="@dimen/empty_list_title_bottom_margin"
+        android:layout_marginLeft="@dimen/empty_list_title_side_margin"
+        android:layout_marginRight="@dimen/empty_list_title_side_margin"
+        android:textSize="@dimen/empty_view_text_size" />
+
+    <GridView
+        android:id="@+id/media_adapter_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="4dp"
+        android:verticalSpacing="2dp"
+        android:horizontalSpacing="2dp"
+        android:numColumns="2"/>
+
+</LinearLayout>

--- a/WordPress/src/main/res/menu/menu_media_picker_action_mode.xml
+++ b/WordPress/src/main/res/menu/menu_media_picker_action_mode.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/menu_media_content_selection_gallery"
+        android:title="@string/new_media_gallery"
+        android:icon="@drawable/tab_icon_create_gallery"
+        android:enabled="true"
+        android:visible="true" />
+
+    <item
+        android:id="@+id/menu_media_selection_confirmed"
+        android:title="@string/confirm"
+        android:icon="@drawable/action_mode_confirm_checkmark"
+        android:enabled="true"
+        android:visible="true" />
+
+</menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -119,6 +119,19 @@
     <string name="pick_video">Select video</string>
     <string name="media_error_no_permission">You don\'t have permission to view the media library</string>
     <string name="media_fetching">Fetching media…</string>
+    <string name="loading_videos">Loading videos</string>
+    <string name="loading_images">Loading images</string>
+    <string name="loading_blog_images">Fetching library images</string>
+    <string name="loading_blog_videos">Fetching library videos</string>
+    <string name="no_media">No media</string>
+    <string name="error_loading_images">Error loading device images</string>
+    <string name="error_loading_videos">"Error loading device videos "</string>
+    <string name="error_loading_blog_images">"Unable to fetch blog images "</string>
+    <string name="error_loading_blog_videos">"Unable to fetch blog videos "</string>
+    <string name="no_device_images">No images on device</string>
+    <string name="no_device_videos">No videos on device</string>
+    <string name="no_blog_images">No blog images</string>
+    <string name="no_blog_videos">No blog videos</string>
 
     <!-- Upload Media -->
     <string name="media_no_video_title">VideoPress unavailable</string>


### PR DESCRIPTION
Fixes #2512 by deferring data loading from the post editor to the picker fragment.