### PR TITLE
Fixed missing FAB (again)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -84,18 +84,17 @@ public class MySiteFragment extends Fragment
         if (ServiceUtils.isServiceRunning(getActivity(), StatsService.class)) {
             getActivity().stopService(new Intent(getActivity(), StatsService.class));
         }
+
         // redisplay hidden fab after a short delay
-        if (mFabView.getVisibility() != View.VISIBLE) {
-            long delayMs = getResources().getInteger(R.integer.fab_animation_delay);
-            new Handler().postDelayed(new Runnable() {
-                @Override
-                public void run() {
-                    if (isAdded()) {
-                        AniUtils.showFab(mFabView, true);
-                    }
+        long delayMs = getResources().getInteger(R.integer.fab_animation_delay);
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                if (isAdded() && (mFabView.getVisibility() != View.VISIBLE || mFabView.getTranslationY() != 0)) {
+                    AniUtils.showFab(mFabView, true);
                 }
-            }, delayMs);
-        }
+            }
+        }, delayMs);
     }
 
     @Override


### PR DESCRIPTION
Fix #3030 - the [previous fix](https://github.com/wordpress-mobile/WordPress-Android/pull/3031) for this bug wasn't reliable. This resolves the problem by making sure the FAB reappears not just if it's invisible, but also if it's offscreen (which it can be due to the animation which hides the FAB).