### PR TITLE
Removing ReaderPost.isLikesEnabled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -151,7 +151,6 @@ public class ReaderPostActions {
                     localPost.numLikes = serverPost.numLikes;
                     localPost.isFollowedByCurrentUser = serverPost.isFollowedByCurrentUser;
                     localPost.isLikedByCurrentUser = serverPost.isLikedByCurrentUser;
-                    localPost.isLikesEnabled = serverPost.isLikesEnabled;
                     localPost.isCommentsOpen = serverPost.isCommentsOpen;
                     localPost.setTitle(serverPost.getTitle());
                     localPost.setText(serverPost.getText());


### PR DESCRIPTION
isLikesEnabled is no longer used as all posts (except for Discover posts) have likes enabled

Needs review: @nbradbury 