### PR TITLE
fix #2639: Catch the AssertionError on Fragment. getString

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
@@ -89,12 +89,14 @@ public class StatsCommentsFragment extends StatsAbstractListFragment {
         if (mDatamodels[1] != null && !isErrorResponse(1)) { // check if comment-followers is already here
             mTotalsLabel.setVisibility(View.VISIBLE);
             int totalNumberOfFollowers = ((CommentFollowersModel) mDatamodels[1]).getTotal();
-            mTotalsLabel.setText(
-                    getString(
-                            R.string.stats_comments_total_comments_followers,
-                            FormatUtils.formatDecimal(totalNumberOfFollowers)
-                    )
-            );
+            try {
+                mTotalsLabel.setText(getString(R.string.stats_comments_total_comments_followers,
+                                     FormatUtils.formatDecimal(totalNumberOfFollowers)));
+            } catch (AssertionError e) {
+                // Workaround for a weird bug in Android 4.2.2 with en_GB or en_AU locale
+                // https://github.com/wordpress-mobile/WordPress-Android/issues/2639
+                mTotalsLabel.setVisibility(View.GONE);
+            }
         } else {
             mTotalsLabel.setVisibility(View.GONE);
         }


### PR DESCRIPTION
fix #2639

I've checked manual language selection was sanitized: https://github.com/wordpress-mobile/WordPress-Android/blob/615d636bdc0063490b64cf0e344c5d4ac5e9a9bf/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java#L320-L323

Also tried to reproduce on a 4.2.2 emulator, but failed.

I would not fix it if it wasn't the cause of a crash loop.