### PR TITLE
Issue/masterbar me sizing fixes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -12,6 +12,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewOutlineProvider;
+import android.widget.TextView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -20,14 +21,13 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.util.AccountHelper;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
-import org.wordpress.android.widgets.WPTextView;
 
 public class MeFragment extends Fragment {
 
     private WPNetworkImageView mAvatarImageView;
-    private WPTextView mDisplayNameTextView;
-    private WPTextView mUsernameTextView;
-    private WPTextView mLoginLogoutTextView;
+    private TextView mDisplayNameTextView;
+    private TextView mUsernameTextView;
+    private TextView mLoginLogoutTextView;
 
     public static MeFragment newInstance() {
         return new MeFragment();
@@ -38,10 +38,10 @@ public class MeFragment extends Fragment {
                              Bundle savedInstanceState) {
         final ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.fragment_me, container, false);
         mAvatarImageView = (WPNetworkImageView) rootView.findViewById(R.id.me_avatar);
-        mDisplayNameTextView = (WPTextView) rootView.findViewById(R.id.me_display_name);
-        mUsernameTextView = (WPTextView) rootView.findViewById(R.id.me_username);
+        mDisplayNameTextView = (TextView) rootView.findViewById(R.id.me_display_name);
+        mUsernameTextView = (TextView) rootView.findViewById(R.id.me_username);
 
-        WPTextView settingsTextView = (WPTextView) rootView.findViewById(R.id.me_settings_text_view);
+        TextView settingsTextView = (TextView) rootView.findViewById(R.id.me_settings_text_view);
         settingsTextView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -49,7 +49,7 @@ public class MeFragment extends Fragment {
             }
         });
 
-        WPTextView supportTextView = (WPTextView) rootView.findViewById(R.id.me_support_text_view);
+        TextView supportTextView = (TextView) rootView.findViewById(R.id.me_support_text_view);
         supportTextView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -57,7 +57,7 @@ public class MeFragment extends Fragment {
             }
         });
 
-        mLoginLogoutTextView = (WPTextView) rootView.findViewById(R.id.me_login_logout_text_view);
+        mLoginLogoutTextView = (TextView) rootView.findViewById(R.id.me_login_logout_text_view);
 
         addDropShadow(rootView.findViewById(R.id.frame_avatar));
         refreshAccountDetails();

--- a/WordPress/src/main/res/layout/fragment_me.xml
+++ b/WordPress/src/main/res/layout/fragment_me.xml
@@ -77,7 +77,7 @@
                 android:contentDescription="@string/me_btn_support"
                 android:src="@drawable/me_icon_support" />
 
-            <org.wordpress.android.widgets.WPTextView
+            <org.wordpress.android.widgets.WPAutoResizeTextView
                 android:id="@+id/me_support_text_view"
                 style="@style/MeListRowTextView"
                 android:text="@string/me_btn_support" />
@@ -92,7 +92,7 @@
                 android:contentDescription="@string/me_btn_login_logout"
                 android:src="@drawable/me_icon_login_logout" />
 
-            <org.wordpress.android.widgets.WPTextView
+            <org.wordpress.android.widgets.WPAutoResizeTextView
                 android:id="@+id/me_login_logout_text_view"
                 style="@style/MeListRowTextView"
                 tools:text="@string/me_btn_login_logout" />

--- a/WordPress/src/main/res/layout/fragment_me.xml
+++ b/WordPress/src/main/res/layout/fragment_me.xml
@@ -1,97 +1,103 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/scroll_view"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingLeft="@dimen/content_margin"
-    android:paddingRight="@dimen/content_margin"
-    android:orientation="vertical">
-
-    <FrameLayout
-        android:id="@+id/frame_avatar"
-        android:layout_width="@dimen/avatar_sz_large"
-        android:layout_height="@dimen/avatar_sz_large"
-        android:layout_marginTop="@dimen/me_avatar_margin_top"
-        android:layout_gravity="center_horizontal">
-
-        <org.wordpress.android.widgets.WPNetworkImageView
-            android:id="@+id/me_avatar"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" />
-
-    </FrameLayout>
-
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/me_display_name"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="@dimen/margin_large"
-        android:ellipsize="end"
-        android:maxLines="1"
-        android:textColor="@color/grey_dark"
-        android:textSize="@dimen/text_sz_large"
-        android:textStyle="bold"
-        app:fontVariation="light"
-        tools:text="Full Name" />
-
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/me_username"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:ellipsize="end"
-        android:maxLines="1"
-        android:textColor="@color/grey"
-        android:textSize="@dimen/text_sz_medium"
-        tools:text="username" />
+    android:layout_height="wrap_content">
 
     <LinearLayout
-        android:layout_marginTop="@dimen/me_list_margin_top"
-        style="@style/MeListRowLayout">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingLeft="@dimen/content_margin"
+        android:paddingRight="@dimen/content_margin">
 
-        <ImageView
-            style="@style/MeListRowIcon"
-            android:id="@+id/me_settings_icon"
-            android:contentDescription="@string/me_btn_settings"
-            android:src="@drawable/me_icon_settings" />
+        <FrameLayout
+            android:id="@+id/frame_avatar"
+            android:layout_width="@dimen/avatar_sz_large"
+            android:layout_height="@dimen/avatar_sz_large"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/me_avatar_margin_top">
 
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/me_settings_text_view"
-            style="@style/MeListRowTextView"
-            android:text="@string/me_btn_settings" />
+            <org.wordpress.android.widgets.WPNetworkImageView
+                android:id="@+id/me_avatar"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
 
-    </LinearLayout>
-
-    <LinearLayout style="@style/MeListRowLayout">
-
-        <ImageView
-            android:id="@+id/me_support_icon"
-            style="@style/MeListRowIcon"
-            android:contentDescription="@string/me_btn_support"
-            android:src="@drawable/me_icon_support" />
+        </FrameLayout>
 
         <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/me_support_text_view"
-            style="@style/MeListRowTextView"
-            android:text="@string/me_btn_support" />
-
-    </LinearLayout>
-
-    <LinearLayout style="@style/MeListRowLayout">
-
-        <ImageView
-            android:id="@+id/me_login_logout_icon"
-            style="@style/MeListRowIcon"
-            android:contentDescription="@string/me_btn_login_logout"
-            android:src="@drawable/me_icon_login_logout" />
+            android:id="@+id/me_display_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/margin_large"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@color/grey_dark"
+            android:textSize="@dimen/text_sz_large"
+            android:textStyle="bold"
+            app:fontVariation="light"
+            tools:text="Full Name" />
 
         <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/me_login_logout_text_view"
-            style="@style/MeListRowTextView"
-            tools:text="@string/me_btn_login_logout" />
+            android:id="@+id/me_username"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@color/grey"
+            android:textSize="@dimen/text_sz_medium"
+            tools:text="username" />
+
+        <LinearLayout
+            style="@style/MeListRowLayout"
+            android:layout_marginTop="@dimen/me_list_margin_top">
+
+            <ImageView
+                android:id="@+id/me_settings_icon"
+                style="@style/MeListRowIcon"
+                android:contentDescription="@string/me_btn_settings"
+                android:src="@drawable/me_icon_settings" />
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/me_settings_text_view"
+                style="@style/MeListRowTextView"
+                android:text="@string/me_btn_settings" />
+
+        </LinearLayout>
+
+        <LinearLayout style="@style/MeListRowLayout">
+
+            <ImageView
+                android:id="@+id/me_support_icon"
+                style="@style/MeListRowIcon"
+                android:contentDescription="@string/me_btn_support"
+                android:src="@drawable/me_icon_support" />
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/me_support_text_view"
+                style="@style/MeListRowTextView"
+                android:text="@string/me_btn_support" />
+
+        </LinearLayout>
+
+        <LinearLayout style="@style/MeListRowLayout">
+
+            <ImageView
+                android:id="@+id/me_login_logout_icon"
+                style="@style/MeListRowIcon"
+                android:contentDescription="@string/me_btn_login_logout"
+                android:src="@drawable/me_icon_login_logout" />
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/me_login_logout_text_view"
+                style="@style/MeListRowTextView"
+                tools:text="@string/me_btn_login_logout" />
+
+        </LinearLayout>
 
     </LinearLayout>
-
-</LinearLayout>
+</ScrollView>


### PR DESCRIPTION
Two fixes for the masterbar "Me" page to accommodate smaller displays:

1. Wraps the layout in a ScrollView to enable scrolling the page when cut off (happens when in landscape)
2. #2593 Changes the "Disconnect" label to use a `WPAutoResizeTextView` so it resizes rather than gets cropped ([example](https://cloudup.com/cIoCouMrtnY)).
