### PR TITLE
Issue/3518 reader detail get post failure

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -676,22 +676,27 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             // the title if it wasn't set above
             if (!postExists) {
                 AppLog.d(T.COMMENTS, "comment detail > retrieving post");
-                ReaderPostActions.requestPost(blogId, postId, new ReaderActions.ActionListener() {
-                    @Override
-                    public void onActionResult(boolean succeeded) {
-                        if (!isAdded())
-                            return;
-                        // update title if it wasn't set above
-                        if (!hasTitle) {
-                            String postTitle = ReaderPostTable.getPostTitle(blogId, postId);
-                            if (!TextUtils.isEmpty(postTitle)) {
-                                setPostTitle(txtPostTitle, postTitle, true);
-                            } else {
-                                txtPostTitle.setText(R.string.untitled);
+                ReaderPostActions.requestPost(blogId, postId, new ReaderActions.OnRequestListener() {
+                            @Override
+                            public void onSuccess() {
+                                if (!isAdded()) return;
+
+                                // update title if it wasn't set above
+                                if (!hasTitle) {
+                                    String postTitle = ReaderPostTable.getPostTitle(blogId, postId);
+                                    if (!TextUtils.isEmpty(postTitle)) {
+                                        setPostTitle(txtPostTitle, postTitle, true);
+                                    } else {
+                                        txtPostTitle.setText(R.string.untitled);
+                                    }
+                                }
                             }
-                        }
-                    }
-                });
+
+                            @Override
+                            public void onFailure(int statusCode) {
+                                // noop
+                            }
+                        });
             }
 
             txtPostTitle.setOnClickListener(new View.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -26,4 +26,5 @@ public class ReaderConstants {
     static final String KEY_ALREADY_REQUESTED = "already_requested";
     static final String KEY_RESTORE_POSITION  = "restore_position";
     static final String KEY_WAS_PAUSED        = "was_paused";
+    static final String KEY_ERROR_MESSAGE     = "error_message";
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -5,7 +5,6 @@ import android.app.Fragment;
 import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.support.annotation.StringRes;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
@@ -511,19 +510,23 @@ public class ReaderPostDetailFragment extends Fragment
                 if (isAdded()) {
                     progress.setVisibility(View.GONE);
                     int errMsgResId;
-                    switch (statusCode) {
-                        case 401:
-                        case 403:
-                            errMsgResId = R.string.reader_err_get_post_not_authorized;
-                            break;
-                        case 404:
-                            errMsgResId = R.string.reader_err_get_post_not_found;
-                            break;
-                        default:
-                            errMsgResId = R.string.reader_err_get_post_generic;
-                            break;
+                    if (!NetworkUtils.isNetworkAvailable(getActivity())) {
+                        errMsgResId = R.string.no_network_message;
+                    } else {
+                        switch (statusCode) {
+                            case 401:
+                            case 403:
+                                errMsgResId = R.string.reader_err_get_post_not_authorized;
+                                break;
+                            case 404:
+                                errMsgResId = R.string.reader_err_get_post_not_found;
+                                break;
+                            default:
+                                errMsgResId = R.string.reader_err_get_post_generic;
+                                break;
+                        }
                     }
-                    showError(errMsgResId);
+                    showError(getString(errMsgResId));
                 }
             }
         };
@@ -533,13 +536,13 @@ public class ReaderPostDetailFragment extends Fragment
     /*
      * hide the entire post detail container and show an error message in the middle of the screen
      */
-    private void showError(@StringRes int resId) {
+    private void showError(String errorMessage) {
         if (!isAdded()) return;
 
         getView().findViewById(R.id.layout_post_detail_container).setVisibility(View.GONE);
 
         TextView txtError = (TextView) getView().findViewById(R.id.text_error);
-        txtError.setText(resId);
+        txtError.setText(errorMessage);
         if (txtError.getVisibility() != View.VISIBLE) {
             AniUtils.fadeIn(txtError, AniUtils.Duration.MEDIUM);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -501,12 +501,14 @@ public class ReaderPostDetailFragment extends Fragment
             @Override
             public void onSuccess() {
                 if (isAdded()) {
+                    progress.setVisibility(View.GONE);
                     showPost();
                 }
             }
             @Override
             public void onFailure(int statusCode) {
                 if (isAdded()) {
+                    progress.setVisibility(View.GONE);
                     int errMsgResId;
                     switch (statusCode) {
                         case 401:

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -5,6 +5,7 @@ import android.app.Fragment;
 import android.content.Intent;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.annotation.StringRes;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
@@ -513,20 +514,35 @@ public class ReaderPostDetailFragment extends Fragment
                     switch (statusCode) {
                         case 401:
                         case 403:
-                            errMsgResId = R.string.reader_toast_err_get_post_not_authorized;
+                            errMsgResId = R.string.reader_err_get_post_not_authorized;
                             break;
                         case 404:
-                            errMsgResId = R.string.reader_toast_err_get_post_not_found;
+                            errMsgResId = R.string.reader_err_get_post_not_found;
                             break;
                         default:
-                            errMsgResId = R.string.reader_toast_err_get_post;
+                            errMsgResId = R.string.reader_err_get_post_generic;
                             break;
                     }
-                    ToastUtils.showToast(getActivity(), errMsgResId, ToastUtils.Duration.LONG);
+                    showError(errMsgResId);
                 }
             }
         };
         ReaderPostActions.requestPost(mBlogId, mPostId, listener);
+    }
+
+    /*
+     * hide the entire post detail container and show an error message in the middle of the screen
+     */
+    private void showError(@StringRes int resId) {
+        if (!isAdded()) return;
+
+        getView().findViewById(R.id.layout_post_detail_container).setVisibility(View.GONE);
+
+        TextView txtError = (TextView) getView().findViewById(R.id.text_error);
+        txtError.setText(resId);
+        if (txtError.getVisibility() != View.VISIBLE) {
+            AniUtils.fadeIn(txtError, AniUtils.Duration.MEDIUM);
+        }
     }
 
     private void showPost() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -507,8 +507,20 @@ public class ReaderPostDetailFragment extends Fragment
             @Override
             public void onFailure(int statusCode) {
                 if (isAdded()) {
-                    // TODO: separate message for auth failure
-                    ToastUtils.showToast(getActivity(), R.string.reader_toast_err_get_post, ToastUtils.Duration.LONG);
+                    int errMsgResId;
+                    switch (statusCode) {
+                        case 401:
+                        case 403:
+                            errMsgResId = R.string.reader_toast_err_get_post_not_authorized;
+                            break;
+                        case 404:
+                            errMsgResId = R.string.reader_toast_err_get_post_not_found;
+                            break;
+                        default:
+                            errMsgResId = R.string.reader_toast_err_get_post;
+                            break;
+                    }
+                    ToastUtils.showToast(getActivity(), errMsgResId, ToastUtils.Duration.LONG);
                 }
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -497,29 +497,22 @@ public class ReaderPostDetailFragment extends Fragment
         progress.setVisibility(View.VISIBLE);
         progress.bringToFront();
 
-        ReaderActions.ActionListener actionListener = new ReaderActions.ActionListener() {
+        ReaderActions.OnRequestListener listener = new ReaderActions.OnRequestListener() {
             @Override
-            public void onActionResult(boolean succeeded) {
+            public void onSuccess() {
                 if (isAdded()) {
-                    progress.setVisibility(View.GONE);
-                    if (succeeded) {
-                        showPost();
-                    } else {
-                        postFailed();
-                    }
+                    showPost();
+                }
+            }
+            @Override
+            public void onFailure(int statusCode) {
+                if (isAdded()) {
+                    // TODO: separate message for auth failure
+                    ToastUtils.showToast(getActivity(), R.string.reader_toast_err_get_post, ToastUtils.Duration.LONG);
                 }
             }
         };
-        ReaderPostActions.requestPost(mBlogId, mPostId, actionListener);
-    }
-
-    /*
-     * called when post couldn't be loaded and failed to be returned from server
-     */
-    private void postFailed() {
-        if (isAdded()) {
-            ToastUtils.showToast(getActivity(), R.string.reader_toast_err_get_post, ToastUtils.Duration.LONG);
-        }
+        ReaderPostActions.requestPost(mBlogId, mPostId, listener);
     }
 
     private void showPost() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -361,7 +361,7 @@ public class ReaderSubsActivity extends AppCompatActivity
 
         showAddUrlProgress();
 
-        ReaderActions.OnCheckUrlReachableListener urlListener = new ReaderActions.OnCheckUrlReachableListener() {
+        ReaderActions.OnRequestListener requestListener = new ReaderActions.OnRequestListener() {
             @Override
             public void onSuccess() {
                 if (!isFinishing()) {
@@ -369,7 +369,7 @@ public class ReaderSubsActivity extends AppCompatActivity
                 }
             }
             @Override
-            public void onFailed(int statusCode) {
+            public void onFailure(int statusCode) {
                 if (!isFinishing()) {
                     hideAddUrlProgress();
                     String errMsg;
@@ -389,7 +389,7 @@ public class ReaderSubsActivity extends AppCompatActivity
                 }
             }
         };
-        ReaderBlogActions.checkUrlReachable(blogUrl, urlListener);
+        ReaderBlogActions.checkUrlReachable(blogUrl, requestListener);
     }
 
     private void followBlogUrl(String normUrl) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderActions.java
@@ -27,17 +27,25 @@ public class ReaderActions {
     }
 
     /*
-     * result when a specific action is performed (liking a post, etc.)
+     * listener when a specific action is performed (liking a post, etc.)
      */
     public interface ActionListener {
-        public void onActionResult(boolean succeeded);
+        void onActionResult(boolean succeeded);
     }
 
     /*
-     * result when submitting a comment
+     * listener when the failure status code is required
+     */
+    public interface OnRequestListener {
+        void onSuccess();
+        void onFailure(int statusCode);
+    }
+
+    /*
+     * listener when submitting a comment
      */
     public interface CommentActionListener {
-        public void onActionResult(boolean succeeded, ReaderComment newComment);
+        void onActionResult(boolean succeeded, ReaderComment newComment);
     }
 
     /*
@@ -53,29 +61,21 @@ public class ReaderActions {
         }
     }
     public interface UpdateResultListener {
-        public void onUpdateResult(UpdateResult result);
+        void onUpdateResult(UpdateResult result);
     }
 
     /*
      * used by adapters to notify when more data should be loaded
      */
     public interface DataRequestedListener {
-        public void onRequestData();
+        void onRequestData();
     }
 
     /*
      * used by blog preview when requesting latest info about a blog
      */
     public interface UpdateBlogInfoListener {
-        public void onResult(ReaderBlog blogInfo);
-    }
-
-    /*
-     * used when checking whether a blog's url is reachable
-     */
-    public interface OnCheckUrlReachableListener {
-        void onSuccess();
-        void onFailed(int statusCode);
+        void onResult(ReaderBlog blogInfo);
     }
 
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -362,16 +362,14 @@ public class ReaderBlogActions {
      * account for 404 replacement pages used by ISPs such as Charter
      */
     public static void checkUrlReachable(final String blogUrl,
-                                         final ReaderActions.OnCheckUrlReachableListener urlListener) {
+                                         final ReaderActions.OnRequestListener requestListener) {
         // listener is required
-        if (urlListener == null) {
-            return;
-        }
+        if (requestListener == null) return;
 
         Response.Listener<String> listener = new Response.Listener<String>() {
             @Override
             public void onResponse(String response) {
-                urlListener.onSuccess();
+                requestListener.onSuccess();
             }
         };
         Response.ErrorListener errorListener = new Response.ErrorListener() {
@@ -389,9 +387,9 @@ public class ReaderBlogActions {
                 // Volley treats a 301 redirect as a failure here, we should treat it as
                 // success since it means the blog url is reachable
                 if (statusCode == 301) {
-                    urlListener.onSuccess();
+                    requestListener.onSuccess();
                 } else {
-                    urlListener.onFailed(statusCode);
+                    requestListener.onFailure(statusCode);
                 }
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -19,7 +19,6 @@ import org.wordpress.android.datasets.ReaderUserTable;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderUserIdList;
 import org.wordpress.android.models.ReaderUserList;
-import org.wordpress.android.ui.reader.actions.ReaderActions.ActionListener;
 import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResult;
 import org.wordpress.android.ui.reader.actions.ReaderActions.UpdateResultListener;
 import org.wordpress.android.util.AppLog;
@@ -205,7 +204,9 @@ public class ReaderPostActions {
     /**
      * similar to updatePost, but used when post doesn't already exist in local db
      **/
-    public static void requestPost(final long blogId, final long postId, final ActionListener actionListener) {
+    public static void requestPost(final long blogId,
+                                   final long postId,
+                                   final ReaderActions.OnRequestListener actionListener) {
         String path = "read/sites/" + blogId + "/posts/" + postId + "/?meta=site,likes";
 
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
@@ -215,7 +216,7 @@ public class ReaderPostActions {
                 ReaderPostTable.addOrUpdatePost(post);
                 handlePostLikes(post, jsonObject);
                 if (actionListener != null) {
-                    actionListener.onActionResult(true);
+                    actionListener.onSuccess();
                 }
             }
         };
@@ -224,7 +225,9 @@ public class ReaderPostActions {
             public void onErrorResponse(VolleyError volleyError) {
                 AppLog.e(T.READER, volleyError);
                 if (actionListener != null) {
-                    actionListener.onActionResult(false);
+                    int statusCode = VolleyUtils.statusCodeFromVolleyError(volleyError);
+                    // TODO: parse response for error code
+                    actionListener.onFailure(statusCode);
                 }
             }
         };

--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -68,6 +68,23 @@
             tools:visibility="visible" />
     </RelativeLayout>
 
+    <!-- error message when requesting post fails -->
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/text_error"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginLeft="@dimen/reader_detail_margin"
+        android:layout_marginRight="@dimen/reader_detail_margin"
+        android:drawablePadding="@dimen/margin_small"
+        android:drawableTop="@drawable/noticon_warning_big_grey"
+        android:gravity="center"
+        android:textColor="@color/grey"
+        android:textSize="@dimen/text_sz_extra_large"
+        android:visibility="gone"
+        tools:text="Error message"
+        tools:visibility="visible" />
+
     <!-- container for webView custom view - this is where fullscreen video will appear -->
     <FrameLayout
         android:id="@+id/layout_custom_view_container"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -897,7 +897,6 @@
     <string name="reader_toast_err_share_intent">Unable to share</string>
     <string name="reader_toast_err_view_image">Unable to view image</string>
     <string name="reader_toast_err_url_intent">Unable to open %s</string>
-    <string name="reader_toast_err_get_post">Unable to retrieve this post</string>
     <string name="reader_toast_err_get_comment">Unable to retrieve this comment</string>
     <string name="reader_toast_err_get_blog_info">Unable to show this blog</string>
     <string name="reader_toast_err_already_follow_blog">You already follow this blog</string>
@@ -910,6 +909,10 @@
     <string name="reader_toast_err_generic">Unable to perform this action</string>
     <string name="editor_toast_invalid_path">Invalid file path</string>
     <string name="editor_toast_changes_saved">Changes saved</string>
+
+    <string name="reader_toast_err_get_post">Unable to retrieve this post</string>
+    <string name="reader_toast_err_get_post_not_authorized">You\'re not authorized to view this post</string>
+    <string name="reader_toast_err_get_post_not_found">This post no longer exists</string>
 
     <!-- empty list/grid text -->
     <string name="reader_empty_posts_no_connection" translatable="false">@string/no_network_title</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -909,7 +909,7 @@
     <string name="reader_toast_err_generic">Unable to perform this action</string>
     <string name="editor_toast_invalid_path">Invalid file path</string>
     <string name="editor_toast_changes_saved">Changes saved</string>
-
+    <!-- toast failure messages when retrieving a single reader post -->
     <string name="reader_toast_err_get_post">Unable to retrieve this post</string>
     <string name="reader_toast_err_get_post_not_authorized">You\'re not authorized to view this post</string>
     <string name="reader_toast_err_get_post_not_found">This post no longer exists</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -909,10 +909,11 @@
     <string name="reader_toast_err_generic">Unable to perform this action</string>
     <string name="editor_toast_invalid_path">Invalid file path</string>
     <string name="editor_toast_changes_saved">Changes saved</string>
-    <!-- toast failure messages when retrieving a single reader post -->
-    <string name="reader_toast_err_get_post">Unable to retrieve this post</string>
-    <string name="reader_toast_err_get_post_not_authorized">You\'re not authorized to view this post</string>
-    <string name="reader_toast_err_get_post_not_found">This post no longer exists</string>
+
+    <!-- failure messages when retrieving a single reader post -->
+    <string name="reader_err_get_post_generic">Unable to retrieve this post</string>
+    <string name="reader_err_get_post_not_authorized">You\'re not authorized to view this post</string>
+    <string name="reader_err_get_post_not_found">This post no longer exists</string>
 
     <!-- empty list/grid text -->
     <string name="reader_empty_posts_no_connection" translatable="false">@string/no_network_title</string>


### PR DESCRIPTION
Resolves #3518 - previously, reader detail would show a generic "Unable to retrieve post" toast upon failure, which wasn't ideal for two reasons:

1. Since posts are displayed in a ViewPager, it was possible to see the toast for an offscreen post.
2. The error message didn't give any indication what the problem was.

This PR resolves this by replacing the toast with an error message in the middle of the detail view itself, and then differentiating between failures due to 401/403/404/no connection.

Note that a big reason this was added was to better support cross posts (see #3519), which are more likely to fail due to permission issues than other posts.

![reader403](https://cloud.githubusercontent.com/assets/3903757/11827517/a7aecfc2-a35a-11e5-9e32-72e00bc07172.png)
