### PR TITLE
issue/postlist-fixes-4_4

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/PostsListPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/PostsListPost.java
@@ -45,7 +45,7 @@ public class PostsListPost {
 
         status = post.getPostStatus();
         isLocalDraft = post.isLocalDraft();
-        hasLocalChanges = post.hasChangedFromLocalDraftToPublished();
+        hasLocalChanges = post.isLocalChange();
         isUploading = post.isUploading();
 
         setDateCreatedGmt(post.getDate_created_gmt());


### PR DESCRIPTION
Fixes a few post list issues specific to v4.4:
1. Posts with local changes don't have "Local changes" status text
2. Doing a PTR never gets new posts if there are local changes, even if you tell it to overwrite local changes
3. PTR spinner remains visible after PTR fails