### PR TITLE
Notifications: Removed left and right margin from List

### DIFF
--- a/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
+++ b/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
@@ -8,8 +8,8 @@
         android:id="@+id/recycler_view_notes"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:paddingLeft="@dimen/content_margin"
-        android:paddingRight="@dimen/content_margin"
+        android:paddingLeft="@dimen/notifications_content_margin"
+        android:paddingRight="@dimen/notifications_content_margin"
         android:scrollbars="vertical"
         android:scrollbarStyle="outsideOverlay" />
 

--- a/WordPress/src/main/res/values-land/dimens.xml
+++ b/WordPress/src/main/res/values-land/dimens.xml
@@ -1,5 +1,6 @@
 <resources>
     <dimen name="reader_detail_margin">@dimen/reader_detail_margin_normal_landscape</dimen>
     <dimen name="content_margin">@dimen/content_margin_normal_landscape</dimen>
+    <dimen name="notifications_content_margin">@dimen/content_margin</dimen>
     <dimen name="tabstrip_icon_spacing">@dimen/tabstrip_icon_spacing_landscape</dimen>
 </resources>

--- a/WordPress/src/main/res/values-sw600dp/dimens.xml
+++ b/WordPress/src/main/res/values-sw600dp/dimens.xml
@@ -7,6 +7,7 @@
     <dimen name="postlist_featured_image_height">@dimen/postlist_featured_image_height_tablet</dimen>
     <dimen name="notifications_list_margin">48dp</dimen>
     <dimen name="content_margin">@dimen/content_margin_tablet</dimen>
+    <dimen name="notifications_content_margin">@dimen/content_margin</dimen>
     <dimen name="tabstrip_icon_spacing">@dimen/tabstrip_icon_spacing_tablet</dimen>
     <dimen name="fab_margin">@dimen/fab_margin_tablet</dimen>
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -120,6 +120,7 @@
     <dimen name="comment_avatar_margin_top">6dp</dimen>
     <dimen name="notifications_max_image_size">240dp</dimen>
     <dimen name="notifications_adjusted_font_margin">10dp</dimen>
+    <dimen name="notifications_content_margin">0dp</dimen>
 
     <dimen name="progress_bar_height">3dp</dimen>
 


### PR DESCRIPTION
<img width="525" alt="screen shot 2015-07-15 at 12 23 06 pm" src="https://cloud.githubusercontent.com/assets/789137/8707731/63e91e28-2aec-11e5-8766-dd610ef2aebf.png">

Margin will still apply in landscape and on tablets. Fixes #2938