### PR TITLE
Accessibility labels added for tabbar items

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -87,6 +87,13 @@ public class WPMainActivity extends Activity
                            R.drawable.main_tab_me,
                            R.drawable.main_tab_notifications};
         mTabs.setCustomTabView(R.layout.tab_icon, R.id.tab_icon, R.id.tab_badge, icons);
+
+        // content descriptions
+        mTabs.setContentDescription(WPMainTabAdapter.TAB_MY_SITE, getString(R.string.tabbar_accessibility_label_my_site));
+        mTabs.setContentDescription(WPMainTabAdapter.TAB_READER, getString(R.string.reader));
+        mTabs.setContentDescription(WPMainTabAdapter.TAB_ME, getString(R.string.tabbar_accessibility_label_me));
+        mTabs.setContentDescription(WPMainTabAdapter.TAB_NOTIFS, getString(R.string.notifications));
+
         mTabs.setViewPager(mViewPager);
         mTabs.setOnSingleTabClickListener(this);
 

--- a/WordPress/src/main/java/org/wordpress/android/widgets/SlidingTabLayout.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/SlidingTabLayout.java
@@ -48,6 +48,7 @@ import android.widget.HorizontalScrollView;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 /**
  * To be used with ViewPager to provide a tab indicator component which give constant feedback as to
@@ -319,9 +320,21 @@ public class SlidingTabLayout extends HorizontalScrollView {
             }
 
             tabView.setOnClickListener(tabClickListener);
-            String desc = mContentDescriptions.get(i, null);
+            final String desc = mContentDescriptions.get(i, null);
             if (desc != null) {
                 tabView.setContentDescription(desc);
+                // show toast with content description on long click
+                tabView.setOnLongClickListener(new OnLongClickListener() {
+                    @Override
+                    public boolean onLongClick(View v) {
+                        int offsetX = v.getLeft();
+                        int offsetY = v.getTop() + v.getHeight() + (v.getHeight() / 2);
+                        Toast toast = Toast.makeText(v.getContext(), desc, Toast.LENGTH_SHORT);
+                        toast.setGravity(Gravity.LEFT | Gravity.TOP, offsetX, offsetY);
+                        toast.show();
+                        return true;
+                    }
+                });
             }
 
             mTabStrip.addView(tabView);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -886,4 +886,8 @@
     <string name="me_connect_to_wordpress_com">Connect to WordPress.com</string>
     <string name="me_disconnect_from_wordpress_com">Disconnect from WordPress.com</string>
 
+    <!--TabBar Accessibility Labels-->
+    <string name="tabbar_accessibility_label_my_site">My Site</string>
+    <string name="tabbar_accessibility_label_me">Me</string>
+
 </resources>


### PR DESCRIPTION
Fixes #2769. I have tested it with voice over, but tap & hold doesn't bring up a label. I am assuming there is nothing we can do about it.