### PR TITLE
Use Latest Version of Simperium

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     compile 'org.wordpress:emailchecker:0.3'
 
     // Simperium
-    compile 'com.simperium.android:simperium:0.6.4'
+    compile 'com.simperium.android:simperium:0.6.6'
 
     releaseCompile project(path:':libs:utils:WordPressUtils', configuration: 'release')
     debugCompile project(path:':libs:utils:WordPressUtils', configuration: 'debug')


### PR DESCRIPTION
Updates to latest version of Simperium, which included a fix that allows it to function on a non-ui thread.

To test that this works:
1. Start the app, load notifications tab.
2. Kill the app.
3. Send yourself a push notification, then open it. You should be taken to the note detail.

Refs #3177 and https://github.com/Simperium/simperium-android/issues/182