### PR TITLE
Verifying dialog is non-null

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -354,8 +354,8 @@ public class NotificationsSettingsFragment extends PreferenceFragment {
     }
 
     public void addToolbarToPreferenceScreen(PreferenceScreen preferenceScreen) {
-        if (!isAdded()) return;
         final Dialog dialog = preferenceScreen.getDialog();
+        if (!isAdded() || dialog == null) return;
 
         LinearLayout root = (LinearLayout) dialog.findViewById(android.R.id.list).getParent();
         Toolbar toolbar = (Toolbar) LayoutInflater.from(getActivity()).inflate(R.layout.toolbar, root, false);


### PR DESCRIPTION
Recreating PR for `hotfix/4.5.2`.

Fixes #3235 