### PR TITLE
Wait until onResume() to restore note detail UI

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -109,6 +109,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     private TextView mBtnTrashComment;
 
     private String mRestoredReplyText;
+    private String mRestoredNoteId;
 
     private boolean mIsUsersBlog = false;
     private boolean mShouldFocusReplyField;
@@ -171,7 +172,9 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         super.onCreate(savedInstanceState);
         if (savedInstanceState != null) {
             if (savedInstanceState.getString(KEY_NOTE_ID) != null) {
-                setNoteWithNoteId(savedInstanceState.getString(KEY_NOTE_ID));
+                // The note will be set in onResume() because Simperium will be running there
+                // See WordPress.deferredInit()
+                mRestoredNoteId = savedInstanceState.getString(KEY_NOTE_ID);
             } else {
                 int localBlogId = savedInstanceState.getInt(KEY_LOCAL_BLOG_ID);
                 long commentId = savedInstanceState.getLong(KEY_COMMENT_ID);
@@ -299,6 +302,12 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     public void onResume() {
         super.onResume();
         ActivityId.trackLastActivity(ActivityId.COMMENT_DETAIL);
+
+        // Set the note if we retrieved the noteId from savedInstanceState
+        if (!TextUtils.isEmpty(mRestoredNoteId)) {
+            setNoteWithNoteId(mRestoredNoteId);
+            mRestoredNoteId = null;
+        }
     }
 
     private void setupSuggestionServiceAndAdapter() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -63,6 +63,7 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
     private LinearLayout mRootLayout;
     private ViewGroup mFooterView;
 
+    private String mRestoredNoteId;
     private int mBackgroundColor;
     private int mCommentListPosition = ListView.INVALID_POSITION;
     private boolean mIsUnread;
@@ -85,7 +86,9 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
         super.onCreate(savedInstanceState);
 
         if (savedInstanceState != null && savedInstanceState.containsKey(KEY_NOTE_ID)) {
-            setNoteWithNoteId(savedInstanceState.getString(KEY_NOTE_ID));
+            // The note will be set in onResume() because Simperium will be running there
+            // See WordPress.deferredInit()
+            mRestoredNoteId = savedInstanceState.getString(KEY_NOTE_ID);
             mRestoredListPosition = savedInstanceState.getInt(KEY_LIST_POSITION, 0);
         }
     }
@@ -120,9 +123,16 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
     public void onResume() {
         super.onResume();
 
-        // start listening to bucket change events
+        // Start listening to bucket change events
         if (SimperiumUtils.getNotesBucket() != null) {
             SimperiumUtils.getNotesBucket().addListener(this);
+        }
+
+        // Set the note if we retrieved the noteId from savedInstanceState
+        if (!TextUtils.isEmpty(mRestoredNoteId)) {
+            setNoteWithNoteId(mRestoredNoteId);
+            reloadNoteBlocks();
+            mRestoredNoteId = null;
         }
     }
 


### PR DESCRIPTION
The addition of `WordPress.deferredInit()` caused #3359. Since Simperium isn't loaded until `onResume()`, we need to wait until then to load the note object if the activity and fragment are recreated.

You can test this works by loading a note detail view (such as a like or comment reply), then press the home button. Then `adb shell`, `ps`, and `kill` the `org.wordpress.android` process. Then return to the app and you should see the detail view get restored.

Fixes #3359