### PR TITLE
fix #2927: Replace the HttpURLConnection call by a synchronized Volley call.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/networking/SelfSignedSSLCertsManager.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/SelfSignedSSLCertsManager.java
@@ -29,6 +29,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 
 import javax.security.auth.x500.X500Principal;
 
@@ -54,7 +55,10 @@ public class SelfSignedSSLCertsManager {
                         SelfSignedSSLCertsManager selfSignedSSLCertsManager;
                         try {
                             selfSignedSSLCertsManager = SelfSignedSSLCertsManager.getInstance(ctx);
-                            selfSignedSSLCertsManager.addCertificates(selfSignedSSLCertsManager.getLastFailureChain());
+                            X509Certificate[] certificates = selfSignedSSLCertsManager.getLastFailureChain();
+                            AppLog.i(T.NUX, "Add the following certificate to our Certificate Manager: " +
+                                    Arrays.toString(certificates));
+                            selfSignedSSLCertsManager.addCertificates(certificates);
                         } catch (GeneralSecurityException e) {
                             AppLog.e(T.API, e);
                         } catch (IOException e) {

--- a/WordPress/src/main/java/org/xmlrpc/android/ApiHelper.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/ApiHelper.java
@@ -1106,13 +1106,17 @@ public class ApiHelper {
     }
 
     private static String getRedirectURL(String oldURL, NetworkResponse networkResponse) {
-        if (networkResponse.headers != null  && networkResponse.headers.containsKey("Location")) {
+        if (networkResponse.headers != null && networkResponse.headers.containsKey("Location")) {
             String newURL = networkResponse.headers.get("Location");
-            // Relative URL case
-            if (newURL.startsWith("/")) {
+            // Relative URL
+            if (newURL != null && newURL.startsWith("/")) {
                 Uri oldUri = Uri.parse(oldURL);
+                if (oldUri.getScheme() == null || oldUri.getAuthority() == null) {
+                    return null;
+                }
                 return oldUri.getScheme() + "://" + oldUri.getAuthority() + newURL;
             }
+            // Absolute URL
             return newURL;
         }
         return null;

--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
@@ -60,6 +60,8 @@ import de.greenrobot.event.EventBus;
  */
 
 public class XMLRPCClient implements XMLRPCClientInterface {
+    public static final int DEFAULT_CONNECTION_TIMEOUT = 30000;
+    public static final int DEFAULT_SOCKET_TIMEOUT = 60000;
 
     public interface OnBytesUploadedListener {
         public void onBytesUploaded(long uploadedBytes);
@@ -73,8 +75,6 @@ public class XMLRPCClient implements XMLRPCClientInterface {
     private static final String TAG_FAULT = "fault";
     private static final String TAG_FAULT_CODE = "faultCode";
     private static final String TAG_FAULT_STRING = "faultString";
-    private static final int DEFAULT_CONNECTION_TIMEOUT = 30000;
-    private static final int DEFAULT_SOCKET_TIMEOUT = 60000;
 
     private Map<Long,Caller> backgroundCalls = new HashMap<Long, Caller>();
 

--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
@@ -131,7 +131,7 @@ public class XMLRPCClient implements XMLRPCClientInterface {
         if (uri != null && uri.getHost() != null && uri.getHost().endsWith("wordpress.com")) {
             mIsWpcom = true;
         }
-        if (mIsWpcom || (uri == null || uri.getScheme() == null || uri.getScheme().equals("http"))) {
+        if (mIsWpcom) {
             //wpcom blog or self-hosted blog on plain HTTP
             client = new DefaultHttpClient();
         } else {
@@ -143,10 +143,10 @@ public class XMLRPCClient implements XMLRPCClientInterface {
             try {
                 client = new ConnectionClient(port);
             } catch (GeneralSecurityException e) {
-                AppLog.e(T.API, "Cannot create the DefaultHttpClient object with our TrustAllSSLSocketFactory", e);
+                AppLog.e(T.API, "Cannot create the DefaultHttpClient object with our TrustUserSSLCertsSocketFactory", e);
                 client = null;
             } catch (IOException e) {
-                AppLog.e(T.API, "Cannot create the DefaultHttpClient object with our TrustAllSSLSocketFactory", e);
+                AppLog.e(T.API, "Cannot create the DefaultHttpClient object with our TrustUserSSLCertsSocketFactory", e);
                 client = null;
             }
 


### PR DESCRIPTION
Replace the HttpURLConnection call by a synchronized Volley call.

IMO, the replaement is not as clean as the previous use of HttpURLConnection, but it uses the exact same Http Stack than other logins network calls. That Http Stack uses the underlying TrustUserSSLCertsSocketFactory that allows us to save the state of the latest SSL failure (via setLastFailureChain).