### PR TITLE
Issue/3092 reader tap targets too small

### DIFF
--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -175,7 +175,6 @@
                 android:layout_height="wrap_content"
                 android:layout_alignWithParentIfMissing="true"
                 android:layout_centerVertical="true"
-                android:layout_marginRight="@dimen/margin_medium"
                 android:layout_toLeftOf="@+id/count_likes"
                 android:padding="@dimen/margin_medium"
                 wp:readerIcon="comment" />

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -151,7 +151,7 @@
             android:id="@+id/layout_footer"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_large"
+            android:layout_marginBottom="@dimen/margin_small"
             android:layout_marginLeft="@dimen/reader_card_content_padding"
             android:layout_marginRight="@dimen/reader_card_content_padding"
             android:layout_marginTop="@dimen/margin_medium">
@@ -177,6 +177,7 @@
                 android:layout_centerVertical="true"
                 android:layout_marginRight="@dimen/margin_medium"
                 android:layout_toLeftOf="@+id/count_likes"
+                android:padding="@dimen/margin_medium"
                 wp:readerIcon="comment" />
 
             <org.wordpress.android.ui.reader.views.ReaderIconCountView
@@ -185,7 +186,7 @@
                 android:layout_height="wrap_content"
                 android:layout_alignParentRight="true"
                 android:layout_centerVertical="true"
-                android:layout_marginLeft="@dimen/margin_small"
+                android:padding="@dimen/margin_medium"
                 wp:readerIcon="like" />
 
         </RelativeLayout>

--- a/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
@@ -24,10 +24,9 @@
         style="@style/ReaderTextView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/divider_footer"
         android:layout_centerVertical="true"
         android:layout_marginLeft="@dimen/reader_detail_margin"
-        android:layout_toLeftOf="@+id/layout_icons"
+        android:layout_marginTop="@dimen/margin_medium"
         android:background="?android:selectableItemBackground"
         android:ellipsize="end"
         android:gravity="center_vertical"
@@ -41,9 +40,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
-        android:layout_below="@+id/divider_footer"
         android:layout_centerVertical="true"
         android:layout_marginRight="@dimen/reader_detail_margin"
+        android:layout_marginTop="@dimen/margin_medium"
         android:orientation="horizontal">
 
         <org.wordpress.android.ui.reader.views.ReaderIconCountView
@@ -51,6 +50,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
+            android:padding="@dimen/margin_medium"
             wp:readerIcon="comment" />
 
         <org.wordpress.android.ui.reader.views.ReaderIconCountView
@@ -58,7 +58,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
-            android:layout_marginLeft="@dimen/margin_large"
+            android:padding="@dimen/margin_medium"
             wp:readerIcon="like" />
 
     </LinearLayout>


### PR DESCRIPTION
Fix #3092 - increased the tap target area for like & comment icons on both the reader list & detail views.