### PR TITLE
issue/3146-reader-reply-to-comment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -188,12 +188,14 @@ public class ReaderCommentListActivity extends AppCompatActivity {
                 }
             }, 300);
 
-            // reset to replying to the post when user hits the back button in the editText
-            // to hide the soft keyboard
+            // reset to replying to the post when user hasn't entered any text and hits
+            // the back button in the editText to hide the soft keyboard
             mEditComment.setOnBackListener(new SuggestionAutoCompleteText.OnEditTextBackListener() {
                 @Override
                 public void onEditTextBack() {
-                    setReplyToCommentId(0);
+                    if (EditTextUtils.isEmpty(mEditComment)) {
+                        setReplyToCommentId(0);
+                    }
                 }
             });
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -117,7 +117,7 @@ public class ReaderCommentListActivity extends AppCompatActivity {
         mCommentBox = (ViewGroup) findViewById(R.id.layout_comment_box);
         mEditComment = (SuggestionAutoCompleteText) mCommentBox.findViewById(R.id.edit_comment);
         mEditComment.getAutoSaveTextHelper().setUniqueId(String.format("%s%d%d", AccountHelper
-                        .getCurrentUsernameForBlog(null), mPostId, mBlogId));
+                .getCurrentUsernameForBlog(null), mPostId, mBlogId));
         mSubmitReplyBtn = mCommentBox.findViewById(R.id.btn_submit_reply);
 
         if (!loadPost()) {
@@ -187,6 +187,17 @@ public class ReaderCommentListActivity extends AppCompatActivity {
                     scrollToCommentId(mReplyToCommentId);
                 }
             }, 300);
+
+            // reset to replying to the post when user hits the back button in the editText
+            // to hide the soft keyboard
+            mEditComment.setOnBackListener(new SuggestionAutoCompleteText.OnEditTextBackListener() {
+                @Override
+                public void onEditTextBack() {
+                    setReplyToCommentId(0);
+                }
+            });
+        } else {
+            mEditComment.setOnBackListener(null);
         }
     }
 
@@ -471,5 +482,4 @@ public class ReaderCommentListActivity extends AppCompatActivity {
             return 0;
         }
     }
-
 }

--- a/WordPress/src/main/java/org/wordpress/android/widgets/SuggestionAutoCompleteText.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/SuggestionAutoCompleteText.java
@@ -2,6 +2,7 @@ package org.wordpress.android.widgets;
 
 import android.content.Context;
 import android.util.AttributeSet;
+import android.view.KeyEvent;
 import android.view.inputmethod.EditorInfo;
 import android.widget.MultiAutoCompleteTextView;
 
@@ -10,6 +11,11 @@ import org.wordpress.persistentedittext.PersistentEditTextHelper;
 
 public class SuggestionAutoCompleteText extends MultiAutoCompleteTextView {
     PersistentEditTextHelper mPersistentEditTextHelper;
+    private OnEditTextBackListener mBackListener;
+
+    public interface OnEditTextBackListener {
+        void onEditTextBack();
+    }
 
     public SuggestionAutoCompleteText(Context context) {
         super(context, null);
@@ -55,5 +61,22 @@ public class SuggestionAutoCompleteText extends MultiAutoCompleteTextView {
             return;
         }
         getAutoSaveTextHelper().saveString(this);
+    }
+
+    public void setOnBackListener(OnEditTextBackListener listener) {
+        mBackListener = listener;
+    }
+
+    /*
+     * detect when user hits the back button while soft keyboard is showing (hiding the keyboard)
+     */
+    @Override
+    public boolean onKeyPreIme(int keyCode, KeyEvent event) {
+        if (mBackListener != null
+                && event.getKeyCode() == KeyEvent.KEYCODE_BACK
+                && event.getAction() == KeyEvent.ACTION_UP) {
+            mBackListener.onEditTextBack();
+        }
+        return super.dispatchKeyEvent(event);
     }
 }


### PR DESCRIPTION
Fixes #3146 - detects when the user hits the back button to hide the soft keyboard while replying to a comment and resets to replying to the post when that occurs.