### PR TITLE
Fix #3426, upload newly captured video

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1203,7 +1203,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         mediaFile.setTitle(mediaTitle);
         mediaFile.setFilePath(imageUri.toString());
         if (imageUri.getEncodedPath() != null) {
-            mediaFile.setVideo(MediaUtils.isVideo(imageUri.toString()));
+            mediaFile.setVideo(MediaUtils.isVideo(imageUri.toString())
+                    || mediaTitle.equals(getResources().getString(R.string.video)));
         }
         WordPress.wpDB.saveMediaFile(mediaFile);
         mEditorFragment.appendMediaFile(mediaFile, mediaFile.getFilePath(), WordPress.imageLoader);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1203,8 +1203,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         mediaFile.setTitle(mediaTitle);
         mediaFile.setFilePath(imageUri.toString());
         if (imageUri.getEncodedPath() != null) {
-            mediaFile.setVideo(MediaUtils.isVideo(imageUri.toString())
-                    || mediaTitle.equals(getResources().getString(R.string.video)));
+            mediaFile.setVideo(MediaUtils.isVideo(imageUri.toString()));
         }
         WordPress.wpDB.saveMediaFile(mediaFile);
         mEditorFragment.appendMediaFile(mediaFile, mediaFile.getFilePath(), WordPress.imageLoader);

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -68,7 +68,7 @@ public class MediaUtils {
         }
         return url.endsWith(".ogv") || url.endsWith(".mp4") || url.endsWith(".m4v") || url.endsWith(".mov") ||
                 url.endsWith(".wmv") || url.endsWith(".avi") || url.endsWith(".mpg") || url.endsWith(".3gp") ||
-                url.endsWith(".3g2");
+                url.endsWith(".3g2") || url.contains("video");
     }
 
     public static boolean isAudio(String url) {


### PR DESCRIPTION
New video is now classified as video, and trying to upload without VideoPress enabled gives the correct error.

I don't have a self-hosted server or a wp.com account with VideoPress enabled, so I have not tested it when it actually should work to upload, but I do not see why this small change would affect that.