### PR TITLE
Fix Blank Notifications Settings

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -101,6 +101,9 @@
             android:configChanges="locale|orientation"
             android:theme="@style/CalypsoTheme"/>
         <activity
+            android:name=".ui.prefs.NotificationsSettingsActivity"
+            android:theme="@style/CalypsoTheme"/>
+        <activity
             android:name=".networking.SSLCertsViewActivity"
             android:theme="@style/Calypso.NoActionBar" />
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/NotificationsSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/NotificationsSettingsActivity.java
@@ -1,0 +1,51 @@
+package org.wordpress.android.ui.prefs;
+
+import android.app.FragmentManager;
+import android.os.Bundle;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.view.MenuItem;
+
+import org.wordpress.android.R;
+import org.wordpress.android.ui.ActivityLauncher;
+
+// Simple wrapper activity for NotificationsSettingsFragment
+public class NotificationsSettingsActivity extends AppCompatActivity {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setElevation(0.0f);
+            actionBar.setHomeButtonEnabled(true);
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+        setContentView(R.layout.settings_activity);
+
+        setTitle(R.string.notifications);
+
+        FragmentManager fragmentManager = getFragmentManager();
+        if (savedInstanceState == null) {
+            fragmentManager.beginTransaction()
+                    .add(R.id.fragment_container, new NotificationsSettingsFragment())
+                    .commit();
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(final MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void finish() {
+        super.finish();
+        ActivityLauncher.slideOutToRight(this);
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/NotificationsSettingsFragment.java
@@ -33,7 +33,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 
-public class NotificationSettingsFragment extends PreferenceFragment {
+public class NotificationsSettingsFragment extends PreferenceFragment {
     public static final String TAG = "NotificationSettingsFragment";
     private ArrayList<StringMap<Double>> mMutedBlogsList;
     private Map<String, Object> mNotificationSettings;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/NotificationsSettingsFragment.java
@@ -46,12 +46,6 @@ public class NotificationsSettingsFragment extends PreferenceFragment {
         loadNotifications();
     }
 
-    @Override
-    public void onResume() {
-        super.onResume();
-        getActivity().setTitle(R.string.manage_notifications);
-    }
-
     private void loadNotifications() {
         AppLog.d(T.NOTIFS, "Preferences > loading notification settings");
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
@@ -276,7 +276,7 @@ public class SettingsFragment extends PreferenceFragment implements OnPreference
 
     private boolean handleNotificationPreferenceClick() {
         getFragmentManager().beginTransaction()
-                .replace(R.id.fragment_container, new NotificationSettingsFragment())
+                .replace(R.id.fragment_container, new NotificationsSettingsFragment())
                 .addToBackStack(null)
                 .commit();
         return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
@@ -31,6 +31,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.models.AccountHelper;
+import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.ShareIntentReceiverActivity;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.util.ActivityUtils;
@@ -275,10 +276,8 @@ public class SettingsFragment extends PreferenceFragment implements OnPreference
     }
 
     private boolean handleNotificationPreferenceClick() {
-        getFragmentManager().beginTransaction()
-                .replace(R.id.fragment_container, new NotificationsSettingsFragment())
-                .addToBackStack(null)
-                .commit();
+        Intent notificationsIntent = new Intent(getActivity(), NotificationsSettingsActivity.class);
+        ActivityLauncher.slideInFromRight(getActivity(), notificationsIntent);
         return true;
     }
 


### PR DESCRIPTION
Adds a wrapper activity for `NotificationsSettingsFragment` instead of adding it to the fragment stack, which conflicted with the new passcode lock library.