### PR TITLE
Show the correct error message if the user can't access Stats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -759,7 +759,7 @@ public class StatsActivity extends AppCompatActivity
     }
 
     @SuppressWarnings("unused")
-    public void onEventMainThread(StatsEvents.JetpackAuthError event) {
+    public void onEventMainThread(StatsEvents.StatsAuthError event) {
         if (isFinishing() || !mIsInFront) {
             return;
         }
@@ -768,6 +768,14 @@ public class StatsActivity extends AppCompatActivity
             // The user has changed blog
             return;
         }
+
+        if (!event.mIsJetpack) {
+            // Trying to access stats for a .com blog where the user cannot see Stats
+            Toast.makeText(this, R.string.stats_cannot_access_stats, Toast.LENGTH_LONG).show();
+            finish();
+            return;
+        }
+
         mSwipeToRefreshHelper.setRefreshing(false);
         startWPComLoginActivity();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsEvents.java
@@ -38,11 +38,18 @@ public class StatsEvents {
         }
     }
 
-    public static class JetpackAuthError {
+    public static class StatsAuthError {
         public final int mLocalBlogId; // This is the local blogID
+        public final boolean mIsJetpack;
 
-        public JetpackAuthError(int blogId) {
+        public StatsAuthError(int blogId) {
             mLocalBlogId = blogId;
+            mIsJetpack = false;
+        }
+
+        public StatsAuthError(int blogId, boolean isJetpack) {
+            mLocalBlogId = blogId;
+            mIsJetpack = isJetpack;
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -848,13 +848,17 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
 
         @Override
         public void onErrorResponse(final VolleyError volleyError) {
-            if (volleyError != null) {
-                AppLog.e(AppLog.T.STATS, "Error while reading Stats details "
-                        + volleyError.getMessage(), volleyError);
-            }
+            StatsUtils.logVolleyErrorDetails(volleyError);
             if (mActivityRef.get() == null || mActivityRef.get().isFinishing()) {
                 return;
             }
+
+            if (StatsUtils.isAuthenticationError(volleyError)) {
+                Toast.makeText(mActivityRef.get(), R.string.stats_cannot_access_stats, Toast.LENGTH_LONG).show();
+                finish();
+                return;
+            }
+
             resetModelVariables();
 
             String label = mActivityRef.get().getString(R.string.error_refresh_stats);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
@@ -352,6 +352,18 @@ public class StatsUtils {
         AppLog.e(T.STATS, "Volley Error details: " + volleyError.getMessage(), volleyError);
     }
 
+    public static synchronized  boolean isAuthenticationError(final VolleyError volleyError) {
+        if (volleyError != null && volleyError.networkResponse != null) {
+            NetworkResponse networkResponse = volleyError.networkResponse;
+            if (networkResponse.statusCode == 403 && networkResponse.data != null) {
+                if (new String(networkResponse.data).contains("unauthorized")) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     public static synchronized Serializable parseResponse(StatsService.StatsEndpointsEnum endpointName, String blogID, JSONObject response)
             throws JSONException {
         Serializable model = null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -402,19 +402,15 @@ public class StatsService extends Service {
                     StatsUtils.logVolleyErrorDetails(volleyError);
 
                     // Check here if this is an authentication error
-                    // .com authentication errors are handled automatically by the app
-                    if (volleyError.networkResponse != null) {
-                        NetworkResponse networkResponse = volleyError.networkResponse;
-                        if (networkResponse.statusCode == 403 && networkResponse.data != null) {
-                            if (new String(networkResponse.data).contains("unauthorized")) {
-                                int localId = WordPress.wpDB.getLocalTableBlogIdForRemoteBlogId(
-                                        Integer.parseInt(mRequestBlogId)
-                                );
-                                Blog blog = WordPress.wpDB.instantiateBlogByLocalId(localId);
-                                if (blog != null && blog.isJetpackPowered()) {
-                                    EventBus.getDefault().post(new StatsEvents.JetpackAuthError(localId));
-                                }
-                            }
+                    if (StatsUtils.isAuthenticationError(volleyError)) {
+                        int localId = WordPress.wpDB.getLocalTableBlogIdForRemoteBlogId(
+                                Integer.parseInt(mRequestBlogId)
+                        );
+                        Blog blog = WordPress.wpDB.instantiateBlogByLocalId(localId);
+                        if (blog != null) {
+                            EventBus.getDefault().post(
+                                    new StatsEvents.StatsAuthError(localId, blog.isJetpackPowered())
+                            );
                         }
                     }
                     mResponseObjectModel = volleyError;

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -398,6 +398,7 @@
     <!-- stats: errors -->
     <string name="stats_no_blog">Stats couldn\'t be loaded for the required blog</string>
     <string name="stats_generic_error">Required Stats couldn\'t be loaded</string>
+    <string name="stats_cannot_access_stats">You can\'t view stats for this site.</string>
     <string name="stats_sign_in_jetpack_different_com_account">To view your stats, sign in to the WordPress.com account you used to connect Jetpack.</string>
 
     <!-- stats: labels for timeframes -->


### PR DESCRIPTION
This PR fixes 2 cases where the user tries to access stats for a blog, or a single item, where she/he cannot see Stats.

Fix #2919