### PR TITLE
Analytics - Update the way mixpanel uniques are handled

### DIFF
--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -4,12 +4,9 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
-import org.wordpress.android.util.AppLog;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 public final class AnalyticsTracker {
     private static boolean mHasUserOptedOut;

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -4,9 +4,12 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 
+import org.wordpress.android.util.AppLog;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public final class AnalyticsTracker {
     private static boolean mHasUserOptedOut;
@@ -104,16 +107,6 @@ public final class AnalyticsTracker {
         NOTIFICATION_SETTINGS_STREAMS_OPENED,
         NOTIFICATION_SETTINGS_DETAILS_OPENED,
         NOTIFICATION_SETTINGS_UPDATED,
-    }
-
-    public interface Tracker {
-        void track(Stat stat);
-        void track(Stat stat, Map<String, ?> properties);
-        void endSession();
-        void refreshMetadata(boolean isUserConnected,boolean isWordPressComUser, boolean isJetpackUser,
-                             int sessionCount, int numBlogs, int versionCode, String username, String email);
-        void clearAllData();
-        void registerPushNotificationToken(String regId);
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<Tracker>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
@@ -9,7 +9,6 @@ import android.content.SharedPreferences;
 import android.os.Build;
 import android.preference.PreferenceManager;
 
-import com.automattic.android.tracks.TracksClient;
 import com.mixpanel.android.mpmetrics.MixpanelAPI;
 
 import org.json.JSONException;
@@ -34,7 +33,7 @@ public class AnalyticsTrackerMixpanel extends Tracker {
     private static final String APP_LOCALE = "app_locale";
     private static final String MIXPANEL_ANON_ID = "mixpanel_user_anon_id";
 
-    public AnalyticsTrackerMixpanel(Context context, String token) {
+    public AnalyticsTrackerMixpanel(Context context, String token) throws IllegalArgumentException {
         super(context);
         mAggregatedProperties = new EnumMap<AnalyticsTracker.Stat, JSONObject>(AnalyticsTracker.Stat.class);
         mMixpanel = MixpanelAPI.getInstance(context, token);

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
@@ -19,10 +19,9 @@ import java.util.EnumMap;
 import java.util.Iterator;
 import java.util.Map;
 
-public class AnalyticsTrackerMixpanel implements AnalyticsTracker.Tracker {
+public class AnalyticsTrackerMixpanel extends Tracker {
     public static final String SESSION_COUNT = "sessionCount";
 
-    private Context mContext;
     private MixpanelAPI mMixpanel;
     private EnumMap<AnalyticsTracker.Stat, JSONObject> mAggregatedProperties;
     private static final String MIXPANEL_PLATFORM = "platform";
@@ -32,11 +31,12 @@ public class AnalyticsTrackerMixpanel implements AnalyticsTracker.Tracker {
     private static final String MIXPANEL_NUMBER_OF_BLOGS = "number_of_blogs";
     private static final String VERSION_CODE = "version_code";
     private static final String APP_LOCALE = "app_locale";
+    private static final String MIXPANEL_ANON_ID = "mixpanel_user_anon_id";
 
     public AnalyticsTrackerMixpanel(Context context, String token) {
+        super(context);
         mAggregatedProperties = new EnumMap<AnalyticsTracker.Stat, JSONObject>(AnalyticsTracker.Stat.class);
         mMixpanel = MixpanelAPI.getInstance(context, token);
-        mContext = context;
     }
 
     @SuppressWarnings("deprecation")
@@ -55,6 +55,10 @@ public class AnalyticsTrackerMixpanel implements AnalyticsTracker.Tracker {
         }
         notification.flags |= Notification.FLAG_AUTO_CANCEL;
         nm.notify(0, notification);
+    }
+
+    String getAnonIdPrefKey() {
+        return MIXPANEL_ANON_ID;
     }
 
     @Override

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -22,7 +22,6 @@ public class AnalyticsTrackerNosara extends Tracker {
 
     private static final String EVENTS_PREFIX = "wpandroid_";
 
-    private String mWpcomUserName = null;
     private TracksClient mNosaraClient;
 
     public AnalyticsTrackerNosara(Context context) {
@@ -347,8 +346,8 @@ public class AnalyticsTrackerNosara extends Tracker {
 
         final String user;
         final TracksClient.NosaraUserType userType;
-        if (mWpcomUserName != null) {
-            user = mWpcomUserName;
+        if (getWordPressComUserName() != null) {
+            user = getWordPressComUserName();
             userType = TracksClient.NosaraUserType.WPCOM;
         } else {
             // This is just a security checks since the anonID is already available here.
@@ -402,6 +401,7 @@ public class AnalyticsTrackerNosara extends Tracker {
         mNosaraClient.flush();
     }
 
+
     @Override
     public void refreshMetadata(boolean isUserConnected, boolean isWordPressComUser, boolean isJetpackUser,
                                 int sessionCount, int numBlogs, int versionCode, String username, String email) {
@@ -410,15 +410,15 @@ public class AnalyticsTrackerNosara extends Tracker {
         }
 
         if (isUserConnected && isWordPressComUser) {
-            mWpcomUserName = username;
+            setWordPressComUserName(username);
             // Re-unify the user
             if (getAnonID() != null) {
-                mNosaraClient.trackAliasUser(mWpcomUserName, getAnonID());
+                mNosaraClient.trackAliasUser(getWordPressComUserName(), getAnonID());
                 clearAnonID();
             }
         } else {
             // Not wpcom connected. Check if anonID is already present
-            mWpcomUserName = null;
+            setWordPressComUserName(null);
             if (getAnonID() == null) {
                 generateNewAnonID();
             }
@@ -443,7 +443,7 @@ public class AnalyticsTrackerNosara extends Tracker {
         mNosaraClient.clearUserProperties();
         // Reset the anon ID here
         clearAnonID();
-        mWpcomUserName = null;
+        setWordPressComUserName(null);
     }
 
     @Override

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-public class AnalyticsTrackerNosara implements AnalyticsTracker.Tracker {
+public class AnalyticsTrackerNosara extends Tracker {
 
     private static final String JETPACK_USER = "jetpack_user";
     private static final String NUMBER_OF_BLOGS = "number_of_blogs";
@@ -23,18 +23,19 @@ public class AnalyticsTrackerNosara implements AnalyticsTracker.Tracker {
     private static final String EVENTS_PREFIX = "wpandroid_";
 
     private String mWpcomUserName = null;
-    private String mAnonID = null; // do not access this variable directly. Use methods.
-
     private TracksClient mNosaraClient;
-    private Context mContext;
 
     public AnalyticsTrackerNosara(Context context) {
+        super(context);
         if (null == context) {
             mNosaraClient = null;
             return;
         }
-        mContext = context;
         mNosaraClient = TracksClient.getClient(context);
+    }
+
+    String getAnonIdPrefKey() {
+        return TRACKS_ANON_ID;
     }
 
     @Override
@@ -391,41 +392,7 @@ public class AnalyticsTrackerNosara implements AnalyticsTracker.Tracker {
         }
     }
 
-    private void clearAnonID() {
-        mAnonID = null;
-        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(mContext);
-        if (preferences.contains(TRACKS_ANON_ID)) {
-            final SharedPreferences.Editor editor = preferences.edit();
-            editor.remove(TRACKS_ANON_ID);
-            editor.commit();
-        }
-    }
 
-    private String getAnonID() {
-        if (mAnonID == null) {
-            SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(mContext);
-            mAnonID = preferences.getString(TRACKS_ANON_ID, null);
-        }
-        return mAnonID;
-    }
-
-    private String generateNewAnonID() {
-        String uuid = UUID.randomUUID().toString();
-        String[] uuidSplitted = uuid.split("-");
-        StringBuilder builder = new StringBuilder();
-        for (String currentPart : uuidSplitted) {
-            builder.append(currentPart);
-        }
-        uuid = builder.toString();
-        AppLog.d(AppLog.T.STATS, "New anon ID generated: " + uuid);
-        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(mContext);
-        final SharedPreferences.Editor editor = preferences.edit();
-        editor.putString(TRACKS_ANON_ID, uuid);
-        editor.commit();
-
-        mAnonID = uuid;
-        return uuid;
-    }
 
     @Override
     public void endSession() {

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -437,13 +437,11 @@ public class AnalyticsTrackerNosara extends Tracker {
 
     @Override
     public void clearAllData() {
+        super.clearAllData();
         if (mNosaraClient == null) {
             return;
         }
         mNosaraClient.clearUserProperties();
-        // Reset the anon ID here
-        clearAnonID();
-        setWordPressComUserName(null);
     }
 
     @Override

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -1,8 +1,6 @@
 package org.wordpress.android.analytics;
 
 import android.content.Context;
-import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
 
 import com.automattic.android.tracks.TracksClient;
 
@@ -12,7 +10,6 @@ import org.wordpress.android.util.AppLog;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 public class AnalyticsTrackerNosara extends Tracker {
 
@@ -24,12 +21,8 @@ public class AnalyticsTrackerNosara extends Tracker {
 
     private TracksClient mNosaraClient;
 
-    public AnalyticsTrackerNosara(Context context) {
+    public AnalyticsTrackerNosara(Context context) throws IllegalArgumentException {
         super(context);
-        if (null == context) {
-            mNosaraClient = null;
-            return;
-        }
         mNosaraClient = TracksClient.getClient(context);
     }
 

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/Tracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/Tracker.java
@@ -16,7 +16,6 @@ public abstract class Tracker {
     abstract void endSession();
     abstract void refreshMetadata(boolean isUserConnected,boolean isWordPressComUser, boolean isJetpackUser,
                          int sessionCount, int numBlogs, int versionCode, String username, String email);
-    abstract void clearAllData();
     abstract void registerPushNotificationToken(String regId);
     abstract String getAnonIdPrefKey();
 
@@ -29,6 +28,12 @@ public abstract class Tracker {
             return;
         }
         mContext = context;
+    }
+
+    void clearAllData() {
+        // Reset the anon ID here
+        clearAnonID();
+        setWordPressComUserName(null);
     }
 
     void clearAnonID() {

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/Tracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/Tracker.java
@@ -1,0 +1,69 @@
+package org.wordpress.android.analytics;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.wordpress.android.analytics.AnalyticsTracker.Stat;
+import org.wordpress.android.util.AppLog;
+
+public abstract class Tracker {
+    abstract void track(Stat stat);
+    abstract void track(Stat stat, Map<String, ?> properties);
+    abstract void endSession();
+    abstract void refreshMetadata(boolean isUserConnected,boolean isWordPressComUser, boolean isJetpackUser,
+                         int sessionCount, int numBlogs, int versionCode, String username, String email);
+    abstract void clearAllData();
+    abstract void registerPushNotificationToken(String regId);
+    abstract String getAnonIdPrefKey();
+
+    private String mAnonID = null; // do not access this variable directly. Use methods.
+    Context mContext;
+
+    public Tracker(Context context) {
+        if (null == context) {
+            return;
+        }
+        mContext = context;
+    }
+
+    void clearAnonID() {
+        mAnonID = null;
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(mContext);
+        if (preferences.contains(getAnonIdPrefKey())) {
+            final SharedPreferences.Editor editor = preferences.edit();
+            editor.remove(getAnonIdPrefKey());
+            editor.commit();
+        }
+    }
+
+    String getAnonID() {
+        if (mAnonID == null) {
+            SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(mContext);
+            mAnonID = preferences.getString(getAnonIdPrefKey(), null);
+        }
+        return mAnonID;
+    }
+
+    String generateNewAnonID() {
+        String uuid = UUID.randomUUID().toString();
+        String[] uuidSplitted = uuid.split("-");
+        StringBuilder builder = new StringBuilder();
+        for (String currentPart : uuidSplitted) {
+            builder.append(currentPart);
+        }
+        uuid = builder.toString();
+        AppLog.d(AppLog.T.STATS, "New anon ID generated: " + uuid);
+
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(mContext);
+        final SharedPreferences.Editor editor = preferences.edit();
+        editor.putString(getAnonIdPrefKey(), uuid);
+        editor.commit();
+
+        mAnonID = uuid;
+        return uuid;
+    }
+}

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/Tracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/Tracker.java
@@ -21,6 +21,7 @@ public abstract class Tracker {
     abstract String getAnonIdPrefKey();
 
     private String mAnonID = null; // do not access this variable directly. Use methods.
+    private String mWpcomUserName = null;
     Context mContext;
 
     public Tracker(Context context) {
@@ -65,5 +66,13 @@ public abstract class Tracker {
 
         mAnonID = uuid;
         return uuid;
+    }
+
+    String getWordPressComUserName() {
+        return mWpcomUserName;
+    }
+
+    void setWordPressComUserName(String userName) {
+        mWpcomUserName = userName;
     }
 }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/Tracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/Tracker.java
@@ -62,7 +62,7 @@ public abstract class Tracker {
             builder.append(currentPart);
         }
         uuid = builder.toString();
-        AppLog.d(AppLog.T.STATS, "New anon ID generated: " + uuid);
+        AppLog.d(AppLog.T.STATS, "New anonID generated in " + this.getClass().getSimpleName() + ": " + uuid);
 
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(mContext);
         final SharedPreferences.Editor editor = preferences.edit();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/Tracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/Tracker.java
@@ -23,9 +23,9 @@ public abstract class Tracker {
     private String mWpcomUserName = null;
     Context mContext;
 
-    public Tracker(Context context) {
+    public Tracker(Context context) throws IllegalArgumentException {
         if (null == context) {
-            return;
+            throw new IllegalArgumentException("Tracker requires a not-null context");
         }
         mContext = context;
     }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/Tracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/Tracker.java
@@ -55,13 +55,7 @@ public abstract class Tracker {
     }
 
     String generateNewAnonID() {
-        String uuid = UUID.randomUUID().toString();
-        String[] uuidSplitted = uuid.split("-");
-        StringBuilder builder = new StringBuilder();
-        for (String currentPart : uuidSplitted) {
-            builder.append(currentPart);
-        }
-        uuid = builder.toString();
+        String uuid = UUID.randomUUID().toString().replace("-", "");
         AppLog.d(AppLog.T.STATS, "New anonID generated in " + this.getClass().getSimpleName() + ": " + uuid);
 
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(mContext);


### PR DESCRIPTION
A.k.a: Do not tracks .org users in Mixpanel between "sessions" (login/logout).

This PR fixes the case where .ORG users were tracked between logins/logouts. #3046
Steps to repro the issue:
- Open the app and login with your .ORG account
- Logout, and close the app.
- Reopen the app, and login again by using the same .ORG account.

Tracks reported 2 Unique users (as it should be), Mixpanel reported one Unique user. 

There was an error in the code of our Mixpanel tracker. The error was in the code that registers .ORG  user with the Mixpanel backend. The `username` was used, instead of an `AnonID`. 

Also moved some common code in a base class.

/cc @astralbodies 