### PR TITLE
issue/3222-login-refresh-tab-fragments-46

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainTabAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainTabAdapter.java
@@ -3,7 +3,7 @@ package org.wordpress.android.ui.main;
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.os.Parcelable;
-import android.support.v13.app.FragmentPagerAdapter;
+import android.support.v13.app.FragmentStatePagerAdapter;
 import android.util.SparseArray;
 import android.view.ViewGroup;
 
@@ -13,7 +13,7 @@ import org.wordpress.android.ui.reader.ReaderPostListFragment;
 /**
  * pager adapter containing tab fragments used by WPMainActivity
  */
-class WPMainTabAdapter extends FragmentPagerAdapter {
+class WPMainTabAdapter extends FragmentStatePagerAdapter {
 
     static final int NUM_TABS = 4;
 


### PR DESCRIPTION
Fixes #3222 - problem was caused by the switch from a `FragmentStatePagerAdapter` to a `FragmentPagerAdapter` in v4.6. Switching back to a `FragmentStatePagerAdapter` resolves the problem (but still keeps the offscreen limit that was added to address the [masterbar jank](https://github.com/wordpress-mobile/WordPress-Android/pull/3170)).