### PR TITLE
Revert "Added workaround for onTabReselected bug"

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -64,7 +64,6 @@ public class WPMainActivity extends Activity
     private WPMainTabLayout mTabLayout;
     private WPMainTabAdapter mTabAdapter;
     private TextView mConnectionBar;
-    private int mLastReselectedTabPosition = -1;
 
     public static final String ARG_OPENED_FROM_PUSH = "opened_from_push";
 
@@ -119,20 +118,10 @@ public class WPMainActivity extends Activity
 
             @Override
             public void onTabReselected(TabLayout.Tab tab) {
-                // we want to scroll the active fragment's contents to the top when the user taps
-                // the currently selected tab, but a problem in the v22 support library causes
-                // onTabReselected() to be fired for every tab change rather than just when the
-                // active tab is tapped again - the workaround below, where we check whether the
-                // tab has already been reselected, prevents the problem - note the bug is fixed
-                // in the v23 support lib - https://code.google.com/p/android/issues/detail?id=177189
-                // TODO: remove this workaround once we upgrade to v23 of the support lib
-                if (tab.getPosition() == mLastReselectedTabPosition) {
-                    Fragment fragment = mTabAdapter.getFragment(tab.getPosition());
-                    if (fragment instanceof OnScrollToTopListener) {
-                        ((OnScrollToTopListener) fragment).onScrollToTop();
-                    }
-                } else {
-                    mLastReselectedTabPosition = tab.getPosition();
+                // scroll the active fragment to the top, if available
+                Fragment fragment = mTabAdapter.getFragment(tab.getPosition());
+                if (fragment instanceof OnScrollToTopListener) {
+                    ((OnScrollToTopListener) fragment).onScrollToTop();
                 }
             }
         });


### PR DESCRIPTION
Issue was due to a bug in support libs v22. We upgraded the support libs to v23 that fixes the problem - so I reverted the workaround used in 4.4.

This reverts commit 7178430d4ccc2d9abdd6615ae18585b3a67bfe3b.