### PR TITLE
issue/3175-reader-comment-nesting

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
@@ -19,6 +19,7 @@ import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.JSONUtils;
 import org.wordpress.android.util.VolleyUtils;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -62,9 +63,9 @@ public class ReaderCommentActions {
         newComment.pageNumber = pageNumber;
         newComment.setText(commentText);
 
-        String published = DateTimeUtils.nowUTC().toString();
-        newComment.setPublished(published);
-        newComment.timestamp = DateTimeUtils.iso8601ToTimestamp(published);
+        Date dtPublished = DateTimeUtils.nowUTC();
+        newComment.setPublished(DateTimeUtils.javaDateToIso8601(dtPublished));
+        newComment.timestamp = dtPublished.getTime();
 
         ReaderUser currentUser = ReaderUserTable.getCurrentUser();
         if (currentUser != null) {


### PR DESCRIPTION
Fixes #3175 - Problem was caused by using an incorrect date format for the published date, resulting in an invalid timestamp for the new comment. Since comments are [sorted by timestamp](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/datasets/ReaderCommentTable.java#L133), new child comments were incorrectly sorted/nested.