### PR TITLE
Switching to container-based infrastructure for Travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: android
 jdk: oraclejdk7
+sudo: false
 
 notifications:
   # Slack notification on failure (secured token).


### PR DESCRIPTION
ref http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade

Should speed up the build, we just need to make sure the build doesn't require sudo to run.