### PR TITLE
Analytics - Add notification_type props to notification events

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
@@ -138,7 +138,12 @@ public class GCMIntentService extends GCMBaseIntentService {
         // Bump Analytics
         Map<String, String> properties = new HashMap<>();
         if (!TextUtils.isEmpty(noteType)) {
-            properties.put("notification_type", noteType);
+            // 'comment' and 'comment_pingback' types are sent in PN as type = "c"
+            if (noteType.equals("c")) {
+                properties.put("notification_type", "comment");
+            } else {
+                properties.put("notification_type", noteType);
+            }
         }
         AnalyticsTracker.track(Stat.PUSH_NOTIFICATION_RECEIVED, properties);
 

--- a/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
@@ -135,6 +135,14 @@ public class GCMIntentService extends GCMBaseIntentService {
             }
         }
 
+        // Bump Analytics
+        Map<String, String> properties = new HashMap<>();
+        if (!TextUtils.isEmpty(noteType)) {
+            properties.put("notification_type", noteType);
+        }
+        AnalyticsTracker.track(Stat.PUSH_NOTIFICATION_RECEIVED, properties);
+
+
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         boolean sound, vibrate, light;
 
@@ -255,7 +263,6 @@ public class GCMIntentService extends GCMBaseIntentService {
     @Override
     protected void onMessage(Context context, Intent intent) {
         AppLog.v(T.NOTIFS, "Received Message");
-        AnalyticsTracker.track(Stat.PUSH_NOTIFICATION_RECEIVED);
         Bundle extras = intent.getExtras();
 
         if (extras == null) {

--- a/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
@@ -139,7 +139,7 @@ public class GCMIntentService extends GCMBaseIntentService {
         Map<String, String> properties = new HashMap<>();
         if (!TextUtils.isEmpty(noteType)) {
             // 'comment' and 'comment_pingback' types are sent in PN as type = "c"
-            if (noteType.equals("c")) {
+            if (noteType.equals(NOTE_TYPE_COMMENT)) {
                 properties.put("notification_type", "comment");
             } else {
                 properties.put("notification_type", noteType);

--- a/WordPress/src/main/java/org/wordpress/android/models/Note.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Note.java
@@ -93,7 +93,7 @@ public class Note extends Syncable {
         return String.valueOf(queryJSON("id", 0));
     }
 
-    private String getType() {
+    public String getType() {
         return queryJSON("type", NOTE_UNKNOWN_TYPE);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -12,6 +12,7 @@ import com.simperium.client.BucketObjectMissingException;
 
 import org.wordpress.android.GCMIntentService;
 import org.wordpress.android.R;
+import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.models.Note;
 import org.wordpress.android.ui.ActivityLauncher;
@@ -32,6 +33,9 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.CoreEvents;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import de.greenrobot.event.EventBus;
 
@@ -62,6 +66,10 @@ public class NotificationsDetailActivity extends ActionBarActivity implements
             if (SimperiumUtils.getNotesBucket() != null) {
                 try {
                     Note note = SimperiumUtils.getNotesBucket().get(noteId);
+
+                    Map<String, String> properties = new HashMap<>();
+                    properties.put("notification_type", note.getType());
+                    AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATIONS_OPENED_NOTIFICATION_DETAILS, properties);
 
                     // mark the note as read if it's unread
                     if (note.isUnread()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -12,6 +12,7 @@ import com.simperium.client.BucketObjectMissingException;
 
 import org.wordpress.android.GCMIntentService;
 import org.wordpress.android.R;
+import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.models.AccountHelper;
 import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.models.Note;
@@ -32,6 +33,9 @@ import org.wordpress.android.ui.stats.StatsViewType;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import de.greenrobot.event.EventBus;
 
@@ -62,6 +66,10 @@ public class NotificationsDetailActivity extends ActionBarActivity implements
             if (SimperiumUtils.getNotesBucket() != null) {
                 try {
                     Note note = SimperiumUtils.getNotesBucket().get(noteId);
+
+                    Map<String, String> properties = new HashMap<>();
+                    properties.put("notification_type", note.getType());
+                    AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATIONS_OPENED_NOTIFICATION_DETAILS, properties);
 
                     // mark the note as read if it's unread
                     if (note.isUnread()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -182,8 +182,6 @@ public class NotificationsListFragment extends Fragment
                 R.anim.reader_activity_slide_in,
                 R.anim.do_nothing);
         ActivityCompat.startActivityForResult(activity, detailIntent, RequestCodes.NOTE_DETAIL, options.toBundle());
-
-        AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATIONS_OPENED_NOTIFICATION_DETAILS);
     }
 
     private void setNoteIsHidden(String noteId, boolean isHidden) {


### PR DESCRIPTION
Fix #2636

This PR adds the `notification_type` property to the following notification events:
- `wpandroid_push_notification_received` 
- `wpandroid_notifications_notification_details_opened`

Note that in case of `wpandroid_notifications_notification_details_opened` event, the property can assume the same values of the web version. It's copied from the note object returned in Simperium.

[Edited]
Event `wpandroid_push_notification_received`:  the property can assume the same values of the web version (*).

(*) The object we receive in push notification is slightly different compared to a common note obj.
The push notification obj has a type property that assumes the value of `c` in case of comment or comment-pingback. The prop has that short value of `c` because we need to minimize the bytes sent to identify the type, and use them for the content.
I rewrote the type from "c" to "comment" in code. For all other types of notifications we don't need to do that. Note that the "comment-pingback" type is lost.

/cc @roundhill could you please review this PR since it involves notifications?

/cc @martinremy