### PR TITLE
Add touch feedback to Post Settings buttons

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -855,8 +855,8 @@ public class EditPostSettingsFragment extends Fragment
         LayoutInflater layoutInflater = getActivity().getLayoutInflater();
 
         if (mCategories != null) {
-            AppCompatButton buttonCategory = (AppCompatButton) layoutInflater.inflate(R.layout.category_button, null);
             for (String categoryName : mCategories) {
+                AppCompatButton buttonCategory = (AppCompatButton) layoutInflater.inflate(R.layout.category_button, null);
                 if (categoryName != null && buttonCategory != null) {
                     buttonCategory.setText(Html.fromHtml(categoryName));
                     buttonCategory.setTag(CATEGORY_PREFIX_TAG + categoryName);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -9,6 +9,7 @@ import android.location.Location;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.v7.widget.AppCompatButton;
 import android.text.Editable;
 import android.text.Html;
 import android.text.TextUtils;
@@ -854,8 +855,8 @@ public class EditPostSettingsFragment extends Fragment
         LayoutInflater layoutInflater = getActivity().getLayoutInflater();
 
         if (mCategories != null) {
+            AppCompatButton buttonCategory = (AppCompatButton) layoutInflater.inflate(R.layout.category_button, null);
             for (String categoryName : mCategories) {
-                Button buttonCategory = (Button) layoutInflater.inflate(R.layout.category_button, null);
                 if (categoryName != null && buttonCategory != null) {
                     buttonCategory.setText(Html.fromHtml(categoryName));
                     buttonCategory.setTag(CATEGORY_PREFIX_TAG + categoryName);

--- a/WordPress/src/main/res/layout/category_button.xml
+++ b/WordPress/src/main/res/layout/category_button.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Button
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    style="?android:attr/buttonStyleSmall"
-    android:layout_width="wrap_content"
-    android:layout_height="fill_parent"
+<Button xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/categoryButton"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginLeft="16dp"
+    android:layout_marginRight="16dp"
     android:drawableRight="@drawable/ic_close_grey600_24dp"
-    android:paddingEnd="5dp"
-    android:paddingRight="5dp"/>
+    android:padding="8dp"
+    android:textColor="@color/grey_dark" />

--- a/WordPress/src/main/res/layout/category_select_button.xml
+++ b/WordPress/src/main/res/layout/category_select_button.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Button
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        style="?android:attr/buttonStyleSmall"
-        android:layout_width="wrap_content"
-        android:layout_height="fill_parent"
-        android:id="@+id/selectCategories"
-        android:drawableRight="@drawable/ic_add_grey600_24dp"
-        android:tag="select-category"/>
+<Button xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/selectCategories"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginLeft="16dp"
+    android:clickable="true"
+    android:drawableEnd="@drawable/ic_add_grey600_24dp"
+    android:drawableRight="@drawable/ic_add_grey600_24dp"
+    android:minHeight="48dp"
+    android:minWidth="48dp"
+    android:paddingRight="12dp"
+    android:tag="select-category" />

--- a/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
+++ b/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
@@ -75,6 +75,8 @@
 
             <org.wordpress.android.widgets.FlowLayout
                 android:id="@+id/sectionCategories"
+                android:layout_marginLeft="8dp"
+                android:layout_marginRight="8dp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
 
@@ -82,6 +84,8 @@
                 android:id="@+id/tags"
                 android:layout_width="match_parent"
                 android:layout_marginTop="@dimen/margin_small"
+                android:layout_marginLeft="@dimen/margin_small"
+                android:layout_marginRight="@dimen/margin_small"
                 android:layout_height="wrap_content"
                 android:textSize="@dimen/text_sz_large"
                 android:hint="@string/tags_separate_with_commas"
@@ -93,6 +97,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_small"
+            android:layout_marginLeft="@dimen/margin_small"
+            android:layout_marginRight="@dimen/margin_small"
             android:textSize="@dimen/text_sz_large"
             android:gravity="top"
             android:hint="@string/post_excerpt"
@@ -102,6 +108,8 @@
         <org.wordpress.android.widgets.OpenSansEditText
             android:id="@+id/post_password"
             android:layout_marginTop="@dimen/margin_small"
+            android:layout_marginLeft="@dimen/margin_small"
+            android:layout_marginRight="@dimen/margin_small"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textSize="@dimen/text_sz_large"

--- a/WordPress/src/main/res/layout/media_edit_fragment.xml
+++ b/WordPress/src/main/res/layout/media_edit_fragment.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <LinearLayout
         android:id="@+id/media_edit_linear_layout"
@@ -9,7 +10,8 @@
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:padding="@dimen/margin_extra_large"
-        android:visibility="invisible">
+        android:visibility="invisible"
+        tools:visibility="visible">
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/media_edit_title_text"
@@ -34,7 +36,8 @@
                 android:paddingRight="20dp"
                 android:text="@string/save"
                 android:textColor="@color/white"
-                android:visibility="@integer/media_editor_save_button_visibility" />
+                android:visibility="@integer/media_editor_save_button_visibility"
+                tools:visibility="visible"/>
 
             <org.wordpress.android.widgets.OpenSansEditText
                 android:id="@+id/media_edit_fragment_title"

--- a/WordPress/src/main/res/layout/post_location_settings_add.xml
+++ b/WordPress/src/main/res/layout/post_location_settings_add.xml
@@ -16,7 +16,5 @@
         android:text="@string/add_location"
         android:textSize="@dimen/text_sz_large"
         android:drawableLeft="@drawable/ic_location_on_grey600_24dp"
-        android:drawablePadding="8dp"
-        android:paddingLeft="8dp"
-        android:paddingRight="16dp" />
+        android:drawablePadding="8dp" />
 </LinearLayout>

--- a/WordPress/src/main/res/layout/post_location_settings_search.xml
+++ b/WordPress/src/main/res/layout/post_location_settings_search.xml
@@ -12,18 +12,18 @@
         android:id="@+id/searchLocationText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textSize="@dimen/text_sz_large"
-        android:hint="@string/current_location"
         android:layout_weight="1"
+        android:hint="@string/current_location"
+        android:imeOptions="actionSearch"
         android:inputType="text"
-        android:imeOptions="actionSearch" />
+        android:textSize="@dimen/text_sz_large" />
 
     <Button
         android:id="@+id/searchLocation"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textSize="@dimen/text_sz_large"
         android:ellipsize="end"
         android:lines="1"
-        android:text="@string/search_current_location" />
+        android:text="@string/search_current_location"
+        android:textSize="@dimen/text_sz_large" />
 </LinearLayout>

--- a/WordPress/src/main/res/layout/post_location_settings_view.xml
+++ b/WordPress/src/main/res/layout/post_location_settings_view.xml
@@ -10,42 +10,48 @@
     android:orientation="vertical">
 
     <TextView
-        android:drawableLeft="@drawable/ic_action_location_searching"
-        android:gravity="center_vertical"
         android:id="@+id/locationText"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/locationLabel"
+        android:background="@drawable/selectable_background_wordpress"
+        android:drawableLeft="@drawable/ic_action_location_searching"
+        android:gravity="center_vertical"
         android:paddingBottom="4dp"
         android:paddingRight="4dp"
         android:text="@string/loading"
-        android:textSize="@dimen/text_sz_large"
-        android:background="@drawable/selectable_background_wordpress"/>
+        android:textSize="@dimen/text_sz_large" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/locationText"
         android:orientation="horizontal">
 
         <Button
             android:id="@+id/updateLocation"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:textSize="@dimen/text_sz_large"
+            android:layout_marginEnd="8dp"
+            android:layout_marginLeft="0dp"
+            android:layout_marginRight="8dp"
+            android:layout_marginStart="0dp"
             android:layout_weight="1"
             android:ellipsize="end"
             android:lines="1"
-            android:text="@string/edit_location" />
+            android:text="@string/edit_location"
+            android:textSize="@dimen/text_sz_large" />
 
         <Button
             android:id="@+id/removeLocation"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:textSize="@dimen/text_sz_large"
+            android:layout_marginEnd="0dp"
+            android:layout_marginLeft="8dp"
+            android:layout_marginRight="0dp"
+            android:layout_marginStart="8dp"
             android:layout_weight="1"
             android:ellipsize="end"
             android:lines="1"
-            android:text="@string/remove_location" />
+            android:text="@string/remove_location"
+            android:textSize="@dimen/text_sz_large" />
     </LinearLayout>
 </LinearLayout>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -20,6 +20,8 @@
         <item name="android:actionBarTabBarStyle">@style/TabBarStyle.WordPress</item>
         <item name="android:statusBarColor">@color/status_bar_tint</item>
 
+        <item name="colorButtonNormal">@color/light_gray</item>
+
         <!-- Light.DarkActionBar specific -->
         <item name="android:actionBarWidgetTheme">@style/Theme.WordPress.Widget</item>
 


### PR DESCRIPTION
* Using Appcompat design library adds material touch feedback on API >= 22;
adds a similar touch feedback with same colours, but without ripple effect, on API < 22
* Fixes the elements left alignment in edit_post_settings_fragment.xml
* Optimize multiple buttons creation in EditPostSettingsFragment
* Uses xmlns:tools to preview layout in layout editor