### PR TITLE
Update tracks to 1.1.0

### DIFF
--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.automattic:tracks:1.0.5'
+    compile 'com.automattic:tracks:1.1.0'
     compile 'com.mixpanel.android:mixpanel-android:4.6.4'
     compile 'com.google.android.gms:play-services:3.2.65'
     compile 'org.wordpress:utils:1.3.0'

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -440,7 +440,7 @@ public class AnalyticsTrackerNosara extends Tracker {
             setWordPressComUserName(username);
             // Re-unify the user
             if (getAnonID() != null) {
-                mNosaraClient.trackAliasUser(getWordPressComUserName(), getAnonID());
+                mNosaraClient.trackAliasUser(getWordPressComUserName(), getAnonID(), TracksClient.NosaraUserType.WPCOM);
                 clearAnonID();
             }
         } else {


### PR DESCRIPTION
- Upgrade Tracks to version 1.1.0
- Call the new `trackAliasUser` introduced in 1.1.0. We've just changed the signature of the method so it's safe to use it without so much testing.
- With Tracks 1.0 we're also fixing a rare crash that could happen on Android 4.x when accessing the BlueTooth Adapter.

Ref: https://github.com/Automattic/Automattic-Tracks-Android/pull/23