### PR TITLE
issue/3214-reader-tag-overlap

### DIFF
--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -158,10 +158,13 @@
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/text_tag"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
+                android:layout_toLeftOf="@+id/count_comments"
                 android:background="?android:selectableItemBackground"
+                android:ellipsize="end"
+                android:maxLines="1"
                 android:paddingBottom="@dimen/margin_small"
                 android:paddingRight="@dimen/margin_small"
                 android:paddingTop="@dimen/margin_small"

--- a/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
@@ -27,6 +27,7 @@
         android:layout_centerVertical="true"
         android:layout_marginLeft="@dimen/reader_detail_margin"
         android:layout_marginTop="@dimen/margin_medium"
+        android:layout_toLeftOf="@+id/layout_icons"
         android:background="?android:selectableItemBackground"
         android:ellipsize="end"
         android:gravity="center_vertical"

--- a/WordPress/src/main/res/layout/reader_tag_info_view.xml
+++ b/WordPress/src/main/res/layout/reader_tag_info_view.xml
@@ -19,9 +19,12 @@
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/text_tag"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
+            android:layout_toLeftOf="@+id/follow_button"
+            android:ellipsize="end"
+            android:maxLines="1"
             android:textColor="@color/grey_dark"
             android:textSize="@dimen/text_sz_large"
             tools:text="text_tag" />


### PR DESCRIPTION
Fixes #3214 - long tag names no longer overlap icons or wrap to multiple lines. Screens below show before (top) and after (bottom) for comparison.

![tag-fix](https://cloud.githubusercontent.com/assets/3903757/10026232/84ca6d9a-612e-11e5-8268-1d58d11798fc.png)
