### PR TITLE
Fix #3280 - Sign in: Tapping return from username field should move t…

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -158,20 +158,6 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             }
         });
 
-        mUsernameEditText.setOnKeyListener(new View.OnKeyListener() {
-            @Override
-            public boolean onKey(View v, int keyCode, KeyEvent event) {
-                if ((event != null && (event.getKeyCode() == KeyEvent.KEYCODE_ENTER))
-                        || (keyCode == EditorInfo.IME_ACTION_DONE)
-                        || (event.getKeyCode() == KeyEvent.KEYCODE_NAVIGATE_NEXT)
-                        || (keyCode == EditorInfo.IME_ACTION_NEXT)) {
-                    mPasswordEditText.requestFocus();
-                    return true;
-                }
-                return false;
-            }
-        });
-
         mForgotPassword = (WPTextView) rootView.findViewById(R.id.forgot_password);
         mForgotPassword.setOnClickListener(mForgotPasswordListener);
         mUsernameEditText.setOnFocusChangeListener(new View.OnFocusChangeListener() {
@@ -663,17 +649,18 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         final String password = EditTextUtils.getText(mPasswordEditText).trim();
         boolean retValue = true;
 
+        if (password.equals("")) {
+            mPasswordEditText.setError(getString(R.string.required_field));
+            mPasswordEditText.requestFocus();
+            retValue = false;
+        }
+
         if (username.equals("")) {
             mUsernameEditText.setError(getString(R.string.required_field));
             mUsernameEditText.requestFocus();
             retValue = false;
         }
 
-        if (password.equals("")) {
-            mPasswordEditText.setError(getString(R.string.required_field));
-            mPasswordEditText.requestFocus();
-            retValue = false;
-        }
         return retValue;
     }
 
@@ -701,8 +688,8 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         switch (getErrorType(messageId)) {
             case USERNAME:
             case PASSWORD:
-                showUsernameError(messageId);
                 showPasswordError(messageId);
+                showUsernameError(messageId);
                 return true;
             default:
                 return false;
@@ -814,8 +801,8 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             mUsernameEditText.setError(null);
             showInvalidUsernameOrPasswordDialog();
         } else {
-            showUsernameError(messageId);
             showPasswordError(messageId);
+            showUsernameError(messageId);
         }
         endProgress();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -158,6 +158,20 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             }
         });
 
+        mUsernameEditText.setOnKeyListener(new View.OnKeyListener() {
+            @Override
+            public boolean onKey(View v, int keyCode, KeyEvent event) {
+                if ((event != null && (event.getKeyCode() == KeyEvent.KEYCODE_ENTER))
+                        || (keyCode == EditorInfo.IME_ACTION_DONE)
+                        || (event.getKeyCode() == KeyEvent.KEYCODE_NAVIGATE_NEXT)
+                        || (keyCode == EditorInfo.IME_ACTION_NEXT)) {
+                    mPasswordEditText.requestFocus();
+                    return true;
+                }
+                return false;
+            }
+        });
+
         mForgotPassword = (WPTextView) rootView.findViewById(R.id.forgot_password);
         mForgotPassword.setOnClickListener(mForgotPasswordListener);
         mUsernameEditText.setOnFocusChangeListener(new View.OnFocusChangeListener() {

--- a/WordPress/src/main/res/layout/signin_fragment.xml
+++ b/WordPress/src/main/res/layout/signin_fragment.xml
@@ -96,6 +96,8 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/username_email"
                     android:inputType="textEmailAddress"
+                    android:imeOptions="actionNext"
+                    android:nextFocusDown="@+id/nux_password"
                     app:persistenceEnabled="true" />
 
                 <ImageView


### PR DESCRIPTION
…o password field

Added checks for return key and next key while in the user text field. When this happens, the focus is moved to the password field.