### PR TITLE
Use more detailed HTTP "User-Agent" header so web servers won't fallback to XHTML / WML

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/UserAgentTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/UserAgentTest.java
@@ -1,0 +1,29 @@
+package org.wordpress.android;
+
+import junit.framework.TestCase;
+
+public class UserAgentTest extends TestCase {
+
+    /**
+     * Copy of {@link WordPress#USER_AGENT_APPNAME}.
+     * Copied here in order to be able to catch User-Agent changes and verify that they're intentional.
+     */
+    private static final String USER_AGENT_APPNAME = "wp-android";
+
+    public void testGetDefaultUserAgent() {
+        String defaultUserAgent = WordPress.getDefaultUserAgent();
+        assertNotNull("Default User-Agent must be set", defaultUserAgent);
+        assertTrue("Default User-Agent must not be an empty string", defaultUserAgent.length() > 0);
+        assertFalse("Default User-Agent must not contain app name", defaultUserAgent.contains(USER_AGENT_APPNAME));
+    }
+
+    public void testGetUserAgent() {
+        String userAgent = WordPress.getUserAgent();
+        assertNotNull("User-Agent must be set", userAgent);
+        assertTrue("User-Agent must not be an empty string", userAgent.length() > 0);
+        assertTrue("User-Agent must contain app name substring", userAgent.contains(USER_AGENT_APPNAME));
+
+        String defaultUserAgent = WordPress.getDefaultUserAgent();
+        assertTrue("User-Agent must be derived from default User-Agent", userAgent.contains(defaultUserAgent));
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -576,20 +576,19 @@ public class WordPress extends Application {
 
     /**
      * User-Agent string when making HTTP connections, for both API traffic and WebViews.
-     * Follows the format detailed at http://tools.ietf.org/html/rfc2616#section-14.43,
-     * ie: "AppName/AppVersion (OS Version; Locale; Device)"
-     *    "wp-android/2.6.4 (Android 4.3; en_US; samsung GT-I9505/jfltezh)"
-     *    "wp-android/2.6.3 (Android 4.4.2; en_US; LGE Nexus 5/hammerhead)"
+     * Appends "wp-android/version" to WebView's default User-Agent string for the webservers
+     * to get the full feature list of the browser and serve content accordingly, e.g.:
+     *    "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
+     *    AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile
+     *    Safari/537.36 wp-android/4.7"
      * Note that app versions prior to 2.7 simply used "wp-android" as the user agent
      **/
     private static final String USER_AGENT_APPNAME = "wp-android";
     private static String mUserAgent;
     public static String getUserAgent() {
         if (mUserAgent == null) {
-            mUserAgent = USER_AGENT_APPNAME + "/" + PackageUtils.getVersionName(getContext())
-                       + " (Android " + Build.VERSION.RELEASE + "; "
-                       + Locale.getDefault().toString() + "; "
-                       + Build.MANUFACTURER + " " + Build.MODEL + "/" + Build.PRODUCT + ")";
+            mUserAgent = getDefaultUserAgent() + " "
+                       + USER_AGENT_APPNAME + "/" + PackageUtils.getVersionName(getContext());
         }
         return mUserAgent;
     }

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -14,7 +14,7 @@ import android.os.Bundle;
 import android.os.StrictMode;
 import android.os.SystemClock;
 import android.text.TextUtils;
-import android.webkit.WebSettings;
+import android.webkit.WebView;
 
 import com.android.volley.RequestQueue;
 import com.android.volley.VolleyLog;
@@ -569,7 +569,8 @@ public class WordPress extends Application {
     private static String mDefaultUserAgent;
     public static String getDefaultUserAgent() {
         if (mDefaultUserAgent == null) {
-            mDefaultUserAgent = WebSettings.getDefaultUserAgent(getContext());
+            // TODO: use WebSettings.getDefaultUserAgent() after upgrade to API level 17+
+            mDefaultUserAgent = new WebView(getContext()).getSettings().getUserAgentString();
         }
         return mDefaultUserAgent;
     }

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -14,6 +14,7 @@ import android.os.Bundle;
 import android.os.StrictMode;
 import android.os.SystemClock;
 import android.text.TextUtils;
+import android.webkit.WebSettings;
 
 import com.android.volley.RequestQueue;
 import com.android.volley.VolleyLog;
@@ -556,6 +557,21 @@ public class WordPress extends Application {
         }
 
         return loginURL;
+    }
+
+    /**
+     * Device's default User-Agent string.
+     * E.g.:
+     *    "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv)
+     *    AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile
+     *    Safari/537.36"
+     */
+    private static String mDefaultUserAgent;
+    public static String getDefaultUserAgent() {
+        if (mDefaultUserAgent == null) {
+            mDefaultUserAgent = WebSettings.getDefaultUserAgent(getContext());
+        }
+        return mDefaultUserAgent;
     }
 
     /**


### PR DESCRIPTION
Some web servers (e.g. Facebook video) misinterpret the current `User-Agent` string as if the app was a feature phone and was only able to parse WML content, e.g.:

    wp-android/4.7 (Android 6.0; en_US; <...>)

So, append "wp-android/" to the WebView's default `User-Agent` string and use it instead:

    Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86_64 Build/MASTER; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36 wp-android/4.7

This pull request references iOS project's (PR: wordpress-mobile/WordPress-iOS/pull/4444, issue: wordpress-mobile/WordPress-iOS/issues/4295) problem with Facebook video embed code not loading properly because of a short-spoken `User-Agent` string.

While Android app itself doesn't have this problem (it uses its custom `User-Agent` only in a few select places), it would be neat to have the same UA format across projects for the sake of analytics.
