### PR TITLE
issue/3184-reader-followed-sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -19,7 +19,7 @@ import java.io.OutputStream;
  */
 public class ReaderDatabase extends SQLiteOpenHelper {
     protected static final String DB_NAME = "wpreader.db";
-    private static final int DB_VERSION = 106;
+    private static final int DB_VERSION = 107;
 
     /*
      * version history
@@ -58,6 +58,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      *  104 - added word_count to ReaderPostTable
      *  105 - added date_updated to ReaderBlogTable
      *  106 - dropped is_likes_enabled and is_sharing_enabled from tbl_posts
+     *  107 - "Blogs I Follow" renamed to "Followed Sites"
      */
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -456,10 +456,10 @@ public class ReaderPostTable {
             if (!isFollowed) {
                 if (blogId != 0) {
                     db.delete("tbl_post_tags", "blog_id=? AND tag_name=?",
-                            new String[]{Long.toString(blogId), ReaderTag.TAG_NAME_FOLLOWING});
+                            new String[]{Long.toString(blogId), ReaderTag.TAG_NAME_FOLLOWED_SITES});
                 } else {
                     db.delete("tbl_post_tags", "feed_id=? AND tag_name=?",
-                            new String[]{Long.toString(feedId), ReaderTag.TAG_NAME_FOLLOWING});
+                            new String[]{Long.toString(feedId), ReaderTag.TAG_NAME_FOLLOWED_SITES});
                 }
             }
 
@@ -588,7 +588,7 @@ public class ReaderPostTable {
             // longer followed if this is "Blogs I Follow"
             if (tag.isPostsILike()) {
                 sql += " AND tbl_posts.is_liked != 0";
-            } else if (tag.isBlogsIFollow()) {
+            } else if (tag.isFollowedSites()) {
                 sql += " AND tbl_posts.is_followed != 0";
             }
         }
@@ -658,7 +658,7 @@ public class ReaderPostTable {
         if (tag.tagType == ReaderTagType.DEFAULT) {
             if (tag.isPostsILike()) {
                 sql += " AND tbl_posts.is_liked != 0";
-            } else if (tag.isBlogsIFollow()) {
+            } else if (tag.isFollowedSites()) {
                 sql += " AND tbl_posts.is_followed != 0";
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -14,10 +14,15 @@ public class ReaderTag implements Serializable {
     public final ReaderTagType tagType;
 
     // these are the default tag names, which aren't localized in the /read/menu/ response
-    public static final String TAG_NAME_FOLLOWING = "Blogs I Follow";
     private static final String TAG_NAME_LIKED = "Posts I Like";
     private static final String TAG_NAME_FRESHLY_PRESSED = "Freshly Pressed";
     private static final String TAG_NAME_DEFAULT = TAG_NAME_FRESHLY_PRESSED;
+
+    // as of 15-Sept-2015 this is still "Blogs I Follow" but it will soon be renamed
+    // to "Followed Sites"
+    // TODO: remove TAG_NAME_FOLLOWED_SITES_OLD once backend has been updated
+    public static final String TAG_NAME_FOLLOWED_SITES = "Followed Sites";
+    public static final String TAG_NAME_FOLLOWED_SITES_OLD = "Blogs I Follow";
 
     public ReaderTag(String tagName, String endpoint, ReaderTagType tagType) {
         if (TextUtils.isEmpty(tagName)) {
@@ -128,9 +133,9 @@ public class ReaderTag implements Serializable {
         if (TextUtils.isEmpty(tagName)) {
             return false;
         }
-        return (tagName.equalsIgnoreCase(TAG_NAME_FOLLOWING)
-             || tagName.equalsIgnoreCase(TAG_NAME_FRESHLY_PRESSED)
-             || tagName.equalsIgnoreCase(TAG_NAME_LIKED));
+        return (tagName.equalsIgnoreCase(TAG_NAME_FOLLOWED_SITES)
+                || tagName.equalsIgnoreCase(TAG_NAME_FRESHLY_PRESSED)
+                || tagName.equalsIgnoreCase(TAG_NAME_LIKED));
     }
 
     private String getSanitizedTagName() {
@@ -146,12 +151,12 @@ public class ReaderTag implements Serializable {
     }
 
     public boolean isPostsILike() {
-        return getTagName().equals(TAG_NAME_LIKED);
+        return tagType == ReaderTagType.DEFAULT && getTagName().equals(TAG_NAME_LIKED);
     }
-    public boolean isBlogsIFollow() {
-        return getTagName().equals(TAG_NAME_FOLLOWING);
+    public boolean isFollowedSites() {
+        return tagType == ReaderTagType.DEFAULT && getTagName().equals(TAG_NAME_FOLLOWED_SITES);
     }
     public boolean isFreshlyPressed() {
-        return getTagName().equals(TAG_NAME_FRESHLY_PRESSED);
+        return tagType == ReaderTagType.DEFAULT && getTagName().equals(TAG_NAME_FRESHLY_PRESSED);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -151,12 +151,12 @@ public class ReaderTag implements Serializable {
     }
 
     public boolean isPostsILike() {
-        return tagType == ReaderTagType.DEFAULT && getTagName().equals(TAG_NAME_LIKED);
+        return tagType == ReaderTagType.DEFAULT && getEndpoint().endsWith("/read/liked");
     }
     public boolean isFollowedSites() {
-        return tagType == ReaderTagType.DEFAULT && getTagName().equals(TAG_NAME_FOLLOWED_SITES);
+        return tagType == ReaderTagType.DEFAULT && getEndpoint().endsWith("/read/following");
     }
     public boolean isFreshlyPressed() {
-        return tagType == ReaderTagType.DEFAULT && getTagName().equals(TAG_NAME_FRESHLY_PRESSED);
+        return tagType == ReaderTagType.DEFAULT && getTagName().endsWith("/freshly-pressed");
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -314,10 +314,10 @@ public class ReaderPostListFragment extends Fragment
 
     @SuppressWarnings("unused")
     public void onEventMainThread(ReaderEvents.FollowedBlogsChanged event) {
-        // refresh posts if user is viewing "Blogs I Follow"
+        // refresh posts if user is viewing "Followed Sites"
         if (getPostListType() == ReaderTypes.ReaderPostListType.TAG_FOLLOWED
                 && hasCurrentTag()
-                && getCurrentTag().isBlogsIFollow()) {
+                && getCurrentTag().isFollowedSites()) {
             refreshPosts();
         }
     }
@@ -530,7 +530,7 @@ public class ReaderPostListFragment extends Fragment
         } else if (getPostListType() == ReaderPostListType.BLOG_PREVIEW) {
             titleResId = R.string.reader_empty_posts_in_blog;
         } else if (getPostListType() == ReaderPostListType.TAG_FOLLOWED && hasCurrentTag()) {
-            if (getCurrentTag().isBlogsIFollow()) {
+            if (getCurrentTag().isFollowedSites()) {
                 titleResId = R.string.reader_empty_followed_blogs_title;
                 descriptionResId = R.string.reader_empty_followed_blogs_description;
             } else if (getCurrentTag().isPostsILike()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -202,6 +202,11 @@ public class ReaderUpdateService extends Service {
             if (jsonTopic != null) {
                 String tagName = JSONUtils.getStringDecoded(jsonTopic, "title");
                 String endpoint = JSONUtils.getString(jsonTopic, "URL");
+                // rename "Blogs I Follow" to "Followed Sites"
+                if (topicType == ReaderTagType.DEFAULT
+                        && tagName.equals(ReaderTag.TAG_NAME_FOLLOWED_SITES_OLD)) {
+                    tagName = ReaderTag.TAG_NAME_FOLLOWED_SITES;
+                }
                 topics.add(new ReaderTag(tagName, endpoint, topicType));
             }
         }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -784,8 +784,8 @@
 
     <!-- view pager titles -->
     <string name="reader_page_followed_tags">Followed tags</string>
-    <string name="reader_page_followed_blogs">Followed blogs</string>
-    <string name="reader_page_recommended_blogs">Blogs you may like</string>
+    <string name="reader_page_followed_blogs">Followed sites</string>
+    <string name="reader_page_recommended_blogs">Sites you may like</string>
 
     <!-- share dialog title when sharing a reader url -->
     <string name="reader_share_link">Share link</string>
@@ -870,7 +870,7 @@
     <string name="reader_empty_posts_in_tag_updating">Fetching posts…</string>
     <string name="reader_empty_followed_tags">You don\'t follow any tags</string>
     <string name="reader_empty_recommended_blogs">No recommended blogs</string>
-    <string name="reader_empty_followed_blogs_title">You\'re not following any blogs yet</string>
+    <string name="reader_empty_followed_blogs_title">You\'re not following any sites yet</string>
     <string name="reader_empty_followed_blogs_description">But don\'t worry, just tap the icon at the top right to start exploring!</string>
     <string name="reader_empty_posts_liked">You haven\'t liked any posts</string>
     <string name="reader_empty_comments">No comments yet</string>


### PR DESCRIPTION
Resolves #3184 - prepares the reader to deal with the pending backend rename of "Blogs I Follow" to "Followed Sites" by automatically renaming it to "Followed Sites" [here](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/3184-reader-followed-sites/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java#L206), and then identifying the default tags through their endpoint rather than tag name [here](https://github.com/wordpress-mobile/WordPress-Android/pull/3188/files#diff-058698d08eafb7f08d2ab321bb8dc05cR153).