### PR TITLE
Adds Ability to Search Sites in Notification Settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -55,16 +55,18 @@ import javax.annotation.Nonnull;
 import de.greenrobot.event.EventBus;
 
 public class NotificationsSettingsFragment extends PreferenceFragment {
+
+    private static final String KEY_SEARCH_QUERY = "search_query";
+    private static final int SITE_SEARCH_VISIBILITY_COUNT = 15;
     // The number of notification types we support (e.g. timeline, email, mobile)
     private static final int TYPE_COUNT = 3;
-
-    private static final int SITE_SEARCH_VISIBILITY_COUNT = 15;
 
     private NotificationsSettings mNotificationsSettings;
     private SearchView mSearchView;
     private MenuItem mSearchMenuItem;
 
     private String mDeviceId;
+    private String mRestoredQuery;
     private boolean mNotificationsEnabled;
     private int mSiteCount;
 
@@ -87,6 +89,10 @@ public class NotificationsSettingsFragment extends PreferenceFragment {
 
         if (hasNotificationsSettings()) {
             loadNotificationsAndUpdateUI(true);
+        }
+
+        if (savedInstanceState != null && savedInstanceState.containsKey(KEY_SEARCH_QUERY)) {
+            mRestoredQuery = savedInstanceState.getString(KEY_SEARCH_QUERY);
         }
     }
 
@@ -123,6 +129,21 @@ public class NotificationsSettingsFragment extends PreferenceFragment {
         });
 
         updateSearchMenuVisibility();
+
+        // Check for a restored search query (if device was rotated, etc)
+        if (!TextUtils.isEmpty(mRestoredQuery)) {
+            mSearchMenuItem.expandActionView();
+            mSearchView.setQuery(mRestoredQuery, true);
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        if (mSearchView != null && !TextUtils.isEmpty(mSearchView.getQuery())) {
+            outState.putString(KEY_SEARCH_QUERY, mSearchView.getQuery().toString());
+        }
+
+        super.onSaveInstanceState(outState);
     }
 
     private void refreshSettings() {

--- a/WordPress/src/main/res/menu/notifications_settings.xml
+++ b/WordPress/src/main/res/menu/notifications_settings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/menu_notifications_settings_search"
+        app:actionViewClass="android.support.v7.widget.SearchView"
+        android:icon="@drawable/ic_search_white_24dp"
+        app:showAsAction="collapseActionView|ifRoom"
+        android:title="@string/search_sites"
+        android:visible="false"/>
+</menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -636,6 +636,8 @@
     <string name="notifications_tab_summary">Settings for notifications that appear in the Notifications tab.</string>
     <string name="notifications_email_summary">Settings for notifications that are sent to the email tied to your account.</string>
     <string name="notifications_push_summary">Settings for notifications that appear on your device.</string>
+    <string name="search_sites">Search sites</string>
+    <string name="notifications_no_search_results">No sites matched \'%s\'</string>
     <string-array name="notifications_blog_settings">
         <item>Comments on my site</item>
         <item>Likes on my comments</item>


### PR DESCRIPTION
If you have more than 15 sites in notifications settings, you can now use the search view in the toolbar to filter them.

![device-2015-10-07-142507](https://cloud.githubusercontent.com/assets/789137/10351651/97ac2ce6-6cff-11e5-89e5-cb9f0f30581e.png)

Fixes #3242 

