### PR TITLE
Fixes stacked notifications on Android 4.x

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMIntentService.java
@@ -213,16 +213,7 @@ public class GCMIntentService extends GCMBaseIntentService {
 
         showNotificationForBuilder(builder, context, pushId);
 
-        // Also add a GroupSummary notification. This is REQUIRED to support Android 4.x
-        String subject = String.format(getString(R.string.new_notifications), mActiveNotificationsMap.size());
-        NotificationCompat.Builder groupBuilder = new NotificationCompat.Builder(this)
-                .setSmallIcon(R.drawable.notification_icon)
-                .setColor(getResources().getColor(R.color.blue_wordpress))
-                .setGroup(NOTIFICATION_GROUP_KEY)
-                .setGroupSummary(true)
-                .setAutoCancel(true);
-
-        // Make the notification InboxStyle if we have multiple notifications
+        // Also add a group summary notification, which is required for non-wearable devices
         if (mActiveNotificationsMap.size() > 1) {
             NotificationCompat.InboxStyle inboxStyle = new NotificationCompat.InboxStyle();
             int noteCtr = 1;
@@ -252,23 +243,25 @@ public class GCMIntentService extends GCMBaseIntentService {
                         mActiveNotificationsMap.size() - mMaxInboxItems));
             }
 
-            groupBuilder.setTicker(message)
+            String subject = String.format(getString(R.string.new_notifications), mActiveNotificationsMap.size());
+            NotificationCompat.Builder groupBuilder = new NotificationCompat.Builder(this)
+                    .setSmallIcon(R.drawable.notification_icon)
+                    .setColor(getResources().getColor(R.color.blue_wordpress))
+                    .setGroup(NOTIFICATION_GROUP_KEY)
+                    .setGroupSummary(true)
+                    .setAutoCancel(true)
+                    .setTicker(message)
                     .setContentTitle(getString(R.string.app_name))
                     .setContentText(subject)
                     .setStyle(inboxStyle);
+
+            showNotificationForBuilder(groupBuilder, context, GROUP_NOTIFICATION_ID);
         } else {
-            groupBuilder.setTicker(message)
-                    .setContentTitle(title)
-                    .setContentText(message)
-                    .setStyle(new NotificationCompat.BigTextStyle().bigText(message));
-
-            if (largeIconBitmap != null) {
-                groupBuilder.setLargeIcon(largeIconBitmap);
-            }
+            // Set the individual notification we've already built as the group summary
+            builder.setGroupSummary(true);
+            showNotificationForBuilder(builder, context, GROUP_NOTIFICATION_ID);
         }
-
-        showNotificationForBuilder(groupBuilder, context, GROUP_NOTIFICATION_ID);
-
+        
         EventBus.getDefault().post(new NotificationEvents.NotificationsChanged());
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationDismissBroadcastReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationDismissBroadcastReceiver.java
@@ -1,9 +1,9 @@
 package org.wordpress.android.ui.notifications;
 
-import android.app.NotificationManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.support.v4.app.NotificationManagerCompat;
 
 import org.wordpress.android.GCMIntentService;
 
@@ -21,8 +21,7 @@ public class NotificationDismissBroadcastReceiver extends BroadcastReceiver {
 
             // Dismiss the grouped notification if a user dismisses all notifications from a wear device
             if (!GCMIntentService.hasNotifications()) {
-                NotificationManager notificationManager = (NotificationManager) context
-                        .getSystemService(GCMIntentService.NOTIFICATION_SERVICE);
+                NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
                 notificationManager.cancel(GCMIntentService.GROUP_NOTIFICATION_ID);
             }
         }


### PR DESCRIPTION
Always create the GroupSummary notification, to support Android 4.X. If there is more than one notification, we create an inbox style notification, otherwise it is the same style as an individual notification.

Test Cases:
Android 5.0:
 - [x] Receive single push, should show gravatar  in notification and open to detail view
 - [x] Receive multiple pushes, should show 'inbox style' and open to list view

Android 4.X:
 - [x] Receive single push, should show gravatar  in notification and open to detail view
 - [x] Receive multiple pushes, should show 'inbox style' and open to list view

Android Wear:
 - [x] All notifications should appear individually in a 'stack'

Fixes #3223