### PR TITLE
Issue/3145 reader follow redirect error

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderBlog.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderBlog.java
@@ -121,6 +121,11 @@ public class ReaderBlog {
     public boolean hasUrl() {
         return !TextUtils.isEmpty(url);
     }
+
+    public boolean hasFeedUrl() {
+        return !TextUtils.isEmpty(feedUrl);
+    }
+
     public boolean hasImageUrl() {
         return !TextUtils.isEmpty(imageUrl);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -381,7 +381,13 @@ public class ReaderBlogActions {
                 } else {
                     statusCode = VolleyUtils.statusCodeFromVolleyError(volleyError);
                 }
-                urlListener.onFailed(statusCode);
+                // Volley treats a 301 redirect as a failure here, we should treat it as
+                // success since it means the blog url is reachable
+                if (statusCode == 301) {
+                    urlListener.onSuccess();
+                } else {
+                    urlListener.onFailed(statusCode);
+                }
             }
         };
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
@@ -123,13 +123,18 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
                 case FOLLOWED:
                     final ReaderBlog blogInfo = mFollowedBlogs.get(position);
-                    String domain = UrlUtils.getDomainFromUrl(blogInfo.getUrl());
                     if (blogInfo.hasName()) {
                         blogHolder.txtTitle.setText(blogInfo.getName());
                     } else {
-                        blogHolder.txtTitle.setText(domain);
+                        blogHolder.txtTitle.setText(R.string.reader_untitled_post);
                     }
-                    blogHolder.txtUrl.setText(domain);
+                    if (blogInfo.hasUrl()) {
+                        blogHolder.txtUrl.setText(UrlUtils.getDomainFromUrl(blogInfo.getUrl()));
+                    } else if (blogInfo.hasFeedUrl()) {
+                        blogHolder.txtUrl.setText(UrlUtils.getDomainFromUrl(blogInfo.getFeedUrl()));
+                    } else {
+                        blogHolder.txtUrl.setText("");
+                    }
                     blogHolder.imgBlog.setImageUrl(blogInfo.getImageUrl(), WPNetworkImageView.ImageType.BLAVATAR);
                     break;
             }


### PR DESCRIPTION
Fix #3145 - a 301 is now treated as success when checking whether a blog URL is reachable. Also made a fix to `ReaderBlogAdapter` to handle untitled blogs (discovered while testing this issue).