### PR TITLE
Push Notification Enhancements

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/notifications/GCMIntentServiceTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/notifications/GCMIntentServiceTest.java
@@ -1,0 +1,21 @@
+package org.wordpress.android.ui.notifications;
+
+
+import android.test.AndroidTestCase;
+
+import org.wordpress.android.GCMIntentService;
+
+public class GCMIntentServiceTest extends AndroidTestCase {
+
+    public void testShouldCircularizeNoteIcon() {
+        GCMIntentService intentService = new GCMIntentService();
+
+        String type = "c";
+        assertTrue(intentService.shouldCircularizeNoteIcon(type));
+
+        assertFalse(intentService.shouldCircularizeNoteIcon(null));
+
+        type = "invalidType";
+        assertFalse(intentService.shouldCircularizeNoteIcon(type));
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
@@ -31,6 +31,7 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.HelpshiftHelper;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.PhotonUtils;
+import org.wordpress.android.util.StringUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -115,6 +116,7 @@ public class GCMIntentService extends GCMBaseIntentService {
         }
 
         String iconUrl = extras.getString("icon");
+        String noteType = StringUtils.notNullStr(extras.getString("type"));
         Bitmap largeIconBitmap = null;
         if (iconUrl != null) {
             try {
@@ -123,6 +125,9 @@ public class GCMIntentService extends GCMBaseIntentService {
                         android.R.dimen.notification_large_icon_height);
                 String resizedUrl = PhotonUtils.getPhotonImageUrl(iconUrl, largeIconSize, largeIconSize);
                 largeIconBitmap = ImageUtils.downloadBitmap(resizedUrl);
+                if (largeIconBitmap != null && shouldCircularizeNoteIcon(noteType)) {
+                    largeIconBitmap = ImageUtils.getCircularBitmap(largeIconBitmap);
+                }
             } catch (UnsupportedEncodingException e) {
                 AppLog.e(T.NOTIFS, e);
             }
@@ -158,8 +163,7 @@ public class GCMIntentService extends GCMBaseIntentService {
             }
 
             // Add some actions if this is a comment notification
-            String noteType = extras.getString("type");
-            if (noteType != null && noteType.equals("c")) {
+            if (noteType.equals("c")) {
                 Intent commentReplyIntent = new Intent(this, NotificationsActivity.class);
                 commentReplyIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK
                         | Intent.FLAG_ACTIVITY_CLEAR_TASK);
@@ -232,12 +236,32 @@ public class GCMIntentService extends GCMBaseIntentService {
             mBuilder.setLights(0xff0000ff, 1000, 5000);
         }
 
+        mBuilder.setCategory(NotificationCompat.CATEGORY_SOCIAL);
+
         PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, resultIntent,
                 PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_UPDATE_CURRENT);
         mBuilder.setContentIntent(pendingIntent);
+
         NotificationManager mNotificationManager =
                 (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
         mNotificationManager.notify(PUSH_NOTIFICATION_ID, mBuilder.build());
+    }
+
+    // Returns true if the note type is known to have a gravatar
+    private boolean shouldCircularizeNoteIcon(String noteType) {
+        if (TextUtils.isEmpty(noteType)) return false;
+
+        switch (noteType) {
+            case "c":
+            case "like":
+            case "comment_like":
+            case "automattcher":
+            case "follow":
+            case "reblog":
+                return true;
+            default:
+                return false;
+        }
     }
 
     @Override
@@ -288,7 +312,7 @@ public class GCMIntentService extends GCMBaseIntentService {
                 uuid = UUID.randomUUID().toString();
                 SharedPreferences.Editor editor = settings.edit();
                 editor.putString(NotificationsUtils.WPCOM_PUSH_DEVICE_UUID, uuid);
-                editor.commit();
+                editor.apply();
             }
 
             NotificationsUtils.registerDeviceForPushNotifications(context, regId);

--- a/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
@@ -248,7 +248,7 @@ public class GCMIntentService extends GCMBaseIntentService {
     }
 
     // Returns true if the note type is known to have a gravatar
-    private boolean shouldCircularizeNoteIcon(String noteType) {
+    public boolean shouldCircularizeNoteIcon(String noteType) {
         if (TextUtils.isEmpty(noteType)) return false;
 
         switch (noteType) {

--- a/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
@@ -48,6 +48,13 @@ public class GCMIntentService extends GCMBaseIntentService {
     private static long mPreviousNoteTime = 0L;
     private static final int mMaxInboxItems = 5;
 
+    private static final String NOTE_TYPE_COMMENT = "c";
+    private static final String NOTE_TYPE_LIKE = "like";
+    private static final String NOTE_TYPE_COMMENT_LIKE = "comment_like";
+    private static final String NOTE_TYPE_AUTOMATTCHER = "automattcher";
+    private static final String NOTE_TYPE_FOLLOW = "follow";
+    private static final String NOTE_TYPE_REBLOG = "reblog";
+
     @Override
     protected String[] getSenderIds(Context context) {
         String[] senderIds = new String[1];
@@ -163,7 +170,7 @@ public class GCMIntentService extends GCMBaseIntentService {
             }
 
             // Add some actions if this is a comment notification
-            if (noteType.equals("c")) {
+            if (noteType.equals(NOTE_TYPE_COMMENT)) {
                 Intent commentReplyIntent = new Intent(this, NotificationsActivity.class);
                 commentReplyIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK
                         | Intent.FLAG_ACTIVITY_CLEAR_TASK);
@@ -192,7 +199,7 @@ public class GCMIntentService extends GCMBaseIntentService {
                     break;
                 if (wpPN.getString("msg") == null)
                     continue;
-                if (wpPN.getString("type") != null && wpPN.getString("type").equals("c")) {
+                if (wpPN.getString("type") != null && wpPN.getString("type").equals(NOTE_TYPE_COMMENT)) {
                     String pnTitle = StringEscapeUtils.unescapeHtml((wpPN.getString("title")));
                     String pnMessage = StringEscapeUtils.unescapeHtml((wpPN.getString("msg")));
                     inboxStyle.addLine(pnTitle + ": " + pnMessage);
@@ -252,12 +259,12 @@ public class GCMIntentService extends GCMBaseIntentService {
         if (TextUtils.isEmpty(noteType)) return false;
 
         switch (noteType) {
-            case "c":
-            case "like":
-            case "comment_like":
-            case "automattcher":
-            case "follow":
-            case "reblog":
+            case NOTE_TYPE_COMMENT:
+            case NOTE_TYPE_LIKE:
+            case NOTE_TYPE_COMMENT_LIKE:
+            case NOTE_TYPE_AUTOMATTCHER:
+            case NOTE_TYPE_FOLLOW:
+            case NOTE_TYPE_REBLOG:
                 return true;
             default:
                 return false;


### PR DESCRIPTION
Adds a few small enhancements to Push Notificaitons:

* Notifications that are known to have a gravatar will have a circular icon:
Old:
![screen shot 2015-04-14 at 11 27 53 am](https://cloud.githubusercontent.com/assets/789137/7145109/aa9948e8-e29e-11e4-9c13-7670c5f72d1c.png)
New:
![screen shot 2015-04-14 at 11 48 51 am](https://cloud.githubusercontent.com/assets/789137/7145111/b0595732-e29e-11e4-949f-1486afe83c6a.png)
* Notifications are now placed in the 'Social' category, so they show in the proper area in the notifications panel on lollipop or newer.

