### PR TITLE
issue/reader-empty-string-change

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -868,7 +868,7 @@
     <string name="reader_empty_followed_tags">You don\'t follow any tags</string>
     <string name="reader_empty_recommended_blogs">No recommended blogs</string>
     <string name="reader_empty_followed_blogs_title">You\'re not following any blogs yet</string>
-    <string name="reader_empty_followed_blogs_description">But don\'t worry, just tap the tag icon to start exploring!</string>
+    <string name="reader_empty_followed_blogs_description">But don\'t worry, just tap the icon at the top right to start exploring!</string>
     <string name="reader_empty_posts_liked">You haven\'t liked any posts</string>
     <string name="reader_empty_comments">No comments yet</string>
     <string name="reader_empty_posts_in_blog">This blog is empty</string>


### PR DESCRIPTION
The string that appears when "Blogs I Follow" is empty mentions a tag icon, which was replaced with a gear/settings icon as part of the Calypso redesign. This PR corrects the string.

![device-2015-09-11-110127](https://cloud.githubusercontent.com/assets/3903757/9818141/f13ebd40-5874-11e5-91d2-c95f2c2e12ad.png)
