### PR TITLE
Issue/3471 reader track post info

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -19,7 +19,7 @@ import java.io.OutputStream;
  */
 public class ReaderDatabase extends SQLiteOpenHelper {
     protected static final String DB_NAME = "wpreader.db";
-    private static final int DB_VERSION = 108;
+    private static final int DB_VERSION = 109;
 
     /*
      * version history
@@ -60,6 +60,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      *  106 - dropped is_likes_enabled and is_sharing_enabled from tbl_posts
      *  107 - "Blogs I Follow" renamed to "Followed Sites"
      *  108 - added "has_gap_marker" to tbl_post_tags
+     *  109 - added "feed_item_id" to tbl_posts
      */
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -30,75 +30,78 @@ public class ReaderPostTable {
             "post_id,"              // 1
           + "blog_id,"              // 2
           + "feed_id,"              // 3
-          + "pseudo_id,"            // 4
-          + "author_name,"          // 5
-          + "author_id,"            // 6
-          + "title,"                // 7
-          + "text,"                 // 8
-          + "excerpt,"              // 9
-          + "url,"                  // 10
-          + "short_url,"            // 11
-          + "blog_url,"             // 12
-          + "blog_name,"            // 13
-          + "featured_image,"       // 14
-          + "featured_video,"       // 15
-          + "post_avatar,"          // 16
-          + "timestamp,"            // 17
-          + "published,"            // 18
-          + "num_replies,"          // 19
-          + "num_likes,"            // 20
-          + "is_liked,"             // 21
-          + "is_followed,"          // 22
-          + "is_comments_open,"     // 23
-          + "is_external,"          // 24
-          + "is_private,"           // 25
-          + "is_videopress,"        // 26
-          + "is_jetpack,"           // 27
-          + "primary_tag,"          // 28
-          + "secondary_tag,"        // 29
-          + "attachments_json,"     // 30
-          + "discover_json,"        // 31
-          + "word_count";           // 32
+          + "feed_item_id,"         // 4
+          + "pseudo_id,"            // 5
+          + "author_name,"          // 6
+          + "author_id,"            // 7
+          + "title,"                // 8
+          + "text,"                 // 9
+          + "excerpt,"              // 10
+          + "url,"                  // 11
+          + "short_url,"            // 12
+          + "blog_url,"             // 13
+          + "blog_name,"            // 14
+          + "featured_image,"       // 15
+          + "featured_video,"       // 16
+          + "post_avatar,"          // 17
+          + "timestamp,"            // 18
+          + "published,"            // 19
+          + "num_replies,"          // 20
+          + "num_likes,"            // 21
+          + "is_liked,"             // 22
+          + "is_followed,"          // 23
+          + "is_comments_open,"     // 24
+          + "is_external,"          // 25
+          + "is_private,"           // 26
+          + "is_videopress,"        // 27
+          + "is_jetpack,"           // 28
+          + "primary_tag,"          // 29
+          + "secondary_tag,"        // 30
+          + "attachments_json,"     // 31
+          + "discover_json,"        // 32
+          + "word_count";           // 33
 
     // used when querying multiple rows and skipping tbl_posts.text
     private static final String COLUMN_NAMES_NO_TEXT =
             "tbl_posts.post_id,"              // 1
           + "tbl_posts.blog_id,"              // 2
           + "tbl_posts.feed_id,"              // 3
-          + "tbl_posts.author_id,"            // 4
-          + "tbl_posts.pseudo_id,"            // 5
-          + "tbl_posts.author_name,"          // 6
-          + "tbl_posts.blog_name,"            // 7
-          + "tbl_posts.blog_url,"             // 8
-          + "tbl_posts.excerpt,"              // 9
-          + "tbl_posts.featured_image,"       // 10
-          + "tbl_posts.featured_video,"       // 11
-          + "tbl_posts.title,"                // 12
-          + "tbl_posts.url,"                  // 13
-          + "tbl_posts.short_url,"            // 14
-          + "tbl_posts.post_avatar,"          // 15
-          + "tbl_posts.timestamp,"            // 16
-          + "tbl_posts.published,"            // 17
-          + "tbl_posts.num_replies,"          // 18
-          + "tbl_posts.num_likes,"            // 19
-          + "tbl_posts.is_liked,"             // 20
-          + "tbl_posts.is_followed,"          // 21
-          + "tbl_posts.is_comments_open,"     // 22
-          + "tbl_posts.is_external,"          // 23
-          + "tbl_posts.is_private,"           // 24
-          + "tbl_posts.is_videopress,"        // 25
-          + "tbl_posts.is_jetpack,"           // 26
-          + "tbl_posts.primary_tag,"          // 27
-          + "tbl_posts.secondary_tag,"        // 28
-          + "tbl_posts.attachments_json,"     // 29
-          + "tbl_posts.discover_json,"        // 30
-          + "tbl_posts.word_count";           // 31
+          + "tbl_posts.feed_item_id,"         // 4
+          + "tbl_posts.author_id,"            // 5
+          + "tbl_posts.pseudo_id,"            // 6
+          + "tbl_posts.author_name,"          // 7
+          + "tbl_posts.blog_name,"            // 8
+          + "tbl_posts.blog_url,"             // 9
+          + "tbl_posts.excerpt,"              // 10
+          + "tbl_posts.featured_image,"       // 11
+          + "tbl_posts.featured_video,"       // 12
+          + "tbl_posts.title,"                // 13
+          + "tbl_posts.url,"                  // 14
+          + "tbl_posts.short_url,"            // 15
+          + "tbl_posts.post_avatar,"          // 16
+          + "tbl_posts.timestamp,"            // 17
+          + "tbl_posts.published,"            // 18
+          + "tbl_posts.num_replies,"          // 19
+          + "tbl_posts.num_likes,"            // 20
+          + "tbl_posts.is_liked,"             // 21
+          + "tbl_posts.is_followed,"          // 22
+          + "tbl_posts.is_comments_open,"     // 23
+          + "tbl_posts.is_external,"          // 24
+          + "tbl_posts.is_private,"           // 25
+          + "tbl_posts.is_videopress,"        // 26
+          + "tbl_posts.is_jetpack,"           // 27
+          + "tbl_posts.primary_tag,"          // 28
+          + "tbl_posts.secondary_tag,"        // 29
+          + "tbl_posts.attachments_json,"     // 30
+          + "tbl_posts.discover_json,"        // 31
+          + "tbl_posts.word_count";           // 32
 
     protected static void createTables(SQLiteDatabase db) {
         db.execSQL("CREATE TABLE tbl_posts ("
                 + "	post_id		        INTEGER DEFAULT 0,"
                 + " blog_id             INTEGER DEFAULT 0,"
                 + " feed_id             INTEGER DEFAULT 0,"
+                + " feed_item_id        INTEGER DEFAULT 0,"
                 + " pseudo_id           TEXT NOT NULL,"
                 + "	author_name	        TEXT,"
                 + " author_id           INTEGER DEFAULT 0,"
@@ -586,7 +589,7 @@ public class ReaderPostTable {
         SQLiteStatement stmtPosts = db.compileStatement(
                 "INSERT OR REPLACE INTO tbl_posts ("
                 + COLUMN_NAMES
-                + ") VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28,?29,?30,?31,?32)");
+                + ") VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28,?29,?30,?31,?32,?33)");
         SQLiteStatement stmtTags = db.compileStatement(
                 "INSERT OR REPLACE INTO tbl_post_tags (post_id, blog_id, feed_id, pseudo_id, tag_name, tag_type) VALUES (?1,?2,?3,?4,?5,?6)");
 
@@ -596,36 +599,37 @@ public class ReaderPostTable {
             for (ReaderPost post: posts) {
                 stmtPosts.bindLong  (1,  post.postId);
                 stmtPosts.bindLong  (2,  post.blogId);
-                stmtPosts.bindLong(3,  post.feedId);
-                stmtPosts.bindString(4, post.getPseudoId());
-                stmtPosts.bindString(5, post.getAuthorName());
-                stmtPosts.bindLong(6, post.authorId);
-                stmtPosts.bindString(7, post.getTitle());
-                stmtPosts.bindString(8, maxText(post));
-                stmtPosts.bindString(9,  post.getExcerpt());
-                stmtPosts.bindString(10, post.getUrl());
-                stmtPosts.bindString(11, post.getShortUrl());
-                stmtPosts.bindString(12, post.getBlogUrl());
-                stmtPosts.bindString(13, post.getBlogName());
-                stmtPosts.bindString(14, post.getFeaturedImage());
-                stmtPosts.bindString(15, post.getFeaturedVideo());
-                stmtPosts.bindString(16, post.getPostAvatar());
-                stmtPosts.bindLong(17, post.timestamp);
-                stmtPosts.bindString(18, post.getPublished());
-                stmtPosts.bindLong  (19, post.numReplies);
-                stmtPosts.bindLong  (20, post.numLikes);
-                stmtPosts.bindLong  (21, SqlUtils.boolToSql(post.isLikedByCurrentUser));
-                stmtPosts.bindLong  (22, SqlUtils.boolToSql(post.isFollowedByCurrentUser));
-                stmtPosts.bindLong  (23, SqlUtils.boolToSql(post.isCommentsOpen));
-                stmtPosts.bindLong  (24, SqlUtils.boolToSql(post.isExternal));
-                stmtPosts.bindLong  (25, SqlUtils.boolToSql(post.isPrivate));
-                stmtPosts.bindLong  (26, SqlUtils.boolToSql(post.isVideoPress));
-                stmtPosts.bindLong(27, SqlUtils.boolToSql(post.isJetpack));
-                stmtPosts.bindString(28, post.getPrimaryTag());
-                stmtPosts.bindString(29, post.getSecondaryTag());
-                stmtPosts.bindString(30, post.getAttachmentsJson());
-                stmtPosts.bindString(31, post.getDiscoverJson());
-                stmtPosts.bindLong  (32, post.wordCount);
+                stmtPosts.bindLong  (3,  post.feedId);
+                stmtPosts.bindLong  (4,  post.feedItemId);
+                stmtPosts.bindString(5, post.getPseudoId());
+                stmtPosts.bindString(6, post.getAuthorName());
+                stmtPosts.bindLong  (7, post.authorId);
+                stmtPosts.bindString(8, post.getTitle());
+                stmtPosts.bindString(9, maxText(post));
+                stmtPosts.bindString(10, post.getExcerpt());
+                stmtPosts.bindString(11, post.getUrl());
+                stmtPosts.bindString(12, post.getShortUrl());
+                stmtPosts.bindString(13, post.getBlogUrl());
+                stmtPosts.bindString(14, post.getBlogName());
+                stmtPosts.bindString(15, post.getFeaturedImage());
+                stmtPosts.bindString(16, post.getFeaturedVideo());
+                stmtPosts.bindString(17, post.getPostAvatar());
+                stmtPosts.bindLong  (18, post.timestamp);
+                stmtPosts.bindString(19, post.getPublished());
+                stmtPosts.bindLong  (20, post.numReplies);
+                stmtPosts.bindLong  (21, post.numLikes);
+                stmtPosts.bindLong  (22, SqlUtils.boolToSql(post.isLikedByCurrentUser));
+                stmtPosts.bindLong  (23, SqlUtils.boolToSql(post.isFollowedByCurrentUser));
+                stmtPosts.bindLong  (24, SqlUtils.boolToSql(post.isCommentsOpen));
+                stmtPosts.bindLong  (25, SqlUtils.boolToSql(post.isExternal));
+                stmtPosts.bindLong  (26, SqlUtils.boolToSql(post.isPrivate));
+                stmtPosts.bindLong  (27, SqlUtils.boolToSql(post.isVideoPress));
+                stmtPosts.bindLong  (28, SqlUtils.boolToSql(post.isJetpack));
+                stmtPosts.bindString(29, post.getPrimaryTag());
+                stmtPosts.bindString(30, post.getSecondaryTag());
+                stmtPosts.bindString(31, post.getAttachmentsJson());
+                stmtPosts.bindString(32, post.getDiscoverJson());
+                stmtPosts.bindLong  (33, post.wordCount);
                 stmtPosts.execute();
             }
 
@@ -806,6 +810,7 @@ public class ReaderPostTable {
         post.postId = c.getLong(c.getColumnIndex("post_id"));
         post.blogId = c.getLong(c.getColumnIndex("blog_id"));
         post.feedId = c.getLong(c.getColumnIndex("feed_id"));
+        post.feedItemId = c.getLong(c.getColumnIndex("feed_item_id"));
         post.authorId = c.getLong(c.getColumnIndex("author_id"));
         post.setPseudoId(c.getString(c.getColumnIndex("pseudo_id")));
 

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -23,6 +23,7 @@ public class ReaderPost {
     public long postId;
     public long blogId;
     public long feedId;
+    public long feedItemId;
     public long authorId;
 
     private String title;
@@ -69,6 +70,7 @@ public class ReaderPost {
         post.postId = json.optLong("ID");
         post.blogId = json.optLong("site_ID");
         post.feedId = json.optLong("feed_ID");
+        post.feedItemId = json.optLong("feed_item_ID");
 
         if (json.has("pseudo_ID")) {
             post.pseudoId = JSONUtils.getString(json, "pseudo_ID");  // read/ endpoint
@@ -500,6 +502,8 @@ public class ReaderPost {
         return post != null
                 && post.blogId == this.blogId
                 && post.postId == this.postId
+                && post.feedId == this.feedId
+                && post.feedItemId == this.feedItemId
                 && post.numLikes == this.numLikes
                 && post.numReplies == this.numReplies
                 && post.isFollowedByCurrentUser == this.isFollowedByCurrentUser

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -429,7 +429,8 @@ public class ReaderCommentListActivity extends AppCompatActivity {
             return;
         }
 
-        AnalyticsUtils.trackWithBlogDetails(AnalyticsTracker.Stat.READER_ARTICLE_COMMENTED_ON, mBlogId);
+        AnalyticsUtils.trackWithReaderPostDetails(
+                AnalyticsTracker.Stat.READER_ARTICLE_COMMENTED_ON, mPost);
 
         mSubmitReplyBtn.setEnabled(false);
         mEditComment.setEnabled(false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1018,11 +1018,8 @@ public class ReaderPostListFragment extends Fragment
                 break;
         }
 
-        // Only pass the blogID if available. Do not track feedID
-        AnalyticsUtils.trackWithBlogDetails(
-                AnalyticsTracker.Stat.READER_ARTICLE_OPENED,
-                mCurrentBlogId != 0 ? mCurrentBlogId : null
-        );
+        AnalyticsUtils.trackWithReaderPostDetails(
+                AnalyticsTracker.Stat.READER_ARTICLE_OPENED, post);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1017,9 +1017,6 @@ public class ReaderPostListFragment extends Fragment
                         post.postId);
                 break;
         }
-
-        AnalyticsUtils.trackWithReaderPostDetails(
-                AnalyticsTracker.Stat.READER_ARTICLE_OPENED, post);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
@@ -170,8 +170,8 @@ public class AnalyticsUtils {
     public static void trackWithReaderPostDetails(AnalyticsTracker.Stat stat, ReaderPost post) {
         if (post == null) return;
 
-        // posts from wpcom / jetpack pass { feed_id, feed_item_id, blog_id, post_id, is_jetpack }
-        // posts from RSS pass { feed_id, feed_item_id, is_jetpack }
+        // wpcom/jetpack posts should pass: feed_id, feed_item_id, blog_id, post_id, is_jetpack
+        // RSS pass should pass: feed_id, feed_item_id, is_jetpack
         Map<String, Object> properties =  new HashMap<>();
         if (post.isWP() || post.isJetpack) {
             properties.put(BLOG_ID_KEY, post.blogId);

--- a/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
@@ -9,14 +9,17 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTrackerMixpanel;
 import org.wordpress.android.models.AccountHelper;
 import org.wordpress.android.models.Blog;
+import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.ui.stats.StatsUtils;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 public class AnalyticsUtils {
     private static String BLOG_ID_KEY = "blog_id";
+    private static String POST_ID_KEY = "post_id";
+    private static String FEED_ID_KEY = "feed_id";
+    private static String FEED_ITEM_ID_KEY = "feed_item_id";
     private static String IS_JETPACK_KEY = "is_jetpack";
 
     /**
@@ -155,5 +158,28 @@ public class AnalyticsUtils {
         } catch (NumberFormatException err) {
             AnalyticsTracker.track(stat);
         }
+    }
+
+    /**
+     * Bump Analytics for a reader post
+     *
+     * @param stat The Stat to bump
+     * @param post The reader post to track
+     *
+     */
+    public static void trackWithReaderPostDetails(AnalyticsTracker.Stat stat, ReaderPost post) {
+        if (post == null) return;
+
+        // posts from wpcom / jetpack pass { feed_id, feed_item_id, blog_id, post_id, is_jetpack }
+        // posts from RSS pass { feed_id, feed_item_id, is_jetpack }
+        Map<String, Object> properties =  new HashMap<>();
+        if (post.isWP() || post.isJetpack) {
+            properties.put(BLOG_ID_KEY, post.blogId);
+            properties.put(POST_ID_KEY, post.postId);
+        }
+        properties.put(FEED_ID_KEY, post.feedId);
+        properties.put(FEED_ITEM_ID_KEY, post.feedItemId);
+        properties.put(IS_JETPACK_KEY, post.isJetpack);
+        AnalyticsTracker.track(stat, properties);
     }
 }


### PR DESCRIPTION
Adds post details when tracking `READER_ARTICLE_OPENED` and `READER_ARTICLE_COMMENTED_ON`. Also corrects article opened tracking to account for swiping between posts in the pager view.

cc: @aerych @blowery

 