### PR TITLE
fix #2855 - comments > 2Mb

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/TestUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/TestUtils.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 
+import de.greenrobot.event.EventBus;
+
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
 
@@ -45,7 +47,9 @@ public class TestUtils {
             InputStreamReader inputStreamReader = new InputStreamReader(is);
             BufferedReader f = new BufferedReader(inputStreamReader);
             for (String line = f.readLine(); line != null; line = f.readLine()) {
-                if (TextUtils.isEmpty(line)) continue;
+                if (TextUtils.isEmpty(line)) {
+                    continue;
+                }
                 try {
                     db.execSQL(line);
                 } catch (android.database.sqlite.SQLiteException e) {
@@ -62,6 +66,19 @@ public class TestUtils {
             assertTrue(e.toString(), false);
         }
         return null;
+    }
+
+    public static void resetEventBus() {
+        Field dbField;
+        try {
+            dbField = EventBus.class.getDeclaredField("defaultInstance");
+            dbField.setAccessible(true);
+            dbField.set(EventBus.class, null);
+        } catch (NoSuchFieldException e) {
+            assertTrue(e.toString(), false);
+        } catch (IllegalAccessException e) {
+            assertTrue(e.toString(), false);
+        }
     }
 
     public static void clearDefaultSharedPreferences(Context targetContext) {
@@ -83,7 +100,7 @@ public class TestUtils {
             } catch (Exception e) {
                 // noop
             }
-       }
+        }
         TestUtils.clearDefaultSharedPreferences(context);
         TestUtils.dropDB(context);
     }

--- a/WordPress/src/androidTest/java/org/wordpress/android/database/CommentTableTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/database/CommentTableTest.java
@@ -1,0 +1,61 @@
+package org.wordpress.android.database;
+
+import android.content.Context;
+import android.test.InstrumentationTestCase;
+import android.test.RenamingDelegatingContext;
+
+import org.wordpress.android.TestUtils;
+import org.wordpress.android.datasets.CommentTable;
+import org.wordpress.android.models.Comment;
+
+public class CommentTableTest extends InstrumentationTestCase {
+    protected Context mTargetContext;
+    protected Context mTestContext;
+
+    @Override
+    protected void setUp() throws Exception {
+        // Clean application state
+        mTargetContext = new RenamingDelegatingContext(getInstrumentation().getTargetContext(), "test_");
+        mTestContext = getInstrumentation().getContext();
+        TestUtils.clearApplicationState(mTargetContext);
+        TestUtils.resetEventBus();
+    }
+
+    public void testGetCommentEqualTo1024K() {
+        createAndGetComment(1024 * 1024);
+    }
+
+    public void testGetCommentEqualTo2096550() {
+        createAndGetComment(2096550);  // 1024 * 1024 * 2 - 603
+    }
+
+    public void testGetCommentEqualTo2096549() {
+        createAndGetComment(2096549); // 1024 * 1024 * 2 - 602
+    }
+
+    public void testGetCommentEqualTo2048K() {
+        createAndGetComment(1024 * 1024 * 2);
+    }
+
+    private void createAndGetComment(int commentLength) {
+        // Load a sample DB and inject it into WordPress.wpdb
+        TestUtils.loadDBFromDump(mTargetContext, mTestContext, "taliwutt-blogs-sample.sql");
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < commentLength; ++i) {
+            sb.append('a');
+        }
+        Comment bigComment = new Comment(0,
+                1,
+                "author",
+                "0",
+                sb.toString(),
+                "approve",
+                "arst",
+                "http://mop.com",
+                "mop@mop.com",
+                "");
+        CommentTable.addComment(0, bigComment);
+        CommentTable.getCommentsForBlog(0);
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/database/WordPressDBTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/database/WordPressDBTest.java
@@ -1,17 +1,10 @@
-package org.wordpress.android.models;
+package org.wordpress.android.database;
 
 import android.content.Context;
-import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
 import android.test.InstrumentationTestCase;
 import android.test.RenamingDelegatingContext;
-import android.util.Log;
-import org.wordpress.android.TestUtils;
-import org.wordpress.android.WordPress;
-import org.wordpress.android.WordPressDB;
-import org.wordpress.android.models.CategoryNode;
 
-public class WordPressDB_Test extends InstrumentationTestCase {
+public class WordPressDBTest extends InstrumentationTestCase {
     protected Context testContext;
     protected Context targetContext;
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -74,7 +74,7 @@ public class WordPressDB {
     public static final String COLUMN_NAME_VIDEO_PRESS_SHORTCODE = "videoPressShortcode";
     public static final String COLUMN_NAME_UPLOAD_STATE          = "uploadState";
 
-    private static final int DATABASE_VERSION = 30;
+    private static final int DATABASE_VERSION = 31;
 
     private static final String CREATE_TABLE_BLOGS = "create table if not exists accounts (id integer primary key autoincrement, "
             + "url text, blogName text, username text, password text, imagePlacement text, centerThumbnail boolean, fullSizeImage boolean, maxImageWidth text, maxImageWidthId integer);";
@@ -292,6 +292,10 @@ public class WordPressDB {
                 if (!isNewInstall) {
                     migratePreferencesToAccountTable(context);
                 }
+                currentVersion++;
+            case 30:
+                // Fix big comments issue #2855
+                CommentTable.deleteBigComments(db);
                 currentVersion++;
         }
         db.setVersion(DATABASE_VERSION);

--- a/WordPress/src/main/java/org/wordpress/android/datasets/CommentTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/CommentTable.java
@@ -81,7 +81,7 @@ public class CommentTable {
     }
 
     /**
-     * nbradbury 11/15/13 - add a single comment - will update existing comment with same IDs
+     * add a single comment - will update existing comment with same IDs
      * @param localBlogId - unique id in account table for the blog the comment is from
      * @param comment - comment object to store
      */
@@ -106,7 +106,7 @@ public class CommentTable {
     }
 
     /**
-     * nbradbury 11/11/13 - retrieve a single comment
+     * retrieve a single comment
      * @param localBlogId - unique id in account table for the blog the comment is from
      * @param commentId - commentId of the actual comment
      * @return Comment if found, null otherwise
@@ -124,7 +124,7 @@ public class CommentTable {
     }
 
     /**
-     * nbradbury - get all comments for a blog
+     * get all comments for a blog
      * @param localBlogId - unique id in account table for this blog
      * @return list of comments for this blog
      */
@@ -132,7 +132,8 @@ public class CommentTable {
         CommentList comments = new CommentList();
 
         String[] args = {Integer.toString(localBlogId)};
-        Cursor c = getReadableDb().rawQuery("SELECT * FROM " + COMMENTS_TABLE + " WHERE blog_id=? ORDER BY published DESC", args);
+        Cursor c = getReadableDb().rawQuery(
+                "SELECT * FROM " + COMMENTS_TABLE + " WHERE blog_id=? ORDER BY published DESC", args);
 
         try {
             if (c.moveToFirst()) {
@@ -149,16 +150,16 @@ public class CommentTable {
     }
 
     /**
-    * nbradbury - delete all comments for a blog
-    * @param localBlogId - unique id in account table for this blog
-    * @return number of comments deleted
+     * delete all comments for a blog
+     * @param localBlogId - unique id in account table for this blog
+     * @return number of comments deleted
      */
     public static int deleteCommentsForBlog(int localBlogId) {
         return getWritableDb().delete(COMMENTS_TABLE, "blog_id=?", new String[]{Integer.toString(localBlogId)});
     }
 
     /**
-     * nbradbury - saves comments for passed blog to local db, overwriting existing ones if necessary
+     * saves comments for passed blog to local db, overwriting existing ones if necessary
      * @param localBlogId - unique id in account table for this blog
      * @param comments - list of comments to save
      * @return true if saved, false on failure
@@ -214,7 +215,7 @@ public class CommentTable {
     }
 
     /**
-     * nbradbury - updates the passed comment
+     * updates the passed comment
      * @param localBlogId - unique id in account table for this blog
      * @param comment - comment to update
      */
@@ -224,7 +225,7 @@ public class CommentTable {
     }
 
     /**
-     * nbradbury - updates the status for the passed comment
+     * updates the status for the passed comment
      * @param localBlogId - unique id in account table for this blog
      * @param commentId - id of comment (returned by api)
      * @param newStatus - status to change to
@@ -241,7 +242,7 @@ public class CommentTable {
     }
 
     /**
-     * nbradbury - updates the status for the passed list of comments
+     * updates the status for the passed list of comments
      * @param localBlogId - unique id in account table for this blog
      * @param comments - list of comments to update
      * @param newStatus - status to change to
@@ -261,7 +262,7 @@ public class CommentTable {
     }
 
     /**
-     * nbradbury - updates the post title for the passed comment
+     * updates the post title for the passed comment
      * @param localBlogId - unique id in account table for this blog
      * @param postTitle - title to update to
      * @return true if title updated
@@ -276,7 +277,7 @@ public class CommentTable {
     }
 
     /**
-     * nbradbury 11/12/13 - delete a single comment
+     * delete a single comment
      * @param localBlogId - unique id in account table for this blog
      * @param commentId - commentId of the actual comment
      * @return true if comment deleted, false otherwise
@@ -289,7 +290,7 @@ public class CommentTable {
     }
 
     /**
-     * nbradbury - delete a list of comments
+     * delete a list of comments
      * @param localBlogId - unique id in account table for this blog
      * @param comments - list of comments to delete
      */
@@ -308,7 +309,7 @@ public class CommentTable {
     }
 
     /**
-     * nbradbury - returns the number of unmoderated comments for a specific blog
+     * returns the number of unmoderated comments for a specific blog
      * @param localBlogId - unique id in account table for this blog
      */
     public static int getUnmoderatedCommentCount(int localBlogId) {
@@ -343,7 +344,8 @@ public class CommentTable {
                 profileImageUrl);
     }
 
-    /*
+
+    /**
      * Delete big comments (Maximum 1024 * 1024 = 1048576) (fix #2855)
      * @return number of deleted comments
      */

--- a/WordPress/src/main/java/org/wordpress/android/datasets/CommentTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/CommentTable.java
@@ -235,10 +235,7 @@ public class CommentTable {
         values.put("status", newStatus);
         String[] args = {Integer.toString(localBlogId),
                          Long.toString(commentId)};
-        getWritableDb().update(COMMENTS_TABLE,
-                               values,
-                               "blog_id=? AND comment_id=?",
-                               args);
+        getWritableDb().update(COMMENTS_TABLE, values, "blog_id=? AND comment_id=?", args);
     }
 
     /**
@@ -346,10 +343,10 @@ public class CommentTable {
 
 
     /**
-     * Delete big comments (Maximum 1024 * 1024 = 1048576) (fix #2855)
+     * Delete big comments (Maximum 512 * 1024 = 524288) (fix #2855)
      * @return number of deleted comments
      */
     public static int deleteBigComments(SQLiteDatabase db) {
-        return db.delete(COMMENTS_TABLE, "LENGTH(comment) >= 1048576", null);
+        return db.delete(COMMENTS_TABLE, "LENGTH(comment) >= 524288", null);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/CommentTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/CommentTable.java
@@ -95,7 +95,7 @@ public class CommentTable {
         values.put("comment_id",        comment.commentID);
         values.put("author_name",       comment.getAuthorName());
         values.put("author_url",        comment.getAuthorUrl());
-        values.put("comment",           comment.getCommentText());
+        values.put("comment",           SqlUtils.maxSQLiteText(comment.getCommentText()));
         values.put("status",            comment.getStatus());
         values.put("author_email",      comment.getAuthorEmail());
         values.put("post_title",        comment.getPostTitle());
@@ -190,7 +190,7 @@ public class CommentTable {
                     stmt.bindLong  ( 1, localBlogId);
                     stmt.bindLong  ( 2, comment.postID);
                     stmt.bindLong  ( 3, comment.commentID);
-                    stmt.bindString( 4, comment.getCommentText());
+                    stmt.bindString( 4, SqlUtils.maxSQLiteText(comment.getCommentText()));
                     stmt.bindString( 5, comment.getPublished());
                     stmt.bindString( 6, comment.getStatus());
                     stmt.bindString( 7, comment.getAuthorName());
@@ -341,5 +341,13 @@ public class CommentTable {
                 authorUrl,
                 authorEmail,
                 profileImageUrl);
+    }
+
+    /*
+     * Delete big comments (Maximum 1024 * 1024 = 1048576) (fix #2855)
+     * @return number of deleted comments
+     */
+    public static int deleteBigComments(SQLiteDatabase db) {
+        return db.delete(COMMENTS_TABLE, "LENGTH(comment) >= 1048576", null);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -477,7 +477,7 @@ public class ReaderPostTable {
      * with a very large text column, causing an IllegalStateException when the
      * row is read - prevent this by limiting the amount of text that's stored in
      * the text column - note that this situation very rarely occurs
-     * https://github.com/android/platform_frameworks_base/blob/master/core/res/res/values/config.xml#L946
+     * https://github.com/android/platform_frameworks_base/blob/b77bc869241644a662f7e615b0b00ecb5aee373d/core/res/res/values/config.xml#L1268
      * https://github.com/android/platform_frameworks_base/blob/3bdbf644d61f46b531838558fabbd5b990fc4913/core/java/android/database/CursorWindow.java#L103
      */
     private static final int MAX_TEXT_LEN = (1024 * 1024) / 2;

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/SqlUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/SqlUtils.java
@@ -129,7 +129,8 @@ public class SqlUtils {
      * https://github.com/android/platform_frameworks_base/blob/b77bc869241644a662f7e615b0b00ecb5aee373d/core/res/res/values/config.xml#L1268
      * https://github.com/android/platform_frameworks_base/blob/3bdbf644d61f46b531838558fabbd5b990fc4913/core/java/android/database/CursorWindow.java#L103
      */
-    private static final int MAX_TEXT_LEN = 1024 * 1024;
+    // Max 512K characters (a UTF-8 char is 4 bytes max, so a 512K characters string is always < 2Mb)
+    private static final int MAX_TEXT_LEN = 1024 * 1024 / 2;
     public static String maxSQLiteText(final String text) {
         if (text.length() <= MAX_TEXT_LEN) {
             return text;

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/SqlUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/SqlUtils.java
@@ -7,6 +7,8 @@ import android.database.sqlite.SQLiteDoneException;
 import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteStatement;
 
+import org.wordpress.android.util.AppLog.T;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -117,5 +119,22 @@ public class SqlUtils {
         } finally {
             db.endTransaction();
         }
+    }
+
+    /*
+     * Android's CursorWindow has a max size of 2MB per row which can be exceeded
+     * with a very large text column, causing an IllegalStateException when the
+     * row is read - prevent this by limiting the amount of text that's stored in
+     * the text column.
+     * https://github.com/android/platform_frameworks_base/blob/b77bc869241644a662f7e615b0b00ecb5aee373d/core/res/res/values/config.xml#L1268
+     * https://github.com/android/platform_frameworks_base/blob/3bdbf644d61f46b531838558fabbd5b990fc4913/core/java/android/database/CursorWindow.java#L103
+     */
+    private static final int MAX_TEXT_LEN = 1024 * 1024;
+    public static String maxSQLiteText(final String text) {
+        if (text.length() <= MAX_TEXT_LEN) {
+            return text;
+        }
+        AppLog.w(T.UTILS, "sqlite > max text exceeded, storing truncated text");
+        return text.substring(0, MAX_TEXT_LEN);
     }
 }


### PR DESCRIPTION
fix #2855 by deleting big comments and truncating new inserted comments.

New unit test to reproduce the issue.

```shell
git checkout a9f1b03
./gradlew :WordPress:cAT
```
 
You should get 2 failed tests with the same exception as in #2855 