### PR TITLE
fix #3341 status bar color signin theme

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -1,11 +1,9 @@
 package org.wordpress.android.ui.main;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Fragment;
 import android.content.Intent;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.design.widget.TabLayout;
@@ -79,8 +77,6 @@ public class WPMainActivity extends Activity
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        setStatusBarColor();
-
         ProfilingUtils.split("WPMainActivity.onCreate");
 
         super.onCreate(savedInstanceState);
@@ -197,13 +193,6 @@ public class WPMainActivity extends Activity
     protected void onSaveInstanceState(Bundle outState) {
         outState.putInt(KEY_LAST_RESELECTED_TAB_POSITION, mLastReselectedTabPosition);
         super.onSaveInstanceState(outState);
-    }
-
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    private void setStatusBarColor() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            getWindow().setStatusBarColor(getResources().getColor(R.color.status_bar_tint));
-        }
     }
 
     @Override

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -40,6 +40,7 @@
     <style name="SignInTheme" parent="Theme.AppCompat.NoActionBar">
         <item name="colorControlActivated">@color/color_control_activated</item>
         <item name="colorControlHighlight">@color/color_control_highlight</item>
+        <item name="android:statusBarColor">@color/status_bar_tint</item>
     </style>
 
     <style name="TabBarStyle.WordPress" parent="@android:style/Widget.Holo.ActionBar.TabBar">

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -18,11 +18,12 @@
         <item name="android:actionModeBackground">@color/color_primary_dark</item>
         <item name="android:actionBarTabTextStyle">@style/TabTextStyle.WordPress</item>
         <item name="android:actionBarTabBarStyle">@style/TabBarStyle.WordPress</item>
-        <item name="windowActionModeOverlay">true</item>
+        <item name="android:statusBarColor">@color/status_bar_tint</item>
 
         <!-- Light.DarkActionBar specific -->
         <item name="android:actionBarWidgetTheme">@style/Theme.WordPress.Widget</item>
 
+        <item name="windowActionModeOverlay">true</item>
         <item name="swipeToRefreshStyle">@style/WordPress.SwipeToRefresh</item>
     </style>
 


### PR DESCRIPTION
fix #3341 status bar color signin theme

I'm not sure why the color was set programmatically in `WPMainActivity` since `android:statusBarColor` is ignored on device < 5.0 - seems easier and cleaner to use the theme instead.
