### PR TITLE
Checking for a null URI when adding media to a post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1095,7 +1095,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     }
 
     private boolean addMedia(Uri imageUri) {
-        if (!MediaUtils.isInMediaStore(imageUri) && !imageUri.toString().startsWith("/")) {
+        if (imageUri != null && !MediaUtils.isInMediaStore(imageUri) && !imageUri.toString().startsWith("/")) {
             imageUri = MediaUtils.downloadExternalMedia(this, imageUri);
         }
 


### PR DESCRIPTION
`imageUri` is [the culprit](https://github.com/wordpress-mobile/WordPress-Android/blob/4.4.2/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L1110) for the NPE.

Addresses #3198