### PR TITLE
issue/3422-masterbar-height

### DIFF
--- a/WordPress/src/main/res/layout/main_activity.xml
+++ b/WordPress/src/main/res/layout/main_activity.xml
@@ -10,7 +10,7 @@
     <org.wordpress.android.ui.main.WPMainTabLayout
         android:id="@+id/tab_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="@dimen/toolbar_height"
         android:background="@color/tab_background"
         android:elevation="@dimen/tabs_elevation"
         app:tabIndicatorColor="@color/tab_indicator" />


### PR DESCRIPTION
Resolves #3422 by using `@dimen/toolbar_height` (56dp) as the height of the masterbar tabs.