### PR TITLE
Feature/reader adapter enhancements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPostList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPostList.java
@@ -23,4 +23,20 @@ public class ReaderPostList extends ArrayList<ReaderPost> {
         return posts;
     }
 
+    public int indexOfPost(ReaderPost post) {
+        if (post == null) {
+            return -1;
+        }
+        for (int i = 0; i < size(); i++) {
+            if (this.get(i).postId == post.postId) {
+                if (post.isExternal && post.feedId == this.get(i).feedId) {
+                    return i;
+                } else if (!post.isExternal && post.blogId == this.get(i).blogId) {
+                    return i;
+                }
+            }
+        }
+        return -1;
+    }
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPostList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPostList.java
@@ -23,42 +23,4 @@ public class ReaderPostList extends ArrayList<ReaderPost> {
         return posts;
     }
 
-    @Override
-    public Object clone() {
-        return super.clone();
-    }
-
-    public int indexOfPost(ReaderPost post) {
-        if (post == null) {
-            return -1;
-        }
-        for (int i = 0; i < size(); i++) {
-            if (this.get(i).postId == post.postId) {
-                if (post.isExternal && post.feedId == this.get(i).feedId) {
-                    return i;
-                } else if (!post.isExternal && post.blogId == this.get(i).blogId) {
-                    return i;
-                }
-            }
-        }
-        return -1;
-    }
-
-    /*
-     * does passed list contain the same posts as this list?
-     */
-    public boolean isSameList(ReaderPostList posts) {
-        if (posts == null || posts.size() != this.size()) {
-            return false;
-        }
-
-        for (ReaderPost post: posts) {
-            int index = indexOfPost(post);
-            if (index == -1 || !post.isSamePost(this.get(index))) {
-                return false;
-            }
-        }
-
-        return true;
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPostList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPostList.java
@@ -61,17 +61,4 @@ public class ReaderPostList extends ArrayList<ReaderPost> {
 
         return true;
     }
-
-    /*
-     * returns posts in this list which are in the passed blog
-     */
-    public ReaderPostList getPostsInBlog(long blogId) {
-        ReaderPostList postsInBlog = new ReaderPostList();
-        for (ReaderPost post: this) {
-            if (post.blogId == blogId) {
-                postsInBlog.add(post);
-            }
-        }
-        return postsInBlog;
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -670,8 +670,8 @@ public class ReaderPostListFragment extends Fragment
                 ReaderBlogActions.blockBlogFromReader(post.blogId, actionListener);
         AnalyticsTracker.track(AnalyticsTracker.Stat.READER_BLOCKED_BLOG);
 
-        // remove posts in this blog from the adapter
-        getPostAdapter().removePostsInBlog(post.blogId);
+        // reload adapter so deleted posts no long appear
+        reloadPosts();
 
         // show the undo snackbar enabling the user to undo the block
         View.OnClickListener undoListener = new View.OnClickListener() {
@@ -994,6 +994,13 @@ public class ReaderPostListFragment extends Fragment
         hideNewPostsBar();
         if (hasPostAdapter()) {
             getPostAdapter().refresh();
+        }
+    }
+
+    private void reloadPosts() {
+        hideNewPostsBar();
+        if (hasPostAdapter()) {
+            getPostAdapter().reload();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -406,22 +406,14 @@ public class ReaderBlogActions {
         blockResult.wasFollowing = ReaderBlogTable.isFollowedBlog(blogId);
 
         ReaderPostTable.deletePostsInBlog(blogId);
+        ReaderBlogTable.setIsFollowedBlogId(blogId, false);
 
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
             public void onResponse(JSONObject jsonObject) {
-                boolean success = (jsonObject != null && jsonObject.optBoolean("success"));
-                if (success) {
-                    // blocking endpoint unfollows the blog, so do the same here
-                    ReaderBlogTable.setIsFollowedBlogId(blogId, false);
-                } else {
-                    AppLog.w(T.READER, "failed to block blog " + blogId);
-                    ReaderPostTable.addOrUpdatePosts(null, blockResult.deletedPosts);
-                }
                 if (actionListener != null) {
-                    actionListener.onActionResult(success);
+                    actionListener.onActionResult(true);
                 }
-
             }
         };
         RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
@@ -429,6 +421,9 @@ public class ReaderBlogActions {
             public void onErrorResponse(VolleyError volleyError) {
                 AppLog.e(T.READER, volleyError);
                 ReaderPostTable.addOrUpdatePosts(null, blockResult.deletedPosts);
+                if (blockResult.wasFollowing) {
+                    ReaderBlogTable.setIsFollowedBlogId(blogId, true);
+                }
                 if (actionListener != null) {
                     actionListener.onActionResult(false);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -67,6 +67,10 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private static final boolean EXCLUDE_TEXT_COLUMN = true;
     private static final int MAX_ROWS = ReaderConstants.READER_MAX_POSTS_TO_DISPLAY;
 
+    private static final int VIEW_TYPE_SPACER = 1;
+    private static final int VIEW_TYPE_POST = 2;
+    private static final long ITEM_ID_SPACER = -1L;
+
     private final SortedList<ReaderPost> mPosts = new SortedList<>(ReaderPost.class, new SortedListAdapterCallback<ReaderPost>(this) {
         @Override
         public int compare(ReaderPost item1, ReaderPost item2) {
@@ -107,7 +111,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         private final WPNetworkImageView imgAvatar;
 
         private final ViewGroup layoutPostHeader;
-        private final View toolbarSpacer;
 
         private final ViewGroup layoutDiscover;
         private final WPNetworkImageView imgDiscoverAvatar;
@@ -133,7 +136,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             imgMore = (ImageView) itemView.findViewById(R.id.image_more);
 
             layoutPostHeader = (ViewGroup) itemView.findViewById(R.id.layout_post_header);
-            toolbarSpacer = itemView.findViewById(R.id.spacer_toolbar);
 
             layoutDiscover = (ViewGroup) itemView.findViewById(R.id.layout_discover);
             imgDiscoverAvatar = (WPNetworkImageView) layoutDiscover.findViewById(R.id.image_discover_avatar);
@@ -141,22 +143,44 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
     }
 
+    class SpacerViewHolder extends RecyclerView.ViewHolder {
+        public SpacerViewHolder(View itemView) {
+            super(itemView);
+        }
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        if (position == 0 && mShowToolbarSpacer) {
+            return VIEW_TYPE_SPACER;
+        }
+        return VIEW_TYPE_POST;
+    }
+
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
-        View postView = LayoutInflater.from(parent.getContext()).inflate(R.layout.reader_cardview_post, parent, false);
-        return new ReaderPostViewHolder(postView);
+        Context context = parent.getContext();
+        if (viewType == VIEW_TYPE_SPACER) {
+            View spacerView = LayoutInflater.from(context).inflate(R.layout.reader_toolbar_spacer, parent, false);
+            return new SpacerViewHolder(spacerView);
+        } else {
+            View postView = LayoutInflater.from(context).inflate(R.layout.reader_cardview_post, parent, false);
+            return new ReaderPostViewHolder(postView);
+        }
     }
 
     @Override
     public void onBindViewHolder(final RecyclerView.ViewHolder holder, final int position) {
+        if (holder instanceof SpacerViewHolder) {
+            return;
+        }
+
         final ReaderPost post = getItem(position);
         final ReaderPostViewHolder postHolder = (ReaderPostViewHolder) holder;
         ReaderTypes.ReaderPostListType postListType = getPostListType();
 
         postHolder.txtTitle.setText(post.getTitle());
         postHolder.txtDate.setText(DateTimeUtils.javaDateToTimeSpan(post.getDatePublished()));
-
-        postHolder.toolbarSpacer.setVisibility(position == 0 && mShowToolbarSpacer ? View.VISIBLE : View.GONE);
 
         // hide the post header (avatar, blog name & follow button) if we're showing posts
         // in a specific blog
@@ -548,21 +572,32 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     private ReaderPost getItem(int position) {
-        return mPosts.get(position);
+        if (mShowToolbarSpacer) {
+            return position == 0 ? null : mPosts.get(position - 1);
+        } else {
+            return mPosts.get(position);
+        }
     }
 
     @Override
+    public long getItemId(int position) {
+        if (getItemViewType(position) == VIEW_TYPE_SPACER) {
+            return ITEM_ID_SPACER;
+        }
+        return getItem(position).getStableId();
+    }
+
+
+    @Override
     public int getItemCount() {
+        if (mShowToolbarSpacer && mPosts.size() > 0) {
+            return mPosts.size() + 1;
+        }
         return mPosts.size();
     }
 
     public boolean isEmpty() {
         return (mPosts.size() == 0);
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return getItem(position).getStableId();
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -84,7 +84,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
         @Override
         public boolean areItemsTheSame(ReaderPost item1, ReaderPost item2) {
-            return item1.isSamePost(item2);
+            return item1.getStableId() == item2.getStableId();
         }
     });
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -161,7 +161,11 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         Context context = parent.getContext();
         if (viewType == VIEW_TYPE_SPACER) {
-            View spacerView = LayoutInflater.from(context).inflate(R.layout.reader_toolbar_spacer, parent, false);
+            View spacerView = new View(context);
+            int toolbarHeight = context.getResources().getDimensionPixelSize(R.dimen.toolbar_height);
+            int dividerHeight = context.getResources().getDimensionPixelSize(R.dimen.reader_card_gutters);
+            int spacerHeight = toolbarHeight - dividerHeight;
+            spacerView.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, spacerHeight));
             return new SpacerViewHolder(spacerView);
         } else {
             View postView = LayoutInflater.from(context).inflate(R.layout.reader_cardview_post, parent, false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -647,9 +647,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
      */
     private boolean mIsTaskRunning = false;
 
-    private class LoadPostsTask extends AsyncTask<Void, Void, Boolean> {
-        ReaderPostList allPosts;
-
+    private class LoadPostsTask extends AsyncTask<Void, Void, ReaderPostList> {
         @Override
         protected void onPreExecute() {
             mIsTaskRunning = true;
@@ -661,55 +659,38 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
 
         @Override
-        protected Boolean doInBackground(Void... params) {
+        protected ReaderPostList doInBackground(Void... params) {
             final int numExisting;
+            final ReaderPostList posts;
             switch (getPostListType()) {
                 case TAG_PREVIEW:
                 case TAG_FOLLOWED:
-                    allPosts = ReaderPostTable.getPostsWithTag(mCurrentTag, MAX_ROWS, EXCLUDE_TEXT_COLUMN);
+                    posts = ReaderPostTable.getPostsWithTag(mCurrentTag, MAX_ROWS, EXCLUDE_TEXT_COLUMN);
                     numExisting = ReaderPostTable.getNumPostsWithTag(mCurrentTag);
                     break;
                 case BLOG_PREVIEW:
-                    allPosts = ReaderPostTable.getPostsInBlog(mCurrentBlogId, MAX_ROWS, EXCLUDE_TEXT_COLUMN);
+                    posts = ReaderPostTable.getPostsInBlog(mCurrentBlogId, MAX_ROWS, EXCLUDE_TEXT_COLUMN);
                     numExisting = ReaderPostTable.getNumPostsInBlog(mCurrentBlogId);
                     break;
                 default:
-                    return false;
-            }
-
-            boolean isSame;
-            if (allPosts.size() != mPosts.size()) {
-                isSame = false;
-            } else {
-                isSame = true;
-                for (int i = 0; i < allPosts.size(); i++) {
-                    if (mPosts.indexOf(allPosts.get(i)) == -1) {
-                        isSame = false;
-                        break;
-                    }
-                }
-            }
-            if (isSame) {
-                return false;
+                    return null;
             }
 
             // if we're not already displaying the max # posts, enable requesting more when
             // the user scrolls to the end of the list
             mCanRequestMorePosts = (numExisting < ReaderConstants.READER_MAX_POSTS_TO_DISPLAY);
 
-            return true;
+            return posts;
         }
 
         @Override
-        protected void onPostExecute(Boolean result) {
-            if (result) {
-                mPosts.addAll(allPosts);
+        protected void onPostExecute(ReaderPostList posts) {
+            if (posts != null) {
+                mPosts.addAll(posts);
             }
-
             if (mDataLoadedListener != null) {
                 mDataLoadedListener.onDataLoaded(isEmpty());
             }
-
             mIsTaskRunning = false;
         }
     }

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -1,202 +1,188 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:wp="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/card_view"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:stateListAnimator="@anim/pressed_card"
+    card_view:cardBackgroundColor="@color/white"
+    card_view:cardCornerRadius="@dimen/cardview_default_radius"
+    card_view:cardElevation="@dimen/card_elevation">
 
-    <View
-        android:id="@+id/spacer_toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/toolbar_height"
-        android:clickable="false"
-        android:visibility="gone" />
-
-    <android.support.v7.widget.CardView
-        android:id="@+id/card_view"
+    <RelativeLayout
+        android:id="@+id/layout_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:stateListAnimator="@anim/pressed_card"
-        card_view:cardBackgroundColor="@color/white"
-        card_view:cardCornerRadius="@dimen/cardview_default_radius"
-        card_view:cardElevation="@dimen/card_elevation">
+        android:background="?android:selectableItemBackground">
 
         <RelativeLayout
-            android:id="@+id/layout_container"
+            android:id="@+id/layout_post_header"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="?android:selectableItemBackground">
-
-            <RelativeLayout
-                android:id="@+id/layout_post_header"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingBottom="@dimen/margin_large"
-                android:paddingLeft="@dimen/reader_card_content_padding"
-                android:paddingRight="@dimen/reader_card_content_padding">
-
-                <org.wordpress.android.widgets.WPNetworkImageView
-                    android:id="@+id/image_avatar"
-                    style="@style/ReaderImageView.Avatar"
-                    android:layout_marginRight="@dimen/margin_large"
-                    android:layout_marginTop="@dimen/margin_large"
-                    android:background="?android:selectableItemBackground"
-                    tools:src="@drawable/gravatar_placeholder" />
-
-                <org.wordpress.android.widgets.WPTextView
-                    android:id="@+id/text_blog_name"
-                    style="@style/ReaderTextView"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginRight="@dimen/margin_large"
-                    android:layout_marginTop="@dimen/margin_large"
-                    android:layout_toLeftOf="@+id/image_more"
-                    android:layout_toRightOf="@+id/image_avatar"
-                    android:ellipsize="end"
-                    android:maxLines="1"
-                    android:textColor="@color/grey_dark"
-                    android:textSize="@dimen/text_sz_small"
-                    tools:text="text_blog_name" />
-
-                <org.wordpress.android.ui.reader.views.ReaderFollowButton
-                    android:id="@+id/follow_button"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_below="@+id/text_blog_name"
-                    android:layout_marginTop="@dimen/margin_small"
-                    android:layout_toRightOf="@+id/image_avatar" />
-
-                <ImageView
-                    android:id="@+id/image_more"
-                    android:layout_width="32dp"
-                    android:layout_height="32dp"
-                    android:layout_alignParentRight="true"
-                    android:layout_centerVertical="true"
-                    android:layout_marginLeft="@dimen/margin_small"
-                    android:background="?android:selectableItemBackground"
-                    android:paddingBottom="6dp"
-                    android:paddingTop="6dp"
-                    android:src="@drawable/ic_action_more" />
-
-            </RelativeLayout>
+            android:paddingBottom="@dimen/margin_large"
+            android:paddingLeft="@dimen/reader_card_content_padding"
+            android:paddingRight="@dimen/reader_card_content_padding">
 
             <org.wordpress.android.widgets.WPNetworkImageView
-                android:id="@+id/image_featured"
-                style="@style/ReaderImageView.Featured"
-                android:layout_below="@+id/layout_post_header" />
-
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/text_title"
-                style="@style/ReaderTextView.Post.Title"
-                android:layout_below="@+id/image_featured"
-                android:layout_marginLeft="@dimen/reader_card_content_padding"
-                android:layout_marginRight="@dimen/reader_card_content_padding"
+                android:id="@+id/image_avatar"
+                style="@style/ReaderImageView.Avatar"
+                android:layout_marginRight="@dimen/margin_large"
                 android:layout_marginTop="@dimen/margin_large"
-                tools:text="text_title" />
+                android:background="?android:selectableItemBackground"
+                tools:src="@drawable/gravatar_placeholder" />
 
             <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/text_excerpt"
-                style="@style/ReaderTextView.Post.Excerpt"
-                android:layout_height="wrap_content"
-                android:layout_below="@+id/text_title"
-                android:layout_marginLeft="@dimen/reader_card_content_padding"
-                android:layout_marginRight="@dimen/reader_card_content_padding"
-                android:layout_marginTop="@dimen/margin_medium"
-                tools:text="text_excerpt" />
-
-            <!-- attribution section for discover posts -->
-            <LinearLayout
-                android:id="@+id/layout_discover"
+                android:id="@+id/text_blog_name"
+                style="@style/ReaderTextView"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_below="@+id/text_excerpt"
-                android:layout_marginBottom="@dimen/margin_small"
-                android:layout_marginLeft="@dimen/reader_card_content_padding"
-                android:layout_marginRight="@dimen/reader_card_content_padding"
+                android:layout_marginRight="@dimen/margin_large"
                 android:layout_marginTop="@dimen/margin_large"
-                android:orientation="horizontal"
-                android:visibility="gone"
-                tools:visibility="visible">
+                android:layout_toLeftOf="@+id/image_more"
+                android:layout_toRightOf="@+id/image_avatar"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:textColor="@color/grey_dark"
+                android:textSize="@dimen/text_sz_small"
+                tools:text="text_blog_name" />
 
-                <org.wordpress.android.widgets.WPNetworkImageView
-                    android:id="@+id/image_discover_avatar"
-                    style="@style/ReaderImageView.Avatar.Small"
-                    android:layout_marginRight="@dimen/margin_large"
-                    android:background="?android:selectableItemBackground"
-                    tools:src="@drawable/gravatar_placeholder" />
-
-                <org.wordpress.android.widgets.WPTextView
-                    android:id="@+id/text_discover"
-                    style="@style/ReaderTextView"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:ellipsize="end"
-                    android:maxLines="3"
-                    android:textColor="@color/grey"
-                    android:textSize="@dimen/text_sz_medium"
-                    tools:text="text_attribution" />
-
-            </LinearLayout>
-
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/text_tag"
-                style="@style/ReaderTextView.Post.Tag"
-                android:layout_below="@+id/layout_discover"
-                android:layout_marginLeft="@dimen/reader_card_content_padding"
+            <org.wordpress.android.ui.reader.views.ReaderFollowButton
+                android:id="@+id/follow_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/text_blog_name"
                 android:layout_marginTop="@dimen/margin_small"
-                android:paddingBottom="@dimen/margin_small"
-                android:paddingRight="@dimen/margin_small"
-                android:paddingTop="@dimen/margin_small"
-                tools:text="text_tag" />
+                android:layout_toRightOf="@+id/image_avatar" />
 
-            <View
-                android:id="@+id/divider"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_below="@+id/text_tag"
-                android:layout_marginLeft="@dimen/reader_card_content_padding"
-                android:layout_marginRight="@dimen/reader_card_content_padding"
-                android:layout_marginTop="@dimen/margin_medium"
-                android:background="@color/reader_divider_grey" />
+            <ImageView
+                android:id="@+id/image_more"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:layout_alignParentRight="true"
+                android:layout_centerVertical="true"
+                android:layout_marginLeft="@dimen/margin_small"
+                android:background="?android:selectableItemBackground"
+                android:paddingBottom="6dp"
+                android:paddingTop="6dp"
+                android:src="@drawable/ic_action_more" />
 
-            <LinearLayout
-                android:id="@id/layout_bottom"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_below="@+id/divider"
-                android:layout_marginLeft="@dimen/reader_card_content_padding"
-                android:layout_marginRight="@dimen/reader_card_content_padding"
-                android:orientation="horizontal">
-
-                <org.wordpress.android.widgets.WPTextView
-                    android:id="@+id/text_date"
-                    style="@style/ReaderTextView.Date"
-                    android:layout_width="0dp"
-                    android:layout_height="@dimen/reader_button_icon"
-                    android:layout_weight="2"
-                    android:gravity="center_vertical"
-                    tools:text="text_date" />
-
-                <org.wordpress.android.ui.reader.views.ReaderIconCountView
-                    android:id="@+id/count_comments"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/margin_small"
-                    wp:readerIcon="comment" />
-
-                <org.wordpress.android.ui.reader.views.ReaderIconCountView
-                    android:id="@+id/count_likes"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/margin_small"
-                    wp:readerIcon="like" />
-
-            </LinearLayout>
         </RelativeLayout>
-    </android.support.v7.widget.CardView>
 
-</LinearLayout>
+        <org.wordpress.android.widgets.WPNetworkImageView
+            android:id="@+id/image_featured"
+            style="@style/ReaderImageView.Featured"
+            android:layout_below="@+id/layout_post_header" />
+
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/text_title"
+            style="@style/ReaderTextView.Post.Title"
+            android:layout_below="@+id/image_featured"
+            android:layout_marginLeft="@dimen/reader_card_content_padding"
+            android:layout_marginRight="@dimen/reader_card_content_padding"
+            android:layout_marginTop="@dimen/margin_large"
+            tools:text="text_title" />
+
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/text_excerpt"
+            style="@style/ReaderTextView.Post.Excerpt"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/text_title"
+            android:layout_marginLeft="@dimen/reader_card_content_padding"
+            android:layout_marginRight="@dimen/reader_card_content_padding"
+            android:layout_marginTop="@dimen/margin_medium"
+            tools:text="text_excerpt" />
+
+        <!-- attribution section for discover posts -->
+        <LinearLayout
+            android:id="@+id/layout_discover"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/text_excerpt"
+            android:layout_marginBottom="@dimen/margin_small"
+            android:layout_marginLeft="@dimen/reader_card_content_padding"
+            android:layout_marginRight="@dimen/reader_card_content_padding"
+            android:layout_marginTop="@dimen/margin_large"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <org.wordpress.android.widgets.WPNetworkImageView
+                android:id="@+id/image_discover_avatar"
+                style="@style/ReaderImageView.Avatar.Small"
+                android:layout_marginRight="@dimen/margin_large"
+                android:background="?android:selectableItemBackground"
+                tools:src="@drawable/gravatar_placeholder" />
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/text_discover"
+                style="@style/ReaderTextView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:ellipsize="end"
+                android:maxLines="3"
+                android:textColor="@color/grey"
+                android:textSize="@dimen/text_sz_medium"
+                tools:text="text_attribution" />
+
+        </LinearLayout>
+
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/text_tag"
+            style="@style/ReaderTextView.Post.Tag"
+            android:layout_below="@+id/layout_discover"
+            android:layout_marginLeft="@dimen/reader_card_content_padding"
+            android:layout_marginTop="@dimen/margin_small"
+            android:paddingBottom="@dimen/margin_small"
+            android:paddingRight="@dimen/margin_small"
+            android:paddingTop="@dimen/margin_small"
+            tools:text="text_tag" />
+
+        <View
+            android:id="@+id/divider"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_below="@+id/text_tag"
+            android:layout_marginLeft="@dimen/reader_card_content_padding"
+            android:layout_marginRight="@dimen/reader_card_content_padding"
+            android:layout_marginTop="@dimen/margin_medium"
+            android:background="@color/reader_divider_grey" />
+
+        <LinearLayout
+            android:id="@id/layout_bottom"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/divider"
+            android:layout_marginLeft="@dimen/reader_card_content_padding"
+            android:layout_marginRight="@dimen/reader_card_content_padding"
+            android:orientation="horizontal">
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/text_date"
+                style="@style/ReaderTextView.Date"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/reader_button_icon"
+                android:layout_weight="2"
+                android:gravity="center_vertical"
+                tools:text="text_date" />
+
+            <org.wordpress.android.ui.reader.views.ReaderIconCountView
+                android:id="@+id/count_comments"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/margin_small"
+                wp:readerIcon="comment" />
+
+            <org.wordpress.android.ui.reader.views.ReaderIconCountView
+                android:id="@+id/count_likes"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/margin_small"
+                wp:readerIcon="like" />
+
+        </LinearLayout>
+    </RelativeLayout>
+</android.support.v7.widget.CardView>

--- a/WordPress/src/main/res/layout/reader_toolbar_spacer.xml
+++ b/WordPress/src/main/res/layout/reader_toolbar_spacer.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<!--
-    empty "spacer" view used by ReaderPostListAdapter to make room for tag toolbar
--->
-
-<View xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="@dimen/toolbar_height" />

--- a/WordPress/src/main/res/layout/reader_toolbar_spacer.xml
+++ b/WordPress/src/main/res/layout/reader_toolbar_spacer.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    empty "spacer" view used by ReaderPostListAdapter to make room for tag toolbar
+-->
+
+<View xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/toolbar_height" />


### PR DESCRIPTION
## Adds two related enhancements to ReaderPostAdapter

### 1. #2590 - Use a [SortedList](https://developer.android.com/reference/android/support/v7/util/SortedList.html) to maintain the list of posts

Switching to a SortedList provides these benefits:

* Batch upating - wrap multiple changes between `beginBatchedUpdate`...`endBatchedUpdate` for more efficient handling
* It takes care of telling the RecyclerView when (and what) to update, so we don't ever have to call `notifyDataSetChanged` or `notifyItemChanged`
* It takes care of de-duping and sorting

### 2. #3025 - Use a separate view type for the toolbar spacer

In the current code, we show a transparent "spacer" at the top of the first post (the one at position 0) to avoid overlapping the toolbar. This means that when new posts are added we have to hide the previous spacer and make sure the post that's now at position 0 shows it.

That approach won't work now that we've switched to a SortedList, and it was cumbersome to start with. This new approach relies on `getItemViewType()` to always show the spacer at position 0.