### PR TITLE
issue/3264-comment-detail-comes-back-on-rotate

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -204,7 +204,7 @@ public class CommentsActivity extends AppCompatActivity
         }
 
         // retain the id of the highlighted and selected comments
-        if (mSelectedCommentId != 0) {
+        if (mSelectedCommentId != 0 && hasDetailFragment()) {
             outState.putLong(KEY_SELECTED_COMMENT_ID, mSelectedCommentId);
         }
 


### PR DESCRIPTION
Fix #3264 - only retain the selected comment ID when the detail view is showing (this prevents the detail from being restored after rotation).