### PR TITLE
Clear access token on signout

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -492,6 +492,7 @@ public class WordPress extends Application {
 
         // Save that this user signed out
         AccountHelper.getDefaultAccount().setUserTappedSignedOutButton(true);
+        AccountHelper.getDefaultAccount().setAccessToken(null);
         AccountHelper.getDefaultAccount().save();
 
         wpDB.updateLastBlogId(-1);


### PR DESCRIPTION
Fix #2621 - previously, restarting the app after tapping "Disconnect from WordPress.com" would cause it to act like the user never signed out. This was due to not clearing the access token when they signed out, which is fixed in this PR.

Note that this is different from #2524, which will be addressed separately.