### PR TITLE
Issue/3263 reader janky subs viewpager

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
@@ -119,7 +119,7 @@ public class ReaderBlogFragment extends Fragment
     }
 
     void refresh() {
-        if (hasBlogAdapter()) {
+        if (hasBlogAdapter()) {AppLog.d(AppLog.T.READER, "reader subs > refreshing blog fragment " + getBlogType().name());
             getBlogAdapter().refresh();
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
@@ -119,7 +119,8 @@ public class ReaderBlogFragment extends Fragment
     }
 
     void refresh() {
-        if (hasBlogAdapter()) {AppLog.d(AppLog.T.READER, "reader subs > refreshing blog fragment " + getBlogType().name());
+        if (hasBlogAdapter()) {
+            AppLog.d(AppLog.T.READER, "reader subs > refreshing blog fragment " + getBlogType().name());
             getBlogAdapter().refresh();
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -71,6 +71,8 @@ public class ReaderSubsActivity extends AppCompatActivity
 
     private static final String KEY_LAST_ADDED_TAG_NAME = "last_added_tag_name";
 
+    private static final int NUM_TABS = 3;
+
     private static final int TAB_IDX_FOLLOWED_TAGS = 0;
     private static final int TAB_IDX_FOLLOWED_BLOGS = 1;
     private static final int TAB_IDX_RECOMMENDED_BLOGS = 2;
@@ -83,7 +85,7 @@ public class ReaderSubsActivity extends AppCompatActivity
         restoreState(savedInstanceState);
 
         mViewPager = (WPViewPager) findViewById(R.id.viewpager);
-        mViewPager.setOffscreenPageLimit(2);
+        mViewPager.setOffscreenPageLimit(NUM_TABS - 1);
         mViewPager.setAdapter(getPageAdapter());
 
         TabLayout tabLayout = (TabLayout) findViewById(R.id.tab_layout);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -83,6 +83,7 @@ public class ReaderSubsActivity extends AppCompatActivity
         restoreState(savedInstanceState);
 
         mViewPager = (WPViewPager) findViewById(R.id.viewpager);
+        mViewPager.setOffscreenPageLimit(2);
         mViewPager.setAdapter(getPageAdapter());
 
         TabLayout tabLayout = (TabLayout) findViewById(R.id.tab_layout);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -38,6 +38,7 @@ import org.wordpress.android.ui.reader.adapters.ReaderBlogAdapter.ReaderBlogType
 import org.wordpress.android.ui.reader.adapters.ReaderTagAdapter;
 import org.wordpress.android.ui.reader.services.ReaderUpdateService;
 import org.wordpress.android.ui.reader.services.ReaderUpdateService.UpdateTask;
+import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.NetworkUtils;
@@ -168,16 +169,19 @@ public class ReaderSubsActivity extends AppCompatActivity
 
     @SuppressWarnings("unused")
     public void onEventMainThread(ReaderEvents.FollowedTagsChanged event) {
+        AppLog.d(AppLog.T.READER, "reader subs > followed tags changed");
         getPageAdapter().refreshFollowedTagFragment();
     }
 
     @SuppressWarnings("unused")
     public void onEventMainThread(ReaderEvents.FollowedBlogsChanged event) {
+        AppLog.d(AppLog.T.READER, "reader subs > followed blogs changed");
         getPageAdapter().refreshBlogFragments(ReaderBlogType.FOLLOWED);
     }
 
     @SuppressWarnings("unused")
     public void onEventMainThread(ReaderEvents.RecommendedBlogsChanged event) {
+        AppLog.d(AppLog.T.READER, "reader subs > recommended blogs changed");
         getPageAdapter().refreshBlogFragments(ReaderBlogType.RECOMMENDED);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
@@ -50,11 +50,12 @@ public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagD
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         mRecyclerView.setAdapter(getTagAdapter());
-        getTagAdapter().refresh();
+        refresh();
     }
 
     void refresh() {
         if (hasTagAdapter()) {
+            AppLog.d(AppLog.T.READER, "reader subs > refreshing tag fragment");
             getTagAdapter().refresh();
         }
     }


### PR DESCRIPTION
Fixes #3263 - jank was due to the first fragment being destroyed when you swipe to the last tab, forcing it to be recreated when you swipe back again (similarly for the last fragment when you swipe to the first tab).

Resolved by using `setOffscreenPageLimit` on the activity's ViewPager to keep the fragments in memory.