### PR TITLE
Notifications PTR progress now disappears as expected

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -108,14 +108,30 @@ public class NotificationsListFragment extends Fragment
 
         mEmptyTextView = (TextView) view.findViewById(R.id.empty_view);
 
+        mFauxSwipeToRefreshHelper = new SwipeToRefreshHelper(
+                getActivity(),
+                (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
+                new SwipeToRefreshHelper.RefreshListener() {
+                    @Override
+                    public void onRefreshStarted() {
+                        // Show a fake refresh animation for a few seconds
+                        new Handler().postDelayed(new Runnable() {
+                            @Override
+                            public void run() {
+                                if (isAdded()) {
+                                    mFauxSwipeToRefreshHelper.setRefreshing(false);
+                                }
+                            }
+                        }, 2000);
+                    }
+                });
+
         return view;
     }
 
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
-
-        initSwipeToRefreshHelper();
 
         if (savedInstanceState != null) {
             setRestoredListPosition(savedInstanceState.getInt(KEY_LIST_SCROLL_POSITION, RecyclerView.NO_POSITION));
@@ -159,26 +175,6 @@ public class NotificationsListFragment extends Fragment
         }
 
         super.onDestroy();
-    }
-
-    private void initSwipeToRefreshHelper() {
-        mFauxSwipeToRefreshHelper = new SwipeToRefreshHelper(
-                getActivity(),
-                (CustomSwipeRefreshLayout) getActivity().findViewById(R.id.ptr_layout),
-                new SwipeToRefreshHelper.RefreshListener() {
-                    @Override
-                    public void onRefreshStarted() {
-                        // Show a fake refresh animation for a few seconds
-                        new Handler().postDelayed(new Runnable() {
-                            @Override
-                            public void run() {
-                                if (isAdded()) {
-                                    mFauxSwipeToRefreshHelper.setRefreshing(false);
-                                }
-                            }
-                        }, 2000);
-                    }
-                });
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -5,7 +5,6 @@ import android.app.Fragment;
 import android.app.NotificationManager;
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Handler;
 import android.os.Parcelable;
 import android.support.annotation.StringRes;
 import android.support.v4.app.ActivityCompat;
@@ -40,8 +39,6 @@ import org.wordpress.android.util.AccountHelper;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
-import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 
 import javax.annotation.Nonnull;
 
@@ -55,7 +52,6 @@ public class NotificationsListFragment extends Fragment
 
     private static final String KEY_LIST_SCROLL_POSITION = "scrollPosition";
 
-    private SwipeToRefreshHelper mFauxSwipeToRefreshHelper;
     private NotesAdapter mNotesAdapter;
     private LinearLayoutManager mLinearLayoutManager;
     private RecyclerView mRecyclerView;
@@ -125,8 +121,6 @@ public class NotificationsListFragment extends Fragment
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
-        initSwipeToRefreshHelper();
-
         if (savedInstanceState != null) {
             setRestoredListPosition(savedInstanceState.getInt(KEY_LIST_SCROLL_POSITION, RecyclerView.NO_POSITION));
         }
@@ -169,26 +163,6 @@ public class NotificationsListFragment extends Fragment
         }
 
         super.onDestroy();
-    }
-
-    private void initSwipeToRefreshHelper() {
-        mFauxSwipeToRefreshHelper = new SwipeToRefreshHelper(
-                getActivity(),
-                (CustomSwipeRefreshLayout) getActivity().findViewById(R.id.ptr_layout),
-                new SwipeToRefreshHelper.RefreshListener() {
-                    @Override
-                    public void onRefreshStarted() {
-                        // Show a fake refresh animation for a few seconds
-                        new Handler().postDelayed(new Runnable() {
-                            @Override
-                            public void run() {
-                                if (isAdded()) {
-                                    mFauxSwipeToRefreshHelper.setRefreshing(false);
-                                }
-                            }
-                        }, 2000);
-                    }
-                });
     }
 
     /**

--- a/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
+++ b/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
@@ -2,21 +2,13 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/ptr_layout"
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/recycler_view_notes"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <android.support.v7.widget.RecyclerView
-            android:id="@+id/recycler_view_notes"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:scrollbars="vertical" />
-
-    </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
+        android:layout_height="match_parent"
+        android:scrollbars="vertical" />
 
     <LinearLayout
         android:id="@+id/empty_view"


### PR DESCRIPTION
Fixed #2610 - the PTR progress now disappears after two seconds, as it should. Problem was caused by locating the PTR layout using **getActivity()**.`findViewById()` instead of finding it using the fragment's view. This also fixes an intermittent problem where the PTR progress style used incorrect colors.