### PR TITLE
Reader: make discover the default (for hotfix/4.7.1)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -105,21 +105,9 @@ public class ReaderPost {
         // parse the author section
         assignAuthorFromJson(post, json.optJSONObject("author"));
 
-        // only freshly-pressed posts have the "editorial" section
-        JSONObject jsonEditorial = json.optJSONObject("editorial");
-        if (jsonEditorial != null) {
-            post.blogId = jsonEditorial.optLong("blog_id");
-            post.blogName = JSONUtils.getStringDecoded(jsonEditorial, "blog_name");
-            post.featuredImage = ReaderImageScanner.getImageUrlFromFPFeaturedImageUrl(
-                    JSONUtils.getString(jsonEditorial, "image"));
-            post.setPrimaryTag(JSONUtils.getString(jsonEditorial, "highlight_topic_title")); //  highlight_topic?
-            // we want freshly-pressed posts to show & store the date they were chosen rather than the day they were published
-            post.published = JSONUtils.getString(jsonEditorial, "displayed_on");
-        } else {
-            post.featuredImage = JSONUtils.getString(json, "featured_image");
-            post.blogName = JSONUtils.getStringDecoded(json, "site_name");
-            post.published = JSONUtils.getString(json, "date");
-        }
+        post.featuredImage = JSONUtils.getString(json, "featured_image");
+        post.blogName = JSONUtils.getStringDecoded(json, "site_name");
+        post.published = JSONUtils.getString(json, "date");
 
         // the date a post was liked is only returned by the read/liked/ endpoint - if this exists,
         // set it as the timestamp so posts are sorted by the date they were liked rather than the
@@ -251,8 +239,7 @@ public class ReaderPost {
             }
         }
 
-        // don't set primary tag if one is already set (may have been set from the editorial
-        // section if this is a Freshly Pressed post)
+        // don't set primary tag if one is already set
         if (!post.hasPrimaryTag()) {
             post.setPrimaryTag(mostPopularTag);
         }
@@ -390,8 +377,7 @@ public class ReaderPost {
         return StringUtils.notNullStr(primaryTag);
     }
     public void setPrimaryTag(String tagName) {
-        // this is a bit of a hack to avoid setting the primary tag to one of the default
-        // tag names ("Freshly Pressed", etc.)
+        // this is a bit of a hack to avoid setting the primary tag to a default tag name
         if (!ReaderTag.isDefaultTagName(tagName)) {
             this.primaryTag = StringUtils.notNullStr(tagName);
         }

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -15,8 +15,8 @@ public class ReaderTag implements Serializable {
 
     // these are the default tag names, which aren't localized in the /read/menu/ response
     private static final String TAG_NAME_LIKED = "Posts I Like";
-    private static final String TAG_NAME_FRESHLY_PRESSED = "Freshly Pressed";
-    private static final String TAG_NAME_DEFAULT = TAG_NAME_FRESHLY_PRESSED;
+    private static final String TAG_NAME_DISCOVER = "Discover";
+    private static final String TAG_NAME_DEFAULT = TAG_NAME_DISCOVER;
 
     // as of 15-Sept-2015 this is still "Blogs I Follow" but it will soon be renamed
     // to "Followed Sites"
@@ -134,7 +134,7 @@ public class ReaderTag implements Serializable {
             return false;
         }
         return (tagName.equalsIgnoreCase(TAG_NAME_FOLLOWED_SITES)
-                || tagName.equalsIgnoreCase(TAG_NAME_FRESHLY_PRESSED)
+                || tagName.equalsIgnoreCase(TAG_NAME_DISCOVER)
                 || tagName.equalsIgnoreCase(TAG_NAME_LIKED));
     }
 
@@ -155,9 +155,6 @@ public class ReaderTag implements Serializable {
     }
     public boolean isFollowedSites() {
         return tagType == ReaderTagType.DEFAULT && getEndpoint().endsWith("/read/following");
-    }
-    public boolean isFreshlyPressed() {
-        return tagType == ReaderTagType.DEFAULT && getEndpoint().endsWith("/freshly-pressed");
     }
     public boolean isTagTopic() {
         String endpoint = getEndpoint();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1041,9 +1041,7 @@ public class ReaderPostListFragment extends Fragment
     private void trackTagLoaded(ReaderTag tag) {
         AnalyticsTracker.Stat stat = null;
 
-        if (tag.isFreshlyPressed()) {
-            stat = AnalyticsTracker.Stat.READER_FRESHLY_PRESSED_LOADED;
-        } else if (tag.isTagTopic()) {
+        if (tag.isTagTopic()) {
             stat = AnalyticsTracker.Stat.READER_TAG_LOADED;
         } else if (tag.isListTopic()) {
             stat = AnalyticsTracker.Stat.READER_LIST_LOADED;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
@@ -1,11 +1,8 @@
 package org.wordpress.android.ui.reader.utils;
 
-import android.net.Uri;
 import android.text.TextUtils;
 
 import org.wordpress.android.ui.reader.models.ReaderImageList;
-import org.wordpress.android.util.PhotonUtils;
-import org.wordpress.android.util.UrlUtils;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -102,35 +99,5 @@ public class ReaderImageScanner {
      */
     public String getLargestImage() {
         return getLargestImage(-1);
-    }
-
-    /*
-     * returns the actual image url from a Freshly Pressed featured image url - this is necessary because the
-     * featured image returned by the API is often an ImagePress url that formats the actual image url for a
-     * specific size, and we want to define the size in the app when the image is requested.
-     * here's an example of an ImagePress featured image url from a freshly-pressed post:
-     *   https://s1.wp.com/imgpress?
-     *          crop=0px%2C0px%2C252px%2C160px
-     *          &url=https%3A%2F%2Fs2.wp.com%2Fimgpress%3Fw%3D252%26url%3Dhttp%253A%252F%252Fmostlybrightideas.files.wordpress.com%252F2013%252F08%252Ftablet.png
-     *          &unsharpmask=80,0.5,3
-     */
-    public static String getImageUrlFromFPFeaturedImageUrl(final String url) {
-        if (url == null || !url.startsWith("http")) {
-            return null;
-        } else if (url.contains("/imgpress")) {
-            String imageUrl = Uri.parse(url).getQueryParameter("url");
-            if (imageUrl != null && imageUrl.contains("url=")) {
-                // url still contains a url= param, process it again
-                return getImageUrlFromFPFeaturedImageUrl(imageUrl);
-            } else {
-                return UrlUtils.removeQuery(imageUrl);
-            }
-        } else if (PhotonUtils.isMshotsUrl(url)) {
-            // if this is an mshots image, return the actual url without the query string (?h=n&w=n),
-            // and change it from https to http so it can be cached
-            return UrlUtils.removeQuery(url).replaceFirst("https", "http");
-        } else {
-            return url;
-        }
     }
 }


### PR DESCRIPTION
Fixes #3431 - "Freshly Pressed" has been dropped in favor of the new "Discover" topic (which [just went live](https://discover.wordpress.com/2015/11/23/hello-world/)). The current release of the app makes "Freshly Pressed" the default topic, so it needs to be changed to default to "Discover."

To test this, simply logout of the app, then log back in and switch to the reader. It should default to showing "Discover" posts.

Note: The fact that the current version defaults to "Freshly Pressed" won't be a problem - it'll default to the first available topic instead.