### PR TITLE
Hotfix - Fix the logout for wpcom account that have Jetpack sites linked to them

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -655,8 +655,13 @@ public class WordPressDB {
             deleteAllPostsForLocalTableBlogId(localBlogId);
         }
 
+        // H4ck alert: We need to delete the Jetpack sites that were added in the initial
+        // WP.com get blogs call. These sites will not have the dotcomFlag set and will
+        // have an empty password.
+        String args = String.format("dotcomFlag=1 OR (dotcomFlag=0 AND password='%s')", encryptPassword(""));
+
         // Delete blogs
-        int rowsAffected = db.delete(BLOGS_TABLE, "dotcomFlag=1", null);
+        int rowsAffected = db.delete(BLOGS_TABLE, args, null);
         return (rowsAffected > 0);
     }
 


### PR DESCRIPTION
Fix #3215 by deleting Jetpack "ghost" blogs added during the initial wpcom setup.