### PR TITLE
fix #2701: back button now makes the app go to background

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
@@ -38,6 +38,7 @@ public class WPLaunchActivity extends ActionBarActivity {
         }
 
         Intent intent = new Intent(this, WPMainActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
         startActivity(intent);
         finish();
     }


### PR DESCRIPTION
fix #2701: back button now makes the app go to background

before the fix: https://cloudup.com/iTRGPsjEuDY
after the fix: https://cloudup.com/itHUP2Ow05j
