### PR TITLE
fix #2690: on receive SuggestionNameListUpdated npe

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -380,7 +380,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     @SuppressWarnings("unused")
     public void onEventMainThread(SuggestionEvents.SuggestionNameListUpdated event) {
         // check if the updated suggestions are for the current blog and update the suggestions
-        if (event.mRemoteBlogId != 0 && event.mRemoteBlogId == mRemoteBlogId) {
+        if (event.mRemoteBlogId != 0 && event.mRemoteBlogId == mRemoteBlogId && mSuggestionAdapter != null) {
             List<Suggestion> suggestions = SuggestionTable.getSuggestionsForSite(event.mRemoteBlogId);
             mSuggestionAdapter.setSuggestionList(suggestions);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/ViewPostFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/ViewPostFragment.java
@@ -78,7 +78,7 @@ public class ViewPostFragment extends Fragment {
     public void onEventMainThread(SuggestionEvents.SuggestionNameListUpdated event) {
         int remoteBlogId = WordPress.getCurrentRemoteBlogId();
         // check if the updated suggestions are for the current blog and update the suggestions
-        if (event.mRemoteBlogId != 0 && event.mRemoteBlogId == remoteBlogId) {
+        if (event.mRemoteBlogId != 0 && event.mRemoteBlogId == remoteBlogId && mSuggestionAdapter != null) {
             List<Suggestion> suggestions = SuggestionTable.getSuggestionsForSite(event.mRemoteBlogId);
             mSuggestionAdapter.setSuggestionList(suggestions);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -144,7 +144,7 @@ public class ReaderCommentListActivity extends ActionBarActivity {
     @SuppressWarnings("unused")
     public void onEventMainThread(SuggestionEvents.SuggestionNameListUpdated event) {
         // check if the updated suggestions are for the current blog and update the suggestions
-        if (event.mRemoteBlogId != 0 && event.mRemoteBlogId == mBlogId) {
+        if (event.mRemoteBlogId != 0 && event.mRemoteBlogId == mBlogId && mSuggestionAdapter != null) {
             List<Suggestion> suggestions = SuggestionTable.getSuggestionsForSite(event.mRemoteBlogId);
             mSuggestionAdapter.setSuggestionList(suggestions);
         }


### PR DESCRIPTION
fix #2690 
SuggestionEvents.SuggestionNameListUpdated can be received before mSuggestionAdapter is initialized - null check mSuggestionAdapter on event received.