### PR TITLE
Issue/3168 reader always enable liking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -19,7 +19,7 @@ import java.io.OutputStream;
  */
 public class ReaderDatabase extends SQLiteOpenHelper {
     protected static final String DB_NAME = "wpreader.db";
-    private static final int DB_VERSION = 105;
+    private static final int DB_VERSION = 106;
 
     /*
      * version history
@@ -57,6 +57,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      *  103 - added discover_json to ReaderPostTable
      *  104 - added word_count to ReaderPostTable
      *  105 - added date_updated to ReaderBlogTable
+     *  106 - dropped is_likes_enabled and is_sharing_enabled from tbl_posts
      */
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -56,11 +56,9 @@ public class ReaderPostTable {
           + "is_jetpack,"           // 27
           + "primary_tag,"          // 28
           + "secondary_tag,"        // 29
-          + "is_likes_enabled,"     // 30
-          + "is_sharing_enabled,"   // 31
-          + "attachments_json,"     // 32
-          + "discover_json,"        // 33
-          + "word_count";           // 34
+          + "attachments_json,"     // 30
+          + "discover_json,"        // 31
+          + "word_count";           // 32
 
     // used when querying multiple rows and skipping tbl_posts.text
     private static final String COLUMN_NAMES_NO_TEXT =
@@ -92,11 +90,9 @@ public class ReaderPostTable {
           + "tbl_posts.is_jetpack,"           // 26
           + "tbl_posts.primary_tag,"          // 27
           + "tbl_posts.secondary_tag,"        // 28
-          + "tbl_posts.is_likes_enabled,"     // 29
-          + "tbl_posts.is_sharing_enabled,"   // 30
-          + "tbl_posts.attachments_json,"     // 31
-          + "tbl_posts.discover_json,"        // 32
-          + "tbl_posts.word_count";           // 33
+          + "tbl_posts.attachments_json,"     // 29
+          + "tbl_posts.discover_json,"        // 30
+          + "tbl_posts.word_count";           // 31
 
     protected static void createTables(SQLiteDatabase db) {
         db.execSQL("CREATE TABLE tbl_posts ("
@@ -130,8 +126,6 @@ public class ReaderPostTable {
                 + " is_jetpack          INTEGER DEFAULT 0,"
                 + " primary_tag         TEXT,"
                 + " secondary_tag       TEXT,"
-                + " is_likes_enabled    INTEGER DEFAULT 0,"
-                + " is_sharing_enabled  INTEGER DEFAULT 0,"
                 + " attachments_json    TEXT,"
                 + " discover_json       TEXT,"
                 + " PRIMARY KEY (post_id, blog_id)"
@@ -510,7 +504,7 @@ public class ReaderPostTable {
         SQLiteStatement stmtPosts = db.compileStatement(
                 "INSERT OR REPLACE INTO tbl_posts ("
                 + COLUMN_NAMES
-                + ") VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28,?29,?30,?31,?32,?33,?34)");
+                + ") VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28,?29,?30,?31,?32)");
         SQLiteStatement stmtTags = db.compileStatement(
                 "INSERT OR REPLACE INTO tbl_post_tags (post_id, blog_id, feed_id, pseudo_id, tag_name, tag_type) VALUES (?1,?2,?3,?4,?5,?6)");
 
@@ -523,7 +517,7 @@ public class ReaderPostTable {
                 stmtPosts.bindLong  (3,  post.feedId);
                 stmtPosts.bindString(4, post.getPseudoId());
                 stmtPosts.bindString(5,  post.getAuthorName());
-                stmtPosts.bindLong(6, post.authorId);
+                stmtPosts.bindLong  (6, post.authorId);
                 stmtPosts.bindString(7, post.getTitle());
                 stmtPosts.bindString(8,  maxText(post));
                 stmtPosts.bindString(9,  post.getExcerpt());
@@ -534,9 +528,9 @@ public class ReaderPostTable {
                 stmtPosts.bindString(14, post.getFeaturedImage());
                 stmtPosts.bindString(15, post.getFeaturedVideo());
                 stmtPosts.bindString(16, post.getPostAvatar());
-                stmtPosts.bindLong(17, post.timestamp);
+                stmtPosts.bindLong  (17, post.timestamp);
                 stmtPosts.bindString(18, post.getPublished());
-                stmtPosts.bindLong(19, post.numReplies);
+                stmtPosts.bindLong  (19, post.numReplies);
                 stmtPosts.bindLong  (20, post.numLikes);
                 stmtPosts.bindLong  (21, SqlUtils.boolToSql(post.isLikedByCurrentUser));
                 stmtPosts.bindLong  (22, SqlUtils.boolToSql(post.isFollowedByCurrentUser));
@@ -547,11 +541,9 @@ public class ReaderPostTable {
                 stmtPosts.bindLong  (27, SqlUtils.boolToSql(post.isJetpack));
                 stmtPosts.bindString(28, post.getPrimaryTag());
                 stmtPosts.bindString(29, post.getSecondaryTag());
-                stmtPosts.bindLong(30, SqlUtils.boolToSql(post.isLikesEnabled));
-                stmtPosts.bindLong  (31, SqlUtils.boolToSql(post.isSharingEnabled));
-                stmtPosts.bindString(32, post.getAttachmentsJson());
-                stmtPosts.bindString(33, post.getDiscoverJson());
-                stmtPosts.bindLong  (34, post.wordCount);
+                stmtPosts.bindString(30, post.getAttachmentsJson());
+                stmtPosts.bindString(31, post.getDiscoverJson());
+                stmtPosts.bindLong  (32, post.wordCount);
                 stmtPosts.execute();
             }
 
@@ -764,9 +756,6 @@ public class ReaderPostTable {
 
         post.setPrimaryTag(c.getString(c.getColumnIndex("primary_tag")));
         post.setSecondaryTag(c.getString(c.getColumnIndex("secondary_tag")));
-
-        post.isLikesEnabled = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_likes_enabled")));
-        post.isSharingEnabled = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_sharing_enabled")));
 
         post.setAttachmentsJson(c.getString(c.getColumnIndex("attachments_json")));
         post.setDiscoverJson(c.getString(c.getColumnIndex("discover_json")));

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -55,9 +55,6 @@ public class ReaderPost {
     public boolean isVideoPress;
     public boolean isJetpack;
 
-    public boolean isLikesEnabled;
-    public boolean isSharingEnabled;    // currently unused
-
     private String attachmentsJson;
     private String discoverJson;
 
@@ -94,9 +91,6 @@ public class ReaderPost {
         post.isExternal = JSONUtils.getBool(json, "is_external");
         post.isPrivate = JSONUtils.getBool(json, "site_is_private");
         post.isJetpack = JSONUtils.getBool(json, "is_jetpack");
-
-        post.isLikesEnabled = JSONUtils.getBool(json, "likes_enabled");
-        post.isSharingEnabled = JSONUtils.getBool(json, "sharing_enabled");
 
         JSONObject jsonDiscussion = json.optJSONObject("discussion");
         if (jsonDiscussion != null) {
@@ -509,8 +503,7 @@ public class ReaderPost {
                 && post.numReplies == this.numReplies
                 && post.isFollowedByCurrentUser == this.isFollowedByCurrentUser
                 && post.isLikedByCurrentUser == this.isLikedByCurrentUser
-                && post.isCommentsOpen == this.isCommentsOpen
-                && post.isLikesEnabled == this.isLikesEnabled;
+                && post.isCommentsOpen == this.isCommentsOpen;
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -513,6 +513,13 @@ public class ReaderPost {
                 && post.isLikesEnabled == this.isLikesEnabled;
     }
 
+    /*
+     * liking is enabled for all wp.com and jp posts with the exception of discover posts
+     */
+    public boolean canLikePost() {
+        return (isWP() || isJetpack) && (!isDiscoverPost());
+    }
+
     /****
      * the following are transient variables - not stored in the db or returned in the json - whose
      * sole purpose is to cache commonly-used values for the post that speeds up using them inside

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -886,8 +886,7 @@ public class ReaderPostDetailFragment extends Fragment
 
     private boolean canShowLikeCount() {
         return mPost != null
-                && !mPost.isDiscoverPost()
-                && mPost.canLikePost();
+                && (mPost.canLikePost() || mPost.numLikes > 0);
     }
 
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -411,7 +411,7 @@ public class ReaderPostDetailFragment extends Fragment
             countLikes.setSelected(mPost.isLikedByCurrentUser);
             if (mIsLoggedOutReader) {
                 countLikes.setEnabled(false);
-            } else if (mPost.isLikesEnabled) {
+            } else if (mPost.canLikePost()) {
                 countLikes.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
@@ -434,7 +434,7 @@ public class ReaderPostDetailFragment extends Fragment
      * show latest likes for this post
      */
     private void refreshLikes() {
-        if (!isAdded() || !hasPost() || !mPost.isWP() || !mPost.isLikesEnabled) {
+        if (!isAdded() || !hasPost() || !mPost.canLikePost()) {
             return;
         }
 
@@ -887,7 +887,7 @@ public class ReaderPostDetailFragment extends Fragment
     private boolean canShowLikeCount() {
         return mPost != null
                 && !mPost.isDiscoverPost()
-                && mPost.isLikesEnabled;
+                && mPost.canLikePost();
     }
 
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -289,7 +289,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
             return;
         }
 
-        if (mPost.isLikesEnabled) {
+        if (mPost.canLikePost()) {
             holder.countLikes.setVisibility(View.VISIBLE);
             holder.countLikes.setSelected(comment.isLikedByCurrentUser);
             holder.countLikes.setCount(comment.numLikes);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -325,7 +325,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             showLikes = post.numLikes > 0;
             showComments = post.numReplies > 0;
         } else {
-            showLikes = post.isWP() && post.isLikesEnabled;
+            showLikes = post.canLikePost();
             showComments = post.isWP() && !post.isJetpack && (post.isCommentsOpen || post.numReplies > 0);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderCommentsPostHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderCommentsPostHeaderView.java
@@ -56,7 +56,7 @@ public class ReaderCommentsPostHeaderView extends LinearLayout {
         if (post.isCommentsOpen || post.numReplies > 0) {
             dateLine += "  \u2022  " + ReaderUtils.getShortCommentLabelText(getContext(), post.numReplies);
         }
-        if (post.isLikesEnabled) {
+        if (post.canLikePost() || post.numLikes > 0) {
             dateLine += "  \u2022  " + ReaderUtils.getShortLikeLabelText(getContext(), post.numLikes);
         }
         txtDateline.setText(dateLine);


### PR DESCRIPTION
Fix #3168 - to match the web reader, likes are now always enabled for wp.com and Jetpack posts, regardless of whether the author has enabled likes for the posts.