### PR TITLE
Fixing null or empty theme id

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -407,7 +407,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
         String toastText = getString(R.string.no_network_message);
 
         if (NetworkUtils.isNetworkAvailable(this)) {
-            if (mCurrentTheme != null) {
+            if (mCurrentTheme != null && (themeId != null || !themeId.isEmpty())) {
                 boolean isCurrentTheme = mCurrentTheme.getId().equals(themeId);
                 Map<String, Object> themeProperties = new HashMap<>();
                 themeProperties.put(THEME_ID, themeId);


### PR DESCRIPTION
Addresses #3520

There was a null themeId being passed in, which caused the sql call to fail. Now we check to see if themeId is not null or not empty. If so, we show a toast saying we can't find the theme.

Needs review: @maxme 