### PR TITLE
Fix #2698 - Using commitAllowingStateLoss to avoid runtime issues

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -290,7 +290,7 @@ public class MediaBrowserActivity extends ActionBarActivity implements MediaGrid
             mMediaItemFragment = MediaItemFragment.newInstance(mediaId);
             ft.add(R.id.media_browser_container, mMediaItemFragment, MediaItemFragment.TAG);
             ft.addToBackStack(null);
-            ft.commit();
+            ft.commitAllowingStateLoss();
         }
     }
 


### PR DESCRIPTION
Addresses #2698 

This seems safe enough since the only potential for data loss is the existing search query and if they just selected media they likely don't need the query anymore.