### PR TITLE
Back button added to HelpActivity

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -82,7 +82,8 @@
             android:theme="@style/SignInTheme"/>
         <activity
             android:name=".ui.accounts.HelpActivity"
-            android:theme="@style/SignInTheme"/>
+            android:theme="@style/CalypsoTheme"
+            android:label=""/> <!-- empty title -->
 
         <!-- Preferences activities -->
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.java
@@ -3,7 +3,9 @@ package org.wordpress.android.ui.accounts;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBarActivity;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
 
@@ -31,6 +33,14 @@ public class HelpActivity extends ActionBarActivity {
             initDefaultLayout();
         }
 
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setHomeAsUpIndicator(R.drawable.ic_close_white_24dp);
+            actionBar.setHomeButtonEnabled(true);
+            actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setElevation(0); //remove shadow
+        }
+
         // Init common elements
         WPTextView version = (WPTextView) findViewById(R.id.nux_help_version);
         version.setText(getString(R.string.version) + " " + WordPress.versionName);
@@ -42,6 +52,15 @@ public class HelpActivity extends ActionBarActivity {
                 startActivity(new Intent(v.getContext(), AppLogViewerActivity.class));
             }
         });
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(final MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            onBackPressed();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override


### PR DESCRIPTION
Fixes #2739. @nbradbury you mentioned the status bar color is different in Me and Help page, do you mind checking it again after these changes? I suspect changing the theme of `HelpActivity` would fix it, because we're not explicitly setting status color in other activities.

Here is how it looks like in different emulators:

https://cloudup.com/ckiEWaFTMm6
https://cloudup.com/cHfzwCu_8sU