### PR TITLE
Issue/3231 siteless add self hosted

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -204,7 +204,7 @@ public class ActivityLauncher {
 
     public static void newAccountForResult(Activity activity) {
         Intent intent = new Intent(activity, NewAccountActivity.class);
-        activity.startActivityForResult(intent, SignInActivity.CREATE_ACCOUNT_REQUEST);
+        activity.startActivityForResult(intent, RequestCodes.ADD_ACCOUNT);
     }
 
     public static void newBlogForResult(Activity activity) {
@@ -246,7 +246,7 @@ public class ActivityLauncher {
     public static void addSelfHostedSiteForResult(Activity activity) {
         Intent intent = new Intent(activity, SignInActivity.class);
         intent.putExtra(SignInActivity.START_FRAGMENT_KEY, SignInActivity.ADD_SELF_HOSTED_BLOG);
-        activity.startActivityForResult(intent, SignInActivity.CREATE_ACCOUNT_REQUEST);
+        activity.startActivityForResult(intent, RequestCodes.ADD_ACCOUNT);
     }
 
     public static void slideInFromRight(Context context, Intent intent) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInActivity.java
@@ -15,7 +15,6 @@ public class SignInActivity extends Activity {
     public static final int SIGN_IN_REQUEST = 1;
     public static final int REQUEST_CODE = 5000;
     public static final int ADD_SELF_HOSTED_BLOG = 2;
-    public static final int CREATE_ACCOUNT_REQUEST = 3;
     public static final int SHOW_CERT_DETAILS = 4;
     public static String START_FRAGMENT_KEY = "start-fragment";
     public static final String ARG_JETPACK_SITE_AUTH = "ARG_JETPACK_SITE_AUTH";

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -76,7 +76,9 @@ public class MySiteFragment extends Fragment
     @Override
     public void onPause() {
         super.onPause();
-        AniUtils.showFab(mFabView, false);
+        if (mFabView.getVisibility() == View.VISIBLE) {
+            AniUtils.showFab(mFabView, false);
+        }
     }
 
     @Override
@@ -90,7 +92,9 @@ public class MySiteFragment extends Fragment
         new Handler().postDelayed(new Runnable() {
             @Override
             public void run() {
-                if (isAdded() && (mFabView.getVisibility() != View.VISIBLE || mFabView.getTranslationY() != 0)) {
+                if (isAdded()
+                        && mBlog != null
+                        && (mFabView.getVisibility() != View.VISIBLE || mFabView.getTranslationY() != 0)) {
                     AniUtils.showFab(mFabView, true);
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -199,7 +199,7 @@ public class MySiteFragment extends Fragment
         rootView.findViewById(R.id.my_site_add_site_btn).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                ActivityLauncher.newBlogForResult(getActivity());
+                SitePickerActivity.addSite(getActivity());
             }
         });
 
@@ -238,6 +238,7 @@ public class MySiteFragment extends Fragment
                     showAlert(getView().findViewById(R.id.postsGlowBackground));
                 }
                 break;
+
             case RequestCodes.CREATE_BLOG:
                 // if the user created a new blog refresh the blog details
                 mBlog = WordPress.getCurrentBlog();

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.main;
 
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
@@ -29,7 +30,6 @@ import org.wordpress.android.models.AccountHelper;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
-import org.wordpress.android.ui.accounts.SignInActivity;
 import org.wordpress.android.ui.main.SitePickerAdapter.SiteList;
 import org.wordpress.android.ui.main.SitePickerAdapter.SiteRecord;
 import org.wordpress.android.ui.stats.datasets.StatsTable;
@@ -143,7 +143,7 @@ public class SitePickerActivity extends AppCompatActivity
             showSoftKeyboard();
             return true;
         } else if (itemId == R.id.menu_add) {
-            addSite();
+            addSite(this);
             return true;
         }
         return super.onOptionsItemSelected(item);
@@ -154,7 +154,7 @@ public class SitePickerActivity extends AppCompatActivity
         super.onActivityResult(requestCode, resultCode, data);
 
         switch (requestCode) {
-            case SignInActivity.CREATE_ACCOUNT_REQUEST:
+            case RequestCodes.ADD_ACCOUNT:
             case RequestCodes.CREATE_BLOG:
                 if (resultCode != RESULT_CANCELED) {
                     getAdapter().loadSites();
@@ -428,15 +428,15 @@ public class SitePickerActivity extends AppCompatActivity
         }
     }
 
-    private void addSite() {
+    public static void addSite(Activity activity) {
         // if user is signed into wp.com use the dialog to enable choosing whether to
         // create a new wp.com blog or add a self-hosted one
         if (AccountHelper.isSignedInWordPressDotCom()) {
             DialogFragment dialog = new AddSiteDialog();
-            dialog.show(this.getFragmentManager(), AddSiteDialog.ADD_SITE_DIALOG_TAG);
+            dialog.show(activity.getFragmentManager(), AddSiteDialog.ADD_SITE_DIALOG_TAG);
         } else {
             // user isn't signed into wp.com, so simply enable adding self-hosted
-            ActivityLauncher.addSelfHostedSiteForResult(SitePickerActivity.this);
+            ActivityLauncher.addSelfHostedSiteForResult(activity);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -428,7 +428,7 @@ public class SitePickerActivity extends AppCompatActivity
         }
     }
 
-    static void addSite(Activity activity) {
+    public static void addSite(Activity activity) {
         // if user is signed into wp.com use the dialog to enable choosing whether to
         // create a new wp.com blog or add a self-hosted one
         if (AccountHelper.isSignedInWordPressDotCom()) {
@@ -444,7 +444,7 @@ public class SitePickerActivity extends AppCompatActivity
      * dialog which appears after user taps "Add site" - enables choosing whether to create
      * a new wp.com blog or add an existing self-hosted one
      */
-    static class AddSiteDialog extends DialogFragment {
+    public static class AddSiteDialog extends DialogFragment {
         static final String ADD_SITE_DIALOG_TAG = "add_site_dialog";
 
         @NonNull

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -428,7 +428,7 @@ public class SitePickerActivity extends AppCompatActivity
         }
     }
 
-    public static void addSite(Activity activity) {
+    static void addSite(Activity activity) {
         // if user is signed into wp.com use the dialog to enable choosing whether to
         // create a new wp.com blog or add a self-hosted one
         if (AccountHelper.isSignedInWordPressDotCom()) {
@@ -444,7 +444,7 @@ public class SitePickerActivity extends AppCompatActivity
      * dialog which appears after user taps "Add site" - enables choosing whether to create
      * a new wp.com blog or add an existing self-hosted one
      */
-    public static class AddSiteDialog extends DialogFragment {
+    static class AddSiteDialog extends DialogFragment {
         static final String ADD_SITE_DIALOG_TAG = "add_site_dialog";
 
         @NonNull

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -351,6 +351,7 @@ public class WPMainActivity extends Activity
         super.onActivityResult(requestCode, resultCode, data);
         switch (requestCode) {
             case RequestCodes.EDIT_POST:
+            case RequestCodes.CREATE_BLOG:
                 if (resultCode == RESULT_OK) {
                     MySiteFragment mySiteFragment = getMySiteFragment();
                     if (mySiteFragment != null) {
@@ -400,14 +401,6 @@ public class WPMainActivity extends Activity
             case RequestCodes.ACCOUNT_SETTINGS:
                 if (resultCode == SettingsFragment.LANGUAGE_CHANGED) {
                     resetFragments();
-                }
-                break;
-            case RequestCodes.CREATE_BLOG:
-                if (resultCode == RESULT_OK) {
-                    MySiteFragment mySiteFragment = getMySiteFragment();
-                    if (mySiteFragment != null) {
-                        mySiteFragment.onActivityResult(requestCode, resultCode, data);
-                    }
                 }
                 break;
         }


### PR DESCRIPTION
Fixes #3231 - when logged into a siteless wp.com account (which can be created [here](https://wordpress.com/start/account/user)), the "Add Site" button on the My Site tab now shows the same menu as the site picker which enables creating a wp.com site or adding a self-hosted site.

Also fixed bug that caused the FAB to appear on the My Site tab even when the user has no sites.