### PR TITLE
issue/reader-subs-tweak

### DIFF
--- a/WordPress/src/main/res/layout/reader_activity_subs.xml
+++ b/WordPress/src/main/res/layout/reader_activity_subs.xml
@@ -2,7 +2,6 @@
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/white">
@@ -60,7 +59,7 @@
             android:layout_height="wrap_content"
             android:background="?android:selectableItemBackground"
             android:padding="@dimen/margin_small"
-            android:src="@drawable/ic_add_grey600_24dp" />
+            android:src="@drawable/reader_follow" />
 
     </LinearLayout>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -805,7 +805,7 @@
     <!-- EditText hints -->
     <string name="reader_hint_comment_on_post">Reply to post…</string>
     <string name="reader_hint_comment_on_comment">Reply to comment…</string>
-    <string name="reader_hint_add_tag_or_url">Enter a tag or URL to follow</string>
+    <string name="reader_hint_add_tag_or_url">Enter a URL or tag to follow</string>
 
     <!-- TextView labels -->
     <string name="reader_label_new_posts">New posts</string>


### PR DESCRIPTION
Two very minor tweaks to the reader subs activity:

* Change the EditText hint from "Enter a tag or URL to follow" to "Enter a URL or tag to follow"
* Change the plus icon in the EditText to a follow icon

![device-2015-09-21-111822](https://cloud.githubusercontent.com/assets/3903757/9995921/9f95fad6-6052-11e5-8e57-522f1ffe6034.png)
