### PR TITLE
Notifications: Adds support for 'Automattcher' ranges in bold text.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlockClickableSpan.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlockClickableSpan.java
@@ -61,15 +61,21 @@ public class NoteBlockClickableSpan extends ClickableSpan {
             mUrl = JSONUtils.queryJSON(mBlockData, "url", "");
             mIndices = NotificationsUtils.getIndicesForRange(mBlockData);
 
-            // Don't link certain range types, or unknown ones, unless we have a URL
-            mShouldLink = mShouldLink && mRangeType != NoteBlockRangeType.BLOCKQUOTE &&
-                    (mRangeType != NoteBlockRangeType.UNKNOWN || !TextUtils.isEmpty(mUrl));
+            mShouldLink = shouldLinkRangeType();
 
             // Apply grey color to some types
             if (mIsFooter || getRangeType() == NoteBlockRangeType.BLOCKQUOTE || getRangeType() == NoteBlockRangeType.POST) {
                 mTextColor = mLightTextColor;
             }
         }
+    }
+
+    // Don't link certain range types, or unknown ones, unless we have a URL
+    private boolean shouldLinkRangeType() {
+        return  mShouldLink &&
+                mRangeType != NoteBlockRangeType.BLOCKQUOTE &&
+                mRangeType != NoteBlockRangeType.MATCH &&
+                (mRangeType != NoteBlockRangeType.UNKNOWN || !TextUtils.isEmpty(mUrl));
     }
 
     @Override
@@ -94,6 +100,7 @@ public class NoteBlockClickableSpan extends ClickableSpan {
 
         switch (getRangeType()) {
             case USER:
+            case MATCH:
                 return Typeface.BOLD;
             case SITE:
             case POST:

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlockRangeType.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlockRangeType.java
@@ -15,6 +15,7 @@ public enum NoteBlockRangeType {
     FOLLOW,
     NOTICON,
     LIKE,
+    MATCH,
     UNKNOWN;
 
     public static NoteBlockRangeType fromString(String value) {
@@ -39,6 +40,8 @@ public enum NoteBlockRangeType {
                 return NOTICON;
             case "like":
                 return LIKE;
+            case "match":
+                return MATCH;
             default:
                 return UNKNOWN;
         }


### PR DESCRIPTION
When you open a comment `Automattcher` notification, it will display the matched text in bold:
![screen shot 2015-06-02 at 4 19 19 pm](https://cloud.githubusercontent.com/assets/789137/7949525/791d683c-0943-11e5-958f-d196daf3fada.png)

Fixes #2766