### PR TITLE
Fix MeFragment EventBusException

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -121,6 +121,12 @@ public class MeFragment extends Fragment {
     }
 
     @Override
+    public void onStart() {
+        super.onStart();
+        EventBus.getDefault().register(this);
+    }
+
+    @Override
     public void onStop() {
         EventBus.getDefault().unregister(this);
         super.onStop();
@@ -130,7 +136,6 @@ public class MeFragment extends Fragment {
     public void onResume() {
         super.onResume();
         refreshAccountDetails();
-        EventBus.getDefault().register(this);
     }
 
     @Override


### PR DESCRIPTION
In rare case, when user opens any activity from the main screen and immediately closes it - the app crashes.

This happens because onStop() methods of ViewPager Fragments are not being called before onResume() is called again after activity is closed.
And in case of MeFragment this caused EventBus to try and register itself again, when it's already registered, which threw an exception.

The ```EventBus.getDefault().register(this);``` should be called in onStart() like it is in the rest of the ViewPager fragments, or at least ```EventBus.getDefault().isRegistered(this)``` should be checked beforehand.

Issue mostly happens after closing Media and Comments activities, but could be easily reproduced in any activity launched from main screen by adding finish() to top of their onCreate methods.

Fixes #3553