### PR TITLE
Unescape html entities for blog names and handle empty ones

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ViewSiteActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ViewSiteActivity.java
@@ -21,6 +21,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.util.AccountHelper;
+import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.WPWebViewClient;
 import org.wordpress.android.util.helpers.WPWebChromeClient;
 import org.wordpress.passcodelock.AppLockManager;
@@ -63,7 +64,7 @@ public class ViewSiteActivity extends ActionBarActivity {
         mWebView.getSettings().setJavaScriptEnabled(true);
         mWebView.getSettings().setDomStorageEnabled(true);
 
-        this.setTitle(mBlog.getBlogName());
+        this.setTitle(StringUtils.unescapeHTML(mBlog.getBlogName()));
         loadSiteURL();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.main;
 
 import android.app.Fragment;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -182,8 +183,12 @@ public class MySiteFragment extends Fragment
         mBlavatarImageView.setErrorImageResId(mBlog.isDotcomFlag() ? R.drawable.blavatar_placeholder_com : R.drawable.blavatar_placeholder_org);
         mBlavatarImageView.setImageUrl(GravatarUtils.blavatarFromUrl(mBlog.getUrl(), mBlavatarSz), WPNetworkImageView.ImageType.BLAVATAR);
 
-        mBlogTitleTextView.setText(mBlog.getBlogName());
-        mBlogSubtitleTextView.setText(StringUtils.getHost(mBlog.getUrl()));
+        String blogName = StringUtils.unescapeHTML(mBlog.getBlogName());
+        String hostName = StringUtils.getHost(mBlog.getUrl());
+        String blogTitle = TextUtils.isEmpty(blogName) ? hostName : blogName;
+
+        mBlogTitleTextView.setText(blogTitle);
+        mBlogSubtitleTextView.setText(hostName);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -125,7 +125,7 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
     public void onBindViewHolder(SiteViewHolder holder, final int position) {
         SiteRecord site = getItem(position);
 
-        holder.txtTitle.setText(site.blogName);
+        holder.txtTitle.setText(site.getBlogNameOrHostName());
         holder.txtDomain.setText(site.hostName);
         holder.imgBlavatar.setErrorImageResId(site.isDotCom ? R.drawable.blavatar_placeholder_com : R.drawable.blavatar_placeholder_org);
         holder.imgBlavatar.setImageUrl(site.blavatarUrl, WPNetworkImageView.ImageType.BLAVATAR);


### PR DESCRIPTION
Fixes #2625. It also fixes the empty title for both `MySiteFragment` & `SitePickerActivity`, when the site doesn't have a blog name. As we do in Calypso and iOS, if the blog name is empty, it will now show the host name instead.

/cc @nbradbury 