### PR TITLE
Using newest MediaPicker library (v1.2.3) to address NPE.

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     compile 'com.crashlytics.sdk.android:crashlytics:2.2.2'
 
     // Provided by maven central
-    compile ('org.wordpress:mediapicker:1.2.2') {
+    compile ('org.wordpress:mediapicker:1.2.3') {
         exclude group:'com.android.support'
     }
     compile 'com.google.code.gson:gson:2.2.2'


### PR DESCRIPTION
@maxme fixed the NPE in the [library](https://github.com/wordpress-mobile/MediaPicker-Android/pull/22), this PR uses the newest version of the library to get that fix.