### PR TITLE
Issue/2676 site picker delay

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -1,9 +1,6 @@
 package org.wordpress.android.ui.main;
 
 import android.content.Intent;
-import android.content.res.Resources;
-import android.graphics.Canvas;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBarActivity;
@@ -28,6 +25,7 @@ import org.wordpress.android.ui.main.SitePickerAdapter.SiteRecord;
 import org.wordpress.android.ui.stats.datasets.StatsTable;
 import org.wordpress.android.util.CoreEvents;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.widgets.DividerItemDecoration;
 
 import de.greenrobot.event.EventBus;
 
@@ -63,10 +61,9 @@ public class SitePickerActivity extends ActionBarActivity
 
         RecyclerView recycler = (RecyclerView) findViewById(R.id.recycler_view);
         recycler.setLayoutManager(new LinearLayoutManager(this));
-        recycler.setAdapter(getAdapter());
-        recycler.setClipToPadding(false);
         recycler.setScrollBarStyle(View.SCROLLBARS_OUTSIDE_OVERLAY);
-        recycler.addItemDecoration(new SitePickerItemDecoration(this.getResources()));
+        recycler.addItemDecoration(new DividerItemDecoration(this, LinearLayoutManager.VERTICAL));
+        recycler.setAdapter(getAdapter());
     }
 
     @Override
@@ -307,35 +304,6 @@ public class SitePickerActivity extends ActionBarActivity
             }
             getAdapter().setEnableEditMode(false);
             mActionMode = null;
-        }
-    }
-
-    /**
-     * dividers for sites
-     */
-    public static class SitePickerItemDecoration extends RecyclerView.ItemDecoration {
-        private final Drawable mDivider;
-
-        public SitePickerItemDecoration(Resources resources) {
-            mDivider = resources.getDrawable(R.drawable.site_picker_divider);
-        }
-
-        public void onDrawOver(Canvas c, RecyclerView parent, RecyclerView.State state) {
-            int left = parent.getPaddingLeft();
-            int right = parent.getWidth() - parent.getPaddingRight();
-
-            int childCount = parent.getChildCount();
-            for (int i = 0; i < childCount; i++) {
-                View child = parent.getChildAt(i);
-
-                RecyclerView.LayoutParams params = (RecyclerView.LayoutParams) child.getLayoutParams();
-
-                int top = child.getBottom() + params.bottomMargin;
-                int bottom = top + mDivider.getIntrinsicHeight();
-
-                mDivider.setBounds(left, top, right, bottom);
-                mDivider.draw(c);
-            }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -145,8 +145,8 @@ public class SitePickerActivity extends ActionBarActivity
             onBackPressed();
             return true;
         } else if (itemId == R.id.menu_edit) {
-            getAdapter().setEnableEditMode(true);
             mRecycleView.setItemAnimator(new DefaultItemAnimator());
+            getAdapter().setEnableEditMode(true);
             startSupportActionMode(new ActionModeCallback());
             return true;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -26,7 +26,6 @@ import org.wordpress.android.ui.main.SitePickerAdapter.SiteRecord;
 import org.wordpress.android.ui.stats.datasets.StatsTable;
 import org.wordpress.android.util.CoreEvents;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.widgets.DividerItemDecoration;
 
 import de.greenrobot.event.EventBus;
 
@@ -64,7 +63,6 @@ public class SitePickerActivity extends ActionBarActivity
         mRecycleView = (RecyclerView) findViewById(R.id.recycler_view);
         mRecycleView.setLayoutManager(new LinearLayoutManager(this));
         mRecycleView.setScrollBarStyle(View.SCROLLBARS_OUTSIDE_OVERLAY);
-        mRecycleView.addItemDecoration(new DividerItemDecoration(this, LinearLayoutManager.VERTICAL));
         mRecycleView.setItemAnimator(null);
         mRecycleView.setAdapter(getAdapter());
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBarActivity;
 import android.support.v7.view.ActionMode;
+import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.Menu;
@@ -36,6 +37,7 @@ public class SitePickerActivity extends ActionBarActivity
     public static final String KEY_LOCAL_ID = "local_id";
 
     private SitePickerAdapter mAdapter;
+    private RecyclerView mRecycleView;
     private ActionMode mActionMode;
     private int mCurrentLocalId;
 
@@ -59,11 +61,12 @@ public class SitePickerActivity extends ActionBarActivity
 
         setupFab();
 
-        RecyclerView recycler = (RecyclerView) findViewById(R.id.recycler_view);
-        recycler.setLayoutManager(new LinearLayoutManager(this));
-        recycler.setScrollBarStyle(View.SCROLLBARS_OUTSIDE_OVERLAY);
-        recycler.addItemDecoration(new DividerItemDecoration(this, LinearLayoutManager.VERTICAL));
-        recycler.setAdapter(getAdapter());
+        mRecycleView = (RecyclerView) findViewById(R.id.recycler_view);
+        mRecycleView.setLayoutManager(new LinearLayoutManager(this));
+        mRecycleView.setScrollBarStyle(View.SCROLLBARS_OUTSIDE_OVERLAY);
+        mRecycleView.addItemDecoration(new DividerItemDecoration(this, LinearLayoutManager.VERTICAL));
+        mRecycleView.setItemAnimator(null);
+        mRecycleView.setAdapter(getAdapter());
     }
 
     @Override
@@ -143,6 +146,7 @@ public class SitePickerActivity extends ActionBarActivity
             return true;
         } else if (itemId == R.id.menu_edit) {
             getAdapter().setEnableEditMode(true);
+            mRecycleView.setItemAnimator(new DefaultItemAnimator());
             startSupportActionMode(new ActionModeCallback());
             return true;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -324,16 +324,22 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
             List<Map<String, Object>> blogs;
             String[] extraFields = {"isHidden", "dotcomFlag"};
 
-            // add wp.com blogs
             if (mShowHiddenSites) {
-                blogs = WordPress.wpDB.getBlogsBy("dotcomFlag=1", extraFields);
+                if (mShowSelfHostedSites) {
+                    // all self-hosted blogs and all wp.com blogs
+                    blogs = WordPress.wpDB.getBlogsBy(null, extraFields);
+                } else {
+                    // only wp.com blogs
+                    blogs = WordPress.wpDB.getBlogsBy("dotcomFlag=1", extraFields);
+                }
             } else {
-                blogs = WordPress.wpDB.getBlogsBy("isHidden=0 AND dotcomFlag=1", extraFields);
-            }
-
-            // add self-hosted
-            if (mShowSelfHostedSites) {
-                blogs.addAll(WordPress.wpDB.getBlogsBy("dotcomFlag=0", extraFields));
+                if (mShowSelfHostedSites) {
+                    // all self-hosted blogs plus visible wp.com blogs
+                    blogs = WordPress.wpDB.getBlogsBy("dotcomFlag=0 OR (isHidden=0 AND dotcomFlag=1) ", extraFields);
+                } else {
+                    // only visible wp.com blogs
+                    blogs = WordPress.wpDB.getBlogsBy("isHidden=0 AND dotcomFlag=1", extraFields);
+                }
             }
 
             SiteList sites = new SiteList(blogs);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -5,6 +5,7 @@ import android.graphics.Typeface;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -139,9 +140,9 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
         });
 
         if (site.localId == mCurrentLocalId || (mIsMultiSelectEnabled && isItemSelected(position))) {
-            holder.layoutContainer.setBackgroundDrawable(mSelectedItemBackground);
+            setBackgroundCompat(holder.layoutContainer, mSelectedItemBackground);
         } else {
-            holder.layoutContainer.setBackgroundDrawable(null);
+            setBackgroundCompat(holder.layoutContainer, null);
         }
 
         // different styling for visible/hidden sites
@@ -150,6 +151,15 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
             holder.txtTitle.setTextColor(site.isHidden ? mTextColorHidden : mTextColorNormal);
             holder.txtTitle.setTypeface(holder.txtTitle.getTypeface(), site.isHidden ? Typeface.NORMAL : Typeface.BOLD);
             holder.imgBlavatar.setAlpha(site.isHidden ? 0.5f : 1f);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private void setBackgroundCompat(View view, Drawable drawable) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            view.setBackground(drawable);
+        } else {
+            view.setBackgroundDrawable(drawable);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -5,7 +5,6 @@ import android.graphics.Typeface;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -140,9 +139,9 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
         });
 
         if (site.localId == mCurrentLocalId || (mIsMultiSelectEnabled && isItemSelected(position))) {
-            setBackgroundCompat(holder.layoutContainer, mSelectedItemBackground);
+            holder.layoutContainer.setBackgroundDrawable(mSelectedItemBackground);
         } else {
-            setBackgroundCompat(holder.layoutContainer, null);
+            holder.layoutContainer.setBackgroundDrawable(null);
         }
 
         // different styling for visible/hidden sites
@@ -151,15 +150,6 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
             holder.txtTitle.setTextColor(site.isHidden ? mTextColorHidden : mTextColorNormal);
             holder.txtTitle.setTypeface(holder.txtTitle.getTypeface(), site.isHidden ? Typeface.NORMAL : Typeface.BOLD);
             holder.imgBlavatar.setAlpha(site.isHidden ? 0.5f : 1f);
-        }
-    }
-
-    @SuppressWarnings("deprecation")
-    private void setBackgroundCompat(View view, Drawable drawable) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            view.setBackground(drawable);
-        } else {
-            view.setBackgroundDrawable(drawable);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -62,6 +62,7 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
         private final TextView txtTitle;
         private final TextView txtDomain;
         private final WPNetworkImageView imgBlavatar;
+        private final View divider;
         private Boolean isSiteHidden;
 
         public SiteViewHolder(View view) {
@@ -70,6 +71,7 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
             txtTitle = (TextView) view.findViewById(R.id.text_title);
             txtDomain = (TextView) view.findViewById(R.id.text_domain);
             imgBlavatar = (WPNetworkImageView) view.findViewById(R.id.image_blavatar);
+            divider = view.findViewById(R.id.divider);
             isSiteHidden = null;
         }
     }
@@ -151,6 +153,10 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
             holder.txtTitle.setTypeface(holder.txtTitle.getTypeface(), site.isHidden ? Typeface.NORMAL : Typeface.BOLD);
             holder.imgBlavatar.setAlpha(site.isHidden ? 0.5f : 1f);
         }
+
+        // hide the divider for the last item
+        boolean isLastItem = (position == getItemCount() - 1);
+        holder.divider.setVisibility(isLastItem ?  View.INVISIBLE : View.VISIBLE);
     }
 
     private boolean isValidPosition(int position) {

--- a/WordPress/src/main/res/drawable/site_picker_divider.xml
+++ b/WordPress/src/main/res/drawable/site_picker_divider.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-    <size
-        android:width="1dp"
-        android:height="1dp" />
-    <solid android:color="@color/grey_lighten_20" />
-</shape>

--- a/WordPress/src/main/res/layout/site_picker_listitem.xml
+++ b/WordPress/src/main/res/layout/site_picker_listitem.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?android:selectableItemBackground">
+    android:background="?android:selectableItemBackground"
+    android:orientation="vertical">
 
     <RelativeLayout
         android:id="@+id/layout_container"
@@ -51,4 +52,9 @@
 
     </RelativeLayout>
 
-</FrameLayout>
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/grey_lighten_20" />
+
+</LinearLayout>

--- a/WordPress/src/main/res/layout/site_picker_listitem.xml
+++ b/WordPress/src/main/res/layout/site_picker_listitem.xml
@@ -53,6 +53,7 @@
     </RelativeLayout>
 
     <View
+        android:id="@+id/divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:background="@color/grey_lighten_20" />


### PR DESCRIPTION
Fix #2676 - site picker no longer has a noticeable delay when populated - problem was due to:

* The custom item decoration, which has been replaced with the built-in `DividerItemDecoration` (which I wasn't aware of until now!)
* The default item animation, which has been removed until action mode has been enabled

cc: @oguzkocer 