### PR TITLE
issue/2871-reader-card-footer

### DIFF
--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -134,14 +134,14 @@
                 android:layout_below="@+id/divider"
                 android:layout_marginLeft="@dimen/reader_card_content_padding"
                 android:layout_marginRight="@dimen/reader_card_content_padding"
-                android:gravity="center_vertical"
                 android:orientation="horizontal">
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/text_date"
                     style="@style/ReaderTextView.Date"
                     android:layout_width="0dp"
-                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:layout_height="@dimen/reader_button_icon"
                     android:layout_weight="2"
                     tools:text="text_date" />
 


### PR DESCRIPTION
Fix #2871 - date TextView in card footer now has a fixed height which matches the like & comment icon heights to prevent the footer from shrinking.