### PR TITLE
Use white background in cardviews

### DIFF
--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -21,7 +21,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_medium"
-                android:background="@color/white"
+                card_view:cardBackgroundColor="@color/white"
                 card_view:cardCornerRadius="@dimen/cardview_default_radius"
                 card_view:cardElevation="@dimen/card_elevation">
 

--- a/WordPress/src/main/res/layout/post_cardview.xml
+++ b/WordPress/src/main/res/layout/post_cardview.xml
@@ -6,6 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:stateListAnimator="@anim/pressed_card"
+    card_view:cardBackgroundColor="@color/white"
     card_view:cardCornerRadius="@dimen/cardview_default_radius"
     card_view:cardElevation="@dimen/card_elevation">
 

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -19,6 +19,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:stateListAnimator="@anim/pressed_card"
+        card_view:cardBackgroundColor="@color/white"
         card_view:cardCornerRadius="@dimen/cardview_default_radius"
         card_view:cardElevation="@dimen/card_elevation">
 
@@ -140,9 +141,9 @@
                     android:id="@+id/text_date"
                     style="@style/ReaderTextView.Date"
                     android:layout_width="0dp"
-                    android:gravity="center_vertical"
                     android:layout_height="@dimen/reader_button_icon"
                     android:layout_weight="2"
+                    android:gravity="center_vertical"
                     tools:text="text_date" />
 
                 <org.wordpress.android.ui.reader.views.ReaderIconCountView


### PR DESCRIPTION
Fix #2892 - changes the background color of CardViews from the default `#FAFAFA` to white. Don't worry if you don't notice any difference - you're unlikely to see any unless you're a designer (which I'm not) :smile: 