### PR TITLE
issue/3050-reader-taglist-concurrent

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTagList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTagList.java
@@ -4,11 +4,6 @@ import java.util.ArrayList;
 
 public class ReaderTagList extends ArrayList<ReaderTag> {
 
-    @Override
-    public Object clone() {
-        return super.clone();
-    }
-
     public int indexOfTagName(String tagName) {
         if (tagName == null || isEmpty()) {
             return -1;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
@@ -33,7 +33,7 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
     }
 
     private final WeakReference<Context> mWeakContext;
-    private ReaderTagList mTags = new ReaderTagList();
+    private final ReaderTagList mTags = new ReaderTagList();
     private TagDeletedListener mTagDeletedListener;
     private ReaderInterfaces.DataLoadedListener mDataLoadedListener;
 
@@ -148,8 +148,7 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
      * AsyncTask to load tags
      */
     private boolean mIsTaskRunning = false;
-    private class LoadTagsTask extends AsyncTask<Void, Void, Boolean> {
-        ReaderTagList tmpTags;
+    private class LoadTagsTask extends AsyncTask<Void, Void, ReaderTagList> {
         @Override
         protected void onPreExecute() {
             mIsTaskRunning = true;
@@ -159,14 +158,14 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
             mIsTaskRunning = false;
         }
         @Override
-        protected Boolean doInBackground(Void... params) {
-            tmpTags = ReaderTagTable.getFollowedTags();
-            return !mTags.isSameList(tmpTags);
+        protected ReaderTagList doInBackground(Void... params) {
+            return ReaderTagTable.getFollowedTags();
         }
         @Override
-        protected void onPostExecute(Boolean result) {
-            if (result) {
-                mTags = (ReaderTagList)(tmpTags.clone());
+        protected void onPostExecute(ReaderTagList tagList) {
+            if (tagList != null && !tagList.isSameList(mTags)) {
+                mTags.clear();
+                mTags.addAll(tagList);
                 notifyDataSetChanged();
             }
             mIsTaskRunning = false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagSpinnerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagSpinnerAdapter.java
@@ -20,7 +20,7 @@ import org.wordpress.android.util.AppLog.T;
  * populates spinner with reader tags
  */
 public class ReaderTagSpinnerAdapter extends BaseAdapter {
-    private ReaderTagList mTags = new ReaderTagList();
+    private final ReaderTagList mTags = new ReaderTagList();
     private final LayoutInflater mInflater;
     private final ReaderInterfaces.DataLoadedListener mDataListener;
 
@@ -120,8 +120,7 @@ public class ReaderTagSpinnerAdapter extends BaseAdapter {
     }
 
     private boolean mIsTaskRunning = false;
-    private class LoadTagsTask extends AsyncTask<Void, Void, Boolean> {
-        private final ReaderTagList tmpTags = new ReaderTagList();
+    private class LoadTagsTask extends AsyncTask<Void, Void, ReaderTagList> {
         @Override
         protected void onPreExecute() {
             mIsTaskRunning = true;
@@ -131,15 +130,16 @@ public class ReaderTagSpinnerAdapter extends BaseAdapter {
             mIsTaskRunning = false;
         }
         @Override
-        protected Boolean doInBackground(Void... voids) {
-            tmpTags.addAll(ReaderTagTable.getDefaultTags());
-            tmpTags.addAll(ReaderTagTable.getFollowedTags());
-            return !mTags.isSameList(tmpTags);
+        protected ReaderTagList doInBackground(Void... voids) {
+            ReaderTagList tagList = ReaderTagTable.getDefaultTags();
+            tagList.addAll(ReaderTagTable.getFollowedTags());
+            return tagList;
         }
         @Override
-        protected void onPostExecute(Boolean result) {
-            if (result) {
-                mTags = (ReaderTagList) tmpTags.clone();
+        protected void onPostExecute(ReaderTagList tagList) {
+            if (tagList != null && !tagList.isSameList(mTags)) {
+                mTags.clear();
+                mTags.addAll(tagList);
                 notifyDataSetChanged();
                 if (mDataListener != null) {
                     mDataListener.onDataLoaded(mTags.isEmpty());


### PR DESCRIPTION
Fix #3050 - I believe this was already fixed by #3029, which dropped the problematic `hasSameTag()` method. But just to be cautious I moved the `isSameList()` comparisons to the main thread in both tag adapters.