### PR TITLE
fix #3340 minor changes to post uploaded notification

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -932,7 +932,6 @@ public class PostUploadService extends Service {
             // Get the sharableUrl
             String sharableUrl = WPMeShortlinks.getPostShortlink(post);
             if (sharableUrl == null && !TextUtils.isEmpty(post.getPermaLink())) {
-                    // No short link or perma link - can't share, abort
                     sharableUrl = post.getPermaLink();
             }
 
@@ -965,6 +964,7 @@ public class PostUploadService extends Service {
                 Intent share = new Intent(Intent.ACTION_SEND);
                 share.setType("text/plain");
                 share.putExtra(Intent.EXTRA_TEXT, sharableUrl);
+                share.putExtra(Intent.EXTRA_SUBJECT, post.getTitle());
                 PendingIntent pendingIntent = PendingIntent.getActivity(mContext, 0, share,
                         PendingIntent.FLAG_UPDATE_CURRENT);
                 notificationBuilder.addAction(R.drawable.ic_share_white_24dp, getString(R.string.share_action),

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -439,8 +439,6 @@ public class PostUploadService extends Service {
         }
 
         private void trackUploadAnalytics() {
-            mPost.getStatusEnum();
-
             boolean isFirstTimePublishing = false;
             if (mPost.hasChangedFromDraftToPublished() ||
                     (mPost.isLocalDraft() && mPost.getStatusEnum() == PostStatus.PUBLISHED)) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -230,8 +230,10 @@
     <!-- post view -->
     <string name="post_id">Post</string>
     <string name="upload_failed">Upload failed</string>
-    <string name="post_uploaded">Post uploaded</string>
-    <string name="page_uploaded">Page uploaded</string>
+    <string name="post_published">Post published</string>
+    <string name="page_published">Page published</string>
+    <string name="post_updated">Post updated</string>
+    <string name="page_updated">Page updated</string>
     <string name="post_password">Password (optional)</string>
     <string name="caption">Caption (optional)</string>
     <string name="horizontal_alignment">Horizontal alignment</string>


### PR DESCRIPTION
fix #3340 minor changes to post uploaded notification. 

https://cloudup.com/cmyA23WzBSj

I'm wondering if we should only show that notification when the post has been published for the first time (ie. went from localdraft or draft to published) @mattmiklic - we could also add an analytics event to see how it's used.



