### PR TITLE
Fixed site picker cardview appearance on pre-L

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -27,7 +27,6 @@ import org.wordpress.android.ui.main.SitePickerAdapter.SiteRecord;
 import org.wordpress.android.util.AccountHelper;
 import org.wordpress.android.util.CoreEvents;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.widgets.DividerItemDecoration;
 
 import de.greenrobot.event.EventBus;
 
@@ -69,7 +68,6 @@ public class SitePickerActivity extends ActionBarActivity
 
         RecyclerView recycler = (RecyclerView) findViewById(R.id.recycler_view);
         recycler.setLayoutManager(new LinearLayoutManager(this));
-        recycler.addItemDecoration(new DividerItemDecoration(this, DividerItemDecoration.VERTICAL_LIST));
         recycler.setAdapter(getAdapter());
     }
 

--- a/WordPress/src/main/res/layout/site_picker_card.xml
+++ b/WordPress/src/main/res/layout/site_picker_card.xml
@@ -2,7 +2,7 @@
 
 <android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:cardview="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/card_view"
     android:layout_width="match_parent"
@@ -10,9 +10,9 @@
     android:layout_marginLeft="@dimen/content_margin"
     android:layout_marginRight="@dimen/content_margin"
     android:stateListAnimator="@anim/pressed_card"
-    card_view:cardCornerRadius="@dimen/cardview_default_radius"
-    card_view:cardElevation="@dimen/card_elevation"
-    card_view:cardUseCompatPadding="true">
+    cardview:cardCornerRadius="@dimen/cardview_default_radius"
+    cardview:cardElevation="@dimen/card_elevation"
+    cardview:cardUseCompatPadding="true">
 
     <FrameLayout
         android:layout_width="match_parent"
@@ -22,20 +22,21 @@
         <RelativeLayout
             android:id="@+id/layout_container"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:padding="@dimen/margin_large">
 
             <org.wordpress.android.widgets.WPNetworkImageView
                 android:id="@+id/image_blavatar"
                 android:layout_width="@dimen/blavatar_sz"
                 android:layout_height="@dimen/blavatar_sz"
-                android:layout_margin="@dimen/margin_large"
-                android:gravity="center_vertical" />
+                android:layout_marginRight="@dimen/margin_large"
+                android:gravity="center_vertical"
+                tools:src="@drawable/gravatar_placeholder" />
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/text_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/my_site_blog_name_margin_top"
                 android:layout_toRightOf="@id/image_blavatar"
                 android:ellipsize="end"
                 android:gravity="center_vertical"

--- a/WordPress/src/main/res/layout/site_picker_card.xml
+++ b/WordPress/src/main/res/layout/site_picker_card.xml
@@ -7,13 +7,12 @@
     android:id="@+id/card_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="@dimen/margin_extra_small"
     android:layout_marginLeft="@dimen/content_margin"
     android:layout_marginRight="@dimen/content_margin"
-    android:layout_marginTop="@dimen/margin_small"
     android:stateListAnimator="@anim/pressed_card"
     card_view:cardCornerRadius="@dimen/cardview_default_radius"
-    card_view:cardElevation="@dimen/card_elevation">
+    card_view:cardElevation="@dimen/card_elevation"
+    card_view:cardUseCompatPadding="true">
 
     <FrameLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
Fix #2608 - Site picker cardview now appears the same on pre-L devices as it does on Lollipop.