### PR TITLE
Fix comment moderation animation on notifications list gravatar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -357,6 +357,9 @@ public class NotificationsListFragment extends Fragment
     @SuppressWarnings("unused")
     public void onEventMainThread(NotificationEvents.NoteModerationStatusChanged event) {
         setNoteIsModerating(event.mNoteId, event.mIsModerating);
+
+        // Clear out the sticky event
+        EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteModerationStatusChanged.class);
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -358,7 +358,6 @@ public class NotificationsListFragment extends Fragment
     public void onEventMainThread(NotificationEvents.NoteModerationStatusChanged event) {
         setNoteIsModerating(event.mNoteId, event.mIsModerating);
 
-        // Clear out the sticky event
         EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteModerationStatusChanged.class);
     }
 
@@ -366,7 +365,6 @@ public class NotificationsListFragment extends Fragment
     public void onEventMainThread(NotificationEvents.NoteVisibilityChanged event) {
         setNoteIsHidden(event.mNoteId, event.mIsHidden);
 
-        // Clear out the sticky event
         EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteVisibilityChanged.class);
     }
 
@@ -374,6 +372,8 @@ public class NotificationsListFragment extends Fragment
     public void onEventMainThread(NotificationEvents.NoteModerationFailed event) {
         if (isAdded()) {
             ToastUtils.showToast(getActivity(), R.string.error_moderate_comment, Duration.LONG);
+
+            EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteModerationFailed.class);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -372,8 +372,8 @@ public class NotificationsListFragment extends Fragment
     public void onEventMainThread(NotificationEvents.NoteModerationFailed event) {
         if (isAdded()) {
             ToastUtils.showToast(getActivity(), R.string.error_moderate_comment, Duration.LONG);
-
-            EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteModerationFailed.class);
         }
+
+        EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteModerationFailed.class);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -563,7 +563,7 @@ public class NotificationsUtils {
         if (newStatus == CommentStatus.APPROVED || newStatus == CommentStatus.UNAPPROVED) {
             note.setLocalStatus(CommentStatus.toRESTString(newStatus));
             note.save();
-            EventBus.getDefault().post(new NoteModerationStatusChanged(note.getId(), true));
+            EventBus.getDefault().postSticky(new NoteModerationStatusChanged(note.getId(), true));
             CommentActions.moderateCommentForNote(note, newStatus,
                     new CommentActions.CommentActionListener() {
                         @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -536,8 +536,8 @@ public class NotificationsUtils {
                                     @Override
                                     public void onActionResult(boolean succeeded) {
                                         if (!succeeded) {
-                                            EventBus.getDefault().post(new NoteVisibilityChanged(note.getId(), false));
-                                            EventBus.getDefault().post(new NoteModerationFailed());
+                                            EventBus.getDefault().postSticky(new NoteVisibilityChanged(note.getId(), false));
+                                            EventBus.getDefault().postSticky(new NoteModerationFailed());
                                         }
                                     }
                                 });
@@ -550,7 +550,7 @@ public class NotificationsUtils {
 
                     @Override
                     public void onUndo(Parcelable parcelable) {
-                        EventBus.getDefault().post(new NoteVisibilityChanged(note.getId(), false));
+                        EventBus.getDefault().postSticky(new NoteVisibilityChanged(note.getId(), false));
                     }
                 }).show();
     }
@@ -568,11 +568,11 @@ public class NotificationsUtils {
                     new CommentActions.CommentActionListener() {
                         @Override
                         public void onActionResult(boolean succeeded) {
-                            EventBus.getDefault().post(new NoteModerationStatusChanged(note.getId(), false));
+                            EventBus.getDefault().postSticky(new NoteModerationStatusChanged(note.getId(), false));
                             if (!succeeded) {
                                 note.setLocalStatus(null);
                                 note.save();
-                                EventBus.getDefault().post(new NoteModerationFailed());
+                                EventBus.getDefault().postSticky(new NoteModerationFailed());
                             }
                         }
                     });


### PR DESCRIPTION
Similar fix to #2832, but for approving/unapproving a comment notification.

When moderating a comment with either approve or unapprove status, you should see an activity indicator over the gravatar.