### PR TITLE
Issue/3600 websettings default user agent

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -15,6 +15,7 @@ import android.os.StrictMode;
 import android.os.SystemClock;
 import android.text.TextUtils;
 import android.util.AndroidRuntimeException;
+import android.webkit.WebSettings;
 import android.webkit.WebView;
 
 import com.android.volley.RequestQueue;
@@ -574,11 +575,14 @@ public class WordPress extends Application {
     private static String mDefaultUserAgent;
     public static String getDefaultUserAgent() {
         if (mDefaultUserAgent == null) {
-            // TODO: use WebSettings.getDefaultUserAgent() after upgrade to API level 17+
             try {
                 // Catch AndroidRuntimeException that could be raised by the WebView() constructor.
                 // See https://github.com/wordpress-mobile/WordPress-Android/issues/3594
-                mDefaultUserAgent = new WebView(getContext()).getSettings().getUserAgentString();
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                    mDefaultUserAgent = WebSettings.getDefaultUserAgent(getContext());
+                } else {
+                    mDefaultUserAgent = new WebView(getContext()).getSettings().getUserAgentString();
+                }
             } catch (AndroidRuntimeException e) {
                 // init with the empty string, it's a rare issue
                 mDefaultUserAgent = "";

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -14,6 +14,8 @@ import android.os.Bundle;
 import android.os.StrictMode;
 import android.os.SystemClock;
 import android.text.TextUtils;
+import android.util.AndroidRuntimeException;
+import android.webkit.WebSettings;
 import android.webkit.WebView;
 
 import com.android.volley.RequestQueue;
@@ -573,8 +575,18 @@ public class WordPress extends Application {
     private static String mDefaultUserAgent;
     public static String getDefaultUserAgent() {
         if (mDefaultUserAgent == null) {
-            // TODO: use WebSettings.getDefaultUserAgent() after upgrade to API level 17+
-            mDefaultUserAgent = new WebView(getContext()).getSettings().getUserAgentString();
+            try {
+                // Catch AndroidRuntimeException that could be raised by the WebView() constructor.
+                // See https://github.com/wordpress-mobile/WordPress-Android/issues/3594
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                    mDefaultUserAgent = WebSettings.getDefaultUserAgent(getContext());
+                } else {
+                    mDefaultUserAgent = new WebView(getContext()).getSettings().getUserAgentString();
+                }
+            } catch (AndroidRuntimeException e) {
+                // init with the empty string, it's a rare issue
+                mDefaultUserAgent = "";
+            }
         }
         return mDefaultUserAgent;
     }


### PR DESCRIPTION
Fix #3600 - uses `WebSettings.getDefaultUserAgent()` on devices running SDK 17 or later.

I'm unsure whether the `AndroidRuntimeException` handler is still necessary so I left it in place, but this does at least do away with the unnecessary WebView creation.