### PR TITLE
Remove stray popBackStack Fixes #3446

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -109,7 +109,6 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
     @Override
     protected void onPause() {
         super.onPause();
-        getFragmentManager().popBackStack();
         mIsRunning = false;
     }
 


### PR DESCRIPTION
The `ThemeSearchFragment` was removed from the backstack `onResume()` making it appear that rotation was losing the search mode.

This PR just removes the (apparently) stray popBackStack call.

Pinging @daniloercoli for reviewing, thanks! ;)