### PR TITLE
Issue/3070 reader scrollbar bounds

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -145,16 +145,8 @@ public class ReaderPostDetailFragment extends Fragment
         mLayoutFooter.setVisibility(View.INVISIBLE);
         mScrollView.setVisibility(View.INVISIBLE);
 
-        // if the activity supports toolbar auto-hiding, set the top padding of the scrollView
-        // to the toolbar height so the toolbar doesn't overlap the content
-        if (mAutoHideToolbarListener != null) {
-            mScrollView.setPadding(0, mToolbarHeight, 0, 0);
-        }
-
         return view;
     }
-
-
 
     @Override
     public void onDestroy() {
@@ -619,6 +611,12 @@ public class ReaderPostDetailFragment extends Fragment
             if (!canShowFooter()) {
                 mLayoutFooter.setVisibility(View.GONE);
             }
+
+            // add padding to the scrollView to make room for the top and bottom toolbars - this also
+            // ensures the scrollbar matches the content so it doesn't disappear behind the toolbars
+            int topPadding = (mAutoHideToolbarListener != null ? mToolbarHeight : 0);
+            int bottomPadding = (canShowFooter() ? mLayoutFooter.getHeight() : 0);
+            mScrollView.setPadding(0, topPadding, 0, bottomPadding);
 
             // scrollView was hidden in onCreateView, show it now that we have the post
             mScrollView.setVisibility(View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -145,10 +145,11 @@ public class ReaderPostDetailFragment extends Fragment
         mLayoutFooter.setVisibility(View.INVISIBLE);
         mScrollView.setVisibility(View.INVISIBLE);
 
-        // spacer that's set to the same height as the toolbar needs to be visible if fragment is
-        // in an activity that supports toolbar auto-hiding (e.g. ReaderPostPagerActivity)
-        View spacer = view.findViewById(R.id.toolbar_spacer);
-        spacer.setVisibility(mAutoHideToolbarListener != null ? View.VISIBLE : View.GONE);
+        // if the activity supports toolbar auto-hiding, set the top padding of the scrollView
+        // to the toolbar height so the toolbar doesn't overlap the content
+        if (mAutoHideToolbarListener != null) {
+            mScrollView.setPadding(0, mToolbarHeight, 0, 0);
+        }
 
         return view;
     }

--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -22,11 +22,6 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
 
-                <View
-                    android:id="@+id/toolbar_spacer"
-                    android:layout_width="match_parent"
-                    android:layout_height="@dimen/toolbar_height" />
-
                 <include
                     layout="@layout/reader_include_post_detail_header"
                     android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -15,7 +15,9 @@
             android:id="@+id/scroll_view_reader"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:fillViewport="true">
+            android:clipToPadding="false"
+            android:fillViewport="true"
+            android:scrollbarStyle="insideOverlay">
 
             <LinearLayout
                 android:layout_width="match_parent"


### PR DESCRIPTION
Resolves #3070 - content scrollbar in reader detail now takes top/bottom toolbars into account. Another hat tip to @tonyr59h for the solution.