### PR TITLE
New visual editor analytics

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -333,7 +333,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     protected void onDestroy() {
         super.onDestroy();
 
-        AnalyticsTracker.track(AnalyticsTracker.Stat.EDITOR_CLOSED_POST);
+        AnalyticsTracker.track(AnalyticsTracker.Stat.EDITOR_CLOSED);
 
         if (mSuggestionServiceConnectionManager != null) {
             mSuggestionServiceConnectionManager.unbindFromService();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -16,6 +16,7 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
+import android.provider.MediaStore.Audio.Media;
 import android.support.annotation.NonNull;
 import android.support.v13.app.FragmentPagerAdapter;
 import android.support.v4.app.ActivityCompat;
@@ -42,6 +43,7 @@ import org.wordpress.android.Constants;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.editor.EditorFragmentAbstract;
 import org.wordpress.android.editor.EditorFragmentAbstract.EditorFragmentListener;
 import org.wordpress.android.editor.LegacyEditorFragment;
@@ -123,8 +125,10 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     public static final int MEDIA_PERMISSION_REQUEST_CODE = 1;
     public static final int LOCATION_PERMISSION_REQUEST_CODE = 2;
 
-    private static final String ANALYTIC_PROP_NUM_LOCAL_PHOTOS_ADDED = "number_of_local_photos_added";
-    private static final String ANALYTIC_PROP_NUM_WP_PHOTOS_ADDED = "number_of_wp_library_photos_added";
+    private static final String PROP_LOCAL_PHOTOS = "number_of_local_photos_added";
+    private static final String PROP_LIBRARY_PHOTOS = "number_of_wp_library_photos_added";
+    private static final String PROP_LOCAL_VIDEOS = "number_of_local_videos_added";
+    private static final String PROP_LIBRARY_VIDEOS = "number_of_wp_library_videos_added";
 
     private static int PAGE_CONTENT = 0;
     private static int PAGE_SETTINGS = 1;
@@ -1248,10 +1252,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 case RequestCodes.PICTURE_LIBRARY:
                     Uri imageUri = data.getData();
                     fetchMedia(imageUri);
-                    AnalyticsUtils.trackWithBlogDetails(
-                            AnalyticsTracker.Stat.EDITOR_ADDED_PHOTO_VIA_LOCAL_LIBRARY,
-                            WordPress.getBlog(mPost.getLocalTableBlogId())
-                    );
+                    AnalyticsUtils.trackWithBlogDetails(AnalyticsTracker.Stat.EDITOR_ADDED_PHOTO_VIA_LOCAL_LIBRARY,
+                            WordPress.getBlog(mPost.getLocalTableBlogId()));
                     break;
                 case RequestCodes.TAKE_PHOTO:
                     if (resultCode == Activity.RESULT_OK) {
@@ -1265,8 +1267,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                                     + Environment.getExternalStorageDirectory())));
                             AnalyticsUtils.trackWithBlogDetails(
                                     AnalyticsTracker.Stat.EDITOR_ADDED_PHOTO_VIA_LOCAL_LIBRARY,
-                                    WordPress.getBlog(mPost.getLocalTableBlogId())
-                            );
+                                    WordPress.getBlog(mPost.getLocalTableBlogId()));
                         } catch (RuntimeException e) {
                             AppLog.e(T.POSTS, e);
                         } catch (OutOfMemoryError e) {
@@ -1282,6 +1283,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 case RequestCodes.VIDEO_LIBRARY:
                     Uri videoUri = data.getData();
                     fetchMedia(videoUri);
+                    AnalyticsUtils.trackWithBlogDetails(Stat.EDITOR_ADDED_VIDEO_VIA_LOCAL_LIBRARY,
+                            WordPress.getBlog(mPost.getLocalTableBlogId()));
                     break;
                 case RequestCodes.TAKE_VIDEO:
                     if (resultCode == Activity.RESULT_OK) {
@@ -1289,6 +1292,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                         if (!addMedia(capturedVideoUri)) {
                             ToastUtils.showToast(this, R.string.gallery_error, Duration.SHORT);
                         }
+                        AnalyticsUtils.trackWithBlogDetails(Stat.EDITOR_ADDED_VIDEO_VIA_LOCAL_LIBRARY,
+                                WordPress.getBlog(mPost.getLocalTableBlogId()));
                     } else if (TextUtils.isEmpty(mEditorFragment.getContent())) {
                         // TODO: check if it was mQuickMediaType > -1
                         // Quick Photo was cancelled, delete post and finish activity
@@ -1391,7 +1396,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         }
     }
 
-
     /**
      * Handles result from {@link org.wordpress.android.ui.media.MediaPickerActivity} by adding the
      * selected media to the Post.
@@ -1400,44 +1404,47 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
      *  result {@link android.content.Intent} with selected media items
      */
     private void handleMediaSelectionResult(Intent data) {
-        if (data != null) {
-            final List<MediaItem> selectedContent =
-                    data.getParcelableArrayListExtra(MediaPickerActivity.SELECTED_CONTENT_RESULTS_KEY);
-            if (selectedContent != null && selectedContent.size() > 0) {
-                Integer localMediaAdded = 0;
-                Integer libraryMediaAdded = 0;
+        if (data == null) {
+            return;
+        }
+        final List<MediaItem> selectedContent =
+                data.getParcelableArrayListExtra(MediaPickerActivity.SELECTED_CONTENT_RESULTS_KEY);
+        if (selectedContent != null && selectedContent.size() > 0) {
+            int localPhotoAdded = 0, libraryPhotoAdded = 0;
+            int localVideoAdded = 0, libraryVideoAdded = 0;
 
-                for (MediaItem media : selectedContent) {
-                    if (URLUtil.isNetworkUrl(media.getSource().toString())) {
-                        addExistingMediaToEditor(media.getTag());
-                        ++libraryMediaAdded;
-                    } else {
-                        addMedia(media.getSource());
-                        ++localMediaAdded;
+            for (MediaItem media : selectedContent) {
+                String mediaSource = media.getSource().toString().toLowerCase();
+                if (URLUtil.isNetworkUrl(media.getSource().toString())) {
+                    addExistingMediaToEditor(media.getTag());
+                    if (MediaUtils.isVideo(mediaSource)) {
+                        libraryVideoAdded++;
+                    } else if (MediaUtils.isValidImage(mediaSource)) {
+                        libraryPhotoAdded++;
+                    }
+                } else {
+                    addMedia(media.getSource());
+                    if (MediaUtils.isVideo(mediaSource)) {
+                        localVideoAdded++;
+                    } else if (MediaUtils.isValidImage(mediaSource)) {
+                        localPhotoAdded++;
                     }
                 }
-
-                if (localMediaAdded > 0) {
-                    Map<String, Object> analyticsProperties = new HashMap<>();
-                    analyticsProperties.put(ANALYTIC_PROP_NUM_LOCAL_PHOTOS_ADDED, localMediaAdded);
-                    AnalyticsUtils.trackWithBlogDetails(
-                            AnalyticsTracker.Stat.EDITOR_ADDED_PHOTO_VIA_LOCAL_LIBRARY,
-                            WordPress.getBlog(mPost.getLocalTableBlogId()),
-                            analyticsProperties
-                    );
-                }
-
-                if (libraryMediaAdded > 0) {
-                    Map<String, Object> analyticsProperties = new HashMap<>();
-                    analyticsProperties.put(ANALYTIC_PROP_NUM_WP_PHOTOS_ADDED, libraryMediaAdded);
-                    AnalyticsUtils.trackWithBlogDetails(
-                            AnalyticsTracker.Stat.EDITOR_ADDED_PHOTO_VIA_WP_MEDIA_LIBRARY,
-                            WordPress.getBlog(mPost.getLocalTableBlogId()),
-                            analyticsProperties
-                    );
-                }
             }
+            trackMediaNumber(Stat.EDITOR_ADDED_PHOTO_VIA_LOCAL_LIBRARY, PROP_LOCAL_PHOTOS, localPhotoAdded);
+            trackMediaNumber(Stat.EDITOR_ADDED_PHOTO_VIA_WP_MEDIA_LIBRARY, PROP_LIBRARY_PHOTOS, libraryPhotoAdded);
+            trackMediaNumber(Stat.EDITOR_ADDED_VIDEO_VIA_LOCAL_LIBRARY, PROP_LOCAL_VIDEOS, localVideoAdded);
+            trackMediaNumber(Stat.EDITOR_ADDED_VIDEO_VIA_WP_MEDIA_LIBRARY, PROP_LIBRARY_VIDEOS, libraryVideoAdded);
         }
+    }
+
+    private void trackMediaNumber(Stat event, String propName, int numberOfElements) {
+        if (numberOfElements == 0) {
+            return;
+        }
+        Map<String, Object> analyticsProperties = new HashMap<>();
+        analyticsProperties.put(propName, numberOfElements);
+        AnalyticsUtils.trackWithBlogDetails(event, WordPress.getBlog(mPost.getLocalTableBlogId()), analyticsProperties);
     }
 
     /**

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -55,20 +55,33 @@ public final class AnalyticsTracker {
         STATS_WIDGET_TAPPED,
         EDITOR_CREATED_POST,
         EDITOR_ADDED_PHOTO_VIA_LOCAL_LIBRARY,
+        EDITOR_ADDED_VIDEO_VIA_LOCAL_LIBRARY,
         EDITOR_ADDED_PHOTO_VIA_WP_MEDIA_LIBRARY,
+        EDITOR_ADDED_VIDEO_VIA_WP_MEDIA_LIBRARY,
         EDITOR_UPDATED_POST,
         EDITOR_SCHEDULED_POST,
-        EDITOR_CLOSED_POST,
+        EDITOR_CLOSED,
         EDITOR_PUBLISHED_POST,
         EDITOR_SAVED_DRAFT,
+        EDITOR_DISCARDED_CHANGES, // Visual editor only
+        EDITOR_EDITED_IMAGE, // Visual editor only
+        EDITOR_ENABLED_NEW_VERSION, // Visual editor only
+        EDITOR_TOGGLED_OFF, // Visual editor only
+        EDITOR_TOGGLED_ON, // Visual editor only
+        EDITOR_UPDLOAD_MEDIA_FAILED, // Visual editor only
+        EDITOR_UPDLOAD_MEDIA_RETRIED, // Visual editor only
         EDITOR_TAPPED_BLOCKQUOTE,
         EDITOR_TAPPED_BOLD,
+        EDITOR_TAPPED_HTML, // Visual editor only
         EDITOR_TAPPED_IMAGE,
         EDITOR_TAPPED_ITALIC,
         EDITOR_TAPPED_LINK,
         EDITOR_TAPPED_MORE,
         EDITOR_TAPPED_STRIKETHROUGH,
         EDITOR_TAPPED_UNDERLINE,
+        EDITOR_TAPPED_ORDERED_LIST, // Visual editor only
+        EDITOR_TAPPED_UNLINK, // Visual editor only
+        EDITOR_TAPPED_UNORDERED_LIST, // Visual editor only
         ME_ACCESSED,
         MY_SITE_ACCESSED,
         NOTIFICATIONS_ACCESSED,

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
@@ -422,6 +422,20 @@ public class AnalyticsTrackerMixpanel extends Tracker {
                         "number_of_times_added_photo_via_wp_media_library");
                 instructions.setCurrentDateForPeopleProperty("last_time_added_photo_via_wp_media_library_to_post");
                 break;
+            case EDITOR_ADDED_VIDEO_VIA_LOCAL_LIBRARY:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Editor - Added Video via Local Library");
+                instructions.
+                        setSuperPropertyAndPeoplePropertyToIncrement("number_of_times_added_video_via_local_library");
+                instructions.setCurrentDateForPeopleProperty("last_time_added_video_via_local_library_to_post");
+                break;
+            case EDITOR_ADDED_VIDEO_VIA_WP_MEDIA_LIBRARY:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Editor - Added Video via WP Media Library");
+                instructions.setSuperPropertyAndPeoplePropertyToIncrement(
+                        "number_of_times_added_video_via_wp_media_library");
+                instructions.setCurrentDateForPeopleProperty("last_time_added_video_via_wp_media_library_to_post");
+                break;
             case EDITOR_PUBLISHED_POST:
                 instructions = AnalyticsTrackerMixpanelInstructionsForStat.
                         mixpanelInstructionsForEventName("Editor - Published Post");

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
@@ -403,7 +403,7 @@ public class AnalyticsTrackerMixpanel extends Tracker {
                 instructions.setSuperPropertyAndPeoplePropertyToIncrement("number_of_times_editor_saved_draft");
                 instructions.setCurrentDateForPeopleProperty("last_time_saved_draft");
                 break;
-            case EDITOR_CLOSED_POST:
+            case EDITOR_CLOSED:
                 instructions = AnalyticsTrackerMixpanelInstructionsForStat.
                         mixpanelInstructionsForEventName("Editor - Closed");
                 instructions.setSuperPropertyAndPeoplePropertyToIncrement("number_of_times_editor_closed");

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
@@ -403,6 +403,45 @@ public class AnalyticsTrackerMixpanel extends Tracker {
                 instructions.setSuperPropertyAndPeoplePropertyToIncrement("number_of_times_editor_saved_draft");
                 instructions.setCurrentDateForPeopleProperty("last_time_saved_draft");
                 break;
+            case EDITOR_DISCARDED_CHANGES:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Editor - Discarded Changes");
+                instructions.setSuperPropertyAndPeoplePropertyToIncrement("number_of_times_editor_discarded_changes");
+                instructions.setCurrentDateForPeopleProperty("last_time_discarded_changes");
+                break;
+            case EDITOR_EDITED_IMAGE:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Editor - Edited Image");
+                instructions.setSuperPropertyAndPeoplePropertyToIncrement("number_of_times_editor_edited_image");
+                instructions.setCurrentDateForPeopleProperty("last_time_edited_image");
+                break;
+            case EDITOR_ENABLED_NEW_VERSION:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Editor - Enabled New Version");
+                instructions.addSuperPropertyToFlag("enabled_new_editor");
+                break;
+            case EDITOR_TOGGLED_ON:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Editor - Toggled New Editor On");
+                instructions.setPeoplePropertyToValue("enabled_new_editor", true);
+                break;
+            case EDITOR_TOGGLED_OFF:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Editor - Toggled New Editor Off");
+                instructions.setPeoplePropertyToValue("enabled_new_editor", true);
+                break;
+            case EDITOR_UPDLOAD_MEDIA_FAILED:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Editor - Upload Media Failed");
+                instructions.setSuperPropertyAndPeoplePropertyToIncrement("number_of_times_editor_upload_media_failed");
+                instructions.setCurrentDateForPeopleProperty("last_time_editor_upload_media_failed");
+                break;
+            case EDITOR_UPDLOAD_MEDIA_RETRIED:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Editor - Retried Uploading Media");
+                instructions.setSuperPropertyAndPeoplePropertyToIncrement("number_of_times_editor_retried_uploading_media");
+                instructions.setCurrentDateForPeopleProperty("last_time_editor_retried_uploading_media");
+                break;
             case EDITOR_CLOSED:
                 instructions = AnalyticsTrackerMixpanelInstructionsForStat.
                         mixpanelInstructionsForEventName("Editor - Closed");
@@ -501,6 +540,30 @@ public class AnalyticsTrackerMixpanel extends Tracker {
                         mixpanelInstructionsForEventName("Editor - Tapped Underline Button");
                 instructions.setSuperPropertyAndPeoplePropertyToIncrement("number_of_times_editor_tapped_underline");
                 instructions.setCurrentDateForPeopleProperty("last_time_tapped_underline_in_editor");
+                break;
+            case EDITOR_TAPPED_HTML:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Editor - Tapped HTML Button");
+                instructions.setSuperPropertyAndPeoplePropertyToIncrement("number_of_times_editor_tapped_html");
+                instructions.setCurrentDateForPeopleProperty("last_time_tapped_html_in_editor");
+                break;
+            case EDITOR_TAPPED_ORDERED_LIST:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Editor - Tapped Ordered List Button");
+                instructions.setSuperPropertyAndPeoplePropertyToIncrement("number_of_times_editor_tapped_ordered_list");
+                instructions.setCurrentDateForPeopleProperty("last_time_tapped_ordered_list_in_editor");
+                break;
+            case EDITOR_TAPPED_UNLINK:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Editor - Tapped Unlink Button");
+                instructions.setSuperPropertyAndPeoplePropertyToIncrement("number_of_times_editor_tapped_unlink");
+                instructions.setCurrentDateForPeopleProperty("last_time_tapped_unlink_in_editor");
+                break;
+            case EDITOR_TAPPED_UNORDERED_LIST:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Editor - Tapped Unordered List Button");
+                instructions.setSuperPropertyAndPeoplePropertyToIncrement("number_of_times_editor_tapped_unordered_list");
+                instructions.setCurrentDateForPeopleProperty("last_time_tapped_unordered_list_in_editor");
                 break;
             case NOTIFICATIONS_ACCESSED:
                 instructions = AnalyticsTrackerMixpanelInstructionsForStat.

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -131,6 +131,14 @@ public class AnalyticsTrackerNosara extends Tracker {
                 eventName = "editor_photo_added";
                 predefinedEventProperties.put("via", "media_library");
                 break;
+            case EDITOR_ADDED_VIDEO_VIA_LOCAL_LIBRARY:
+                eventName = "editor_video_added";
+                predefinedEventProperties.put("via", "local_library");
+                break;
+            case EDITOR_ADDED_VIDEO_VIA_WP_MEDIA_LIBRARY:
+                eventName = "editor_video_added";
+                predefinedEventProperties.put("via", "media_library");
+                break;
             case EDITOR_PUBLISHED_POST:
                 eventName = "editor_post_published";
                 break;

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -129,7 +129,7 @@ public class AnalyticsTrackerNosara extends Tracker {
                 break;
             case EDITOR_ADDED_PHOTO_VIA_WP_MEDIA_LIBRARY:
                 eventName = "editor_photo_added";
-                predefinedEventProperties.put("via", "wp_media_library");
+                predefinedEventProperties.put("via", "media_library");
                 break;
             case EDITOR_PUBLISHED_POST:
                 eventName = "editor_post_published";

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -120,6 +120,27 @@ public class AnalyticsTrackerNosara extends Tracker {
             case EDITOR_SAVED_DRAFT:
                 eventName = "editor_draft_saved";
                 break;
+            case EDITOR_DISCARDED_CHANGES:
+                eventName = "editor_discarded_changes";
+                break;
+            case EDITOR_EDITED_IMAGE:
+                eventName = "editor_image_edited";
+                break;
+            case EDITOR_ENABLED_NEW_VERSION:
+                eventName = "editor_enabled_new_version";
+                break;
+            case EDITOR_TOGGLED_OFF:
+                eventName = "editor_toggled_off";
+                break;
+            case EDITOR_TOGGLED_ON:
+                eventName = "editor_toggled_on";
+                break;
+            case EDITOR_UPDLOAD_MEDIA_FAILED:
+                eventName = "editor_upload_media_failed";
+                break;
+            case EDITOR_UPDLOAD_MEDIA_RETRIED:
+                eventName = "editor_upload_media_retried";
+                break;
             case EDITOR_CLOSED:
                 eventName = "editor_closed";
                 break;
@@ -179,6 +200,22 @@ public class AnalyticsTrackerNosara extends Tracker {
             case EDITOR_TAPPED_UNDERLINE:
                 eventName = "editor_button_tapped";
                 predefinedEventProperties.put("button", "underline");
+                break;
+            case EDITOR_TAPPED_HTML:
+                eventName = "editor_button_tapped";
+                predefinedEventProperties.put("button", "html");
+                break;
+            case EDITOR_TAPPED_ORDERED_LIST:
+                eventName = "editor_button_tapped";
+                predefinedEventProperties.put("button", "ordered_list");
+                break;
+            case EDITOR_TAPPED_UNLINK:
+                eventName = "editor_button_tapped";
+                predefinedEventProperties.put("button", "unlink");
+                break;
+            case EDITOR_TAPPED_UNORDERED_LIST:
+                eventName = "editor_button_tapped";
+                predefinedEventProperties.put("button", "unordered_list");
                 break;
             case NOTIFICATIONS_ACCESSED:
                 eventName = "notifications_accessed";

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -120,7 +120,7 @@ public class AnalyticsTrackerNosara extends Tracker {
             case EDITOR_SAVED_DRAFT:
                 eventName = "editor_draft_saved";
                 break;
-            case EDITOR_CLOSED_POST:
+            case EDITOR_CLOSED:
                 eventName = "editor_closed";
                 break;
             case EDITOR_ADDED_PHOTO_VIA_LOCAL_LIBRARY:


### PR DESCRIPTION
Note, this is the first step to fix: https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/15 

I noticed `EDITOR_ADDED_VIDEO_VIA_LOCAL_LIBRARY` and `EDITOR_ADDED_VIDEO_VIA_WP_MEDIA_LIBRARY` could be added in the legacy editor too, so here is the PR.

cc @daniloercoli since it's analytics related.