### PR TITLE
Stats - Fix Jetpack issue on Authors module

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAuthorsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAuthorsFragment.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseExpandableListAdapter;
 
+import org.apache.commons.lang.StringUtils;
 import org.wordpress.android.R;
 import org.wordpress.android.ui.stats.models.AuthorModel;
 import org.wordpress.android.ui.stats.models.AuthorsModel;
@@ -182,6 +183,10 @@ public class StatsAuthorsFragment extends StatsAbstractListFragment {
             AuthorModel group = (AuthorModel) getGroup(groupPosition);
 
             String name = group.getName();
+            if (StringUtils.isBlank(name)) {
+                // Jetpack case: articles published before the activation of Jetpack.
+                name = getString(R.string.stats_unknown_author);
+            }
             int total = group.getViews();
             String icon = group.getAvatar();
             int children = getChildrenCount(groupPosition);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -497,6 +497,9 @@
     <!-- stats: search terms -->
     <string name="stats_search_terms_unknown_search_terms">Unknown Search Terms</string>
 
+    <!-- stats: Authors -->
+    <string name="stats_unknown_author">Unknown Author</string>
+
     <!-- Stats: Single post details view -->
     <string name="stats_period">Period</string>
     <string name="stats_total">Total</string>


### PR DESCRIPTION
Fix #2605 by showing a default label  `Unknown Author` when the name of the authors is blank. This could happen on Jetpack sites for articles published before the activation of Jetpack. We do't have the possibility to properly assign those articles on client side.

A fix on the server side API is required, and is in the backlog with low priority.