### PR TITLE
Fix login issue with Jetpack blog, and fixes issues with Jetp

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -808,7 +808,7 @@ public class WordPressDB {
      * Jetpack blogs have the "wpcom" blog_id stored in options->api_blogid. This is because self-hosted blogs have both
      * a blogID (local to their network), and a unique blogID on wpcom.
      */
-    private int getLocalTableBlogIdForJetpackRemoteID(int remoteBlogId, String xmlRpcUrl) {
+    public int getLocalTableBlogIdForJetpackRemoteID(int remoteBlogId, String xmlRpcUrl) {
         if (TextUtils.isEmpty(xmlRpcUrl)) {
             String sql = "SELECT id FROM " + BLOGS_TABLE + " WHERE dotcomFlag=0 AND api_blogid=?";
             String[] args = {Integer.toString(remoteBlogId)};

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractInsightsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractInsightsFragment.java
@@ -129,7 +129,10 @@ public abstract class StatsAbstractInsightsFragment extends StatsAbstractFragmen
         }
 
         if (isDataEmpty(0)) {
-            showErrorUI(null);
+            // This is just an additional check. We only have 1 endpoint per fragment here.
+            // mDatamodels is either null or not empty at position 0
+            String label = "<b>" + getString(R.string.error_refresh_stats) + "</b>";
+            showErrorUI(label);
             return;
         }
 
@@ -156,6 +159,10 @@ public abstract class StatsAbstractInsightsFragment extends StatsAbstractFragmen
 
         if (error instanceof NoConnectionError) {
             label += "<br/>" + getString(R.string.no_network_message);
+        }
+
+        if (StatsUtils.isRESTDisabledError(error)) {
+            label += "<br/>" + getString(R.string.stats_enable_rest_api_in_jetpack);
         }
 
         showErrorUI(label);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
@@ -353,6 +353,20 @@ public class StatsUtils {
         AppLog.e(T.STATS, "Volley Error Message: " + volleyError.getMessage(), volleyError);
     }
 
+    public static synchronized boolean isRESTDisabledError(final Serializable error) {
+        if (error == null || !(error instanceof com.android.volley.AuthFailureError)) {
+            return false;
+        }
+        com.android.volley.AuthFailureError volleyError = (com.android.volley.AuthFailureError) error;
+        if (volleyError.networkResponse != null && volleyError.networkResponse.data != null) {
+            String errorMessage = new String(volleyError.networkResponse.data).toLowerCase();
+            return errorMessage.contains("api calls") && errorMessage.contains("disabled");
+        } else {
+            AppLog.e(T.STATS, "Network response is null in Volley. Can't check if it is a Rest Disabled error.");
+            return false;
+        }
+    }
+
     public static synchronized Serializable parseResponse(StatsService.StatsEndpointsEnum endpointName, String blogID, JSONObject response)
             throws JSONException {
         Serializable model = null;

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -433,7 +433,7 @@
     <string name="stats_no_blog">Stats couldn\'t be loaded for the required blog</string>
     <string name="stats_generic_error">Required Stats couldn\'t be loaded</string>
     <string name="stats_sign_in_jetpack_different_com_account">To view your stats, sign in to the WordPress.com account you used to connect Jetpack.</string>
-    <string name="stats_enable_rest_api_in_jetpack">To view your stats, enable the REST API module in Jetpack.</string>
+    <string name="stats_enable_rest_api_in_jetpack">To view your stats, enable the JSON API module in Jetpack.</string>
 
     <!-- stats: labels for timeframes -->
     <string name="stats_timeframe_today">Today</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -433,6 +433,7 @@
     <string name="stats_no_blog">Stats couldn\'t be loaded for the required blog</string>
     <string name="stats_generic_error">Required Stats couldn\'t be loaded</string>
     <string name="stats_sign_in_jetpack_different_com_account">To view your stats, sign in to the WordPress.com account you used to connect Jetpack.</string>
+    <string name="stats_enable_rest_api_in_jetpack">To view your stats, enable the REST API module in Jetpack.</string>
 
     <!-- stats: labels for timeframes -->
     <string name="stats_timeframe_today">Today</string>


### PR DESCRIPTION
This PR fixes login issues with Jetpack blogs, and fixes issues with Jetpack blogs that have REST API disabled. (The rest api is only used in 1 fragment in insights. It's a kind of edge case for now).

- Fix #3210 by  reading the correct localBlogID for a Jetpack blog.
- Fix #3187 by showing the correct error message when REST API are disabled on the blog.