### PR TITLE
fix #3334: app full backup

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -46,7 +46,8 @@
 
     <application
         android:name="WordPress"
-        android:allowBackup="false"
+        android:allowBackup="true"
+        android:fullBackupContent="@xml/backup_scheme"
         android:hardwareAccelerated="true"
         android:icon="@drawable/app_icon"
         android:label="@string/app_name"

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -83,6 +83,8 @@ public class WordPressDB {
     private static final String CREATE_TABLE_MEDIA = "create table if not exists media (id integer primary key autoincrement, "
             + "postID integer not null, filePath text default '', fileName text default '', title text default '', description text default '', caption text default '', horizontalAlignment integer default 0, width integer default 0, height integer default 0, mimeType text default '', featured boolean default false, isVideo boolean default false);";
     public static final String BLOGS_TABLE = "accounts";
+
+    // Warning if you rename DATABASE_NAME, that could break previous App backups (see: xml/backup_scheme.xml)
     private static final String DATABASE_NAME = "wordpress";
     private static final String MEDIA_TABLE = "media";
 

--- a/WordPress/src/main/res/xml/backup_scheme.xml
+++ b/WordPress/src/main/res/xml/backup_scheme.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+  <!-- Following files could be saved, but they're useless and takes
+  significant space -->
+  <exclude domain="database" path="wpreader.db"/>
+  <exclude domain="database" path="simperium-store"/>
+  <exclude domain="database" path="stats.db"/>
+  <exclude domain="database" path="tracks.db"/>
+  <exclude domain="database" path="mixpanel"/>
+
+  <!-- Contains regId - must be different on each device -->
+  <exclude domain="sharedpref" path="com.google.android.gcm.xml"/>
+</full-backup-content>

--- a/WordPress/src/main/res/xml/backup_scheme.xml
+++ b/WordPress/src/main/res/xml/backup_scheme.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <full-backup-content>
-  <!-- Following files could be saved, but they're useless and takes
-  significant space -->
-  <exclude domain="database" path="wpreader.db"/>
-  <exclude domain="database" path="simperium-store"/>
-  <exclude domain="database" path="stats.db"/>
-  <exclude domain="database" path="tracks.db"/>
-  <exclude domain="database" path="mixpanel"/>
-
-  <!-- Contains regId - must be different on each device -->
-  <exclude domain="sharedpref" path="com.google.android.gcm.xml"/>
+  <include domain="database" path="wordpress"/>
+  <include domain="database" path="persistentedittext.db"/>
+  <include domain="sharedpref" path="self_signed_certs_truststore.bks"/>
+  <include domain="sharedpref" path="org.wordpress.android_preferences.xml"/>
+  <include domain="sharedpref" path="simperium.xml"/>
 </full-backup-content>


### PR DESCRIPTION
I originally excluded some files from the full backup in  ff43c06  to make the app future proof (in case we'll create new database) - but that probably not a good idea, since we really want to only backup: login data, local drafts, app settings - everything else is a "bonus". So I changed that and now only include a few files in 6fbd9de