### PR TITLE
Issue/3575 blank reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -75,6 +75,7 @@ public class ReaderPostDetailFragment extends Fragment
     private boolean mHasAlreadyUpdatedPost;
     private boolean mHasAlreadyRequestedPost;
     private boolean mIsLoggedOutReader;
+    private boolean mIsWebViewPaused;
     private int mToolbarHeight;
     private String mErrorMessage;
 
@@ -269,9 +270,19 @@ public class ReaderPostDetailFragment extends Fragment
         pauseWebView();
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        // resume the webView if it was paused above - without this the content may not re-appear
+        if (mIsWebViewPaused) {
+            resumeWebView();
+        }
+    }
+
     /*
-     * changes the like on the passed post
-     */
+         * changes the like on the passed post
+         */
     private void togglePostLike() {
         if (!isAdded() || !hasPost() || !NetworkUtils.checkConnection(getActivity())) {
             return;
@@ -875,11 +886,23 @@ public class ReaderPostDetailFragment extends Fragment
     }
 
     void pauseWebView() {
-        if (mReaderWebView != null) {
+        if (mReaderWebView == null) {
+            AppLog.w(T.READER, "reader post detail > attempt to pause null webView");
+        } else {
+            AppLog.d(T.READER, "reader post detail > pausing webView");
             mReaderWebView.hideCustomView();
             mReaderWebView.onPause();
+            mIsWebViewPaused = true;
+        }
+    }
+
+    void resumeWebView() {
+        if (mReaderWebView == null) {
+            AppLog.w(T.READER, "reader post detail > attempt to resume null webView");
         } else {
-            AppLog.i(T.READER, "reader post detail > attempt to pause webView when null");
+            AppLog.d(T.READER, "reader post detail > resuming webView");
+            mReaderWebView.onResume();
+            mIsWebViewPaused = true;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -275,9 +275,7 @@ public class ReaderPostDetailFragment extends Fragment
         super.onResume();
 
         // resume the webView if it was paused above - without this the content may not re-appear
-        if (mIsWebViewPaused) {
-            resumeWebView();
-        }
+        resumeWebViewIfPaused();
     }
 
     /*
@@ -896,13 +894,13 @@ public class ReaderPostDetailFragment extends Fragment
         }
     }
 
-    void resumeWebView() {
+    private void resumeWebViewIfPaused() {
         if (mReaderWebView == null) {
             AppLog.w(T.READER, "reader post detail > attempt to resume null webView");
-        } else {
-            AppLog.d(T.READER, "reader post detail > resuming webView");
+        } else if (mIsWebViewPaused) {
+            AppLog.d(T.READER, "reader post detail > resuming paused webView");
             mReaderWebView.onResume();
-            mIsWebViewPaused = true;
+            mIsWebViewPaused = false;
         }
     }
 


### PR DESCRIPTION
Fix #3575 - Problem resolving by resuming the paused webView when the fragment is resumed.