### PR TITLE
Issue/2579 language tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
@@ -35,6 +35,7 @@ import org.wordpress.android.models.AccountHelper;
 import org.wordpress.android.ui.ShareIntentReceiverActivity;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.util.ActivityUtils;
+import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.ToastUtils;
@@ -265,8 +266,10 @@ public class SettingsFragment extends PreferenceFragment {
                         conf.locale = new Locale(localString);
                     }
                     res.updateConfiguration(conf, dm);
-
                     mSettings.edit().putString(SETTINGS_PREFERENCES, localeMap.get(values[position])).apply();
+
+                    // Language is now part of metadata, so we need to refresh them
+                    AnalyticsUtils.refreshMetadata();
 
                     Intent refresh = new Intent(getActivity(), getActivity().getClass());
                     startActivity(refresh);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
@@ -270,7 +270,9 @@ public class SettingsFragment extends PreferenceFragment {
                     res.updateConfiguration(conf, dm);
                     mSettings.edit().putString(SETTINGS_PREFERENCES, localeMap.get(values[position])).apply();
 
-                    // Track the change only if the user selected a non default Device language
+                    // Track the change only if the user selected a non default Device language. This is only used in
+                    // Mixpanel, because we have both the device language and app selected language data in Tracks
+                    // metadata.
                     if (position != 0) {
                         Map<String, Object> properties = new HashMap<String, Object>();
                         properties.put("forced_app_locale", conf.locale.toString());

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -90,7 +90,8 @@ public final class AnalyticsTracker {
         SUPPORT_OPENED_HELPSHIFT_SCREEN,
         SUPPORT_SENT_REPLY_TO_SUPPORT_MESSAGE,
         LOGIN_FAILED,
-        LOGIN_FAILED_TO_GUESS_XMLRPC
+        LOGIN_FAILED_TO_GUESS_XMLRPC,
+        SETTINGS_LANGUAGE_SELECTION_FORCED,
     }
 
     public interface Tracker {

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
@@ -17,6 +17,7 @@ import org.wordpress.android.util.AppLog;
 
 import java.util.EnumMap;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 
 public class AnalyticsTrackerMixpanel implements AnalyticsTracker.Tracker {
@@ -31,6 +32,7 @@ public class AnalyticsTrackerMixpanel implements AnalyticsTracker.Tracker {
     private static final String JETPACK_USER = "jetpack_user";
     private static final String MIXPANEL_NUMBER_OF_BLOGS = "number_of_blogs";
     private static final String VERSION_CODE = "version_code";
+    private static final String APP_LOCALE = "app_locale";
 
     public AnalyticsTrackerMixpanel(Context context, String token) {
         mAggregatedProperties = new EnumMap<AnalyticsTracker.Stat, JSONObject>(AnalyticsTracker.Stat.class);
@@ -174,6 +176,7 @@ public class AnalyticsTrackerMixpanel implements AnalyticsTracker.Tracker {
             properties.put(JETPACK_USER, isJetpackUser);
             properties.put(MIXPANEL_NUMBER_OF_BLOGS, numBlogs);
             properties.put(VERSION_CODE, versionCode);
+            properties.put(APP_LOCALE, mContext.getResources().getConfiguration().locale.toString());
             mMixpanel.registerSuperProperties(properties);
         } catch (JSONException e) {
             AppLog.e(AppLog.T.UTILS, e);

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
@@ -620,6 +620,10 @@ public class AnalyticsTrackerMixpanel implements AnalyticsTracker.Tracker {
                 instructions = AnalyticsTrackerMixpanelInstructionsForStat.
                         mixpanelInstructionsForEventName("Login - Failed To Guess XMLRPC");
                 break;
+            case SETTINGS_LANGUAGE_SELECTION_FORCED:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Settings - Forced Language Selection");
+                break;
             default:
                 instructions = null;
                 break;

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -295,6 +295,9 @@ public class AnalyticsTrackerNosara implements AnalyticsTracker.Tracker {
             case LOGIN_FAILED_TO_GUESS_XMLRPC:
                 eventName = "login_failed_to_guess_xmlrpc";
                 break;
+            case SETTINGS_LANGUAGE_SELECTION_FORCED:
+                eventName = "settings_language_selection_forced";
+                break;
             default:
                 eventName = null;
                 break;

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -295,9 +295,6 @@ public class AnalyticsTrackerNosara implements AnalyticsTracker.Tracker {
             case LOGIN_FAILED_TO_GUESS_XMLRPC:
                 eventName = "login_failed_to_guess_xmlrpc";
                 break;
-            case SETTINGS_LANGUAGE_SELECTION_FORCED:
-                eventName = "settings_language_selection_forced";
-                break;
             default:
                 eventName = null;
                 break;


### PR DESCRIPTION
@daniloercoli I think we should change this line https://github.com/Automattic/Automattic-Tracks-Android/blob/4d9d98cb36e5965a02ef815ff98c5f71cb48f99a/AutomatticTracks/src/main/java/com/automattic/android/tracks/DeviceInformation.java#L84

`Locale.getDefault()` returns the default device language, not the app language.

Well, actually it's the correct behavior for `getDeviceLanguage()`, but we should create and use another method like `getAppLanguage()`.

This is how I got the app language for mixpanel: 
https://github.com/wordpress-mobile/WordPress-Android/blob/3d8f63eee43db410a6458a15939576d0c5e23d1f/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java#L179