### PR TITLE
Hiding App notifications settings on devices without GCM services

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -84,25 +84,12 @@ public class NotificationsUtils {
             return;
         }
 
-        String gcmToken = GCMRegistrar.getRegistrationId(context);
-        if (TextUtils.isEmpty(gcmToken)) {
+        if (TextUtils.isEmpty(GCMRegistrar.getRegistrationId(context))) {
             AppLog.e(T.NOTIFS, "can't get push notification settings, gcm token is null.");
-            if (errorListener != null) {
-                errorListener.onErrorResponse(new VolleyError("Notifications: Invalid gcm token."));
-            }
-            return;
         }
 
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
         String deviceID = settings.getString(WPCOM_PUSH_DEVICE_SERVER_ID, null);
-        if (TextUtils.isEmpty(deviceID)) {
-            AppLog.e(T.NOTIFS, "device_ID is null in preferences. Get device settings skipped.");
-            if (errorListener != null) {
-                errorListener.onErrorResponse(new VolleyError("Notifications: No device ID found."));
-            }
-            return;
-        }
-
         WordPress.getRestClientUtilsV1_1().get("/me/notifications/settings/?device_id=" + deviceID, listener, errorListener);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -76,6 +76,8 @@ public class NotificationsUtils {
     private static final String CHECK_OP_NO_THROW = "checkOpNoThrow";
     private static final String OP_POST_NOTIFICATION = "OP_POST_NOTIFICATION";
 
+    private static final String WPCOM_SETTINGS_ENDPOINT = "/me/notifications/settings/";
+
     private static boolean mSnackbarDidUndo;
 
     public static void getPushNotificationSettings(Context context, RestRequest.Listener listener,
@@ -90,7 +92,9 @@ public class NotificationsUtils {
 
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
         String deviceID = settings.getString(WPCOM_PUSH_DEVICE_SERVER_ID, null);
-        WordPress.getRestClientUtilsV1_1().get("/me/notifications/settings/?device_id=" + deviceID, listener, errorListener);
+        String settingsEndpoint = WPCOM_SETTINGS_ENDPOINT;
+        if (!TextUtils.isEmpty(deviceID)) settingsEndpoint +=  "?device_id=" + deviceID;
+        WordPress.getRestClientUtilsV1_1().get(settingsEndpoint, listener, errorListener);
     }
 
     public static void registerDeviceForPushNotifications(final Context ctx, String token) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -93,7 +93,9 @@ public class NotificationsUtils {
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
         String deviceID = settings.getString(WPCOM_PUSH_DEVICE_SERVER_ID, null);
         String settingsEndpoint = WPCOM_SETTINGS_ENDPOINT;
-        if (!TextUtils.isEmpty(deviceID)) settingsEndpoint +=  "?device_id=" + deviceID;
+        if (!TextUtils.isEmpty(deviceID)) {
+            settingsEndpoint += "?device_id=" + deviceID;
+        }
         WordPress.getRestClientUtilsV1_1().get(settingsEndpoint, listener, errorListener);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -14,6 +14,7 @@ import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
 import android.provider.Settings;
 import android.support.v7.widget.Toolbar;
+import android.text.TextUtils;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -188,7 +189,8 @@ public class NotificationsSettingsFragment extends PreferenceFragment {
                 category.addPreference(disabledMessage);
             }
 
-            if (category.getPreference(TYPE_COUNT - 1) != null) {
+            if (category.getPreferenceCount() >= TYPE_COUNT &&
+                    category.getPreference(TYPE_COUNT - 1) != null) {
                 category.getPreference(TYPE_COUNT - 1).setEnabled(mNotificationsEnabled);
             }
         }
@@ -266,15 +268,19 @@ public class NotificationsSettingsFragment extends PreferenceFragment {
         emailPreference.setSummary(R.string.notifications_email_summary);
         rootCategory.addPreference(emailPreference);
 
-        NotificationsSettingsDialogPreference devicePreference = new NotificationsSettingsDialogPreference(
-                context, null, channel, NotificationsSettings.Type.DEVICE, blogId, mNotificationsSettings, mOnSettingsChangedListener
-        );
-        devicePreference.setIcon(R.drawable.ic_phone_grey);
-        devicePreference.setTitle(R.string.app_notifications);
-        devicePreference.setDialogTitle(R.string.app_notifications);
-        devicePreference.setSummary(R.string.notifications_push_summary);
-        devicePreference.setEnabled(mNotificationsEnabled);
-        rootCategory.addPreference(devicePreference);
+        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context);
+        String deviceID = settings.getString(NotificationsUtils.WPCOM_PUSH_DEVICE_SERVER_ID, null);
+        if (!TextUtils.isEmpty(deviceID)) {
+            NotificationsSettingsDialogPreference devicePreference = new NotificationsSettingsDialogPreference(
+                    context, null, channel, NotificationsSettings.Type.DEVICE, blogId, mNotificationsSettings, mOnSettingsChangedListener
+            );
+            devicePreference.setIcon(R.drawable.ic_phone_grey);
+            devicePreference.setTitle(R.string.app_notifications);
+            devicePreference.setDialogTitle(R.string.app_notifications);
+            devicePreference.setSummary(R.string.notifications_push_summary);
+            devicePreference.setEnabled(mNotificationsEnabled);
+            rootCategory.addPreference(devicePreference);
+        }
 
         mTypePreferenceCategories.add(rootCategory);
     }


### PR DESCRIPTION
Addresses #3252 by removing an early return when GCM services are not available. This will allow the notification settings to be fetched. If no device ID is available the App notifications preference is not shown.