### PR TITLE
Enable fragment to receive media activity result

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaAddFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaAddFragment.java
@@ -264,25 +264,25 @@ public class MediaAddFragment extends Fragment implements LaunchCameraCallback {
 
     public void launchCamera() {
         if (isAdded()) {
-            WordPressMediaUtils.launchCamera(getActivity(), this);
+            WordPressMediaUtils.launchCamera(this, this);
         }
     }
 
     public void launchVideoCamera() {
         if (isAdded()) {
-            WordPressMediaUtils.launchVideoCamera(getActivity());
+            WordPressMediaUtils.launchVideoCamera(this);
         }
     }
 
     public void launchVideoLibrary() {
         if (isAdded()) {
-            WordPressMediaUtils.launchVideoLibrary(getActivity());
+            WordPressMediaUtils.launchVideoLibrary(this);
         }
     }
 
     public void launchPictureLibrary() {
         if (isAdded()) {
-            WordPressMediaUtils.launchPictureLibrary(getActivity());
+            WordPressMediaUtils.launchPictureLibrary(this);
         }
     }
 


### PR DESCRIPTION
Returned values from startActivityForResult in WordpressMediaUtils
can now be passed to both activity and fragment.
Fix #2614