### PR TITLE
fix #3338: use an authenticated webview for wpcom sites linked from the Reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -13,6 +13,7 @@ import android.view.View;
 
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.models.AccountHelper;
 import org.wordpress.android.models.ReaderComment;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderTag;
@@ -20,6 +21,7 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.UrlUtils;
 
 public class ReaderActivityLauncher {
 
@@ -220,11 +222,14 @@ public class ReaderActivityLauncher {
         }
 
         if (openUrlType == OpenUrlType.INTERNAL) {
-            // Open the URL by using the internal browser without authenticating to wpcom.
-            // See: https://github.com/wordpress-mobile/WordPress-Android/issues/1921
-            // If you pass a wpcom URL that needs authentication to be viewed, it will work since
-            // the reader authenticates to wpcom at startup by calling ReaderAuthActions.updateCookies
-            WPWebViewActivity.openURL(context, url);
+            // That won't work on wpcom sites with custom urls
+            // TODO: #2785 (util method to check if a URL is wpcom)
+            if (UrlUtils.getDomainFromUrl(url).endsWith("wordpress.com")) {
+                WPWebViewActivity.openUrlByUsingWPCOMCredentials(context, url,
+                        AccountHelper.getDefaultAccount().getUserName());
+            } else {
+                WPWebViewActivity.openURL(context, url);
+            }
         } else {
             try {
                 Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));


### PR DESCRIPTION
fix #3338: use an authenticated webview for wpcom sites linked from the Reader