### PR TITLE
Updating build tools to 23.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ android:
   components:
     - extra-android-m2repository
     - extra-android-support
-    - build-tools-23.0.0
+    - build-tools-23.0.1
     - android-23
 
 env:

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -28,7 +28,7 @@ android {
     }
 
     compileSdkVersion 23
-    buildToolsVersion "23.0.0"
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         applicationId "org.wordpress.android"
@@ -73,11 +73,11 @@ dependencies {
     }
     compile 'com.google.code.gson:gson:2.2.2'
     compile 'org.ccil.cowan.tagsoup:tagsoup:1.2.1'
-    compile 'com.android.support:support-v13:23.0.0'
-    compile 'com.android.support:appcompat-v7:23.0.0'
-    compile 'com.android.support:cardview-v7:23.0.0'
-    compile 'com.android.support:recyclerview-v7:23.0.0'
-    compile 'com.android.support:design:23.0.0'
+    compile 'com.android.support:support-v13:23.0.1'
+    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:cardview-v7:23.0.1'
+    compile 'com.android.support:recyclerview-v7:23.0.1'
+    compile 'com.android.support:design:23.0.1'
     compile 'com.github.chrisbanes.photoview:library:1.2.4'
     compile 'com.helpshift:android-aar:3.8.0'
     compile 'de.greenrobot:eventbus:2.4.0'

--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -26,7 +26,7 @@ android {
     publishNonDefault true
 
     compileSdkVersion 23
-    buildToolsVersion '23.0.0'
+    buildToolsVersion '23.0.1'
 
     defaultConfig {
         versionName "1.0.0"

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -22,7 +22,7 @@ android {
     publishNonDefault true
 
     compileSdkVersion 23
-    buildToolsVersion "23.0.0"
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         versionCode 3
@@ -48,8 +48,8 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:23.0.0'
-    compile 'com.android.support:support-v4:23.0.0'
+    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:support-v4:23.0.1'
     compile 'org.wordpress:analytics:1.0.0'
     compile 'org.wordpress:utils:1.6.0'
 

--- a/libs/editor/example/build.gradle
+++ b/libs/editor/example/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.0"
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         applicationId "org.wordpress.editorexample"

--- a/libs/networking/WordPressNetworking/build.gradle
+++ b/libs/networking/WordPressNetworking/build.gradle
@@ -19,7 +19,7 @@ android {
     publishNonDefault true
 
     compileSdkVersion 23
-    buildToolsVersion '23.0.0'
+    buildToolsVersion '23.0.1'
 
     defaultConfig {
         minSdkVersion 14

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -20,7 +20,7 @@ dependencies {
         exclude group: 'commons-logging'
     }
     compile 'com.mcxiaoke.volley:library:1.0.18'
-    compile 'com.android.support:support-v13:23.0.0'
+    compile 'com.android.support:support-v13:23.0.1'
 }
 
 android {
@@ -29,7 +29,7 @@ android {
     publishNonDefault true
 
     compileSdkVersion 23
-    buildToolsVersion '23.0.0'
+    buildToolsVersion '23.0.1'
 
     defaultConfig {
         versionName "1.5.0"


### PR DESCRIPTION
For some reason it looks like Google or Travis pulled their 23.0.0 build tools. No biggie, it's a good thing to update anyways.