### PR TITLE
issue/3644-site-settings-multiline

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/WPPrefUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPPrefUtils.java
@@ -171,6 +171,7 @@ public class WPPrefUtils {
         setTextViewAttributes(view, size, R.color.grey_dark, getNormalTypeface(view.getContext()));
         view.setHintTextColor(view.getResources().getColor(R.color.grey_lighten_10));
         view.setTextColor(view.getResources().getColor(R.color.grey_dark));
+        view.setSingleLine(true);
     }
 
     /**


### PR DESCRIPTION
Fixes #3644 - changes EditTexts used in site settings to a single line, which corrects the multiline behavior of site title, site tagline, comment moderation, and comment blacklist settings.