### PR TITLE
Stats - Refactor of the Single Item details screen

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -165,7 +165,7 @@
         <activity android:name=".ui.stats.StatsViewAllActivity"
                   android:theme="@style/CalypsoTheme"/>
 
-        <activity android:name=".ui.stats.StatsSinglePostDetailsActivity"
+        <activity android:name=".ui.stats.StatsSingleItemDetailsActivity"
             android:theme="@style/CalypsoTheme"/>
 
         <activity android:name=".ui.WPWebViewActivity"

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -189,7 +189,7 @@ public class ActivityLauncher {
         statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_REMOTE_ITEM_ID, post.getItemID());
         statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_REMOTE_ITEM_TYPE, post.getPostType());
         statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_ITEM_TITLE, post.getTitle());
-        statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_ITEM_URL, post.getTitle());
+        statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_ITEM_URL, post.getUrl());
         context.startActivity(statsPostViewIntent);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -27,7 +27,7 @@ import org.wordpress.android.ui.posts.PostsListActivity;
 import org.wordpress.android.ui.prefs.BlogPreferencesActivity;
 import org.wordpress.android.ui.prefs.SettingsActivity;
 import org.wordpress.android.ui.stats.StatsActivity;
-import org.wordpress.android.ui.stats.StatsSinglePostDetailsActivity;
+import org.wordpress.android.ui.stats.StatsSingleItemDetailsActivity;
 import org.wordpress.android.ui.stats.models.PostModel;
 import org.wordpress.android.ui.themes.ThemeBrowserActivity;
 import org.wordpress.android.util.AppLog;
@@ -184,8 +184,12 @@ public class ActivityLauncher {
     public static void viewStatsSinglePostDetails(Context context, PostModel post) {
         if (post == null) return;
 
-        Intent statsPostViewIntent = new Intent(context, StatsSinglePostDetailsActivity.class);
-        statsPostViewIntent.putExtra(StatsSinglePostDetailsActivity.ARG_REMOTE_POST_OBJECT, post);
+        Intent statsPostViewIntent = new Intent(context, StatsSingleItemDetailsActivity.class);
+        statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_REMOTE_BLOG_ID, post.getBlogID());
+        statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_REMOTE_ITEM_ID, post.getItemID());
+        statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_REMOTE_ITEM_TYPE, post.getPostType());
+        statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_ITEM_TITLE, post.getTitle());
+        statsPostViewIntent.putExtra(StatsSingleItemDetailsActivity.ARG_ITEM_URL, post.getTitle());
         context.startActivity(statsPostViewIntent);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConstants.java
@@ -1,6 +1,6 @@
 package org.wordpress.android.ui.stats;
 
-class StatsConstants {
+public class StatsConstants {
 
     // Date formatting constants
     public static final String STATS_INPUT_DATE_FORMAT = "yyyy-MM-dd";
@@ -14,4 +14,7 @@ class StatsConstants {
 
     public static final long STATS_SCROLL_TO_DELAY = 75L;
 
+    public static final String ITEM_TYPE_POST = "post";
+    public static final String ITEM_TYPE_PAGE = "page";
+    public static final String ITEM_TYPE_HOME_PAGE = "homepage";
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -196,8 +196,9 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
         if (mItemTitle != null || mItemURL != null) {
             mStatsForLabel.setVisibility(View.VISIBLE);
             mStatsForLabel.setText(mItemTitle != null ? mItemTitle : mItemURL );
-            // make the label clickable is the URL is available
+            // make the label clickable if the URL is available
             if (mItemURL != null) {
+                mStatsForLabel.setTextColor(getResources().getColor(R.color.stats_link_text_color));
                 mStatsForLabel.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
@@ -209,6 +210,8 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
                                 mItemURL);
                     }
                 });
+            } else {
+                mStatsForLabel.setTextColor(getResources().getColor(R.color.grey_darken_20));
             }
         } else {
             mStatsForLabel.setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -799,7 +799,7 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
             parseResponseExecutor.submit(new Thread() {
                 @Override
                 public void run() {
-                    AppLog.d(AppLog.T.STATS, "The REST response: " + response.toString());
+                    //AppLog.d(AppLog.T.STATS, "The REST response: " + response.toString());
                     mSelectedBarGraphIndex = -1;
                     try {
                         mRestResponseParsed = new PostViewsModel(response);
@@ -835,7 +835,13 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
             mIsUpdatingStats = false;
             mSwipeToRefreshHelper.setRefreshing(false);
 
-            updateUI();
+            // Update the UI
+            mHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    updateUI();
+                }
+            });
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -261,6 +261,13 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
     }
 
     @Override
+    protected void onPause() {
+        super.onPause();
+        mIsUpdatingStats = false;
+        mSwipeToRefreshHelper.setRefreshing(false);
+    }
+
+    @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -193,9 +193,10 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
         }
 
         // Setup the main top label that opens the post in the Reader where possible
-        if (mItemTitle != null) {
+        if (mItemTitle != null || mItemURL != null) {
             mStatsForLabel.setVisibility(View.VISIBLE);
-            mStatsForLabel.setText(mItemTitle);
+            mStatsForLabel.setText(mItemTitle != null ? mItemTitle : mItemURL );
+            // make the label clickable is the URL is available
             if (mItemURL != null) {
                 mStatsForLabel.setOnClickListener(new View.OnClickListener() {
                     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
@@ -411,12 +411,17 @@ public class StatsUtils {
         return model;
     }
 
-    public static void openPostInReaderOrInAppWebview(Context ctx, final PostModel post) {
-        final String postType = post.getPostType();
-        final String url = post.getUrl();
-        final long blogID = Long.parseLong(post.getBlogID());
-        final long itemID = Long.parseLong(post.getItemID());
-        if (postType.equals("post") || postType.equals("page")) {
+    public static void openPostInReaderOrInAppWebview(Context ctx, final String remoteBlogID,
+                                                      final String remoteItemID,
+                                                      final String itemType,
+                                                      final String itemURL) {
+        final long blogID = Long.parseLong(remoteBlogID);
+        final long itemID = Long.parseLong(remoteItemID);
+        if (itemType == null) {
+            // If we don't know the type of the item, open it with the browser.
+            AppLog.d(AppLog.T.UTILS, "Tpe of the item is null. Opening it in the in-app browser: " + itemURL);
+            WPWebViewActivity.openURL(ctx, itemURL);
+        } else if (itemType.equals("post") || itemType.equals("page")) {
             // If the post/page has ID == 0 is the home page, and we need to load the blog preview,
             // otherwise 404 is returned if we try to show the post in the reader
             if (itemID == 0) {
@@ -431,15 +436,23 @@ public class StatsUtils {
                         itemID
                 );
             }
-        } else if (postType.equals("homepage")) {
+        } else if (itemType.equals("homepage")) {
             ReaderActivityLauncher.showReaderBlogPreview(
                     ctx,
                     blogID
             );
         } else {
-            AppLog.d(AppLog.T.UTILS, "Opening the in-app browser: " + url);
-            WPWebViewActivity.openURL(ctx, url);
+            AppLog.d(AppLog.T.UTILS, "Opening the in-app browser: " + itemURL);
+            WPWebViewActivity.openURL(ctx, itemURL);
         }
+    }
+
+    public static void openPostInReaderOrInAppWebview(Context ctx, final PostModel post) {
+        final String postType = post.getPostType();
+        final String url = post.getUrl();
+        final String blogID = post.getBlogID();
+        final String itemID = post.getItemID();
+        openPostInReaderOrInAppWebview(ctx, blogID, itemID, postType, url);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
@@ -419,7 +419,7 @@ public class StatsUtils {
         final long itemID = Long.parseLong(remoteItemID);
         if (itemType == null) {
             // If we don't know the type of the item, open it with the browser.
-            AppLog.d(AppLog.T.UTILS, "Tpe of the item is null. Opening it in the in-app browser: " + itemURL);
+            AppLog.d(AppLog.T.UTILS, "Type of the item is null. Opening it in the in-app browser: " + itemURL);
             WPWebViewActivity.openURL(ctx, itemURL);
         } else if (itemType.equals("post") || itemType.equals("page")) {
             // If the post/page has ID == 0 is the home page, and we need to load the blog preview,

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
@@ -421,7 +421,8 @@ public class StatsUtils {
             // If we don't know the type of the item, open it with the browser.
             AppLog.d(AppLog.T.UTILS, "Type of the item is null. Opening it in the in-app browser: " + itemURL);
             WPWebViewActivity.openURL(ctx, itemURL);
-        } else if (itemType.equals("post") || itemType.equals("page")) {
+        } else if (itemType.equals(StatsConstants.ITEM_TYPE_POST)
+                || itemType.equals(StatsConstants.ITEM_TYPE_PAGE)) {
             // If the post/page has ID == 0 is the home page, and we need to load the blog preview,
             // otherwise 404 is returned if we try to show the post in the reader
             if (itemID == 0) {
@@ -436,7 +437,7 @@ public class StatsUtils {
                         itemID
                 );
             }
-        } else if (itemType.equals("homepage")) {
+        } else if (itemType.equals(StatsConstants.ITEM_TYPE_HOME_PAGE)) {
             ReaderActivityLauncher.showReaderBlogPreview(
                     ctx,
                     blogID

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/models/CommentsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/models/CommentsModel.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.stats.models;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.wordpress.android.ui.stats.StatsConstants;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -40,7 +41,7 @@ public class CommentsModel implements Serializable {
                 String name = currentPostJSON.getString("name");
                 int totals = currentPostJSON.getInt("comments");
                 String link = currentPostJSON.getString("link");
-                PostModel currentPost = new PostModel(blogID, mDate, itemID, name, totals, link, "post");
+                PostModel currentPost = new PostModel(blogID, mDate, itemID, name, totals, link, StatsConstants.ITEM_TYPE_POST);
                 mPosts.add(currentPost);
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/models/PostModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/models/PostModel.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.stats.models;
 
+import org.wordpress.android.ui.stats.StatsConstants;
+
 import java.io.Serializable;
 
 public class PostModel extends SingleItemModel implements Serializable {
@@ -13,7 +15,7 @@ public class PostModel extends SingleItemModel implements Serializable {
 
     public PostModel(String blogId, long date, String itemID, String title, int totals, String url) {
         super(blogId, date, itemID, title, totals, url, null);
-        this.mPostType = "post";
+        this.mPostType = StatsConstants.ITEM_TYPE_POST;
     }
 
     public String getPostType() {


### PR DESCRIPTION
This PR renames the StatsSinglePostDetailsActivity to StatsSingleItemDetailsActivity since it could be used to show stats for any kind of WP item. Media items too.

Also changed the parameters used to launch this Activity making it more generic.

/cc @nbradbury 