### PR TITLE
Cleans up some code in NotesAdapter

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -11,7 +11,6 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.simperium.client.Bucket;
-import com.simperium.client.BucketObjectMissingException;
 import com.simperium.client.Query;
 
 import org.wordpress.android.R;
@@ -35,9 +34,9 @@ public class NotesAdapter extends CursorRecyclerViewAdapter<NotesAdapter.NoteVie
     private final Bucket<Note> mNotesBucket;
     private final int mColorRead;
     private final int mColorUnread;
-    private final List<String> mHiddenNoteIds = new ArrayList<String>();
-    private final List<String> mModeratingNoteIds = new ArrayList<String>();
-    private final Context mContext;
+    private final int mTextIndentSize;
+    private final List<String> mHiddenNoteIds = new ArrayList<>();
+    private final List<String> mModeratingNoteIds = new ArrayList<>();
 
     private Query mQuery;
 
@@ -48,7 +47,6 @@ public class NotesAdapter extends CursorRecyclerViewAdapter<NotesAdapter.NoteVie
 
         setHasStableIds(true);
 
-        mContext = context;
         mNotesBucket = bucket;
         // build a query that sorts by timestamp descending
         mQuery = new Query();
@@ -56,6 +54,7 @@ public class NotesAdapter extends CursorRecyclerViewAdapter<NotesAdapter.NoteVie
         mAvatarSz = (int) context.getResources().getDimension(R.dimen.notifications_avatar_sz);
         mColorRead = context.getResources().getColor(R.color.white);
         mColorUnread = context.getResources().getColor(R.color.grey_light);
+        mTextIndentSize = context.getResources().getDimensionPixelSize(R.dimen.notifications_text_indent_sz);
     }
 
     public void closeCursor() {
@@ -63,25 +62,6 @@ public class NotesAdapter extends CursorRecyclerViewAdapter<NotesAdapter.NoteVie
         if (cursor != null) {
             cursor.close();
         }
-    }
-
-    public Note getNote(int position) {
-        if (getCursor() == null) {
-            return null;
-        }
-
-        Bucket.ObjectCursor<Note> cursor = (Bucket.ObjectCursor<Note>)getCursor();
-
-        if (cursor.moveToPosition(position)) {
-            String noteId = cursor.getSimperiumKey();
-            try {
-                return mNotesBucket.get(noteId);
-            } catch (BucketObjectMissingException e) {
-                return null;
-            }
-        }
-
-        return null;
     }
 
     private Query getQueryDefaults() {
@@ -187,15 +167,15 @@ public class NotesAdapter extends CursorRecyclerViewAdapter<NotesAdapter.NoteVie
             noteViewHolder.headerView.setVisibility(View.GONE);
         } else {
             if (timeGroup == Note.NoteTimeGroup.GROUP_TODAY) {
-                noteViewHolder.headerText.setText(mContext.getString(R.string.stats_timeframe_today).toUpperCase());
+                noteViewHolder.headerText.setText(R.string.stats_timeframe_today);
             } else if (timeGroup == Note.NoteTimeGroup.GROUP_YESTERDAY) {
-                noteViewHolder.headerText.setText(mContext.getString(R.string.stats_timeframe_yesterday).toUpperCase());
+                noteViewHolder.headerText.setText(R.string.stats_timeframe_yesterday);
             } else if (timeGroup == Note.NoteTimeGroup.GROUP_OLDER_TWO_DAYS) {
-                noteViewHolder.headerText.setText(mContext.getString(R.string.older_two_days).toUpperCase());
+                noteViewHolder.headerText.setText(R.string.older_two_days);
             } else if (timeGroup == Note.NoteTimeGroup.GROUP_OLDER_WEEK) {
-                noteViewHolder.headerText.setText(mContext.getString(R.string.older_last_week).toUpperCase());
+                noteViewHolder.headerText.setText(R.string.older_last_week);
             } else {
-                noteViewHolder.headerText.setText(mContext.getString(R.string.older_month).toUpperCase());
+                noteViewHolder.headerText.setText(R.string.older_month);
             }
 
             noteViewHolder.headerView.setVisibility(View.VISIBLE);
@@ -233,7 +213,7 @@ public class NotesAdapter extends CursorRecyclerViewAdapter<NotesAdapter.NoteVie
 
         String noteSubjectNoticon = getStringForColumnName(objectCursor, Note.Schema.COMMENT_SUBJECT_NOTICON);
         if (!TextUtils.isEmpty(noteSubjectNoticon)) {
-            CommentUtils.indentTextViewFirstLine(noteViewHolder.txtSubject, DisplayUtils.dpToPx(mContext, 22));
+            CommentUtils.indentTextViewFirstLine(noteViewHolder.txtSubject, mTextIndentSize);
             noteViewHolder.txtSubjectNoticon.setText(noteSubjectNoticon);
             noteViewHolder.txtSubjectNoticon.setVisibility(View.VISIBLE);
         } else {

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -32,9 +32,10 @@
                 android:layout_gravity="center_vertical"
                 android:layout_marginLeft="-3dp"
                 android:layout_marginStart="-3dp"
+                android:layout_marginBottom="-1dp"
                 android:textColor="@color/grey_lighten_10"
                 android:textSize="18sp"
-                tools:text="\uf303" />
+                android:text="\uf303" />
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/header_date_text"

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -44,6 +44,7 @@
                 android:layout_gravity="center_vertical"
                 android:layout_marginLeft="@dimen/margin_small"
                 android:layout_marginStart="@dimen/margin_small"
+                android:textAllCaps="true"
                 tools:text="TODAY" />
         </LinearLayout>
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -134,6 +134,7 @@
     <dimen name="notifications_adjusted_font_margin">10dp</dimen>
     <dimen name="notifications_content_margin">0dp</dimen>
     <dimen name="notifications_avatar_sz">48dp</dimen>
+    <dimen name="notifications_text_indent_sz">22dp</dimen>
 
     <dimen name="progress_bar_height">3dp</dimen>
 


### PR DESCRIPTION
I made a few improvements to the code in `NotesAdapter`. There was a missing noticon in the time grouping header text and I killed a `context` class member. Also removed a now-unused method.