### PR TITLE
issue/3039-fab-position

### DIFF
--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -385,16 +385,22 @@
 
     </LinearLayout>
 
-    <android.support.design.widget.FloatingActionButton
-        android:id="@+id/fab_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="end|bottom"
-        android:layout_marginBottom="@dimen/fab_margin"
-        android:layout_marginRight="@dimen/fab_margin"
-        android:src="@drawable/gridicon_create_light"
-        app:borderWidth="0dp"
-        app:elevation="@dimen/fab_elevation"
-        app:rippleColor="@color/fab_pressed" />
+    <!-- this coordinator is only here due to https://code.google.com/p/android/issues/detail?id=175330 -->
+    <android.support.design.widget.CoordinatorLayout
+        android:id="@+id/coordinator"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <android.support.design.widget.FloatingActionButton
+            android:id="@+id/fab_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end|bottom"
+            android:layout_marginBottom="@dimen/fab_margin"
+            android:layout_marginRight="@dimen/fab_margin"
+            android:src="@drawable/gridicon_create_light"
+            app:borderWidth="0dp"
+            app:rippleColor="@color/fab_pressed" />
+    </android.support.design.widget.CoordinatorLayout>
 
 </FrameLayout>

--- a/WordPress/src/main/res/layout/post_list_fragment.xml
+++ b/WordPress/src/main/res/layout/post_list_fragment.xml
@@ -66,7 +66,6 @@
             android:layout_marginRight="@dimen/fab_margin"
             android:src="@drawable/gridicon_create_light"
             app:borderWidth="0dp"
-            app:elevation="@dimen/fab_elevation"
             app:rippleColor="@color/fab_pressed" />
 
     </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
Fixes #3039 - This one is annoying and takes a little explaining, so bear with me...

The issue is that on pre-L devices, the right margin is too large on the "My Site" FAB. This is because on pre-L the shadow (elevation) is drawn within the view's bounds, which modifies its visual padding. This isn't an issue on Lollipop since it natively supports elevation.

Yet strangely, the right margin looks just fine on the post list FAB. This is because it's inside a `CoordinatorLayout`, and `CoordinatorLayout` automatically offsets the FAB to account for the shadow on pre-L devices. Yes, this is insane - for details see https://code.google.com/p/android/issues/detail?id=175330

This leaves us with four choices:

1. Leave it the way it is
2. Remove the elevation on pre-L devices
3. Write a bunch of code to deal specifically with the "My Site" FAB
4. Add a CoordinatorLayout to "My Site"

I chose #4 and wrapped the My Site FAB in a `CoordinatorLayout` so it would take care of fixing the margins. I also chose to remove the elevation (`fab_elevation`) from the layouts in favor of letting FloatingActionButton set the elevation itself.