### PR TITLE
Add support for stacked notifications on Android Wear

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationDismissBroadcastReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationDismissBroadcastReceiver.java
@@ -20,7 +20,7 @@ public class NotificationDismissBroadcastReceiver extends BroadcastReceiver {
             GCMIntentService.getNotificationsMap().remove(notificationId);
 
             // Dismiss the grouped notification if a user dismisses all notifications from a wear device
-            if (GCMIntentService.getNotificationsMap().size() == 0) {
+            if (GCMIntentService.getNotificationsMap().isEmpty()) {
                 NotificationManager notificationManager = (NotificationManager) context
                         .getSystemService(GCMIntentService.NOTIFICATION_SERVICE);
                 notificationManager.cancel(GCMIntentService.GROUP_NOTIFICATION_ID);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationDismissBroadcastReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationDismissBroadcastReceiver.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.notifications;
 
+import android.app.NotificationManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -12,6 +13,18 @@ import org.wordpress.android.GCMIntentService;
 public class NotificationDismissBroadcastReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
-        GCMIntentService.clearNotificationsMap();
+        int notificationId = intent.getIntExtra("notificationId", 0);
+        if (notificationId == GCMIntentService.GROUP_NOTIFICATION_ID) {
+            GCMIntentService.clearNotificationsMap();
+        } else {
+            GCMIntentService.getNotificationsMap().remove(notificationId);
+
+            // Dismiss the grouped notification if a user dismisses all notifications from a wear device
+            if (GCMIntentService.getNotificationsMap().size() == 0) {
+                NotificationManager notificationManager = (NotificationManager) context
+                        .getSystemService(GCMIntentService.NOTIFICATION_SERVICE);
+                notificationManager.cancel(GCMIntentService.GROUP_NOTIFICATION_ID);
+            }
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -364,7 +364,7 @@ public class NotificationsListFragment extends Fragment
 
     // Removes app notifications from the system bar
     private void cancelNotifications() {
-        if (GCMIntentService.getNotificationsMap().size() == 0) {
+        if (GCMIntentService.getNotificationsMap().isEmpty()) {
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -4,8 +4,10 @@ import android.app.Activity;
 import android.app.Fragment;
 import android.app.NotificationManager;
 import android.content.Intent;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.StringRes;
+import android.support.v4.util.ArrayMap;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -135,9 +137,8 @@ public class NotificationsListFragment extends Fragment
             mBucket.addListener(this);
         }
 
-        // Remove notification if it is showing when we resume this activity.
-        NotificationManager notificationManager = (NotificationManager) getActivity().getSystemService(GCMIntentService.NOTIFICATION_SERVICE);
-        notificationManager.cancel(GCMIntentService.PUSH_NOTIFICATION_ID);
+        // Remove app notification if it is showing when we resume
+        new CancelNotificationsTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
 
         if (SimperiumUtils.isUserAuthorized()) {
             SimperiumUtils.startBuckets();
@@ -360,6 +361,23 @@ public class NotificationsListFragment extends Fragment
     public void onStart() {
         super.onStart();
         EventBus.getDefault().registerSticky(this);
+    }
+
+    // Removes app notifications from the system bar
+    class CancelNotificationsTask extends AsyncTask<Void, Void, Void> {
+
+        @Override
+        protected Void doInBackground(Void... nada) {
+            NotificationManager notificationManager = (NotificationManager) getActivity()
+                    .getSystemService(GCMIntentService.NOTIFICATION_SERVICE);
+            ArrayMap<Integer, Bundle> notificationsMap = GCMIntentService.getNotificationsMap();
+            for (Integer pushId : notificationsMap.keySet()) {
+                notificationManager.cancel(pushId);
+            }
+            notificationManager.cancel(GCMIntentService.GROUP_NOTIFICATION_ID);
+
+            return null;
+        }
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.app.Fragment;
 import android.app.NotificationManager;
 import android.content.Intent;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.StringRes;
 import android.support.v4.util.ArrayMap;
@@ -138,7 +137,7 @@ public class NotificationsListFragment extends Fragment
         }
 
         // Remove app notification if it is showing when we resume
-        new CancelNotificationsTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        cancelNotifications();
 
         if (SimperiumUtils.isUserAuthorized()) {
             SimperiumUtils.startBuckets();
@@ -364,20 +363,18 @@ public class NotificationsListFragment extends Fragment
     }
 
     // Removes app notifications from the system bar
-    class CancelNotificationsTask extends AsyncTask<Void, Void, Void> {
-
-        @Override
-        protected Void doInBackground(Void... nada) {
-            NotificationManager notificationManager = (NotificationManager) getActivity()
-                    .getSystemService(GCMIntentService.NOTIFICATION_SERVICE);
-            ArrayMap<Integer, Bundle> notificationsMap = GCMIntentService.getNotificationsMap();
-            for (Integer pushId : notificationsMap.keySet()) {
-                notificationManager.cancel(pushId);
+    private void cancelNotifications() {
+        new Thread(new Runnable() {
+            public void run() {
+                NotificationManager notificationManager = (NotificationManager) getActivity()
+                        .getSystemService(GCMIntentService.NOTIFICATION_SERVICE);
+                ArrayMap<Integer, Bundle> notificationsMap = GCMIntentService.getNotificationsMap();
+                for (Integer pushId : notificationsMap.keySet()) {
+                    notificationManager.cancel(pushId);
+                }
+                notificationManager.cancel(GCMIntentService.GROUP_NOTIFICATION_ID);
             }
-            notificationManager.cancel(GCMIntentService.GROUP_NOTIFICATION_ID);
-
-            return null;
-        }
+        }).start();
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -364,6 +364,10 @@ public class NotificationsListFragment extends Fragment
 
     // Removes app notifications from the system bar
     private void cancelNotifications() {
+        if (GCMIntentService.getNotificationsMap().size() == 0) {
+            return;
+        }
+
         new Thread(new Runnable() {
             public void run() {
                 NotificationManager notificationManager = (NotificationManager) getActivity()

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -66,7 +66,7 @@ public class NotificationsListFragment extends Fragment
      * For responding to tapping of notes
      */
     public interface OnNoteClickListener {
-        public void onClickNote(String noteId);
+        void onClickNote(String noteId);
     }
 
     @Override


### PR DESCRIPTION
Uses a new method added to the support library to support stacking of notifications on wearable devices. Required a few tweaks to how notifications are set up in `GCMIntentService`. 

![stacked](https://cloud.githubusercontent.com/assets/789137/9363985/9ea46bac-465e-11e5-823e-92a9797bd707.png)

Reviewer: You'll obviously need a wear device to test this :) I have some test cases set up here: https://github.com/wordpress-mobile/WordPress-Android/issues/3038#issuecomment-132700233

See: https://developer.android.com/training/wearables/notifications/stacks.html

Fixes #3038 