### PR TITLE
Issue/2879 skipping image loop

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
@@ -50,6 +50,7 @@ public class WPNetworkImageView extends ImageView {
 
     private int mDefaultImageResId;
     private int mErrorImageResId;
+    private boolean mRequestDidFail;
 
     private static final HashSet<String> mUrlSkipList = new HashSet<>();
 
@@ -66,6 +67,7 @@ public class WPNetworkImageView extends ImageView {
     public void setImageUrl(String url, ImageType imageType) {
         mUrl = url;
         mImageType = imageType;
+        mRequestDidFail = false;
 
         // The URL has potentially changed. See if we need to load it.
         loadImageIfNecessary(false);
@@ -76,6 +78,7 @@ public class WPNetworkImageView extends ImageView {
      */
     public void setVideoUrl(final long postId, final String videoUrl) {
         mImageType = ImageType.VIDEO;
+        mRequestDidFail = false;
 
         if (TextUtils.isEmpty(videoUrl)) {
             showDefaultImage();
@@ -110,8 +113,8 @@ public class WPNetworkImageView extends ImageView {
      * @param isInLayoutPass True if this was invoked from a layout pass, false otherwise.
      */
     private void loadImageIfNecessary(final boolean isInLayoutPass) {
-        // do nothing if image type hasn't been set yet
-        if (mImageType == ImageType.NONE) {
+        // do nothing if image type hasn't been set yet or the previous request failed
+        if (mImageType == ImageType.NONE || mRequestDidFail) {
             return;
         }
 
@@ -167,6 +170,7 @@ public class WPNetworkImageView extends ImageView {
                 new ImageLoader.ImageListener() {
                     @Override
                     public void onErrorResponse(VolleyError error) {
+                        mRequestDidFail = true;
                         showErrorImage();
                         // keep track of URLs that 404 so we can skip them the next time
                         int statusCode = VolleyUtils.statusCodeFromVolleyError(error);

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
@@ -156,6 +156,7 @@ public class WPNetworkImageView extends ImageView {
         // skip this URL if a previous request for it returned a 404
         if (mUrlSkipList.contains(mUrl)) {
             AppLog.d(AppLog.T.READER, "skipping image request " + mUrl);
+            mRequestDidFail = true;
             showErrorImage();
             return;
         }


### PR DESCRIPTION
Fixes #2879 - the problem was caused by [onLayout](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java#L231) attempting to show the image with each layout pass, but when the image URL is in the 404 skip list we [show the error image](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java#L156) - which eventually triggers `onLayout` again.

Problem resolved by using a boolean (`mRequestDidFail`) to detect when the previous request failed and  immediately exiting `loadImageIfNecessary` when that boolean is true.