### PR TITLE
Issue/2501 return to editor crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSourceWPImages.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSourceWPImages.java
@@ -177,14 +177,12 @@ public class MediaSourceWPImages implements MediaSource {
     }
 
     private void removeDeletedEntries() {
-        List<MediaItem> existingItems = new ArrayList<>(mMediaItems);
+        final List<MediaItem> existingItems = new ArrayList<>(mMediaItems);
 
-        for (MediaItem mediaItem : existingItems) {
-            final boolean callLoaded = existingItems.indexOf(mediaItem) == existingItems.size() - 1;
-
+        for (final MediaItem mediaItem : existingItems) {
             LimitedBackgroundOperation<MediaItem, Void, MediaItem> backgroundCheck =
                     new LimitedBackgroundOperation<MediaItem, Void, MediaItem>() {
-                int responseCode;
+                private int responseCode;
 
                 @Override
                 protected MediaItem performBackgroundOperation(MediaItem[] params) {
@@ -212,10 +210,13 @@ public class MediaSourceWPImages implements MediaSource {
                         resultList.add(result);
                         if (responseCode == 200) {
                             mVerifiedItems.add(result);
-                            mListener.onMediaAdded(MediaSourceWPImages.this, resultList);
+
+                            if ((existingItems.size() - mVerifiedItems.size()) % 3 == 0) {
+                                mListener.onMediaAdded(MediaSourceWPImages.this, resultList);
+                            }
                         }
 
-                        if (callLoaded) {
+                        if (existingItems.indexOf(mediaItem) == existingItems.size() - 1) {
                             mListener.onMediaLoaded(true);
                         }
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -137,7 +137,6 @@ public class EditPostActivity extends ActionBarActivity implements EditorFragmen
     private EditPostPreviewFragment mEditPostPreviewFragment;
 
     private boolean mIsNewPost;
-
     private boolean mHasSetPostContent;
 
     @Override
@@ -546,7 +545,7 @@ public class EditPostActivity extends ActionBarActivity implements EditorFragmen
             // getItem is called to instantiate the fragment for the given page.
             switch (position) {
                 case 0:
-                    // TODO: switch between legacy and new editor here (AB mHasSetPostContent?)
+                    // TODO: switch between legacy and new editor here (AB test?)
                     return new LegacyEditorFragment();
                 case 1:
                     return new EditPostSettingsFragment();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -26,7 +26,6 @@ import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.style.CharacterStyle;
 import android.text.style.SuggestionSpan;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -96,6 +95,7 @@ public class EditPostActivity extends ActionBarActivity implements EditorFragmen
     public static final String EXTRA_QUICKPRESS_BLOG_ID = "quickPressBlogId";
     public static final String STATE_KEY_CURRENT_POST = "stateKeyCurrentPost";
     public static final String STATE_KEY_ORIGINAL_POST = "stateKeyOriginalPost";
+    public static final String STATE_KEY_EDITOR_FRAGMENT = "editorFragment";
 
     private static final String ANALYTIC_PROP_NUM_LOCAL_PHOTOS_ADDED = "number_of_local_photos_added";
     private static final String ANALYTIC_PROP_NUM_WP_PHOTOS_ADDED = "number_of_wp_library_photos_added";
@@ -201,7 +201,7 @@ public class EditPostActivity extends ActionBarActivity implements EditorFragmen
                     mPost = null;
                 }
             }
-            mEditorFragment = (EditorFragmentAbstract) fragmentManager.getFragment(savedInstanceState, "test-fragment");
+            mEditorFragment = (EditorFragmentAbstract) fragmentManager.getFragment(savedInstanceState, STATE_KEY_EDITOR_FRAGMENT);
         }
         test = mEditorFragment == null;
 
@@ -309,7 +309,7 @@ public class EditPostActivity extends ActionBarActivity implements EditorFragmen
         outState.putSerializable(STATE_KEY_CURRENT_POST, mPost);
         outState.putSerializable(STATE_KEY_ORIGINAL_POST, mOriginalPost);
 
-        getFragmentManager().putFragment(outState, "test-fragment", mEditorFragment);
+        getFragmentManager().putFragment(outState, STATE_KEY_EDITOR_FRAGMENT, mEditorFragment);
     }
 
     @Override
@@ -684,7 +684,6 @@ public class EditPostActivity extends ActionBarActivity implements EditorFragmen
         @Override
         protected void onPostExecute(Spanned spanned) {
             if (spanned != null) {
-                Log.e("", "xyz LoadPostContentTask#onPostExecute(spanned=" + spanned + ")");
                 mEditorFragment.setContent(spanned);
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -138,7 +138,7 @@ public class EditPostActivity extends ActionBarActivity implements EditorFragmen
 
     private boolean mIsNewPost;
 
-    private boolean test;
+    private boolean mHasSetPostContent;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -203,9 +203,8 @@ public class EditPostActivity extends ActionBarActivity implements EditorFragmen
             }
             mEditorFragment = (EditorFragmentAbstract) fragmentManager.getFragment(savedInstanceState, STATE_KEY_EDITOR_FRAGMENT);
         }
-        test = mEditorFragment == null;
 
-        if (!test) {
+        if (mHasSetPostContent = mEditorFragment != null) {
             mEditorFragment.setImageLoader(WordPress.imageLoader);
         }
 
@@ -547,7 +546,7 @@ public class EditPostActivity extends ActionBarActivity implements EditorFragmen
             // getItem is called to instantiate the fragment for the given page.
             switch (position) {
                 case 0:
-                    // TODO: switch between legacy and new editor here (AB test?)
+                    // TODO: switch between legacy and new editor here (AB mHasSetPostContent?)
                     return new LegacyEditorFragment();
                 case 1:
                     return new EditPostSettingsFragment();
@@ -707,8 +706,8 @@ public class EditPostActivity extends ActionBarActivity implements EditorFragmen
         // Set post title and content
         Post post = getPost();
         if (post != null) {
-            if (!TextUtils.isEmpty(post.getContent()) && test) {
-                test = false;
+            if (!TextUtils.isEmpty(post.getContent()) && !mHasSetPostContent) {
+                mHasSetPostContent = true;
                 if (post.isLocalDraft()) {
                     // Load local post content in the background, as it may take time to generate images
                     new LoadPostContentTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -2,6 +2,7 @@ package org.wordpress.android.editor;
 
 import android.app.Activity;
 import android.app.Fragment;
+import android.os.Bundle;
 import android.text.Spanned;
 
 import com.android.volley.toolbox.ImageLoader;
@@ -20,9 +21,13 @@ public abstract class EditorFragmentAbstract extends Fragment {
     // TODO: remove this as soon as we can (we'll need to drop the legacy editor or fix html2spanned translation)
     public abstract Spanned getSpannedContent();
 
+    private static final String FEATURED_IMAGE_SUPPORT_KEY = "featured-image-supported";
+    private static final String FEATURED_IMAGE_WIDTH_KEY   = "featured-image-width";
+
     protected EditorFragmentListener mEditorFragmentListener;
     protected boolean mFeaturedImageSupported;
     protected String mBlogSettingMaxImageWidth;
+    protected ImageLoader mImageLoader;
 
     @Override
     public void onAttach(Activity activity) {
@@ -32,6 +37,32 @@ public abstract class EditorFragmentAbstract extends Fragment {
         } catch (ClassCastException e) {
             throw new ClassCastException(activity.toString() + " must implement EditorFragmentListener");
         }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        outState.putBoolean(FEATURED_IMAGE_SUPPORT_KEY, mFeaturedImageSupported);
+        outState.putString(FEATURED_IMAGE_WIDTH_KEY, mBlogSettingMaxImageWidth);
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (savedInstanceState != null) {
+            if (savedInstanceState.containsKey(FEATURED_IMAGE_SUPPORT_KEY)) {
+                mFeaturedImageSupported = savedInstanceState.getBoolean(FEATURED_IMAGE_SUPPORT_KEY);
+            }
+            if (savedInstanceState.containsKey(FEATURED_IMAGE_WIDTH_KEY)) {
+                mBlogSettingMaxImageWidth = savedInstanceState.getString(FEATURED_IMAGE_WIDTH_KEY);
+            }
+        }
+    }
+
+    public void setImageLoader(ImageLoader imageLoader) {
+        mImageLoader = imageLoader;
     }
 
     public void setFeaturedImageSupported(boolean featuredImageSupported) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
@@ -227,18 +227,19 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
         moreButton.setOnClickListener(mFormatBarButtonClickListener);
         mEditorFragmentListener.onEditorFragmentInitialized();
 
-        Parcelable[] spans = null;
         if (savedInstanceState != null) {
-            spans = savedInstanceState.getParcelableArray(KEY_IMAGE_SPANS);
+            Parcelable[] spans = savedInstanceState.getParcelableArray(KEY_IMAGE_SPANS);
 
-            mContent = savedInstanceState.getString(KEY_CONTENT);
+            mContent = savedInstanceState.getString(KEY_CONTENT, "");
             mContentEditText.setText(mContent);
-            mContentEditText.setSelection(savedInstanceState.getInt(KEY_START), savedInstanceState.getInt(KEY_END));
+            mContentEditText.setSelection(savedInstanceState.getInt(KEY_START, 0),
+                                          savedInstanceState.getInt(KEY_END, 0));
 
             if (spans != null && spans.length > 0) {
                 for (Parcelable s : spans) {
                     WPImageSpan editSpan = (WPImageSpan)s;
-                    addMediaFile(editSpan.getMediaFile(), editSpan.getMediaFile().getFilePath(), mImageLoader, editSpan.getStartPosition(), editSpan.getEndPosition());
+                    addMediaFile(editSpan.getMediaFile(), editSpan.getMediaFile().getFilePath(),
+                            mImageLoader, editSpan.getStartPosition(), editSpan.getEndPosition());
                 }
             }
         }
@@ -1060,7 +1061,7 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
                 s.insert(selectionEnd + 1, "\n\n");
 
                 // Fetch and replace the WPImageSpan if it's a remote media
-                if (imageLoader != null) {
+                if (imageLoader != null && URLUtil.isNetworkUrl(imageUrl)) {
                     loadWPImageSpanThumbnail(mediaFile, imageUrl, imageLoader);
                 }
             }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
@@ -10,6 +10,8 @@ import android.graphics.BitmapFactory;
 import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.Parcelable;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBarActivity;
@@ -26,7 +28,6 @@ import android.text.style.QuoteSpan;
 import android.text.style.StrikethroughSpan;
 import android.text.style.StyleSpan;
 import android.text.style.URLSpan;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -68,8 +69,6 @@ import org.wordpress.android.util.helpers.WPImageSpan;
 import org.wordpress.android.util.helpers.WPUnderlineSpan;
 import org.wordpress.android.util.widgets.WPEditText;
 
-import java.util.ArrayList;
-
 public class LegacyEditorFragment extends EditorFragmentAbstract implements TextWatcher,
         WPEditText.OnSelectionChangedListener, View.OnTouchListener {
     public static final int ACTIVITY_REQUEST_CODE_CREATE_LINK = 4;
@@ -78,6 +77,10 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
 
     private static final int MIN_THUMBNAIL_WIDTH = 200;
     private static final int CONTENT_ANIMATION_DURATION = 250;
+    private static final String KEY_IMAGE_SPANS = "image-spans";
+    private static final String KEY_START = "start";
+    private static final String KEY_END = "end";
+    private static final String KEY_CONTENT = "content";
     private static final String TAG_FORMAT_BAR_BUTTON_STRONG = "strong";
     private static final String TAG_FORMAT_BAR_BUTTON_EM = "em";
     private static final String TAG_FORMAT_BAR_BUTTON_UNDERLINE = "u";
@@ -142,7 +145,6 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
     @Override
     public void setContent(CharSequence text) {
         mContent = text;
-        Log.e("", "xyz setContent(text=" + text + ")");
         if (mContentEditText != null) {
             mContentEditText.setText(text);
             mContentEditText.setSelection(mSelectionStart, mSelectionEnd);
@@ -180,31 +182,6 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
                 return false;
             }
         });
-        mContentEditText = (WPEditText) rootView.findViewById(R.id.post_content);
-
-        Parcelable[] spans = null;
-        if (savedInstanceState != null) {
-            spans = savedInstanceState.getParcelableArray("image-spans");
-
-            mContent = savedInstanceState.getString("content");
-            mContentEditText.setText(mContent);
-            mContentEditText.setSelection(savedInstanceState.getInt("start"), savedInstanceState.getInt("end"));
-
-            if (spans != null && spans.length > 0) {
-                Log.e("", "xyz onCreateView(mContent=" + mContent + ", start;end=" + mContentEditText.getSelectionStart() + ";" + mContentEditText.getSelectionEnd() + "), spans=" + spans.length);
-                for (Parcelable s : spans) {
-                    WPImageSpan editSpan = (WPImageSpan)s;
-                    addMediaFile(editSpan.getMediaFile(), editSpan.getMediaFile().getFilePath(), mImageLoader, editSpan.getStartPosition(), editSpan.getEndPosition());
-//                    Log.e("", "xyz start;end=" + editSpan.getStartPosition() + ";" + editSpan.getEndPosition() + ")");
-//                    WPImageSpan newSpan = createWPEditImageSpan(getActivity(), editSpan.getMediaFile());
-//                    newSpan.setMediaFile(editSpan.getMediaFile());
-//                    newSpan.setPosition(editSpan.getStartPosition(), editSpan.getEndPosition());
-//                    Editable editable = mContentEditText.getText();
-//                    editable.insert(newSpan.getEndPosition(), " ");
-//                    mContentEditText.getText().setSpan(newSpan, newSpan.getStartPosition(), newSpan.getEndPosition() + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
-                }
-            }
-        }
 
         mPostContentLinearLayout = (LinearLayout) rootView.findViewById(R.id.post_content_wrapper);
         mPostSettingsLinearLayout = (LinearLayout) rootView.findViewById(R.id.post_settings_wrapper);
@@ -225,6 +202,7 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
         Button moreButton = (Button) rootView.findViewById(R.id.more);
 
         registerForContextMenu(mAddPictureButton);
+        mContentEditText = (WPEditText) rootView.findViewById(R.id.post_content);
         mContentEditText.setOnSelectionChangedListener(this);
         mContentEditText.setOnTouchListener(this);
         mContentEditText.addTextChangedListener(this);
@@ -248,6 +226,23 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
         mBquoteToggleButton.setOnClickListener(mFormatBarButtonClickListener);
         moreButton.setOnClickListener(mFormatBarButtonClickListener);
         mEditorFragmentListener.onEditorFragmentInitialized();
+
+        Parcelable[] spans = null;
+        if (savedInstanceState != null) {
+            spans = savedInstanceState.getParcelableArray(KEY_IMAGE_SPANS);
+
+            mContent = savedInstanceState.getString(KEY_CONTENT);
+            mContentEditText.setText(mContent);
+            mContentEditText.setSelection(savedInstanceState.getInt(KEY_START), savedInstanceState.getInt(KEY_END));
+
+            if (spans != null && spans.length > 0) {
+                for (Parcelable s : spans) {
+                    WPImageSpan editSpan = (WPImageSpan)s;
+                    addMediaFile(editSpan.getMediaFile(), editSpan.getMediaFile().getFilePath(), mImageLoader, editSpan.getStartPosition(), editSpan.getEndPosition());
+                }
+            }
+        }
+
         return rootView;
     }
 
@@ -1003,22 +998,23 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
         WPImageSpan[] spans = mContentEditText.getText().getSpans(0, mContentEditText.getText().length(), WPEditImageSpan.class);
 
         if (spans != null && spans.length > 0) {
-            outState.putParcelableArray("image-spans", spans);
+            outState.putParcelableArray(KEY_IMAGE_SPANS, spans);
         }
 
-        outState.putInt("start", mContentEditText.getSelectionStart());
-        outState.putInt("end", mContentEditText.getSelectionEnd());
-        outState.putString("content", mContentEditText.getText().toString());
+        outState.putInt(KEY_START, mContentEditText.getSelectionStart());
+        outState.putInt(KEY_END, mContentEditText.getSelectionEnd());
+        outState.putString(KEY_CONTENT, mContentEditText.getText().toString());
     }
 
     public void addMediaFile(final MediaFile mediaFile, final String imageUrl, final ImageLoader imageLoader, final int start, final int end) {
-        mActivity.runOnUiThread(new Runnable() {
+        final WPEditImageSpan imageSpan = createWPEditImageSpan(mActivity, mediaFile);
+        mEditorFragmentListener.saveMediaFile(mediaFile);
+        imageSpan.setMediaFile(mediaFile);
+
+        Handler handler = new Handler(Looper.getMainLooper());
+        final Runnable r = new Runnable() {
             @Override
             public void run() {
-                WPEditImageSpan imageSpan = createWPEditImageSpan(mActivity, mediaFile);
-
-                Log.e("", "xyz appendMediaFile(mContent=" + mContent + ", start;end=" + start + ";" + end + ")");
-
                 // Insert the WPImageSpan in the content field
                 int selectionStart = start;
                 int selectionEnd = end;
@@ -1055,26 +1051,19 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
                     selectionEnd = selectionEnd + 1;
                 }
 
-                if (mediaFile.getFileURL() == null) {
-                    mediaFile.setFileURL(imageUrl);
-                }
-
-                imageSpan.setMediaFile(mediaFile);
-
                 s.insert(selectionStart, " ");
                 s.setSpan(imageSpan, selectionStart, selectionEnd + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
                 AlignmentSpan.Standard as = new AlignmentSpan.Standard(Layout.Alignment.ALIGN_CENTER);
                 s.setSpan(as, selectionStart, selectionEnd + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
                 s.insert(selectionEnd + 1, "\n\n");
 
-                mEditorFragmentListener.saveMediaFile(mediaFile);
-
                 // Fetch and replace the WPImageSpan if it's a remote media
                 if (mediaFile.getFileURL() != null && imageLoader != null) {
                     loadWPImageSpanThumbnail(mediaFile, imageUrl, imageLoader);
                 }
             }
-        });
+        };
+        handler.postDelayed(r, 1);
     }
 
     @Override

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/legacy/WPEditImageSpan.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/legacy/WPEditImageSpan.java
@@ -7,12 +7,19 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.net.Uri;
+import android.os.Parcel;
+import android.os.Parcelable;
 
 import org.wordpress.android.editor.R;
+import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.WPImageSpan;
 
 public class WPEditImageSpan extends WPImageSpan {
     private Bitmap mEditIconBitmap;
+
+    protected WPEditImageSpan() {
+        super();
+    }
 
     public WPEditImageSpan(Context context, Bitmap b, Uri src) {
         super(context, b, src);
@@ -49,4 +56,18 @@ public class WPEditImageSpan extends WPImageSpan {
             canvas.drawBitmap(mEditIconBitmap, editIconXPosition, editIconYPosition, paint);
         }
     }
+
+    public static final Parcelable.Creator<WPEditImageSpan> CREATOR
+            = new Parcelable.Creator<WPEditImageSpan>() {
+        public WPEditImageSpan createFromParcel(Parcel in) {
+            WPEditImageSpan editSpan = new WPEditImageSpan();
+            editSpan.setupFromParcel(in);
+
+            return editSpan;
+        }
+
+        public WPEditImageSpan[] newArray(int size) {
+            return new WPEditImageSpan[size];
+        }
+    };
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/WPImageSpan.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/WPImageSpan.java
@@ -5,12 +5,19 @@ package org.wordpress.android.util.helpers;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.text.style.ImageSpan;
 
-public class WPImageSpan extends ImageSpan {
+public class WPImageSpan extends ImageSpan implements Parcelable {
     protected Uri mImageSource = null;
     protected boolean mNetworkImageLoaded = false;
     protected MediaFile mMediaFile;
+    protected int mStartPosition, mEndPosition;
+
+    protected WPImageSpan() {
+        super((Bitmap) null);
+    }
 
     public WPImageSpan(Context context, Bitmap b, Uri src) {
         super(context, b);
@@ -22,6 +29,19 @@ public class WPImageSpan extends ImageSpan {
         super(context, resId);
         this.mImageSource = src;
         mMediaFile = new MediaFile();
+    }
+
+    public void setPosition(int start, int end) {
+        mStartPosition = start;
+        mEndPosition = end;
+    }
+
+    public int getStartPosition() {
+        return mStartPosition >= 0 ? mStartPosition : 0;
+    }
+
+    public int getEndPosition() {
+        return mEndPosition < mStartPosition ? mStartPosition : mEndPosition;
     }
 
     public MediaFile getMediaFile() {
@@ -46,5 +66,75 @@ public class WPImageSpan extends ImageSpan {
 
     public void setNetworkImageLoaded(boolean networkImageLoaded) {
         this.mNetworkImageLoaded = networkImageLoaded;
+    }
+
+    protected void setupFromParcel(Parcel in) {
+        MediaFile mediaFile = new MediaFile();
+
+        boolean[] booleans = new boolean[2];
+        in.readBooleanArray(booleans);
+        setNetworkImageLoaded(booleans[0]);
+        mediaFile.setVideo(booleans[1]);
+
+        setImageSource(Uri.parse(in.readString()));
+        mediaFile.setMediaId(in.readString());
+        mediaFile.setBlogId(in.readString());
+        mediaFile.setPostID(in.readLong());
+        mediaFile.setCaption(in.readString());
+        mediaFile.setDescription(in.readString());
+        mediaFile.setTitle(in.readString());
+        mediaFile.setMimeType(in.readString());
+        mediaFile.setFileName(in.readString());
+        mediaFile.setThumbnailURL(in.readString());
+        mediaFile.setVideoPressShortCode(in.readString());
+        mediaFile.setFileURL(in.readString());
+        mediaFile.setFilePath(in.readString());
+        mediaFile.setDateCreatedGMT(in.readLong());
+        mediaFile.setWidth(in.readInt());
+        mediaFile.setHeight(in.readInt());
+        setPosition(in.readInt(), in.readInt());
+
+        setMediaFile(mediaFile);
+    }
+
+    public static final Parcelable.Creator<WPImageSpan> CREATOR
+            = new Parcelable.Creator<WPImageSpan>() {
+        public WPImageSpan createFromParcel(Parcel in) {
+            WPImageSpan imageSpan = new WPImageSpan();
+            imageSpan.setupFromParcel(in);
+            return imageSpan;
+        }
+
+        public WPImageSpan[] newArray(int size) {
+            return new WPImageSpan[size];
+        }
+    };
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeBooleanArray(new boolean[] {mNetworkImageLoaded, mMediaFile.isVideo()});
+        parcel.writeString(mImageSource.toString());
+        parcel.writeString(mMediaFile.getMediaId());
+        parcel.writeString(mMediaFile.getBlogId());
+        parcel.writeLong(mMediaFile.getPostID());
+        parcel.writeString(mMediaFile.getCaption());
+        parcel.writeString(mMediaFile.getDescription());
+        parcel.writeString(mMediaFile.getTitle());
+        parcel.writeString(mMediaFile.getMimeType());
+        parcel.writeString(mMediaFile.getFileName());
+        parcel.writeString(mMediaFile.getThumbnailURL());
+        parcel.writeString(mMediaFile.getVideoPressShortCode());
+        parcel.writeString(mMediaFile.getFileURL());
+        parcel.writeString(mMediaFile.getFilePath());
+        parcel.writeLong(mMediaFile.getDateCreatedGMT());
+        parcel.writeInt(mMediaFile.getWidth());
+        parcel.writeInt(mMediaFile.getHeight());
+        parcel.writeInt(getStartPosition());
+        parcel.writeInt(getEndPosition());
     }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/WPImageSpan.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/WPImageSpan.java
@@ -41,7 +41,7 @@ public class WPImageSpan extends ImageSpan implements Parcelable {
     }
 
     public int getEndPosition() {
-        return mEndPosition < mStartPosition ? mStartPosition : mEndPosition;
+        return mEndPosition < getStartPosition() ? getStartPosition() : mEndPosition;
     }
 
     public MediaFile getMediaFile() {


### PR DESCRIPTION
Addresses #2501 (and #2564 I _think_)

Preventing the crash required saving and restoring the Activity and Fragment states. Of course since the lifecycle calls are not invoked in the same order as boot-up there were tons of other problems.

Getting WPImageSpan and WPEditSpan data back after the Activity has been destroyed required adding the Parcelable interface to each so that the appropriate class is instantiated (since they're always passed as WPImageSpan).

Images from the blog library now notify the Activity after every 3 images, previously on every image.

_Note to reviewer: Changes were made in the editor module that will need to be pushed to its [repo](https://github.com/wordpress-mobile/WordPress-Editor-Android)._