### PR TITLE
issue/3297-reader-subs-tab-shadow

### DIFF
--- a/WordPress/src/main/res/layout/reader_activity_subs.xml
+++ b/WordPress/src/main/res/layout/reader_activity_subs.xml
@@ -6,24 +6,30 @@
     android:layout_height="wrap_content"
     android:background="@color/white">
 
-    <include
-        android:id="@+id/toolbar"
-        layout="@layout/toolbar" />
-
-    <android.support.design.widget.TabLayout
-        android:id="@+id/tab_layout"
+    <android.support.design.widget.AppBarLayout
+        android:id="@+id/appbar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/toolbar"
-        android:background="@color/tab_background"
-        app:tabIndicatorColor="@color/tab_indicator" />
+        android:layout_height="wrap_content">
+
+        <include
+            android:id="@+id/toolbar"
+            layout="@layout/toolbar" />
+
+        <android.support.design.widget.TabLayout
+            android:id="@+id/tab_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/toolbar"
+            android:background="@color/tab_background"
+            app:tabIndicatorColor="@color/tab_indicator" />
+    </android.support.design.widget.AppBarLayout>
 
     <org.wordpress.android.widgets.WPViewPager
         android:id="@+id/viewpager"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_above="@+id/divider_list"
-        android:layout_below="@+id/tab_layout" />
+        android:layout_below="@+id/appbar" />
 
     <View
         android:id="@+id/divider_list"


### PR DESCRIPTION
Resolves #3297 by wrapping the toolbar and tabs in an AppBar layout so a shadow appears beneath the tabs. A similar change should probably be made to the main themes activity.

![device-2015-10-02-191239](https://cloud.githubusercontent.com/assets/3903757/10259753/f74eb5e8-6939-11e5-89fa-fd5d2bfe1f22.png)

Note: the shadow will only appear on devices running Lollipop or later.
