### PR TITLE
Don't show the badge on the notifications tab when it is already active.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -312,6 +312,13 @@ public class WPMainActivity extends Activity
         if (mIsCheckingNoteBadge) {
             AppLog.v(AppLog.T.NOTIFS, "already checking note badge");
             return;
+        } else if (isViewingNotificationsTab()) {
+            // Don't show the badge if the notifications tab is active
+            if (mTabs.isBadged(WPMainTabAdapter.TAB_NOTIFS)) {
+                mTabs.setBadge(WPMainTabAdapter.TAB_NOTIFS, false);
+            }
+
+            return;
         }
 
         mIsCheckingNoteBadge = true;
@@ -333,6 +340,10 @@ public class WPMainActivity extends Activity
                 }
             }
         }.start();
+    }
+
+    private boolean isViewingNotificationsTab() {
+        return mViewPager.getCurrentItem() == WPMainTabAdapter.TAB_NOTIFS;
     }
 
     // Events


### PR DESCRIPTION
Also fixes issue where the notification badge would linger around after opening the app from a push notification.

Fixes #2547