### PR TITLE
Issue/2915 add wp post thumbnail

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -84,12 +84,39 @@ public class WordPressDB {
     private static final String DATABASE_NAME = "wordpress";
     private static final String MEDIA_TABLE = "media";
 
-    private static final String CREATE_TABLE_POSTS = "create table if not exists posts (id integer primary key autoincrement, blogID text, "
-            + "postid text, title text default '', dateCreated date, date_created_gmt date, categories text default '', custom_fields text default '', "
-            + "description text default '', link text default '', mt_allow_comments boolean, mt_allow_pings boolean, "
-            + "mt_excerpt text default '', mt_keywords text default '', mt_text_more text default '', permaLink text default '', post_status text default '', userid integer default 0, "
-            + "wp_author_display_name text default '', wp_author_id text default '', wp_password text default '', wp_post_format text default '', wp_slug text default '', mediaPaths text default '', "
-            + "latitude real, longitude real, localDraft boolean default 0, uploaded boolean default 0, isPage boolean default 0, wp_page_parent_id text, wp_page_parent_title text);";
+    private static final String CREATE_TABLE_POSTS =
+        "create table if not exists posts ("
+            + "id integer primary key autoincrement,"
+            + "blogID text,"
+            + "postid text,"
+            + "title text default '',"
+            + "dateCreated date,"
+            + "date_created_gmt date,"
+            + "categories text default '',"
+            + "custom_fields text default '',"
+            + "description text default '',"
+            + "link text default '',"
+            + "mt_allow_comments boolean,"
+            + "mt_allow_pings boolean,"
+            + "mt_excerpt text default '',"
+            + "mt_keywords text default '',"
+            + "mt_text_more text default '',"
+            + "permaLink text default '',"
+            + "post_status text default '',"
+            + "userid integer default 0,"
+            + "wp_author_display_name text default '',"
+            + "wp_author_id text default '',"
+            + "wp_password text default '',"
+            + "wp_post_format text default '',"
+            + "wp_slug text default '',"
+            + "mediaPaths text default '',"
+            + "latitude real,"
+            + "longitude real,"
+            + "localDraft boolean default 0,"
+            + "uploaded boolean default 0,"
+            + "isPage boolean default 0,"
+            + "wp_page_parent_id text,"
+            + "wp_page_parent_title text);";
 
     private static final String POSTS_TABLE = "posts";
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -980,6 +980,7 @@ public class WordPressDB {
                     values.put("wp_password", MapUtils.getMapStr(postMap, "wp_password"));
                     values.put("wp_author_id", MapUtils.getMapStr(postMap, "wp_author_id"));
                     values.put("wp_author_display_name", MapUtils.getMapStr(postMap, "wp_author_display_name"));
+                    values.put("wp_post_thumbnail", MapUtils.getMapStr(postMap, "wp_post_thumbnail"));
                     values.put("post_status", MapUtils.getMapStr(postMap, (isPage) ? "page_status" : "post_status"));
                     values.put("userid", MapUtils.getMapStr(postMap, "userid"));
 
@@ -1079,6 +1080,7 @@ public class WordPressDB {
             putPostLocation(post, values);
             values.put("isLocalChange", post.isLocalChange());
             values.put("mt_excerpt", post.getPostExcerpt());
+            values.put("wp_post_thumbnail", post.getPostThumbnail());
 
             result = db.insert(POSTS_TABLE, null, values);
 
@@ -1115,6 +1117,8 @@ public class WordPressDB {
             values.put("wp_post_format", post.getPostFormat());
             values.put("isLocalChange", post.isLocalChange());
             values.put("mt_excerpt", post.getPostExcerpt());
+            values.put("wp_post_thumbnail", post.getPostThumbnail());
+
             putPostLocation(post, values);
 
             result = db.update(POSTS_TABLE, values, "blogID=? AND id=? AND isPage=?",
@@ -1218,6 +1222,7 @@ public class WordPressDB {
                 post.setAuthorId(c.getString(c.getColumnIndex("wp_author_id")));
                 post.setPassword(c.getString(c.getColumnIndex("wp_password")));
                 post.setPostFormat(c.getString(c.getColumnIndex("wp_post_format")));
+                post.setPostThumbnail(c.getString(c.getColumnIndex("wp_post_thumbnail")));
                 post.setSlug(c.getString(c.getColumnIndex("wp_slug")));
                 post.setMediaPaths(c.getString(c.getColumnIndex("mediaPaths")));
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -1079,7 +1079,7 @@ public class WordPressDB {
             putPostLocation(post, values);
             values.put("isLocalChange", post.isLocalChange());
             values.put("mt_excerpt", post.getPostExcerpt());
-            values.put("wp_post_thumbnail", post.getPostThumbnail());
+            values.put("wp_post_thumbnail", post.getFeaturedImageId());
 
             result = db.insert(POSTS_TABLE, null, values);
 
@@ -1116,7 +1116,7 @@ public class WordPressDB {
             values.put("wp_post_format", post.getPostFormat());
             values.put("isLocalChange", post.isLocalChange());
             values.put("mt_excerpt", post.getPostExcerpt());
-            values.put("wp_post_thumbnail", post.getPostThumbnail());
+            values.put("wp_post_thumbnail", post.getFeaturedImageId());
 
             putPostLocation(post, values);
 
@@ -1221,7 +1221,7 @@ public class WordPressDB {
                 post.setAuthorId(c.getString(c.getColumnIndex("wp_author_id")));
                 post.setPassword(c.getString(c.getColumnIndex("wp_password")));
                 post.setPostFormat(c.getString(c.getColumnIndex("wp_post_format")));
-                post.setPostThumbnail(c.getInt(c.getColumnIndex("wp_post_thumbnail")));
+                post.setFeaturedImageId(c.getInt(c.getColumnIndex("wp_post_thumbnail")));
                 post.setSlug(c.getString(c.getColumnIndex("wp_slug")));
                 post.setMediaPaths(c.getString(c.getColumnIndex("mediaPaths")));
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -18,7 +18,6 @@ import org.wordpress.android.datasets.CommentTable;
 import org.wordpress.android.datasets.SuggestionTable;
 import org.wordpress.android.models.Account;
 import org.wordpress.android.models.Blog;
-import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.models.Post;
 import org.wordpress.android.models.PostLocation;
 import org.wordpress.android.models.PostsListPost;
@@ -31,6 +30,7 @@ import org.wordpress.android.util.BlogUtils;
 import org.wordpress.android.util.MapUtils;
 import org.wordpress.android.util.SqlUtils;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.helpers.MediaFile;
 
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -109,7 +109,6 @@ public class WordPressDB {
             + "wp_password text default '',"
             + "wp_post_format text default '',"
             + "wp_slug text default '',"
-            + "wp_post_thumbnail default '',"
             + "mediaPaths text default '',"
             + "latitude real,"
             + "longitude real,"
@@ -169,7 +168,7 @@ public class WordPressDB {
     private static final String ADD_IS_UPLOADING = "alter table posts add isUploading boolean default 0";
 
     // add wp_post_thumbnail to posts table
-    private static final String ADD_POST_THUMBNAIL = "alter table posts add wp_post_thumbnail text default '';";
+    private static final String ADD_POST_THUMBNAIL = "alter table posts add wp_post_thumbnail integer default 0;";
 
     //add boolean to track if featured image should be included in the post content
     private static final String ADD_FEATURED_IN_POST = "alter table media add isFeaturedInPost boolean default false;";
@@ -980,7 +979,7 @@ public class WordPressDB {
                     values.put("wp_password", MapUtils.getMapStr(postMap, "wp_password"));
                     values.put("wp_author_id", MapUtils.getMapStr(postMap, "wp_author_id"));
                     values.put("wp_author_display_name", MapUtils.getMapStr(postMap, "wp_author_display_name"));
-                    values.put("wp_post_thumbnail", MapUtils.getMapStr(postMap, "wp_post_thumbnail"));
+                    values.put("wp_post_thumbnail", MapUtils.getMapInt(postMap, "wp_post_thumbnail"));
                     values.put("post_status", MapUtils.getMapStr(postMap, (isPage) ? "page_status" : "post_status"));
                     values.put("userid", MapUtils.getMapStr(postMap, "userid"));
 
@@ -1222,7 +1221,7 @@ public class WordPressDB {
                 post.setAuthorId(c.getString(c.getColumnIndex("wp_author_id")));
                 post.setPassword(c.getString(c.getColumnIndex("wp_password")));
                 post.setPostFormat(c.getString(c.getColumnIndex("wp_post_format")));
-                post.setPostThumbnail(c.getString(c.getColumnIndex("wp_post_thumbnail")));
+                post.setPostThumbnail(c.getInt(c.getColumnIndex("wp_post_thumbnail")));
                 post.setSlug(c.getString(c.getColumnIndex("wp_slug")));
                 post.setMediaPaths(c.getString(c.getColumnIndex("mediaPaths")));
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -74,7 +74,7 @@ public class WordPressDB {
     public static final String COLUMN_NAME_VIDEO_PRESS_SHORTCODE = "videoPressShortcode";
     public static final String COLUMN_NAME_UPLOAD_STATE          = "uploadState";
 
-    private static final int DATABASE_VERSION = 31;
+    private static final int DATABASE_VERSION = 32;
 
     private static final String CREATE_TABLE_BLOGS = "create table if not exists accounts (id integer primary key autoincrement, "
             + "url text, blogName text, username text, password text, imagePlacement text, centerThumbnail boolean, fullSizeImage boolean, maxImageWidth text, maxImageWidthId integer);";
@@ -109,6 +109,7 @@ public class WordPressDB {
             + "wp_password text default '',"
             + "wp_post_format text default '',"
             + "wp_slug text default '',"
+            + "wp_post_thumbnail default '',"
             + "mediaPaths text default '',"
             + "latitude real,"
             + "longitude real,"
@@ -166,6 +167,9 @@ public class WordPressDB {
 
     // Add boolean to POSTS to track posts currently being uploaded
     private static final String ADD_IS_UPLOADING = "alter table posts add isUploading boolean default 0";
+
+    // add wp_post_thumbnail to posts table
+    private static final String ADD_POST_THUMBNAIL = "alter table posts add wp_post_thumbnail text default '';";
 
     //add boolean to track if featured image should be included in the post content
     private static final String ADD_FEATURED_IN_POST = "alter table media add isFeaturedInPost boolean default false;";
@@ -324,7 +328,12 @@ public class WordPressDB {
                 // Fix big comments issue #2855
                 CommentTable.deleteBigComments(db);
                 currentVersion++;
+            case 31:
+                // add wp_post_thumbnail to posts table
+                db.execSQL(ADD_POST_THUMBNAIL);
+                currentVersion++;
         }
+
         db.setVersion(DATABASE_VERSION);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/models/Post.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Post.java
@@ -41,6 +41,7 @@ public class Post implements Serializable {
     private String password;
     private String postFormat;
     private String slug;
+    private String postThumbnail;
     private boolean localDraft;
     private boolean uploaded;
     private boolean mIsUploading;
@@ -489,5 +490,15 @@ public class Post implements Serializable {
 
     public boolean isPublishable() {
         return !(getContent().isEmpty() && getPostExcerpt().isEmpty() && getTitle().isEmpty());
+    }
+
+    public void setPostThumbnail(String thumbnail) {
+        this.postThumbnail = StringUtils.notNullStr(thumbnail);
+    }
+    public String getPostThumbnail() {
+        return StringUtils.notNullStr(postThumbnail);
+    }
+    public boolean hasPostThumbnail() {
+        return !TextUtils.isEmpty(postThumbnail);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/Post.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Post.java
@@ -41,7 +41,7 @@ public class Post implements Serializable {
     private String password;
     private String postFormat;
     private String slug;
-    private String postThumbnail;
+
     private boolean localDraft;
     private boolean uploaded;
     private boolean mIsUploading;
@@ -53,6 +53,7 @@ public class Post implements Serializable {
     private String mediaPaths;
     private String quickPostType;
     private PostLocation mPostLocation;
+    private int postThumbnailId;
 
     public Post() {
     }
@@ -492,13 +493,13 @@ public class Post implements Serializable {
         return !(getContent().isEmpty() && getPostExcerpt().isEmpty() && getTitle().isEmpty());
     }
 
-    public void setPostThumbnail(String thumbnail) {
-        this.postThumbnail = StringUtils.notNullStr(thumbnail);
+    public void setPostThumbnail(int thumbnailId) {
+        this.postThumbnailId = thumbnailId;
     }
-    public String getPostThumbnail() {
-        return StringUtils.notNullStr(postThumbnail);
+    public int getPostThumbnail() {
+        return postThumbnailId;
     }
     public boolean hasPostThumbnail() {
-        return !TextUtils.isEmpty(postThumbnail);
+        return (postThumbnailId != 0);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/Post.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Post.java
@@ -53,7 +53,8 @@ public class Post implements Serializable {
     private String mediaPaths;
     private String quickPostType;
     private PostLocation mPostLocation;
-    private int postThumbnailId;
+
+    private int featuredImageId;
 
     public Post() {
     }
@@ -493,13 +494,10 @@ public class Post implements Serializable {
         return !(getContent().isEmpty() && getPostExcerpt().isEmpty() && getTitle().isEmpty());
     }
 
-    public void setPostThumbnail(int thumbnailId) {
-        this.postThumbnailId = thumbnailId;
+    public int getFeaturedImageId() {
+        return featuredImageId;
     }
-    public int getPostThumbnail() {
-        return postThumbnailId;
-    }
-    public boolean hasPostThumbnail() {
-        return (postThumbnailId != 0);
+    public void setFeaturedImageId(int id) {
+        this.featuredImageId = id;
     }
 }


### PR DESCRIPTION
Closes #2915 - adds `wp_post_thumbnail` to the posts table and post model. This is currently unused, but will be necessary soon in order to display a post's featured image in the post list.