### PR TITLE
issue/3194-snackbar-dismiss

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/Constants.java
+++ b/WordPress/src/main/java/org/wordpress/android/Constants.java
@@ -20,7 +20,4 @@ public class Constants {
     public static int QUICK_POST_PHOTO_LIBRARY = 1;
 
     public static final int INTENT_COMMENT_EDITOR     = 1010;
-
-    // SnackbarManager.LONG_DURATION_MS
-    public static final long SNACKBAR_LONG_DURATION_MS = 2750;
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -6,14 +6,12 @@ import android.app.FragmentManager;
 import android.app.FragmentTransaction;
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Handler;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
 import android.view.View;
 
-import org.wordpress.android.Constants;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.BlogPairId;
@@ -267,14 +265,15 @@ public class CommentsActivity extends AppCompatActivity
                 }
             };
 
-            Snackbar.make(getListFragment().getView(), message, Snackbar.LENGTH_LONG)
-                    .setAction(R.string.undo, undoListener)
-                    .show();
+            Snackbar snackbar = Snackbar.make(getListFragment().getView(), message, Snackbar.LENGTH_LONG)
+                    .setAction(R.string.undo, undoListener);
 
             // do the actual moderation once the undo bar has been hidden
-            new Handler().postDelayed(new Runnable() {
+            snackbar.setCallback(new Snackbar.Callback() {
                 @Override
-                public void run() {
+                public void onDismissed(Snackbar snackbar, int event) {
+                    super.onDismissed(snackbar, event);
+
                     // comment will no longer exist in moderating list if action was undone
                     if (!isFinishing()
                             && hasListFragment()
@@ -289,9 +288,7 @@ public class CommentsActivity extends AppCompatActivity
                             if (isFinishing() || !hasListFragment()) {
                                 return;
                             }
-
                             getListFragment().setCommentIsModerating(comment.commentID, false);
-
                             if (!succeeded) {
                                 // show comment again upon error
                                 getListFragment().loadComments();
@@ -303,7 +300,9 @@ public class CommentsActivity extends AppCompatActivity
                         }
                     });
                 }
-            }, Constants.SNACKBAR_LONG_DURATION_MS);
+            });
+
+            snackbar.show();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -11,7 +11,6 @@ import android.content.res.Resources;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.support.design.widget.Snackbar;
 import android.text.Layout;
@@ -33,7 +32,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.BuildConfig;
-import org.wordpress.android.Constants;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -469,15 +467,15 @@ public class NotificationsUtils {
         };
 
         mSnackbarDidUndo = false;
-        Snackbar.make(parentView, message, Snackbar.LENGTH_LONG)
-                .setAction(R.string.undo, undoListener)
-                .show();
+        Snackbar snackbar = Snackbar.make(parentView, message, Snackbar.LENGTH_LONG)
+                .setAction(R.string.undo, undoListener);
 
         // Deleted notifications in Simperium never come back, so we won't
         // make the request until the undo bar fades away
-        new Handler().postDelayed(new Runnable() {
+        snackbar.setCallback(new Snackbar.Callback() {
             @Override
-            public void run() {
+            public void onDismissed(Snackbar snackbar, int event) {
+                super.onDismissed(snackbar, event);
                 if (mSnackbarDidUndo) {
                     return;
                 }
@@ -492,7 +490,9 @@ public class NotificationsUtils {
                             }
                         });
             }
-        }, Constants.SNACKBAR_LONG_DURATION_MS);
+        });
+
+        snackbar.show();
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -17,7 +17,6 @@ import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import org.wordpress.android.Constants;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Post;
@@ -468,14 +467,15 @@ public class PostsListFragment extends Fragment
             text = mIsPage ? getString(R.string.page_trashed) : getString(R.string.post_trashed);
         }
 
-        Snackbar.make(getView().findViewById(R.id.coordinator), text, Snackbar.LENGTH_LONG)
-                .setAction(R.string.undo, undoListener)
-                .show();
+        Snackbar snackbar = Snackbar.make(getView().findViewById(R.id.coordinator), text, Snackbar.LENGTH_LONG)
+                .setAction(R.string.undo, undoListener);
 
         // wait for the undo snackbar to disappear before actually deleting the post
-        new Handler().postDelayed(new Runnable() {
+        snackbar.setCallback(new Snackbar.Callback() {
             @Override
-            public void run() {
+            public void onDismissed(Snackbar snackbar, int event) {
+                super.onDismissed(snackbar, event);
+
                 // if the post no longer exists in the list of trashed posts it's because the
                 // user undid the trash, so don't perform the deletion
                 if (!mTrashedPosts.contains(post)) {
@@ -493,6 +493,8 @@ public class PostsListFragment extends Fragment
                     new ApiHelper.DeleteSinglePostTask().execute(apiArgs);
                 }
             }
-        }, Constants.SNACKBAR_LONG_DURATION_MS);
+        });
+
+        snackbar.show();
     }
 }


### PR DESCRIPTION
Fixes #3194 - Updated the snackbars in CommentsActivity, NotificationsUtils, and PostListFragment to use the new `onDismissed` event.