### PR TITLE
Issue/3436 reader wrong featured image

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderThumbnailTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderThumbnailTable.java
@@ -4,7 +4,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteStatement;
 import android.text.TextUtils;
 
-import org.wordpress.android.ui.reader.utils.ReaderVideoUtils;
 import org.wordpress.android.util.SqlUtils;
 
 /**
@@ -45,15 +44,13 @@ public class ReaderThumbnailTable {
     }
 
     public static String getThumbnailUrl(String fullUrl) {
-        if (TextUtils.isEmpty(fullUrl))
+        if (TextUtils.isEmpty(fullUrl)) {
             return null;
-
-        // if this is a YouTube video we can determine the thumbnail url from the passed url, so we
-        // don't need to store the full url nor query for it
-        if (ReaderVideoUtils.isYouTubeVideoLink(fullUrl))
-            return ReaderVideoUtils.getYouTubeThumbnailUrl(fullUrl);
-
-        return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(), "SELECT thumbnail_url FROM tbl_thumbnails WHERE full_url=?", new String[]{fullUrl});
+        }
+        return SqlUtils.stringForQuery(
+                ReaderDatabase.getReadableDb(),
+                "SELECT thumbnail_url FROM tbl_thumbnails WHERE full_url=?",
+                new String[]{fullUrl});
     }
 
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -293,7 +293,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             postHolder.imgFeatured.setImageUrl(imageUrl, WPNetworkImageView.ImageType.PHOTO);
             postHolder.imgFeatured.setVisibility(View.VISIBLE);
             titleMargin = mMarginLarge;
-        } else if (post.hasFeaturedVideo()) {
+        } else if (post.hasFeaturedVideo() && WPNetworkImageView.canShowVideoThumbnail(post.getFeaturedVideo())) {
             postHolder.imgFeatured.setVideoUrl(post.postId, post.getFeaturedVideo());
             postHolder.imgFeatured.setVisibility(View.VISIBLE);
             titleMargin = mMarginLarge;

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.reader.utils.ReaderVideoUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.ImageUtils;
+import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.VolleyUtils;
 
 import java.util.HashSet;
@@ -75,29 +76,45 @@ public class WPNetworkImageView extends ImageView {
     }
 
     /*
+     * determine whether we can show a thumbnail image for the passed video - currently
+     * we support YouTube, Vimeo & standard images
+     */
+    public static boolean canShowVideoThumbnail(String videoUrl) {
+        return ReaderVideoUtils.isVimeoLink(videoUrl)
+                || ReaderVideoUtils.isYouTubeVideoLink(videoUrl)
+                || MediaUtils.isValidImage(videoUrl);
+    }
+
+    /*
      * retrieves and displays the thumbnail for the passed video
      */
     public void setVideoUrl(final long postId, final String videoUrl) {
         mImageType = ImageType.VIDEO;
         mRequestDidFail = false;
 
-        showDefaultImage();
-
         if (TextUtils.isEmpty(videoUrl)) {
+            showErrorImage();
             return;
         }
 
-        // if we already have a cached thumbnail for this video, show it immediately
-        String cachedThumbnail = ReaderThumbnailTable.getThumbnailUrl(videoUrl);
-        if (!TextUtils.isEmpty(cachedThumbnail)) {
-            AppLog.d(AppLog.T.UTILS, "showing cached video thumbnail");
-            setImageUrl(cachedThumbnail, ImageType.VIDEO);
+        // if this is a YouTube video we can determine the thumbnail url from the passed url,
+        // otherwise check if we've already cached the thumbnail url for this video
+        String thumbnailUrl;
+        if (ReaderVideoUtils.isYouTubeVideoLink(videoUrl)) {
+            thumbnailUrl = ReaderVideoUtils.getYouTubeThumbnailUrl(videoUrl);
+        } else {
+            thumbnailUrl = ReaderThumbnailTable.getThumbnailUrl(videoUrl);
+        }
+        if (!TextUtils.isEmpty(thumbnailUrl)) {
+            setImageUrl(thumbnailUrl, ImageType.VIDEO);
             return;
         }
 
-        // vimeo videos require network request to get thumbnail
-        if (ReaderVideoUtils.isVimeoLink(videoUrl)) {
-            AppLog.d(AppLog.T.UTILS, "requesting vimeo thumbnail");
+        if (MediaUtils.isValidImage(videoUrl)) {
+            setImageUrl(videoUrl, ImageType.VIDEO);
+        } else if (ReaderVideoUtils.isVimeoLink(videoUrl)) {
+            // vimeo videos require network request to get thumbnail
+            showDefaultImage();
             ReaderVideoUtils.requestVimeoThumbnail(videoUrl, new ReaderVideoUtils.VideoThumbnailListener() {
                 @Override
                 public void onResponse(boolean successful, String thumbnailUrl) {
@@ -107,6 +124,9 @@ public class WPNetworkImageView extends ImageView {
                     }
                 }
             });
+        } else {
+            AppLog.d(AppLog.T.UTILS, "no video thumbnail for " + videoUrl);
+            showErrorImage();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
@@ -81,22 +81,23 @@ public class WPNetworkImageView extends ImageView {
         mImageType = ImageType.VIDEO;
         mRequestDidFail = false;
 
+        showDefaultImage();
+
         if (TextUtils.isEmpty(videoUrl)) {
-            showDefaultImage();
             return;
         }
 
         // if we already have a cached thumbnail for this video, show it immediately
         String cachedThumbnail = ReaderThumbnailTable.getThumbnailUrl(videoUrl);
         if (!TextUtils.isEmpty(cachedThumbnail)) {
+            AppLog.d(AppLog.T.UTILS, "showing cached video thumbnail");
             setImageUrl(cachedThumbnail, ImageType.VIDEO);
             return;
         }
 
-        showDefaultImage();
-
         // vimeo videos require network request to get thumbnail
         if (ReaderVideoUtils.isVimeoLink(videoUrl)) {
+            AppLog.d(AppLog.T.UTILS, "requesting vimeo thumbnail");
             ReaderVideoUtils.requestVimeoThumbnail(videoUrl, new ReaderVideoUtils.VideoThumbnailListener() {
                 @Override
                 public void onResponse(boolean successful, String thumbnailUrl) {


### PR DESCRIPTION
Fixes #3436 and #2612 - problem was due to making the ImageView visible whenever a video URL existed, regardless of whether a thumbnail for it could be shown. This resulted in the previous image (ie: featured image) remaining.