### PR TITLE
Issue/3597 default post format

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
@@ -106,7 +106,6 @@ public class SiteSettingsModel {
     public CategoryModel[] categories;
     public String defaultPostFormat;
     public Map<String, String> postFormats;
-    public String[] postFormatKeys;
     public boolean showRelatedPosts;
     public boolean showRelatedPostHeader;
     public boolean showRelatedPostImages;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -136,14 +136,12 @@ class DotComSiteSettings extends SiteSettingsInterface {
                         mRemoteSettings.localTableId = mBlog.getRemoteBlogId();
                         deserializeDotComRestResponse(mBlog, response);
                         if (!mRemoteSettings.equals(mSettings)) {
-                            // postFormats and postFormatKeys are not returned by this api call so copy it over
+                            // postFormats setting is not returned by this api call so copy it over
                             final Map<String, String> currentPostFormats = mSettings.postFormats;
-                            final String[] currentPostFormatKeys = mSettings.postFormatKeys;
 
                             mSettings.copyFrom(mRemoteSettings);
 
                             mSettings.postFormats = currentPostFormats;
-                            mSettings.postFormatKeys = currentPostFormatKeys;
 
                             SiteSettingsTable.saveSettings(mSettings);
                             notifyUpdatedOnUiThread(null);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -136,7 +136,15 @@ class DotComSiteSettings extends SiteSettingsInterface {
                         mRemoteSettings.localTableId = mBlog.getRemoteBlogId();
                         deserializeDotComRestResponse(mBlog, response);
                         if (!mRemoteSettings.equals(mSettings)) {
+                            // postFormats and postFormatKeys are not returned by this api call so copy it over
+                            final Map<String, String> currentPostFormats = mSettings.postFormats;
+                            final String[] currentPostFormatKeys = mSettings.postFormatKeys;
+
                             mSettings.copyFrom(mRemoteSettings);
+
+                            mSettings.postFormats = currentPostFormats;
+                            mSettings.postFormatKeys = currentPostFormatKeys;
+
                             SiteSettingsTable.saveSettings(mSettings);
                             notifyUpdatedOnUiThread(null);
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SelfHostedSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SelfHostedSiteSettings.java
@@ -193,7 +193,14 @@ class SelfHostedSiteSettings extends SiteSettingsInterface {
                 credentialsVerified(true);
 
                 deserializeOptionsResponse(mRemoteSettings, (Map) result);
+
+                // postFormats setting is not returned by this api call so copy it over
+                final Map<String, String> currentPostFormats = mSettings.postFormats;
+
                 mSettings.copyFrom(mRemoteSettings);
+
+                mSettings.postFormats = currentPostFormats;
+
                 SiteSettingsTable.saveSettings(mSettings);
                 notifyUpdatedOnUiThread(null);
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -711,18 +711,12 @@ public class SiteSettingsFragment extends PreferenceFragment
             return;
         }
 
-        Map<String, String> formats = mSiteSettings.getFormats();
-        String[] formatKeys = mSiteSettings.getFormatKeys();
-        String[] entries = new String[formatKeys.length];
-        String[] values = new String[formatKeys.length];
+        // clone the post formats map
+        final Map<String, String> postFormats = new HashMap<>(mSiteSettings.getFormats());
 
-        for (int i = 0; i < entries.length; ++i) {
-            entries[i] = formats.get(formatKeys[i]);
-            values[i] = formatKeys[i];
-        }
-
-        mFormatPref.setEntries(entries);
-        mFormatPref.setEntryValues(values);
+        // transform the keys and values into arrays and set the ListPreference's data
+        mFormatPref.setEntries(postFormats.values().toArray(new String[0]));
+        mFormatPref.setEntryValues(postFormats.keySet().toArray(new String[0]));
         mFormatPref.setValue(String.valueOf(mSiteSettings.getDefaultPostFormat()));
         mFormatPref.setSummary(mSiteSettings.getDefaultPostFormatDisplay());
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -770,6 +770,7 @@ public abstract class SiteSettingsInterface {
                     String[] formatKeys = new String[mRemoteSettings.postFormats.size()];
                     mRemoteSettings.postFormatKeys = mRemoteSettings.postFormats.keySet().toArray(formatKeys);
                     mSettings.postFormatKeys = mRemoteSettings.postFormatKeys.clone();
+                    SiteSettingsTable.saveSettings(mSettings);
 
                     notifyUpdatedOnUiThread(null);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -282,11 +282,6 @@ public abstract class SiteSettingsInterface {
         return mSettings.postFormats;
     }
 
-    public @NonNull String[] getFormatKeys() {
-        if (mSettings.postFormatKeys == null) mSettings.postFormatKeys = new String[0];
-        return mSettings.postFormatKeys;
-    }
-
     public @NonNull CategoryModel[] getCategories() {
         if (mSettings.categories == null) mSettings.categories = new CategoryModel[0];
         return mSettings.categories;
@@ -768,8 +763,6 @@ public abstract class SiteSettingsInterface {
                     }
                     mSettings.postFormats = new HashMap<>(mRemoteSettings.postFormats);
                     String[] formatKeys = new String[mRemoteSettings.postFormats.size()];
-                    mRemoteSettings.postFormatKeys = mRemoteSettings.postFormats.keySet().toArray(formatKeys);
-                    mSettings.postFormatKeys = mRemoteSettings.postFormatKeys.clone();
                     SiteSettingsTable.saveSettings(mSettings);
 
                     notifyUpdatedOnUiThread(null);


### PR DESCRIPTION
Currently, the site's default post format setting feature has two separate api calls behind it: one for the general settings that holds the current post format selected and one for the available post formats. This duality makes things a bit more complicated than it could be.

This PR:
* makes sure that the local (cached) settings are updated when any of those calls finishes
* protects the cached list of post formats from getting overwritten by the general settings call (that call does not curry any list of formats from the server)
* simplifies the usage of `SiteSettingsModel.postFormats` by removing the `SiteSettingsModel.postFormatKeys` member
* fixes #3597 

I would probably like to hear @tonyr59h 's review on this one but anyone is welcomed to review. Cheers!