### PR TITLE
Use homeURL instead of hostName to show the blog address on UI

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -151,14 +151,15 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
     }
 
     private String[] getBlogNames() {
-        List<Map<String, Object>> accounts = WordPress.wpDB.getVisibleBlogs();
+        String[] extraFields = {"homeURL"};
+        List<Map<String, Object>> accounts = WordPress.wpDB.getBlogsBy("isHidden = 0", extraFields);
         if (accounts.size() > 0) {
             final String blogNames[] = new String[accounts.size()];
             mAccountIDs = new int[accounts.size()];
             Blog blog;
             for (int i = 0; i < accounts.size(); i++) {
                 Map<String, Object> account = accounts.get(i);
-                blogNames[i] = BlogUtils.getBlogNameOrHostNameFromAccountMap(account);
+                blogNames[i] = BlogUtils.getBlogNameOrHomeURLFromAccountMap(account);
                 mAccountIDs[i] = (Integer) account.get("id");
                 blog = WordPress.wpDB.instantiateBlogByLocalId(mAccountIDs[i]);
                 if (blog == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -31,6 +31,7 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.ServiceUtils;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
 import org.wordpress.android.widgets.WPTextView;
 
@@ -303,10 +304,8 @@ public class MySiteFragment extends Fragment
         String blogName = StringUtils.unescapeHTML(mBlog.getBlogName());
         String homeURL;
         if (!TextUtils.isEmpty(mBlog.getHomeURL())) {
-            homeURL = mBlog.getHomeURL().replace("http://", "").replace("https://", "").trim();
-            if (homeURL.endsWith("/")) {
-                homeURL = homeURL.substring(0, homeURL.length() -1);
-            }
+            homeURL = UrlUtils.removeScheme(mBlog.getHomeURL());
+            homeURL = StringUtils.removeTrailingSlash(homeURL);
         } else {
             homeURL = StringUtils.getHost(mBlog.getUrl());
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -301,11 +301,19 @@ public class MySiteFragment extends Fragment
         mBlavatarImageView.setImageUrl(GravatarUtils.blavatarFromUrl(mBlog.getUrl(), mBlavatarSz), WPNetworkImageView.ImageType.BLAVATAR);
 
         String blogName = StringUtils.unescapeHTML(mBlog.getBlogName());
-        String hostName = StringUtils.getHost(mBlog.getUrl());
-        String blogTitle = TextUtils.isEmpty(blogName) ? hostName : blogName;
+        String homeURL;
+        if (!TextUtils.isEmpty(mBlog.getHomeURL())) {
+            homeURL = mBlog.getHomeURL().replace("http://", "").replace("https://", "").trim();
+            if (homeURL.endsWith("/")) {
+                homeURL = homeURL.substring(0, homeURL.length() -1);
+            }
+        } else {
+            homeURL = StringUtils.getHost(mBlog.getUrl());
+        }
+        String blogTitle = TextUtils.isEmpty(blogName) ? homeURL : blogName;
 
         mBlogTitleTextView.setText(blogTitle);
-        mBlogSubtitleTextView.setText(hostName);
+        mBlogSubtitleTextView.setText(homeURL);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -245,7 +245,7 @@ public class SitePickerActivity extends AppCompatActivity
             for (SiteRecord site : hiddenSites) {
                 if (site.localId == mCurrentLocalId) {
                     skippedCurrentSite = true;
-                    currentSiteName = site.getBlogNameOrHostName();
+                    currentSiteName = site.getBlogNameOrHomeURL();
                 } else {
                     WordPress.wpDB.setDotComBlogsVisibility(site.localId, false);
                     StatsTable.deleteStatsForBlog(this, site.localId); // Remove stats data for hidden sites

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -133,8 +133,8 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
     public void onBindViewHolder(SiteViewHolder holder, final int position) {
         SiteRecord site = getItem(position);
 
-        holder.txtTitle.setText(site.getBlogNameOrHostName());
-        holder.txtDomain.setText(site.hostName);
+        holder.txtTitle.setText(site.getBlogNameOrHomeURL());
+        holder.txtDomain.setText(site.homeURL);
         holder.imgBlavatar.setImageUrl(site.blavatarUrl, WPNetworkImageView.ImageType.BLAVATAR);
 
         holder.itemView.setOnClickListener(new View.OnClickListener() {
@@ -343,7 +343,7 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
         for (int i = 0; i < sites.size(); i++) {
             SiteRecord record = sites.get(i);
             String siteNameLowerCase = record.blogName.toLowerCase();
-            String hostNameLowerCase = record.hostName.toLowerCase();
+            String hostNameLowerCase = record.homeURL.toLowerCase();
 
             if (siteNameLowerCase.contains(mLastSearch.toLowerCase()) || hostNameLowerCase.contains(mLastSearch.toLowerCase())) {
                 filteredSiteList.add(record);
@@ -373,7 +373,7 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
         @Override
         protected Void doInBackground(Void... params) {
             List<Map<String, Object>> blogs;
-            String[] extraFields = {"isHidden", "dotcomFlag"};
+            String[] extraFields = {"isHidden", "dotcomFlag", "homeURL"};
 
             if (mIsInSearchMode) {
                 blogs = WordPress.wpDB.getBlogsBy(null, extraFields);
@@ -394,7 +394,7 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
                             return 1;
                         }
                     }
-                    return site1.getBlogNameOrHostName().compareToIgnoreCase(site2.getBlogNameOrHostName());
+                    return site1.getBlogNameOrHomeURL().compareToIgnoreCase(site2.getBlogNameOrHomeURL());
                 }
             });
 
@@ -440,7 +440,7 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
         final int localId;
         final int blogId;
         final String blogName;
-        final String hostName;
+        final String homeURL;
         final String url;
         final String blavatarUrl;
         final boolean isDotCom;
@@ -449,17 +449,17 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
         SiteRecord(Map<String, Object> account) {
             localId = MapUtils.getMapInt(account, "id");
             blogId = MapUtils.getMapInt(account, "blogId");
-            blogName = BlogUtils.getBlogNameFromAccountMap(account);
-            hostName = BlogUtils.getHostNameFromAccountMap(account);
+            blogName = BlogUtils.getBlogNameOrHomeURLFromAccountMap(account);
+            homeURL = BlogUtils.getHomeURLOrHostNameFromAccountMap(account);
             url = MapUtils.getMapStr(account, "url");
             blavatarUrl = GravatarUtils.blavatarFromUrl(url, mBlavatarSz);
             isDotCom = MapUtils.getMapBool(account, "dotcomFlag");
             isHidden = MapUtils.getMapBool(account, "isHidden");
         }
 
-        String getBlogNameOrHostName() {
+        String getBlogNameOrHomeURL() {
             if (TextUtils.isEmpty(blogName)) {
-                return hostName;
+                return homeURL;
             }
             return blogName;
         }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/BlogUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/BlogUtils.java
@@ -8,19 +8,19 @@ public class BlogUtils {
         public int compare(Object blog1, Object blog2) {
             Map<String, Object> blogMap1 = (Map<String, Object>) blog1;
             Map<String, Object> blogMap2 = (Map<String, Object>) blog2;
-            String blogName1 = getBlogNameOrHostNameFromAccountMap(blogMap1);
-            String blogName2 = getBlogNameOrHostNameFromAccountMap(blogMap2);
+            String blogName1 = getBlogNameOrHomeURLFromAccountMap(blogMap1);
+            String blogName2 = getBlogNameOrHomeURLFromAccountMap(blogMap2);
             return blogName1.compareToIgnoreCase(blogName2);
         }
     };
 
     /**
-     * Return a blog name or blog url (host part only) if trimmed name is an empty string
+     * Return a blog name or blog home URL if trimmed name is an empty string
      */
-    public static String getBlogNameOrHostNameFromAccountMap(Map<String, Object> account) {
+    public static String getBlogNameOrHomeURLFromAccountMap(Map<String, Object> account) {
         String blogName = getBlogNameFromAccountMap(account);
         if (blogName.trim().length() == 0) {
-            blogName = StringUtils.getHost(MapUtils.getMapStr(account, "url"));
+            blogName = BlogUtils.getHomeURLOrHostNameFromAccountMap(account);
         }
         return blogName;
     }
@@ -33,9 +33,18 @@ public class BlogUtils {
     }
 
     /**
-     * Return blog url (host part only) if trimmed name is an empty string
+     * Return the blog home URL setting or the host name if home URL is an empty string.
      */
-    public static String getHostNameFromAccountMap(Map<String, Object> account) {
-        return StringUtils.getHost(MapUtils.getMapStr(account, "url"));
+    public static String getHomeURLOrHostNameFromAccountMap(Map<String, Object> account) {
+        String homeURL = MapUtils.getMapStr(account, "homeURL").replace("http://", "").replace("https://", "").trim();
+        if (homeURL.endsWith("/")) {
+            homeURL = homeURL.substring(0, homeURL.length() -1);
+        }
+
+        if (homeURL.length() == 0) {
+            return StringUtils.getHost(MapUtils.getMapStr(account, "url"));
+        }
+
+        return homeURL;
     }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/BlogUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/BlogUtils.java
@@ -36,10 +36,8 @@ public class BlogUtils {
      * Return the blog home URL setting or the host name if home URL is an empty string.
      */
     public static String getHomeURLOrHostNameFromAccountMap(Map<String, Object> account) {
-        String homeURL = MapUtils.getMapStr(account, "homeURL").replace("http://", "").replace("https://", "").trim();
-        if (homeURL.endsWith("/")) {
-            homeURL = homeURL.substring(0, homeURL.length() -1);
-        }
+        String homeURL = UrlUtils.removeScheme(MapUtils.getMapStr(account, "homeURL"));
+        homeURL = StringUtils.removeTrailingSlash(homeURL);
 
         if (homeURL.length() == 0) {
             return StringUtils.getHost(MapUtils.getMapStr(account, "url"));

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/StringUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/StringUtils.java
@@ -180,6 +180,14 @@ public class StringUtils {
         return new StringBuilder(strLen).append(Character.toTitleCase(firstChar)).append(str.substring(1)).toString();
     }
 
+    public static String removeTrailingSlash(final String str) {
+        if (TextUtils.isEmpty(str) || !str.endsWith("/")) {
+            return str;
+        }
+
+        return str.substring(0, str.length() -1);
+    }
+
     /*
      * Wrap an image URL in a photon URL
      * Check out http://developer.wordpress.com/docs/photon/

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
@@ -138,6 +138,25 @@ public class UrlUtils {
         }
     }
 
+
+    /**
+     * returns the passed url without the scheme
+     */
+    public static String removeScheme(final String urlString) {
+        if (urlString == null) {
+            return null;
+        }
+
+        int doubleslash = urlString.indexOf("//");
+        if (doubleslash == -1) {
+            doubleslash = 0;
+        } else {
+            doubleslash += 2;
+        }
+
+        return urlString.substring(doubleslash, urlString.length());
+    }
+
     /**
      * returns the passed url without the query parameters
      */


### PR DESCRIPTION
Fix #3171 by using homeURL field to show the address of the blog on the UI.

Note: WordPress can be installed in a sub-directory, and so the hostName will be the same for two subdir installations on the same host. 