### PR TITLE
Fix scheme issue with loading private blog images

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/networking/WPDelayedHurlStack.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/WPDelayedHurlStack.java
@@ -99,10 +99,8 @@ public class WPDelayedHurlStack implements HttpStack {
                 additionalHeaders.put("Authorization", auth);
             }
 
-            String blogUriScheme = WordPress.currentBlog.getUri().getScheme();
-
             if (StringUtils.getHost(request.getUrl()).endsWith("files.wordpress.com") && mCtx != null
-                    && AccountHelper.isSignedInWordPressDotCom() && blogUriScheme.equals("https")) {
+                    && AccountHelper.isSignedInWordPressDotCom()) {
                 // Add the auth header to access private WP.com files
                 additionalHeaders.put("Authorization", "Bearer " + AccountHelper.getDefaultAccount().getAccessToken());
             }

--- a/WordPress/src/main/java/org/wordpress/android/networking/WPDelayedHurlStack.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/WPDelayedHurlStack.java
@@ -23,6 +23,7 @@ import org.wordpress.android.models.AccountHelper;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.UrlUtils;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -98,8 +99,10 @@ public class WPDelayedHurlStack implements HttpStack {
                 additionalHeaders.put("Authorization", auth);
             }
 
+            String blogUriScheme = WordPress.currentBlog.getUri().getScheme();
+
             if (StringUtils.getHost(request.getUrl()).endsWith("files.wordpress.com") && mCtx != null
-                    && AccountHelper.isSignedInWordPressDotCom()) {
+                    && AccountHelper.isSignedInWordPressDotCom() && blogUriScheme.equals("https")) {
                 // Add the auth header to access private WP.com files
                 additionalHeaders.put("Authorization", "Bearer " + AccountHelper.getDefaultAccount().getAccessToken());
             }
@@ -108,6 +111,12 @@ public class WPDelayedHurlStack implements HttpStack {
         additionalHeaders.put("User-Agent", WordPress.getUserAgent());
 
         String url = request.getUrl();
+
+        // Ensure that an HTTPS request is made for images in private sites
+        if (additionalHeaders.containsKey("Authorization")) {
+            url = UrlUtils.makeHttps(url);
+        }
+
         HashMap<String, String> map = new HashMap<String, String>();
         map.putAll(request.getHeaders());
         map.putAll(additionalHeaders);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -583,7 +583,8 @@ public class ReaderPostDetailFragment extends Fragment
                 }
             }
 
-            mReaderWebView.setIsPrivatePost(mPost.isPrivate && UrlUtils.isHttps(mPost.getBlogUrl()));
+            mReaderWebView.setIsPrivatePost(mPost.isPrivate);
+            mReaderWebView.setBlogSchemeIsHttps(UrlUtils.isHttps(mPost.getBlogUrl()));
 
             txtTitle = (TextView) container.findViewById(R.id.text_title);
             txtBlogName = (TextView) container.findViewById(R.id.text_blog_name);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -583,7 +583,7 @@ public class ReaderPostDetailFragment extends Fragment
                 }
             }
 
-            mReaderWebView.setIsPrivatePost(mPost.isPrivate);
+            mReaderWebView.setIsPrivatePost(mPost.isPrivate && UrlUtils.isHttps(mPost.getBlogUrl()));
 
             txtTitle = (TextView) container.findViewById(R.id.text_title);
             txtBlogName = (TextView) container.findViewById(R.id.text_blog_name);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -53,6 +53,7 @@ public class ReaderWebView extends WebView {
 
     private static String mToken;
     private static boolean mIsPrivatePost;
+    private static boolean mBlogSchemeIsHttps;
 
     private boolean mIsDestroyed;
 
@@ -139,6 +140,10 @@ public class ReaderWebView extends WebView {
         mIsPrivatePost = isPrivatePost;
     }
 
+    public void setBlogSchemeIsHttps(boolean blogSchemeIsHttps) {
+        mBlogSchemeIsHttps = blogSchemeIsHttps;
+    }
+
     private static boolean isValidClickedUrl(String url) {
         // only return true for http(s) urls so we avoid file: and data: clicks
         return (url != null && (url.startsWith("http") || url.startsWith("wordpress:")));
@@ -211,7 +216,7 @@ public class ReaderWebView extends WebView {
         @Override
         public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
             // Intercept requests for private images and add the WP.com authorization header
-            if (mIsPrivatePost && !TextUtils.isEmpty(mToken) && UrlUtils.isImageUrl(url)) {
+            if (mIsPrivatePost && mBlogSchemeIsHttps && !TextUtils.isEmpty(mToken) && UrlUtils.isImageUrl(url)) {
                 try {
                     URL imageUrl = new URL(UrlUtils.makeHttps(url));
                     HttpURLConnection conn = (HttpURLConnection) imageUrl.openConnection();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -213,7 +213,7 @@ public class ReaderWebView extends WebView {
             // Intercept requests for private images and add the WP.com authorization header
             if (mIsPrivatePost && !TextUtils.isEmpty(mToken) && UrlUtils.isImageUrl(url)) {
                 try {
-                    URL imageUrl = new URL(url);
+                    URL imageUrl = new URL(UrlUtils.makeHttps(url));
                     HttpURLConnection conn = (HttpURLConnection) imageUrl.openConnection();
                     conn.setRequestProperty("Authorization", "Bearer " + mToken);
                     conn.setReadTimeout(WPRestClient.REST_TIMEOUT_MS);

--- a/WordPress/src/main/java/org/wordpress/android/util/WPWebViewClient.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPWebViewClient.java
@@ -16,6 +16,7 @@ import org.wordpress.android.networking.SelfSignedSSLCertsManager;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.security.GeneralSecurityException;
 
@@ -90,9 +91,11 @@ public class WPWebViewClient extends WebViewClient {
     @Override
     public WebResourceResponse shouldInterceptRequest(WebView view, String stringUrl) {
         // Intercept requests for private images and add the WP.com authorization header
-        if (mBlog != null && mBlog.isPrivate() && !TextUtils.isEmpty(mToken) && UrlUtils.isImageUrl(stringUrl)) {
+        if (mBlog != null && mBlog.isPrivate() && mBlog.getUri().getScheme().equals("https") &&
+                !TextUtils.isEmpty(mToken) && UrlUtils.isImageUrl(stringUrl)) {
             try {
-                URL url = new URL(stringUrl);
+                // Force use of HTTPS for the resource, otherwise the request will fail for private sites
+                URL url = new URL(UrlUtils.makeHttps(stringUrl));
                 HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
                 urlConnection.setRequestProperty("Authorization", "Bearer " + mToken);
                 urlConnection.setReadTimeout(WPRestClient.REST_TIMEOUT_MS);


### PR DESCRIPTION
Fixes #3510 by forcing `HTTPS` usage for images in private sites. They were failing to load when a post included images using the `HTTP` scheme, returning a 301 redirect instead of retrieving the image.

The bug was only occurring in the post list preview, but I applied the change to other areas in the app where resource requests are made just in case.
