### PR TITLE
replace WordPress.onPostUploadedListener by a sticky event

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -85,8 +85,6 @@ public class WordPress extends Application {
     public static Blog currentBlog;
     public static Post currentPost;
     public static WordPressDB wpDB;
-    public static OnPostUploadedListener onPostUploadedListener = null;
-    public static boolean postsShouldRefresh;
     public static RestClientUtils mRestClientUtils;
     public static RestClientUtils mRestClientUtilsVersion1_1;
     public static RequestQueue requestQueue;
@@ -375,40 +373,6 @@ public class WordPress extends Application {
             HelpshiftHelper.getInstance().registerDeviceToken(context, regId);
         }
         AnalyticsTracker.registerPushNotificationToken(regId);
-    }
-
-    public interface OnPostUploadedListener {
-        public abstract void OnPostUploaded(int localBlogId, String postId, boolean isPage);
-
-        public abstract void OnPostUploadFailed(int localBlogId);
-    }
-
-    public static void setOnPostUploadedListener(OnPostUploadedListener listener) {
-        onPostUploadedListener = listener;
-    }
-
-    public static void postUploaded(int localBlogId, String postId, boolean isPage) {
-        if (onPostUploadedListener != null) {
-            try {
-                onPostUploadedListener.OnPostUploaded(localBlogId, postId, isPage);
-            } catch (Exception e) {
-                postsShouldRefresh = true;
-            }
-        } else {
-            postsShouldRefresh = true;
-        }
-    }
-
-    public static void postUploadFailed(int localBlogId) {
-        if (onPostUploadedListener != null) {
-            try {
-                onPostUploadedListener.OnPostUploadFailed(localBlogId);
-            } catch (Exception e) {
-                postsShouldRefresh = true;
-            }
-        } else {
-            postsShouldRefresh = true;
-        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadEvents.java
@@ -1,0 +1,23 @@
+package org.wordpress.android.ui.posts;
+
+public class PostUploadEvents {
+    public static class PostUploadSucceed {
+        public final int mLocalBlogId;
+        public final String mRemotePostId;
+        public final boolean mIsPage;
+
+        PostUploadSucceed(int localBlogId, String remotePostId, boolean isPage) {
+            mLocalBlogId = localBlogId;
+            mRemotePostId = remotePostId;
+            mIsPage = isPage;
+        }
+    }
+
+    public static class PostUploadFailed {
+        public final int mLocalId;
+
+        PostUploadFailed(int localId) {
+            mLocalId = localId;
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
@@ -34,6 +34,8 @@ import org.wordpress.android.models.FeatureSet;
 import org.wordpress.android.models.Post;
 import org.wordpress.android.models.PostLocation;
 import org.wordpress.android.models.PostStatus;
+import org.wordpress.android.ui.posts.PostUploadEvents.PostUploadFailed;
+import org.wordpress.android.ui.posts.PostUploadEvents.PostUploadSucceed;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DisplayUtils;
@@ -60,6 +62,8 @@ import java.util.Map;
 import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import de.greenrobot.event.EventBus;
 
 public class PostUploadService extends Service {
     private static Context mContext;
@@ -168,11 +172,13 @@ public class PostUploadService extends Service {
             WordPress.wpDB.updatePost(mPost);
 
             if (postUploadedSuccessfully) {
-                WordPress.postUploaded(mPost.getLocalTableBlogId(), mPost.getRemotePostId(), mPost.isPage());
+                EventBus.getDefault().postSticky(
+                        new PostUploadSucceed(mPost.getLocalTableBlogId(), mPost.getRemotePostId(),
+                                mPost.isPage()));
                 mPostUploadNotifier.cancelNotification();
                 WordPress.wpDB.deleteMediaFilesForPost(mPost);
             } else {
-                WordPress.postUploadFailed(mPost.getLocalTableBlogId());
+                EventBus.getDefault().postSticky(new PostUploadFailed(mPost.getLocalTableBlogId()));
                 mPostUploadNotifier.updateNotificationWithError(mErrorMessage, mIsMediaError, mPost.isPage(),
                         mErrorUnavailableVideoPress);
             }
@@ -187,7 +193,7 @@ public class PostUploadService extends Service {
             if (mPostUploadNotifier != null && mPost != null) {
                 mPostUploadNotifier.updateNotificationWithError(mErrorMessage, mIsMediaError, mPost.isPage(),
                         mErrorUnavailableVideoPress);
-                WordPress.postUploadFailed(mPost.getLocalTableBlogId());
+                EventBus.getDefault().postSticky(new PostUploadFailed(mPost.getLocalTableBlogId()));
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUploadService.java
@@ -172,13 +172,12 @@ public class PostUploadService extends Service {
             WordPress.wpDB.updatePost(mPost);
 
             if (postUploadedSuccessfully) {
-                EventBus.getDefault().postSticky(
-                        new PostUploadSucceed(mPost.getLocalTableBlogId(), mPost.getRemotePostId(),
+                EventBus.getDefault().post(new PostUploadSucceed(mPost.getLocalTableBlogId(), mPost.getRemotePostId(),
                                 mPost.isPage()));
                 mPostUploadNotifier.cancelNotification();
                 WordPress.wpDB.deleteMediaFilesForPost(mPost);
             } else {
-                EventBus.getDefault().postSticky(new PostUploadFailed(mPost.getLocalTableBlogId()));
+                EventBus.getDefault().post(new PostUploadFailed(mPost.getLocalTableBlogId()));
                 mPostUploadNotifier.updateNotificationWithError(mErrorMessage, mIsMediaError, mPost.isPage(),
                         mErrorUnavailableVideoPress);
             }
@@ -193,7 +192,7 @@ public class PostUploadService extends Service {
             if (mPostUploadNotifier != null && mPost != null) {
                 mPostUploadNotifier.updateNotificationWithError(mErrorMessage, mIsMediaError, mPost.isPage(),
                         mErrorUnavailableVideoPress);
-                EventBus.getDefault().postSticky(new PostUploadFailed(mPost.getLocalTableBlogId()));
+                EventBus.getDefault().post(new PostUploadFailed(mPost.getLocalTableBlogId()));
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
@@ -197,12 +197,6 @@ public class PostsActivity extends ActionBarActivity
                 finish();
             }*/
         }
-
-        if (WordPress.postsShouldRefresh) {
-            requestPosts();
-            mPostList.setRefreshing(true);
-            WordPress.postsShouldRefresh = false;
-        }
     }
 
     public void newPost() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
@@ -26,7 +26,6 @@ import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.posts.PostsListFragment.OnPostActionListener;
 import org.wordpress.android.ui.posts.PostsListFragment.OnPostSelectedListener;
 import org.wordpress.android.ui.posts.ViewPostFragment.OnDetailPostActionListener;
-import org.wordpress.android.models.AccountHelper;
 import org.wordpress.android.util.AlertUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -182,20 +181,6 @@ public class PostsActivity extends ActionBarActivity
             } catch (RuntimeException e) {
                 AppLog.e(T.POSTS, e);
             }
-        }
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-
-        // posts can't be shown if there aren't any visible blogs, so redirect to the reader and
-        // exit the post list in this situation
-        if (AccountHelper.isSignedIn()) {
-            // TODO:
-            /*if (showCorrectActivityForAccountIfRequired()) {
-                finish();
-            }*/
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -253,6 +253,7 @@ public class PostsListFragment extends ListFragment implements EmptyViewAnimatio
         mEmptyViewAnimationHandler = new EmptyViewAnimationHandler(mEmptyViewTitle, mEmptyViewImage, this);
 
         if (NetworkUtils.isNetworkAvailable(getActivity())) {
+            // If we remove or throttle the following call, we should make PostUpload events sticky
             ((PostsActivity) getActivity()).requestPosts();
         } else {
             updateEmptyView(EmptyViewMessageType.NETWORK_ERROR);
@@ -276,11 +277,6 @@ public class PostsListFragment extends ListFragment implements EmptyViewAnimatio
             throw new ClassCastException(activity.toString()
                     + " must implement Callback");
         }
-    }
-
-    @Override
-    public void onDetach() {
-        super.onDetach();
     }
 
     public void onResume() {
@@ -455,7 +451,6 @@ public class PostsListFragment extends ListFragment implements EmptyViewAnimatio
             return;
         }
 
-        EventBus.getDefault().removeStickyEvent(event.getClass());
         // Fetch the newly uploaded post
         if (!TextUtils.isEmpty(event.mRemotePostId)) {
             final boolean reloadPosts = sameBlogId;
@@ -500,7 +495,6 @@ public class PostsListFragment extends ListFragment implements EmptyViewAnimatio
     }
 
     public void onEventMainThread(PostUploadFailed event) {
-        EventBus.getDefault().removeStickyEvent(event.getClass());
         mSwipeToRefreshHelper.setRefreshing(true);
 
         if (!isAdded()) {
@@ -634,7 +628,7 @@ public class PostsListFragment extends ListFragment implements EmptyViewAnimatio
     @Override
     public void onStart() {
         super.onStart();
-        EventBus.getDefault().registerSticky(this);
+        EventBus.getDefault().register(this);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -23,6 +23,8 @@ import org.wordpress.android.models.Post;
 import org.wordpress.android.models.PostsListPost;
 import org.wordpress.android.ui.EmptyViewAnimationHandler;
 import org.wordpress.android.ui.EmptyViewMessageType;
+import org.wordpress.android.ui.posts.PostUploadEvents.PostUploadFailed;
+import org.wordpress.android.ui.posts.PostUploadEvents.PostUploadSucceed;
 import org.wordpress.android.ui.posts.adapters.PostsListAdapter;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ServiceUtils;
@@ -39,8 +41,9 @@ import org.xmlrpc.android.ApiHelper.ErrorType;
 import java.util.List;
 import java.util.Vector;
 
-public class PostsListFragment extends ListFragment
-        implements WordPress.OnPostUploadedListener, EmptyViewAnimationHandler.OnAnimationProgressListener {
+import de.greenrobot.event.EventBus;
+
+public class PostsListFragment extends ListFragment implements EmptyViewAnimationHandler.OnAnimationProgressListener {
     public static final int POSTS_REQUEST_COUNT = 20;
 
     private SwipeToRefreshHelper mSwipeToRefreshHelper;
@@ -238,7 +241,6 @@ public class PostsListFragment extends ListFragment
         });
 
         initSwipeToRefreshHelper();
-        WordPress.setOnPostUploadedListener(this);
 
         mFabButton = (FloatingActionButton) getView().findViewById(R.id.fab_button);
         mFabButton.setOnClickListener(new View.OnClickListener() {
@@ -278,7 +280,6 @@ public class PostsListFragment extends ListFragment
 
     @Override
     public void onDetach() {
-        WordPress.setOnPostUploadedListener(null);
         super.onDetach();
     }
 
@@ -437,15 +438,14 @@ public class PostsListFragment extends ListFragment
         mShouldSelectFirstPost = shouldSelect;
     }
 
-    @Override
-    public void OnPostUploaded(int localBlogId, String postId, boolean isPage) {
+    public void onEventMainThread(PostUploadSucceed event) {
         if (!isAdded()) {
             return;
         }
 
         // If the user switched to a different blog while uploading his post, don't reload posts and refresh the view
         boolean sameBlogId = true;
-        if (WordPress.getCurrentBlog() == null || WordPress.getCurrentBlog().getLocalTableBlogId() != localBlogId) {
+        if (WordPress.getCurrentBlog() == null || WordPress.getCurrentBlog().getLocalTableBlogId() != event.mLocalBlogId) {
             sameBlogId = false;
         }
 
@@ -455,13 +455,14 @@ public class PostsListFragment extends ListFragment
             return;
         }
 
+        EventBus.getDefault().removeStickyEvent(event.getClass());
         // Fetch the newly uploaded post
-        if (!TextUtils.isEmpty(postId)) {
+        if (!TextUtils.isEmpty(event.mRemotePostId)) {
             final boolean reloadPosts = sameBlogId;
             List<Object> apiArgs = new Vector<Object>();
-            apiArgs.add(WordPress.wpDB.instantiateBlogByLocalId(localBlogId));
-            apiArgs.add(postId);
-            apiArgs.add(isPage);
+            apiArgs.add(WordPress.wpDB.instantiateBlogByLocalId(event.mLocalBlogId));
+            apiArgs.add(event.mRemotePostId);
+            apiArgs.add(event.mIsPage);
 
             mCurrentFetchSinglePostTask = new ApiHelper.FetchSinglePostTask(
                     new ApiHelper.FetchSinglePostTask.Callback() {
@@ -498,8 +499,8 @@ public class PostsListFragment extends ListFragment
         }
     }
 
-    @Override
-    public void OnPostUploadFailed(int localBlogId) {
+    public void onEventMainThread(PostUploadFailed event) {
+        EventBus.getDefault().removeStickyEvent(event.getClass());
         mSwipeToRefreshHelper.setRefreshing(true);
 
         if (!isAdded()) {
@@ -507,7 +508,7 @@ public class PostsListFragment extends ListFragment
         }
 
         // If the user switched to a different blog while uploading his post, don't reload posts and refresh the view
-        if (WordPress.getCurrentBlog() == null || WordPress.getCurrentBlog().getLocalTableBlogId() != localBlogId) {
+        if (WordPress.getCurrentBlog() == null || WordPress.getCurrentBlog().getLocalTableBlogId() != event.mLocalId) {
             return;
         }
 
@@ -628,5 +629,17 @@ public class PostsListFragment extends ListFragment
             default:
                 break;
         }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        EventBus.getDefault().registerSticky(this);
+    }
+
+    @Override
+    public void onStop() {
+        EventBus.getDefault().unregister(this);
+        super.onStop();
     }
 }


### PR DESCRIPTION
Note: the stickiness is probably too much because we're refreshing the list each time the activity is created: https://github.com/wordpress-mobile/WordPress-Android/blob/12bc1ec101e035b945c84f4aab1f944ab6297043/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java#L256