### PR TITLE
issue/3100-fab-animation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.posts;
 import android.app.Fragment;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
@@ -100,6 +101,14 @@ public class PostsListFragment extends Fragment
         int spacingVertical = mIsPage ? 0 : context.getResources().getDimensionPixelSize(R.dimen.reader_card_gutters);
         int spacingHorizontal = context.getResources().getDimensionPixelSize(R.dimen.content_margin);
         mRecyclerView.addItemDecoration(new RecyclerItemDecoration(spacingHorizontal, spacingVertical));
+
+        // hide the fab so we can animate it in - note that we only do this on Lollipop and higher
+        // due to a bug in the current implementation which prevents it from being hidden
+        // correctly on pre-L devices (which makes animating it in/out ugly)
+        // https://code.google.com/p/android/issues/detail?id=175331
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            mFabView.setVisibility(View.GONE);
+        }
 
         mFabView.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/WordPress/src/main/res/layout/post_list_fragment.xml
+++ b/WordPress/src/main/res/layout/post_list_fragment.xml
@@ -65,11 +65,9 @@
             android:layout_marginBottom="@dimen/fab_margin"
             android:layout_marginRight="@dimen/fab_margin"
             android:src="@drawable/gridicon_create_light"
-            android:visibility="gone"
             app:borderWidth="0dp"
             app:elevation="@dimen/fab_elevation"
-            app:rippleColor="@color/fab_pressed"
-            tools:visibility="visible" />
+            app:rippleColor="@color/fab_pressed" />
 
     </android.support.design.widget.CoordinatorLayout>
 


### PR DESCRIPTION
Fixes #3100 - the problem turned out not to be in our code but instead due to [this bug](https://code.google.com/p/android/issues/detail?id=175331) in FloatingActionButton which causes it to briefly appear even when made invisible. This bug doesn't occur on devices running Lollipop, but I reproduced it on 4.1 and 4.4.4.

Note that this has not been fixed in the latest version of the design support library (23), and the suggested solution in that Google issue (use the built-in `show()` and `hide()` methods) doesn't work.

So, on pre-L devices we simply don't hide the FAB or animate it in.
