### PR TITLE
Update blog settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -430,8 +430,8 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                     BlogUtils.addBlogs(userBlogList, mUsername, mPassword, mHttpUsername, mHttpPassword);
                 }
 
-                // refresh first blog
-                refreshFirstBlogContent();
+                // refresh the first 10 blogs
+                refreshFirstTenBlogsContent();
             }
 
             trackAnalyticsSignIn();
@@ -859,16 +859,19 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     }
 
     /**
-     * Get first blog and call RefreshBlogContentTask. First blog will be autoselected when user login.
+     * Get the first ten blogs and call RefreshBlogContentTask. First blog will be autoselected when user login.
      * Also when a user add a new self hosted blog, userBlogList contains only one element.
      * We don't want to refresh the whole list because it can be huge and each blog is refreshed when
      * user selects it.
      */
-    private void refreshFirstBlogContent() {
+    private void refreshFirstTenBlogsContent() {
         List<Map<String, Object>> visibleBlogs = WordPress.wpDB.getBlogsBy("isHidden = 0", null, 1);
         if (visibleBlogs != null && !visibleBlogs.isEmpty()) {
-            Map<String, Object> firstBlog = visibleBlogs.get(0);
-            refreshBlogContent(firstBlog);
+            int numberOfBlogsBeingRefreshed = Math.min(10, visibleBlogs.size());
+            for (int i = 0; i < numberOfBlogsBeingRefreshed; i++) {
+                Map<String, Object> currentBlog = visibleBlogs.get(i);
+                refreshBlogContent(currentBlog);
+            }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -865,7 +865,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
      * user selects it.
      */
     private void refreshFirstTenBlogsContent() {
-        List<Map<String, Object>> visibleBlogs = WordPress.wpDB.getBlogsBy("isHidden = 0", null, 1);
+        List<Map<String, Object>> visibleBlogs = WordPress.wpDB.getBlogsBy("isHidden = 0", null, 10);
         if (visibleBlogs != null && !visibleBlogs.isEmpty()) {
             int numberOfBlogsBeingRefreshed = Math.min(10, visibleBlogs.size());
             for (int i = 0; i < numberOfBlogsBeingRefreshed; i++) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -430,8 +430,8 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                     BlogUtils.addBlogs(userBlogList, mUsername, mPassword, mHttpUsername, mHttpPassword);
                 }
 
-                // refresh the first 10 blogs
-                refreshFirstTenBlogsContent();
+                // refresh the first 5 blogs
+                refreshFirstFiveBlogsContent();
             }
 
             trackAnalyticsSignIn();
@@ -859,15 +859,15 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     }
 
     /**
-     * Get the first ten blogs and call RefreshBlogContentTask. First blog will be autoselected when user login.
+     * Get the first five blogs and call RefreshBlogContentTask. First blog will be autoselected when user login.
      * Also when a user add a new self hosted blog, userBlogList contains only one element.
      * We don't want to refresh the whole list because it can be huge and each blog is refreshed when
      * user selects it.
      */
-    private void refreshFirstTenBlogsContent() {
-        List<Map<String, Object>> visibleBlogs = WordPress.wpDB.getBlogsBy("isHidden = 0", null, 10);
+    private void refreshFirstFiveBlogsContent() {
+        List<Map<String, Object>> visibleBlogs = WordPress.wpDB.getBlogsBy("isHidden = 0", null, 5);
         if (visibleBlogs != null && !visibleBlogs.isEmpty()) {
-            int numberOfBlogsBeingRefreshed = Math.min(10, visibleBlogs.size());
+            int numberOfBlogsBeingRefreshed = Math.min(5, visibleBlogs.size());
             for (int i = 0; i < numberOfBlogsBeingRefreshed; i++) {
                 Map<String, Object> currentBlog = visibleBlogs.get(i);
                 refreshBlogContent(currentBlog);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.view.MenuItemCompat;
@@ -34,6 +35,7 @@ import org.wordpress.android.ui.main.SitePickerAdapter.SiteRecord;
 import org.wordpress.android.ui.stats.datasets.StatsTable;
 import org.wordpress.android.util.CoreEvents;
 import org.wordpress.android.util.ToastUtils;
+import org.xmlrpc.android.ApiHelper;
 
 import de.greenrobot.event.EventBus;
 
@@ -348,6 +350,9 @@ public class SitePickerActivity extends AppCompatActivity
             WordPress.wpDB.updateLastBlogId(site.localId);
             setResult(RESULT_OK);
             mDidUserSelectSite = true;
+            new ApiHelper.RefreshBlogContentTask(WordPress.getCurrentBlog(), null).executeOnExecutor(
+                    AsyncTask.THREAD_POOL_EXECUTOR, false);
+
             finish();
         }
     }


### PR DESCRIPTION
This PR fixes #3140 by adding the following behavior:

- Refresh the first 10 (visible) blogs during the initial signin.
- Refresh the content of the blog when the user select it in the sidebar.


Not 100% happy with this solution, since it could end up in a lot of unnecessary calls if the user switches blogs often. A solution that uses a kind of RateLimitedTask should be better.