### PR TITLE
Removed popular tags

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -59,7 +59,7 @@ import de.greenrobot.event.EventBus;
  * followed tags, popular tags, followed blogs, and recommended blogs
  */
 public class ReaderSubsActivity extends ActionBarActivity
-                                implements ReaderTagAdapter.TagActionListener,
+                                implements ReaderTagAdapter.TagDeletedListener,
                                            ActionBar.TabListener {
 
     private EditText mEditAdd;
@@ -77,9 +77,8 @@ public class ReaderSubsActivity extends ActionBarActivity
     static final String KEY_LAST_ADDED_TAG_NAME = "last_added_tag_name";
 
     private static final int TAB_IDX_FOLLOWED_TAGS = 0;
-    private static final int TAB_IDX_SUGGESTED_TAGS = 1;
-    private static final int TAB_IDX_FOLLOWED_BLOGS = 2;
-    private static final int TAB_IDX_RECOMMENDED_BLOGS = 3;
+    private static final int TAB_IDX_FOLLOWED_BLOGS = 1;
+    private static final int TAB_IDX_RECOMMENDED_BLOGS = 2;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -167,12 +166,7 @@ public class ReaderSubsActivity extends ActionBarActivity
     @SuppressWarnings("unused")
     public void onEventMainThread(ReaderEvents.FollowedTagsChanged event) {
         mTagsChanged = true;
-        getPageAdapter().refreshTagFragments();
-    }
-
-    @SuppressWarnings("unused")
-    public void onEventMainThread(ReaderEvents.RecommendedTagsChanged event) {
-        getPageAdapter().refreshTagFragments();
+        getPageAdapter().refreshFollowedTagFragment();
     }
 
     @SuppressWarnings("unused")
@@ -193,8 +187,7 @@ public class ReaderSubsActivity extends ActionBarActivity
 
         ReaderUpdateService.startService(this,
                 EnumSet.of(UpdateTask.TAGS,
-                           UpdateTask.FOLLOWED_BLOGS,
-                           UpdateTask.RECOMMENDED_BLOGS));
+                           UpdateTask.FOLLOWED_BLOGS));
 
         mHasPerformedUpdate = true;
     }
@@ -212,11 +205,7 @@ public class ReaderSubsActivity extends ActionBarActivity
         if (mPageAdapter == null) {
             List<Fragment> fragments = new ArrayList<>();
 
-            // add tag fragments
-            fragments.add(ReaderTagFragment.newInstance(ReaderTagType.FOLLOWED));
-            fragments.add(ReaderTagFragment.newInstance(ReaderTagType.RECOMMENDED));
-
-            // add blog fragments
+            fragments.add(ReaderTagFragment.newInstance());
             fragments.add(ReaderBlogFragment.newInstance(ReaderBlogType.FOLLOWED));
             fragments.add(ReaderBlogFragment.newInstance(ReaderBlogType.RECOMMENDED));
 
@@ -349,7 +338,7 @@ public class ReaderSubsActivity extends ActionBarActivity
             @Override
             public void onActionResult(boolean succeeded) {
                 if (!succeeded && !isFinishing()) {
-                    getPageAdapter().refreshTagFragments();
+                    getPageAdapter().refreshFollowedTagFragment();
                     ToastUtils.showToast(ReaderSubsActivity.this, R.string.reader_toast_err_add_tag);
                     mLastAddedTagName = null;
                 }
@@ -359,7 +348,11 @@ public class ReaderSubsActivity extends ActionBarActivity
         ReaderTag tag = new ReaderTag(tagName, ReaderTagType.FOLLOWED);
 
         if (ReaderTagActions.performTagAction(tag, TagAction.ADD, actionListener)) {
-            onTagAction(tag, TagAction.ADD);
+            AnalyticsTracker.track(AnalyticsTracker.Stat.READER_FOLLOWED_READER_TAG);
+            mLastAddedTagName = tag.getTagName();
+            // make sure addition is reflected on followed tags
+            getPageAdapter().refreshFollowedTagFragment();
+            showInfoToast(getString(R.string.reader_label_added_tag, tag.getCapitalizedTagName()));
         }
     }
 
@@ -448,32 +441,17 @@ public class ReaderSubsActivity extends ActionBarActivity
         toast.show();
     }
     /*
-     * triggered by a tag fragment's adapter after user adds/removes a tag, or from this activity
-     * after user adds a tag - note that network request has been made by the time this is called
+     * triggered by a tag fragment's adapter after user removes a tag - note that the network
+     * request has already been made when this is called
      */
     @Override
-    public void onTagAction(ReaderTag tag, TagAction action) {
+    public void onTagDeleted(ReaderTag tag) {
         mTagsChanged = true;
-
-        switch (action) {
-            case ADD:
-                AnalyticsTracker.track(AnalyticsTracker.Stat.READER_FOLLOWED_READER_TAG);
-                mLastAddedTagName = tag.getTagName();
-                // user added from recommended tags, make sure addition is reflected on followed tags
-                getPageAdapter().refreshTagFragments(ReaderTagType.FOLLOWED);
-                showInfoToast(getString(R.string.reader_label_added_tag, tag.getCapitalizedTagName()));
-                break;
-
-            case DELETE:
-                AnalyticsTracker.track(AnalyticsTracker.Stat.READER_UNFOLLOWED_READER_TAG);
-                if (mLastAddedTagName != null && mLastAddedTagName.equalsIgnoreCase(tag.getTagName())) {
-                    mLastAddedTagName = null;
-                }
-                // user deleted from followed tags, make sure deletion is reflected on recommended tags
-                getPageAdapter().refreshTagFragments(ReaderTagType.RECOMMENDED);
-                showInfoToast(getString(R.string.reader_label_removed_tag, tag.getCapitalizedTagName()));
-                break;
+        AnalyticsTracker.track(AnalyticsTracker.Stat.READER_UNFOLLOWED_READER_TAG);
+        if (mLastAddedTagName != null && mLastAddedTagName.equalsIgnoreCase(tag.getTagName())) {
+            mLastAddedTagName = null;
         }
+        showInfoToast(getString(R.string.reader_label_removed_tag, tag.getCapitalizedTagName()));
     }
 
     /*
@@ -531,9 +509,6 @@ public class ReaderSubsActivity extends ActionBarActivity
                 case TAB_IDX_FOLLOWED_TAGS:
                     title = getString(R.string.reader_page_followed_tags);
                     break;
-                case TAB_IDX_SUGGESTED_TAGS:
-                    title = getString(R.string.reader_page_popular_tags);
-                    break;
                 case TAB_IDX_RECOMMENDED_BLOGS:
                     title = getString(R.string.reader_page_recommended_blogs);
                     break;
@@ -558,16 +533,11 @@ public class ReaderSubsActivity extends ActionBarActivity
             return mFragments.size();
         }
 
-        private void refreshTagFragments() {
-            refreshTagFragments(null);
-        }
-        private void refreshTagFragments(ReaderTagType tagType) {
+        private void refreshFollowedTagFragment() {
             for (Fragment fragment: mFragments) {
                 if (fragment instanceof ReaderTagFragment) {
                     ReaderTagFragment tagFragment = (ReaderTagFragment) fragment;
-                    if (tagType == null || tagType.equals(tagFragment.getTagType())) {
-                        tagFragment.refresh();
-                    }
+                    tagFragment.refresh();
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
@@ -10,56 +10,21 @@ import android.widget.TextView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.models.ReaderTag;
-import org.wordpress.android.models.ReaderTagType;
-import org.wordpress.android.ui.reader.actions.ReaderTagActions.TagAction;
 import org.wordpress.android.ui.reader.adapters.ReaderTagAdapter;
-import org.wordpress.android.ui.reader.adapters.ReaderTagAdapter.TagActionListener;
 import org.wordpress.android.ui.reader.views.ReaderRecyclerView;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.WPActivityUtils;
 
 /*
- * fragment hosted by ReaderSubsActivity which shows either followed or popular tags
+ * fragment hosted by ReaderSubsActivity which shows followed tags
  */
-public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagActionListener {
+public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagDeletedListener {
     private ReaderRecyclerView mRecyclerView;
     private ReaderTagAdapter mTagAdapter;
-    private ReaderTagType mTagType;
-    private static final String ARG_TAG_TYPE = "tag_type";
 
-    static ReaderTagFragment newInstance(ReaderTagType tagType) {
+    static ReaderTagFragment newInstance() {
         AppLog.d(AppLog.T.READER, "reader tag list > newInstance");
-
-        Bundle args = new Bundle();
-        args.putSerializable(ARG_TAG_TYPE, tagType);
-        ReaderTagFragment fragment = new ReaderTagFragment();
-        fragment.setArguments(args);
-
-        return fragment;
-    }
-
-    @Override
-    public void setArguments(Bundle args) {
-        super.setArguments(args);
-        restoreState(args);
-    }
-
-    private void restoreState(Bundle args) {
-        if (args == null) {
-            return;
-        }
-        if (args.containsKey(ARG_TAG_TYPE)) {
-            mTagType = (ReaderTagType) args.getSerializable(ARG_TAG_TYPE);
-        }
-    }
-
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        if (savedInstanceState != null) {
-            AppLog.d(AppLog.T.READER, "reader tag fragment > restoring instance state");
-            restoreState(savedInstanceState);
-        }
+        return new ReaderTagFragment();
     }
 
     @Override
@@ -69,23 +34,16 @@ public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagA
         return view;
     }
 
-    void checkEmptyView() {
+    private void checkEmptyView() {
         if (!isAdded()) {
             return;
         }
         boolean isEmpty = hasTagAdapter() && getTagAdapter().isEmpty();
         TextView emptyView = (TextView) getView().findViewById(R.id.text_empty);
-        if (isEmpty) {
-            switch (getTagType()) {
-                case FOLLOWED:
-                    emptyView.setText(R.string.reader_empty_followed_tags);
-                    break;
-                case RECOMMENDED:
-                    emptyView.setText(R.string.reader_empty_popular_tags);
-                    break;
-            }
-        }
         emptyView.setVisibility(isEmpty ? View.VISIBLE : View.GONE);
+        if (isEmpty) {
+            emptyView.setText(R.string.reader_empty_followed_tags);
+        }
     }
 
     @Override
@@ -95,27 +53,17 @@ public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagA
         getTagAdapter().refresh();
     }
 
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        outState.putSerializable(ARG_TAG_TYPE, getTagType());
-        super.onSaveInstanceState(outState);
-    }
-
     void refresh() {
         if (hasTagAdapter()) {
             getTagAdapter().refresh();
         }
     }
 
-    ReaderTagType getTagType() {
-        return mTagType;
-    }
-
     private ReaderTagAdapter getTagAdapter() {
         if (mTagAdapter == null) {
             Context context = WPActivityUtils.getThemedContext(getActivity());
-            mTagAdapter = new ReaderTagAdapter(context, getTagType());
-            mTagAdapter.setTagActionListener(this);
+            mTagAdapter = new ReaderTagAdapter(context);
+            mTagAdapter.setTagDeletedListener(this);
             mTagAdapter.setDataLoadedListener(new ReaderInterfaces.DataLoadedListener() {
                 @Override
                 public void onDataLoaded(boolean isEmpty) {
@@ -131,15 +79,15 @@ public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagA
     }
 
     /*
-     * called from adapter when user adds/removes a tag - note that the network request
+     * called from adapter when user removes a tag - note that the network request
      * has been made by the time this is called
      */
     @Override
-    public void onTagAction(ReaderTag tag, TagAction action) {
+    public void onTagDeleted(ReaderTag tag) {
         checkEmptyView();
         // let the host activity know about the change
-        if (getActivity() instanceof TagActionListener) {
-            ((TagActionListener) getActivity()).onTagAction(tag, action);
+        if (getActivity() instanceof ReaderTagAdapter.TagDeletedListener) {
+            ((ReaderTagAdapter.TagDeletedListener) getActivity()).onTagDeleted(tag);
         }
     }
 }

--- a/WordPress/src/main/res/layout/reader_listitem_tag.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_tag.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-    list item which shows either a followed or popular/recommended tag - see ReaderTagAdapter
+    list item which shows a followed tag - see ReaderTagAdapter
  -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
@@ -26,7 +26,7 @@
         tools:text="text_topic" />
 
     <ImageButton
-        android:id="@+id/btn_add_remove"
+        android:id="@+id/btn_remove"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -687,7 +687,6 @@
 
     <!-- view pager titles -->
     <string name="reader_page_followed_tags">Followed tags</string>
-    <string name="reader_page_popular_tags">Popular tags</string>
     <string name="reader_page_followed_blogs">Followed blogs</string>
     <string name="reader_page_recommended_blogs">Blogs you may like</string>
 
@@ -771,7 +770,6 @@
     <string name="reader_empty_posts_in_tag">No posts with this tag</string>
     <string name="reader_empty_posts_in_tag_updating">Fetching posts…</string>
     <string name="reader_empty_followed_tags">You don\'t follow any tags</string>
-    <string name="reader_empty_popular_tags">No popular tags</string>
     <string name="reader_empty_recommended_blogs">No recommended blogs</string>
     <string name="reader_empty_followed_blogs_title">You\'re not following any blogs yet</string>
     <string name="reader_empty_followed_blogs_description">But don\'t worry, just tap the tag icon to start exploring!</string>


### PR DESCRIPTION
Resolves #2826 - removes the "Popular Tags" page from ReaderSubsActivity - this was dropped because it was too English-centric and is being removed in Calypso as well.