### PR TITLE
Fix null blog crash in MySiteFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -55,6 +55,8 @@ public class ActivityLauncher {
     }
 
     public static void viewBlogStats(Context context, int blogLocalTableId) {
+        if (blogLocalTableId == 0) return;
+
         Intent intent = new Intent(context, StatsActivity.class);
         intent.putExtra(StatsActivity.ARG_LOCAL_TABLE_BLOG_ID, blogLocalTableId);
         context.startActivity(intent);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -101,7 +101,10 @@ public class MySiteFragment extends Fragment
         statsTextView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                ActivityLauncher.viewBlogStats(getActivity(), mBlog.getLocalTableBlogId());
+                // if the blog is empty, fail silently
+                if (mBlog != null) {
+                    ActivityLauncher.viewBlogStats(getActivity(), mBlog.getLocalTableBlogId());
+                }
             }
         });
 


### PR DESCRIPTION
Fixes #2724. Please note that, this PR only fixes the crash. As discussed in #2724, I've opened #2734 to better handle null blog in `MySiteFragment` and will take care of it separately later on.

Steps to reproduce:
* Login with a user with no blogs (alternatively you can set `mBlog = null;` in `onCreate` of `MySiteFragment` for testing)
* Tap on the Stats button
* It doesn't crash anymore

/cc @nbradbury 