### PR TITLE
Update comment list whenever a comment is posted from the application.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -83,6 +83,7 @@ import de.greenrobot.event.EventBus;
 public class CommentDetailFragment extends Fragment implements NotificationFragment {
     private int mLocalBlogId;
     private int mRemoteBlogId;
+    private boolean mUpdateCommentsList = false;
 
     private Comment mComment;
     private Note mNote;
@@ -793,6 +794,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
                         ToastUtils.showToast(getActivity(), getString(R.string.note_reply_successful));
                         mEditReply.setText(null);
                         mEditReply.getAutoSaveTextHelper().clearSavedText(mEditReply);
+                        mUpdateCommentsList = true;
                     } else {
                         ToastUtils.showToast(getActivity(), R.string.reply_failed, ToastUtils.Duration.LONG);
                         // refocus editor on failure and show soft keyboard
@@ -1089,6 +1091,10 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         if (mEditReply == null) return null;
 
         return mEditReply.getText().toString();
+    }
+
+    public boolean getUpdateCommentsList() {
+        return mUpdateCommentsList;
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -86,7 +86,12 @@ public class CommentsActivity extends AppCompatActivity
 
     @Override
     public void onBackPressed() {
+        AppLog.d(AppLog.T.COMMENTS, String.valueOf(getFragmentManager().getBackStackEntryCount()));
         if (getFragmentManager().getBackStackEntryCount() > 0) {
+            if (getDetailFragment().getUpdateCommentsList()) {
+                reloadCommentList();
+                updateCommentList();
+            }
             getFragmentManager().popBackStack();
         } else {
             super.onBackPressed();
@@ -98,7 +103,6 @@ public class CommentsActivity extends AppCompatActivity
         super.onNewIntent(intent);
         AppLog.d(AppLog.T.COMMENTS, "comment activity new intent");
     }
-
 
     private CommentDetailFragment getDetailFragment() {
         Fragment fragment = getFragmentManager().findFragmentByTag(getString(


### PR DESCRIPTION
Every time someone replies to a comment and then returns to the comment list, it gets updated. There is an alternative of updating the comment list every time someone returns to it, irrespective of what he did earlier (which for some reason I like more, but I think it's not what is wanted). I might run an "experiment"/metric on those two approaches to see what people think about it. This is kind of my first pull request so please be gentle ;p Let me know if I did something wrong :) Cheers