### PR TITLE
Issue/2600 account model

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -191,6 +191,8 @@ public class WordPressDB {
 
         // Update tables for new installs and app updates
         int currentVersion = db.getVersion();
+        boolean isNewInstall = (currentVersion == 0);
+
         switch (currentVersion) {
             case 0:
                 // New install
@@ -287,7 +289,9 @@ public class WordPressDB {
             case 29:
                 // Migrate WordPress.com token and infos to the DB
                 AccountTable.createTables(db);
-                migratePreferencesToAccountTable(context);
+                if (!isNewInstall) {
+                    migratePreferencesToAccountTable(context);
+                }
                 currentVersion++;
         }
         db.setVersion(DATABASE_VERSION);
@@ -301,7 +305,6 @@ public class WordPressDB {
         account.setUserName(oldUsername);
         if (oldAccessToken != null) {
             account.setAccessToken(oldAccessToken);
-            account.setIsWordPressComUser(true);
         }
         AccountTable.save(account, db);
 

--- a/WordPress/src/main/java/org/wordpress/android/models/AccountModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/AccountModel.java
@@ -98,7 +98,7 @@ public class AccountModel {
     }
 
     public void setAccessToken(String accessToken) {
-        mIsWordPressComUser = true;
+        mIsWordPressComUser = !TextUtils.isEmpty(accessToken);
         mAccessToken = accessToken;
     }
 


### PR DESCRIPTION
Fix #2600 - account model no longer sets `mIsWordPressDotComUser` to true when the passed token is empty.