### PR TITLE
Stats Widget - Fix UI overflow

### DIFF
--- a/WordPress/src/main/res/layout/stats_widget_layout.xml
+++ b/WordPress/src/main/res/layout/stats_widget_layout.xml
@@ -24,7 +24,7 @@
         <TextView
             android:id="@+id/blog_title"
             style="@style/StatsModuleTitle"
-            android:textSize="@dimen/text_sz_medium"
+            android:textSize="@dimen/stats_widget_text_sz"
             android:ellipsize="end"
             android:singleLine="true"
             android:textColor="@color/white"
@@ -47,12 +47,13 @@
         android:minHeight="@dimen/stats_widget_main_container_size"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
+        android:gravity="center_vertical"
         android:orientation="horizontal">
 
         <!-- Views -->
         <LinearLayout
             android:layout_width="0dp"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_weight="1"
             android:orientation="vertical"
             android:padding="@dimen/margin_medium"
@@ -75,7 +76,8 @@
 
                 <TextView
                     android:textColor="@color/grey_dark"
-                    android:textSize="@dimen/text_sz_extra_small"
+                    android:textSize="@dimen/stats_widget_text_sz_small"
+                    android:textAllCaps="true"
                     android:maxLines="1"
                     android:ellipsize="end"
                     android:text="@string/stats_views"
@@ -86,7 +88,7 @@
             <TextView
                 android:id="@+id/stats_widget_views"
                 android:textColor="@color/blue_wordpress"
-                android:textSize="@dimen/text_sz_small"
+                android:textSize="@dimen/stats_widget_text_sz"
                 android:paddingTop="@dimen/margin_extra_small"
                 android:maxLines="1"
                 android:ellipsize="end"
@@ -98,7 +100,7 @@
         <!-- Visitors -->
         <LinearLayout
             android:layout_width="0dp"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_weight="1"
             android:orientation="vertical"
             android:padding="@dimen/margin_medium"
@@ -121,7 +123,8 @@
 
                 <TextView
                     android:textColor="@color/grey_dark"
-                    android:textSize="@dimen/text_sz_extra_small"
+                    android:textSize="@dimen/stats_widget_text_sz_small"
+                    android:textAllCaps="true"
                     android:maxLines="1"
                     android:text="@string/stats_visitors"
                     android:ellipsize="end"
@@ -132,7 +135,7 @@
             <TextView
                 android:id="@+id/stats_widget_visitors"
                 android:textColor="@color/blue_wordpress"
-                android:textSize="@dimen/text_sz_small"
+                android:textSize="@dimen/stats_widget_text_sz"
                 android:paddingTop="@dimen/margin_extra_small"
                 android:maxLines="1"
                 android:ellipsize="end"
@@ -144,7 +147,7 @@
         <!-- Likes -->
         <LinearLayout
             android:layout_width="0dp"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_weight="1"
             android:orientation="vertical"
             android:padding="@dimen/margin_medium"
@@ -167,7 +170,8 @@
 
                 <TextView
                     android:textColor="@color/grey_dark"
-                    android:textSize="@dimen/text_sz_extra_small"
+                    android:textSize="@dimen/stats_widget_text_sz_small"
+                    android:textAllCaps="true"
                     android:maxLines="1"
                     android:text="@string/stats_likes"
                     android:ellipsize="end"
@@ -178,7 +182,7 @@
             <TextView
                 android:id="@+id/stats_widget_likes"
                 android:textColor="@color/blue_wordpress"
-                android:textSize="@dimen/text_sz_small"
+                android:textSize="@dimen/stats_widget_text_sz"
                 android:paddingTop="@dimen/margin_extra_small"
                 android:maxLines="1"
                 android:ellipsize="end"
@@ -190,7 +194,7 @@
         <!-- Comments -->
         <LinearLayout
             android:layout_width="0dp"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_weight="1"
             android:orientation="vertical"
             android:padding="@dimen/margin_medium"
@@ -213,7 +217,8 @@
 
                 <TextView
                     android:textColor="@color/grey_dark"
-                    android:textSize="@dimen/text_sz_extra_small"
+                    android:textSize="@dimen/stats_widget_text_sz_small"
+                    android:textAllCaps="true"
                     android:maxLines="1"
                     android:text="@string/stats_comments"
                     android:ellipsize="end"
@@ -224,7 +229,7 @@
             <TextView
                 android:id="@+id/stats_widget_comments"
                 android:textColor="@color/blue_wordpress"
-                android:textSize="@dimen/text_sz_small"
+                android:textSize="@dimen/stats_widget_text_sz"
                 android:paddingTop="@dimen/margin_extra_small"
                 android:maxLines="1"
                 android:ellipsize="end"
@@ -242,10 +247,11 @@
         android:layout_width="match_parent"
         android:minHeight="@dimen/stats_widget_main_container_size"
         android:layout_height="wrap_content"
+        android:gravity="center_vertical"
         android:orientation="horizontal">
         <TextView
             android:id="@+id/stats_widget_error_text"
-            android:textSize="@dimen/text_sz_small"
+            android:textSize="@dimen/stats_widget_text_sz"
             android:textColor="@color/grey_darken_20"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/stats_widget_layout.xml
+++ b/WordPress/src/main/res/layout/stats_widget_layout.xml
@@ -44,8 +44,8 @@
 
     <LinearLayout
         android:id="@+id/stats_widget_values_container"
-        android:minHeight="@dimen/stats_widget_main_container_size"
-        android:layout_height="wrap_content"
+        android:layout_height="@dimen/stats_widget_main_container_size"
+        android:minHeight="@dimen/stats_widget_main_container_min_size"
         android:layout_width="match_parent"
         android:gravity="center_vertical"
         android:orientation="horizontal">
@@ -53,10 +53,9 @@
         <!-- Views -->
         <LinearLayout
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
             android:orientation="vertical"
-            android:padding="@dimen/margin_medium"
             android:gravity="center"
             android:background="@drawable/stats_visitors_and_views_button_white"
             android:clickable="false">
@@ -100,10 +99,9 @@
         <!-- Visitors -->
         <LinearLayout
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
             android:orientation="vertical"
-            android:padding="@dimen/margin_medium"
             android:gravity="center"
             android:background="@drawable/stats_visitors_and_views_button_white"
             android:clickable="false">
@@ -147,10 +145,9 @@
         <!-- Likes -->
         <LinearLayout
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
             android:orientation="vertical"
-            android:padding="@dimen/margin_medium"
             android:gravity="center"
             android:background="@drawable/stats_visitors_and_views_button_white"
             android:clickable="false">
@@ -194,10 +191,9 @@
         <!-- Comments -->
         <LinearLayout
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="1"
             android:orientation="vertical"
-            android:padding="@dimen/margin_medium"
             android:gravity="center"
             android:background="@drawable/stats_visitors_and_views_button_latest_white"
             android:clickable="false">
@@ -245,8 +241,8 @@
         android:id="@+id/stats_widget_error_container"
         android:visibility="gone"
         android:layout_width="match_parent"
-        android:minHeight="@dimen/stats_widget_main_container_size"
-        android:layout_height="wrap_content"
+        android:layout_height="@dimen/stats_widget_main_container_size"
+        android:minHeight="@dimen/stats_widget_main_container_min_size"
         android:gravity="center_vertical"
         android:orientation="horizontal">
         <TextView

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -153,7 +153,7 @@
     <dimen name="stats_widget_one_cell">40dp</dimen>
     <dimen name="stats_widget_four_cells">250dp</dimen>
     <dimen name="stats_widget_five_cells">320dp</dimen>
-    <dimen name="stats_widget_main_container_size">44dp</dimen>
+    <dimen name="stats_widget_main_container_size">48dp</dimen>
     <dimen name="stats_widget_image_layout_size">12dp</dimen>
     <dimen name="stats_widget_image_layout_margin">3dp</dimen>
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -142,16 +142,18 @@
     <dimen name="progress_bar_height">3dp</dimen>
 
     <!-- stats -->
-    <dimen name="stats_widget_icon_size">18dp</dimen>
     <dimen name="stats_button_corner_radius">2dp</dimen>
     <dimen name="stats_barchart_height">128dp</dimen>
     <dimen name="stats_barchart_legend_item">12dp</dimen>
 
     <!-- stats widget-->
+    <dimen name="stats_widget_icon_size">18dp</dimen>
+    <dimen name="stats_widget_text_sz">14dp</dimen>
+    <dimen name="stats_widget_text_sz_small">10dp</dimen>
     <dimen name="stats_widget_one_cell">40dp</dimen>
     <dimen name="stats_widget_four_cells">250dp</dimen>
     <dimen name="stats_widget_five_cells">320dp</dimen>
-    <dimen name="stats_widget_main_container_size">48dp</dimen>
+    <dimen name="stats_widget_main_container_size">44dp</dimen>
     <dimen name="stats_widget_image_layout_size">12dp</dimen>
     <dimen name="stats_widget_image_layout_margin">3dp</dimen>
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -150,10 +150,11 @@
     <dimen name="stats_widget_icon_size">18dp</dimen>
     <dimen name="stats_widget_text_sz">14dp</dimen>
     <dimen name="stats_widget_text_sz_small">10dp</dimen>
-    <dimen name="stats_widget_one_cell">40dp</dimen>
+    <dimen name="stats_widget_min_height">62dp</dimen>
+    <dimen name="stats_widget_main_container_min_size">38dp</dimen>
+    <dimen name="stats_widget_main_container_size">48dp</dimen>
     <dimen name="stats_widget_four_cells">250dp</dimen>
     <dimen name="stats_widget_five_cells">320dp</dimen>
-    <dimen name="stats_widget_main_container_size">48dp</dimen>
     <dimen name="stats_widget_image_layout_size">12dp</dimen>
     <dimen name="stats_widget_image_layout_margin">3dp</dimen>
 

--- a/WordPress/src/main/res/xml/stats_widget_info.xml
+++ b/WordPress/src/main/res/xml/stats_widget_info.xml
@@ -2,7 +2,7 @@
 <appwidget-provider
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:initialLayout="@layout/stats_widget_layout"
-    android:minHeight="@dimen/stats_widget_one_cell"
+    android:minHeight="@dimen/stats_widget_min_height"
     android:configure="org.wordpress.android.ui.stats.StatsWidgetConfigureActivity"
     android:resizeMode="horizontal"
     android:minWidth="@dimen/stats_widget_five_cells"


### PR DESCRIPTION
Fix #3496 by using `dp` instead of `sp` for textSize.

See the ticket for more details about this decision.