### PR TITLE
Fix #2768: Move comment moderation from NotificationsListFragment.onActivityResu…

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
@@ -1,16 +1,12 @@
 package org.wordpress.android.ui.comments;
 
-import android.app.Activity;
 import android.os.Handler;
-import android.os.Parcelable;
 import android.text.TextUtils;
 
 import com.android.volley.VolleyError;
-import com.cocosw.undobar.UndoBarController;
 import com.wordpress.rest.RestRequest;
 
 import org.json.JSONObject;
-import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.CommentTable;
 import org.wordpress.android.models.Blog;
@@ -18,9 +14,6 @@ import org.wordpress.android.models.Comment;
 import org.wordpress.android.models.CommentList;
 import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.models.Note;
-import org.wordpress.android.ui.notifications.NotificationEvents.NoteModerationFailed;
-import org.wordpress.android.ui.notifications.NotificationEvents.NoteModerationStatusChanged;
-import org.wordpress.android.ui.notifications.NotificationEvents.NoteVisibilityChanged;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.xmlpull.v1.XmlPullParserException;
@@ -31,10 +24,6 @@ import org.xmlrpc.android.XMLRPCFactory;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.annotation.Nonnull;
-
-import de.greenrobot.event.EventBus;
 
 /**
  * actions related to comments - replies, moderating, etc.
@@ -312,66 +301,6 @@ public class CommentActions {
                     }
                 }
         );
-    }
-
-    public static void showUndoBarForNote(final Note note, final CommentStatus status, final Activity activity) {
-        new UndoBarController.UndoBar(activity)
-                .message(status == CommentStatus.TRASH ? R.string.comment_trashed : R.string.comment_spammed)
-                .listener(new UndoBarController.AdvancedUndoListener() {
-                    @Override
-                    public void onHide(Parcelable parcelable) {
-                        // Deleted notifications in Simperium never come back, so we won't
-                        // make the request until the undo bar fades away
-                        CommentActions.moderateCommentForNote(note, status,
-                                new CommentActions.CommentActionListener() {
-                                    @Override
-                                    public void onActionResult(boolean succeeded) {
-                                        if (!succeeded) {
-                                            EventBus.getDefault().post(new NoteVisibilityChanged(note.getId(), false));
-                                            EventBus.getDefault().post(new NoteModerationFailed(note.getId(), status));
-                                        }
-                                    }
-                                });
-                    }
-
-                    @Override
-                    public void onClear(@Nonnull Parcelable[] token) {
-                        //noop
-                    }
-
-                    @Override
-                    public void onUndo(Parcelable parcelable) {
-                        EventBus.getDefault().post(new NoteVisibilityChanged(note.getId(), false));
-                    }
-                }).show();
-    }
-
-    /**
-     * Moderate a comment from a WPCOM notification.
-     * Broadcast EventBus events on update/success/failure
-     */
-    public static void moderateCommentForNote(final Note note, final CommentStatus newStatus, final Activity activity) {
-        if (newStatus == CommentStatus.APPROVED || newStatus == CommentStatus.UNAPPROVED) {
-            note.setLocalStatus(CommentStatus.toRESTString(newStatus));
-            note.save();
-            EventBus.getDefault().post(new NoteModerationStatusChanged(note.getId(), true));
-            CommentActions.moderateCommentForNote(note, newStatus,
-                    new CommentActions.CommentActionListener() {
-                        @Override
-                        public void onActionResult(boolean succeeded) {
-                            EventBus.getDefault().post(new NoteModerationStatusChanged(note.getId(), false));
-                            if (!succeeded) {
-                                note.setLocalStatus(null);
-                                note.save();
-                                EventBus.getDefault().post(new NoteModerationFailed(note.getId(), newStatus));
-                            }
-                        }
-                    });
-        } else if (newStatus == CommentStatus.TRASH || newStatus == CommentStatus.SPAM) {
-            EventBus.getDefault().post(new NoteVisibilityChanged(note.getId(), true));
-            // Show undo bar for trash or spam actions
-            showUndoBarForNote(note, newStatus, activity);
-        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -248,11 +248,13 @@ public class WPMainActivity extends Activity
 
     private void moderateCommentOnActivityResult(Intent data) {
         try {
-            Note note = SimperiumUtils.getNotesBucket().get(StringUtils.notNullStr(data.getStringExtra
-                    (NotificationsListFragment.NOTE_MODERATE_ID_EXTRA)));
-            CommentStatus status = CommentStatus.fromString(data.getStringExtra(
-                    NotificationsListFragment.NOTE_MODERATE_STATUS_EXTRA));
-            NotificationsUtils.moderateCommentForNote(note, status, this);
+            if (SimperiumUtils.getNotesBucket() != null) {
+                Note note = SimperiumUtils.getNotesBucket().get(StringUtils.notNullStr(data.getStringExtra
+                        (NotificationsListFragment.NOTE_MODERATE_ID_EXTRA)));
+                CommentStatus status = CommentStatus.fromString(data.getStringExtra(
+                        NotificationsListFragment.NOTE_MODERATE_STATUS_EXTRA));
+                NotificationsUtils.moderateCommentForNote(note, status, this);
+            }
         } catch (BucketObjectMissingException e) {
             AppLog.e(T.NOTIFS, e);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -7,12 +7,10 @@ import android.app.FragmentManager;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Parcelable;
 import android.support.v4.view.ViewPager;
 import android.text.TextUtils;
 import android.view.View;
 
-import com.cocosw.undobar.UndoBarController;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketObjectMissingException;
 
@@ -25,11 +23,10 @@ import org.wordpress.android.models.Note;
 import org.wordpress.android.networking.SelfSignedSSLCertsManager;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
-import org.wordpress.android.ui.comments.CommentActions;
 import org.wordpress.android.ui.media.MediaAddFragment;
 import org.wordpress.android.ui.notifications.NotificationEvents;
-import org.wordpress.android.ui.notifications.NotificationEvents.NoteVisibilityChanged;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
+import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.notifications.utils.SimperiumUtils;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.BlogPreferencesActivity;
@@ -44,11 +41,8 @@ import org.wordpress.android.util.CoreEvents.UserSignedOutCompletely;
 import org.wordpress.android.util.CoreEvents.UserSignedOutWordPressCom;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.widgets.SlidingTabLayout;
 import org.wordpress.android.widgets.WPMainViewPager;
-
-import javax.annotation.Nonnull;
 
 import de.greenrobot.event.EventBus;
 
@@ -258,7 +252,7 @@ public class WPMainActivity extends Activity
                     (NotificationsListFragment.NOTE_MODERATE_ID_EXTRA)));
             CommentStatus status = CommentStatus.fromString(data.getStringExtra(
                     NotificationsListFragment.NOTE_MODERATE_STATUS_EXTRA));
-            CommentActions.moderateCommentForNote(note, status, this);
+            NotificationsUtils.moderateCommentForNote(note, status, this);
         } catch (BucketObjectMissingException e) {
             AppLog.e(T.NOTIFS, e);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
@@ -1,10 +1,9 @@
 package org.wordpress.android.ui.notifications;
 
-import org.wordpress.android.models.CommentStatus;
-
 public class NotificationEvents {
     public static class SimperiumNotAuthorized {}
     public static class NotificationsChanged {}
+    public static class NoteModerationFailed {}
     public static class NoteModerationStatusChanged {
         boolean mIsModerating;
         String mNoteId;
@@ -19,14 +18,6 @@ public class NotificationEvents {
         public NoteVisibilityChanged(String noteId, boolean isHidden) {
             mNoteId = noteId;
             mIsHidden = isHidden;
-        }
-    }
-    public static class NoteModerationFailed {
-        CommentStatus mStatus;
-        String mNoteId;
-        public NoteModerationFailed(String noteId, CommentStatus status) {
-            mNoteId = noteId;
-            mStatus = status;
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
@@ -1,6 +1,32 @@
 package org.wordpress.android.ui.notifications;
 
+import org.wordpress.android.models.CommentStatus;
+
 public class NotificationEvents {
     public static class SimperiumNotAuthorized {}
     public static class NotificationsChanged {}
+    public static class NoteModerationStatusChanged {
+        boolean mIsModerating;
+        String mNoteId;
+        public NoteModerationStatusChanged(String noteId, boolean isModerating) {
+            mNoteId = noteId;
+            mIsModerating = isModerating;
+        }
+    }
+    public static class NoteVisibilityChanged {
+        boolean mIsHidden;
+        String mNoteId;
+        public NoteVisibilityChanged(String noteId, boolean isHidden) {
+            mNoteId = noteId;
+            mIsHidden = isHidden;
+        }
+    }
+    public static class NoteModerationFailed {
+        CommentStatus mStatus;
+        String mNoteId;
+        public NoteModerationFailed(String noteId, CommentStatus status) {
+            mNoteId = noteId;
+            mStatus = status;
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -5,7 +5,6 @@ import android.app.Fragment;
 import android.app.NotificationManager;
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Parcelable;
 import android.support.annotation.StringRes;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
@@ -17,7 +16,6 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
 
-import com.cocosw.undobar.UndoBarController;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketObject;
 import com.simperium.client.BucketObjectMissingException;
@@ -25,19 +23,19 @@ import com.simperium.client.BucketObjectMissingException;
 import org.wordpress.android.GCMIntentService;
 import org.wordpress.android.R;
 import org.wordpress.android.models.AccountHelper;
-import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.models.Note;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
-import org.wordpress.android.ui.comments.CommentActions;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter;
 import org.wordpress.android.ui.notifications.utils.SimperiumUtils;
 import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.ToastUtils.Duration;
 
 import javax.annotation.Nonnull;
+
+import de.greenrobot.event.EventBus;
 
 public class NotificationsListFragment extends Fragment
         implements Bucket.Listener<Note>,
@@ -301,88 +299,6 @@ public class NotificationsListFragment extends Fragment
         mRestoredScrollPosition = listPosition;
     }
 
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == RequestCodes.NOTE_DETAIL && resultCode == Activity.RESULT_OK && data != null) {
-            if (SimperiumUtils.getNotesBucket() == null) return;
-
-            try {
-                Note note = SimperiumUtils.getNotesBucket().get(StringUtils.notNullStr(data.getStringExtra(NOTE_MODERATE_ID_EXTRA)));
-                CommentStatus commentStatus = CommentStatus.fromString(data.getStringExtra(NOTE_MODERATE_STATUS_EXTRA));
-                moderateCommentForNote(note, commentStatus);
-            } catch (BucketObjectMissingException e) {
-                e.printStackTrace();
-            }
-        }
-
-        super.onActivityResult(requestCode, resultCode, data);
-    }
-
-    private void moderateCommentForNote(final Note note, final CommentStatus newStatus) {
-        if (!isAdded()) return;
-
-        if (newStatus == CommentStatus.APPROVED || newStatus == CommentStatus.UNAPPROVED) {
-            note.setLocalStatus(CommentStatus.toRESTString(newStatus));
-            note.save();
-            setNoteIsModerating(note.getId(), true);
-            CommentActions.moderateCommentForNote(note, newStatus,
-                    new CommentActions.CommentActionListener() {
-                        @Override
-                        public void onActionResult(boolean succeeded) {
-                            if (!isAdded()) return;
-
-                            setNoteIsModerating(note.getId(), false);
-
-                            if (!succeeded) {
-                                note.setLocalStatus(null);
-                                note.save();
-                                ToastUtils.showToast(getActivity(),
-                                        R.string.error_moderate_comment,
-                                        ToastUtils.Duration.LONG
-                                );
-                            }
-                        }
-                    });
-        } else if (newStatus == CommentStatus.TRASH || newStatus == CommentStatus.SPAM) {
-            setNoteIsHidden(note.getId(), true);
-            // Show undo bar for trash or spam actions
-            new UndoBarController.UndoBar(getActivity())
-                    .message(newStatus == CommentStatus.TRASH ? R.string.comment_trashed : R.string.comment_spammed)
-                    .listener(new UndoBarController.AdvancedUndoListener() {
-                        @Override
-                        public void onHide(Parcelable parcelable) {
-                            // Deleted notifications in Simperium never come back, so we won't
-                            // make the request until the undo bar fades away
-                            CommentActions.moderateCommentForNote(note, newStatus,
-                                    new CommentActions.CommentActionListener() {
-                                        @Override
-                                        public void onActionResult(boolean succeeded) {
-                                            if (!isAdded()) return;
-
-                                            if (!succeeded) {
-                                                setNoteIsHidden(note.getId(), false);
-                                                ToastUtils.showToast(getActivity(),
-                                                        R.string.error_moderate_comment,
-                                                        ToastUtils.Duration.LONG
-                                                );
-                                            }
-                                        }
-                                    });
-                        }
-
-                        @Override
-                        public void onClear(@Nonnull Parcelable[] token) {
-                            //noop
-                        }
-
-                        @Override
-                        public void onUndo(Parcelable parcelable) {
-                            setNoteIsHidden(note.getId(), false);
-                        }
-                    }).show();
-        }
-    }
-
     /**
      * Simperium bucket listener methods
      */
@@ -426,4 +342,32 @@ public class NotificationsListFragment extends Fragment
         }
     }
 
+    @Override
+    public void onStop() {
+        EventBus.getDefault().unregister(this);
+        super.onStop();
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        EventBus.getDefault().register(this);
+    }
+
+    @SuppressWarnings("unused")
+    public void onEventMainThread(NotificationEvents.NoteModerationStatusChanged event) {
+        setNoteIsModerating(event.mNoteId, event.mIsModerating);
+    }
+
+    @SuppressWarnings("unused")
+    public void onEventMainThread(NotificationEvents.NoteVisibilityChanged event) {
+        setNoteIsHidden(event.mNoteId, event.mIsHidden);
+    }
+
+    @SuppressWarnings("unused")
+    public void onEventMainThread(NotificationEvents.NoteModerationFailed event) {
+        if (isAdded()) {
+            ToastUtils.showToast(getActivity(), R.string.error_moderate_comment, Duration.LONG);
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -480,7 +480,7 @@ public class NotificationsUtils {
                                     public void onActionResult(boolean succeeded) {
                                         if (!succeeded) {
                                             EventBus.getDefault().post(new NoteVisibilityChanged(note.getId(), false));
-                                            EventBus.getDefault().post(new NoteModerationFailed(note.getId(), status));
+                                            EventBus.getDefault().post(new NoteModerationFailed());
                                         }
                                     }
                                 });
@@ -515,7 +515,7 @@ public class NotificationsUtils {
                             if (!succeeded) {
                                 note.setLocalStatus(null);
                                 note.save();
-                                EventBus.getDefault().post(new NoteModerationFailed(note.getId(), newStatus));
+                                EventBus.getDefault().post(new NoteModerationFailed());
                             }
                         }
                     });

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -1,10 +1,12 @@
 package org.wordpress.android.ui.notifications.utils;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.os.Parcelable;
 import android.preference.PreferenceManager;
 import android.text.Layout;
 import android.text.Spannable;
@@ -18,6 +20,7 @@ import android.view.View;
 import android.widget.TextView;
 
 import com.android.volley.VolleyError;
+import com.cocosw.undobar.UndoBarController;
 import com.google.android.gcm.GCMRegistrar;
 import com.google.gson.Gson;
 import com.google.gson.internal.StringMap;
@@ -31,6 +34,12 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.ReaderPostTable;
 import org.wordpress.android.models.AccountHelper;
+import org.wordpress.android.models.CommentStatus;
+import org.wordpress.android.models.Note;
+import org.wordpress.android.ui.comments.CommentActions;
+import org.wordpress.android.ui.notifications.NotificationEvents.NoteModerationFailed;
+import org.wordpress.android.ui.notifications.NotificationEvents.NoteModerationStatusChanged;
+import org.wordpress.android.ui.notifications.NotificationEvents.NoteVisibilityChanged;
 import org.wordpress.android.ui.notifications.NotificationsDetailActivity;
 import org.wordpress.android.ui.notifications.blocks.NoteBlock;
 import org.wordpress.android.ui.notifications.blocks.NoteBlockClickableSpan;
@@ -44,6 +53,10 @@ import org.wordpress.android.util.helpers.WPImageGetter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.annotation.Nonnull;
+
+import de.greenrobot.event.EventBus;
 
 public class NotificationsUtils {
 
@@ -451,5 +464,65 @@ public class NotificationsUtils {
 
     public static boolean spannableHasCharacterAtIndex(Spannable spannable, char character, int index) {
         return spannable != null && index < spannable.length() && spannable.charAt(index) == character;
+    }
+
+    private static void showUndoBarForNote(final Note note, final CommentStatus status, final Activity activity) {
+        new UndoBarController.UndoBar(activity)
+                .message(status == CommentStatus.TRASH ? R.string.comment_trashed : R.string.comment_spammed)
+                .listener(new UndoBarController.AdvancedUndoListener() {
+                    @Override
+                    public void onHide(Parcelable parcelable) {
+                        // Deleted notifications in Simperium never come back, so we won't
+                        // make the request until the undo bar fades away
+                        CommentActions.moderateCommentForNote(note, status,
+                                new CommentActions.CommentActionListener() {
+                                    @Override
+                                    public void onActionResult(boolean succeeded) {
+                                        if (!succeeded) {
+                                            EventBus.getDefault().post(new NoteVisibilityChanged(note.getId(), false));
+                                            EventBus.getDefault().post(new NoteModerationFailed(note.getId(), status));
+                                        }
+                                    }
+                                });
+                    }
+
+                    @Override
+                    public void onClear(@Nonnull Parcelable[] token) {
+                        //noop
+                    }
+
+                    @Override
+                    public void onUndo(Parcelable parcelable) {
+                        EventBus.getDefault().post(new NoteVisibilityChanged(note.getId(), false));
+                    }
+                }).show();
+    }
+
+    /**
+     * Moderate a comment from a WPCOM notification.
+     * Broadcast EventBus events on update/success/failure and show an undo bar if new status is Trash or Spam
+     */
+    public static void moderateCommentForNote(final Note note, final CommentStatus newStatus, final Activity activity) {
+        if (newStatus == CommentStatus.APPROVED || newStatus == CommentStatus.UNAPPROVED) {
+            note.setLocalStatus(CommentStatus.toRESTString(newStatus));
+            note.save();
+            EventBus.getDefault().post(new NoteModerationStatusChanged(note.getId(), true));
+            CommentActions.moderateCommentForNote(note, newStatus,
+                    new CommentActions.CommentActionListener() {
+                        @Override
+                        public void onActionResult(boolean succeeded) {
+                            EventBus.getDefault().post(new NoteModerationStatusChanged(note.getId(), false));
+                            if (!succeeded) {
+                                note.setLocalStatus(null);
+                                note.save();
+                                EventBus.getDefault().post(new NoteModerationFailed(note.getId(), newStatus));
+                            }
+                        }
+                    });
+        } else if (newStatus == CommentStatus.TRASH || newStatus == CommentStatus.SPAM) {
+            EventBus.getDefault().post(new NoteVisibilityChanged(note.getId(), true));
+            // Show undo bar for trash or spam actions
+            showUndoBarForNote(note, newStatus, activity);
+        }
     }
 }


### PR DESCRIPTION
Fix #2768

Move comment moderation from NotificationsListFragment.onActivityResult to WPMainActivity.onActivityResult so comment will be moderated even if NotificationsListFragment is not instantiated.

