### PR TITLE
fix #2492: update to tracks 1.0.1

### DIFF
--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.automattic:tracks:1.0.0'
+    compile 'com.automattic:tracks:1.0.1'
     compile 'com.mixpanel.android:mixpanel-android:4.3.0@aar'
     compile 'org.wordpress:utils:1.3.0'
 }


### PR DESCRIPTION
fix #2492: update to tracks 1.0.1 - artifact has been published to sonatype (~2 hours for full propagation to maven repos)