### PR TITLE
Add utility methods to check if a URL is wpcom

### DIFF
--- a/WordPress/src/androidTest/java/URITest.java
+++ b/WordPress/src/androidTest/java/URITest.java
@@ -1,0 +1,56 @@
+import android.test.InstrumentationTestCase;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class URITest extends InstrumentationTestCase {
+    public void testGetHost1() {
+        URI uri = null;
+        try {
+            uri = new URI("https://wordpress.com");
+        } catch (URISyntaxException e) {}
+        assertNotNull(uri);
+
+        assertEquals("wordpress.com", uri.getHost());
+    }
+
+    public void testGetHost2() {
+        URI uri = null;
+        try {
+            uri = new URI("http://a.com#.b.com/test");
+        } catch (URISyntaxException e) {}
+        assertNotNull(uri);
+
+        assertEquals("a.com", uri.getHost());
+    }
+
+    public void testGetHost3() {
+        URI uri = null;
+        try {
+            uri = new URI("https://a.com");
+        } catch (URISyntaxException e) {}
+        assertNotNull(uri);
+
+        assertEquals("a.com", uri.getHost());
+    }
+
+    public void testGetHost4() {
+        URI uri = null;
+        try {
+            uri = new URI("https://a.com/test#test");
+        } catch (URISyntaxException e) {}
+        assertNotNull(uri);
+
+        assertEquals("a.com", uri.getHost());
+    }
+
+    public void testGetHost5() {
+        URI uri = null;
+        try {
+            uri = new URI("a.com");
+        } catch (URISyntaxException e) {}
+        assertNotNull(uri);
+
+        assertNull(uri.getHost());
+    }
+}

--- a/WordPress/src/androidTest/java/URLTest.java
+++ b/WordPress/src/androidTest/java/URLTest.java
@@ -1,5 +1,3 @@
-package org.wordpress.android.util;
-
 import android.test.InstrumentationTestCase;
 
 import java.net.MalformedURLException;

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/URLTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/URLTest.java
@@ -1,0 +1,57 @@
+package org.wordpress.android.util;
+
+import android.test.InstrumentationTestCase;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class URLTest extends InstrumentationTestCase {
+    public void testGetHost1() {
+        URL url = null;
+        try {
+            url = new URL("https://wordpress.com");
+        } catch (MalformedURLException e) {}
+        assertNotNull(url);
+
+        assertEquals("wordpress.com", url.getHost());
+    }
+
+    public void testGetHost2() {
+        URL url = null;
+        try {
+            url = new URL("http://a.com#.b.com/test");
+        } catch (MalformedURLException e) {}
+        assertNotNull(url);
+
+        assertEquals("a.com", url.getHost());
+    }
+
+    public void testGetHost3() {
+        URL url = null;
+        try {
+            url = new URL("https://a.com");
+        } catch (MalformedURLException e) {}
+        assertNotNull(url);
+
+        assertEquals("a.com", url.getHost());
+    }
+
+    public void testGetHost4() {
+        URL url = null;
+        try {
+            url = new URL("https://a.com/test#test");
+        } catch (MalformedURLException e) {}
+        assertNotNull(url);
+
+        assertEquals("a.com", url.getHost());
+    }
+
+    public void testGetHost5() {
+        URL url = null;
+        try {
+            url = new URL("a.com");
+        } catch (MalformedURLException e) {}
+
+        assertNull(url);
+    }
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/WPUrlUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/WPUrlUtilsTest.java
@@ -1,0 +1,219 @@
+package org.wordpress.android.util;
+
+import android.test.InstrumentationTestCase;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+public class WPUrlUtilsTest extends InstrumentationTestCase {
+
+    private static final String wpcomAddress1 = "http://wordpress.com/xmlrpc.php";
+    private static final String wpcomAddress2 = "http://wordpress.com#.b.com/test";
+    private static final String wpcomAddress3 = "http://wordpress.com/xmlrpc.php";
+    private static final String wpcomAddress4 = "https://wordpress.com";
+    private static final String wpcomAddress5 = "https://wordpress.com/test#test";
+    private static final String notWpcomAddress1 = "http://i2.wp.com.eritreo.it#.files.wordpress.com/testpicture.gif?strip=all&quality=100&resize=1024,768";
+    private static final String notWpcomAddress2 = "wordpress.com";
+
+
+    public void testSafeToAddAuthToken1() {
+        // Not HTTPS
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(wpcomAddress1));
+    }
+
+    public void testSafeToAddAuthToken2() {
+        // Not HTTPS
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(wpcomAddress2));
+    }
+
+    public void testSafeToAddAuthToken3() {
+        // Not HTTPS
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(wpcomAddress3));
+    }
+
+    public void testSafeToAddAuthToken4() {
+        assertTrue(WPUrlUtils.safeToAddWordPressComAuthToken(wpcomAddress4));
+    }
+    public void testSafeToAddAuthToken5() {
+        assertTrue(WPUrlUtils.safeToAddWordPressComAuthToken(wpcomAddress5));
+    }
+
+    public void testSafeToAddAuthToken6() {
+        // Not wpcom
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(notWpcomAddress1));
+    }
+
+    public void testSafeToAddAuthToken7() {
+        // Not wpcom
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(notWpcomAddress2));
+    }
+
+    public void testSafeToAddAuthToken8() {
+        // Not HTTPS
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(buildURL(wpcomAddress1)));
+    }
+
+    public void testSafeToAddAuthToken9() {
+        // Not HTTPS
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(buildURL(wpcomAddress2)));
+    }
+
+    public void testSafeToAddAuthToken10() {
+        // Not HTTPS
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(buildURL(wpcomAddress3)));
+    }
+
+    public void testSafeToAddAuthToken11() {
+        assertTrue(WPUrlUtils.safeToAddWordPressComAuthToken(buildURL(wpcomAddress4)));
+    }
+    public void testSafeToAddAuthToken12() {
+        assertTrue(WPUrlUtils.safeToAddWordPressComAuthToken(buildURL(wpcomAddress5)));
+    }
+
+    public void testSafeToAddAuthToken13() {
+        // Not wpcom
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(buildURL(notWpcomAddress1)));
+    }
+
+    public void testSafeToAddAuthToken14() {
+        // Not wpcom
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(buildURL(notWpcomAddress2)));
+    }
+
+    public void testSafeToAddAuthToken15() {
+        // Not HTTPS
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(buildURI(wpcomAddress1)));
+    }
+
+    public void testSafeToAddAuthToken16() {
+        // Not HTTPS
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(buildURI(wpcomAddress2)));
+    }
+
+    public void testSafeToAddAuthToken17() {
+        // Not HTTPS
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(buildURI(wpcomAddress3)));
+    }
+
+    public void testSafeToAddAuthToken18() {
+        assertTrue(WPUrlUtils.safeToAddWordPressComAuthToken(buildURI(wpcomAddress4)));
+    }
+    public void testSafeToAddAuthToken19() {
+        assertTrue(WPUrlUtils.safeToAddWordPressComAuthToken(buildURI(wpcomAddress5)));
+    }
+
+    public void testSafeToAddAuthToken20() {
+        // Not wpcom
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(buildURI(notWpcomAddress1)));
+    }
+
+    public void testSafeToAddAuthToken21() {
+        // Not wpcom
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(buildURI(notWpcomAddress2)));
+    }
+
+
+    public void testIsWPCOMString1() {
+        assertTrue(WPUrlUtils.isWordPressCom(wpcomAddress1));
+    }
+
+    public void testIsWPCOMString2() {
+        assertTrue(WPUrlUtils.isWordPressCom(wpcomAddress2));
+    }
+
+    public void testIsWPCOMString3() {
+        assertTrue(WPUrlUtils.isWordPressCom(wpcomAddress3));
+    }
+
+    public void testIsWPCOMString4() {
+        assertTrue(WPUrlUtils.isWordPressCom(wpcomAddress4));
+    }
+    public void testIsWPCOMString5() {
+        assertTrue(WPUrlUtils.isWordPressCom(wpcomAddress5));
+    }
+
+    private URL buildURL(String address) {
+        URL url = null;
+        try {
+            url = new URL(address);
+        } catch (MalformedURLException e) {}
+        return url;
+    }
+
+    public void testIsWPCOMURL1() {
+        assertTrue(WPUrlUtils.isWordPressCom(buildURL(wpcomAddress1)));
+    }
+
+    public void testIsWPCOMURL2() {
+        assertTrue(WPUrlUtils.isWordPressCom(buildURL(wpcomAddress2)));
+    }
+
+    public void testIsWPCOMURL3() {
+        assertTrue(WPUrlUtils.isWordPressCom(buildURL(wpcomAddress3)));
+    }
+
+    public void testIsWPCOMURL4() {
+        assertTrue(WPUrlUtils.isWordPressCom(buildURL(wpcomAddress4)));
+    }
+
+    public void testIsWPCOMURL5() {
+        assertTrue(WPUrlUtils.isWordPressCom(buildURL(wpcomAddress5)));
+    }
+
+
+    private URI buildURI(String address) {
+        URI uri = null;
+        try {
+            uri = new URI(address);
+        } catch (URISyntaxException e) {}
+        return uri;
+    }
+
+    public void testIsWPCOMURI1() {
+        assertTrue(WPUrlUtils.isWordPressCom(buildURI(wpcomAddress1)));
+    }
+
+    public void testIsWPCOMURI2() {
+        assertTrue(WPUrlUtils.isWordPressCom(buildURI(wpcomAddress2)));
+    }
+
+    public void testIsWPCOMURI3() {
+        assertTrue(WPUrlUtils.isWordPressCom(buildURI(wpcomAddress3)));
+    }
+
+    public void testIsWPCOMURI4() {
+        assertTrue(WPUrlUtils.isWordPressCom(buildURI(wpcomAddress4)));
+    }
+
+    public void testIsWPCOMURI5() {
+        assertTrue(WPUrlUtils.isWordPressCom(buildURI(wpcomAddress5)));
+    }
+
+
+    public void testIsNOTWPCOM1() {
+        assertFalse(WPUrlUtils.isWordPressCom(notWpcomAddress1));
+    }
+
+    public void testIsNOTWPCOM2() {
+        assertFalse(WPUrlUtils.isWordPressCom(notWpcomAddress2));
+    }
+
+    public void testIsNOTWPCOM3() {
+        assertFalse(WPUrlUtils.isWordPressCom(buildURL(notWpcomAddress1)));
+    }
+
+    public void testIsNOTWPCOM4() {
+        assertFalse(WPUrlUtils.isWordPressCom(buildURL(notWpcomAddress2)));
+    }
+
+    public void testIsNOTWPCOM5() {
+        assertFalse(WPUrlUtils.isWordPressCom(buildURI(notWpcomAddress1)));
+    }
+
+    public void testIsNOTWPCOM6() {
+        assertFalse(WPUrlUtils.isWordPressCom(buildURI(notWpcomAddress2)));
+    }
+
+}

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/WPUrlUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/WPUrlUtilsTest.java
@@ -159,8 +159,13 @@ public class WPUrlUtilsTest extends InstrumentationTestCase {
     public void testIsWPCOMString4() {
         assertTrue(WPUrlUtils.isWordPressCom(wpcomAddress4));
     }
+
     public void testIsWPCOMString5() {
         assertTrue(WPUrlUtils.isWordPressCom(wpcomAddress5));
+    }
+
+    public void testIsWPCOMString6() {
+        assertTrue(WPUrlUtils.isWordPressCom(wpcomAddress6));
     }
 
     private URL buildURL(String address) {
@@ -189,6 +194,10 @@ public class WPUrlUtilsTest extends InstrumentationTestCase {
 
     public void testIsWPCOMURL5() {
         assertTrue(WPUrlUtils.isWordPressCom(buildURL(wpcomAddress5)));
+    }
+
+    public void testIsWPCOMURL6() {
+        assertTrue(WPUrlUtils.isWordPressCom(buildURL(wpcomAddress6)));
     }
 
 
@@ -220,6 +229,9 @@ public class WPUrlUtilsTest extends InstrumentationTestCase {
         assertTrue(WPUrlUtils.isWordPressCom(buildURI(wpcomAddress5)));
     }
 
+    public void testIsWPCOMURI6() {
+        assertTrue(WPUrlUtils.isWordPressCom(buildURI(wpcomAddress6)));
+    }
 
     public void testIsNOTWPCOM1() {
         assertFalse(WPUrlUtils.isWordPressCom(notWpcomAddress1));
@@ -243,6 +255,18 @@ public class WPUrlUtilsTest extends InstrumentationTestCase {
 
     public void testIsNOTWPCOM6() {
         assertFalse(WPUrlUtils.isWordPressCom(buildURI(notWpcomAddress2)));
+    }
+
+    public void testIsNOTWPCOM7() {
+        assertFalse(WPUrlUtils.isWordPressCom(notWpcomAddress3));
+    }
+
+    public void testIsNOTWPCOM8() {
+        assertFalse(WPUrlUtils.isWordPressCom(buildURL(notWpcomAddress3)));
+    }
+
+    public void testIsNOTWPCOM9() {
+        assertFalse(WPUrlUtils.isWordPressCom(buildURI(notWpcomAddress3)));
     }
 
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/WPUrlUtilsTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/WPUrlUtilsTest.java
@@ -14,8 +14,10 @@ public class WPUrlUtilsTest extends InstrumentationTestCase {
     private static final String wpcomAddress3 = "http://wordpress.com/xmlrpc.php";
     private static final String wpcomAddress4 = "https://wordpress.com";
     private static final String wpcomAddress5 = "https://wordpress.com/test#test";
+    private static final String wpcomAddress6 = "https://developer.wordpress.com";
     private static final String notWpcomAddress1 = "http://i2.wp.com.eritreo.it#.files.wordpress.com/testpicture.gif?strip=all&quality=100&resize=1024,768";
     private static final String notWpcomAddress2 = "wordpress.com";
+    private static final String notWpcomAddress3 = "https://thisisnotwordpress.com";
 
 
     public void testSafeToAddAuthToken1() {
@@ -112,6 +114,33 @@ public class WPUrlUtilsTest extends InstrumentationTestCase {
     public void testSafeToAddAuthToken21() {
         // Not wpcom
         assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(buildURI(notWpcomAddress2)));
+    }
+
+    public void testSafeToAddAuthToken22() {
+        // Not wpcom
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(notWpcomAddress3));
+    }
+
+    public void testSafeToAddAuthToken23() {
+        // Not wpcom
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(buildURL(notWpcomAddress3)));
+    }
+
+    public void testSafeToAddAuthToken24() {
+        // Not wpcom
+        assertFalse(WPUrlUtils.safeToAddWordPressComAuthToken(buildURI(notWpcomAddress3)));
+    }
+
+    public void testSafeToAddAuthToken25() {
+        assertTrue(WPUrlUtils.safeToAddWordPressComAuthToken(wpcomAddress6));
+    }
+
+    public void testSafeToAddAuthToken26() {
+        assertTrue(WPUrlUtils.safeToAddWordPressComAuthToken(buildURL(wpcomAddress6)));
+    }
+
+    public void testSafeToAddAuthToken27() {
+        assertTrue(WPUrlUtils.safeToAddWordPressComAuthToken(buildURI(wpcomAddress6)));
     }
 
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -33,6 +33,7 @@ import org.wordpress.android.util.BlogUtils;
 import org.wordpress.android.util.MapUtils;
 import org.wordpress.android.util.SqlUtils;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 
 import java.io.FileInputStream;
@@ -80,7 +81,7 @@ public class WordPressDB {
     public static final String COLUMN_NAME_VIDEO_PRESS_SHORTCODE = "videoPressShortcode";
     public static final String COLUMN_NAME_UPLOAD_STATE          = "uploadState";
 
-    private static final int DATABASE_VERSION = 38;
+    private static final int DATABASE_VERSION = 39;
 
     private static final String CREATE_TABLE_BLOGS = "create table if not exists accounts (id integer primary key autoincrement, "
             + "url text, blogName text, username text, password text, imagePlacement text, centerThumbnail boolean, fullSizeImage boolean, maxImageWidth text, maxImageWidthId integer);";
@@ -380,8 +381,28 @@ public class WordPressDB {
             case 37:
                 resetThemeTable();
                 currentVersion++;
+            case 38:
+                updateDotcomFlag();
+                currentVersion++;
         }
         db.setVersion(DATABASE_VERSION);
+    }
+
+    private void updateDotcomFlag() {
+        // Loop over all .com blogs in the app and check that are really hosted on wpcom
+        List<Map<String, Object>> allBlogs = getBlogsBy("dotcomFlag=1", null, 0, false);
+        for (Map<String, Object> blog : allBlogs) {
+            String xmlrpcURL = MapUtils.getMapStr(blog, "url");
+            if (!WPUrlUtils.isWordPressCom(xmlrpcURL)) {
+                // .org blog marked as .com. Fix it.
+                int blogID = MapUtils.getMapInt(blog, "id");
+                if (blogID > 0) {
+                    ContentValues values = new ContentValues();
+                    values.put("dotcomFlag", false); // Mark as .org blog
+                    db.update(BLOGS_TABLE, values, "id=" + blogID, null);
+                }
+            }
+        }
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/models/Blog.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Blog.java
@@ -415,6 +415,9 @@ public class Blog {
     }
 
     public boolean isPrivate() {
+        if (!isDotcomFlag()) {
+            return false; // only wpcom blogs can be marked private.
+        }
         JSONObject jsonOptions = getBlogOptionsJSONObject();
         if (jsonOptions != null && jsonOptions.has("blog_public")) {
             try {

--- a/WordPress/src/main/java/org/wordpress/android/networking/WPDelayedHurlStack.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/WPDelayedHurlStack.java
@@ -24,6 +24,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.UrlUtils;
+import org.wordpress.android.util.WPUrlUtils;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -92,14 +93,14 @@ public class WPDelayedHurlStack implements HttpStack {
     public HttpResponse performRequest(Request<?> request, Map<String, String> additionalHeaders)
             throws IOException, AuthFailureError {
         if (request.getUrl() != null) {
-            if (!UrlUtils.getHost(request.getUrl()).endsWith("wordpress.com") && mCurrentBlog != null
+            if (!WPUrlUtils.isWordPressCom(request.getUrl()) && mCurrentBlog != null
                     && mCurrentBlog.hasValidHTTPAuthCredentials()) {
                 String creds = String.format("%s:%s", mCurrentBlog.getHttpuser(), mCurrentBlog.getHttppassword());
                 String auth = "Basic " + Base64.encodeToString(creds.getBytes(), Base64.DEFAULT);
                 additionalHeaders.put("Authorization", auth);
             }
 
-            if (UrlUtils.getHost(request.getUrl()).endsWith("files.wordpress.com") && mCtx != null
+            if (WPUrlUtils.safeToAddWordPressComAuthToken(request.getUrl()) && mCtx != null
                     && AccountHelper.isSignedInWordPressDotCom()) {
                 // Add the auth header to access private WP.com files
                 additionalHeaders.put("Authorization", "Bearer " + AccountHelper.getDefaultAccount().getAccessToken());
@@ -171,8 +172,8 @@ public class WPDelayedHurlStack implements HttpStack {
      */
     protected HttpURLConnection createConnection(URL url) throws IOException {
         // Check that the custom SslSocketFactory is not null on HTTPS connections
-        if ("https".equals(url.getProtocol()) && !url.getHost().endsWith("wordpress.com")
-                && !url.getHost().endsWith("gravatar.com")) {
+        if (UrlUtils.isHttps(url) && !WPUrlUtils.isWordPressCom(url)
+                && !WPUrlUtils.isGravatar(url)) {
             // WordPress.com doesn't need the custom mSslSocketFactory
             synchronized (monitor) {
                 while (mSslSocketFactory == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -25,6 +25,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPMeShortlinks;
+import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.util.WPWebViewClient;
 import org.wordpress.android.util.helpers.WPWebChromeClient;
 import org.wordpress.passcodelock.AppLockManager;
@@ -242,7 +243,8 @@ public class WPWebViewActivity extends WebViewActivity {
             );
 
             // Add token authorization when signing in to WP.com
-            if (authenticationUrl.contains("wordpress.com/wp-login.php") && !TextUtils.isEmpty(token)) {
+            if (WPUrlUtils.safeToAddWordPressComAuthToken(authenticationUrl)
+                    && authenticationUrl.contains("wordpress.com/wp-login.php") && !TextUtils.isEmpty(token)) {
                 postData += "&authorization=Bearer " + URLEncoder.encode(token, ENCODING_UTF8);
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
@@ -10,6 +10,7 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.MapUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.UrlUtils;
+import org.wordpress.android.util.WPUrlUtils;
 
 import java.util.HashSet;
 import java.util.List;
@@ -112,7 +113,7 @@ public class BlogUtils {
             // deprecated
             blog.setMaxImageWidthId(0);
             blog.setRemoteBlogId(Integer.parseInt(blogId));
-            blog.setDotcomFlag(xmlRpcUrl.contains("wordpress.com"));
+            blog.setDotcomFlag(WPUrlUtils.isWordPressCom(xmlRpcUrl));
             // assigned later in getOptions call
             blog.setWpVersion("");
             blog.setAdmin(isAdmin);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -57,6 +57,7 @@ import org.wordpress.android.util.HelpshiftHelper.Tag;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.widgets.WPTextView;
 import org.wordpress.emailchecker.EmailChecker;
 import org.xmlrpc.android.ApiHelper;
@@ -302,7 +303,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
 
     private boolean isWPComLogin() {
         String selfHostedUrl = EditTextUtils.getText(mUrlEditText).trim();
-        return !mSelfHosted || TextUtils.isEmpty(selfHostedUrl) || selfHostedUrl.contains("wordpress.com");
+        return !mSelfHosted || TextUtils.isEmpty(selfHostedUrl) || WPUrlUtils.isWordPressCom(selfHostedUrl);
     }
 
     private boolean isJetpackAuth() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/FetchBlogListWPOrg.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/FetchBlogListWPOrg.java
@@ -12,6 +12,7 @@ import org.wordpress.android.util.CrashlyticsUtils;
 import org.wordpress.android.util.CrashlyticsUtils.ExceptionType;
 import org.wordpress.android.util.CrashlyticsUtils.ExtraKey;
 import org.wordpress.android.util.UrlUtils;
+import org.wordpress.android.util.WPUrlUtils;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlrpc.android.ApiHelper;
 import org.xmlrpc.android.XMLRPCClientInterface;
@@ -105,13 +106,13 @@ public class FetchBlogListWPOrg extends FetchBlogListAbstract {
                 return null;
             }
         } catch (SSLHandshakeException e) {
-            if (!UrlUtils.getHost(baseUrl).endsWith("wordpress.com")) {
+            if (!WPUrlUtils.isWordPressCom(baseUrl)) {
                 mErroneousSslCertificate = true;
             }
             AppLog.w(T.NUX, "SSLHandshakeException failed. Erroneous SSL certificate detected.");
             return null;
         } catch (SSLPeerUnverifiedException e) {
-            if (!UrlUtils.getHost(baseUrl).endsWith("wordpress.com")) {
+            if (!WPUrlUtils.isWordPressCom(baseUrl)) {
                 mErroneousSslCertificate = true;
             }
             AppLog.w(T.NUX, "SSLPeerUnverifiedException failed. Erroneous SSL certificate detected.");
@@ -150,13 +151,13 @@ public class FetchBlogListWPOrg extends FetchBlogListAbstract {
             AnalyticsTracker.track(Stat.LOGIN_FAILED_TO_GUESS_XMLRPC);
             AppLog.e(T.NUX, "system.listMethods failed on: " + guessURL, e);
         } catch (SSLHandshakeException e) {
-            if (!UrlUtils.getHost(baseUrl).endsWith("wordpress.com")) {
+            if (!WPUrlUtils.isWordPressCom(baseUrl)) {
                 mErroneousSslCertificate = true;
             }
             AppLog.w(T.NUX, "SSLHandshakeException failed. Erroneous SSL certificate detected.");
             return null;
         } catch (SSLPeerUnverifiedException e) {
-            if (!UrlUtils.getHost(baseUrl).endsWith("wordpress.com")) {
+            if (!WPUrlUtils.isWordPressCom(baseUrl)) {
                 mErroneousSslCertificate = true;
             }
             AppLog.w(T.NUX, "SSLPeerUnverifiedException failed. Erroneous SSL certificate detected.");
@@ -195,7 +196,7 @@ public class FetchBlogListWPOrg extends FetchBlogListAbstract {
         try {
             rsdUrl = UrlUtils.addUrlSchemeIfNeeded(getRsdUrl(url), false);
         } catch (SSLHandshakeException e) {
-            if (!UrlUtils.getHost(url).endsWith("wordpress.com")) {
+            if (!WPUrlUtils.isWordPressCom(url)) {
                 mErroneousSslCertificate = true;
             }
             AppLog.w(T.NUX, "SSLHandshakeException failed. Erroneous SSL certificate detected.");
@@ -212,7 +213,7 @@ public class FetchBlogListWPOrg extends FetchBlogListAbstract {
                 xmlrpcUrl = UrlUtils.addUrlSchemeIfNeeded(getXmlrpcByUserEnteredPath(url), false);
             }
         } catch (SSLHandshakeException e) {
-            if (!UrlUtils.getHost(url).endsWith("wordpress.com")) {
+            if (!WPUrlUtils.isWordPressCom(url)) {
                 mErroneousSslCertificate = true;
             }
             AppLog.w(T.NUX, "SSLHandshakeException failed. Erroneous SSL certificate detected.");
@@ -277,7 +278,7 @@ public class FetchBlogListWPOrg extends FetchBlogListAbstract {
                 AppLog.e(T.NUX, "XMLRPCException received from XMLRPC call wp.getUsersBlogs", xmlRpcException);
                 mErrorMsgId = org.wordpress.android.R.string.no_site_error;
             } catch (SSLHandshakeException e) {
-                if (xmlrpcUri.getHost() != null && xmlrpcUri.getHost().endsWith("wordpress.com")) {
+                if (WPUrlUtils.isWordPressCom(xmlrpcUri)) {
                     mErroneousSslCertificate = true;
                 }
                 AppLog.w(T.NUX, "SSLHandshakeException failed. Erroneous SSL certificate detected.");

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -23,6 +23,7 @@ import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
+import org.wordpress.android.util.WPUrlUtils;
 
 public class ReaderActivityLauncher {
 
@@ -227,8 +228,7 @@ public class ReaderActivityLauncher {
 
         if (openUrlType == OpenUrlType.INTERNAL) {
             // That won't work on wpcom sites with custom urls
-            // TODO: #2785 (util method to check if a URL is wpcom)
-            if (UrlUtils.getHost(url).endsWith("wordpress.com")) {
+            if (WPUrlUtils.isWordPressCom(url)) {
                 WPWebViewActivity.openUrlByUsingWPCOMCredentials(context, url,
                         AccountHelper.getDefaultAccount().getUserName());
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/util/WPUrlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPUrlUtils.java
@@ -39,8 +39,7 @@ public class WPUrlUtils {
         if (url == null) {
             return false;
         }
-        return url.getHost().endsWith("gravatar.com");
+        return url.getHost().equals("gravatar.com") || url.getHost().endsWith(".gravatar.com");
     }
-
 
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPUrlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPUrlUtils.java
@@ -18,21 +18,21 @@ public class WPUrlUtils {
     }
 
     public static synchronized boolean isWordPressCom(String url) {
-        return UrlUtils.getHost(url).endsWith("wordpress.com");
+        return UrlUtils.getHost(url).endsWith(".wordpress.com") || UrlUtils.getHost(url).equals("wordpress.com");
     }
-    
+
     public static synchronized boolean isWordPressCom(URL url) {
         if (url == null) {
             return false;
         }
-        return url.getHost().endsWith("wordpress.com");
+        return url.getHost().endsWith(".wordpress.com") || url.getHost().equals("wordpress.com");
     }
 
     public static synchronized boolean isWordPressCom(URI uri) {
         if (uri == null || uri.getHost() == null) {
             return false;
         }
-        return uri.getHost().endsWith("wordpress.com");
+        return uri.getHost().endsWith(".wordpress.com") || uri.getHost().equals("wordpress.com");
     }
 
     public static synchronized boolean isGravatar(URL url) {

--- a/WordPress/src/main/java/org/wordpress/android/util/WPUrlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPUrlUtils.java
@@ -1,0 +1,50 @@
+package org.wordpress.android.util;
+
+import java.net.URI;
+import java.net.URL;
+
+public class WPUrlUtils {
+
+    public static synchronized boolean safeToAddWordPressComAuthToken(String url) {
+        return UrlUtils.isHttps(url) && isWordPressCom(url);
+    }
+
+    public static synchronized boolean safeToAddWordPressComAuthToken(URL url) {
+        return UrlUtils.isHttps(url) && isWordPressCom(url);
+    }
+
+    public static synchronized boolean safeToAddWordPressComAuthToken(URI uri) {
+        return UrlUtils.isHttps(uri) && isWordPressCom(uri);
+    }
+
+    public static synchronized boolean isWordPressCom(String url) {
+        return UrlUtils.getHost(url).endsWith("wordpress.com");
+    }
+
+    public static synchronized boolean isFilesWordPressCom(String url) {
+        return UrlUtils.getHost(url).endsWith("files.wordpress.com");
+    }
+
+    public static synchronized boolean isWordPressCom(URL url) {
+        if (url == null) {
+            return false;
+        }
+        return url.getHost().endsWith("wordpress.com");
+    }
+
+    public static synchronized boolean isWordPressCom(URI uri) {
+        if (uri == null || uri.getHost() == null) {
+            return false;
+        }
+        return uri.getHost().endsWith("wordpress.com");
+    }
+
+    public static synchronized boolean isGravatar(URL url) {
+        if (url == null) {
+            return false;
+        }
+        return url.getHost().endsWith("gravatar.com");
+    }
+
+
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/WPUrlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPUrlUtils.java
@@ -20,11 +20,7 @@ public class WPUrlUtils {
     public static synchronized boolean isWordPressCom(String url) {
         return UrlUtils.getHost(url).endsWith("wordpress.com");
     }
-
-    public static synchronized boolean isFilesWordPressCom(String url) {
-        return UrlUtils.getHost(url).endsWith("files.wordpress.com");
-    }
-
+    
     public static synchronized boolean isWordPressCom(URL url) {
         if (url == null) {
             return false;

--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
@@ -25,6 +25,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.CoreEvents;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.WPUrlUtils;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
@@ -128,7 +129,7 @@ public class XMLRPCClient implements XMLRPCClientInterface {
 
     private DefaultHttpClient instantiateClientForUri(URI uri, UsernamePasswordCredentials usernamePasswordCredentials) {
         DefaultHttpClient client = null;
-        if (uri != null && uri.getHost() != null && uri.getHost().endsWith("wordpress.com")) {
+        if (WPUrlUtils.isWordPressCom(uri)) {
             mIsWpcom = true;
         }
         if (mIsWpcom) {
@@ -648,7 +649,7 @@ public class XMLRPCClient implements XMLRPCClientInterface {
             return false;
         }
 
-        return path.equals("/xmlrpc.php") && host.endsWith("wordpress.com") && protocol.equals("https");
+        return path.equals("/xmlrpc.php") && WPUrlUtils.safeToAddWordPressComAuthToken(clientUri) && protocol.equals("https");
     }
 
     private class CancelException extends RuntimeException {

--- a/libs/utils/WordPressUtils/src/androidTest/java/org/wordpress/android/util/UrlUtilsTest.java
+++ b/libs/utils/WordPressUtils/src/androidTest/java/org/wordpress/android/util/UrlUtilsTest.java
@@ -2,6 +2,8 @@ package org.wordpress.android.util;
 
 import android.test.InstrumentationTestCase;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -74,5 +76,33 @@ public class UrlUtilsTest extends InstrumentationTestCase {
         if (!url.equals("/relative/test?h=300&w=200") && !url.equals("/relative/test?w=200&h=300")) {
             assertTrue("failed test on url: " + url, false);
         }
+    }
+
+    public void testHttps1() {
+        assertFalse(UrlUtils.isHttps(buildURL("http://wordpress.com/xmlrpc.php")));
+    }
+
+    public void testHttps2() {
+        assertFalse(UrlUtils.isHttps(buildURL("http://wordpress.com#.b.com/test")));
+    }
+
+    public void testHttps3() {
+        assertFalse(UrlUtils.isHttps(buildURL("http://wordpress.com/xmlrpc.php")));
+    }
+
+    public void testHttps4() {
+        assertTrue(UrlUtils.isHttps(buildURL("https://wordpress.com")));
+    }
+
+    public void testHttps5() {
+        assertTrue(UrlUtils.isHttps(buildURL("https://wordpress.com/test#test")));
+    }
+
+    private URL buildURL(String address) {
+        URL url = null;
+        try {
+            url = new URL(address);
+        } catch (MalformedURLException e) {}
+        return url;
     }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
@@ -10,6 +10,7 @@ import org.wordpress.android.util.AppLog.T;
 import java.io.UnsupportedEncodingException;
 import java.net.IDN;
 import java.net.URI;
+import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
@@ -170,6 +171,17 @@ public class UrlUtils {
      */
     public static boolean isHttps(final String urlString) {
         return (urlString != null && urlString.startsWith("https:"));
+    }
+
+    public static boolean isHttps(URL url) {
+        return url != null && "https".equals(url.getProtocol());
+    }
+
+    public static boolean isHttps(URI uri) {
+        if (uri == null) return false;
+
+        String protocol = uri.getScheme();
+        return protocol != null && protocol.equals("https");
     }
 
     /**


### PR DESCRIPTION
Fix #2785  by adding utility methods that check if a URL is wpcom, and check if it's safe to add the Authentication token to the HTTP request.