### PR TITLE
fix #3453: media browser was setting blank image when reloading network image

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -289,7 +289,6 @@ public class MediaGridAdapter extends CursorAdapter {
             String filepath = uri.getLastPathSegment();
 
             int placeholderResId = WordPressMediaUtils.getPlaceholder(filepath);
-            imageView.setImageResource(0);
             imageView.setErrorImageResId(placeholderResId);
 
             // no default image while downloading


### PR DESCRIPTION
fix #3453: media browser was setting blank images when reloading network image