### PR TITLE
Bringing back the menu options for adding media in the post editor.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
@@ -60,7 +60,7 @@ public class WordPressMediaUtils {
 
         AppLockManager.getInstance().setExtendedTimeout();
         activity.startActivityForResult(Intent.createChooser(intent, activity.getString(R.string.pick_video)),
-                RequestCode.ACTIVITY_REQUEST_CODE_PICTURE_LIBRARY);
+                RequestCode.ACTIVITY_REQUEST_CODE_VIDEO_LIBRARY);
     }
 
     public static void launchVideoCamera(Activity activity) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -322,6 +322,7 @@
     <string name="select_photo">Select a photo from gallery</string>
     <string name="select_video">Select a video from gallery</string>
     <string name="select_from_media_library">Select from media library</string>
+    <string name="select_from_new_picker">Multi-select with the new picker</string>
 
     <!-- category management -->
     <string name="categories">Categories</string>


### PR DESCRIPTION
Added an option for the new media picker.

@maxme, I've tested each option, cancelled selection in each option as well. All working well except record video ends up adding a WPImageSpan to the post instead of the video icon.