### PR TITLE
Hide the Me avatar frame for non-wp.com

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -44,6 +44,7 @@ public class MeFragment extends Fragment {
         mAvatarImageView = (WPNetworkImageView) rootView.findViewById(R.id.me_avatar);
         mDisplayNameTextView = (TextView) rootView.findViewById(R.id.me_display_name);
         mUsernameTextView = (TextView) rootView.findViewById(R.id.me_username);
+        mLoginLogoutTextView = (TextView) rootView.findViewById(R.id.me_login_logout_text_view);
 
         TextView settingsTextView = (TextView) rootView.findViewById(R.id.me_settings_text_view);
         settingsTextView.setOnClickListener(new View.OnClickListener() {
@@ -61,9 +62,6 @@ public class MeFragment extends Fragment {
             }
         });
 
-        mLoginLogoutTextView = (TextView) rootView.findViewById(R.id.me_login_logout_text_view);
-
-        addDropShadow(rootView.findViewById(R.id.frame_avatar));
         refreshAccountDetails();
 
         return rootView;
@@ -73,15 +71,23 @@ public class MeFragment extends Fragment {
      * adds a circular drop shadow to the avatar's parent view (Lollipop+ only)
      */
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    private void addDropShadow(View view) {
+    private void addDropShadow() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            view.setOutlineProvider(new ViewOutlineProvider() {
+            mAvatarFrame.setOutlineProvider(new ViewOutlineProvider() {
                 @Override
                 public void getOutline(View view, Outline outline) {
                     outline.setOval(0, 0, view.getWidth(), view.getHeight());
                 }
             });
-            view.setElevation(view.getResources().getDimensionPixelSize(R.dimen.card_elevation));
+            mAvatarFrame.setElevation(mAvatarFrame.getResources().getDimensionPixelSize(R.dimen.card_elevation));
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private void removeDropShadow() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            mAvatarFrame.setOutlineProvider(null);
+            mAvatarFrame.setElevation(0);
         }
     }
 
@@ -90,13 +96,13 @@ public class MeFragment extends Fragment {
         if (AccountHelper.isSignedInWordPressDotCom()) {
             Account defaultAccount = AccountHelper.getDefaultAccount();
 
-            mAvatarFrame.setVisibility(View.VISIBLE);
             mDisplayNameTextView.setVisibility(View.VISIBLE);
             mUsernameTextView.setVisibility(View.VISIBLE);
 
             int avatarSz = getResources().getDimensionPixelSize(R.dimen.avatar_sz_large);
             String avatarUrl = GravatarUtils.fixGravatarUrl(defaultAccount.getAvatarUrl(), avatarSz);
             mAvatarImageView.setImageUrl(avatarUrl, WPNetworkImageView.ImageType.AVATAR);
+            addDropShadow();
 
             mUsernameTextView.setText("@" + defaultAccount.getUserName());
 
@@ -115,7 +121,9 @@ public class MeFragment extends Fragment {
                 }
             });
         } else {
-            mAvatarFrame.setVisibility(View.GONE);
+            mAvatarImageView.setImageResource(R.drawable.blavatar_placeholder_org);
+            removeDropShadow();
+
             mDisplayNameTextView.setVisibility(View.GONE);
             mUsernameTextView.setVisibility(View.GONE);
 
@@ -131,15 +139,15 @@ public class MeFragment extends Fragment {
 
     private void signoutWithConfirmation() {
         new AlertDialog.Builder(getActivity())
-            .setMessage(getString(R.string.sign_out_confirm))
-            .setPositiveButton(R.string.signout, new DialogInterface.OnClickListener() {
-                public void onClick(DialogInterface dialog, int whichButton) {
-                    signout();
-                }
-            })
-            .setNegativeButton(R.string.cancel, null)
-            .setCancelable(true)
-            .create().show();
+                .setMessage(getString(R.string.sign_out_confirm))
+                .setPositiveButton(R.string.signout, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int whichButton) {
+                        signout();
+                    }
+                })
+                .setNegativeButton(R.string.cancel, null)
+                .setCancelable(true)
+                .create().show();
     }
 
     private void signout() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -25,6 +25,7 @@ import org.wordpress.android.widgets.WPNetworkImageView;
 
 public class MeFragment extends Fragment {
 
+    private ViewGroup mAvatarFrame;
     private WPNetworkImageView mAvatarImageView;
     private TextView mDisplayNameTextView;
     private TextView mUsernameTextView;
@@ -38,6 +39,8 @@ public class MeFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         final ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.fragment_me, container, false);
+
+        mAvatarFrame = (ViewGroup) rootView.findViewById(R.id.frame_avatar);
         mAvatarImageView = (WPNetworkImageView) rootView.findViewById(R.id.me_avatar);
         mDisplayNameTextView = (TextView) rootView.findViewById(R.id.me_display_name);
         mUsernameTextView = (TextView) rootView.findViewById(R.id.me_username);
@@ -87,7 +90,7 @@ public class MeFragment extends Fragment {
         if (AccountHelper.isSignedInWordPressDotCom()) {
             Account defaultAccount = AccountHelper.getDefaultAccount();
 
-            mAvatarImageView.setVisibility(View.VISIBLE);
+            mAvatarFrame.setVisibility(View.VISIBLE);
             mDisplayNameTextView.setVisibility(View.VISIBLE);
             mUsernameTextView.setVisibility(View.VISIBLE);
 
@@ -112,7 +115,7 @@ public class MeFragment extends Fragment {
                 }
             });
         } else {
-            mAvatarImageView.setVisibility(View.GONE);
+            mAvatarFrame.setVisibility(View.GONE);
             mDisplayNameTextView.setVisibility(View.GONE);
             mUsernameTextView.setVisibility(View.GONE);
 

--- a/WordPress/src/main/res/layout/fragment_me.xml
+++ b/WordPress/src/main/res/layout/fragment_me.xml
@@ -23,7 +23,8 @@
             <org.wordpress.android.widgets.WPNetworkImageView
                 android:id="@+id/me_avatar"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+                android:layout_height="match_parent"
+                tools:src="@drawable/blavatar_placeholder_org" />
 
         </FrameLayout>
 


### PR DESCRIPTION
Fix #2633 - ~~hides the shadow frame which contains the avatar when the user is disconnected from wp.com and has a self-hosted blog.~~

**Update:** After talking with design on Slack, we've decided that the Me page was too barren when the user isn't signed into wp.com (see screenshot below), so we now show the default .org blavatar in this situation.

![fk7qy6cuiz](https://cloud.githubusercontent.com/assets/3903757/7481732/48c87122-f340-11e4-8305-1b7e33100f1f.png)
