### PR TITLE
Fix #3141 re enable the connection bar

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -340,5 +340,11 @@
 
         <receiver android:name=".ui.notifications.NotificationDismissBroadcastReceiver" />
 
+        <receiver android:name=".networking.ConnectionChangeReceiver">
+            <intent-filter>
+                <action android:name="android.net.conn.CONNECTIVITY_CHANGE" />
+            </intent-filter>
+        </receiver>
+
     </application>
 </manifest>

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -340,9 +340,10 @@
 
         <receiver android:name=".ui.notifications.NotificationDismissBroadcastReceiver" />
 
-        <receiver android:name=".networking.ConnectionChangeReceiver">
+        <receiver android:name=".networking.ConnectionChangeReceiver"
+                  android:enabled="false">
             <intent-filter>
-                <action android:name="android.net.conn.CONNECTIVITY_CHANGE" />
+                <action android:name="android.net.conn.CONNECTIVITY_CHANGE"/>
             </intent-filter>
         </receiver>
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -237,7 +237,6 @@ public class WordPress extends Application {
         ABTestingUtils.init();
 
         AnalyticsUtils.refreshMetadata();
-        AnalyticsTracker.track(Stat.APPLICATION_STARTED);
     }
 
     // Configure Simperium and start buckets if we are signed in to WP.com
@@ -726,7 +725,7 @@ public class WordPress extends Application {
                 }
                 AnalyticsTracker.track(AnalyticsTracker.Stat.APPLICATION_CLOSED, properties);
                 AnalyticsTracker.endSession(false);
-                onToBackground();
+                onAppGoesToBackground();
             } else {
                 mIsInBackground = false;
             }
@@ -789,7 +788,7 @@ public class WordPress extends Application {
             }
         }
 
-        public void onToBackground() {
+        public void onAppGoesToBackground() {
             AppLog.i(T.UTILS, "App goes to background");
             setConnectionChangeReceiverEnabled(false);
         }
@@ -799,7 +798,7 @@ public class WordPress extends Application {
          * 1. the app starts (but it's not opened by a service or a broadcast receiver, i.e. an activity is resumed)
          * 2. the app was in background and is now foreground
          */
-        public void onFromBackground() {
+        public void onAppComesFromBackground() {
             AppLog.i(T.UTILS, "App comes from background");
             setConnectionChangeReceiverEnabled(true);
             AnalyticsUtils.refreshMetadata();
@@ -822,7 +821,7 @@ public class WordPress extends Application {
         public void onActivityResumed(Activity activity) {
             if (mIsInBackground) {
                 // was in background before
-                onFromBackground();
+                onAppComesFromBackground();
             }
             mIsInBackground = false;
             if (mFirstActivityResumed) {

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -217,6 +217,14 @@ public class WordPress extends Application {
         AppPrefs.setLastAppVersionCode(versionCode);
     }
 
+    /**
+     * Application.onCreate is called before any activity, service, or receiver - and it can be called while the app
+     * is in background by a sticky service or a receiver so we don't want Application.onCreate to make network request
+     * or other heavy tasks.
+     *
+     * This deferredInit method is called when the users start an activity for the first time, ie. when he see a
+     * screen for the first time, and it allows us to have heavy calls on first activity startup instead of app startup.
+     */
     public void deferredInit() {
         AppLog.i(T.UTILS, "Deferred Initialisation");
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -161,9 +161,6 @@ public class WordPress extends Application {
     public void onCreate() {
         super.onCreate();
 
-        // disable ConnectionChangeReceive by default
-        setConnectionChangeReceiverEnabled(false);
-
         mContext = this;
 
         ProfilingUtils.start("WordPress.onCreate");

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -680,15 +680,6 @@ public class WordPress extends Application {
         }
     }
 
-    private void setConnectionChangeReceiverEnabled(boolean enabled) {
-        AppLog.i(T.UTILS, "setConnectionChangeReceiverEnabled " + enabled);
-        int flag = (enabled ?
-                PackageManager.COMPONENT_ENABLED_STATE_ENABLED :
-                PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
-        ComponentName component = new ComponentName(this, ConnectionChangeReceiver.class);
-        getPackageManager().setComponentEnabledSetting(component, flag, PackageManager.DONT_KILL_APP);
-    }
-
     /**
      * Detect when the app goes to the background and come back to the foreground.
      *
@@ -795,7 +786,7 @@ public class WordPress extends Application {
 
         public void onAppGoesToBackground() {
             AppLog.i(T.UTILS, "App goes to background");
-            setConnectionChangeReceiverEnabled(false);
+            ConnectionChangeReceiver.setEnabled(WordPress.this, false);
         }
 
         /**
@@ -805,7 +796,7 @@ public class WordPress extends Application {
          */
         public void onAppComesFromBackground() {
             AppLog.i(T.UTILS, "App comes from background");
-            setConnectionChangeReceiverEnabled(true);
+            ConnectionChangeReceiver.setEnabled(WordPress.this, true);
             AnalyticsUtils.refreshMetadata();
             mApplicationOpenedDate = new Date();
             AnalyticsTracker.track(AnalyticsTracker.Stat.APPLICATION_OPENED);

--- a/WordPress/src/main/java/org/wordpress/android/networking/ConnectionChangeReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/ConnectionChangeReceiver.java
@@ -1,8 +1,10 @@
 package org.wordpress.android.networking;
 
 import android.content.BroadcastReceiver;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -15,9 +17,10 @@ import de.greenrobot.event.EventBus;
  * android.net.conn.CONNECTIVITY_CHANGE
  */
 public class ConnectionChangeReceiver extends BroadcastReceiver {
-
     private static boolean mIsFirstReceive = true;
     private static boolean mWasConnected = true;
+    private static boolean mIsEnabled = false; // this value must be synchronized with the ConnectionChangeReceiver
+                                               // state in our AndroidManifest
 
     public static class ConnectionChangeEvent {
         private final boolean mIsConnected;
@@ -39,10 +42,29 @@ public class ConnectionChangeReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         boolean isConnected = NetworkUtils.isNetworkAvailable(context);
         if (mIsFirstReceive || isConnected != mWasConnected) {
-            AppLog.i(T.UTILS, "Connection status changed, isConnected=" + isConnected);
-            mWasConnected = isConnected;
-            mIsFirstReceive = false;
-            EventBus.getDefault().post(new ConnectionChangeEvent(isConnected));
+            postConnectionChangeEvent(isConnected);
+        }
+    }
+
+    private static void postConnectionChangeEvent(boolean isConnected) {
+        AppLog.i(T.UTILS, "Connection status changed, isConnected=" + isConnected);
+        mWasConnected = isConnected;
+        mIsFirstReceive = false;
+        EventBus.getDefault().post(new ConnectionChangeEvent(isConnected));
+    }
+
+    public static void setEnabled(Context context, boolean enabled) {
+        if (mIsEnabled == enabled) {
+            return;
+        }
+        mIsEnabled = enabled;
+        AppLog.i(T.UTILS, "ConnectionChangeReceiver.setEnabled " + enabled);
+        int flag = (enabled ? PackageManager.COMPONENT_ENABLED_STATE_ENABLED :
+                              PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
+        ComponentName component = new ComponentName(context, ConnectionChangeReceiver.class);
+        context.getPackageManager().setComponentEnabledSetting(component, flag, PackageManager.DONT_KILL_APP);
+        if (mIsEnabled) {
+            postConnectionChangeEvent(NetworkUtils.isNetworkAvailable(context));
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -265,6 +265,8 @@ public class WPMainActivity extends Activity
         // We need to track the current item on the screen when this activity is resumed.
         // Ex: Notifications -> notifications detail -> back to notifications
         trackLastVisibleTab(mViewPager.getCurrentItem());
+
+        checkConnection();
     }
 
     private void trackLastVisibleTab(int position) {


### PR DESCRIPTION
Fix #3141 add connection bar and move some onCreate method to a deferred init.

`CONNECTION_CHANGE` receiver is enabled when the app comes from background and disabled when it goes to background, thus the `ConnectionChangeEvent` could be used in all Activities (not only WPMainActivity)

cc @nbradbury 