### PR TITLE
Drop android-cq (code quality) plugin

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -5,7 +5,6 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.5.0'
-        classpath 'com.github.nrudenko:gradle-android-cq-plugin:0.1+'
         classpath 'io.fabric.tools:gradle:1.+'
     }
 }
@@ -17,7 +16,6 @@ repositories {
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'android-cq'
 apply plugin: 'io.fabric'
 
 android {


### PR DESCRIPTION
android-cq [updated their dependencies](https://github.com/nrudenko/gradle-android-cq-plugin/commit/25b476bdb80b86136f723313fcd5641b523121f4#diff-387920f8bbb4c6bbdf91f697268be1f0) and it breaks our build.

I rarely used it to run checkstyle, and we still have the checkstyle [config](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/cq-configs/checkstyle/checkstyle.xml) and [script](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/tools/checkstyle.sh)