### PR TITLE
Issue/3625 comments oob exception

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
@@ -194,7 +194,7 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         holder.itemView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (mOnCommentPressedListener != null) {
+                if (mOnCommentPressedListener != null && isPositionValid(position)) {
                     mOnCommentPressedListener.onCommentPressed(position, v);
                 }
             }
@@ -203,7 +203,7 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         holder.itemView.setOnLongClickListener(new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View v) {
-                if (mOnCommentPressedListener != null) {
+                if (mOnCommentPressedListener != null && isPositionValid(position)) {
                     mOnCommentPressedListener.onCommentLongPressed(position, v);
                 }
                 return true;
@@ -217,7 +217,11 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     }
 
     public Comment getItem(int position) {
-        return mComments.get(position);
+        if (isPositionValid(position)) {
+            return mComments.get(position);
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
@@ -65,7 +65,8 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
     private boolean mEnableSelection;
 
-    class CommentHolder extends RecyclerView.ViewHolder {
+    class CommentHolder extends RecyclerView.ViewHolder
+            implements View.OnClickListener, View.OnLongClickListener {
         private final TextView txtTitle;
         private final TextView txtComment;
         private final TextView txtStatus;
@@ -85,6 +86,24 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
             imgAvatar = (WPNetworkImageView) view.findViewById(R.id.avatar);
             progressBar = view.findViewById(R.id.moderate_progress);
             containerView = (ViewGroup) view.findViewById(R.id.layout_container);
+
+            itemView.setOnClickListener(this);
+            itemView.setOnLongClickListener(this);
+        }
+
+        @Override
+        public void onClick(View v) {
+            if (mOnCommentPressedListener != null) {
+                mOnCommentPressedListener.onCommentPressed(getAdapterPosition(), v);
+            }
+        }
+
+        @Override
+        public boolean onLongClick(View v) {
+            if (mOnCommentPressedListener != null) {
+                mOnCommentPressedListener.onCommentLongPressed(getAdapterPosition(), v);
+            }
+            return true;
         }
     }
 
@@ -132,7 +151,7 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     }
 
     @Override
-    public void onBindViewHolder(RecyclerView.ViewHolder viewHolder, final int position) {
+    public void onBindViewHolder(RecyclerView.ViewHolder viewHolder, int position) {
         Comment comment = mComments.get(position);
         CommentHolder holder = (CommentHolder) viewHolder;
 
@@ -190,25 +209,6 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         } else {
             params.addRule(RelativeLayout.LEFT_OF, 0);
         }
-
-        holder.itemView.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (mOnCommentPressedListener != null && isPositionValid(position)) {
-                    mOnCommentPressedListener.onCommentPressed(position, v);
-                }
-            }
-        });
-
-        holder.itemView.setOnLongClickListener(new View.OnLongClickListener() {
-            @Override
-            public boolean onLongClick(View v) {
-                if (mOnCommentPressedListener != null && isPositionValid(position)) {
-                    mOnCommentPressedListener.onCommentLongPressed(position, v);
-                }
-                return true;
-            }
-        });
 
         // request to load more comments when we near the end
         if (mOnLoadMoreListener != null && position >= getItemCount()-1) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -111,12 +111,15 @@ public class CommentsListFragment extends Fragment {
             CommentAdapter.OnCommentPressedListener pressedListener = new CommentAdapter.OnCommentPressedListener() {
                 @Override
                 public void onCommentPressed(int position, View view) {
-                    long commentId = getAdapter().getItem(position).commentID;
+                    Comment comment = getAdapter().getItem(position);
+                    if (comment == null) {
+                        return;
+                    }
                     if (mActionMode == null) {
-                        if (!getAdapter().isModeratingCommentId(commentId)) {
+                        if (!getAdapter().isModeratingCommentId(comment.commentID)) {
                             mRecycler.invalidate();
                             if (getActivity() instanceof OnCommentSelectedListener) {
-                                ((OnCommentSelectedListener) getActivity()).onCommentSelected(commentId);
+                                ((OnCommentSelectedListener) getActivity()).onCommentSelected(comment.commentID);
                             }
                         }
                     } else {


### PR DESCRIPTION
Fixes #3625 - prevents the NPE by checking for a valid position [here](https://github.com/wordpress-mobile/WordPress-Android/compare/issue/3625-comments-oob-exception?expand=1#diff-9bf89cfb41a8e6dc16df599edefa9f06R220) and checking for a null comment [here](https://github.com/wordpress-mobile/WordPress-Android/compare/issue/3625-comments-oob-exception?expand=1#diff-47e49711ee316e90f04719764dd23902R115).

This also moves the click & long press handlers to the view holder [here](https://github.com/wordpress-mobile/WordPress-Android/compare/issue/3625-comments-oob-exception?expand=1#diff-9bf89cfb41a8e6dc16df599edefa9f06R95) since that's a better / more accurate way to do this.