### PR TITLE
Stats - Improve errors handling in the single item details screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -256,16 +256,22 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
     protected void onResume() {
         super.onResume();
         if (mRestResponseParsed == null) {
-            mHandler.postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    if (!isFinishing()) {
-                        setupEmptyGraph("");
-                        showHideEmptyModulesIndicator(true);
-                        refreshStats();
+            // check if network is available, if not shows the empty UI immediately
+            if (!NetworkUtils.checkConnection(this)) {
+                mSwipeToRefreshHelper.setRefreshing(false);
+                setupEmptyUI();
+            } else {
+                mHandler.postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (!isFinishing()) {
+                            setupEmptyGraph("");
+                            showHideEmptyModulesIndicator(true);
+                            refreshStats();
+                        }
                     }
-                }
-            }, 75L);
+                }, 75L);
+            }
         } else {
             updateUI();
         }
@@ -298,9 +304,8 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
             return;
         }
 
-        if (!NetworkUtils.isNetworkAvailable(this)) {
+        if (!NetworkUtils.checkConnection(this)) {
             mSwipeToRefreshHelper.setRefreshing(false);
-            ToastUtils.showToast(this, this.getString(R.string.connection_error), ToastUtils.Duration.LONG);
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -182,7 +182,7 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
             if (savedInstanceState.containsKey(ARG_YEARS_EXPANDED_ROWS)) {
                 mYearsIdToExpandedMap = savedInstanceState.getParcelable(ARG_YEARS_EXPANDED_ROWS);
             }
-        } else if (getIntent() != null) {
+        } else if (getIntent() != null && getIntent().getExtras() != null) {
             Bundle extras = getIntent().getExtras();
             mRemoteItemID = extras.getString(ARG_REMOTE_ITEM_ID);
             mRemoteBlogID = extras.getString(ARG_REMOTE_BLOG_ID);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -31,7 +31,6 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.networking.RestClientUtils;
 import org.wordpress.android.ui.ActivityId;
-import org.wordpress.android.ui.stats.models.PostModel;
 import org.wordpress.android.ui.stats.models.PostViewsModel;
 import org.wordpress.android.ui.stats.models.VisitModel;
 import org.wordpress.android.util.AppLog;
@@ -855,7 +854,7 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
 
             String label = mActivityRef.get().getString(R.string.error_refresh_stats);
             if (volleyError instanceof NoConnectionError) {
-                label += "<br/>" + mActivityRef.get().getString(R.string.no_network_message);
+                label += "\n" + mActivityRef.get().getString(R.string.no_network_message);
             }
 
             ToastUtils.showToast(mActivityRef.get(), label, ToastUtils.Duration.LONG);

--- a/WordPress/src/main/res/layout/stats_activity_single_post_details.xml
+++ b/WordPress/src/main/res/layout/stats_activity_single_post_details.xml
@@ -79,6 +79,7 @@
 
             <!-- Months and Years -->
             <LinearLayout
+                android:id="@+id/stats_months_years_module"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="@drawable/stats_white_background"
@@ -140,6 +141,7 @@
 
             <!-- Average per Day -->
             <LinearLayout
+                android:id="@+id/stats_averages_module"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="@drawable/stats_white_background"
@@ -201,6 +203,7 @@
 
             <!-- Recent Weeks -->
             <LinearLayout
+                android:id="@+id/stats_recent_weeks_module"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:background="@drawable/stats_white_background"


### PR DESCRIPTION
Fix #2900

The animated GIF below shows what happens in case of server side error: A Toast is shown on the screen with the error message in it, and only the graph module is kept on the screen with a "No stats" label. Instead all of others modules are dismissed.

There is still space for other improvements, like the ability of showing placeholders of bars in the graph, but we've another ticket for this.

![stats-details-issue-01](https://cloud.githubusercontent.com/assets/518232/8284666/62ff93a2-18fe-11e5-9610-9472cb586585.gif)