### PR TITLE
Remove -dontobfuscate option from proguard

### DIFF
--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -4,7 +4,6 @@
 -dontpreverify
 -dontoptimize
 -dontshrink
--dontobfuscate
 
 -keepclassmembers class ** {
     public void onEvent*(**);


### PR DESCRIPTION
I thought options order was important in Proguard, but it seems `-dontobfuscate` take over the Samsung Menuview workaround -keep class !android.support.v7.internal.view.menu.**,** {*;}.**,** {*;}`

We keep all classes excepted in `android.support.v7.internal.view.menu.*`, so I guess it's safe to remove `-dontobfuscate` completely.