### PR TITLE
Changed tag icon in reader toolbar

### DIFF
--- a/WordPress/src/main/res/menu/reader_list.xml
+++ b/WordPress/src/main/res/menu/reader_list.xml
@@ -4,7 +4,7 @@
 
     <item
         android:id="@+id/menu_tags"
-        android:icon="@drawable/ic_genericon_tag_grey_24dp"
+        android:icon="@drawable/ic_add_blue_24dp"
         app:showAsAction="always"
         android:title="@string/reader_menu_tags" />
 


### PR DESCRIPTION
Fix #2921 - the tag icon in the reader toolbar has been changed to a plus icon to make it more obvious.

Here's how it used to look:

![android-tags-before](https://cloud.githubusercontent.com/assets/3903757/8368395/8866976e-1b5e-11e5-9042-8ade153101cb.png)

And here's how it looks in this PR:

![android-tags-after](https://cloud.githubusercontent.com/assets/3903757/8368397/8c90d430-1b5e-11e5-8fee-cddda5a878a6.png)
