### PR TITLE
Issue/3207 reader liking users

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -14,6 +14,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
@@ -68,7 +69,7 @@ public class ReaderPostDetailFragment extends Fragment
     private ViewGroup mLayoutFooter;
     private ReaderWebView mReaderWebView;
     private ReaderLikingUsersView mLikingUsersView;
-    private View mLikingUsersContainer;
+    private View mLikingUsersDivider;
 
     private boolean mHasAlreadyUpdatedPost;
     private boolean mHasAlreadyRequestedPost;
@@ -135,7 +136,7 @@ public class ReaderPostDetailFragment extends Fragment
 
         mLayoutFooter = (ViewGroup) view.findViewById(R.id.layout_post_detail_footer);
         mLikingUsersView = (ReaderLikingUsersView) view.findViewById(R.id.layout_liking_users_view);
-        mLikingUsersContainer = view.findViewById(R.id.liking_users_container);
+        mLikingUsersDivider = view.findViewById(R.id.layout_liking_users_divider);
 
         // setup the ReaderWebView
         mReaderWebView = (ReaderWebView) view.findViewById(R.id.reader_webview);
@@ -146,6 +147,19 @@ public class ReaderPostDetailFragment extends Fragment
         // hide footer and scrollView until the post is loaded
         mLayoutFooter.setVisibility(View.INVISIBLE);
         mScrollView.setVisibility(View.INVISIBLE);
+
+        // set the footer spacer height to match the footer height once it's laid out
+        mLayoutFooter.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+            @Override
+            public void onGlobalLayout() {
+                mScrollView.getViewTreeObserver().removeGlobalOnLayoutListener(this);
+                if (isAdded()) {
+                    int footerHeight = mLayoutFooter.getHeight();
+                    View spacer = getView().findViewById(R.id.footer_spacer);
+                    spacer.getLayoutParams().height = footerHeight;
+                }
+            }
+        });
 
         return view;
     }
@@ -421,10 +435,11 @@ public class ReaderPostDetailFragment extends Fragment
                     }
                 });
             }
-            // if we know refreshLikes() is going to show the liking layout, force it to take up
-            // space right now
-            if (mPost.numLikes > 0 && mLikingUsersContainer.getVisibility() == View.GONE) {
-                mLikingUsersContainer.setVisibility(View.INVISIBLE);
+            // if we know refreshLikes() is going to show the liking users, force liking user
+            // views to take up space right now
+            if (mPost.numLikes > 0 && mLikingUsersView.getVisibility() == View.GONE) {
+                mLikingUsersView.setVisibility(View.INVISIBLE);
+                mLikingUsersDivider.setVisibility(View.INVISIBLE);
             }
         } else {
             countLikes.setVisibility(View.INVISIBLE);
@@ -442,9 +457,8 @@ public class ReaderPostDetailFragment extends Fragment
 
         // nothing more to do if no likes
         if (mPost.numLikes == 0) {
-            if (mLikingUsersContainer.getVisibility() != View.GONE) {
-                AniUtils.fadeOut(mLikingUsersContainer, AniUtils.Duration.SHORT);
-            }
+            mLikingUsersView.setVisibility(View.GONE);
+            mLikingUsersDivider.setVisibility(View.GONE);
             return;
         }
 
@@ -456,10 +470,8 @@ public class ReaderPostDetailFragment extends Fragment
             }
         });
 
-        if (mLikingUsersContainer.getVisibility() != View.VISIBLE) {
-            AniUtils.fadeIn(mLikingUsersContainer, AniUtils.Duration.SHORT);
-        }
-
+        mLikingUsersDivider.setVisibility(View.VISIBLE);
+        mLikingUsersView.setVisibility(View.VISIBLE);
         mLikingUsersView.showLikingUsers(mPost);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -14,7 +14,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewTreeObserver;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
@@ -147,19 +146,6 @@ public class ReaderPostDetailFragment extends Fragment
         // hide footer and scrollView until the post is loaded
         mLayoutFooter.setVisibility(View.INVISIBLE);
         mScrollView.setVisibility(View.INVISIBLE);
-
-        // set the footer spacer height to match the footer height once it's laid out
-        mLayoutFooter.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
-            @Override
-            public void onGlobalLayout() {
-                mScrollView.getViewTreeObserver().removeGlobalOnLayoutListener(this);
-                if (isAdded()) {
-                    int footerHeight = mLayoutFooter.getHeight();
-                    View spacer = getView().findViewById(R.id.footer_spacer);
-                    spacer.getLayoutParams().height = footerHeight;
-                }
-            }
-        });
 
         return view;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderLikingUsersView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderLikingUsersView.java
@@ -63,10 +63,10 @@ public class ReaderLikingUsersView extends LinearLayout {
      * returns count of avatars that can fit the current space
      */
     private int getMaxAvatars() {
-        int marginExtraSmall = getResources().getDimensionPixelSize(R.dimen.margin_extra_small);
-        int marginLarge = getResources().getDimensionPixelSize(R.dimen.margin_large);
-        int likeAvatarSizeWithMargin = mLikeAvatarSz + (marginExtraSmall * 2);
-        int spaceForAvatars = getWidth() - (marginLarge * 2);
+        int marginAvatar = getResources().getDimensionPixelSize(R.dimen.margin_extra_small);
+        int marginReader = getResources().getDimensionPixelSize(R.dimen.reader_detail_margin);
+        int likeAvatarSizeWithMargin = mLikeAvatarSz + (marginAvatar * 2);
+        int spaceForAvatars = getWidth() - (marginReader * 2);
         return spaceForAvatars / likeAvatarSizeWithMargin;
     }
 

--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -14,9 +14,8 @@
         <org.wordpress.android.widgets.WPScrollView
             android:id="@+id/scroll_view_reader"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:clipToPadding="false"
-            android:fillViewport="true"
             android:scrollbarStyle="insideOverlay">
 
             <LinearLayout
@@ -42,11 +41,6 @@
                     layout="@layout/reader_include_post_detail_content"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content" />
-
-                <View
-                    android:id="@+id/footer_spacer"
-                    android:layout_width="match_parent"
-                    android:layout_height="96dp" />
 
             </LinearLayout>
 

--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -43,6 +43,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content" />
 
+                <!-- spacer so toolbar footer doesn't overlay content -->
                 <View
                     android:id="@+id/footer_spacer"
                     android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -43,11 +43,10 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content" />
 
-                <!-- spacer so toolbar footer doesn't overlay content -->
                 <View
                     android:id="@+id/footer_spacer"
                     android:layout_width="match_parent"
-                    android:layout_height="@dimen/toolbar_height" />
+                    android:layout_height="96dp" />
 
             </LinearLayout>
 

--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -42,6 +42,11 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content" />
 
+                <View
+                    android:id="@+id/footer_spacer"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/toolbar_height" />
+
             </LinearLayout>
 
         </org.wordpress.android.widgets.WPScrollView>

--- a/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
@@ -8,7 +8,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:paddingBottom="@dimen/margin_large"
     android:paddingTop="@dimen/margin_large">
 
     <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
@@ -38,33 +38,26 @@
         android:layout_marginTop="@dimen/margin_large"
         android:scrollbars="none" />
 
-    <LinearLayout
-        android:id="@+id/liking_users_container"
+    <View
+        android:id="@+id/layout_liking_users_divider"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
+        android:layout_height="1dp"
+        android:layout_marginTop="@dimen/margin_medium"
+        android:background="@color/reader_divider_grey"
         android:visibility="gone"
-        tools:visibility="visible">
+        tools:visibility="visible" />
 
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginBottom="@dimen/margin_small"
-            android:layout_marginTop="@dimen/margin_small"
-            android:background="@color/reader_divider_grey" />
-
-        <!-- liking avatars are inserted into this view at runtime -->
-        <org.wordpress.android.ui.reader.views.ReaderLikingUsersView
-            android:id="@+id/layout_liking_users_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?android:selectableItemBackground"
-            android:minHeight="@dimen/avatar_sz_small"
-            android:paddingBottom="@dimen/margin_medium"
-            android:paddingLeft="@dimen/reader_detail_margin"
-            android:paddingRight="@dimen/reader_detail_margin"
-            android:paddingTop="@dimen/margin_medium" />
-
-    </LinearLayout>
+    <!-- liking avatars are inserted into this view at runtime -->
+    <org.wordpress.android.ui.reader.views.ReaderLikingUsersView
+        android:id="@+id/layout_liking_users_view"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/avatar_sz_small"
+        android:layout_marginBottom="@dimen/margin_medium"
+        android:layout_marginTop="@dimen/margin_medium"
+        android:background="?android:selectableItemBackground"
+        android:paddingLeft="@dimen/reader_detail_margin"
+        android:paddingRight="@dimen/reader_detail_margin"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/reader_like_avatar.xml
+++ b/WordPress/src/main/res/layout/reader_like_avatar.xml
@@ -5,5 +5,6 @@
 -->
 <org.wordpress.android.widgets.WPNetworkImageView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/image_like_avatar"
-    style="@style/ReaderImageView.Avatar.Like"
+    android:layout_width="@dimen/avatar_sz_small"
+    android:layout_height="@dimen/avatar_sz_small"
     android:layout_marginRight="@dimen/margin_small" />

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -103,10 +103,6 @@
         <item name="android:layout_width">@dimen/avatar_sz_small</item>
         <item name="android:layout_height">@dimen/avatar_sz_small</item>
     </style>
-    <style name="ReaderImageView.Avatar.Like" parent="ReaderImageView">
-        <item name="android:layout_width">@dimen/avatar_sz_small</item>
-        <item name="android:layout_height">@dimen/avatar_sz_small</item>
-    </style>
 
     <!-- progress bars -->
     <style name="ReaderProgressBar" parent="@android:style/Widget.Holo.Light.ProgressBar" />


### PR DESCRIPTION
Fixes #3207 - Problem was due to the spacer below the reader content not being tall enough to prevent the footer toolbar from overlaying it. This problem likely existed in previous versions but it become more noticeable in 4.6 due to the inclusion of a container view and [divider](https://github.com/wordpress-mobile/WordPress-Android/pull/3179) for liking users.

This container view has been dropped, and I also removed the animation of the liking users view (unnecessary since each avatar already animates in).