### PR TITLE
issue/3114-posts-gallery-shortcodes

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/posts/PostUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/posts/PostUtilsTest.java
@@ -1,0 +1,23 @@
+package org.wordpress.android.ui.posts;
+
+import android.test.AndroidTestCase;
+
+public class PostUtilsTest extends AndroidTestCase {
+
+    public void testCollapseShortcodes() {
+        String postContent = "Text before first gallery [gallery number=\"one\"]"
+                + " text between galleries"
+                + " [gallery number=\"two\"]"
+                + " text after second gallery"
+                + " [unknown shortcode].";
+        String collapsedContent = PostUtils.collapseShortcodes(postContent);
+
+        // make sure [gallery] now exists and [gallery number] does not
+        assertTrue(collapsedContent.contains("[gallery]"));
+        assertFalse(collapsedContent.contains("[gallery number]"));
+
+        // make sure the unknown shortcode is intact
+        assertTrue(collapsedContent.contains("[unknown shortcode]"));
+    }
+
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/posts/PostUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/posts/PostUtilsTest.java
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.posts;
 import android.test.AndroidTestCase;
 
 public class PostUtilsTest extends AndroidTestCase {
-
     public void testCollapseShortcodes() {
         String postContent = "Text before first gallery [gallery number=\"one\"]"
                 + " text between galleries"
@@ -20,4 +19,15 @@ public class PostUtilsTest extends AndroidTestCase {
         assertTrue(collapsedContent.contains("[unknown shortcode]"));
     }
 
+    public void testShortcodeSpaces() {
+        String postContent = "[   gallery number=\"arst\"     /]";
+        String collapsedContent = PostUtils.collapseShortcodes(postContent);
+        assertEquals("[gallery]", collapsedContent);
+    }
+
+    public void testOpeningClosingShortcode() {
+        String postContent = "[recipe difficulty=\"easy\"]Put your recipe here.[/recipe]";
+        String collapsedContent = PostUtils.collapseShortcodes(postContent);
+        assertEquals("[recipe]Put your recipe here.[/recipe]", collapsedContent);
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewFragment.java
@@ -111,7 +111,7 @@ public class PostPreviewFragment extends Fragment {
                 ? "(" + getResources().getText(R.string.untitled) + ")"
                 : StringUtils.unescapeHTML(post.getTitle()));
 
-        String postContent = PostUtils.collapseShortcode(PostUtils.SHORTCODE_GALLERY, post.getDescription());
+        String postContent = PostUtils.collapseShortcodes(post.getDescription());
         if (!TextUtils.isEmpty(post.getMoreText())) {
             postContent += "\n\n" + post.getMoreText();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewFragment.java
@@ -111,7 +111,7 @@ public class PostPreviewFragment extends Fragment {
                 ? "(" + getResources().getText(R.string.untitled) + ")"
                 : StringUtils.unescapeHTML(post.getTitle()));
 
-        String postContent = post.getDescription();
+        String postContent = PostUtils.collapseShortcode(PostUtils.SHORTCODE_GALLERY, post.getDescription());
         if (!TextUtils.isEmpty(post.getMoreText())) {
             postContent += "\n\n" + post.getMoreText();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -22,7 +22,7 @@ public class PostUtils {
         }
 
         String shortCode;
-        Pattern p = Pattern.compile("(\\[ *?([^ ]+) .*?\\])");
+        Pattern p = Pattern.compile("(\\[ *([^ ]+) [^\\[\\]]*\\])");
         Matcher m = p.matcher(postContent);
         StringBuffer sb = new StringBuffer();
         while (m.find()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -43,21 +43,25 @@ public class PostUtils {
 
         // populate on first use
         if (mShortcodeTable.size() == 0) {
-            // video
+            // default shortcodes
+            mShortcodeTable.add("audio");
+            mShortcodeTable.add("caption");
+            mShortcodeTable.add("embed");
+            mShortcodeTable.add("gallery");
+            mShortcodeTable.add("playlist");
+            mShortcodeTable.add("video");
+            mShortcodeTable.add("wp_caption");
+            // audio/video
             mShortcodeTable.add("dailymotion");
             mShortcodeTable.add("flickr");
             mShortcodeTable.add("hulu");
             mShortcodeTable.add("kickstarter");
+            mShortcodeTable.add("soundcloud");
             mShortcodeTable.add("vimeo");
             mShortcodeTable.add("vine");
             mShortcodeTable.add("wpvideo");
             mShortcodeTable.add("youtube");
-            // audio
-            mShortcodeTable.add("audio");
-            mShortcodeTable.add("playlist");
-            mShortcodeTable.add("soundcloud");
             // images and documents
-            mShortcodeTable.add("gallery");
             mShortcodeTable.add("instagram");
             mShortcodeTable.add("scribd");
             mShortcodeTable.add("slideshare");

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -1,0 +1,23 @@
+package org.wordpress.android.ui.posts;
+
+public class PostUtils {
+
+    public static final String SHORTCODE_GALLERY = "gallery";
+
+    /*
+     * collapses the passed shortcode in the passed post content, stripping anything between the
+     * shortcode name and the closing brace.
+     * ex: collapseShortcode("gallery", "[gallery ids="1206,1205,1191"]") -> "[gallery]"
+     */
+    public static String collapseShortcode(String shortCode, String postContent) {
+        // speed things up by skipping regex if content doesn't contain a brace
+        if (postContent == null || !postContent.contains("[")) {
+            return postContent;
+        }
+
+        String regex = "\\[" + shortCode + "(.+?)\\]";
+        String replacement = "\\[" + shortCode + "\\]";
+        return postContent.replaceAll(regex, replacement);
+    }
+
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -1,23 +1,79 @@
 package org.wordpress.android.ui.posts;
 
+import org.wordpress.android.util.AppLog;
+
+import java.util.HashSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class PostUtils {
 
-    public static final String SHORTCODE_GALLERY = "gallery";
+    private static final HashSet<String> mShortcodeTable = new HashSet<>();
 
     /*
-     * collapses the passed shortcode in the passed post content, stripping anything between the
-     * shortcode name and the closing brace.
-     * ex: collapseShortcode("gallery", "[gallery ids="1206,1205,1191"]") -> "[gallery]"
+     * collapses shortcodes in the passed post content, stripping anything between the
+     * shortcode name and the closing brace
+     * ex: collapseShortcodes("[gallery ids="1206,1205,1191"]") -> "[gallery]"
      */
-    public static String collapseShortcode(String shortCode, String postContent) {
+    public static String collapseShortcodes(final String postContent) {
         // speed things up by skipping regex if content doesn't contain a brace
         if (postContent == null || !postContent.contains("[")) {
             return postContent;
         }
 
-        String regex = "\\[" + shortCode + "(.+?)\\]";
-        String replacement = "\\[" + shortCode + "\\]";
-        return postContent.replaceAll(regex, replacement);
+        String shortCode;
+        Pattern p = Pattern.compile("(\\[ *?([^ ]+) .*?\\])");
+        Matcher m = p.matcher(postContent);
+        StringBuffer sb = new StringBuffer();
+        while (m.find()) {
+            shortCode = m.group(2);
+            if (isKnownShortcode(shortCode)) {
+                m.appendReplacement(sb, "[" + shortCode + "]");
+            } else {
+                AppLog.d(AppLog.T.POSTS, "unknown shortcode - " + shortCode);
+            }
+        }
+        m.appendTail(sb);
+
+        return sb.toString();
     }
 
+    private static boolean isKnownShortcode(String shortCode) {
+        if (shortCode == null) return false;
+
+        // populate on first use
+        if (mShortcodeTable.size() == 0) {
+            // video
+            mShortcodeTable.add("dailymotion");
+            mShortcodeTable.add("flickr");
+            mShortcodeTable.add("hulu");
+            mShortcodeTable.add("kickstarter");
+            mShortcodeTable.add("vimeo");
+            mShortcodeTable.add("vine");
+            mShortcodeTable.add("wpvideo");
+            mShortcodeTable.add("youtube");
+            // audio
+            mShortcodeTable.add("audio");
+            mShortcodeTable.add("playlist");
+            mShortcodeTable.add("soundcloud");
+            // images and documents
+            mShortcodeTable.add("gallery");
+            mShortcodeTable.add("instagram");
+            mShortcodeTable.add("scribd");
+            mShortcodeTable.add("slideshare");
+            mShortcodeTable.add("slideshow");
+            mShortcodeTable.add("presentation");
+            mShortcodeTable.add("googleapps");
+            mShortcodeTable.add("office");
+            // other
+            mShortcodeTable.add("googlemaps");
+            mShortcodeTable.add("polldaddy");
+            mShortcodeTable.add("recipe");
+            mShortcodeTable.add("sitemap");
+            mShortcodeTable.add("twitter-timeline");
+            mShortcodeTable.add("upcomingevents");
+        }
+
+        return mShortcodeTable.contains(shortCode);
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -27,6 +27,7 @@ import org.wordpress.android.models.Blog;
 import org.wordpress.android.models.PostStatus;
 import org.wordpress.android.models.PostsListPost;
 import org.wordpress.android.models.PostsListPostList;
+import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.posts.PostsListFragment;
 import org.wordpress.android.ui.posts.services.PostMediaService;
 import org.wordpress.android.ui.reader.utils.ReaderImageScanner;
@@ -184,7 +185,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
             if (post.hasExcerpt()) {
                 postHolder.txtExcerpt.setVisibility(View.VISIBLE);
-                postHolder.txtExcerpt.setText(post.getExcerpt());
+                postHolder.txtExcerpt.setText(PostUtils.collapseShortcode(PostUtils.SHORTCODE_GALLERY, post.getExcerpt()));
             } else {
                 postHolder.txtExcerpt.setVisibility(View.GONE);
             }
@@ -673,4 +674,5 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             }
         }
     }
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -185,7 +185,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
             if (post.hasExcerpt()) {
                 postHolder.txtExcerpt.setVisibility(View.VISIBLE);
-                postHolder.txtExcerpt.setText(PostUtils.collapseShortcode(PostUtils.SHORTCODE_GALLERY, post.getExcerpt()));
+                postHolder.txtExcerpt.setText(PostUtils.collapseShortcodes(post.getExcerpt()));
             } else {
                 postHolder.txtExcerpt.setVisibility(View.GONE);
             }


### PR DESCRIPTION
Fixes #3114 - Collapses shortcodes in the post list and post preview. For example, `[gallery ids="1206,1205,1191"]` is collapsed to just `[gallery]`.