### PR TITLE
issue/3347-reader-list-npe

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -818,6 +818,8 @@ public class ReaderPostListFragment extends Fragment
      * get latest posts for this tag from the server
      */
     private void updatePostsWithTag(ReaderTag tag, UpdateAction updateAction) {
+        if (!isAdded()) return;
+
         if (!NetworkUtils.isNetworkAvailable(getActivity())) {
             AppLog.i(T.READER, "reader post list > network unavailable, canceled tag update");
             return;
@@ -842,7 +844,7 @@ public class ReaderPostListFragment extends Fragment
         new Thread() {
             @Override
             public void run() {
-                if (isAdded() && ReaderTagTable.shouldAutoUpdateTag(getCurrentTag())) {
+                if (ReaderTagTable.shouldAutoUpdateTag(getCurrentTag()) && isAdded()) {
                     getActivity().runOnUiThread(new Runnable() {
                         @Override
                         public void run() {


### PR DESCRIPTION
Fix #3347 - I'm not 100% confident this was the problem, but I *think* the NPE was the result of calling `shouldAutoUpdateTag` after checking `isAdded`. Since `shouldAutoUpdateTag` hits the local db, it's possible the activity was valid prior to it being called and invalid afterwards.