### PR TITLE
Fix #2808 add to media library crash when there is no current blo

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ViewSiteActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ViewSiteActivity.java
@@ -48,6 +48,7 @@ public class ViewSiteActivity extends ActionBarActivity {
             Toast.makeText(this, getResources().getText(R.string.blog_not_found),
                     Toast.LENGTH_SHORT).show();
             finish();
+            return;
         }
 
         setContentView(R.layout.webview);
@@ -64,7 +65,7 @@ public class ViewSiteActivity extends ActionBarActivity {
         mWebView.getSettings().setJavaScriptEnabled(true);
         mWebView.getSettings().setDomStorageEnabled(true);
 
-        this.setTitle(StringUtils.unescapeHTML(mBlog.getBlogName()));
+        setTitle(StringUtils.unescapeHTML(mBlog.getBlogName()));
         loadSiteURL();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -43,6 +43,7 @@ import org.wordpress.android.ui.media.MediaItemFragment.MediaItemFragmentCallbac
 import org.wordpress.android.ui.media.services.MediaDeleteService;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.widgets.WPAlertDialogFragment;
 import org.xmlrpc.android.ApiHelper;
 import org.xmlrpc.android.ApiHelper.GetFeatures.Callback;
@@ -88,6 +89,12 @@ public class MediaBrowserActivity extends ActionBarActivity implements MediaGrid
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        // This should be removed when #2734 is fixed
+        if (WordPress.getCurrentBlog() == null) {
+            ToastUtils.showToast(this, R.string.blog_not_found, ToastUtils.Duration.SHORT);
+            finish();
+            return;
+        }
 
         setContentView(R.layout.media_browser_activity);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsActivity.java
@@ -65,6 +65,12 @@ public class PostsActivity extends ActionBarActivity
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        // This should be removed when #2734 is fixed
+        if (WordPress.getCurrentBlog() == null) {
+            ToastUtils.showToast(this, R.string.blog_not_found, ToastUtils.Duration.SHORT);
+            finish();
+            return;
+        }
         ProfilingUtils.split("PostsActivity.onCreate");
         ProfilingUtils.dump();
 


### PR DESCRIPTION
Fix #2808 add to media library crash when there is no current blog

To reproduce the crash:

* Hide all blogs (on the Web or using a previous app version)
* Go to Media Library
* Tap the plus button
* Tap any button on the Add menu

Note: #2734 will avoid activities to be launched with no current blog.