### PR TITLE
Fix #3452: Clear activity stack's top  when sharing something to wpandroid

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -206,6 +206,7 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
             intent.setAction(action);
             intent.setType(getIntent().getType());
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
             intent.putExtra(Intent.EXTRA_TEXT, getIntent().getStringExtra(Intent.EXTRA_TEXT));
             intent.putExtra(Intent.EXTRA_SUBJECT, getIntent().getStringExtra(Intent.EXTRA_SUBJECT));


### PR DESCRIPTION
Fix #3452: Clear activity stack's top  when sharing something to wpandroid