### PR TITLE
issue/3217-reader-comment-keyboard

### DIFF
--- a/WordPress/src/main/res/layout/reader_activity_comment_list.xml
+++ b/WordPress/src/main/res/layout/reader_activity_comment_list.xml
@@ -21,9 +21,8 @@
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/text_empty"
         style="@style/ReaderTextView.EmptyList"
-        android:layout_centerInParent="true"
-        android:paddingBottom="@dimen/margin_large"
-        android:paddingTop="@dimen/margin_large"
+        android:layout_above="@+id/layout_bottom"
+        android:layout_marginBottom="@dimen/margin_extra_large"
         android:text="@string/reader_empty_comments"
         android:textColor="@color/grey_darken_10"
         android:visibility="gone"


### PR DESCRIPTION
Fixes #3217 - this one turned out to be trickier than it should've been. I tried a few things, including hiding the empty text when the soft keyboard appears and then redisplaying it when the keyboard is hidden, but none of them worked very well. In the end I chose to simply place the empty text right above the comment EditText, so it would automatically move up with the EditText without obscuring the post header.