### PR TITLE
Fix Sticky Unread Notifications Indicator

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
@@ -448,5 +448,7 @@ public class GCMIntentService extends GCMBaseIntentService {
             notificationManager.cancel(pushId);
         }
         notificationManager.cancel(GCMIntentService.GROUP_NOTIFICATION_ID);
+
+        clearNotifications();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
@@ -422,11 +422,31 @@ public class GCMIntentService extends GCMBaseIntentService {
         }
     }
 
-    public static void clearNotificationsMap() {
+    public static void clearNotifications() {
         mActiveNotificationsMap.clear();
     }
 
-    public static ArrayMap<Integer, Bundle> getNotificationsMap() {
-        return mActiveNotificationsMap;
+    public static int getNotificationsCount() {
+        return mActiveNotificationsMap.size();
+    }
+
+    public static boolean hasNotifications() {
+        return !mActiveNotificationsMap.isEmpty();
+    }
+
+    public static void removeNotification(int notificationId) {
+        mActiveNotificationsMap.remove(notificationId);
+    }
+
+    // Removes all app notifications from the system bar
+    public static void removeAllNotifications(Context context) {
+        if (context == null || !hasNotifications()) return;
+
+        NotificationManager notificationManager = (NotificationManager) context
+                .getSystemService(GCMIntentService.NOTIFICATION_SERVICE);
+        for (Integer pushId : mActiveNotificationsMap.keySet()) {
+            notificationManager.cancel(pushId);
+        }
+        notificationManager.cancel(GCMIntentService.GROUP_NOTIFICATION_ID);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -220,13 +220,15 @@ public class WPMainActivity extends Activity
 
         mViewPager.setCurrentItem(WPMainTabAdapter.TAB_NOTIFS);
 
-        String noteId = getIntent().getStringExtra(NotificationsListFragment.NOTE_ID_EXTRA);
         boolean shouldShowKeyboard = getIntent().getBooleanExtra(NotificationsListFragment.NOTE_INSTANT_REPLY_EXTRA, false);
-
-        if (!TextUtils.isEmpty(noteId)) {
-            NotificationsListFragment.openNote(this, noteId, shouldShowKeyboard, false);
-            GCMIntentService.clearNotificationsMap();
+        if (GCMIntentService.getNotificationsMap().size() == 1) {
+            String noteId = getIntent().getStringExtra(NotificationsListFragment.NOTE_ID_EXTRA);
+            if (!TextUtils.isEmpty(noteId)) {
+                NotificationsListFragment.openNote(this, noteId, shouldShowKeyboard, false);
+            }
         }
+
+        GCMIntentService.clearNotificationsMap();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -221,14 +221,14 @@ public class WPMainActivity extends Activity
         mViewPager.setCurrentItem(WPMainTabAdapter.TAB_NOTIFS);
 
         boolean shouldShowKeyboard = getIntent().getBooleanExtra(NotificationsListFragment.NOTE_INSTANT_REPLY_EXTRA, false);
-        if (GCMIntentService.getNotificationsMap().size() == 1) {
+        if (GCMIntentService.getNotificationsCount() == 1) {
             String noteId = getIntent().getStringExtra(NotificationsListFragment.NOTE_ID_EXTRA);
             if (!TextUtils.isEmpty(noteId)) {
                 NotificationsListFragment.openNote(this, noteId, shouldShowKeyboard, false);
             }
         }
 
-        GCMIntentService.clearNotificationsMap();
+        GCMIntentService.clearNotifications();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -426,19 +426,19 @@ public class WPMainActivity extends Activity
     }
 
     // Updates `last_seen` notifications flag in Simperium and removes tab indicator
-    private class UpdateLastSeenTask extends AsyncTask<Void, Void, Void> {
+    private class UpdateLastSeenTask extends AsyncTask<Void, Void, Boolean> {
         @Override
-        protected Void doInBackground(Void... voids) {
-            SimperiumUtils.updateLastSeenTime();
-
-            return null;
+        protected Boolean doInBackground(Void... voids) {
+            return SimperiumUtils.updateLastSeenTime();
         }
 
         @Override
-        protected void onPostExecute(Void nada) {
+        protected void onPostExecute(Boolean lastSeenTimeUpdated) {
             if (isFinishing()) return;
 
-            mTabLayout.showNoteBadge(false);
+            if (lastSeenTimeUpdated) {
+                mTabLayout.showNoteBadge(false);
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -409,13 +409,6 @@ public class WPMainActivity extends Activity
     }
 
     /*
-     * returns the notification list fragment from the notification tab
-     */
-    private NotificationsListFragment getNotificationListFragment() {
-        return getFragmentByPosition(WPMainTabAdapter.TAB_NOTIFS, NotificationsListFragment.class);
-    }
-
-    /*
      * returns the my site fragment from the sites tab
      */
     public MySiteFragment getMySiteFragment() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationDismissBroadcastReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationDismissBroadcastReceiver.java
@@ -15,12 +15,12 @@ public class NotificationDismissBroadcastReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         int notificationId = intent.getIntExtra("notificationId", 0);
         if (notificationId == GCMIntentService.GROUP_NOTIFICATION_ID) {
-            GCMIntentService.clearNotificationsMap();
+            GCMIntentService.clearNotifications();
         } else {
-            GCMIntentService.getNotificationsMap().remove(notificationId);
+            GCMIntentService.removeNotification(notificationId);
 
             // Dismiss the grouped notification if a user dismisses all notifications from a wear device
-            if (GCMIntentService.getNotificationsMap().isEmpty()) {
+            if (!GCMIntentService.hasNotifications()) {
                 NotificationManager notificationManager = (NotificationManager) context
                         .getSystemService(GCMIntentService.NOTIFICATION_SERVICE);
                 notificationManager.cancel(GCMIntentService.GROUP_NOTIFICATION_ID);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -19,7 +19,6 @@ import org.wordpress.android.models.Note;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.comments.CommentActions;
-import org.wordpress.android.ui.comments.CommentDetailActivity;
 import org.wordpress.android.ui.comments.CommentDetailFragment;
 import org.wordpress.android.ui.notifications.blocks.NoteBlockRangeType;
 import org.wordpress.android.ui.notifications.utils.SimperiumUtils;
@@ -101,7 +100,7 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
             getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN);
         }
 
-        GCMIntentService.clearNotificationsMap();
+        GCMIntentService.clearNotifications();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -216,22 +216,6 @@ public class NotificationsListFragment extends Fragment
         }
     }
 
-    public void updateLastSeenTime() {
-        // set the timestamp to now
-        try {
-            if (mNotesAdapter != null && mNotesAdapter.getCount() > 0 && SimperiumUtils.getMetaBucket() != null) {
-                Note newestNote = mNotesAdapter.getNote(0);
-                BucketObject meta = SimperiumUtils.getMetaBucket().get("meta");
-                if (meta != null && newestNote != null) {
-                    meta.setProperty("last_seen", newestNote.getTimestamp());
-                    meta.save();
-                }
-            }
-        } catch (BucketObjectMissingException e) {
-            // try again later, meta is created by wordpress.com
-        }
-    }
-
     private void showEmptyView(@StringRes int stringResId, boolean showSignIn) {
         if (isAdded() && mEmptyView != null) {
             ((TextView) mEmptyView.findViewById(R.id.text_empty)).setText(stringResId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -348,19 +348,9 @@ public class NotificationsListFragment extends Fragment
 
     // Removes app notifications from the system bar
     private void cancelNotifications() {
-        if (GCMIntentService.getNotificationsMap().isEmpty()) {
-            return;
-        }
-
         new Thread(new Runnable() {
             public void run() {
-                NotificationManager notificationManager = (NotificationManager) getActivity()
-                        .getSystemService(GCMIntentService.NOTIFICATION_SERVICE);
-                ArrayMap<Integer, Bundle> notificationsMap = GCMIntentService.getNotificationsMap();
-                for (Integer pushId : notificationsMap.keySet()) {
-                    notificationManager.cancel(pushId);
-                }
-                notificationManager.cancel(GCMIntentService.GROUP_NOTIFICATION_ID);
+                GCMIntentService.removeAllNotifications(getActivity());
             }
         }).start();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/SimperiumUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/SimperiumUtils.java
@@ -30,7 +30,7 @@ public class SimperiumUtils {
     private static Simperium mSimperium;
     private static Bucket<Note> mNotesBucket;
     private static Bucket<BucketObject> mMetaBucket;
-    
+
     public static Bucket<Note> getNotesBucket() {
         return mNotesBucket;
     }
@@ -168,7 +168,7 @@ public class SimperiumUtils {
                     meta.save();
                 }
             } catch (BucketObjectMissingException e) {
-                e.printStackTrace();
+                AppLog.e(AppLog.T.NOTIFS, "Meta bucket not found.");
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/SimperiumUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/SimperiumUtils.java
@@ -23,10 +23,14 @@ import org.wordpress.android.util.StringUtils;
 import de.greenrobot.event.EventBus;
 
 public class SimperiumUtils {
+    private static final String NOTE_TIMESTAMP = "timestamp";
+    private static final String META_BUCKET_NAME = "meta";
+    private static final String META_LAST_SEEN = "last_seen";
+
     private static Simperium mSimperium;
     private static Bucket<Note> mNotesBucket;
     private static Bucket<BucketObject> mMetaBucket;
-
+    
     public static Bucket<Note> getNotesBucket() {
         return mNotesBucket;
     }
@@ -44,7 +48,7 @@ public class SimperiumUtils {
 
             try {
                 mNotesBucket = mSimperium.bucket(new Note.Schema());
-                mMetaBucket = mSimperium.bucket("meta");
+                mMetaBucket = mSimperium.bucket(META_BUCKET_NAME);
 
                 mSimperium.setUserStatusChangeListener(new User.StatusChangeListener() {
 
@@ -130,9 +134,9 @@ public class SimperiumUtils {
         if (getNotesBucket() == null || getMetaBucket() == null) return false;
 
         try {
-            BucketObject meta = getMetaBucket().get("meta");
-            if (meta != null && meta.getProperty("last_seen") instanceof Integer) {
-                Integer lastSeenTimestamp = (Integer)meta.getProperty("last_seen");
+            BucketObject meta = getMetaBucket().get(META_BUCKET_NAME);
+            if (meta != null && meta.getProperty(META_LAST_SEEN) instanceof Integer) {
+                Integer lastSeenTimestamp = (Integer)meta.getProperty(META_LAST_SEEN);
 
                 Query<Note> query = new Query<>(getNotesBucket());
                 query.where(Note.Schema.UNREAD_INDEX, Query.ComparisonType.EQUAL_TO, true);
@@ -144,5 +148,28 @@ public class SimperiumUtils {
         }
 
         return false;
+    }
+
+    // Updates the 'last_seen' field in the meta bucket with the latest note's timestamp
+    public static void updateLastSeenTime() {
+        if (getNotesBucket() == null || getMetaBucket() == null) return;
+
+        Query<Note> query = new Query<>(getNotesBucket());
+        query.order(NOTE_TIMESTAMP, Query.SortType.DESCENDING);
+        query.limit(1);
+
+        Bucket.ObjectCursor<Note> cursor = query.execute();
+        if (cursor.moveToFirst()) {
+            long latestNoteTimestamp = cursor.getObject().getTimestamp();
+            try {
+                BucketObject meta = getMetaBucket().get(META_BUCKET_NAME);
+                if (meta != null) {
+                    meta.setProperty(META_LAST_SEEN, latestNoteTimestamp);
+                    meta.save();
+                }
+            } catch (BucketObjectMissingException e) {
+                e.printStackTrace();
+            }
+        }
     }
 }


### PR DESCRIPTION
The main cause of #3090 was that the notifications list fragment wasn't created yet, so the `updateSeenTime()` method would not be executed. I recreated it as a static method in `SimperiumUtils`. 

I also fixed a bug where opening multiple notifications would take you to an individual note's detail view, where it instead should just show the list.

And one more thing! If you are viewing the notifications list, and receive a push notification, the unread indicator will now not show. This seemed like a better UX to me.