### PR TITLE
Editor - Follow HTTP redirects for media

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebViewAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebViewAbstract.java
@@ -69,27 +69,27 @@ public abstract class EditorWebViewAbstract extends WebView {
                     return super.shouldInterceptRequest(view, request);
                 }
 
-                try {
-                    // Keep any existing request headers from the WebResourceRequest
-                    Map<String, String> headerMap = request.getRequestHeaders();
-                    for (Map.Entry<String, String> entry : mHeaderMap.entrySet()) {
-                        headerMap.put(entry.getKey(), entry.getValue());
-                    }
-
-                    // Request and add an authorization header for HTTPS resource requests.
-                    // Use https:// when requesting the auth header, in case the resource is incorrectly using http://.
-                    // If an auth header is returned, force https:// for the actual HTTP request.
-                    String authHeader = mAuthHeaderRequestListener.onAuthHeaderRequested(UrlUtils.makeHttps(url));
-                    if (StringUtils.notNullStr(authHeader).length() > 0) {
+                // Request and add an authorization header for HTTPS resource requests.
+                // Use https:// when requesting the auth header, in case the resource is incorrectly using http://.
+                // If an auth header is returned, force https:// for the actual HTTP request.
+                String authHeader = mAuthHeaderRequestListener.onAuthHeaderRequested(UrlUtils.makeHttps(url));
+                if (StringUtils.notNullStr(authHeader).length() > 0) {
+                    try {
                         url = UrlUtils.makeHttps(url);
-                        headerMap.put("Authorization", authHeader);
-                    }
 
-                    HttpURLConnection conn = HTTPUtils.setupUrlConnection(url, headerMap);
-                    return new WebResourceResponse(conn.getContentType(), conn.getContentEncoding(),
-                            conn.getInputStream());
-                } catch (IOException e) {
-                    AppLog.e(AppLog.T.EDITOR, e);
+                        // Keep any existing request headers from the WebResourceRequest
+                        Map<String, String> headerMap = request.getRequestHeaders();
+                        for (Map.Entry<String, String> entry : mHeaderMap.entrySet()) {
+                            headerMap.put(entry.getKey(), entry.getValue());
+                        }
+                        headerMap.put("Authorization", authHeader);
+
+                        HttpURLConnection conn = HTTPUtils.setupUrlConnection(url, headerMap);
+                        return new WebResourceResponse(conn.getContentType(), conn.getContentEncoding(),
+                                conn.getInputStream());
+                    } catch (IOException e) {
+                        AppLog.e(AppLog.T.EDITOR, e);
+                    }
                 }
 
                 return super.shouldInterceptRequest(view, request);
@@ -105,22 +105,23 @@ public abstract class EditorWebViewAbstract extends WebView {
                     return super.shouldInterceptRequest(view, url);
                 }
 
-                try {
-                    // Request and add an authorization header for HTTPS resource requests.
-                    // Use https:// when requesting the auth header, in case the resource is incorrectly using http://.
-                    // If an auth header is returned, force https:// for the actual HTTP request.
-                    Map<String, String> headerMap = new HashMap<>(mHeaderMap);
-                    String authHeader = mAuthHeaderRequestListener.onAuthHeaderRequested(UrlUtils.makeHttps(url));
-                    if (StringUtils.notNullStr(authHeader).length() > 0) {
+                // Request and add an authorization header for HTTPS resource requests.
+                // Use https:// when requesting the auth header, in case the resource is incorrectly using http://.
+                // If an auth header is returned, force https:// for the actual HTTP request.
+                String authHeader = mAuthHeaderRequestListener.onAuthHeaderRequested(UrlUtils.makeHttps(url));
+                if (StringUtils.notNullStr(authHeader).length() > 0) {
+                    try {
                         url = UrlUtils.makeHttps(url);
-                        headerMap.put("Authorization", authHeader);
-                    }
 
-                    HttpURLConnection conn = HTTPUtils.setupUrlConnection(url, headerMap);
-                    return new WebResourceResponse(conn.getContentType(), conn.getContentEncoding(),
-                            conn.getInputStream());
-                } catch (IOException e) {
-                    AppLog.e(AppLog.T.EDITOR, e);
+                        Map<String, String> headerMap = new HashMap<>(mHeaderMap);
+                        headerMap.put("Authorization", authHeader);
+
+                        HttpURLConnection conn = HTTPUtils.setupUrlConnection(url, headerMap);
+                        return new WebResourceResponse(conn.getContentType(), conn.getContentEncoding(),
+                                conn.getInputStream());
+                    } catch (IOException e) {
+                        AppLog.e(AppLog.T.EDITOR, e);
+                    }
                 }
 
                 return super.shouldInterceptRequest(view, url);


### PR DESCRIPTION
Addresses https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/275.

Fixes an issue where the new editor would not follow redirects when requesting images and fail to display them (both in the editor and for the image thumbnail in the 'edit image' dialog).

To reproduce the original issue, attempt to load a post in the new editor containing a non-Photon WordPress.com image using HTTP (e.g. `http://someblog.wordpress.com/2016/01/image.png`).