### PR TITLE
Issue/2920 reader follow by url

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -373,21 +373,24 @@ public class ReaderSubsActivity extends AppCompatActivity
 
         showAddUrlProgress();
 
-        ReaderActions.ActionListener urlActionListener = new ReaderActions.ActionListener() {
+        ReaderActions.OnCheckUrlReachableListener urlListener = new ReaderActions.OnCheckUrlReachableListener() {
             @Override
-            public void onActionResult(boolean succeeded) {
-                if (isFinishing()) {
-                    return;
-                }
-                if (succeeded) {
+            public void onSuccess() {
+                if (!isFinishing()) {
                     followBlogUrl(blogUrl);
-                } else {
+                }
+            }
+            @Override
+            public void onFailed(int statusCode) {
+                if (!isFinishing()) {
                     hideAddUrlProgress();
-                    ToastUtils.showToast(ReaderSubsActivity.this, R.string.reader_toast_err_follow_blog);
+                    String errMsg = getString(R.string.reader_toast_err_follow_blog)
+                            + " (" + Integer.toString(statusCode) + ")";
+                    ToastUtils.showToast(ReaderSubsActivity.this, errMsg);
                 }
             }
         };
-        ReaderBlogActions.checkBlogUrlReachable(blogUrl, urlActionListener);
+        ReaderBlogActions.checkUrlReachable(blogUrl, urlListener);
     }
 
     private void followBlogUrl(String normUrl) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -386,9 +386,6 @@ public class ReaderSubsActivity extends AppCompatActivity
                     hideAddUrlProgress();
                     String errMsg;
                     switch (statusCode) {
-                        case 301:
-                            errMsg = getString(R.string.reader_toast_err_follow_blog_moved);
-                            break;
                         case 401:
                             errMsg = getString(R.string.reader_toast_err_follow_blog_not_authorized);
                             break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -384,8 +384,22 @@ public class ReaderSubsActivity extends AppCompatActivity
             public void onFailed(int statusCode) {
                 if (!isFinishing()) {
                     hideAddUrlProgress();
-                    String errMsg = getString(R.string.reader_toast_err_follow_blog)
-                            + " (" + Integer.toString(statusCode) + ")";
+                    String errMsg;
+                    switch (statusCode) {
+                        case 301:
+                            errMsg = getString(R.string.reader_toast_err_follow_blog_moved);
+                            break;
+                        case 401:
+                            errMsg = getString(R.string.reader_toast_err_follow_blog_not_authorized);
+                            break;
+                        case 0: // can happen when host name not found
+                        case 404:
+                            errMsg = getString(R.string.reader_toast_err_follow_blog_not_found);
+                            break;
+                        default:
+                            errMsg = getString(R.string.reader_toast_err_follow_blog) + " (" + Integer.toString(statusCode) + ")";
+                            break;
+                    }
                     ToastUtils.showToast(ReaderSubsActivity.this, errMsg);
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderActions.java
@@ -69,4 +69,13 @@ public class ReaderActions {
     public interface UpdateBlogInfoListener {
         public void onResult(ReaderBlog blogInfo);
     }
+
+    /*
+     * used when checking whether a blog's url is reachable
+     */
+    public interface OnCheckUrlReachableListener {
+        void onSuccess();
+        void onFailed(int statusCode);
+    }
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -356,27 +356,25 @@ public class ReaderBlogActions {
      * tests whether the passed url can be reached - does NOT use authentication, and does not
      * account for 404 replacement pages used by ISPs such as Charter
      */
-    public static void checkBlogUrlReachable(final String blogUrl, final ActionListener actionListener) {
-        // ActionListener is required
-        if (actionListener == null) {
-            return;
-        }
-        if (TextUtils.isEmpty(blogUrl)) {
-            actionListener.onActionResult(false);
+    public static void checkUrlReachable(final String blogUrl,
+                                         final ReaderActions.OnCheckUrlReachableListener urlListener) {
+        // listener is required
+        if (urlListener == null) {
             return;
         }
 
         Response.Listener<String> listener = new Response.Listener<String>() {
             @Override
             public void onResponse(String response) {
-                actionListener.onActionResult(true);
+                urlListener.onSuccess();
             }
         };
         Response.ErrorListener errorListener = new Response.ErrorListener() {
             @Override
             public void onErrorResponse(VolleyError volleyError) {
                 AppLog.e(T.READER, volleyError);
-                actionListener.onActionResult(false);
+                int statusCode = VolleyUtils.statusCodeFromVolleyError(volleyError);
+                urlListener.onFailed(statusCode);
             }
         };
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -373,7 +373,14 @@ public class ReaderBlogActions {
             @Override
             public void onErrorResponse(VolleyError volleyError) {
                 AppLog.e(T.READER, volleyError);
-                int statusCode = VolleyUtils.statusCodeFromVolleyError(volleyError);
+                int statusCode;
+                // check specifically for auth failure class rather than relying on status code
+                // since a redirect to an unauthorized url may return a 301 rather than a 401
+                if (volleyError instanceof com.android.volley.AuthFailureError) {
+                    statusCode = 401;
+                } else {
+                    statusCode = VolleyUtils.statusCodeFromVolleyError(volleyError);
+                }
                 urlListener.onFailed(statusCode);
             }
         };

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -754,7 +754,6 @@
     <string name="reader_toast_err_follow_blog">Unable to follow this blog</string>
     <string name="reader_toast_err_follow_blog_not_found">This blog could not be found</string>
     <string name="reader_toast_err_follow_blog_not_authorized">You are not authorized to access this blog</string>
-    <string name="reader_toast_err_follow_blog_moved">This blog no longer exists</string>
     <string name="reader_toast_err_unfollow_blog">Unable to unfollow this blog</string>
     <string name="reader_toast_blog_blocked">Posts from this blog will no longer be shown</string>
     <string name="reader_toast_err_block_blog">Unable to block this blog</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -752,6 +752,9 @@
     <string name="reader_toast_err_get_blog_info">Unable to show this blog</string>
     <string name="reader_toast_err_already_follow_blog">You already follow this blog</string>
     <string name="reader_toast_err_follow_blog">Unable to follow this blog</string>
+    <string name="reader_toast_err_follow_blog_not_found">This blog could not be found</string>
+    <string name="reader_toast_err_follow_blog_not_authorized">You are not authorized to access this blog</string>
+    <string name="reader_toast_err_follow_blog_moved">This blog no longer exists</string>
     <string name="reader_toast_err_unfollow_blog">Unable to unfollow this blog</string>
     <string name="reader_toast_blog_blocked">Posts from this blog will no longer be shown</string>
     <string name="reader_toast_err_block_blog">Unable to block this blog</string>


### PR DESCRIPTION
Fix #2920 - a "friendlier" error toast is now displayed for 301, 401 and 404 when attempting to a follow a blog by url fails.