### PR TITLE
Issue/2959 posts failed refresh

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -211,7 +211,9 @@ public class PostsListFragment extends Fragment
         // posts the first time this is called (ie: not after device rotation)
         if (bundle == null) {
             loadPosts();
-            requestPosts(false);
+            if (NetworkUtils.checkConnection(getActivity())) {
+                requestPosts(false);
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -132,7 +132,7 @@ public class PostsListFragment extends Fragment
                         if (!isAdded()) {
                             return;
                         }
-                        if (!NetworkUtils.isNetworkAvailable(getActivity())) {
+                        if (!NetworkUtils.checkConnection(getActivity())) {
                             setRefreshing(false);
                             updateEmptyView(EmptyViewMessageType.NETWORK_ERROR);
                             return;


### PR DESCRIPTION
Fix #2959 - posts list now shows network failure toast if there's no connection:

1. The first time posts are to be requested after the fragment is created
2. Every time the user performs a PTR