### PR TITLE
fix #3461: Show an error message if mediaUrl is null

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1113,6 +1113,11 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
      */
 
     private void fetchMedia(Uri mediaUri) {
+        if (mediaUri == null) {
+            Toast.makeText(EditPostActivity.this,
+                    getResources().getText(R.string.gallery_error), Toast.LENGTH_SHORT).show();
+            return;
+        }
         if (URLUtil.isNetworkUrl(mediaUri.toString())) {
             // Create an AsyncTask to download the file
             new DownloadMediaTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, mediaUri);


### PR DESCRIPTION
fix #3461: Show an error message if mediaUrl is null

Note: the `gallery_error` label is incorrect (should be something like `media_cant_be_retrieved_error`) but if I change it now, GlotPress translations will be erased.