### PR TITLE
One-line fix to request reader recommended blogs again

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -187,7 +187,8 @@ public class ReaderSubsActivity extends ActionBarActivity
 
         ReaderUpdateService.startService(this,
                 EnumSet.of(UpdateTask.TAGS,
-                           UpdateTask.FOLLOWED_BLOGS));
+                           UpdateTask.FOLLOWED_BLOGS,
+                           UpdateTask.RECOMMENDED_BLOGS));
 
         mHasPerformedUpdate = true;
     }


### PR DESCRIPTION
Fix #2839 by requesting recommended blogs again in the reader subs activity (without this, the "Blogs You May Like" tab will be empty or stale).