### PR TITLE
Fix Notifications not Loading Because of WordPress.deferredInit()

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.notifications.NotificationDismissBroadcastReceiv
 import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
+import org.wordpress.android.ui.notifications.utils.SimperiumUtils;
 import org.wordpress.android.util.ABTestingUtils;
 import org.wordpress.android.util.ABTestingUtils.Feature;
 import org.wordpress.android.models.AccountHelper;
@@ -82,6 +83,9 @@ public class GCMIntentService extends GCMBaseIntentService {
     }
 
     private void handleDefaultPush(Context context, Bundle extras) {
+        // Ensure Simperium is running so that notes sync
+        SimperiumUtils.configureSimperium(context, AccountHelper.getDefaultAccount().getAccessToken());
+
         long wpcomUserId = AccountHelper.getDefaultAccount().getUserId();
         String pushUserId = extras.getString(PUSH_ARG_USER);
         // pushUserId is always set server side, but better to double check it here.

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -81,39 +81,6 @@ public class NotificationsListFragment extends Fragment
         mLinearLayoutManager = new LinearLayoutManager(getActivity());
         mRecyclerView.setLayoutManager(mLinearLayoutManager);
 
-        // setup the initial notes adapter, starts listening to the bucket
-        mBucket = SimperiumUtils.getNotesBucket();
-        if (mBucket != null) {
-            if (mNotesAdapter == null) {
-                mNotesAdapter = new NotesAdapter(getActivity(), mBucket);
-                mNotesAdapter.setOnNoteClickListener(new OnNoteClickListener() {
-                    @Override
-                    public void onClickNote(String noteId) {
-                        if (!isAdded()) {
-                            return;
-                        }
-
-                        if (TextUtils.isEmpty(noteId)) return;
-
-                        // open the latest version of this note just in case it has changed - this can
-                        // happen if the note was tapped from the list fragment after it was updated
-                        // by another fragment (such as NotificationCommentLikeFragment)
-                        openNote(getActivity(), noteId, false, true);
-                    }
-                });
-            }
-
-            mRecyclerView.setAdapter(mNotesAdapter);
-        } else {
-            if (!AccountHelper.isSignedInWordPressDotCom()) {
-                // let user know that notifications require a wp.com account and enable sign-in
-                showEmptyView(R.string.notifications_account_required, true);
-            } else {
-                // failed for some other reason
-                showEmptyView(R.string.error_refresh_notifications, false);
-            }
-        }
-
         return view;
     }
 
@@ -129,6 +96,8 @@ public class NotificationsListFragment extends Fragment
     @Override
     public void onResume() {
         super.onResume();
+
+        configureBucketAndAdapter();
         refreshNotes();
 
         // start listening to bucket change events
@@ -163,6 +132,43 @@ public class NotificationsListFragment extends Fragment
 
         super.onDestroy();
     }
+
+    // Sets up the notes bucket and list adapter
+    private void configureBucketAndAdapter() {
+        mBucket = SimperiumUtils.getNotesBucket();
+        if (mBucket != null) {
+            if (mNotesAdapter == null) {
+                mNotesAdapter = new NotesAdapter(getActivity(), mBucket);
+                mNotesAdapter.setOnNoteClickListener(mOnNoteClickListener);
+            }
+
+            mRecyclerView.setAdapter(mNotesAdapter);
+        } else {
+            if (!AccountHelper.isSignedInWordPressDotCom()) {
+                // let user know that notifications require a wp.com account and enable sign-in
+                showEmptyView(R.string.notifications_account_required, true);
+            } else {
+                // failed for some other reason
+                showEmptyView(R.string.error_refresh_notifications, false);
+            }
+        }
+    }
+
+    private OnNoteClickListener mOnNoteClickListener = new OnNoteClickListener() {
+        @Override
+        public void onClickNote(String noteId) {
+            if (!isAdded()) {
+                return;
+            }
+
+            if (TextUtils.isEmpty(noteId)) return;
+
+            // open the latest version of this note just in case it has changed - this can
+            // happen if the note was tapped from the list fragment after it was updated
+            // by another fragment (such as NotificationCommentLikeFragment)
+            openNote(getActivity(), noteId, false, true);
+        }
+    };
 
     /**
      * Open a note fragment based on the type of note

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -140,9 +140,8 @@ public class NotificationsListFragment extends Fragment
             if (mNotesAdapter == null) {
                 mNotesAdapter = new NotesAdapter(getActivity(), mBucket);
                 mNotesAdapter.setOnNoteClickListener(mOnNoteClickListener);
+                mRecyclerView.setAdapter(mNotesAdapter);
             }
-
-            mRecyclerView.setAdapter(mNotesAdapter);
         } else {
             if (!AccountHelper.isSignedInWordPressDotCom()) {
                 // let user know that notifications require a wp.com account and enable sign-in

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -140,6 +140,9 @@ public class NotificationsListFragment extends Fragment
             if (mNotesAdapter == null) {
                 mNotesAdapter = new NotesAdapter(getActivity(), mBucket);
                 mNotesAdapter.setOnNoteClickListener(mOnNoteClickListener);
+            }
+
+            if (mRecyclerView.getAdapter() == null) {
                 mRecyclerView.setAdapter(mNotesAdapter);
             }
         } else {


### PR DESCRIPTION
Moves the bucket related code to `onResume` of `NotificationsListFragment`

This ensures that the simperium bucket will have been loaded from the `deferredInit()` method in `WordPress.java`

Also added a line in `GCMIntentService` that will start Simperium when a push is received. This way Simperium will still sync when a push is received (this broke with the introduction of deferredInit).

cc @maxme 

Fixes #3177