### PR TITLE
Rename s/Params/Param/ to fix the build issue, also renamed s/Methods/Method/

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/networking/XMLRPCTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/networking/XMLRPCTest.java
@@ -2,7 +2,7 @@ package org.wordpress.android.networking;
 
 import org.wordpress.android.DefaultMocksInstrumentationTestCase;
 import org.wordpress.android.mocks.XMLRPCFactoryTest;
-import org.xmlrpc.android.ApiHelper;
+import org.xmlrpc.android.ApiHelper.Method;
 import org.xmlrpc.android.XMLRPCClientInterface;
 import org.xmlrpc.android.XMLRPCFactory;
 
@@ -14,7 +14,7 @@ public class XMLRPCTest extends DefaultMocksInstrumentationTestCase {
         XMLRPCClientInterface xmlrpcClientInterface = XMLRPCFactory.instantiate(URI.create("http://test.com/ast"), "",
                 "");
         try {
-            xmlrpcClientInterface.call(ApiHelper.Methods.GET_MEDIA_LIBRARY, null);
+            xmlrpcClientInterface.call(Method.GET_MEDIA_LIBRARY, null);
         } catch (NumberFormatException e) {
             return;
         }
@@ -26,7 +26,7 @@ public class XMLRPCTest extends DefaultMocksInstrumentationTestCase {
         XMLRPCClientInterface xmlrpcClientInterface = XMLRPCFactory.instantiate(URI.create("http://test.com/ast"), "",
                 "");
         try {
-            xmlrpcClientInterface.call(ApiHelper.Methods.GET_MEDIA_LIBRARY, null);
+            xmlrpcClientInterface.call(Method.GET_MEDIA_LIBRARY, null);
         } catch (NumberFormatException e) {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/FetchBlogListWPOrg.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/FetchBlogListWPOrg.java
@@ -15,6 +15,7 @@ import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPUrlUtils;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlrpc.android.ApiHelper;
+import org.xmlrpc.android.ApiHelper.Method;
 import org.xmlrpc.android.XMLRPCClientInterface;
 import org.xmlrpc.android.XMLRPCException;
 import org.xmlrpc.android.XMLRPCFactory;
@@ -97,7 +98,7 @@ public class FetchBlogListWPOrg extends FetchBlogListAbstract {
         URI uri = URI.create(baseUrl);
         XMLRPCClientInterface client = XMLRPCFactory.instantiate(uri, mHttpUsername, mHttpPassword);
         try {
-            client.call(ApiHelper.Methods.LIST_METHODS);
+            client.call(Method.LIST_METHODS);
             xmlRpcUrl = baseUrl;
             return xmlRpcUrl;
         } catch (XMLRPCException e) {
@@ -144,7 +145,7 @@ public class FetchBlogListWPOrg extends FetchBlogListAbstract {
         uri = URI.create(guessURL);
         client = XMLRPCFactory.instantiate(uri, mHttpUsername, mHttpPassword);
         try {
-            client.call(ApiHelper.Methods.LIST_METHODS);
+            client.call(Method.LIST_METHODS);
             xmlRpcUrl = guessURL;
             return xmlRpcUrl;
         } catch (XMLRPCException e) {
@@ -252,7 +253,7 @@ public class FetchBlogListWPOrg extends FetchBlogListAbstract {
             XMLRPCClientInterface client = XMLRPCFactory.instantiate(xmlrpcUri, mHttpUsername, mHttpPassword);
             Object[] params = {mUsername, mPassword};
             try {
-                Object[] userBlogs = (Object[]) client.call(ApiHelper.Methods.GET_BLOGS, params);
+                Object[] userBlogs = (Object[]) client.call(Method.GET_BLOGS, params);
                 if (userBlogs == null) {
                     // Could happen if the returned server response is truncated
                     mErrorMsgId = org.wordpress.android.R.string.xmlrpc_error;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
@@ -17,7 +17,7 @@ import org.wordpress.android.models.Note;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.xmlpull.v1.XmlPullParserException;
-import org.xmlrpc.android.ApiHelper;
+import org.xmlrpc.android.ApiHelper.Method;
 import org.xmlrpc.android.XMLRPCClientInterface;
 import org.xmlrpc.android.XMLRPCException;
 import org.xmlrpc.android.XMLRPCFactory;
@@ -108,7 +108,7 @@ public class CommentActions {
 
                 int newCommentID;
                 try {
-                    newCommentID = (Integer) client.call(ApiHelper.Methods.NEW_COMMENT, params);
+                    newCommentID = (Integer) client.call(Method.NEW_COMMENT, params);
                 } catch (XMLRPCException e) {
                     AppLog.e(T.COMMENTS, "Error while sending new comment", e);
                     newCommentID = -1;
@@ -173,7 +173,7 @@ public class CommentActions {
 
                 long newCommentID;
                 try {
-                    Object newCommentIDObject = client.call(ApiHelper.Methods.NEW_COMMENT, params);
+                    Object newCommentIDObject = client.call(Method.NEW_COMMENT, params);
                     if (newCommentIDObject instanceof Integer) {
                         newCommentID = ((Integer) newCommentIDObject).longValue();
                     } else if (newCommentIDObject instanceof Long) {
@@ -375,7 +375,7 @@ public class CommentActions {
 
                 Object result;
                 try {
-                    result = client.call(ApiHelper.Methods.EDIT_COMMENT, params);
+                    result = client.call(Method.EDIT_COMMENT, params);
                 } catch (XMLRPCException e) {
                     AppLog.e(T.COMMENTS, "Error while editing comment", e);
                     result = null;
@@ -453,7 +453,7 @@ public class CommentActions {
 
                     Object result;
                     try {
-                        result = client.call(ApiHelper.Methods.EDIT_COMMENT, params);
+                        result = client.call(Method.EDIT_COMMENT, params);
                         boolean success = (result != null && Boolean.parseBoolean(result.toString()));
                         if (success) {
                             comment.setStatus(newStatusStr);
@@ -512,7 +512,7 @@ public class CommentActions {
 
                 Object result;
                 try {
-                    result = client.call(ApiHelper.Methods.DELETE_COMMENT, params);
+                    result = client.call(Method.DELETE_COMMENT, params);
                 } catch (final XMLRPCException e) {
                     AppLog.e(T.COMMENTS, "Error while deleting comment", e);
                     result = null;
@@ -574,7 +574,7 @@ public class CommentActions {
 
                     Object result;
                     try {
-                        result = client.call(ApiHelper.Methods.DELETE_COMMENT, params);
+                        result = client.call(Method.DELETE_COMMENT, params);
                         boolean success = (result != null && Boolean.parseBoolean(result.toString()));
                         if (success)
                             deletedComments.add(comment);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
@@ -38,7 +38,7 @@ import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.VolleyUtils;
 import org.xmlpull.v1.XmlPullParserException;
-import org.xmlrpc.android.ApiHelper;
+import org.xmlrpc.android.ApiHelper.Method;
 import org.xmlrpc.android.XMLRPCClientInterface;
 import org.xmlrpc.android.XMLRPCException;
 import org.xmlrpc.android.XMLRPCFactory;
@@ -316,7 +316,7 @@ public class EditCommentActivity extends AppCompatActivity {
                     mCommentId), postHash};
 
             try {
-                Object result = client.call(ApiHelper.Methods.EDIT_COMMENT, xmlParams);
+                Object result = client.call(Method.EDIT_COMMENT, xmlParams);
                 boolean isSaved = (result != null && Boolean.parseBoolean(result.toString()));
                 if (isSaved) {
                     mComment.setAuthorEmail(authorEmail);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
@@ -29,7 +29,7 @@ import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper.RefreshListener;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 import org.xmlpull.v1.XmlPullParserException;
-import org.xmlrpc.android.ApiHelper;
+import org.xmlrpc.android.ApiHelper.Method;
 import org.xmlrpc.android.XMLRPCClientInterface;
 import org.xmlrpc.android.XMLRPCException;
 import org.xmlrpc.android.XMLRPCFactory;
@@ -176,7 +176,7 @@ public class SelectCategoriesActivity extends AppCompatActivity {
         mClient = XMLRPCFactory.instantiate(blog.getUri(), blog.getHttpuser(), blog.getHttppassword());
         boolean success = false;
         try {
-            result = (Object[]) mClient.call(ApiHelper.Methods.GET_CATEGORIES, params);
+            result = (Object[]) mClient.call(Method.GET_CATEGORIES, params);
             success = true;
         } catch (XMLRPCException e) {
             AppLog.e(AppLog.T.POSTS, e);
@@ -225,7 +225,7 @@ public class SelectCategoriesActivity extends AppCompatActivity {
 
         Object result = null;
         try {
-            result = mClient.call(ApiHelper.Methods.NEW_CATEGORY, params);
+            result = mClient.call(Method.NEW_CATEGORY, params);
         } catch (XMLRPCException e) {
             AppLog.e(AppLog.T.POSTS, e);
         } catch (IOException e) {
@@ -332,7 +332,7 @@ public class SelectCategoriesActivity extends AppCompatActivity {
         Object[] params = { blog.getRemoteBlogId(), blog.getUsername(), blog.getPassword(), "category", category_id };
         mClient = XMLRPCFactory.instantiate(blog.getUri(), blog.getHttpuser(), blog.getHttppassword());
         try {
-            result = (Map<?, ?>) mClient.call(ApiHelper.Methods.GET_TERM, params);
+            result = (Map<?, ?>) mClient.call(Method.GET_TERM, params);
         } catch (XMLRPCException e) {
             AppLog.e(AppLog.T.POSTS, e);
         } catch (IOException e) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostMediaService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostMediaService.java
@@ -11,7 +11,7 @@ import org.wordpress.android.models.Blog;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.xmlpull.v1.XmlPullParserException;
-import org.xmlrpc.android.ApiHelper;
+import org.xmlrpc.android.ApiHelper.Method;
 import org.xmlrpc.android.XMLRPCClientInterface;
 import org.xmlrpc.android.XMLRPCException;
 import org.xmlrpc.android.XMLRPCFactory;
@@ -112,7 +112,7 @@ public class PostMediaService extends Service {
                 mBlog.getHttppassword());
 
         try {
-            Map<?, ?> results = (Map<?, ?>) client.call(ApiHelper.Methods.GET_MEDIA_ITEM, apiParams);
+            Map<?, ?> results = (Map<?, ?>) client.call(Method.GET_MEDIA_ITEM, apiParams);
             if (results != null) {
                 String strBlogId = Integer.toString(mBlog.getLocalTableBlogId());
                 MediaFile mediaFile = new MediaFile(strBlogId, results, mBlog.isDotcomFlag());

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUpdateService.java
@@ -11,6 +11,7 @@ import org.wordpress.android.models.Blog;
 import org.wordpress.android.util.AppLog;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlrpc.android.ApiHelper;
+import org.xmlrpc.android.ApiHelper.Method;
 import org.xmlrpc.android.XMLRPCClientInterface;
 import org.xmlrpc.android.XMLRPCException;
 import org.xmlrpc.android.XMLRPCFactory;
@@ -111,7 +112,7 @@ public class PostUpdateService extends Service {
         try {
             boolean canLoadMore;
 
-            result = (Object[]) client.call(isPage ? ApiHelper.Methods.GET_PAGES : "metaWeblog.getRecentPosts", xmlrpcParams);
+            result = (Object[]) client.call(isPage ? Method.GET_PAGES : "metaWeblog.getRecentPosts", xmlrpcParams);
             if (result != null && result.length > 0) {
                 canLoadMore = true;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -50,6 +50,7 @@ import org.wordpress.android.util.WPMeShortlinks;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlrpc.android.ApiHelper;
+import org.xmlrpc.android.ApiHelper.Method;
 import org.xmlrpc.android.XMLRPCClient;
 import org.xmlrpc.android.XMLRPCClientInterface;
 import org.xmlrpc.android.XMLRPCException;
@@ -845,7 +846,7 @@ public class PostUploadService extends Service {
             }
 
             try {
-                return mClient.call(ApiHelper.Methods.UPLOAD_FILE, params, tempFile);
+                return mClient.call(Method.UPLOAD_FILE, params, tempFile);
             } catch (XMLRPCException e) {
                 // well formed XML-RPC response from the server, but it's an error. Ok to print the error message
                 AppLog.e(T.API, e);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SelfHostedSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SelfHostedSiteSettings.java
@@ -12,7 +12,7 @@ import org.wordpress.android.models.SiteSettingsModel;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.MapUtils;
-import org.xmlrpc.android.ApiHelper;
+import org.xmlrpc.android.ApiHelper.Method;
 import org.xmlrpc.android.XMLRPCCallback;
 import org.xmlrpc.android.XMLRPCClientInterface;
 import org.xmlrpc.android.XMLRPCException;
@@ -125,7 +125,7 @@ class SelfHostedSiteSettings extends SiteSettingsInterface {
 
         XMLRPCClientInterface xmlrpcInterface = instantiateInterface();
         if (xmlrpcInterface == null) return;
-        xmlrpcInterface.callAsync(callback, ApiHelper.Methods.SET_OPTIONS, callParams);
+        xmlrpcInterface.callAsync(callback, Method.SET_OPTIONS, callParams);
     }
 
     /**
@@ -140,8 +140,8 @@ class SelfHostedSiteSettings extends SiteSettingsInterface {
                 Object[] params = {mBlog.getRemoteBlogId(), mBlog.getUsername(), mBlog.getPassword()};
 
                 // Need two interfaces or the first call gets aborted
-                instantiateInterface().callAsync(mOptionsCallback, ApiHelper.Methods.GET_OPTIONS, params);
-                instantiateInterface().callAsync(mCategoriesCallback, ApiHelper.Methods.GET_CATEGORIES, params);
+                instantiateInterface().callAsync(mOptionsCallback, Method.GET_OPTIONS, params);
+                instantiateInterface().callAsync(mCategoriesCallback, Method.GET_CATEGORIES, params);
             }
         });
         thread.run();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -13,7 +13,8 @@ import org.wordpress.android.models.Blog;
 import org.wordpress.android.models.CategoryModel;
 import org.wordpress.android.models.SiteSettingsModel;
 import org.wordpress.android.util.WPPrefUtils;
-import org.xmlrpc.android.ApiHelper;
+import org.xmlrpc.android.ApiHelper.Method;
+import org.xmlrpc.android.ApiHelper.Param;
 import org.xmlrpc.android.XMLRPCCallback;
 import org.xmlrpc.android.XMLRPCClientInterface;
 import org.xmlrpc.android.XMLRPCFactory;
@@ -738,7 +739,7 @@ public abstract class SiteSettingsInterface {
         if (client == null) return;
 
         Map<String, String> args = new HashMap<>();
-        args.put(ApiHelper.Params.SHOW_SUPPORTED_POST_FORMATS, "true");
+        args.put(Param.SHOW_SUPPORTED_POST_FORMATS, "true");
         Object[] params = { mBlog.getRemoteBlogId(), mBlog.getUsername(),
                 mBlog.getPassword(), args};
         client.callAsync(new XMLRPCCallback() {
@@ -777,7 +778,7 @@ public abstract class SiteSettingsInterface {
             @Override
             public void onFailure(long id, Exception error) {
             }
-        }, ApiHelper.Methods.GET_POST_FORMATS, params);
+        }, Method.GET_POST_FORMATS, params);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -43,6 +43,7 @@ import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper.RefreshListener;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 import org.xmlrpc.android.ApiHelper;
+import org.xmlrpc.android.ApiHelper.Method;
 import org.xmlrpc.android.XMLRPCCallback;
 import org.xmlrpc.android.XMLRPCClientInterface;
 import org.xmlrpc.android.XMLRPCFactory;
@@ -573,7 +574,7 @@ public class StatsActivity extends AppCompatActivity
                                 }
                             });
                         }
-                    }, ApiHelper.Methods.GET_OPTIONS, params);
+                    }, Method.GET_OPTIONS, params);
                 } else {
                     mRequestedDate =  StatsUtils.getCurrentDateTZ(mLocalBlogID);
                     createFragments(true); // Recreate the fragment and start a refresh of Stats

--- a/WordPress/src/main/java/org/xmlrpc/android/ApiHelper.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/ApiHelper.java
@@ -53,7 +53,7 @@ import javax.net.ssl.SSLHandshakeException;
 
 public class ApiHelper {
 
-    public static final class Methods {
+    public static final class Method {
         public static final String GET_MEDIA_LIBRARY  = "wp.getMediaLibrary";
         public static final String GET_POST_FORMATS   = "wp.getPostFormats";
         public static final String GET_CATEGORIES     = "wp.getCategories";
@@ -85,7 +85,7 @@ public class ApiHelper {
         public static final String LIST_METHODS       = "system.listMethods";
     }
 
-    public static final class Params {
+    public static final class Param {
         public static final String SHOW_SUPPORTED_POST_FORMATS = "show-supported";
     }
 
@@ -145,9 +145,9 @@ public class ApiHelper {
                     mBlog.getHttppassword());
             Object result = null;
             Object[] params = { mBlog.getRemoteBlogId(), mBlog.getUsername(),
-                    mBlog.getPassword(), Params.SHOW_SUPPORTED_POST_FORMATS };
+                    mBlog.getPassword(), Param.SHOW_SUPPORTED_POST_FORMATS };
             try {
-                result = client.call(ApiHelper.Methods.GET_POST_FORMATS, params);
+                result = client.call(Method.GET_POST_FORMATS, params);
             } catch (ClassCastException cce) {
                 setError(ErrorType.INVALID_RESULT, cce.getMessage(), cce);
             } catch (XMLRPCException e) {
@@ -278,7 +278,7 @@ public class ApiHelper {
                                     hPost};
                 Object versionResult = null;
                 try {
-                    versionResult = client.call(Methods.GET_OPTIONS, vParams);
+                    versionResult = client.call(Method.GET_OPTIONS, vParams);
                 } catch (ClassCastException cce) {
                     setError(ErrorType.INVALID_RESULT, cce.getMessage(), cce);
                     return false;
@@ -312,7 +312,7 @@ public class ApiHelper {
             // Check if user is an admin
             Object[] userParams = {mBlog.getRemoteBlogId(), mBlog.getUsername(), mBlog.getPassword()};
             try {
-                Map<String, Object> userInfos = (HashMap<String, Object>) client.call(ApiHelper.Methods.GET_PROFILE, userParams);
+                Map<String, Object> userInfos = (HashMap<String, Object>) client.call(Method.GET_PROFILE, userParams);
                 updateBlogAdmin(userInfos);
             } catch (ClassCastException cce) {
                 setError(ErrorType.INVALID_RESULT, cce.getMessage(), cce);
@@ -378,7 +378,7 @@ public class ApiHelper {
 
         int numDeleted = 0;
         try {
-            Object[] result = (Object[]) client.call(ApiHelper.Methods.GET_COMMENTS, params);
+            Object[] result = (Object[]) client.call(Method.GET_COMMENTS, params);
             if (result == null || result.length == 0) {
                 return 0;
             }
@@ -411,7 +411,7 @@ public class ApiHelper {
         XMLRPCClientInterface client = XMLRPCFactory.instantiate(blog.getUri(), blog.getHttpuser(),
                 blog.getHttppassword());
         Object[] result;
-        result = (Object[]) client.call(ApiHelper.Methods.GET_COMMENTS, commentParams);
+        result = (Object[]) client.call(Method.GET_COMMENTS, commentParams);
 
         if (result.length == 0) {
             return null;
@@ -475,7 +475,7 @@ public class ApiHelper {
                     blog.getHttppassword());
             Object[] params = {blog.getRemoteBlogId(), blog.getUsername(), blog.getPassword(), postId};
             try {
-                client.call(isPage ? Methods.DELETE_PAGE : Methods.DELETE_POST, params);
+                client.call(isPage ? Method.DELETE_PAGE : Method.DELETE_POST, params);
                 return true;
             } catch (XMLRPCException | IOException | XmlPullParserException e) {
                 mErrorMessage = e.getMessage();
@@ -527,7 +527,7 @@ public class ApiHelper {
 
             Object[] results = null;
             try {
-                results = (Object[]) client.call(ApiHelper.Methods.GET_MEDIA_LIBRARY, apiParams);
+                results = (Object[]) client.call(Method.GET_MEDIA_LIBRARY, apiParams);
             } catch (ClassCastException cce) {
                 setError(ErrorType.INVALID_RESULT, cce.getMessage(), cce);
                 return 0;
@@ -631,7 +631,7 @@ public class ApiHelper {
 
             Boolean result = null;
             try {
-                result = (Boolean) client.call(ApiHelper.Methods.EDIT_POST, apiParams);
+                result = (Boolean) client.call(Method.EDIT_POST, apiParams);
             } catch (ClassCastException cce) {
                 setError(ErrorType.INVALID_RESULT, cce.getMessage(), cce);
             } catch (XMLRPCException e) {
@@ -691,7 +691,7 @@ public class ApiHelper {
             };
             Map<?, ?> results = null;
             try {
-                results = (Map<?, ?>) client.call(ApiHelper.Methods.GET_MEDIA_ITEM, apiParams);
+                results = (Map<?, ?>) client.call(Method.GET_MEDIA_ITEM, apiParams);
             } catch (ClassCastException cce) {
                 setError(ErrorType.INVALID_RESULT, cce.getMessage(), cce);
             } catch (XMLRPCException e) {
@@ -772,7 +772,7 @@ public class ApiHelper {
 
             Map<?, ?> resultMap;
             try {
-                resultMap = (HashMap<?, ?>) client.call(Methods.UPLOAD_FILE, apiParams, getTempFile(mContext));
+                resultMap = (HashMap<?, ?>) client.call(Method.UPLOAD_FILE, apiParams, getTempFile(mContext));
             } catch (ClassCastException cce) {
                 setError(ErrorType.INVALID_RESULT, cce.getMessage(), cce);
                 return null;
@@ -845,7 +845,7 @@ public class ApiHelper {
 
             try {
                 if (client != null) {
-                    Boolean result = (Boolean) client.call(ApiHelper.Methods.DELETE_POST, apiParams);
+                    Boolean result = (Boolean) client.call(Method.DELETE_POST, apiParams);
                     if (!result) {
                         setError(ErrorType.INVALID_RESULT, "wp.deletePost returned false");
                     }
@@ -911,7 +911,7 @@ public class ApiHelper {
 
             Map<?, ?> resultMap = null;
             try {
-                resultMap = (HashMap<?, ?>) client.call(ApiHelper.Methods.WPCOM_GET_FEATURES, apiParams);
+                resultMap = (HashMap<?, ?>) client.call(Method.WPCOM_GET_FEATURES, apiParams);
             } catch (ClassCastException cce) {
                 AppLog.e(T.API, "wpcom.getFeatures error", cce);
             } catch (XMLRPCException e) {
@@ -1141,7 +1141,7 @@ public class ApiHelper {
         }
 
         try {
-            Object result = client.call(isPage ? ApiHelper.Methods.GET_PAGE : "metaWeblog.getPost", apiParams);
+            Object result = client.call(isPage ? Method.GET_PAGE : "metaWeblog.getPost", apiParams);
 
             if (result != null && result instanceof Map) {
                 Map postMap = (HashMap) result;

--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
@@ -30,6 +30,7 @@ import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlPullParserFactory;
 import org.xmlpull.v1.XmlSerializer;
+import org.xmlrpc.android.ApiHelper.Method;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -338,7 +339,7 @@ public class XMLRPCClient implements XMLRPCClientInterface {
 
     public void preparePostMethod(String method, Object[] params, File tempFile) throws IOException, XMLRPCException, IllegalArgumentException, IllegalStateException {
         // prepare POST body
-        if (method.equals(ApiHelper.Methods.UPLOAD_FILE)) {
+        if (method.equals(Method.UPLOAD_FILE)) {
             if (!tempFile.exists() && !tempFile.mkdirs()) {
                 throw new XMLRPCException("Path to file could not be created.");
             }
@@ -512,7 +513,7 @@ public class XMLRPCClient implements XMLRPCClientInterface {
                         if (!TextUtils.isEmpty(responseString) && responseString.contains("php fatal error") &&
                                 responseString.contains("bytes exhausted")) {
                             String newErrorMsg;
-                            if (method.equals(ApiHelper.Methods.UPLOAD_FILE)) {
+                            if (method.equals(Method.UPLOAD_FILE)) {
                                 newErrorMsg =
                                         "The server doesn't have enough memory to upload this file. You may need to increase the PHP memory limit on your site.";
                             } else {
@@ -620,7 +621,7 @@ public class XMLRPCClient implements XMLRPCClientInterface {
 
     private void deleteTempFile(String method, File tempFile) {
         if (tempFile != null) {
-            if ((method.equals(ApiHelper.Methods.UPLOAD_FILE))){ //get rid of the temp file
+            if ((method.equals(Method.UPLOAD_FILE))){ //get rid of the temp file
                 tempFile.delete();
             }
         }


### PR DESCRIPTION
Rename s/Params/Param/ to fix the build issue, also renamed s/Methods/Method/

Build was failing on my machine due to a conflict between [Params](https://github.com/wordpress-mobile/WordPress-Android/blob/46eb536402d80744ed7ba3221ab68b98850c4759/WordPress/src/main/java/org/xmlrpc/android/ApiHelper.java#L88-L88) and the generic type [Params](https://github.com/wordpress-mobile/WordPress-Android/blob/46eb536402d80744ed7ba3221ab68b98850c4759/WordPress/src/main/java/org/xmlrpc/android/ApiHelper.java#L111). Not sure why it's failing on my side only (java version?).