### PR TITLE
Fix stats NPE on Insights

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractInsightsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractInsightsFragment.java
@@ -166,6 +166,11 @@ public abstract class StatsAbstractInsightsFragment extends StatsAbstractFragmen
             return;
         }
 
+        // Use the generic error message when the string passed to this method is null.
+        if (label == null) {
+            label = "<b>" + getString(R.string.error_refresh_stats) + "</b>";
+        }
+
         if (label.contains("<")) {
             mErrorLabel.setText(Html.fromHtml(label));
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsInsightsLatestPostSummaryFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsInsightsLatestPostSummaryFragment.java
@@ -39,15 +39,17 @@ public class StatsInsightsLatestPostSummaryFragment extends StatsAbstractInsight
         if (event.mEndPointName != StatsService.StatsEndpointsEnum.INSIGHTS_LATEST_POST_VIEWS) {
             super.onEventMainThread(event);
         } else {
-            // Another additional check. It ensures that the main data is available, and it should be at this point!!
-            if (isDataEmpty(0) || !(mDatamodels[0] instanceof InsightsLatestPostModel)) {
-                showErrorUI(null);
-                return;
-            }
 
+            // Check the response of the 2nd rest call before going deeper into updating the UI.
             if (event.mResponseObjectModel instanceof VolleyError ||
                     event.mResponseObjectModel instanceof StatsError) {
                 showErrorUI(event.mResponseObjectModel);
+                return;
+            }
+
+            // Here an another additional check that ensures the main data returned from the 1st call is available.
+            if (isDataEmpty(0) || !(mDatamodels[0] instanceof InsightsLatestPostModel)) {
+                showErrorUI(null);
                 return;
             }
 


### PR DESCRIPTION
Fix #3248 

I really don't know how this issue can happen. The first REST request should be already finished, and the result stored in the correct place, otherwise the 2nd call can't start, and the execution of the code cannot  reach the "crash" point. 
Anyway, there is a check for null error message that fixes the issue.