### PR TITLE
Site picker now sets the current blog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -213,9 +213,9 @@ public class SitePickerActivity extends ActionBarActivity
     @Override
     public void onSiteClick(SiteRecord site) {
         if (mActionMode == null) {
-            Intent data = new Intent();
-            data.putExtra(KEY_LOCAL_ID, site.localId);
-            setResult(RESULT_OK, data);
+            WordPress.setCurrentBlog(site.localId);
+            WordPress.wpDB.updateLastBlogId(site.localId);
+            setResult(RESULT_OK);
             finish();
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -15,7 +15,6 @@ import com.simperium.client.Bucket;
 import org.wordpress.android.GCMIntentService;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
-import org.wordpress.android.models.Blog;
 import org.wordpress.android.models.Note;
 import org.wordpress.android.networking.SelfSignedSSLCertsManager;
 import org.wordpress.android.ui.ActivityLauncher;
@@ -268,16 +267,11 @@ public class WPMainActivity extends Activity
                 }
                 break;
             case RequestCodes.SITE_PICKER:
-                if (resultCode == RESULT_OK && data != null) {
-                    int localId = data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, 0);
-
-                    // when a new blog is picked, set it to the current blog
-                    Blog blog = WordPress.setCurrentBlog(localId);
-                    WordPress.wpDB.updateLastBlogId(localId);
-
+                if (resultCode == RESULT_OK) {
+                    // site picker will have set the current blog, so make sure My Site reflects it
                     MySiteFragment mySiteFragment = getMySiteFragment();
                     if (mySiteFragment != null) {
-                        mySiteFragment.setBlog(blog);
+                        mySiteFragment.setBlog(WordPress.getCurrentBlog());
                     }
                 }
                 break;


### PR DESCRIPTION
Prior to this PR, the site picker would pass the selected siteId via an intent that could be read by the calling activity's `onActivityResult()` ([see here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java#L272)).

However, if the main activity was destroyed due to low memory, `onActivityResult()` would never be called and the selected site wouldn't be shown ([example](https://cloudup.com/csCnBeltWho)).

This PR resolves this by setting the current blog in the site picker, which can be picked up by `onActivityResult` or when the main activity is recreated.