### PR TITLE
Fix a transparent background color on Post Preview snack bar

### DIFF
--- a/WordPress/src/main/res/layout/post_preview_activity.xml
+++ b/WordPress/src/main/res/layout/post_preview_activity.xml
@@ -22,6 +22,7 @@
         android:paddingLeft="@dimen/content_margin"
         android:paddingRight="@dimen/content_margin"
         android:visibility="gone"
+        android:background="@color/snackbar_background_color"
         tools:visibility="visible">
 
         <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -133,6 +133,8 @@
     <color name="placeholder_content_text">@color/blue_wordpress</color>
     <color name="format_bar_background">@color/grey_lighten_30</color>
     <color name="image_options_label">@color/grey_lighten_20</color>
+    <!-- copied from private support lib resource: color/design_snackbar_background_color -->
+    <color name="snackbar_background_color">#323232</color>
 
     <!-- Misc -->
     <color name="pressed_wordpress">@color/semi_transparent_blue_light</color>


### PR DESCRIPTION
fix an issue introduced in 1fdd56bc4ece9a27a0fb9030a734d75e1f0086cb while upgrading design support lib version.

Before:
![screen shot 2015-08-31 at 16 00 07](https://cloud.githubusercontent.com/assets/40213/9580703/465e4db8-4ffb-11e5-97fe-f3604012d178.png)


After:
![screen shot 2015-08-31 at 16 11 20](https://cloud.githubusercontent.com/assets/40213/9580707/4b05f12c-4ffb-11e5-89a2-29ab30efee08.png)
