### PR TITLE
Notifications - illegal state exception

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -75,7 +75,7 @@ public class NotificationsDetailActivity extends ActionBarActivity implements
                     Fragment detailFragment = getDetailFragmentForNote(note);
                     getFragmentManager().beginTransaction()
                             .add(R.id.notifications_detail_container, detailFragment)
-                            .commit();
+                            .commitAllowingStateLoss();
 
                     if (getSupportActionBar() != null) {
                         getSupportActionBar().setTitle(note.getTitle());

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -88,6 +88,10 @@ public class NotificationsListFragment extends Fragment
                 mNotesAdapter.setOnNoteClickListener(new OnNoteClickListener() {
                     @Override
                     public void onClickNote(String noteId) {
+                        if (!isAdded()) {
+                            return;
+                        }
+
                         if (TextUtils.isEmpty(noteId)) return;
 
                         // open the latest version of this note just in case it has changed - this can
@@ -168,6 +172,10 @@ public class NotificationsListFragment extends Fragment
                                 boolean shouldShowKeyboard,
                                 boolean shouldSlideIn) {
         if (noteId == null || activity == null) {
+            return;
+        }
+
+        if (activity.isFinishing()) {
             return;
         }
 


### PR DESCRIPTION
Fix #2859 by using `commitAllowingStateLoss` and added few others activity checks before adding fragments to the stack.