### PR TITLE
Crash report 4.1 rc1 - Do not call getString (int resId, Object... formatArgs). Use getString()

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
@@ -260,7 +260,10 @@ public class SettingsFragment extends PreferenceFragment {
                     Configuration conf = res.getConfiguration();
                     String localString = localeMap.get(values[position]);
                     if (localString.contains("-")) {
-                        conf.locale = new Locale(localString.substring(0, localString.indexOf("-")), localString.substring(localString.indexOf("-") + 1, localString.length()));
+                        conf.locale = new Locale(
+                                localString.substring(0, localString.indexOf("-")),
+                                localString.substring(localString.indexOf("-") + 1, localString.length()).toUpperCase()
+                        );
                     } else {
                         conf.locale = new Locale(localString);
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
@@ -88,16 +88,10 @@ public class StatsCommentsFragment extends StatsAbstractListFragment {
         if (mDatamodels[1] != null && !isErrorResponse(1)) { // check if comment-followers is already here
             mTotalsLabel.setVisibility(View.VISIBLE);
             int totalNumberOfFollowers = ((CommentFollowersModel) mDatamodels[1]).getTotal();
-            try {
-                String totalCommentsFollowers = getString(R.string.stats_comments_total_comments_followers);
-                mTotalsLabel.setText(
-                        String.format(totalCommentsFollowers, FormatUtils.formatDecimal(totalNumberOfFollowers))
-                );
-            } catch (AssertionError e) {
-                // Workaround for a weird bug in Android 4.2.2 with en_GB or en_AU locale
-                // https://github.com/wordpress-mobile/WordPress-Android/issues/2639
-                mTotalsLabel.setVisibility(View.GONE);
-            }
+            String totalCommentsFollowers = getString(R.string.stats_comments_total_comments_followers);
+            mTotalsLabel.setText(
+                    String.format(totalCommentsFollowers, FormatUtils.formatDecimal(totalNumberOfFollowers))
+            );
         } else {
             mTotalsLabel.setVisibility(View.GONE);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
@@ -89,8 +89,10 @@ public class StatsCommentsFragment extends StatsAbstractListFragment {
             mTotalsLabel.setVisibility(View.VISIBLE);
             int totalNumberOfFollowers = ((CommentFollowersModel) mDatamodels[1]).getTotal();
             try {
-                mTotalsLabel.setText(getString(R.string.stats_comments_total_comments_followers,
-                                     FormatUtils.formatDecimal(totalNumberOfFollowers)));
+                String totalCommentsFollowers = getString(R.string.stats_comments_total_comments_followers);
+                mTotalsLabel.setText(
+                        String.format(totalCommentsFollowers, FormatUtils.formatDecimal(totalNumberOfFollowers))
+                );
             } catch (AssertionError e) {
                 // Workaround for a weird bug in Android 4.2.2 with en_GB or en_AU locale
                 // https://github.com/wordpress-mobile/WordPress-Android/issues/2639

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
@@ -378,10 +378,8 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
                 // 90 seconds to 45 minutes
                 if (currentDifference <= 2700 ) {
                     long minutes = this.roundUp(currentDifference, 60);
-                    return getString(
-                            R.string.stats_followers_minutes,
-                            minutes
-                    );
+                    String followersMinutes = getString(R.string.stats_followers_minutes);
+                    return String.format(followersMinutes, minutes);
                 }
 
                 // 45 to 90 minutes
@@ -392,10 +390,8 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
                 // 90 minutes to 22 hours
                 if (currentDifference <= 79200 ) {
                     long hours = this.roundUp(currentDifference, 60*60);
-                    return getString(
-                            R.string.stats_followers_hours,
-                            hours
-                    );
+                    String followersHours = getString(R.string.stats_followers_hours);
+                    return String.format(followersHours, hours);
                 }
 
                 // 22 to 36 hours
@@ -407,10 +403,8 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
                 // 86400 secs in a day -  2160000 secs in 25 days
                 if (currentDifference <= 2160000 ) {
                     long days = this.roundUp(currentDifference, 86400);
-                    return getString(
-                            R.string.stats_followers_days,
-                            days
-                    );
+                    String followersDays = getString(R.string.stats_followers_days);
+                    return String.format(followersDays, days);
                 }
 
                 // 25 to 45 days
@@ -423,10 +417,8 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
                 // 2678400 secs in a month - 29808000 secs in 345 days
                 if (currentDifference <= 29808000 ) {
                     long months = this.roundUp(currentDifference, 2678400);
-                    return getString(
-                            R.string.stats_followers_months,
-                            months
-                    );
+                    String followersMonths = getString(R.string.stats_followers_months);
+                    return String.format(followersMonths, months);
                 }
 
                 // 345 to 547 days (1.5 years)
@@ -437,10 +429,8 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
                 // 548 days+
                 // 31536000 secs in a year
                 long years = this.roundUp(currentDifference, 31536000);
-                return getString(
-                        R.string.stats_followers_years,
-                        years
-                );
+                String followersYears = getString(R.string.stats_followers_years);
+                return String.format(followersYears, years);
 
             } catch (ParseException e) {
                 AppLog.e(AppLog.T.STATS, e);

--- a/WordPress/src/main/res/values/available_languages.xml
+++ b/WordPress/src/main/res/values/available_languages.xml
@@ -79,19 +79,19 @@ uz
 </item>
 
 <item>
-zh-cn
+zh-CN
 </item>
 
 <item>
-zh-tw
+zh-HK
 </item>
 
 <item>
-zh-tw
+zh-TW
 </item>
 
 <item>
-en-gb
+en-GB
 </item>
 
 <item>
@@ -107,7 +107,7 @@ he
 </item>
 
 <item>
-pt-br
+pt-BR
 </item>
 
 <item>
@@ -123,7 +123,7 @@ mk
 </item>
 
 <item>
-en-au
+en-AU
 </item>
 
 <item>


### PR DESCRIPTION
Try to fix #2759 by not calling `getString (int resId, Object... formatArgs)` but use `getString (int resId)` and formatting the string later with `String.format()`. 

Workaround(?) found here: https://code.google.com/p/android/issues/detail?id=43162