### PR TITLE
issue/3389-reader-misleading-message

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderBlogTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderBlogTable.java
@@ -237,6 +237,11 @@ public class ReaderBlogTable {
                 new String[]{Long.toString(feedId)});
     }
 
+    public static boolean hasFollowedBlogs() {
+        String sql = "SELECT 1 FROM tbl_blog_info WHERE is_following!=0 LIMIT 1";
+        return SqlUtils.boolForQuery(ReaderDatabase.getReadableDb(), sql, null);
+    }
+
     public static boolean isFollowedBlogUrl(String blogUrl) {
         if (TextUtils.isEmpty(blogUrl)) {
             return false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -18,6 +18,7 @@ import android.widget.TextView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.datasets.ReaderBlogTable;
 import org.wordpress.android.datasets.ReaderDatabase;
 import org.wordpress.android.datasets.ReaderPostTable;
 import org.wordpress.android.datasets.ReaderTagTable;
@@ -536,8 +537,13 @@ public class ReaderPostListFragment extends Fragment
             titleResId = R.string.reader_empty_posts_in_blog;
         } else if (getPostListType() == ReaderPostListType.TAG_FOLLOWED && hasCurrentTag()) {
             if (getCurrentTag().isFollowedSites()) {
-                titleResId = R.string.reader_empty_followed_blogs_title;
-                descriptionResId = R.string.reader_empty_followed_blogs_description;
+                if (ReaderBlogTable.hasFollowedBlogs()) {
+                    titleResId = R.string.reader_empty_followed_blogs_no_recent_posts_title;
+                    descriptionResId = R.string.reader_empty_followed_blogs_no_recent_posts_description;
+                } else {
+                    titleResId = R.string.reader_empty_followed_blogs_title;
+                    descriptionResId = R.string.reader_empty_followed_blogs_description;
+                }
             } else if (getCurrentTag().isPostsILike()) {
                 titleResId = R.string.reader_empty_posts_liked;
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -533,7 +533,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
     }
 
-    private void clear() {
+    public void clear() {
         mPosts.clear();
         notifyDataSetChanged();
     }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -920,6 +920,8 @@
     <string name="reader_empty_recommended_blogs">No recommended blogs</string>
     <string name="reader_empty_followed_blogs_title">You\'re not following any sites yet</string>
     <string name="reader_empty_followed_blogs_description">But don\'t worry, just tap the icon at the top right to start exploring!</string>
+    <string name="reader_empty_followed_blogs_no_recent_posts_title">No recent posts</string>
+    <string name="reader_empty_followed_blogs_no_recent_posts_description">The sites you follow haven\'t posted anything recently</string>
     <string name="reader_empty_posts_liked">You haven\'t liked any posts</string>
     <string name="reader_empty_comments">No comments yet</string>
     <string name="reader_empty_posts_in_blog">This blog is empty</string>


### PR DESCRIPTION
Resolves #3389 by showing a separate empty message when "Followed Sites" is empty and the user is following at least one site.

For a quick-and-dirty test of this, add these three lines [here](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/3389-reader-misleading-message/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java#L590) then switch to Followed Sites:
```
mEmptyView.setVisibility(View.VISIBLE);
mPostAdapter.clear();
setEmptyTitleAndDescription(false);
```

![empty-followed](https://cloud.githubusercontent.com/assets/3903757/11252493/752eb136-8e04-11e5-8798-41e993662648.png)
