### PR TITLE
Fix #2703 - Adding scrollbar to dropdown lists.

### DIFF
--- a/WordPress/src/main/res/drawable/scrollbar_transparent_black.xml
+++ b/WordPress/src/main/res/drawable/scrollbar_transparent_black.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <solid
+        android:color="@color/translucent_grey" />
+
+    <size
+        android:width="3dp" />
+
+    <stroke
+        android:width="0dp" />
+
+</shape>

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -67,6 +67,8 @@
     <color name="translucent_grey_lighten_10">#80a8bece</color>
     <color name="translucent_grey_lighten_20">#80c8d7e1</color>
     <color name="translucent_grey_lighten_30">#80e9eff3</color>
+    <color name="translucent_grey">#80888888</color>
+
     <!-- END WordPress.com Colors -->
     <!-- ======================== -->
 

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -12,7 +12,7 @@
         <item name="android:windowBackground">@color/grey_lighten_30</item>
         <item name="android:actionBarItemBackground">@drawable/selectable_background_wordpress</item>
         <item name="android:popupMenuStyle">@style/PopupMenu.WordPress</item>
-        <item name="android:dropDownListViewStyle">@style/DropDownListView.Dark.WordPress</item>
+        <item name="android:dropDownListViewStyle">@style/DropDownListView.Light.WordPress</item>
         <item name="android:actionDropDownStyle">@style/DropDownNav.WordPress</item>
         <item name="android:actionModeCloseButtonStyle">@style/ActionButton.CloseMode.WordPress</item>
         <item name="android:actionModeBackground">@color/color_primary_dark</item>
@@ -59,6 +59,7 @@
     <style name="DropDownListView.Light.WordPress" parent="android:Widget.Holo.ListView.DropDown">
         <item name="android:listSelector">@drawable/selectable_background_wordpress</item>
         <item name="android:fadeScrollbars">false</item>
+        <item name="android:scrollbarThumbVertical">@drawable/scrollbar_transparent_black</item>
     </style>
 
     <style name="TabTextStyle.WordPress" parent="android:Widget.Holo.ActionBar.TabText">


### PR DESCRIPTION
Lots of trial and error but I got to a solution that works on pre and post Lollipop. This will also add the scrollbar to other dropdown lists in the app, the Post Settings format list for example. Tested with 5.0/5.1/4.1.2.

Addresses #2703.