### PR TITLE
Update Tracks to 1.0.5 in 4.4

### DIFF
--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.automattic:tracks:1.0.4'
+    compile 'com.automattic:tracks:1.0.5'
     compile 'com.mixpanel.android:mixpanel-android:4.3.0@aar'
     compile 'org.wordpress:utils:1.3.0'
 }


### PR DESCRIPTION
Better to update Tracks library to the version 1.0.5 in wp-android 4.4, without waiting for the version 4.5. Otherwise we need to wait for a long time to check we're going in the right direction. 