### PR TITLE
Issue/3148 reader deleted comments

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderCommentTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderCommentTable.java
@@ -102,11 +102,11 @@ public class ReaderCommentTable {
     }
 
     /*
-     * removes all but the first page of comments for the passed post
+     * removes all comments for the passed post
      */
-    public static void purgeExcessCommentsForPost(long blogId, long postId) {
+    public static void purgeCommentsForPost(long blogId, long postId) {
         String[] args = {Long.toString(blogId), Long.toString(postId)};
-        ReaderDatabase.getWritableDb().delete("tbl_comments", "page_number!=1 AND blog_id=? AND post_id=?", args);
+        ReaderDatabase.getWritableDb().delete("tbl_comments", "blog_id=? AND post_id=?", args);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -276,10 +276,13 @@ public class CommentsActivity extends AppCompatActivity
                 @Override
                 public void run() {
                     // comment will no longer exist in moderating list if action was undone
-                    if (hasListFragment() && !getListFragment().isModeratingComment(comment.commentID)) {
+                    if (!isFinishing()
+                            && hasListFragment()
+                            && !getListFragment().isModeratingComment(comment.commentID)) {
                         AppLog.d(AppLog.T.COMMENTS, "comment moderation undone");
                         return;
                     }
+
                     CommentActions.moderateComment(accountId, comment, newStatus, new CommentActions.CommentActionListener() {
                         @Override
                         public void onActionResult(boolean succeeded) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -7,7 +7,6 @@ import android.app.FragmentTransaction;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
-import android.os.Parcelable;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -41,7 +40,6 @@ public class CommentsActivity extends AppCompatActivity
     static final String KEY_AUTO_REFRESHED = "has_auto_refreshed";
     static final String KEY_EMPTY_VIEW_MESSAGE = "empty_view_message";
     private long mSelectedCommentId;
-    private boolean mSnackbarDidUndo;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -257,7 +255,6 @@ public class CommentsActivity extends AppCompatActivity
                 }
             });
         } else if (newStatus == CommentStatus.SPAM || newStatus == CommentStatus.TRASH) {
-            // Remove comment from comments list
             getListFragment().removeComment(comment);
             getListFragment().setCommentIsModerating(comment.commentID, true);
 
@@ -265,14 +262,11 @@ public class CommentsActivity extends AppCompatActivity
             View.OnClickListener undoListener = new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    mSnackbarDidUndo = true;
                     getListFragment().setCommentIsModerating(comment.commentID, false);
-                    // On undo load from the db to show the comment again
                     getListFragment().loadComments();
                 }
             };
 
-            mSnackbarDidUndo = false;
             Snackbar.make(getListFragment().getView(), message, Snackbar.LENGTH_LONG)
                     .setAction(R.string.undo, undoListener)
                     .show();
@@ -281,7 +275,9 @@ public class CommentsActivity extends AppCompatActivity
             new Handler().postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                    if (mSnackbarDidUndo) {
+                    // comment will no longer exist in moderating list if action was undone
+                    if (hasListFragment() && !getListFragment().isModeratingComment(comment.commentID)) {
+                        AppLog.d(AppLog.T.COMMENTS, "comment moderation undone");
                         return;
                     }
                     CommentActions.moderateComment(accountId, comment, newStatus, new CommentActions.CommentActionListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -398,6 +398,9 @@ public class CommentsListFragment extends Fragment {
         mUpdateCommentsTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
+    public boolean isModeratingComment(long commentId) {
+        return hasCommentAdapter() && getCommentAdapter().isModeratingCommentId(commentId);
+    }
     public void setCommentIsModerating(long commentId, boolean isModerating) {
         if (!hasCommentAdapter()) return;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -102,10 +102,11 @@ public class ReaderCommentListActivity extends AppCompatActivity {
             mBlogId = getIntent().getLongExtra(ReaderConstants.ARG_BLOG_ID, 0);
             mPostId = getIntent().getLongExtra(ReaderConstants.ARG_POST_ID, 0);
             mCommentId = getIntent().getLongExtra(ReaderConstants.ARG_COMMENT_ID, 0);
-            // remove all but the first page of comments for this post if there's an active
-            // connection - infinite scroll will take care of filling in subsequent pages
-            if (NetworkUtils.isNetworkAvailable(this) && mCommentId == 0) {
-                ReaderCommentTable.purgeExcessCommentsForPost(mBlogId, mPostId);
+            // we need to re-request comments every time this activity is shown in order to
+            // correctly reflect deletions and nesting changes - skipped when there's no
+            // connection so we can show existing comments while offline
+            if (NetworkUtils.isNetworkAvailable(this)) {
+                ReaderCommentTable.purgeCommentsForPost(mBlogId, mPostId);
             }
         }
 


### PR DESCRIPTION
Fixes #3148 - there were two problems here:

1. The comment list activity always retained the first page of comments, which meant comments in that first page which were deleted would continue to appear.
2. Undoing a comment trash was unreliable because it used a single boolean variable to determine when the trash was undone. This failed to account for the user quickly trashing multiple comments (a rare situation, but it could result in the wrong comment trash being undone - causing the comment the user thought they'd trashed continuing to appear in the reader).