### PR TITLE
Back button quits the app

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
@@ -37,6 +37,7 @@ public class WPLaunchActivity extends Activity {
         }
 
         Intent intent = new Intent(this, WPMainActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
         startActivity(intent);
         finish();
     }


### PR DESCRIPTION
Seems to be an Android 4.1 issues, I reintroduced the workaround that was removed in https://github.com/wordpress-mobile/WordPress-Android/commit/8c9a8b602f1b3c0cc2eab97b5adf732e1cc07c61#diff-5f7bbc0f00e829f6e38e74e2e89f5c43