### PR TITLE
Fix Simperium SQLiteDatabaseLockedException

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/SimperiumUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/SimperiumUtils.java
@@ -39,7 +39,7 @@ public class SimperiumUtils {
         return mMetaBucket;
     }
 
-    public static Simperium configureSimperium(final Context context, String token) {
+    public static synchronized Simperium configureSimperium(final Context context, String token) {
         // Create a new instance of Simperium if it doesn't exist yet.
         // In any case, authorize the user.
         if (mSimperium == null) {


### PR DESCRIPTION
In rare cases, `SimperiumUtils.configureSimperium()` could be called from multiple threads. I think maybe the most common case would be if a user was launching the app, and received a push notification at nearly the same moment.

Marking the method as synchronized fixed the issue. You can reproduce the crash by changing the call to `configureSimperium`at line 259 in `WordPress.java` to something like this:

```
// spawn a bunch of threads that call configureSimperium()
for (int i=0; i < 1000; i++) {
    new Thread(new Runnable() {
        public void run() {
            SimperiumUtils.configureSimperium(WordPress.this, AccountHelper.getDefaultAccount().getAccessToken());
       }
    }).start();
}
```

Fixes #3531