### PR TITLE
issue/3233-crash-os-licenses-46

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -95,7 +95,7 @@
             android:windowSoftInputMode="stateHidden"/>
         <activity
             android:name=".ui.prefs.LicensesActivity"
-            android:theme="@style/CalypsoTheme"/>
+            android:theme="@style/Calypso.NoActionBar" />
         <activity
             android:name=".ui.prefs.SettingsActivity"
             android:configChanges="locale|orientation"


### PR DESCRIPTION
Fixes #3233 - Resolves crash when showing `LicensesActivity` by setting the correct theme in manifest