### PR TITLE
Fixing build for gradle 1.3.1

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -53,7 +53,7 @@ android {
         release {
             // Proguard is only used to fix an issue with some Samsung device
             // https://github.com/wordpress-mobile/WordPress-Android/issues/2151
-            minifyEnabled true
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg'
         }
 

--- a/libs/utils/WordPressUtils/src/main/AndroidManifest.xml
+++ b/libs/utils/WordPressUtils/src/main/AndroidManifest.xml
@@ -2,4 +2,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="org.wordpress.android.util">
 
+  <uses-permission android:name="android.permission.GET_ACCOUNTS" />
 </manifest>

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
@@ -28,8 +28,7 @@ public class SwipeToRefreshHelper implements OnRefreshListener {
         mSwipeRefreshLayout.setOnRefreshListener(this);
         final TypedArray styleAttrs = obtainStyledAttrsFromThemeAttr(activity, R.attr.swipeToRefreshStyle,
                 R.styleable.RefreshIndicator);
-        int color = styleAttrs.getColor(R.styleable.RefreshIndicator_refreshIndicatorColor,
-                android.R.color.holo_blue_dark);
+        int color = styleAttrs.getColor(R.styleable.RefreshIndicator_refreshIndicatorColor, activity.getResources().getColor(android.R.color.holo_blue_dark));
         mSwipeRefreshLayout.setColorSchemeColors(color, color, color, color);
     }
 


### PR DESCRIPTION
@maxme turns out the lint error wasn't what was stopping the build - it was proguard

```
:WordPress:proguardVanillaRelease
Note: there were 7 duplicate class definitions.
      (http://proguard.sourceforge.net/manual/troubleshooting.html#duplicateclass)
Warning: com.mixpanel.android.mpmetrics.GCMReceiver: can't find referenced method 'void setLatestEventInfo(android.content.Context,java.lang.CharSequence,java.lang.CharSequence,android.app.PendingIntent)' in library class android.app.Notification
Warning: uk.co.senab.photoview.PhotoViewAttacher: can't find referenced method 'float sqrt(float)' in library class android.util.FloatMath
Warning: uk.co.senab.photoview.gestures.CupcakeGestureDetector: can't find referenced method 'float sqrt(float)' in library class android.util.FloatMath
Warning: there were 3 unresolved references to library class members.
         You probably need to update the library versions.
         (http://proguard.sourceforge.net/manual/troubleshooting.html#unresolvedlibraryclassmember)
Exception while processing task 
java.io.IOException: Please correct the above warnings first.
	at proguard.Initializer.execute(Initializer.java:473)
	at proguard.ProGuard.initialize(ProGuard.java:233)
	at proguard.ProGuard.execute(ProGuard.java:98)
	at proguard.gradle.ProGuardTask.proguard(ProGuardTask.java:1074)
	at com.android.build.gradle.tasks.AndroidProGuardTask.doMinification(AndroidProGuardTask.java:139)
	at com.android.build.gradle.tasks.AndroidProGuardTask$1.run(AndroidProGuardTask.java:115)
	at com.android.builder.tasks.Job.runTask(Job.java:48)
	at com.android.build.gradle.tasks.SimpleWorkQueue$EmptyThreadContext.runTask(SimpleWorkQueue.java:41)
	at com.android.builder.tasks.WorkQueue.run(WorkQueue.java:227)
	at java.lang.Thread.run(Thread.java:745)
```

this just disables proguard (which to my knowledge is safe, just results in a slightly larger apk)

To verify it isn't a lint error issue, you can add

```
lintOptions {
    abortOnError false
}
```

into the project and the build will still fail regardless of whether or not there is a lint error.

As for the `WordPress-Utils` fixes, I am not sure whether to include them here or change them in the [wordpress-mobile/WordPress-Utils-Android](https://github.com/wordpress-mobile/WordPress-Utils-Android) repo.