### PR TITLE
Issue/2954 readerutils crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -277,8 +277,9 @@ public class SitePickerActivity extends ActionBarActivity
 
             // let user know the current site wasn't hidden
             if (skippedCurrentSite) {
+                String cantHideCurrentSite = getString(R.string.site_picker_cant_hide_current_site);
                 ToastUtils.showToast(this,
-                        getString(R.string.site_picker_cant_hide_current_site, currentSiteName),
+                        String.format(cantHideCurrentSite, currentSiteName),
                         ToastUtils.Duration.LONG);
             }
 
@@ -297,7 +298,8 @@ public class SitePickerActivity extends ActionBarActivity
     private void updateActionModeTitle() {
         if (mActionMode != null) {
             int numSelected = getAdapter().getNumSelected();
-            mActionMode.setTitle(getString(R.string.cab_selected, numSelected));
+            String cabSelected = getString(R.string.cab_selected);
+            mActionMode.setTitle(String.format(cabSelected, numSelected));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -270,7 +270,8 @@ public class ReaderActivityLauncher {
                 Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
                 context.startActivity(intent);
             } catch (ActivityNotFoundException e) {
-                ToastUtils.showToast(context, context.getString(R.string.reader_toast_err_url_intent, url), ToastUtils.Duration.LONG);
+                String readerToastErrorUrlIntent = context.getString(R.string.reader_toast_err_url_intent);
+                ToastUtils.showToast(context, String.format(readerToastErrorUrlIntent, url), ToastUtils.Duration.LONG);
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerActivity.java
@@ -125,7 +125,8 @@ public class ReaderPhotoViewerActivity extends ActionBarActivity
             return;
         }
 
-        final String title = getString(R.string.reader_title_photo_viewer, position + 1, getImageCount());
+        String titlePhotoViewer = getString(R.string.reader_title_photo_viewer);
+        String title = String.format(titlePhotoViewer, position + 1, getImageCount());
         if (title.equals(mTxtTitle.getText())) {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -354,7 +354,8 @@ public class ReaderSubsActivity extends ActionBarActivity
             mLastAddedTagName = tag.getTagName();
             // make sure addition is reflected on followed tags
             getPageAdapter().refreshFollowedTagFragment();
-            showInfoToast(getString(R.string.reader_label_added_tag, tag.getCapitalizedTagName()));
+            String labelAddedTag = getString(R.string.reader_label_added_tag);
+            showInfoToast(String.format(labelAddedTag, tag.getCapitalizedTagName()));
         }
     }
 
@@ -453,7 +454,8 @@ public class ReaderSubsActivity extends ActionBarActivity
         if (mLastAddedTagName != null && mLastAddedTagName.equalsIgnoreCase(tag.getTagName())) {
             mLastAddedTagName = null;
         }
-        showInfoToast(getString(R.string.reader_label_removed_tag, tag.getCapitalizedTagName()));
+        String labelRemovedTag = getString(R.string.reader_label_removed_tag);
+        showInfoToast(String.format(labelRemovedTag, tag.getCapitalizedTagName()));
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -78,7 +78,8 @@ public class ReaderUtils {
                 case 2:
                     return context.getString(R.string.reader_likes_you_and_one);
                 default:
-                    return context.getString(R.string.reader_likes_you_and_multi, numLikes - 1);
+                    String youAndMultiLikes = context.getString(R.string.reader_likes_you_and_multi);
+                    return String.format(youAndMultiLikes, numLikes - 1);
             }
         } else {
             if (numLikes == 1) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -81,8 +81,12 @@ public class ReaderUtils {
                     return context.getString(R.string.reader_likes_you_and_multi, numLikes - 1);
             }
         } else {
-            return (numLikes == 1 ?
-                    context.getString(R.string.reader_likes_one) : context.getString(R.string.reader_likes_multi, numLikes));
+            if (numLikes == 1) {
+                return context.getString(R.string.reader_likes_one);
+            } else {
+                String likes = context.getString(R.string.reader_likes_multi);
+                return String.format(likes, numLikes);
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLinkMovementMethod.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLinkMovementMethod.java
@@ -63,7 +63,8 @@ public class WPLinkMovementMethod extends LinkMovementMethod {
             Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
             context.startActivity(intent);
         } catch (ActivityNotFoundException e) {
-            ToastUtils.showToast(context, context.getString(R.string.reader_toast_err_url_intent, url), ToastUtils.Duration.LONG);
+            String readerToastUrlErrorIntent = context.getString(R.string.reader_toast_err_url_intent);
+            ToastUtils.showToast(context, String.format(readerToastUrlErrorIntent, url), ToastUtils.Duration.LONG);
         }
     }
 }


### PR DESCRIPTION
Addresses #2954 

On Android 4.2, using `getString(int, formatArgs)` causes an AssertionError sometimes. Fix was to change to `getString(int)` and use `String.format(string, args)` (Same fix as #2760).

Did a regex search and replaced all remaining uses of `getString(int, formatArgs)` to get rid of this crash once and for all.

To Test:
Go to Reader and open a post that has more than 1 like. The string `x` people like this should appear at the bottom.

Needs review: @tonyr59h 