### PR TITLE
Fix 3209 and 3283: disconnect progress dialog crashes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -3,7 +3,6 @@ package org.wordpress.android;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Application;
-import android.app.ProgressDialog;
 import android.content.ComponentCallbacks2;
 import android.content.Context;
 import android.content.res.Configuration;
@@ -67,7 +66,6 @@ import org.xmlrpc.android.ApiHelper;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.ref.WeakReference;
 import java.lang.reflect.Type;
 import java.security.GeneralSecurityException;
 import java.util.Date;
@@ -478,10 +476,6 @@ public class WordPress extends Application {
         return (getCurrentBlog() != null ? getCurrentBlog().getLocalTableBlogId() : -1);
     }
 
-    public static void signOutWordPressComAsyncWithProgressBar(Context context) {
-        new SignOutWordPressComAsync(context).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
-    }
-
     /**
      * Sign out from wpcom account
      */
@@ -524,41 +518,6 @@ public class WordPress extends Application {
 
         // dangerously delete all content!
         wpDB.dangerouslyDeleteAllContent();
-    }
-
-    public static class SignOutWordPressComAsync extends AsyncTask<Void, Void, Void> {
-        ProgressDialog mProgressDialog;
-        WeakReference<Context> mWeakContext;
-
-        public SignOutWordPressComAsync(Context context) {
-            mWeakContext = new WeakReference<Context>(context);
-        }
-
-        @Override
-        protected void onPreExecute() {
-            super.onPreExecute();
-            Context context = mWeakContext.get();
-            if (context != null) {
-                mProgressDialog = ProgressDialog.show(context, null, context.getText(R.string.signing_out), false);
-            }
-        }
-
-        @Override
-        protected Void doInBackground(Void... params) {
-            Context context = mWeakContext.get();
-            if (context != null) {
-                WordPressComSignOut(context);
-            }
-            return null;
-        }
-
-        @Override
-        protected void onPostExecute(Void aVoid) {
-            super.onPostExecute(aVoid);
-            if (mProgressDialog != null) {
-                mProgressDialog.dismiss();
-            }
-        }
     }
 
     public static void removeWpComUserRelatedData(Context context) {

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -539,7 +539,7 @@ public class WordPress extends Application {
             super.onPreExecute();
             Context context = mWeakContext.get();
             if (context != null) {
-                mProgressDialog = ProgressDialog.show(context, null, context.getText(R.string.signing_out));
+                mProgressDialog = ProgressDialog.show(context, null, context.getText(R.string.signing_out), false);
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -3,8 +3,11 @@ package org.wordpress.android.ui.main;
 import android.annotation.TargetApi;
 import android.app.AlertDialog;
 import android.app.Fragment;
+import android.app.ProgressDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.Outline;
+import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -22,6 +25,8 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.HelpshiftHelper.Tag;
 import org.wordpress.android.widgets.WPNetworkImageView;
+
+import java.lang.ref.WeakReference;
 
 public class MeFragment extends Fragment {
 
@@ -157,6 +162,41 @@ public class MeFragment extends Fragment {
     private void signOutWordPressCom() {
         // note that signing out sends a CoreEvents.UserSignedOutWordPressCom EventBus event,
         // which will cause the main activity to recreate this fragment
-        WordPress.signOutWordPressComAsyncWithProgressBar(getActivity());
+        (new SignOutWordPressComAsync(getActivity())).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    }
+
+    private class SignOutWordPressComAsync extends AsyncTask<Void, Void, Void> {
+        ProgressDialog mProgressDialog;
+        WeakReference<Context> mWeakContext;
+
+        public SignOutWordPressComAsync(Context context) {
+            mWeakContext = new WeakReference<Context>(context);
+        }
+
+        @Override
+        protected void onPreExecute() {
+            super.onPreExecute();
+            Context context = mWeakContext.get();
+            if (context != null) {
+                mProgressDialog = ProgressDialog.show(context, null, context.getText(R.string.signing_out), false);
+            }
+        }
+
+        @Override
+        protected Void doInBackground(Void... params) {
+            Context context = mWeakContext.get();
+            if (context != null) {
+                WordPress.WordPressComSignOut(context);
+            }
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(Void aVoid) {
+            super.onPostExecute(aVoid);
+            if (mProgressDialog != null) {
+                mProgressDialog.dismiss();
+            }
+        }
     }
 }


### PR DESCRIPTION
To test if #3283 and #3209 are fixed, I recommend to add `SystemClock.sleep(10000);` [here](https://github.com/wordpress-mobile/WordPress-Android/blob/737cf1101d57da962dd88966618cd69654b68a46/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java#L214)