### PR TITLE
Issue/3099 crash delete only post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -460,6 +460,12 @@ public class PostsListFragment extends Fragment
         mEmptyView.setVisibility(isPostAdapterEmpty() ? View.VISIBLE : View.GONE);
     }
 
+    private void hideEmptyView() {
+        if (isAdded() && mEmptyView != null) {
+            mEmptyView.setVisibility(View.GONE);
+        }
+    }
+
     @Override
     public void onStart() {
         super.onStart();
@@ -488,7 +494,7 @@ public class PostsListFragment extends Fragment
                 updateEmptyView(EmptyViewMessageType.NETWORK_ERROR);
             }
         } else if (postCount > 0) {
-            mEmptyView.setVisibility(View.GONE);
+            hideEmptyView();
         }
     }
 
@@ -568,12 +574,18 @@ public class PostsListFragment extends Fragment
         getPostListAdapter().hidePost(post);
         mTrashedPosts.add(post);
 
+        // make sure empty view shows if user deleted the only post
+        if (getPostListAdapter().getItemCount() == 0) {
+            updateEmptyView(EmptyViewMessageType.NO_CONTENT);
+        }
+
         View.OnClickListener undoListener = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 // user undid the trash, so unhide the post and remove it from the list of trashed posts
                 mTrashedPosts.remove(post);
                 getPostListAdapter().unhidePost(post);
+                hideEmptyView();
             }
         };
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -496,7 +496,14 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         int position = mPosts.indexOfPost(post);
         if (position > -1) {
             mPosts.remove(position);
-            notifyItemRemoved(position);
+            if (mPosts.size() > 0) {
+                notifyItemRemoved(position);
+            } else {
+                // we must call notifyDataSetChanged when the only post has been deleted - if we
+                // call notifyItemRemoved the recycler will throw an IndexOutOfBoundsException
+                // because removing the last post also removes the end list indicator
+                notifyDataSetChanged();
+            }
         }
     }
 


### PR DESCRIPTION
Fix #3099 - resolves a crash that occurs when trashing the only post in the post list. Also ensures that the empty view appears when the last post is trashed, then disappears if the user undoes the trash.