### PR TITLE
Issue/3507 reader comment image size

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -44,7 +44,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
     private static final int MAX_INDENT_LEVEL = 2;
     private final int mIndentPerLevel;
     private final int mAvatarSz;
-    private final int mDisplayWidth;
+    private final int mContentWidth;
 
     private long mHighlightCommentId = 0;
     private boolean mShowProgressForHighlightedComment = false;
@@ -125,7 +125,13 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
 
         mIndentPerLevel = context.getResources().getDimensionPixelSize(R.dimen.reader_comment_indent_per_level);
         mAvatarSz = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_extra_small);
-        mDisplayWidth = DisplayUtils.getDisplayPixelWidth(context);
+
+        // calculate the max width of comment content
+        int displayWidth = DisplayUtils.getDisplayPixelWidth(context);
+        int cardMargin = context.getResources().getDimensionPixelSize(R.dimen.reader_card_margin);
+        int contentPadding = context.getResources().getDimensionPixelSize(R.dimen.reader_card_content_padding);
+        int mediumMargin = context.getResources().getDimensionPixelSize(R.dimen.margin_medium);
+        mContentWidth = displayWidth - (cardMargin * 2) - (contentPadding * 2) - (mediumMargin * 2);
 
         mColorAuthor = context.getResources().getColor(R.color.blue_medium);
         mColorNotAuthor = context.getResources().getColor(R.color.grey_dark);
@@ -252,7 +258,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
             commentHolder.spacerIndent.setVisibility(View.GONE);
         }
 
-        int maxImageWidth = mDisplayWidth - indentWidth;
+        int maxImageWidth = mContentWidth - indentWidth;
         CommentUtils.displayHtmlComment(commentHolder.txtText, comment.getText(), maxImageWidth);
 
         // different background for highlighted comment, with optional progress bar

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
@@ -23,7 +23,7 @@ public class PhotonUtils {
      * returns a photon url for the passed image with the resize query set to the passed
      * dimensions - note that the passed quality parameter will only affect JPEGs
      */
-    public static enum Quality {
+    public enum Quality {
         HIGH,
         MEDIUM,
         LOW
@@ -44,13 +44,6 @@ public class PhotonUtils {
 
         // remove existing query string since it may contain params that conflict with the passed ones
         imageUrl = UrlUtils.removeQuery(imageUrl);
-
-        // don't use with GIFs - photon breaks animated GIFs, and sometimes returns a GIF that
-        // can't be read by BitmapFactory.decodeByteArray (used by Volley in ImageRequest.java
-        // to decode the downloaded image)
-        if (imageUrl.endsWith(".gif")) {
-            return imageUrl;
-        }
 
         // if this is an "mshots" url, skip photon and return it with a query that sets the width/height
         if (isMshotsUrl(imageUrl)) {


### PR DESCRIPTION
Fix #3507 - the main problem was that we were skipping photon with GIFs, which is no longer necessary (photon used to cause problems with animated GIFs, but this is no longer the case). 

Also further improved upon #3492 by reducing the requested image width by taking the comment margins & padding into account when determining the max width.