### PR TITLE
Includes the new MediaPicker that allows for multi-select

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     compile 'com.crashlytics.sdk.android:crashlytics:2.2.2'
 
     // Provided by maven central
-    compile ('org.wordpress:mediapicker:1.2.3') {
+    compile ('org.wordpress:mediapicker:1.2.4') {
         exclude group:'com.android.support'
     }
     compile 'com.google.code.gson:gson:2.2.2'


### PR DESCRIPTION
Addresses wordpress-mobile/MediaPicker-Android#25

Once 1.2.4 is uploaded from @tonyr59h this can be merged in

Needs review: @tonyr59h 