### PR TITLE
feature/wp-checkbox

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPCheckBox.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPCheckBox.java
@@ -1,0 +1,25 @@
+package org.wordpress.android.widgets;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.CheckBox;
+
+/**
+ * A CheckBox that uses the default font from TypefaceCache
+ */
+public class WPCheckBox extends CheckBox {
+    public WPCheckBox(Context context) {
+        super(context);
+        TypefaceCache.setCustomTypeface(context, this, null);
+    }
+
+    public WPCheckBox(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        TypefaceCache.setCustomTypeface(context, this, attrs);
+    }
+
+    public WPCheckBox(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        TypefaceCache.setCustomTypeface(context, this, attrs);
+    }
+}


### PR DESCRIPTION
This PR adds `WPCheckBox`, a CheckBox widget that supports Open Sans. We aren't using this yet, but I'll need one for the "Publicize" feature and thought it best to have as a separate PR.

As a quick test, you can add the XML below to our "About" layout to verify that Open Sans is being used:

```
<org.wordpress.android.widgets.WPCheckBox
    android:layout_width="match_parent"
    android:layout_height="wrap_content"
    android:text="This is a custom checkbox" />

<CheckBox
    android:layout_width="match_parent"
    android:layout_height="wrap_content"
    android:text="This is a standard checkbox" />
```

![checkbox](https://cloud.githubusercontent.com/assets/3903757/12157297/d57c4416-b49e-11e5-8af0-b2688ac13027.png)

