### PR TITLE
issue/3196-ripple-color

### DIFF
--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -12,7 +12,7 @@
     <color name="color_primary_dark">@color/status_bar_tint</color>
     <color name="color_accent">@color/orange_jazzy</color>
     <color name="color_control_activated">@color/blue_light</color>
-    <color name="color_control_highlight">@color/pressed_wordpress</color>
+    <color name="color_control_highlight">@color/grey_lighten_20</color>
 
     <color name="fab_normal">@color/color_accent</color>
     <color name="fab_pressed">@color/orange_fire</color>


### PR DESCRIPTION
Resolves #3196 - Changed `color_control_highlight` to `grey_lighten_20`, which changes the color for ripples & selection highlights.