### PR TITLE
Use default AppCompat theme on EditLink and AddCategory dialog

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -123,11 +123,11 @@
         <activity
             android:name=".ui.posts.AddCategoryActivity"
             android:label="@string/add_new_category"
-            android:theme="@style/WordPress.Dialog" />
+            android:theme="@style/Theme.AppCompat.Light.Dialog" />
         <activity
             android:name=".editor.legacy.EditLinkActivity"
             android:label="@string/create_a_link"
-            android:theme="@style/WordPress.Dialog"
+            android:theme="@style/Theme.AppCompat.Light.Dialog"
             android:windowSoftInputMode="stateVisible" />
         <activity
             android:name=".ui.posts.EditPostActivity"

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/AddCategoryActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/AddCategoryActivity.java
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.posts;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
@@ -30,7 +29,6 @@ public class AddCategoryActivity extends AppCompatActivity {
         if (extras != null) {
             id = extras.getInt("id");
         }
-
         loadCategories();
 
         final Button cancelButton = (Button) findViewById(R.id.cancel);

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -220,13 +220,6 @@
         <item name="android:background">@color/white</item>
     </style>
 
-    <!-- Dialog -->
-    <style name="WordPress.Dialog" parent="Theme.AppCompat.Light.Dialog">
-        <!-- work around a bug that causes weird styling of the dialog title on Android 5 -->
-        <item name="android:windowNoTitle">false</item>
-        <item name="windowActionBar">false</item>
-    </style>
-
     <style name="WordPress.SwipeToRefresh">
         <item name="refreshIndicatorColor">@color/blue_medium</item>
     </style>

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/legacy/EditLinkActivity.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/legacy/EditLinkActivity.java
@@ -3,13 +3,14 @@ package org.wordpress.android.editor.legacy;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 
 import org.wordpress.android.editor.R;
 
-public class EditLinkActivity extends Activity {
+public class EditLinkActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);


### PR DESCRIPTION
Before: 2 titles were displayed
![screen shot 2015-09-01 at 15 38 11](https://cloud.githubusercontent.com/assets/40213/9605974/13e8907a-50c1-11e5-9578-85d87cc3f4d5.png)

