### PR TITLE
Removed swipe progress view offset

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -515,9 +515,6 @@ public class ReaderPostListFragment extends Fragment
                 }
             });
 
-            // move swipe progress down so it doesn't get covered by the toolbar
-            mSwipeToRefreshLayout.setProgressViewOffset(false, 0, mTagToolbarOffset);
-
             // create the tag spinner in the toolbar
             if (mTagSpinner == null) {
                 enableTagSpinner();


### PR DESCRIPTION
Removed [the swipe-to-refresh offset](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java#L519) from the reader list fragment which prevented the STR arrow from animating correctly.