### PR TITLE
issue/2991-freshly-pressed-v1.2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderPostService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderPostService.java
@@ -195,15 +195,7 @@ public class ReaderPostService extends Service {
             }
         };
 
-        // TODO: as of 09-July-2015 there is no v1.2 endpoint for Freshly Pressed, so we have to
-        // request FP posts using the v1.1 endpoint - this hack checks the stored endpoint to see
-        // if it's v1.1 and if so uses that REST client rather than v1.2
-        String endpoint = ReaderTagTable.getEndpointForTag(tag);
-        if (!TextUtils.isEmpty(endpoint) && endpoint.contains("rest/v1.1/")) {
-            WordPress.getRestClientUtilsV1_1().get(sb.toString(), null, null, listener, errorListener);
-        } else {
-            WordPress.getRestClientUtilsV1_2().get(sb.toString(), null, null, listener, errorListener);
-        }
+        WordPress.getRestClientUtilsV1_2().get(sb.toString(), null, null, listener, errorListener);
     }
 
     private static void requestPostsForBlog(final long blogId,


### PR DESCRIPTION
TL;DR: If this PR is bad, then Freshly Pressed will fail to update in the reader. If FP does update, it's good.

Fix #2991 - This simple PR removes [this hack](https://github.com/wordpress-mobile/WordPress-Android/commit/5858a3e1de4b4d220b9a2ab33e20e51293a51f86#diff-b223b02ca0f90eda2bda3d2a2398025bR202) which was added in a previous release to work around an issue in the `read/menu` endpoint.

That endpoint returns a list of the endpoints the app should call in order to update posts in the reader, and at the time it was returning v1.2 endpoints for everything except Freshly Pressed, which required calling a v1.1 endpoint.

This has since been corrected on the server side, so the hack is no longer required.