### PR TITLE
issue/3563-reader-discover-toolbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -638,6 +638,9 @@ public class ReaderPostDetailFragment extends Fragment
 
             if (!isAdded()) return;
 
+            // make sure options menu reflects whether we now have a post
+            getActivity().invalidateOptionsMenu();
+
             if (!result) {
                 // post couldn't be loaded which means it doesn't exist in db, so request it from
                 // the server if it hasn't already been requested


### PR DESCRIPTION
Fix #3563 - problem turned out not to be specific to Discover posts, but instead to any post that had to be downloaded by reader detail before being displayed. This was due to the options menu items [being hidden](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/3563-reader-discover-toolbar/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java#L179) when the post doesn't already exist.

Simple fix: call `invalidateOptionsMenu()` :)