### PR TITLE
Stats - Fix for graph that looks off on low numbers Stats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsBarGraph.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsBarGraph.java
@@ -28,6 +28,9 @@ import java.util.List;
  * Based on BarGraph from the GraphView library.
  */
 class StatsBarGraph extends GraphView {
+
+    private static final int DEFAULT_MAX_Y = 10;
+
     // Keep tracks of every bar drawn on the graph.
     private final List<List<BarChartRect>> mSeriesRectsDrawedOnScreen = (List<List<BarChartRect>>) new LinkedList();
     private int mBarPositionToHighlight = -1;
@@ -292,14 +295,10 @@ class StatsBarGraph extends GraphView {
     protected double getMaxY() {
         double maxY = super.getMaxY();
         if (maxY == 0) {
-            return 10;
+            return DEFAULT_MAX_Y;
         }
 
-        if (maxY % 2 == 0) {
-            return maxY;
-        } else {
-            return maxY+1;
-        }
+        return maxY + (maxY % 2);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsBarGraph.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsBarGraph.java
@@ -286,6 +286,22 @@ class StatsBarGraph extends GraphView {
         return 0;
     }
 
+    // Make sure the highest number is always even, so the halfway mark is correctly balanced in the middle of the graph
+    // Also make sure to display a default value when there is no activity in the period.
+    @Override
+    protected double getMaxY() {
+        double maxY = super.getMaxY();
+        if (maxY == 0) {
+            return 10;
+        }
+
+        if (maxY % 2 == 0) {
+            return maxY;
+        } else {
+            return maxY+1;
+        }
+    }
+
     /**
      * Private class that is used to hold the local (to the canvas) coordinate on the screen
      * of every single bar in the graph


### PR DESCRIPTION
Fix #2562 by making sure the highest label number is always even, so the halfway mark is correctly balanced in the middle of the graph.
