### PR TITLE
Fix #3244: reuse the same notification in case of post edit

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -969,7 +969,19 @@ public class PostUploadService extends Service {
                 notificationBuilder.addAction(R.drawable.ic_share_white_24dp, getString(R.string.share_action),
                         pendingIntent);
             }
-            mNotificationManager.notify((new Random()).nextInt(), notificationBuilder.build());
+            mNotificationManager.notify(getNotificationIdForPost(post), notificationBuilder.build());
+        }
+
+        private int getNotificationIdForPost(Post post) {
+            int remotePostId = 0;
+            try {
+                remotePostId = Integer.parseInt(post.getRemotePostId());
+            } catch (NumberFormatException nfe) {
+                // No op
+            }
+            // We can't use the local table post id here because it can change between first post (local draft) to
+            // first edit (post pulled from the server)
+            return post.getLocalTableBlogId() + remotePostId;
         }
 
         public void updateNotificationError(String mErrorMessage, boolean isMediaError, boolean isPage,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -43,6 +43,7 @@ import org.wordpress.android.util.CrashlyticsUtils;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.MediaUtils;
+import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.SystemServiceFactory;
 import org.wordpress.android.util.WPMeShortlinks;
 import org.wordpress.android.util.helpers.MediaFile;
@@ -973,12 +974,7 @@ public class PostUploadService extends Service {
         }
 
         private int getNotificationIdForPost(Post post) {
-            int remotePostId = 0;
-            try {
-                remotePostId = Integer.parseInt(post.getRemotePostId());
-            } catch (NumberFormatException nfe) {
-                // No op
-            }
+            int remotePostId = StringUtils.stringToInt(post.getRemotePostId());
             // We can't use the local table post id here because it can change between first post (local draft) to
             // first edit (post pulled from the server)
             return post.getLocalTableBlogId() + remotePostId;


### PR DESCRIPTION
Fix #3244: reuse the same notification in case of post edit

Note: I wanted to use the same id for the "uploading in progress" notification but since the same one can be used for several posts, this is not that easy.