### PR TITLE
Differentiating between current theme customization and previewing a theme

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -414,7 +414,11 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
 
                 switch (type) {
                     case PREVIEW:
-                        AnalyticsUtils.trackWithCurrentBlogDetails(AnalyticsTracker.Stat.THEMES_PREVIEWED_SITE, themeProperties);
+                        if (isCurrentTheme) {
+                            AnalyticsUtils.trackWithCurrentBlogDetails(AnalyticsTracker.Stat.THEMES_CUSTOMIZE_ACCESSED, themeProperties);
+                        } else {
+                            AnalyticsUtils.trackWithCurrentBlogDetails(AnalyticsTracker.Stat.THEMES_PREVIEWED_SITE, themeProperties);
+                        }
                         break;
                     case DEMO:
                         AnalyticsUtils.trackWithCurrentBlogDetails(AnalyticsTracker.Stat.THEMES_DEMO_ACCESSED, themeProperties);


### PR DESCRIPTION
Addresses unused analytics event found in #3504, but now merging into release/4.9. Reverted other change

Thanks @daniloercoli

Needs review: @daniloercoli