### PR TITLE
Move StatsUtils.getBlogId to Blog.getDotComBlogId

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -450,10 +450,10 @@ public class WordPress extends Application {
     }
 
     /**
-     * returns the blogID of the current blog or -1 if current blog is null
+     * returns the blogID of the current blog or null if current blog is null or remoteID is null.
      */
-    public static int getCurrentRemoteBlogId() {
-        return (getCurrentBlog() != null ? getCurrentBlog().getRemoteBlogId() : -1);
+    public static String getCurrentRemoteBlogId() {
+        return (getCurrentBlog() != null ? getCurrentBlog().getDotComBlogId() : null);
     }
 
     public static int getCurrentLocalTableBlogId() {

--- a/WordPress/src/main/java/org/wordpress/android/models/Blog.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Blog.java
@@ -467,7 +467,7 @@ public class Blog {
         } else {
             String remoteID =  getApi_blogid();
             // Self-hosted blogs edge cases.
-            if (org.apache.commons.lang.StringUtils.isEmpty(remoteID)) {
+            if (TextUtils.isEmpty(remoteID)) {
                 return null;
             }
             try {
@@ -477,7 +477,7 @@ public class Blog {
                     return null;
                 }
             } catch (NumberFormatException e) {
-                AppLog.e(T.STATS, "The remote blog ID stored in options isn't valid: " + remoteID);
+                AppLog.e(T.UTILS, "The remote blog ID stored in options isn't valid: " + remoteID);
                 return null;
             }
             return remoteID;

--- a/WordPress/src/main/java/org/wordpress/android/models/Blog.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Blog.java
@@ -450,15 +450,34 @@ public class Blog {
     }
 
     /**
-     * Get the WordPress.com blog ID
-     * Stored in blogId for WP.com, api_blogId for Jetpack
+     * Get the remote Blog ID stored on the wpcom backend.
+     *
+     * In the app db it's stored in blogId for WP.com, and in api_blogId for Jetpack.
+     *
+     * For WP.com sites this function returns the same value of getRemoteBlogId().
      *
      * @return WP.com blogId string, potentially null for Jetpack sites
      */
     public String getDotComBlogId() {
-        if (isDotcomFlag())
+        if (isDotcomFlag()) {
             return String.valueOf(getRemoteBlogId());
-        else
-            return getApi_blogid();
+        } else {
+            String remoteID =  getApi_blogid();
+            // Self-hosted blogs edge cases.
+            if (org.apache.commons.lang.StringUtils.isEmpty(remoteID)) {
+                return null;
+            }
+            try {
+                long parsedBlogID = Long.parseLong(remoteID);
+                // remote blogID is always > 1 for Jetpack blogs
+                if (parsedBlogID < 1) {
+                    return null;
+                }
+            } catch (NumberFormatException e) {
+                AppLog.e(T.STATS, "The remote blog ID stored in options isn't valid: " + remoteID);
+                return null;
+            }
+            return remoteID;
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -363,7 +363,16 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         if (mTags != null) {
             mTags.setTokenizer(new SuggestionAutoCompleteText.CommaTokenizer());
 
-            remoteBlogId = WordPress.getCurrentRemoteBlogId();
+            remoteBlogId = -1;
+            String blogID = WordPress.getCurrentRemoteBlogId();
+            if (blogID != null) {
+                try {
+                    remoteBlogId = Integer.parseInt(blogID);
+                } catch (NumberFormatException e) {
+                    AppLog.e(T.EDITOR, "The remote blog ID can't be parsed as Integer: " + remoteBlogId);
+                }
+            }
+
             mSuggestionServiceConnectionManager = new SuggestionServiceConnectionManager(this, remoteBlogId);
             mTagSuggestionAdapter = SuggestionUtils.setupTagSuggestions(remoteBlogId, this, mSuggestionServiceConnectionManager);
             if (mTagSuggestionAdapter != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
@@ -51,13 +51,12 @@ public abstract class StatsAbstractFragment extends Fragment {
             return;
         }
 
-        final String blogId = StatsUtils.getBlogId(getLocalTableBlogID());
         final Blog currentBlog = WordPress.getBlog(getLocalTableBlogID());
-
         if (currentBlog == null) {
             AppLog.w(AppLog.T.STATS, "Current blog is null. This should never happen here.");
             return;
         }
+        final String blogId = currentBlog.getDotComBlogId();
 
         // Make sure the blogId is available.
         if (blogId == null) {
@@ -237,4 +236,12 @@ public abstract class StatsAbstractFragment extends Fragment {
     }
 
     protected abstract String getTitle();
+
+    boolean isSameBlog(StatsEvents.SectionUpdated event) {
+        final Blog currentBlog = WordPress.getBlog(getLocalTableBlogID());
+        if (currentBlog != null && currentBlog.getDotComBlogId() != null) {
+            return event.mRequestBlogId.equals(currentBlog.getDotComBlogId());
+        }
+        return false;
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractInsightsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractInsightsFragment.java
@@ -206,7 +206,7 @@ public abstract class StatsAbstractInsightsFragment extends StatsAbstractFragmen
             return;
         }
 
-        if (!event.mRequestBlogId.equals(StatsUtils.getBlogId(getLocalTableBlogID()))) {
+        if (!isSameBlog(event)) {
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractListFragment.java
@@ -417,7 +417,7 @@ public abstract class StatsAbstractListFragment extends StatsAbstractFragment {
             return;
         }
 
-        if (!event.mRequestBlogId.equals(StatsUtils.getBlogId(getLocalTableBlogID()))) {
+        if (!isSameBlog(event)) {
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -523,7 +523,7 @@ public class StatsActivity extends AppCompatActivity
             mResultCode = resultCode;
             final Blog currentBlog = WordPress.getBlog(mLocalBlogID);
             if (resultCode == RESULT_OK && currentBlog != null && !currentBlog.isDotcomFlag()) {
-                if (StatsUtils.getBlogId(mLocalBlogID) == null) {
+                if (currentBlog.getDotComBlogId() == null) {
                     final Handler handler = new Handler();
                     // Attempt to get the Jetpack blog ID
                     XMLRPCClientInterface xmlrpcClient = XMLRPCFactory.instantiate(currentBlog.getUri(), "", "");
@@ -695,13 +695,14 @@ public class StatsActivity extends AppCompatActivity
             AppLog.w(AppLog.T.STATS, "StatsActivity > cannot check credentials since no internet connection available");
             return false;
         }
-        final String blogId = StatsUtils.getBlogId(mLocalBlogID);
-        final Blog currentBlog = WordPress.getBlog(mLocalBlogID);
 
+        final Blog currentBlog = WordPress.getBlog(mLocalBlogID);
         if (currentBlog == null) {
             AppLog.e(T.STATS, "The blog with local_blog_id " + mLocalBlogID + " cannot be loaded from the DB.");
             return false;
         }
+
+        final String blogId = currentBlog.getDotComBlogId();
 
         // blogId is always available for dotcom blogs. It could be null on Jetpack blogs...
         if (blogId != null) {
@@ -763,7 +764,11 @@ public class StatsActivity extends AppCompatActivity
         mSwipeToRefreshHelper.setRefreshing(false);
 
         if (!event.isError) {
-            if (StatsUtils.getBlogId(mLocalBlogID) == null) {
+            final Blog currentBlog = WordPress.getBlog(mLocalBlogID);
+            if (currentBlog == null) {
+                return;
+            }
+            if (currentBlog.getDotComBlogId() == null) {
                 // Blog has not returned a jetpack_client_id
                 showJetpackMissingAlert();
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
@@ -307,47 +307,6 @@ public class StatsUtils {
         return localId;
     }
 
-    /**
-     * Return the remote blogId as stored on the wpcom backend.
-     * <p>
-     * blogId is always available for dotcom blogs. It could be null on Jetpack blogs
-     * with blogOptions still empty or when the option 'jetpack_client_id' is not available in blogOptions.
-     * </p>
-     * @return String  blogId or null
-     */
-    public static String getBlogId(int localTableBlogID) {
-        Blog currentBlog = WordPress.getBlog(localTableBlogID);
-        if (currentBlog == null) {
-            return null;
-        }
-        return getBlogId(currentBlog);
-    }
-    public static String getBlogId(Blog blog) {
-        if (blog == null) {
-            return null;
-        }
-        if (blog.isDotcomFlag()) {
-            return String.valueOf(blog.getRemoteBlogId());
-        } else {
-            String remoteID =  blog.getApi_blogid();
-            // Self-hosted blogs edge cases.
-            if (StringUtils.isEmpty(remoteID)) {
-               return null;
-            }
-            try {
-                int parsedBlogID = Integer.parseInt(remoteID);
-                // remote blogID is always > 1 for Jetpack blogs
-                if (parsedBlogID < 1) {
-                    return null;
-                }
-            } catch (NumberFormatException e) {
-                AppLog.e(T.STATS, "The remote blog ID stored in options isn't valid: " + remoteID);
-                return null;
-            }
-            return remoteID;
-        }
-    }
-
     public static synchronized void logVolleyErrorDetails(final VolleyError volleyError) {
         if (volleyError == null) {
             AppLog.e(T.STATS, "Tried to log a VolleyError, but the error obj was null!");

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
@@ -21,6 +21,7 @@ import com.jjoe64.graphview.GraphViewSeries;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.models.Blog;
 import org.wordpress.android.ui.stats.exceptions.StatsError;
 import org.wordpress.android.ui.stats.models.VisitModel;
 import org.wordpress.android.ui.stats.models.VisitsModel;
@@ -743,7 +744,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
             return;
         }
 
-        if (!event.mRequestBlogId.equals(StatsUtils.getBlogId(getLocalTableBlogID()))) {
+        if (!isSameBlog(event)) {
             return;
         }
 
@@ -847,8 +848,10 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         // Update the data below the graph
         if (mListener!= null) {
             // Should never be null
-            final String blogId = StatsUtils.getBlogId(getLocalTableBlogID());
-            mListener.onDateChanged(blogId, getTimeframe(), calculatedDate);
+            final Blog currentBlog = WordPress.getBlog(getLocalTableBlogID());
+            if (currentBlog != null && currentBlog.getDotComBlogId() != null) {
+                mListener.onDateChanged(currentBlog.getDotComBlogId(), getTimeframe(), calculatedDate);
+            }
         }
 
         AnalyticsUtils.trackWithBlogDetails(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureActivity.java
@@ -140,8 +140,7 @@ public class StatsWidgetConfigureActivity extends AppCompatActivity
             return;
         }
 
-        final String remoteBlogID = StatsUtils.getBlogId(currentBlog);
-        if (remoteBlogID == null) {
+        if (currentBlog.getDotComBlogId() == null) {
             // The blog could be a self-hosted blog with NO Jetpack installed on it
             // Or a Jetpack blog whose options are not yet synched in the app
             // In both of these cases show a generic message that encourages the user to refresh

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetProvider.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetProvider.java
@@ -439,7 +439,7 @@ public class StatsWidgetProvider extends AppWidgetProvider {
         }
 
         // At this point the remote ID cannot be null.
-        String remoteBlogID = StatsUtils.getBlogId(blog);
+        String remoteBlogID = blog.getDotComBlogId();
         // Add the following check just to be safe
         if (remoteBlogID == null) {
             showMessage(context, new int[]{widgetID},

--- a/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
@@ -109,7 +109,7 @@ public class AnalyticsUtils {
             return;
         }
 
-        String blogID = StatsUtils.getBlogId(blog);
+        String blogID = blog.getDotComBlogId();
         if (blogID != null) {
             if (properties == null) {
                 properties = new HashMap<>();


### PR DESCRIPTION
Fix #3401 by moving the correct implementation of `getDotComBlogId` from `StatsUtils.getBlogId` to the `Blog. getDotComBlogId` method.
Also remove duplicates.

**Note:** Do not use Integer when mapping remote blog IDs. We should upgrade this in all places in the app before we reach the overflow. See what's happened to notifications not long time ago...