### PR TITLE
fix #3372:Resource Leak in SqlUtils.java

### DIFF
--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/SqlUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/SqlUtils.java
@@ -118,6 +118,7 @@ public class SqlUtils {
             return true;
         } finally {
             db.endTransaction();
+            closeCursor(cursor);
         }
     }
 


### PR DESCRIPTION
I think the problem was the curser has never closed. 
We have closeCursor method in the SqlUtils and using that method to close the courser that is used at 102. Of course, close it in the "finally" bracket. 
