### PR TITLE
Stats - pre-review - Refactoring of Stats Service and Fragments

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.main;
 
 import android.app.Fragment;
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -13,8 +14,10 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.ui.ActivityLauncher;
+import org.wordpress.android.ui.stats.service.StatsService;
 import org.wordpress.android.ui.themes.ThemeBrowserActivity;
 import org.wordpress.android.util.GravatarUtils;
+import org.wordpress.android.util.ServiceUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
 import org.wordpress.android.widgets.WPTextView;
@@ -46,6 +49,15 @@ public class MySiteFragment extends Fragment
         super.onCreate(savedInstanceState);
 
         mBlog = WordPress.getCurrentBlog();
+    }
+
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        if (ServiceUtils.isServiceRunning(getActivity(), StatsService.class) ) {
+            getActivity().stopService(new Intent(getActivity(), StatsService.class));
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -55,7 +55,7 @@ public class MySiteFragment extends Fragment
     @Override
     public void onResume() {
         super.onResume();
-        if (ServiceUtils.isServiceRunning(getActivity(), StatsService.class) ) {
+        if (ServiceUtils.isServiceRunning(getActivity(), StatsService.class)) {
             getActivity().stopService(new Intent(getActivity(), StatsService.class));
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
@@ -40,22 +40,29 @@ public abstract class StatsAbstractFragment extends Fragment {
 
         AppLog.d(AppLog.T.STATS, this.getClass().getCanonicalName() + " > refreshStats");
 
+        if (!NetworkUtils.isNetworkAvailable(getActivity())) {
+            AppLog.w(AppLog.T.STATS, this.getClass().getCanonicalName() + "--> no connection, update canceled");
+            return;
+        }
+
+        final String blogId = StatsUtils.getBlogId(getLocalTableBlogID());
         final Blog currentBlog = WordPress.getBlog(getLocalTableBlogID());
+
+        // Make sure the blogId is available.
+        if (blogId == null) {
+            AppLog.e(AppLog.T.STATS, "remote blogID is null: " + currentBlog.getHomeURL());
+            return;
+        }
+
         if (currentBlog == null) {
             AppLog.w(AppLog.T.STATS, "Current blog is null. This should never happen here.");
             return;
         }
 
-        if (!NetworkUtils.checkConnection(getActivity())) {
-            AppLog.w(AppLog.T.STATS, " no connection, update canceled");
-            return;
-        }
-
-        final String blogId = StatsUtils.getBlogId(getLocalTableBlogID());
-
-        // Make sure the blogId is available.
-        if (blogId == null) {
-            AppLog.e(AppLog.T.STATS, "remote blogID is null: " + currentBlog.getHomeURL());
+        // Check credentials for jetpack blogs first
+        if (!currentBlog.isDotcomFlag()
+                && !currentBlog.hasValidJetpackCredentials()) {
+            AppLog.w(AppLog.T.STATS, "Current blog is a Jetpack blog without valid .com credentials stored");
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
@@ -43,7 +43,7 @@ public abstract class StatsAbstractFragment extends Fragment {
             sections = getSectionsToUpdate();
         }
 
-        AppLog.d(AppLog.T.STATS, this.getClass().getCanonicalName() + " > refreshStats");
+        //AppLog.d(AppLog.T.STATS, this.getClass().getCanonicalName() + " > refreshStats");
 
         if (!NetworkUtils.isNetworkAvailable(getActivity())) {
             AppLog.w(AppLog.T.STATS, this.getClass().getCanonicalName() + "--> no connection, update canceled");
@@ -92,7 +92,6 @@ public abstract class StatsAbstractFragment extends Fragment {
        // AppLog.d(AppLog.T.STATS, this.getClass().getCanonicalName() + " > onCreate");
 
         if (savedInstanceState != null) {
-            AppLog.d(AppLog.T.STATS, "savedInstanceState != null");
             if (savedInstanceState.containsKey(ARGS_TIMEFRAME)) {
                 mStatsTimeframe = (StatsTimeframe) savedInstanceState.getSerializable(ARGS_TIMEFRAME);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
@@ -53,14 +53,14 @@ public abstract class StatsAbstractFragment extends Fragment {
         final String blogId = StatsUtils.getBlogId(getLocalTableBlogID());
         final Blog currentBlog = WordPress.getBlog(getLocalTableBlogID());
 
-        // Make sure the blogId is available.
-        if (blogId == null) {
-            AppLog.e(AppLog.T.STATS, "remote blogID is null: " + currentBlog.getHomeURL());
+        if (currentBlog == null) {
+            AppLog.w(AppLog.T.STATS, "Current blog is null. This should never happen here.");
             return;
         }
 
-        if (currentBlog == null) {
-            AppLog.w(AppLog.T.STATS, "Current blog is null. This should never happen here.");
+        // Make sure the blogId is available.
+        if (blogId == null) {
+            AppLog.e(AppLog.T.STATS, "remote blogID is null: " + currentBlog.getHomeURL());
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
@@ -77,9 +77,14 @@ public abstract class StatsAbstractFragment extends Fragment {
         intent.putExtra(StatsService.ARG_PERIOD, mStatsTimeframe);
         intent.putExtra(StatsService.ARG_DATE, mDate);
         if (isSingleView()) {
-            intent.putExtra(StatsService.ARG_MAX_RESULTS, MAX_RESULTS_REQUESTED);
+            if (pageNumberRequested > 0) {
+                // request 20 items per page. It's the maximum number returned by the server in paged mode
+                intent.putExtra(StatsService.ARG_MAX_RESULTS, StatsService.MAX_RESULTS_REQUESTED_PER_PAGE);
+            } else {
+                intent.putExtra(StatsService.ARG_MAX_RESULTS, MAX_RESULTS_REQUESTED);
+            }
         }
-        if (pageNumberRequested  != -1) {
+        if (pageNumberRequested > 0) {
             intent.putExtra(StatsService.ARG_PAGE_REQUESTED, pageNumberRequested);
         }
         intent.putExtra(StatsService.ARG_SECTION, sections);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
@@ -3,35 +3,102 @@ package org.wordpress.android.ui.stats;
 
 import android.app.Activity;
 import android.app.Fragment;
+import android.content.Intent;
 import android.os.Bundle;
 
+import org.wordpress.android.WordPress;
+import org.wordpress.android.models.Blog;
 import org.wordpress.android.ui.stats.service.StatsService;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.NetworkUtils;
 
 
 public abstract class StatsAbstractFragment extends Fragment {
     public static final String TAG = StatsAbstractFragment.class.getSimpleName();
+
     public static final String ARGS_VIEW_TYPE = "ARGS_VIEW_TYPE";
     public static final String ARGS_TIMEFRAME = "ARGS_TIMEFRAME";
-    
-    protected static final String ARGS_START_DATE = "ARGS_START_DATE";
+    protected static final String ARGS_SELECTED_DATE = "ARGS_SELECTED_DATE";
     protected static final String ARG_REST_RESPONSE = "ARG_REST_RESPONSE";
 
-    protected TimeframeDateProvider mTimelineProvider;
     protected OnRequestDataListener mMoreDataListener;
-
-    // Container Activity must implement this interface
-    public interface TimeframeDateProvider {
-        public String getCurrentDate();
-        public StatsTimeframe getCurrentTimeFrame();
-    }
+    protected String mDate;
+    protected StatsTimeframe mStatsTimeframe = StatsTimeframe.DAY;
 
     // Container Activity must implement this interface
     public interface OnRequestDataListener {
-        public void onRefreshRequested(StatsService.StatsEndpointsEnum[] endPointsNeedUpdate);
         public void onMoreDataRequested(StatsService.StatsEndpointsEnum endPointNeedUpdate, int pageNumber);
     }
 
-    public static StatsAbstractFragment newInstance(StatsViewType viewType, int localTableBlogID) {
+    protected abstract StatsService.StatsEndpointsEnum[] getSectionsToUpdate();
+
+    // call an update for the stats shown in the fragment
+    public void refreshStats() {
+        if (!isAdded()) {
+            return;
+        }
+
+        AppLog.d(AppLog.T.STATS, this.getClass().getCanonicalName() + " > refreshStats");
+
+        final Blog currentBlog = WordPress.getBlog(getLocalTableBlogID());
+        if (currentBlog == null) {
+            AppLog.w(AppLog.T.STATS, "Current blog is null. This should never happen here.");
+            return;
+        }
+
+        if (!NetworkUtils.checkConnection(getActivity())) {
+            AppLog.w(AppLog.T.STATS, " no connection, update canceled");
+            return;
+        }
+
+        final String blogId = StatsUtils.getBlogId(getLocalTableBlogID());
+
+        // Make sure the blogId is available.
+        if (blogId == null) {
+            AppLog.e(AppLog.T.STATS, "remote blogID is null: " + currentBlog.getHomeURL());
+            return;
+        }
+
+        // start service to get stats
+        Intent intent = new Intent(getActivity(), StatsService.class);
+        intent.putExtra(StatsService.ARG_BLOG_ID, blogId);
+        intent.putExtra(StatsService.ARG_PERIOD, mStatsTimeframe);
+        intent.putExtra(StatsService.ARG_DATE, mDate);
+        intent.putExtra(StatsService.ARG_SECTION, getSectionsToUpdate());
+        getActivity().startService(intent);
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        AppLog.d(AppLog.T.STATS, this.getClass().getCanonicalName() + " > onCreate");
+
+        if (savedInstanceState != null) {
+            AppLog.d(AppLog.T.STATS, "savedInstanceState != null");
+            if (savedInstanceState.containsKey(ARGS_TIMEFRAME)) {
+                mStatsTimeframe = (StatsTimeframe) savedInstanceState.getSerializable(ARGS_TIMEFRAME);
+            }
+            if (savedInstanceState.containsKey(ARGS_SELECTED_DATE)) {
+                mDate = savedInstanceState.getString(ARGS_SELECTED_DATE);
+            }
+        }
+
+        AppLog.d(AppLog.T.STATS, "mStatsTimeframe: " + mStatsTimeframe.getLabel());
+        AppLog.d(AppLog.T.STATS, "mDate: " + mDate);
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        AppLog.d(AppLog.T.STATS, this.getClass().getCanonicalName() + " > saving instance state");
+        AppLog.d(AppLog.T.STATS, "mStatsTimeframe: " + mStatsTimeframe.getLabel());
+        AppLog.d(AppLog.T.STATS, "mDate: " + mDate);
+        outState.putString(ARGS_SELECTED_DATE, mDate);
+        outState.putSerializable(ARGS_TIMEFRAME, mStatsTimeframe);
+        super.onSaveInstanceState(outState);
+    }
+
+    public static StatsAbstractFragment newInstance(StatsViewType viewType, int localTableBlogID,
+                                                    StatsTimeframe timeframe, String date ) {
         StatsAbstractFragment fragment = null;
 
         switch (viewType) {
@@ -76,6 +143,9 @@ public abstract class StatsAbstractFragment extends Fragment {
                 break;
         }
 
+        fragment.setTimeframe(timeframe);
+        fragment.setDate(date);
+
         Bundle args = new Bundle();
         args.putSerializable(ARGS_VIEW_TYPE, viewType);
         args.putInt(StatsActivity.ARG_LOCAL_TABLE_BLOG_ID, localTableBlogID);
@@ -88,16 +158,26 @@ public abstract class StatsAbstractFragment extends Fragment {
     public void onAttach(Activity activity) {
         super.onAttach(activity);
         try {
-            mTimelineProvider = (TimeframeDateProvider) activity;
-        } catch (ClassCastException e) {
-            throw new ClassCastException(activity.toString() + " must implement TimeframeDateProvider");
-        }
-
-        try {
             mMoreDataListener = (OnRequestDataListener) activity;
         } catch (ClassCastException e) {
             throw new ClassCastException(activity.toString() + " must implement OnRequestMoreDataListener");
         }
+    }
+
+    public void setDate(String newDate) {
+        mDate = newDate;
+    }
+
+    public String getDate() {
+        return mDate;
+    }
+
+    public void setTimeframe(StatsTimeframe newTimeframe) {
+        mStatsTimeframe = newTimeframe;
+    }
+
+    public StatsTimeframe getTimeframe() {
+        return mStatsTimeframe;
     }
 
     protected StatsViewType getViewType() {
@@ -108,16 +188,5 @@ public abstract class StatsAbstractFragment extends Fragment {
         return getArguments().getInt(StatsActivity.ARG_LOCAL_TABLE_BLOG_ID);
     }
 
-    protected StatsTimeframe getTimeframe() {
-        return mTimelineProvider.getCurrentTimeFrame();
-    }
-
-    protected String getStartDate() {
-        return mTimelineProvider.getCurrentDate();
-    }
-
     protected abstract String getTitle();
-
-    protected abstract void resetDataModel();
-
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractListFragment.java
@@ -70,7 +70,6 @@ public abstract class StatsAbstractListFragment extends StatsAbstractFragment {
     protected abstract int getTotalsLabelResId();
     protected abstract int getEmptyLabelTitleResId();
     protected abstract int getEmptyLabelDescResId();
-    protected abstract StatsService.StatsEndpointsEnum[] getSectionsToUpdate();
     protected abstract void updateUI();
     protected abstract boolean isExpandableList();
     protected abstract boolean isViewAllOptionAvailable();
@@ -183,7 +182,7 @@ public abstract class StatsAbstractListFragment extends StatsAbstractFragment {
         } else {
             //showHideNoResultsUI(true);
             showEmptyUI();
-            mMoreDataListener.onRefreshRequested(getSectionsToUpdate());
+            refreshStats();
         }
     }
 
@@ -330,7 +329,7 @@ public abstract class StatsAbstractListFragment extends StatsAbstractFragment {
                 viewAllIntent.putExtra(StatsActivity.ARG_LOCAL_TABLE_BLOG_ID, getLocalTableBlogID());
                 viewAllIntent.putExtra(StatsAbstractFragment.ARGS_TIMEFRAME, getTimeframe());
                 viewAllIntent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, getViewType());
-                viewAllIntent.putExtra(StatsAbstractFragment.ARGS_START_DATE, getStartDate());
+                viewAllIntent.putExtra(StatsAbstractFragment.ARGS_SELECTED_DATE, getDate());
                 viewAllIntent.putExtra(ARGS_IS_SINGLE_VIEW, true);
                 if (mTopPagerContainer.getVisibility() == View.VISIBLE) {
                     viewAllIntent.putExtra(ARGS_TOP_PAGER_SELECTED_BUTTON_INDEX, mTopPagerSelectedButtonIndex);
@@ -413,6 +412,18 @@ public abstract class StatsAbstractListFragment extends StatsAbstractFragment {
             return;
         }
 
+        if (!getDate().equals(event.mDate)) {
+            return;
+        }
+
+        if (!event.mRequestBlogId.equals(StatsUtils.getBlogId(getLocalTableBlogID()))) {
+            return;
+        }
+
+        if (event.mTimeframe != getTimeframe()) {
+            return;
+        }
+
         StatsService.StatsEndpointsEnum sectionToUpdate = event.mEndPointName;
         StatsService.StatsEndpointsEnum[] sectionsToUpdate = getSectionsToUpdate();
         int indexOfDatamodelMatch = -1;
@@ -435,10 +446,5 @@ public abstract class StatsAbstractListFragment extends StatsAbstractFragment {
 
         mDatamodels[indexOfDatamodelMatch] = event.mResponseObjectModel;
         updateUI();
-    }
-
-    @Override
-    protected void resetDataModel() {
-        mDatamodels = null;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractListFragment.java
@@ -19,13 +19,10 @@ import com.android.volley.NoConnectionError;
 import com.android.volley.VolleyError;
 
 import org.wordpress.android.R;
-import org.wordpress.android.WordPress;
-import org.wordpress.android.models.Blog;
 import org.wordpress.android.ui.stats.exceptions.StatsError;
 import org.wordpress.android.ui.stats.service.StatsService;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DisplayUtils;
-import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.widgets.TypefaceCache;
 
 import java.io.Serializable;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractListFragment.java
@@ -19,10 +19,13 @@ import com.android.volley.NoConnectionError;
 import com.android.volley.VolleyError;
 
 import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.models.Blog;
 import org.wordpress.android.ui.stats.exceptions.StatsError;
 import org.wordpress.android.ui.stats.service.StatsService;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DisplayUtils;
+import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.widgets.TypefaceCache;
 
 import java.io.Serializable;
@@ -30,8 +33,6 @@ import java.io.Serializable;
 import de.greenrobot.event.EventBus;
 
 public abstract class StatsAbstractListFragment extends StatsAbstractFragment {
-
-    protected static final String ARGS_IS_SINGLE_VIEW = "ARGS_IS_SINGLE_VIEW";
 
     // Used when the fragment has 2 pages/kind of stats in it. Not meaning the bottom pagination.
     protected static final String ARGS_TOP_PAGER_SELECTED_BUTTON_INDEX = "ARGS_TOP_PAGER_SELECTED_BUTTON_INDEX";
@@ -73,7 +74,6 @@ public abstract class StatsAbstractListFragment extends StatsAbstractFragment {
     protected abstract void updateUI();
     protected abstract boolean isExpandableList();
     protected abstract boolean isViewAllOptionAvailable();
-
 
     protected StatsResourceVars mResourceVars;
 
@@ -300,10 +300,6 @@ public abstract class StatsAbstractListFragment extends StatsAbstractFragment {
     protected boolean isErrorResponse(int index) {
         return mDatamodels != null && mDatamodels[index] != null
                 && (mDatamodels[index] instanceof VolleyError || mDatamodels[index] instanceof StatsError);
-    }
-
-    protected boolean isSingleView() {
-        return getArguments().getBoolean(ARGS_IS_SINGLE_VIEW, false);
     }
 
     private void configureViewAllButton() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractListFragment.java
@@ -122,11 +122,9 @@ public abstract class StatsAbstractListFragment extends StatsAbstractFragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        //AppLog.d(AppLog.T.STATS, this.getTag() + " > onCreate");
         mGroupIdToExpandedMap = new SparseBooleanArray();
 
         if (savedInstanceState != null) {
-            AppLog.d(AppLog.T.STATS, this.getTag() + " > restoring instance state");
             if (savedInstanceState.containsKey(ARG_REST_RESPONSE)) {
                 Serializable oldData = savedInstanceState.getSerializable(ARG_REST_RESPONSE);
                 if (oldData != null && oldData instanceof Serializable[]) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractListFragment.java
@@ -394,7 +394,9 @@ public abstract class StatsAbstractListFragment extends StatsAbstractFragment {
             mTopPagerSelectedButtonIndex = checkedId;
 
             TextView entryLabel = (TextView) getView().findViewById(R.id.stats_list_entry_label);
-            entryLabel.setText(getEntryLabelResId());
+            if (entryLabel != null) {
+                entryLabel.setText(getEntryLabelResId());
+            }
             updateUI();
         }
     };

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -226,11 +226,6 @@ public class StatsActivity extends ActionBarActivity
 
     @Override
     protected void onDestroy() {
-       // stopService(new Intent(this, StatsService.class));
-        if (mIsUpdatingStats) {
-            mIsUpdatingStats = false;
-            mSwipeToRefreshHelper.setRefreshing(false);
-        }
         super.onDestroy();
     }
 
@@ -411,7 +406,7 @@ public class StatsActivity extends ActionBarActivity
                                         public void run() {
                                             mSwipeToRefreshHelper.setRefreshing(true);
                                             mRequestedDate = StatsUtils.getCurrentDateTZ(mLocalBlogID);
-                                            createFragments(true); // Recreate the fragment and start a refresh od Stats
+                                            createFragments(true); // Recreate the fragment and start a refresh of Stats
                                         }
                                     });
                                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -565,6 +565,11 @@ public class StatsActivity extends ActionBarActivity
         final String blogId = StatsUtils.getBlogId(mLocalBlogID);
         final Blog currentBlog = WordPress.getBlog(mLocalBlogID);
 
+        if (currentBlog == null) {
+            AppLog.e(T.STATS, "The blog with local_blog_id " + mLocalBlogID + " cannot be loaded from the DB.");
+            return false;
+        }
+
         // blogId is always available for dotcom blogs. It could be null on Jetpack blogs...
         if (blogId != null) {
             // for self-hosted sites; launch the user into an activity where they can provide their credentials

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -226,7 +226,11 @@ public class StatsActivity extends ActionBarActivity
 
     @Override
     protected void onDestroy() {
-        stopStatsService();
+       // stopService(new Intent(this, StatsService.class));
+        if (mIsUpdatingStats) {
+            mIsUpdatingStats = false;
+            mSwipeToRefreshHelper.setRefreshing(false);
+        }
         super.onDestroy();
     }
 
@@ -610,14 +614,6 @@ public class StatsActivity extends ActionBarActivity
         }
 
         return true;
-    }
-
-    private void stopStatsService() {
-        stopService(new Intent(this, StatsService.class));
-        if (mIsUpdatingStats) {
-            mIsUpdatingStats = false;
-            mSwipeToRefreshHelper.setRefreshing(false);
-        }
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -61,8 +61,7 @@ import de.greenrobot.event.EventBus;
  */
 public class StatsActivity extends ActionBarActivity
         implements ScrollViewExt.ScrollViewListener,
-                StatsVisitorsAndViewsFragment.OnDateChangeListener,
-                StatsAbstractListFragment.OnRequestDataListener {
+                StatsVisitorsAndViewsFragment.OnDateChangeListener {
 
     private static final String SAVED_NAV_POSITION = "SAVED_NAV_POSITION";
     private static final String SAVED_WP_LOGIN_STATE = "SAVED_WP_LOGIN_STATE";
@@ -364,11 +363,6 @@ public class StatsActivity extends ActionBarActivity
         return false;
     }
 
-    @Override
-    public void onMoreDataRequested(StatsService.StatsEndpointsEnum endPointNeedUpdate, int pageNumber) {
-        // nope
-    }
-
     private void startWPComLoginActivity() {
         mResultCode = RESULT_CANCELED;
         Intent signInIntent = new Intent(this, SignInActivity.class);
@@ -609,6 +603,9 @@ public class StatsActivity extends ActionBarActivity
 
     @SuppressWarnings("unused")
     public void onEventMainThread(StatsEvents.UpdateStatusChanged event) {
+        if (isFinishing() || !mIsInFront) {
+            return;
+        }
         mSwipeToRefreshHelper.setRefreshing(event.mUpdating);
         mIsUpdatingStats = event.mUpdating;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
@@ -21,6 +21,7 @@ import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -123,7 +124,7 @@ public class StatsCommentsFragment extends StatsAbstractListFragment {
 
     private List<AuthorModel> getAuthors() {
         if (!hasAuthors()) {
-            return null;
+            return new ArrayList<AuthorModel>(0);
         }
         return ((CommentsModel) mDatamodels[0]).getAuthors();
     }
@@ -136,7 +137,7 @@ public class StatsCommentsFragment extends StatsAbstractListFragment {
 
     private List<PostModel> getPosts() {
         if (!hasPosts()) {
-            return null;
+            return new ArrayList<PostModel>(0);
         }
         return ((CommentsModel) mDatamodels[0]).getPosts();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsEvents.java
@@ -13,11 +13,19 @@ public class StatsEvents {
     }
     public static class SectionUpdated {
         public final StatsEndpointsEnum mEndPointName;
+        public final String mRequestBlogId;
+        public final StatsTimeframe mTimeframe;
+        public final String mDate;
+
         // TODO: replace Serializable by a POJO or use several event types (like SectionXUpdated, SectionYUpdated)
         public final Serializable mResponseObjectModel;
-        public SectionUpdated(StatsEndpointsEnum endPointName, Serializable responseObjectModel) {
+        public SectionUpdated(StatsEndpointsEnum endPointName, String blogId, StatsTimeframe timeframe, String date,
+                              Serializable responseObjectModel) {
             mEndPointName = endPointName;
             mResponseObjectModel = responseObjectModel;
+            mRequestBlogId = blogId;
+            mDate = date;
+            mTimeframe = timeframe;
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsEvents.java
@@ -28,4 +28,10 @@ public class StatsEvents {
             mTimeframe = timeframe;
         }
     }
+    public static class JetpackSettingsCompleted {
+        public final boolean isError;
+        public JetpackSettingsCompleted(boolean isError) {
+            this.isError = isError;
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
@@ -81,12 +81,12 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
             public void run() {
                 // Read all the dotcomBlog blogs and get the list of home URLs.
                 // This will be used later to check if the user is a member of followers blog marked as private.
-                List <Map<String, Object>> dotComUserBlogs = WordPress.wpDB.getBlogsBy("dotcomFlag=1",
+                List<Map<String, Object>> dotComUserBlogs = WordPress.wpDB.getBlogsBy("dotcomFlag=1",
                         new String[]{"homeURL"});
                 for (Map<String, Object> blog : dotComUserBlogs) {
                     if (blog != null && blog.get("homeURL") != null && blog.get("blogId") != null) {
                         String normURL = normalizeAndRemoveScheme(blog.get("homeURL").toString());
-                        Integer blogID = (Integer)blog.get("blogId");
+                        Integer blogID = (Integer) blog.get("blogId");
                         userBlogs.put(normURL, blogID);
                     }
                 }
@@ -157,9 +157,9 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
                             @Override
                             public void onClick(View v) {
                                 setNavigationButtonsEnabled(false);
-                                mMoreDataListener.onMoreDataRequested(
-                                        getSectionsToUpdate()[mTopPagerSelectedButtonIndex],
-                                        followersModel.getPage() - 1
+                                refreshStats(
+                                        followersModel.getPage() - 1,
+                                        new StatsService.StatsEndpointsEnum[]{getSectionsToUpdate()[mTopPagerSelectedButtonIndex]}
                                 );
                             }
                         };
@@ -177,9 +177,9 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
                             @Override
                             public void onClick(View v) {
                                 setNavigationButtonsEnabled(false);
-                                mMoreDataListener.onMoreDataRequested(
-                                        getSectionsToUpdate()[mTopPagerSelectedButtonIndex],
-                                        followersModel.getPage() + 1
+                                refreshStats(
+                                        followersModel.getPage() + 1,
+                                        new StatsService.StatsEndpointsEnum[]{getSectionsToUpdate()[mTopPagerSelectedButtonIndex]}
                                 );
                             }
                         };
@@ -188,7 +188,7 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
                     }
 
                     // Change the total number of followers label by adding the current paging info
-                    int startIndex = followersModel.getPage() * StatsViewAllActivity.MAX_RESULTS_PER_PAGE - StatsViewAllActivity.MAX_RESULTS_PER_PAGE + 1;
+                    int startIndex = followersModel.getPage() * StatsService.MAX_RESULTS_REQUESTED_PER_PAGE - StatsService.MAX_RESULTS_REQUESTED_PER_PAGE + 1;
                     int endIndex = startIndex + followersModel.getFollowers().size() - 1;
                     String pagedLabel  = getString(
                             mTopPagerSelectedButtonIndex == 0 ? R.string.stats_followers_total_wpcom_paged : R.string.stats_followers_total_email_paged,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
@@ -72,7 +72,7 @@ public class StatsGeoviewsFragment extends StatsAbstractListFragment {
                 String label = getResources().getString(getTotalsLabelResId());
 
                 // See: https://developers.google.com/chart/interactive/docs/gallery/geochart
-                StringBuilder htmlPage = new StringBuilder().append("<html>")
+                String htmlPage = new StringBuilder().append("<html>")
                         .append("<head>")
                         .append("<script type=\"text/javascript\" src=\"https://www.google.com/jsapi\"></script>")
                         .append("<script type=\"text/javascript\">")
@@ -93,7 +93,7 @@ public class StatsGeoviewsFragment extends StatsAbstractListFragment {
                         .append("<body>")
                         .append("<div id=\"regions_div\" style=\"width: 100%; height: 100%;\"></div>")
                         .append("</body>")
-                        .append("</html>");
+                        .append("</html>").toString();
 
 
                 WebView webView = new WebView(getActivity());
@@ -111,7 +111,7 @@ public class StatsGeoviewsFragment extends StatsAbstractListFragment {
                 webView.setWebViewClient(new MyWebViewClient()); // Hide map in case of unrecoverable errors
                 webView.getSettings().setJavaScriptEnabled(true);
                 webView.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
-                webView.loadData(htmlPage.toString(), "text/html", "UTF-8");
+                webView.loadData(htmlPage, "text/html", "UTF-8");
 
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsReferrersFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsReferrersFragment.java
@@ -51,7 +51,7 @@ public class StatsReferrersFragment extends StatsAbstractListFragment {
 
     private List<ReferrerGroupModel> getReferrersGroups() {
         if (!hasReferrers()) {
-            return null;
+            return new ArrayList<ReferrerGroupModel>(0);
         }
         return ((ReferrersModel) mDatamodels[0]).getGroups();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsTagsAndCategoriesFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsTagsAndCategoriesFragment.java
@@ -14,6 +14,7 @@ import org.wordpress.android.ui.stats.service.StatsService;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.FormatUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class StatsTagsAndCategoriesFragment extends StatsAbstractListFragment {
@@ -47,7 +48,7 @@ public class StatsTagsAndCategoriesFragment extends StatsAbstractListFragment {
 
     private List<TagsModel> getTags() {
         if (!hasTags()) {
-            return null;
+            return new ArrayList<TagsModel>(0);
         }
         return ((TagsContainerModel) mDatamodels[0]).getTags();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsTopPostsAndPagesFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsTopPostsAndPagesFragment.java
@@ -8,6 +8,7 @@ import org.wordpress.android.ui.stats.models.PostModel;
 import org.wordpress.android.ui.stats.models.TopPostsAndPagesModel;
 import org.wordpress.android.ui.stats.service.StatsService;
 
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -41,7 +42,7 @@ public class StatsTopPostsAndPagesFragment extends StatsAbstractListFragment {
 
     private List<PostModel> getTopPostsAndPages() {
         if (!hasTopPostsAndPages()) {
-            return null;
+            return new ArrayList<PostModel>(0);
         }
         return ((TopPostsAndPagesModel) mDatamodels[0]).getTopPostsAndPages();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVideoplaysFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVideoplaysFragment.java
@@ -12,6 +12,7 @@ import org.wordpress.android.ui.stats.models.VideoPlaysModel;
 import org.wordpress.android.ui.stats.service.StatsService;
 import org.wordpress.android.util.FormatUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -46,7 +47,7 @@ public class StatsVideoplaysFragment extends StatsAbstractListFragment {
 
     private List<SingleItemModel> getVideoplays() {
         if (!hasVideoplays()) {
-            return null;
+            return new ArrayList<SingleItemModel>(0);
         }
         return ((VideoPlaysModel) mDatamodels[0]).getPlays();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.stats;
 
-import android.app.Activity;
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
 import android.os.Bundle;
@@ -11,38 +10,25 @@ import android.view.View;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.android.volley.VolleyError;
-import com.wordpress.rest.RestRequest;
-
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.wordpress.android.R;
-import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
-import org.wordpress.android.networking.RestClientUtils;
-import org.wordpress.android.ui.stats.service.StatsService;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.NetworkUtils;
-import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 
 import java.io.Serializable;
-import java.lang.ref.WeakReference;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
 
 import de.greenrobot.event.EventBus;
 
 /**
  *  Single item details activity.
  */
-public class StatsViewAllActivity extends ActionBarActivity
-        implements StatsAbstractListFragment.OnRequestDataListener {
+public class StatsViewAllActivity extends ActionBarActivity {
 
     private boolean mIsInFront;
     private boolean mIsUpdatingStats;
@@ -56,13 +42,6 @@ public class StatsViewAllActivity extends ActionBarActivity
     private String mDate;
     private Serializable[] mRestResponse;
     private int mOuterPagerSelectedButtonIndex = 0;
-
-    // The number of results to return per page for Paged REST endpoints. Numbers larger than 20 will default to 20 on the server.
-    public static final int MAX_RESULTS_PER_PAGE = 20;
-
-    // The number of results to return for NON Paged REST endpoints.
-    private static final int MAX_RESULTS_REQUESTED = 100;
-
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -146,6 +125,27 @@ public class StatsViewAllActivity extends ActionBarActivity
             ft.replace(R.id.stats_single_view_fragment, mFragment, "ViewAll-Fragment");
             ft.commitAllowingStateLoss();
         }
+    }
+
+    @Override
+    protected void onStop() {
+        EventBus.getDefault().unregister(this);
+        super.onStop();
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        EventBus.getDefault().register(this);
+    }
+
+    @SuppressWarnings("unused")
+    public void onEventMainThread(StatsEvents.UpdateStatusChanged event) {
+        if (isFinishing() || !mIsInFront) {
+            return;
+        }
+        mSwipeToRefreshHelper.setRefreshing(event.mUpdating);
+        mIsUpdatingStats = event.mUpdating;
     }
 
     private String getDateForDisplayInLabels(String date, StatsTimeframe timeframe) {
@@ -243,6 +243,7 @@ public class StatsViewAllActivity extends ActionBarActivity
     protected void onResume() {
         super.onResume();
         mIsInFront = true;
+        NetworkUtils.checkConnection(this); // show the error toast if the nextwork is offline
     }
 
     @Override
@@ -264,182 +265,19 @@ public class StatsViewAllActivity extends ActionBarActivity
         }
     }
 
-    private String getRestPath(StatsService.StatsEndpointsEnum restEndpoint, int pageNumber) {
-        final String blogId = StatsUtils.getBlogId(mLocalBlogID);
-        String endpointPath = "";
-        switch (restEndpoint) {
-            case TOP_POSTS:
-                endpointPath = "top-posts";
-                break;
-            case REFERRERS:
-                endpointPath = "referrers";
-                break;
-            case CLICKS:
-                endpointPath = "clicks";
-                break;
-            case GEO_VIEWS:
-                endpointPath = "country-views";
-                break;
-            case AUTHORS:
-                endpointPath = "top-authors";
-                break;
-            case VIDEO_PLAYS:
-                endpointPath = "video-plays";
-                break;
-            case COMMENTS:
-                endpointPath = "comments";
-                break;
-            case TAGS_AND_CATEGORIES:
-                endpointPath = "tags";
-                break;
-            case PUBLICIZE:
-                endpointPath = "publicize";
-                break;
-            case SEARCH_TERMS:
-                endpointPath = "search-terms";
-                break;
-            case FOLLOWERS_WPCOM:
-                endpointPath = "followers";
-                return String.format("/sites/%s/stats/%s?type=wpcom&period=%s&date=%s&max=%s&page=%s", blogId, endpointPath,
-                        mTimeframe.getLabelForRestCall(), mDate, MAX_RESULTS_PER_PAGE, pageNumber);
-            case FOLLOWERS_EMAIL:
-                endpointPath = "followers";
-                return String.format("/sites/%s/stats/%s?type=email&period=%s&date=%s&max=%s&page=%s", blogId, endpointPath,
-                        mTimeframe.getLabelForRestCall(), mDate, MAX_RESULTS_PER_PAGE, pageNumber);
-            case COMMENT_FOLLOWERS:
-                endpointPath = "comment-followers";
-                return String.format("/sites/%s/stats/%s?period=%s&date=%s&max=%s&page=%s", blogId, endpointPath,
-                    mTimeframe.getLabelForRestCall(), mDate, MAX_RESULTS_PER_PAGE, 1);
-        }
-
-        // All other endpoints returns 100 items in details view
-        return String.format("/sites/%s/stats/%s?period=%s&date=%s&max=%s", blogId, endpointPath,
-                mTimeframe.getLabelForRestCall(), mDate, MAX_RESULTS_REQUESTED);
-    }
-
     private void refreshStats() {
         if (mIsUpdatingStats) {
             return;
         }
-
         if (!NetworkUtils.isNetworkAvailable(this)) {
             mSwipeToRefreshHelper.setRefreshing(false);
             AppLog.w(AppLog.T.STATS, "ViewAll on "+ mFragment.getTag() + " > no connection, update canceled");
             return;
         }
 
-        mSwipeToRefreshHelper.setRefreshing(true);
-        mIsUpdatingStats = true;
-        final RestClientUtils restClientUtils = WordPress.getRestClientUtilsV1_1();
-        final String blogId = StatsUtils.getBlogId(mLocalBlogID);
-        StatsService.StatsEndpointsEnum[] sections = mFragment.getSectionsToUpdate();
-        for (int i = 0; i < sections.length; i++) {
-            StatsService.StatsEndpointsEnum currentSection = sections[i];
-            String singlePostRestPath = getRestPath(currentSection, 1);
-            RestListener vListener = new RestListener(this, currentSection, blogId, mTimeframe);
-            restClientUtils.get(singlePostRestPath, vListener, vListener);
-            AppLog.d(AppLog.T.STATS, "Enqueuing the following Stats request " + singlePostRestPath);
-        }
-    }
-
-    @Override
-    public void onMoreDataRequested(StatsService.StatsEndpointsEnum endPointNeedUpdate, int pageNumber) {
-        if (mFragment == null) {
-            return;
+        if (mFragment != null) {
+            mFragment.refreshStats();
         }
 
-        if (!mFragment.isAdded()) {
-            return;
-        }
-
-        if (mIsUpdatingStats) {
-            AppLog.d(AppLog.T.STATS, "Already loading data");
-            return;
-        }
-
-        if (!NetworkUtils.isNetworkAvailable(this)) {
-            mSwipeToRefreshHelper.setRefreshing(false);
-            AppLog.w(AppLog.T.STATS, "ViewAll on "+ mFragment.getTag() + " > no connection, update canceled");
-            return;
-        }
-
-        mIsUpdatingStats = true;
-        mSwipeToRefreshHelper.setRefreshing(true);
-        final RestClientUtils restClientUtils = WordPress.getRestClientUtilsV1_1();
-        final String blogId = StatsUtils.getBlogId(mLocalBlogID);
-
-        String singlePostRestPath = getRestPath(endPointNeedUpdate, pageNumber);
-        RestListener vListener = new RestListener(this, endPointNeedUpdate, blogId, mTimeframe);
-        restClientUtils.get(singlePostRestPath, vListener, vListener);
-        AppLog.d(AppLog.T.STATS, "Enqueuing the following Stats request " + singlePostRestPath);
-    }
-
-    private class RestListener implements RestRequest.Listener, RestRequest.ErrorListener {
-        private final String mRequestBlogId;
-        private final StatsTimeframe mTimeframe;
-        private final StatsService.StatsEndpointsEnum mEndpointName;
-        private final WeakReference<Activity> mActivityRef;
-
-        public RestListener(Activity activity, StatsService.StatsEndpointsEnum endpointName, String blogId, StatsTimeframe timeframe) {
-                mActivityRef = new WeakReference<>(activity);
-                mRequestBlogId = blogId;
-                mTimeframe = timeframe;
-                mEndpointName = endpointName;
-        }
-
-        @Override
-        public void onResponse(final JSONObject response) {
-            if (mActivityRef.get() == null || mActivityRef.get().isFinishing()) {
-                return;
-            }
-            if (!mFragment.isAdded()) {
-                return;
-            }
-            mIsUpdatingStats = false;
-            mSwipeToRefreshHelper.setRefreshing(false);
-            // single background thread used to parse the response in BG.
-            ThreadPoolExecutor parseResponseExecutor = (ThreadPoolExecutor) Executors.newFixedThreadPool(1);
-            parseResponseExecutor.submit(new Thread() {
-                @Override
-                public void run() {
-                    if (response != null) {
-                        try {
-                            //AppLog.d(AppLog.T.STATS, response.toString());
-                            final Serializable resp = StatsUtils.parseResponse(mEndpointName, mRequestBlogId, response);
-                            EventBus.getDefault().post(new StatsEvents.SectionUpdated(mEndpointName,
-                                    mRequestBlogId, mTimeframe, mDate, resp));
-                        } catch (JSONException e) {
-                            AppLog.e(AppLog.T.STATS, e);
-                        }
-                    }
-                }
-            });
-        }
-
-        @Override
-        public void onErrorResponse(final VolleyError volleyError) {
-            AppLog.e(AppLog.T.STATS, "Error while reading Stats details!");
-            StatsUtils.logVolleyErrorDetails(volleyError);
-
-            if (mActivityRef.get() == null || mActivityRef.get().isFinishing()) {
-                return;
-            }
-            if (!mFragment.isAdded()) {
-                return;
-            }
-
-            resetModelVariables();
-            mFragment.showHideNoResultsUI(true);
-
-            ToastUtils.showToast(mActivityRef.get(),
-                    mActivityRef.get().getString(R.string.error_refresh_stats),
-                    ToastUtils.Duration.LONG);
-            mIsUpdatingStats = false;
-            mSwipeToRefreshHelper.setRefreshing(false);
-        }
-    }
-
-    private void resetModelVariables() {
-        mRestResponse = null;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
@@ -65,8 +65,15 @@ public class StatsViewAllActivity extends ActionBarActivity {
                     public void onRefreshStarted() {
                         if (!NetworkUtils.checkConnection(getBaseContext())) {
                             mSwipeToRefreshHelper.setRefreshing(false);
+                            mIsUpdatingStats = false;
                             return;
                         }
+
+                        if (mIsUpdatingStats) {
+                            AppLog.w(AppLog.T.STATS, "stats are already updating, refresh cancelled");
+                            return;
+                        }
+
                         refreshStats();
                     }
                 }
@@ -243,7 +250,7 @@ public class StatsViewAllActivity extends ActionBarActivity {
     protected void onResume() {
         super.onResume();
         mIsInFront = true;
-        NetworkUtils.checkConnection(this); // show the error toast if the nextwork is offline
+        NetworkUtils.checkConnection(this); // show the error toast if the network is offline
     }
 
     @Override
@@ -278,6 +285,5 @@ public class StatsViewAllActivity extends ActionBarActivity {
         if (mFragment != null) {
             mFragment.refreshStats();
         }
-
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
@@ -469,8 +469,8 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         }
         double largest = Integer.MIN_VALUE;
 
-        for (int i = 0; i < dataToShowOnGraph.length; i++) {
-            int currentItemValue = dataToShowOnGraph[i].getViews();
+        for (VisitModel aDataToShowOnGraph : dataToShowOnGraph) {
+            int currentItemValue = aDataToShowOnGraph.getViews();
             if (currentItemValue > largest) {
                 largest = currentItemValue;
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
@@ -299,7 +299,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
             updateUI();
         } else {
             setupNoResultsUI(true);
-            mMoreDataListener.onRefreshRequested(new StatsService.StatsEndpointsEnum[]{StatsService.StatsEndpointsEnum.VISITS});
+            refreshStats();
         }
     }
 
@@ -579,7 +579,6 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         return "";
     }
 
-
     /**
      * Return the date string that is displayed under each bar in the graph
      */
@@ -653,6 +652,18 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
     @SuppressWarnings("unused")
     public void onEventMainThread(StatsEvents.SectionUpdated event) {
         if (!isAdded()) {
+            return;
+        }
+
+        if (!getDate().equals(event.mDate)) {
+            return;
+        }
+
+        if (!event.mRequestBlogId.equals(StatsUtils.getBlogId(getLocalTableBlogID()))) {
+            return;
+        }
+
+        if (event.mTimeframe != getTimeframe()) {
             return;
         }
 
@@ -786,7 +797,9 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
     }
 
     @Override
-    protected void resetDataModel() {
-        mVisitsData = null;
+    protected StatsService.StatsEndpointsEnum[] getSectionsToUpdate() {
+        return new StatsService.StatsEndpointsEnum[]{
+                StatsService.StatsEndpointsEnum.VISITS
+        };
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/models/PostViewsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/models/PostViewsModel.java
@@ -9,6 +9,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -145,9 +146,9 @@ public class PostViewsModel implements Serializable {
             // Keys could not be ordered fine. Reordering them.
             String[] orderedKeys = orderKeys(yearsJSON.keys(), yearsJSON.length());
 
-            for (int j = 0; j < orderedKeys.length; j++) {
+            for (String orderedKey : orderedKeys) {
                 Year currentYear = new Year();
-                String currentYearKey = orderedKeys[j];
+                String currentYearKey = orderedKey;
                 currentYear.setLabel(currentYearKey);
 
                 JSONObject currentYearObj = yearsJSON.getJSONObject(currentYearKey);
@@ -163,7 +164,7 @@ public class PostViewsModel implements Serializable {
                     monthsList.add(new Month(currentMonthKey, currentMonthVisits));
                 }
 
-                Collections.sort(monthsList, new java.util.Comparator<Month>() {
+                Collections.sort(monthsList, new Comparator<Month>() {
                     public int compare(Month o1, Month o2) {
                         int v1 = Integer.parseInt(o1.getMonth());
                         int v2 = Integer.parseInt(o2.getMonth());

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -150,65 +150,54 @@ public class StatsService extends Service {
         EventBus.getDefault().post(new StatsEvents.UpdateStatusChanged(true));
 
         RestListener vListener = new RestListener(sectionToUpdate, blogId, timeframe, date);
-        String path = String.format("/sites/%s/stats/", blogId);
+
+        final String periodDateMaxPlaceholder =  "?period=%s&date=%s&max=%s";
+
+        String path = String.format("/sites/%s/stats/" + getRestEndpointPath(sectionToUpdate), blogId);
         synchronized (mStatsNetworkRequests) {
             switch (sectionToUpdate) {
                 case VISITS:
-                    path = String.format(path + "visits?unit=%s&quantity=10&date=%s", period, date);
+                    path = String.format(path + "?unit=%s&quantity=10&date=%s", period, date);
                     break;
                 case TOP_POSTS:
-                    path = String.format(path + "top-posts?period=%s&date=%s&max=%s", period, date, maxResultsRequested);
-                    break;
                 case REFERRERS:
-                    path = String.format(path + "referrers?period=%s&date=%s&max=%s", period, date, maxResultsRequested);
-                    break;
                 case CLICKS:
-                    path = String.format(path + "clicks?period=%s&date=%s&max=%s", period, date, maxResultsRequested);
-                    break;
                 case GEO_VIEWS:
-                    path = String.format(path + "country-views?period=%s&date=%s&max=%s", period, date, maxResultsRequested);
-                    break;
                 case AUTHORS:
-                    path = String.format(path + "top-authors?period=%s&date=%s&max=%s", period, date, maxResultsRequested);
-                    break;
                 case VIDEO_PLAYS:
-                    path = String.format(path + "video-plays?period=%s&date=%s&max=%s", period, date, maxResultsRequested);
+                case SEARCH_TERMS:
+                    path = String.format(path + periodDateMaxPlaceholder, period, date, maxResultsRequested);
+                    break;
+                case TAGS_AND_CATEGORIES:
+                case PUBLICIZE:
+                    path = String.format(path + "?max=%s", maxResultsRequested);
                     break;
                 case COMMENTS:
-                    path = path + "comments"; // No max parameter available
+                    // No parameters
                     break;
                 case FOLLOWERS_WPCOM:
-                    if (pageRequested == -1) {
-                        path = String.format(path + "followers?type=wpcom&max=%s", maxResultsRequested);
+                    if (pageRequested < 1) {
+                        path = String.format(path + "&max=%s", maxResultsRequested);
                     } else {
-                        path = String.format(path + "followers?type=wpcom&period=%s&date=%s&max=%s&page=%s",
-                                period, date, MAX_RESULTS_REQUESTED_PER_PAGE, pageRequested);
+                        path = String.format(path + "&period=%s&date=%s&max=%s&page=%s",
+                                period, date, maxResultsRequested, pageRequested);
                     }
                     break;
                 case FOLLOWERS_EMAIL:
-                    if (pageRequested == -1) {
-                        path = String.format(path + "followers?type=email&max=%s", maxResultsRequested);
+                    if (pageRequested < 1) {
+                        path = String.format(path + "&max=%s", maxResultsRequested);
                     } else {
-                        path = String.format(path + "followers?type=email&period=%s&date=%s&max=%s&page=%s",
-                                period, date, MAX_RESULTS_REQUESTED_PER_PAGE, pageRequested);
+                        path = String.format(path + "&period=%s&date=%s&max=%s&page=%s",
+                                period, date, maxResultsRequested, pageRequested);
                     }
                     break;
                 case COMMENT_FOLLOWERS:
-                    if (pageRequested == -1) {
-                        path = String.format(path + "comment-followers?max=%s", maxResultsRequested);
+                    if (pageRequested < 1) {
+                        path = String.format(path + "?max=%s", maxResultsRequested);
                     } else {
-                        path = String.format(path + "comment-followers?period=%s&date=%s&max=%s&page=%s", period,
-                                date, MAX_RESULTS_REQUESTED_PER_PAGE, pageRequested);
+                        path = String.format(path + "?period=%s&date=%s&max=%s&page=%s", period,
+                                date, maxResultsRequested, pageRequested);
                     }
-                    break;
-                case TAGS_AND_CATEGORIES:
-                    path = String.format(path + "tags?max=%s", maxResultsRequested);
-                    break;
-                case PUBLICIZE:
-                    path = String.format(path + "publicize?max=%s", maxResultsRequested);
-                    break;
-                case SEARCH_TERMS:
-                    path = String.format(path + "search-terms?period=%s&date=%s&max=%s", period, date, maxResultsRequested);
                     break;
                 default:
                     AppLog.i(T.STATS, "Called an update of Stats of unknown section!?? " + sectionToUpdate.name());
@@ -224,6 +213,43 @@ public class StatsService extends Service {
             } else {
                 AppLog.d(AppLog.T.STATS, "Stats request is already there:" + path);
             }
+        }
+    }
+
+
+    private String getRestEndpointPath(final StatsEndpointsEnum sectionToUpdate) {
+        switch (sectionToUpdate) {
+            case VISITS:
+                return "visits";
+            case TOP_POSTS:
+                return "top-posts";
+            case REFERRERS:
+                return "referrers";
+            case CLICKS:
+                return "clicks";
+            case GEO_VIEWS:
+                return "country-views";
+            case AUTHORS:
+                return "top-authors";
+            case VIDEO_PLAYS:
+                return "video-plays";
+            case COMMENTS:
+                return "comments";
+            case FOLLOWERS_WPCOM:
+               return "followers?type=wpcom";
+            case FOLLOWERS_EMAIL:
+                return "followers?type=email";
+            case COMMENT_FOLLOWERS:
+               return "comment-followers";
+            case TAGS_AND_CATEGORIES:
+                return "tags";
+            case PUBLICIZE:
+                return "publicize";
+            case SEARCH_TERMS:
+                return "search-terms";
+            default:
+                AppLog.i(T.STATS, "Called an update of Stats of unknown section!?? " + sectionToUpdate.name());
+                return "";
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -211,7 +211,7 @@ public class StatsService extends Service {
                 currentRequest.setTag("StatsCall");
                 mStatsNetworkRequests.add(currentRequest);
             } else {
-                AppLog.d(AppLog.T.STATS, "Stats request is already there:" + path);
+                AppLog.d(AppLog.T.STATS, "Stats request is already in the queue:" + path);
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -174,7 +174,7 @@ public class StatsService extends Service {
                     path = String.format(path + "video-plays?period=%s&date=%s&max=%s", period, date, maxResultsRequested);
                     break;
                 case COMMENTS:
-                    path = String.format(path + "comments"); // No max parameter available
+                    path = path + "comments"; // No max parameter available
                     break;
                 case FOLLOWERS_WPCOM:
                     if (pageRequested == -1) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -289,9 +289,8 @@ public class StatsService extends Service {
                     it.remove();
                 }
             }
-            if (mStatsNetworkRequests.size() == 0) {
-                EventBus.getDefault().post(new StatsEvents.UpdateStatusChanged(false));
-            }
+            boolean isStillWorking = mStatsNetworkRequests.size() > 0 ;
+            EventBus.getDefault().post(new StatsEvents.UpdateStatusChanged(isStillWorking));
         }
     }
 }

--- a/WordPress/src/main/java/org/xmlrpc/android/ApiHelper.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/ApiHelper.java
@@ -188,7 +188,7 @@ public class ApiHelper {
         private GenericCallback mCallback;
 
         public RefreshBlogContentTask(Blog blog, GenericCallback callback) {
-            if ( blog == null) {
+            if (blog == null) {
                 cancel(true);
                 return;
             }


### PR DESCRIPTION
May I get a code pre-review of this upcoming PR that basically fixes #2561, and gives us the capability of introduce single stats fragments everywhere in the app?

- All of the network interactions are now handled in the Stats Service.
- Stats service was simplified a lot and reduced to minimum terms. Don't know why we had that complex service till now.
- The Stats service can now handle multiple blogs, and stats at the same time. This gives us the ability of composing different type of stats screen. EX: an overview stats screen for all of the blogs of the users.
- Each Stats fragment basically calls the service, and ask to load the data for a particular blog_id/stats_type and other optional parameters.
- StatsActivity (the main activity) now correctly handles the Jetpack installation, and also checks if the network is available and shows/dismisses the loading indicator correctly.
- StatsActivity was cleaned a bit, and removed all of that code that handled concurrency of fragment refresh.
- StatsViewAll was simplified, and removed much of the redundant code