### PR TITLE
Update Tracks lib to version 1.0.2

### DIFF
--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.automattic:tracks:1.0.1'
+    compile 'com.automattic:tracks:1.0.2'
     compile 'com.mixpanel.android:mixpanel-android:4.3.0@aar'
     compile 'org.wordpress:utils:1.3.0'
 }


### PR DESCRIPTION
Before merge or test this PR we should publish the new artifacts of the Tracks library on Maven central.

I've already created a tag 1.0.2 on the library github site here: https://github.com/Automattic/Automattic-Tracks-Android
You can even use "develop" since the code is the same of the tag.