### PR TITLE
Fix no permission on media upload

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -134,10 +134,11 @@ public class MediaUploadService extends Service {
 
                 String errorMessageToDisplay = null;
                 // well formed XML-RPC response from the server, but it's an error.
-                if (throwable != null && throwable instanceof XMLRPCFault) {
+                if (throwable instanceof XMLRPCFault) {
                     XMLRPCFault xmlrpcFault = ((XMLRPCFault) throwable);
                     if (xmlrpcFault.getFaultCode() == 401) {
-                        //errorMessageToDisplay = xmlrpcFault.getFaultString();
+                        //Just for reference - xmlrpcFault.getFaultString() returns the error message
+                        // from the server without the ugly "[Code 401]" part.
                         errorMessageToDisplay = getString(R.string.media_error_no_permission_upload);
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -847,16 +847,19 @@ public class PostUploadService extends Service {
             try {
                 return mClient.call(ApiHelper.Methods.UPLOAD_FILE, params, tempFile);
             } catch (XMLRPCException e) {
+                // well formed XML-RPC response from the server, but it's an error. Ok to print the error message
                 AppLog.e(T.API, e);
                 mErrorMessage = mContext.getResources().getString(R.string.error_media_upload) + ": " + e.getMessage();
                 return null;
             } catch (IOException e) {
+                // I/O-related error. Show a generic connection error message
                 AppLog.e(T.API, e);
-                mErrorMessage = mContext.getResources().getString(R.string.error_media_upload) + ": " + e.getMessage();
+                mErrorMessage = mContext.getResources().getString(R.string.error_media_upload_connection);
                 return null;
             } catch (XmlPullParserException e) {
+                // XML-RPC response isn't well formed or valid. DO NOT print the real error message
                 AppLog.e(T.API, e);
-                mErrorMessage = mContext.getResources().getString(R.string.error_media_upload) + ": " + e.getMessage();
+                mErrorMessage = mContext.getResources().getString(R.string.error_media_upload);
                 return null;
             } finally {
                 // remove the temporary upload file now that we're done with it

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -785,6 +785,7 @@
     <string name="error_publish_no_network">Can\'t publish while there is no connection. Saved as draft.</string>
     <string name="error_upload">An error occurred while uploading the %s</string>
     <string name="error_media_upload">An error occurred while uploading media</string>
+    <string name="error_media_upload_connection">A connection error occurred while uploading media</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>
     <string name="fatal_db_error">An error occurred while creating the app database. Try reinstalling the app.</string>
     <string name="error_copy_to_clipboard">An error occurred while copying text to clipboard</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -118,6 +118,7 @@
     <string name="pick_photo">Select photo</string>
     <string name="pick_video">Select video</string>
     <string name="media_error_no_permission">You don\'t have permission to view the media library</string>
+    <string name="media_error_no_permission_upload">You don\'t have permission to upload media to the site</string>
     <string name="access_media_permission_required">Permissions required in order to access media</string>
     <string name="add_media_permission_required">Permissions required in order to add media</string>
     <string name="media_fetching">Fetching media…</string>


### PR DESCRIPTION
Fix #3454  (Inaccurate error message when user doesn't have permissions to upload media to a site) by checking the XMLRPC fault response code. 

Fix #3458 by not showing those obscure messages that IOException returns.  Show  a generic connection error message.