### PR TITLE
Hotfix - 4.6.1 - Could not open notification error

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -33,7 +33,7 @@ android {
     defaultConfig {
         applicationId "org.wordpress.android"
         versionName "4.6.1"
-        versionCode 213
+        versionCode 214
         minSdkVersion 14
         targetSdkVersion 23
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -32,8 +32,8 @@ android {
 
     defaultConfig {
         applicationId "org.wordpress.android"
-        versionName "4.6-rc-1"
-        versionCode 208
+        versionName "4.6.1"
+        versionCode 213
         minSdkVersion 14
         targetSdkVersion 23
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -76,7 +76,7 @@ public class WordPressDB {
     public static final String COLUMN_NAME_VIDEO_PRESS_SHORTCODE = "videoPressShortcode";
     public static final String COLUMN_NAME_UPLOAD_STATE          = "uploadState";
 
-    private static final int DATABASE_VERSION = 35;
+    private static final int DATABASE_VERSION = 36;
 
     private static final String CREATE_TABLE_BLOGS = "create table if not exists accounts (id integer primary key autoincrement, "
             + "url text, blogName text, username text, password text, imagePlacement text, centerThumbnail boolean, fullSizeImage boolean, maxImageWidth text, maxImageWidthId integer);";
@@ -347,6 +347,10 @@ public class WordPressDB {
                 currentVersion++;
             case 34:
                 AccountTable.migrationAddEmailAddressField(db);
+                currentVersion++;
+            case 35:
+                // Delete simperium DB
+                ctx.deleteDatabase("simperium-store");
                 currentVersion++;
         }
         db.setVersion(DATABASE_VERSION);

--- a/WordPress/src/main/java/org/wordpress/android/models/Note.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Note.java
@@ -95,7 +95,9 @@ public class Note extends Syncable {
     }
 
     public String getId() {
-        return String.valueOf(queryJSON("id", 0));
+        if (mNoteJSON == null)
+            return "0";
+        return mNoteJSON.optString("id", "0");
     }
 
     public String getType() {


### PR DESCRIPTION
We found there is a problem loading the noteID from the notification obj. IDs are strings in the JSON of the note, but `getSimperiumKey` and `getId` here https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/models/Note.java#L98 does convert it to `int`.

This PR also deletes the Simperium db to fix the issue on clients.

- Once this PR is merged we need to check the class `JSONUtils` in Utils and make sure every call of `queryJSON` logs when returning the default value. There is no log in the current version of the app that reports it making hard to debug the issue.