### PR TITLE
Tag Name Capitlization

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -68,7 +68,7 @@ public class ReaderActivityLauncher {
         Intent intent = new Intent(context, ReaderPostPagerActivity.class);
         intent.putExtra(ReaderConstants.ARG_POST_LIST_TYPE, postListType);
         intent.putExtra(ReaderConstants.ARG_TAG, tag);
-        intent.putExtra(ReaderConstants.ARG_TITLE, tag.getTagName());
+        intent.putExtra(ReaderConstants.ARG_TITLE, tag.getCapitalizedTagName());
         intent.putExtra(ReaderConstants.ARG_BLOG_ID, blogId);
         intent.putExtra(ReaderConstants.ARG_POST_ID, postId);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -352,8 +352,6 @@ public class ReaderSubsActivity extends ActionBarActivity
         ReaderTag tag = new ReaderTag(tagName, ReaderTagType.FOLLOWED);
 
         if (ReaderTagActions.performTagAction(tag, TagAction.ADD, actionListener)) {
-            showInfoToast(getString(R.string.reader_label_added_tag, tagName));
-            getPageAdapter().refreshTagFragments();
             onTagAction(tag, TagAction.ADD);
         }
     }
@@ -456,7 +454,7 @@ public class ReaderSubsActivity extends ActionBarActivity
                 mLastAddedTagName = tag.getTagName();
                 // user added from recommended tags, make sure addition is reflected on followed tags
                 getPageAdapter().refreshTagFragments(ReaderTagType.FOLLOWED);
-                showInfoToast(getString(R.string.reader_label_added_tag, tag.getTagName()));
+                showInfoToast(getString(R.string.reader_label_added_tag, tag.getCapitalizedTagName()));
                 break;
 
             case DELETE:
@@ -466,7 +464,7 @@ public class ReaderSubsActivity extends ActionBarActivity
                 }
                 // user deleted from followed tags, make sure deletion is reflected on recommended tags
                 getPageAdapter().refreshTagFragments(ReaderTagType.RECOMMENDED);
-                showInfoToast(getString(R.string.reader_label_removed_tag, tag.getTagName()));
+                showInfoToast(getString(R.string.reader_label_removed_tag, tag.getCapitalizedTagName()));
                 break;
         }
     }


### PR DESCRIPTION
I noticed the tag names (which are normally capitalized) weren't being capitalized in two places: the add/delete toast messages and the navbar when viewing posts from the tag feed. Also there were two identical toast message being shown when adding tags, so I removed one of them.

Before pictures:
<img src="https://cloud.githubusercontent.com/assets/5845439/7340797/4acaed08-ec63-11e4-8c23-93c3a03c3d82.png" width="300">
<img src="https://cloud.githubusercontent.com/assets/5845439/7340798/4ad3b528-ec63-11e4-88e1-dcfc211e6754.png" width="300">
