### PR TITLE
 Fixes comment notification from not disappearing from notes list on Spam/Trash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -61,9 +61,6 @@ public class WPMainActivity extends Activity
     private SlidingTabLayout mTabs;
     private WPMainTabAdapter mTabAdapter;
 
-    // Keeps track of the noteId for when a user moderates from a push notification
-    private String mRemovedNoteId;
-
     public static final String ARG_OPENED_FROM_PUSH = "opened_from_push";
 
     /*
@@ -283,32 +280,15 @@ public class WPMainActivity extends Activity
     private void moderateCommentOnActivityResult(Intent data) {
         try {
             if (SimperiumUtils.getNotesBucket() != null) {
-                String noteId = StringUtils.notNullStr(data.getStringExtra(
-                        NotificationsListFragment.NOTE_MODERATE_ID_EXTRA));
-                Note note = SimperiumUtils.getNotesBucket().get(noteId);
+                Note note = SimperiumUtils.getNotesBucket().get(StringUtils.notNullStr(data.getStringExtra
+                        (NotificationsListFragment.NOTE_MODERATE_ID_EXTRA)));
                 CommentStatus status = CommentStatus.fromString(data.getStringExtra(
                         NotificationsListFragment.NOTE_MODERATE_STATUS_EXTRA));
                 NotificationsUtils.moderateCommentForNote(note, status, this);
-
-                if (status == CommentStatus.TRASH || status == CommentStatus.SPAM) {
-                    if (getNotificationListFragment() != null) {
-                        getNotificationListFragment().hideNote(noteId);
-                    } else {
-                        mRemovedNoteId = noteId;
-                    }
-                }
             }
         } catch (BucketObjectMissingException e) {
             AppLog.e(T.NOTIFS, e);
         }
-    }
-
-    public String getRemovedNoteId() {
-        return mRemovedNoteId;
-    }
-
-    public void setRemovedNoteId(String noteId) {
-        mRemovedNoteId = noteId;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -61,6 +61,9 @@ public class WPMainActivity extends Activity
     private SlidingTabLayout mTabs;
     private WPMainTabAdapter mTabAdapter;
 
+    // Keeps track of the noteId for when a user moderates from a push notification
+    private String mRemovedNoteId;
+
     public static final String ARG_OPENED_FROM_PUSH = "opened_from_push";
 
     /*
@@ -280,15 +283,32 @@ public class WPMainActivity extends Activity
     private void moderateCommentOnActivityResult(Intent data) {
         try {
             if (SimperiumUtils.getNotesBucket() != null) {
-                Note note = SimperiumUtils.getNotesBucket().get(StringUtils.notNullStr(data.getStringExtra
-                        (NotificationsListFragment.NOTE_MODERATE_ID_EXTRA)));
+                String noteId = StringUtils.notNullStr(data.getStringExtra(
+                        NotificationsListFragment.NOTE_MODERATE_ID_EXTRA));
+                Note note = SimperiumUtils.getNotesBucket().get(noteId);
                 CommentStatus status = CommentStatus.fromString(data.getStringExtra(
                         NotificationsListFragment.NOTE_MODERATE_STATUS_EXTRA));
                 NotificationsUtils.moderateCommentForNote(note, status, this);
+
+                if (status == CommentStatus.TRASH || status == CommentStatus.SPAM) {
+                    if (getNotificationListFragment() != null) {
+                        getNotificationListFragment().hideNote(noteId);
+                    } else {
+                        mRemovedNoteId = noteId;
+                    }
+                }
             }
         } catch (BucketObjectMissingException e) {
             AppLog.e(T.NOTIFS, e);
         }
+    }
+
+    public String getRemovedNoteId() {
+        return mRemovedNoteId;
+    }
+
+    public void setRemovedNoteId(String noteId) {
+        mRemovedNoteId = noteId;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -351,7 +351,7 @@ public class NotificationsListFragment extends Fragment
     @Override
     public void onStart() {
         super.onStart();
-        EventBus.getDefault().register(this);
+        EventBus.getDefault().registerSticky(this);
     }
 
     @SuppressWarnings("unused")
@@ -362,6 +362,9 @@ public class NotificationsListFragment extends Fragment
     @SuppressWarnings("unused")
     public void onEventMainThread(NotificationEvents.NoteVisibilityChanged event) {
         setNoteIsHidden(event.mNoteId, event.mIsHidden);
+
+        // Clear out the sticky event
+        EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteVisibilityChanged.class);
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -139,6 +139,15 @@ public class NotificationsListFragment extends Fragment
             SimperiumUtils.startBuckets();
             AppLog.i(AppLog.T.NOTIFS, "Starting Simperium buckets");
         }
+
+        if (getActivity() instanceof WPMainActivity) {
+            WPMainActivity activity = (WPMainActivity)getActivity();
+
+            if (!TextUtils.isEmpty(activity.getRemovedNoteId())) {
+                hideNote(activity.getRemovedNoteId());
+                activity.setRemovedNoteId(null);
+            }
+        }
     }
 
     @Override
@@ -179,6 +188,10 @@ public class NotificationsListFragment extends Fragment
         } else {
             activity.startActivityForResult(detailIntent, RequestCodes.NOTE_DETAIL);
         }
+    }
+
+    public void hideNote(String moderatingNoteId) {
+        setNoteIsHidden(moderatingNoteId, true);
     }
 
     private void setNoteIsHidden(String noteId, boolean isHidden) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -139,15 +139,6 @@ public class NotificationsListFragment extends Fragment
             SimperiumUtils.startBuckets();
             AppLog.i(AppLog.T.NOTIFS, "Starting Simperium buckets");
         }
-
-        if (getActivity() instanceof WPMainActivity) {
-            WPMainActivity activity = (WPMainActivity)getActivity();
-
-            if (!TextUtils.isEmpty(activity.getRemovedNoteId())) {
-                hideNote(activity.getRemovedNoteId());
-                activity.setRemovedNoteId(null);
-            }
-        }
     }
 
     @Override
@@ -188,10 +179,6 @@ public class NotificationsListFragment extends Fragment
         } else {
             activity.startActivityForResult(detailIntent, RequestCodes.NOTE_DETAIL);
         }
-    }
-
-    public void hideNote(String moderatingNoteId) {
-        setNoteIsHidden(moderatingNoteId, true);
     }
 
     private void setNoteIsHidden(String noteId, boolean isHidden) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -577,7 +577,6 @@ public class NotificationsUtils {
                         }
                     });
         } else if (newStatus == CommentStatus.TRASH || newStatus == CommentStatus.SPAM) {
-            EventBus.getDefault().post(new NoteVisibilityChanged(note.getId(), true));
             // Show undo bar for trash or spam actions
             showUndoBarForNote(note, newStatus, activity);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -577,6 +577,7 @@ public class NotificationsUtils {
                         }
                     });
         } else if (newStatus == CommentStatus.TRASH || newStatus == CommentStatus.SPAM) {
+            EventBus.getDefault().post(new NoteVisibilityChanged(note.getId(), true));
             // Show undo bar for trash or spam actions
             showUndoBarForNote(note, newStatus, activity);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -577,7 +577,8 @@ public class NotificationsUtils {
                         }
                     });
         } else if (newStatus == CommentStatus.TRASH || newStatus == CommentStatus.SPAM) {
-            EventBus.getDefault().post(new NoteVisibilityChanged(note.getId(), true));
+            // Post as sticky, so that NotificationsListFragment can pick it up after it's created
+            EventBus.getDefault().postSticky(new NoteVisibilityChanged(note.getId(), true));
             // Show undo bar for trash or spam actions
             showUndoBarForNote(note, newStatus, activity);
         }


### PR DESCRIPTION
I wish this was a more elegant solution, maybe the reviewer might have a better idea :)

The NotificationsListFragment needed to check that a noteId had been hidden when it resumed, so I ended up adding a String var to `WPMainActivity` which I wasn't too happy with.

Fixes #2816