### PR TITLE
issue/3267-comment-reply-refresh

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -308,9 +308,15 @@ public class CommentsActivity extends AppCompatActivity
 
     @Override
     public void onCommentChanged(CommentActions.ChangedFrom changedFrom, CommentActions.ChangeType changeType) {
-        if (changedFrom == CommentActions.ChangedFrom.COMMENT_DETAIL
-                && changeType == CommentActions.ChangeType.EDITED) {
-            reloadCommentList();
+        if (changedFrom == CommentActions.ChangedFrom.COMMENT_DETAIL) {
+            switch (changeType) {
+                case EDITED:
+                    reloadCommentList();
+                    break;
+                case REPLIED:
+                    updateCommentList();
+                    break;
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #3267 - replying to a comment now refreshes the comment list to show the reply.