### PR TITLE
Hotfix - 4.6.1 - Could not open notification error

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/Note.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Note.java
@@ -95,7 +95,9 @@ public class Note extends Syncable {
     }
 
     public String getId() {
-        return String.valueOf(queryJSON("id", 0));
+        if (mNoteJSON == null)
+            return "0";
+        return  mNoteJSON.optString("id", "0");
     }
 
     public String getType() {


### PR DESCRIPTION
We found there is a problem loading the noteID from the notification obj. IDs are strings in the JSON of the note, but `getSimperiumKey` and `getId` here https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/models/Note.java#L98 does convert it to `int`.

- Once this PR is merged we need to check the class `JSONUtils` in Utils and make sure every call of `queryJSON` logs when returning the default value. There is no log in the current version of the app that reports it making hard to debug the issue.
