### PR TITLE
Spinner doesn't work on Samsung Galaxy running Lollipop

### DIFF
--- a/WordPress/src/main/res/layout/media_grid_fragment.xml
+++ b/WordPress/src/main/res/layout/media_grid_fragment.xml
@@ -19,7 +19,7 @@
             style="@style/DropDownNav.WordPress"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:clickable="false"
+            android:clickable="true"
             android:paddingLeft="0dp" />
     </FrameLayout>
 


### PR DESCRIPTION
The problem occurs when clickable is set to false and another elemnt performClick on spinner.

Similar case was described here:
http://stackoverflow.com/questions/30481871/android-spinner-not-working-on-samsung-devices-with-android-5-0