### PR TITLE
Referrers and Clicks - Better handling of site's icons

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsClicksFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsClicksFragment.java
@@ -165,8 +165,6 @@ public class StatsClicksFragment extends StatsAbstractListFragment {
             if (convertView == null) {
                 convertView = inflater.inflate(R.layout.stats_list_cell, parent, false);
                 holder = new StatsViewHolder(convertView);
-                holder.networkImageView.setErrorImageResId(R.drawable.stats_icon_default_site_avatar);
-                holder.networkImageView.setDefaultImageResId(R.drawable.stats_icon_default_site_avatar);
                 convertView.setTag(holder);
             } else {
                 holder = (StatsViewHolder) convertView.getTag();
@@ -189,11 +187,13 @@ public class StatsClicksFragment extends StatsAbstractListFragment {
             // totals
             holder.totalsTextView.setText(FormatUtils.formatDecimal(total));
 
-            if (TextUtils.isEmpty(icon)) {
-                holder.networkImageView.setVisibility(View.GONE);
-            } else {
-                holder.networkImageView.setImageUrl(GravatarUtils.fixGravatarUrl(icon, mResourceVars.headerAvatarSizePx), WPNetworkImageView.ImageType.BLAVATAR);
-                holder.networkImageView.setVisibility(View.VISIBLE);
+            // Site icon
+            holder.networkImageView.setVisibility(View.GONE);
+            if (!TextUtils.isEmpty(icon)) {
+                holder.networkImageView.setImageUrl(
+                        GravatarUtils.fixGravatarUrl(icon, mResourceVars.headerAvatarSizePx),
+                        WPNetworkImageView.ImageType.GONE_UNTIL_AVAILABLE
+                );
             }
 
             if (children == 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewHolder.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewHolder.java
@@ -27,7 +27,7 @@ public class StatsViewHolder {
     public final TextView totalsTextView;
     public final WPNetworkImageView networkImageView;
     public final ImageView chevronImageView;
-    private final ImageView linkImageView;
+    public final ImageView linkImageView;
     public final ImageView imgMore;
     public final LinearLayout rowContent;
 


### PR DESCRIPTION
This PR fix #3365, and slightly change the Referrers section of Stats to better match the web version of it.

- Do not show the site icon in Referrers and Clicks if there is an error retrieving it, or if it's not available in the response (Had to modify the WPNetworkImageView to address this case).
- Also modified the Referrers section by skipping the 3 level of children from the UI. Only the first 2 levels are shown on the UI. The prev. version was designed to unfold the 3 level of children but the resulting UI was a bit confusing and did match the web version.