### PR TITLE
Call finish() instead of onBackPressed()

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -113,7 +113,7 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            onBackPressed();
+            finish();
             return true;
         }
 


### PR DESCRIPTION
Fix #2859 by calling `finish()` instead of `onBackPressed()`.
:pray:  