### PR TITLE
Added dividers to post list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -25,6 +25,8 @@ import org.wordpress.android.ui.EmptyViewMessageType;
 import org.wordpress.android.ui.posts.PostUploadEvents.PostUploadFailed;
 import org.wordpress.android.ui.posts.PostUploadEvents.PostUploadSucceed;
 import org.wordpress.android.ui.posts.adapters.PostsListAdapter;
+import org.wordpress.android.ui.reader.views.ReaderRecyclerView;
+import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ServiceUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -88,6 +90,9 @@ public class PostsListFragment extends Fragment implements EmptyViewAnimationHan
         View view = inflater.inflate(R.layout.post_list, container, false);
 
         mRecyclerView = (RecyclerView) view.findViewById(R.id.recycler_view);
+        int spacingVertical = DisplayUtils.dpToPx(getActivity(), 1);
+        mRecyclerView.addItemDecoration(new ReaderRecyclerView.ReaderItemDecoration(0, spacingVertical));
+
         mEmptyView = view.findViewById(R.id.empty_view);
         mEmptyViewImage = view.findViewById(R.id.empty_tags_box_top);
         mEmptyViewTitle = (TextView) view.findViewById(R.id.title_empty);

--- a/WordPress/src/main/res/drawable/post_list_item_background.xml
+++ b/WordPress/src/main/res/drawable/post_list_item_background.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/list_selected" android:state_selected="true" />
-    <item android:drawable="@android:color/transparent" />
+    <item android:drawable="@color/white" />
 </selector>

--- a/WordPress/src/main/res/layout/post_list.xml
+++ b/WordPress/src/main/res/layout/post_list.xml
@@ -2,7 +2,6 @@
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:fab="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:background="@color/background_grey"
     android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/post_list.xml
+++ b/WordPress/src/main/res/layout/post_list.xml
@@ -4,6 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:fab="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:background="@color/background_grey"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -11,7 +12,6 @@
         android:id="@+id/empty_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/background_grey"
         android:gravity="center"
         android:orientation="vertical"
         android:visibility="gone"


### PR DESCRIPTION
Fixes #2935 by returning dividers to the post list. Note that this is a very short-term solution since the post list is being replaced with [a new card view](https://github.com/wordpress-mobile/WordPress-Android/pull/2934) in the next release.