### PR TITLE
Issue/2983 preserve local changes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -1020,6 +1020,10 @@ public class WordPressDB {
                         values.put("wp_post_format", MapUtils.getMapStr(postMap, "wp_post_format"));
                     }
 
+                    if (overwriteLocalChanges) {
+                        values.put("isLocalChange", false);
+                    }
+
                     String whereClause = "blogID=? AND postID=? AND isPage=?";
                     if (!overwriteLocalChanges) {
                         whereClause += " AND NOT isLocalChange=1";

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -1274,20 +1274,6 @@ public class WordPressDB {
         }
     }
 
-    public Post getPostForRemotePostId(int blogID, String remotePostID) {
-        String[] args = {String.valueOf(blogID), remotePostID};
-        Cursor c = db.query(POSTS_TABLE, null, "blogID=? AND postid=?", args, null, null, null);
-        try {
-            if (c.moveToFirst()) {
-                return getPostFromCursor(c);
-            } else {
-                return null;
-            }
-        } finally {
-            SqlUtils.closeCursor(c);
-        }
-    }
-
     // Categories
     public boolean insertCategory(int id, int wp_id, int parent_id, String category_name) {
         ContentValues values = new ContentValues();

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -75,7 +75,7 @@ public class WordPressDB {
     public static final String COLUMN_NAME_VIDEO_PRESS_SHORTCODE = "videoPressShortcode";
     public static final String COLUMN_NAME_UPLOAD_STATE          = "uploadState";
 
-    private static final int DATABASE_VERSION = 32;
+    private static final int DATABASE_VERSION = 33;
 
     private static final String CREATE_TABLE_BLOGS = "create table if not exists accounts (id integer primary key autoincrement, "
             + "url text, blogName text, username text, password text, imagePlacement text, centerThumbnail boolean, fullSizeImage boolean, maxImageWidth text, maxImageWidthId integer);";
@@ -171,6 +171,10 @@ public class WordPressDB {
     // add wp_post_thumbnail to posts table
     private static final String ADD_POST_THUMBNAIL = "alter table posts add wp_post_thumbnail integer default 0;";
 
+    // add postid and blogID indexes to posts table
+    private static final String ADD_POST_ID_INDEX = "CREATE INDEX idx_posts_post_id ON posts(postid);";
+    private static final String ADD_BLOG_ID_INDEX = "CREATE INDEX idx_posts_blog_id ON posts(blogID);";
+
     //add boolean to track if featured image should be included in the post content
     private static final String ADD_FEATURED_IN_POST = "alter table media add isFeaturedInPost boolean default false;";
 
@@ -223,6 +227,10 @@ public class WordPressDB {
         // Update tables for new installs and app updates
         int currentVersion = db.getVersion();
         boolean isNewInstall = (currentVersion == 0);
+
+        if (!isNewInstall && currentVersion != DATABASE_VERSION) {
+            AppLog.d(T.DB, "updgrading database from version " + currentVersion + " to " + DATABASE_VERSION);
+        }
 
         switch (currentVersion) {
             case 0:
@@ -331,6 +339,11 @@ public class WordPressDB {
             case 31:
                 // add wp_post_thumbnail to posts table
                 db.execSQL(ADD_POST_THUMBNAIL);
+                currentVersion++;
+            case 32:
+                // add postid index and blogID index to posts table
+                db.execSQL(ADD_POST_ID_INDEX);
+                db.execSQL(ADD_BLOG_ID_INDEX);
                 currentVersion++;
         }
 

--- a/WordPress/src/main/java/org/xmlrpc/android/ApiHelper.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/ApiHelper.java
@@ -404,9 +404,11 @@ public class ApiHelper {
         private Callback mCallback;
         private String mErrorMessage;
         private int mPostCount;
+        private boolean mOverwriteLocalChanges;
 
-        public FetchPostsTask(Callback callback) {
+        public FetchPostsTask(boolean overwriteLocalChanges, Callback callback) {
             mCallback = callback;
+            mOverwriteLocalChanges = overwriteLocalChanges;
         }
 
         @Override
@@ -452,7 +454,7 @@ public class ApiHelper {
                         postsList.add(postMap);
                     }
 
-                    WordPress.wpDB.savePosts(postsList, blog.getLocalTableBlogId(), isPage, !loadMore);
+                    WordPress.wpDB.savePosts(postsList, blog.getLocalTableBlogId(), isPage, mOverwriteLocalChanges);
                 }
                 return true;
             } catch (XMLRPCFault e) {


### PR DESCRIPTION
Fixes #2983. Right now the post list doesn't automatically refresh if there are posts with local changes. If the user does a pull-to-refresh, they're given a choice between keeping local changes or retrieving new posts. 

This PR resolves this by removing both of those limitations. Whenever the post list refreshes, regardless of whether it was automatic or due to a PTR, local changes are retained. 

This does mean that if the user edits a post outside of the app, the app won't show those edits if it has local changes. This isn't ideal, but I think is still far better than the current situation.

Note that #2997 will improve this by enabling the user to revert local changes for a post.