### PR TITLE
Fix double animation at startup

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -53,7 +53,8 @@
 
         <activity
             android:name=".ui.WPLaunchActivity"
-            android:theme="@style/Calypso.NoActionBar">
+            android:noHistory="true"
+            android:theme="@android:style/Theme.NoDisplay">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
@@ -1,12 +1,12 @@
 package org.wordpress.android.ui;
 
+import android.app.Activity;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
-import android.support.v7.app.ActionBarActivity;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -16,11 +16,12 @@ import org.wordpress.android.util.ToastUtils;
 
 import java.util.Locale;
 
-public class WPLaunchActivity extends ActionBarActivity {
+public class WPLaunchActivity extends Activity {
 
     /*
      * this the main (default) activity, which does nothing more than launch the
-     * previously active activity on startup
+     * previously active activity on startup - note that it's defined in the
+     * manifest to have no UI
      */
 
     @Override
@@ -29,8 +30,6 @@ public class WPLaunchActivity extends ActionBarActivity {
 
         applyLocale();
 
-        setContentView(R.layout.activity_launch);
-
         if (WordPress.wpDB == null) {
             ToastUtils.showToast(this, R.string.fatal_db_error, ToastUtils.Duration.LONG);
             finish();
@@ -38,7 +37,6 @@ public class WPLaunchActivity extends ActionBarActivity {
         }
 
         Intent intent = new Intent(this, WPMainActivity.class);
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
         startActivity(intent);
         finish();
     }

--- a/WordPress/src/main/res/layout/activity_launch.xml
+++ b/WordPress/src/main/res/layout/activity_launch.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/white">
-
-</FrameLayout>


### PR DESCRIPTION
Fix #2710 by changing the launch activity to have no UI and no history.

@maxme The use of `android:noHistory="true"` should be an alternative solution to #2701, but since I was never able to repro that issue it would be good if you could verify this.