### PR TITLE
Take endpoint into account when comparing reader tag lists

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTagList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTagList.java
@@ -9,7 +9,7 @@ public class ReaderTagList extends ArrayList<ReaderTag> {
         return super.clone();
     }
 
-    public int indexOfTagName(final String tagName) {
+    public int indexOfTagName(String tagName) {
         if (tagName == null || isEmpty()) {
             return -1;
         }
@@ -23,18 +23,18 @@ public class ReaderTagList extends ArrayList<ReaderTag> {
         return -1;
     }
 
-    private boolean hasSameTag(ReaderTag tag) {
+    private int indexOfTag(ReaderTag tag) {
         if (tag == null || isEmpty()) {
-            return false;
+            return -1;
         }
 
-        for (ReaderTag thisTag : this) {
-            if (ReaderTag.isSameTag(thisTag, tag)) {
-                return true;
+        for (int i = 0; i < this.size(); i++) {
+            if (ReaderTag.isSameTag(tag, this.get(i))) {
+                return i;
             }
         }
 
-        return false;
+        return -1;
     }
 
     public boolean isSameList(ReaderTagList tagList) {
@@ -42,8 +42,11 @@ public class ReaderTagList extends ArrayList<ReaderTag> {
             return false;
         }
 
-        for (ReaderTag thisTag: tagList) {
-            if (!hasSameTag(thisTag)) {
+        for (ReaderTag tag: tagList) {
+            int i = indexOfTag(tag);
+            if (i == -1) {
+                return false;
+            } else if (!tag.getEndpoint().equals(this.get(i).getEndpoint())) {
                 return false;
             }
         }
@@ -60,9 +63,9 @@ public class ReaderTagList extends ArrayList<ReaderTag> {
             return deletions;
         }
 
-        for (ReaderTag thisTag: this) {
-            if (!tagList.hasSameTag(thisTag)) {
-                deletions.add(thisTag);
+        for (ReaderTag tag: this) {
+            if (indexOfTag(tag) == -1) {
+                deletions.add(tag);
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTagList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTagList.java
@@ -37,16 +37,16 @@ public class ReaderTagList extends ArrayList<ReaderTag> {
         return -1;
     }
 
-    public boolean isSameList(ReaderTagList tagList) {
-        if (tagList == null || tagList.size() != this.size()) {
+    public boolean isSameList(ReaderTagList otherList) {
+        if (otherList == null || otherList.size() != this.size()) {
             return false;
         }
 
-        for (ReaderTag tag: tagList) {
-            int i = indexOfTag(tag);
+        for (ReaderTag otherTag: otherList) {
+            int i = this.indexOfTag(otherTag);
             if (i == -1) {
                 return false;
-            } else if (!tag.getEndpoint().equals(this.get(i).getEndpoint())) {
+            } else if (!otherTag.getEndpoint().equals(this.get(i).getEndpoint())) {
                 return false;
             }
         }
@@ -57,15 +57,15 @@ public class ReaderTagList extends ArrayList<ReaderTag> {
     /*
      * returns a list of tags that are in this list but not in the passed list
      */
-    public ReaderTagList getDeletions(ReaderTagList tagList) {
+    public ReaderTagList getDeletions(ReaderTagList otherList) {
         ReaderTagList deletions = new ReaderTagList();
-        if (tagList == null) {
+        if (otherList == null) {
             return deletions;
         }
 
-        for (ReaderTag tag: this) {
-            if (indexOfTag(tag) == -1) {
-                deletions.add(tag);
+        for (ReaderTag thisTag: this) {
+            if (otherList.indexOfTag(thisTag) == -1) {
+                deletions.add(thisTag);
             }
         }
 


### PR DESCRIPTION
Fixes #3028 - when comparing two lists of reader tags, endpoint changes are now detected.