### PR TITLE
issue/3522-reader-userlist-wrong-like-avatar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderUser.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderUser.java
@@ -81,6 +81,10 @@ public class ReaderUser {
         return !TextUtils.isEmpty(url);
     }
 
+    public boolean hasAvatarUrl() {
+        return !TextUtils.isEmpty(avatarUrl);
+    }
+
     public boolean hasBlogId() {
         return (blogId != 0);
     }

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderUser.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderUser.java
@@ -5,7 +5,6 @@ import android.text.TextUtils;
 import org.json.JSONObject;
 import org.wordpress.android.util.JSONUtils;
 import org.wordpress.android.util.StringUtils;
-import org.wordpress.android.util.UrlUtils;
 
 public class ReaderUser {
     public long userId;
@@ -15,9 +14,6 @@ public class ReaderUser {
     private String url;
     private String profileUrl;
     private String avatarUrl;
-
-    // isFollowed isn't read from json or stored in db - used by ReaderUserAdapter to mark followed users
-    public transient boolean isFollowed;
 
     public static ReaderUser fromJson(JSONObject json) {
         ReaderUser user = new ReaderUser();
@@ -88,23 +84,9 @@ public class ReaderUser {
     public boolean hasBlogId() {
         return (blogId != 0);
     }
-    /*
-     * not stored - used by ReaderUserAdapter for performance
-     */
-    private transient String urlDomain;
-    public String getUrlDomain() {
-        if (urlDomain == null) {
-            if (hasUrl()) {
-                urlDomain = UrlUtils.getDomainFromUrl(getUrl());
-            } else {
-                urlDomain = "";
-            }
-        }
-        return urlDomain;
-    }
 
     public boolean isSameUser(ReaderUser user) {
-        if (user==null)
+        if (user == null)
             return false;
         if (this.userId != user.userId)
             return false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderUserAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderUserAdapter.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.reader.adapters;
 
 import android.content.Context;
-import android.os.Handler;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -9,13 +8,12 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
-import org.wordpress.android.datasets.ReaderBlogTable;
-import org.wordpress.android.models.ReaderUrlList;
 import org.wordpress.android.models.ReaderUser;
 import org.wordpress.android.models.ReaderUserList;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderInterfaces.DataLoadedListener;
 import org.wordpress.android.util.GravatarUtils;
+import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
 /**
@@ -59,7 +57,7 @@ public class ReaderUserAdapter  extends RecyclerView.Adapter<ReaderUserAdapter.U
         holder.txtName.setText(user.getDisplayName());
         if (user.hasUrl()) {
             holder.txtUrl.setVisibility(View.VISIBLE);
-            holder.txtUrl.setText(user.getUrlDomain());
+            holder.txtUrl.setText(UrlUtils.getDomainFromUrl(user.getUrl()));
             holder.itemView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
@@ -76,7 +74,9 @@ public class ReaderUserAdapter  extends RecyclerView.Adapter<ReaderUserAdapter.U
         }
 
         if (user.hasAvatarUrl()) {
-            holder.imgAvatar.setImageUrl(user.getAvatarUrl(), WPNetworkImageView.ImageType.AVATAR);
+            holder.imgAvatar.setImageUrl(
+                    GravatarUtils.fixGravatarUrl(user.getAvatarUrl(), mAvatarSz),
+                    WPNetworkImageView.ImageType.AVATAR);
         } else {
             holder.imgAvatar.showDefaultGravatarImage();
         }
@@ -100,48 +100,14 @@ public class ReaderUserAdapter  extends RecyclerView.Adapter<ReaderUserAdapter.U
         }
     }
 
-    private void clear() {
-        if (mUsers.size() > 0) {
-            mUsers.clear();
-            notifyDataSetChanged();
-        }
-    }
-
     public void setUsers(final ReaderUserList users) {
-        if (users == null || users.size() == 0) {
-            clear();
-            return;
+        mUsers.clear();
+        if (users != null && users.size() > 0) {
+            mUsers.addAll(users);
         }
-
-        final Handler handler = new Handler();
-
-        new Thread() {
-            @Override
-            public void run() {
-                // flag followed users, set avatar urls for use with photon, and pre-load
-                // user domains so we can avoid having to do this for each user when getView()
-                // is called
-                ReaderUrlList followedBlogUrls = ReaderBlogTable.getFollowedBlogUrls();
-                for (ReaderUser user: users) {
-                    user.isFollowed = user.hasUrl() && followedBlogUrls.contains(user.getUrl());
-                    user.getUrlDomain();
-                    if (user.hasAvatarUrl()) {
-                        user.setAvatarUrl(GravatarUtils.fixGravatarUrl(user.getAvatarUrl(), mAvatarSz));
-                    }
-                }
-
-                handler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        mUsers.clear();
-                        mUsers.addAll(users);
-                        notifyDataSetChanged();
-                        if (mDataLoadedListener != null) {
-                            mDataLoadedListener.onDataLoaded(isEmpty());
-                        }
-                    }
-                });
-            }
-        }.start();
+        notifyDataSetChanged();
+        if (mDataLoadedListener != null) {
+            mDataLoadedListener.onDataLoaded(isEmpty());
+        }
     }
 }


### PR DESCRIPTION
Fix #3522 - I wasn't able to repro the issue so I can't guarantee this will fix it, but looking at the original code I can see there's a problem [here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderUserAdapter.java#L111) where I modify the backing array and then perform work in a separate thread prior to calling `notifyDataSetChanged`.

@daniloercoli Could I trouble you for a review, since you're able to repro the bug?