### PR TITLE
issue/3217-reader-comment-keyboard

### DIFF
--- a/WordPress/src/main/res/layout/reader_activity_comment_list.xml
+++ b/WordPress/src/main/res/layout/reader_activity_comment_list.xml
@@ -9,26 +9,24 @@
         android:id="@+id/toolbar"
         layout="@layout/toolbar" />
 
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/text_empty"
+        style="@style/ReaderTextView.EmptyList"
+        android:layout_above="@+id/layout_bottom"
+        android:layout_below="@+id/toolbar"
+        android:text="@string/reader_empty_comments"
+        android:textColor="@color/grey_darken_10"
+        android:visibility="gone"
+        app:fixWidowWords="true"
+        tools:visibility="visible" />
+
     <org.wordpress.android.ui.reader.views.ReaderRecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_above="@+id/layout_bottom"
         android:layout_below="@+id/toolbar"
-        android:scrollbars="vertical"
-        tools:listitem="@layout/reader_listitem_comment" />
-
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/text_empty"
-        style="@style/ReaderTextView.EmptyList"
-        android:layout_centerInParent="true"
-        android:paddingBottom="@dimen/margin_large"
-        android:paddingTop="@dimen/margin_large"
-        android:text="@string/reader_empty_comments"
-        android:textColor="@color/grey_darken_10"
-        android:visibility="gone"
-        app:fixWidowWords="true"
-        tools:visibility="visible" />
+        android:scrollbars="vertical" />
 
     <RelativeLayout
         android:id="@+id/layout_bottom"

--- a/WordPress/src/main/res/layout/reader_comments_post_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_comments_post_header_view.xml
@@ -9,69 +9,79 @@
     android:id="@+id/layout_post_header"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingLeft="@dimen/reader_card_margin"
-    android:paddingRight="@dimen/reader_card_margin"
-    android:paddingTop="@dimen/margin_large"
     android:background="?android:selectableItemBackground">
 
-    <LinearLayout
+    <!--
+        this inner frame layout is necessary to enforce a background color
+        while still enabling ?android:selectableItemBackground (above)
+    -->
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="@dimen/margin_medium"
-        android:layout_marginRight="@dimen/margin_medium"
-        android:orientation="vertical"
-        android:paddingLeft="@dimen/reader_card_content_padding"
-        android:paddingRight="@dimen/reader_card_content_padding">
+        android:background="@color/grey_lighten_30"
+        android:paddingLeft="@dimen/reader_card_margin"
+        android:paddingRight="@dimen/reader_card_margin"
+        android:paddingTop="@dimen/margin_large">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:layout_marginLeft="@dimen/margin_medium"
+            android:layout_marginRight="@dimen/margin_medium"
+            android:orientation="vertical"
+            android:paddingLeft="@dimen/reader_card_content_padding"
+            android:paddingRight="@dimen/reader_card_content_padding">
 
-            <org.wordpress.android.widgets.WPNetworkImageView
-                android:id="@+id/image_post_avatar"
-                android:layout_width="16dp"
-                android:layout_height="16dp"
-                android:layout_gravity="center_vertical"
-                android:layout_marginRight="@dimen/margin_medium"
-                tools:src="@drawable/gravatar_placeholder" />
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <org.wordpress.android.widgets.WPNetworkImageView
+                    android:id="@+id/image_post_avatar"
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginRight="@dimen/margin_medium"
+                    tools:src="@drawable/gravatar_placeholder" />
+
+                <org.wordpress.android.widgets.WPTextView
+                    android:id="@+id/text_blog_name"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical"
+                    android:ellipsize="end"
+                    android:maxLines="2"
+                    android:textColor="@color/grey_dark"
+                    android:textSize="@dimen/text_sz_small"
+                    tools:text="text_blog_name" />
+
+            </LinearLayout>
 
             <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/text_blog_name"
-                android:layout_width="wrap_content"
+                android:id="@+id/text_post_title"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
                 android:ellipsize="end"
                 android:maxLines="2"
+                android:paddingBottom="@dimen/margin_small"
+                android:paddingTop="@dimen/margin_medium"
                 android:textColor="@color/grey_dark"
+                android:textSize="@dimen/text_sz_large"
+                app:fontFamily="merriweather"
+                tools:text="text_post_title" />
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/text_post_dateline"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/margin_large"
+                android:ellipsize="end"
+                android:maxLines="2"
+                android:textColor="@color/grey"
                 android:textSize="@dimen/text_sz_small"
-                tools:text="text_blog_name" />
+                tools:text="text_post_date" />
 
         </LinearLayout>
-
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/text_post_title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:ellipsize="end"
-            android:maxLines="2"
-            android:paddingBottom="@dimen/margin_small"
-            android:paddingTop="@dimen/margin_medium"
-            android:textColor="@color/grey_dark"
-            android:textSize="@dimen/text_sz_large"
-            app:fontFamily="merriweather"
-            tools:text="text_post_title" />
-
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/text_post_dateline"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_large"
-            android:ellipsize="end"
-            android:maxLines="2"
-            android:textColor="@color/grey"
-            android:textSize="@dimen/text_sz_small"
-            tools:text="text_post_date" />
-
-    </LinearLayout>
+    </FrameLayout>
 </FrameLayout>


### PR DESCRIPTION
Fix #3217 - I'm not totally happy with this solution, but I tried a number of alternatives (such as detecting when the soft keyboard shows/hides) and this is by far the simplest and most reliable.

To prevent the "No comments yet" textView from overlapping the header, I added an inner view to the header which enforces the header background color. This way on smaller screens the "No comments yet" textView will be covered by the header.

Screenshots below are from a Galaxy S2 (API 16) Genymotion emulator. Prior to this fix, "No comments yet" would overlap the header after the soft keyboard appears.

![one](https://cloud.githubusercontent.com/assets/3903757/10036257/0c826122-6173-11e5-96a6-0b713afbf599.png)
