### PR TITLE
Fix #3123 by restarting Activity with locale applied

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -60,6 +60,7 @@ import org.wordpress.android.util.ProfilingUtils;
 import org.wordpress.android.util.RateLimitedTask;
 import org.wordpress.android.util.SqlUtils;
 import org.wordpress.android.util.VolleyUtils;
+import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.passcodelock.AbstractAppLock;
 import org.wordpress.passcodelock.AppLockManager;
 import org.xmlrpc.android.ApiHelper;
@@ -684,6 +685,9 @@ public class WordPress extends Application {
         boolean mIsInBackground = true;
         boolean mFirstActivityResumed = true;
 
+        private Class<?> mClass;
+        private int mOrientation = -1;
+
         @Override
         public void onConfigurationChanged(final Configuration newConfig) {
         }
@@ -802,6 +806,17 @@ public class WordPress extends Application {
 
         @Override
         public void onActivityResumed(Activity activity) {
+            // Need to track orientation to apply preferred language on rotation
+            int orientation = activity.getResources().getConfiguration().orientation;
+            boolean shouldRestart =
+                    mOrientation == -1 || mOrientation != orientation || !mClass.equals(activity.getClass());
+
+            if (shouldRestart) {
+                mOrientation = orientation;
+                mClass = activity.getClass();
+            }
+            WPActivityUtils.applyLocale(activity, shouldRestart);
+
             if (mIsInBackground) {
                 // was in background before
                 onAppComesFromBackground();

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
@@ -2,20 +2,13 @@ package org.wordpress.android.ui;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.content.SharedPreferences;
-import android.content.res.Configuration;
-import android.content.res.Resources;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.ui.main.WPMainActivity;
-import org.wordpress.android.ui.prefs.SettingsFragment;
 import org.wordpress.android.util.ProfilingUtils;
 import org.wordpress.android.util.ToastUtils;
-
-import java.util.Locale;
 
 public class WPLaunchActivity extends Activity {
 
@@ -31,8 +24,6 @@ public class WPLaunchActivity extends Activity {
 
         ProfilingUtils.split("WPLaunchActivity.onCreate");
 
-        applyLocale();
-
         if (WordPress.wpDB == null) {
             ToastUtils.showToast(this, R.string.fatal_db_error, ToastUtils.Duration.LONG);
             finish();
@@ -43,24 +34,5 @@ public class WPLaunchActivity extends Activity {
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
         startActivity(intent);
         finish();
-    }
-
-    private void applyLocale() {
-        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
-
-        if (sharedPreferences.contains(SettingsFragment.SETTINGS_PREFERENCES)) {
-            String locale = sharedPreferences.getString(SettingsFragment.SETTINGS_PREFERENCES, "");
-
-            if (!locale.equals(Locale.getDefault().getDisplayLanguage())) {
-                Resources resources = getResources();
-                Configuration conf = resources.getConfiguration();
-                conf.locale = new Locale(locale);
-                resources.updateConfiguration(conf, resources.getDisplayMetrics());
-
-                Intent refresh = new Intent(this, WPLaunchActivity.class);
-                startActivity(refresh);
-                finish();
-            }
-        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
@@ -48,7 +48,7 @@ import java.util.Map;
 
 @SuppressWarnings("deprecation")
 public class SettingsFragment extends PreferenceFragment implements OnPreferenceClickListener {
-    public static final String SETTINGS_PREFERENCES = "settings-pref";
+    public static final String LANGUAGE_PREF_KEY = "language-pref";
     public static final int LANGUAGE_CHANGED = 1000;
 
     private AlertDialog mDialog;
@@ -199,7 +199,7 @@ public class SettingsFragment extends PreferenceFragment implements OnPreference
                     conf.locale = new Locale(localString);
                 }
                 res.updateConfiguration(conf, dm);
-                mSettings.edit().putString(SETTINGS_PREFERENCES, localeMap.get(values[position])).apply();
+                mSettings.edit().putString(LANGUAGE_PREF_KEY, localeMap.get(values[position])).apply();
 
                 // Track the change only if the user selected a non default Device language. This is only used in
                 // Mixpanel, because we have both the device language and app selected language data in Tracks

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -1,10 +1,50 @@
 package org.wordpress.android.util;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.preference.PreferenceManager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
+import android.text.TextUtils;
+
+import org.wordpress.android.ui.prefs.SettingsFragment;
+
+import java.util.Locale;
 
 public class WPActivityUtils {
+    public static void applyLocale(Activity context, boolean restart) {
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+
+        if (sharedPreferences.contains(SettingsFragment.LANGUAGE_PREF_KEY)) {
+            Locale contextLocale = context.getResources().getConfiguration().locale;
+            String contextLanguage = contextLocale.getLanguage();
+            String contextCountry = contextLocale.getCountry();
+            String locale = sharedPreferences.getString(SettingsFragment.LANGUAGE_PREF_KEY, "");
+
+            if (!TextUtils.isEmpty(contextCountry)) {
+                contextLanguage += "-" + contextCountry;
+            }
+
+            if (!locale.equals(contextLanguage)) {
+                Resources resources = context.getResources();
+                Configuration conf = resources.getConfiguration();
+                conf.locale = new Locale(locale);
+                resources.updateConfiguration(conf, resources.getDisplayMetrics());
+
+                if (restart) {
+                    Intent refresh = new Intent(context, context.getClass());
+                    refresh.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+                    context.startActivity(refresh);
+                    context.finish();
+                    context.overridePendingTransition(0, 0);
+                }
+            }
+        }
+    }
 
     public static Context getThemedContext(Context context) {
         if (context instanceof AppCompatActivity) {


### PR DESCRIPTION
Addresses #3123 

The Activity has to be restarted for locale changes to effect every view. If we don't restart some strings will remain in the device default locale. Restarting the Activity causes a fade-in/fade-out so it's only done when the language is not the same as the device default.

cc @maxme, I tried disabling the animation altogether without luck. Any ideas on how to remove that transition when restarting?