### PR TITLE
issue/3266-comment-moderation-delay

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -243,7 +243,7 @@ public class CommentsActivity extends AppCompatActivity
                     getListFragment().setCommentIsModerating(comment.commentID, false);
 
                     if (succeeded) {
-                        getListFragment().updateComments(false);
+                        reloadCommentList();
                     } else {
                         ToastUtils.showToast(CommentsActivity.this,
                                 R.string.error_moderate_comment,


### PR DESCRIPTION
Fix #3266 - to reproduce the original issue, use an emulator with a throttled connection (or a real device with a slow connection). The delay showing the new status was caused by updating the comment list from the server once moderation completed.

The fix was to simply reload the comment list from the local db, since the status has already been changed locally (so no need to re-get from server). 