### PR TITLE
Issue/3497 snackbar multiple dismiss

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -77,7 +77,7 @@ public class NotificationsUtils {
 
     private static final String WPCOM_SETTINGS_ENDPOINT = "/me/notifications/settings/";
 
-    private static boolean mSnackbarDidUndoOrDismiss;
+    private static boolean mSnackbarDidUndo;
 
     public static void getPushNotificationSettings(Context context, RestRequest.Listener listener,
                                                    RestRequest.ErrorListener errorListener) {
@@ -448,12 +448,12 @@ public class NotificationsUtils {
         View.OnClickListener undoListener = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                mSnackbarDidUndoOrDismiss = true;
+                mSnackbarDidUndo = true;
                 EventBus.getDefault().postSticky(new NoteVisibilityChanged(note.getId(), false));
             }
         };
 
-        mSnackbarDidUndoOrDismiss = false;
+        mSnackbarDidUndo = false;
         Snackbar snackbar = Snackbar.make(parentView, message, Snackbar.LENGTH_LONG)
                 .setAction(R.string.undo, undoListener);
 
@@ -463,10 +463,9 @@ public class NotificationsUtils {
             @Override
             public void onDismissed(Snackbar snackbar, int event) {
                 super.onDismissed(snackbar, event);
-                if (mSnackbarDidUndoOrDismiss) {
+                if (mSnackbarDidUndo) {
                     return;
                 }
-                mSnackbarDidUndoOrDismiss = true;
                 CommentActions.moderateCommentForNote(note, status,
                         new CommentActions.CommentActionListener() {
                             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -77,7 +77,7 @@ public class NotificationsUtils {
 
     private static final String WPCOM_SETTINGS_ENDPOINT = "/me/notifications/settings/";
 
-    private static boolean mSnackbarDidUndo;
+    private static boolean mSnackbarDidUndoOrDismiss;
 
     public static void getPushNotificationSettings(Context context, RestRequest.Listener listener,
                                                    RestRequest.ErrorListener errorListener) {
@@ -448,12 +448,12 @@ public class NotificationsUtils {
         View.OnClickListener undoListener = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                mSnackbarDidUndo = true;
+                mSnackbarDidUndoOrDismiss = true;
                 EventBus.getDefault().postSticky(new NoteVisibilityChanged(note.getId(), false));
             }
         };
 
-        mSnackbarDidUndo = false;
+        mSnackbarDidUndoOrDismiss = false;
         Snackbar snackbar = Snackbar.make(parentView, message, Snackbar.LENGTH_LONG)
                 .setAction(R.string.undo, undoListener);
 
@@ -463,9 +463,10 @@ public class NotificationsUtils {
             @Override
             public void onDismissed(Snackbar snackbar, int event) {
                 super.onDismissed(snackbar, event);
-                if (mSnackbarDidUndo) {
+                if (mSnackbarDidUndoOrDismiss) {
                     return;
                 }
+                mSnackbarDidUndoOrDismiss = true;
                 CommentActions.moderateCommentForNote(note, status,
                         new CommentActions.CommentActionListener() {
                             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -479,9 +479,13 @@ public class PostsListFragment extends Fragment
                 // if the post no longer exists in the list of trashed posts it's because the
                 // user undid the trash, so don't perform the deletion
                 if (!mTrashedPosts.contains(post)) {
-                    AppLog.d(AppLog.T.POSTS, "user undid trashing");
                     return;
                 }
+
+                // remove from the list of trashed posts in case onDismissed is called multiple
+                // times - this way the above check prevents us making the call to delete it twice
+                // https://code.google.com/p/android/issues/detail?id=190529
+                mTrashedPosts.remove(post);
 
                 WordPress.wpDB.deletePost(fullPost);
 


### PR DESCRIPTION
Fix #3497 - prevents the [multiple dismiss bug](https://code.google.com/p/android/issues/detail?id=190529) in the snackbar from causing multiple calls when trashing a post, comment, or notification. This will work in both v4.8 (which uses the snackbar containing this bug) and v4.9 (which uses the fixed snackbar).