### PR TITLE
Check note badge on main thread from simperium listener

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -443,7 +443,14 @@ public class WPMainActivity extends Activity
     @Override
     public void onNetworkChange(Bucket<Note> noteBucket, Bucket.ChangeType changeType, String s) {
         if (changeType == Bucket.ChangeType.INSERT || changeType == Bucket.ChangeType.MODIFY) {
-            mTabLayout.checkNoteBadge();
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    if (!isFinishing()) {
+                        mTabLayout.checkNoteBadge();
+                    }
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Fix #2890 - note badge check is now done on UI thread when Simperium detects a network change.