### PR TITLE
Stats- Fix Authentication issues for Jetpack sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/Blog.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Blog.java
@@ -442,7 +442,7 @@ public class Blog {
     }
 
     public boolean hasValidJetpackCredentials() {
-        return !TextUtils.isEmpty(getDotcom_username()) && !TextUtils.isEmpty(getDotcom_password());
+        return !TextUtils.isEmpty(getDotcom_username()) && !TextUtils.isEmpty(getApi_key());
     }
 
     public boolean hasValidHTTPAuthCredentials() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/LoginWPCom.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/LoginWPCom.java
@@ -77,6 +77,7 @@ public class LoginWPCom extends LoginAbstract {
                 if (mJetpackBlog != null) {
                     // Store token in blog object for Jetpack sites
                     mJetpackBlog.setApi_key(token.toString());
+                    mJetpackBlog.setDotcom_username(mUsername);
                     WordPress.wpDB.saveBlog(mJetpackBlog);
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsEvents.java
@@ -13,7 +13,7 @@ public class StatsEvents {
     }
     public static class SectionUpdated {
         public final StatsEndpointsEnum mEndPointName;
-        public final String mRequestBlogId;
+        public final String mRequestBlogId; // This is the remote blog ID
         public final StatsTimeframe mTimeframe;
         public final String mDate;
 
@@ -32,6 +32,14 @@ public class StatsEvents {
         public final boolean isError;
         public JetpackSettingsCompleted(boolean isError) {
             this.isError = isError;
+        }
+    }
+
+    public static class JetpackAuthError {
+        public final int mLocalBlogId; // This is the local blogID
+
+        public JetpackAuthError(int blogId) {
+            mLocalBlogId = blogId;
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.IBinder;
 import android.text.TextUtils;
 
+import com.android.volley.NetworkResponse;
 import com.android.volley.Request;
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
@@ -12,6 +13,8 @@ import com.wordpress.rest.RestRequest;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.WordPressDB;
+import org.wordpress.android.models.Blog;
 import org.wordpress.android.networking.RestClientUtils;
 import org.wordpress.android.ui.stats.StatsEvents;
 import org.wordpress.android.ui.stats.StatsTimeframe;
@@ -334,8 +337,25 @@ public class StatsService extends Service {
             singleThreadNetworkHandler.submit(new Thread() {
                 @Override
                 public void run() {
-                    AppLog.e(T.STATS, this.getClass().getName() + " responded with an Error");
+                    AppLog.e(T.STATS, "Error while loading Stats!");
                     StatsUtils.logVolleyErrorDetails(volleyError);
+
+                    // Check here if this is an authentication error
+                    // .com authentication errors are handled automatically by the app
+                    if (volleyError.networkResponse != null) {
+                        NetworkResponse networkResponse = volleyError.networkResponse;
+                        if (networkResponse.statusCode == 403 && networkResponse.data != null) {
+                            if (new String(networkResponse.data).contains("unauthorized")) {
+                                int localId = WordPress.wpDB.getLocalTableBlogIdForRemoteBlogId(
+                                        Integer.parseInt(mRequestBlogId)
+                                );
+                                Blog blog = WordPress.wpDB.instantiateBlogByLocalId(localId);
+                                if (blog != null && blog.isJetpackPowered()) {
+                                    EventBus.getDefault().post(new StatsEvents.JetpackAuthError(localId));
+                                }
+                            }
+                        }
+                    }
                     mResponseObjectModel = volleyError;
                     EventBus.getDefault().post(new StatsEvents.SectionUpdated(mEndpointName, mRequestBlogId, mTimeframe, mDate, mResponseObjectModel));
                     checkAllRequestsFinished(currentRequest);


### PR DESCRIPTION
There were some authentication problems with Jetpack sites. Especially on those blogs that are not connected with the main .com account logged into the app. 
I fixed those issues and tested the app in different configurations:
 
- Blank app, add a Jetpack site, Go to Stats. (The .com login should popup here and credentials should be stored at blog level)

- App logged in a .com account. Add a Jetpack site that is already connected to the same .com account. Go to stats, the app should try to load the stats by using the main .com account. No action required by the user.

- App connected with .com account. Add a Jetpack site that is NOT connected with main .com account. Go to stats, the app should try to load the stats by using the main .com account, then the login to .com should popup. Inserting the correct credentials must load stats.

- Add a self hosted site with NO Jetpack. The Jepack popup should appeat after a while. Clicking on cancel should dismiss it.