### PR TITLE
Add new release checks

### DIFF
--- a/tools/release-checks.sh
+++ b/tools/release-checks.sh
@@ -36,6 +36,7 @@ function checkSamsungWorkaround() {
 	apktool -f -r d WordPress/build/outputs/apk/WordPress-vanilla-release-unaligned.apk -o /tmp/wpandroid-checksamsungworkaround/ > /dev/null && ls -1 /tmp/wpandroid-checksamsungworkaround/smali/android/support/v7/internal/view/menu/MenuBuilder* > /dev/null 2>&1
 	if [ $? -eq 0 ]; then
 		pFail
+		echo "See http://stackoverflow.com/q/24809580/58332 for more informations"
 		exit 4
 	fi
 	pOk

--- a/tools/release-checks.sh
+++ b/tools/release-checks.sh
@@ -27,6 +27,19 @@ function pFail() {
 	echo "[$(tput setaf 1)KO$(tput sgr0)]"
 }
 
+function checkSamsungWorkaround() {
+	/bin/echo -n "Check for the Samsung android.support.v7.internal.view.menu workaround..."
+	./gradlew clean > /dev/null 2>&1
+	./gradlew assembleVanillaRelease > /dev/null 2>&1
+	apktool -f -r d WordPress/build/outputs/apk/WordPress-vanilla-release-unaligned.apk -o /tmp/wpandroid-checksamsungworkaround/ > /dev/null
+	ls -1 /tmp/wpandroid-checksamsungworkaround/smali/android/support/v7/internal/view/menu/MenuBuilder* > /dev/null 2>&1
+	if [ $? -eq 0 ]; then
+		pFail
+		exit 4
+	fi
+	pOk
+}
+
 function checkENStrings() {
 	if [[ -n $(git status --porcelain|grep "M res") ]]; then
 		/bin/echo -n "Unstagged changes detected in $RESDIR/ - can't continue..."
@@ -83,5 +96,6 @@ function checkVersions() {
 checkNewLanguages
 checkENStrings
 checkVersions
+checkSamsungWorkaround
 # checkDeviceToTest
 # runConnectedTests

--- a/tools/release-checks.sh
+++ b/tools/release-checks.sh
@@ -93,9 +93,21 @@ function checkVersions() {
 	echo "last git tag version is $tag"
 }
 
+function checkGradleProperties() {
+	/bin/echo -n "Check WordPress/gradle.properties..."
+	checksum=`cat WordPress/gradle.properties|grep "^wp."|tr "[A-Z]" "[a-z]"|sed "s/ //g"|sort|sha1sum |cut -d- -f1| sed "s/ //g"`
+	known_checksum="e55897c69b6c2e17facb1c9ad4afe45f566eed20"
+	if [ x$checksum != x$known_checksum ]; then
+		pFail
+		exit 5
+	fi
+	pOk
+}
+
 checkNewLanguages
 checkENStrings
 checkVersions
 checkSamsungWorkaround
+checkGradleProperties
 # checkDeviceToTest
 # runConnectedTests

--- a/tools/release-checks.sh
+++ b/tools/release-checks.sh
@@ -29,10 +29,11 @@ function pFail() {
 
 function checkSamsungWorkaround() {
 	/bin/echo -n "Check for the Samsung android.support.v7.internal.view.menu workaround..."
-	./gradlew clean > /dev/null 2>&1
-	./gradlew assembleVanillaRelease > /dev/null 2>&1
-	apktool -f -r d WordPress/build/outputs/apk/WordPress-vanilla-release-unaligned.apk -o /tmp/wpandroid-checksamsungworkaround/ > /dev/null
-	ls -1 /tmp/wpandroid-checksamsungworkaround/smali/android/support/v7/internal/view/menu/MenuBuilder* > /dev/null 2>&1
+	apktool > /dev/null 2>&1 || (pFail; echo "You need apktool installed to run this check (brew install apktool)"; exit 1) || exit 4
+	./gradlew clean --offline > /dev/null 2>&1
+	./gradlew assembleVanillaRelease --offline > /dev/null 2>&1
+	rm -rf /tmp/wpandroid-checksamsungworkaround/
+	apktool -f -r d WordPress/build/outputs/apk/WordPress-vanilla-release-unaligned.apk -o /tmp/wpandroid-checksamsungworkaround/ > /dev/null && ls -1 /tmp/wpandroid-checksamsungworkaround/smali/android/support/v7/internal/view/menu/MenuBuilder* > /dev/null 2>&1
 	if [ $? -eq 0 ]; then
 		pFail
 		exit 4


### PR DESCRIPTION
2 new checks:

1. Make sure the Samsung workaround that rename `check for the Samsung android.support.v7.internal.view.menu.MenuBuilder*` classes is in the release apk
1. Make sure the `wp.` fields in gradle.properties file are correctly set - they rarely change so not a big deal to have the checksum hardcoded here

cc @kwonye for de6a2af ;)
