### PR TITLE
Not re-creating Fragments during Activity lifecycle (rotation changes)

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -108,7 +108,7 @@
             android:theme="@style/Calypso.NoActionBar" />
         <activity
             android:name=".ui.prefs.SettingsActivity"
-            android:configChanges="locale|orientation"
+            android:configChanges="locale|orientation|screenSize"
             android:theme="@style/CalypsoTheme"/>
         <activity
             android:name=".ui.prefs.notifications.NotificationsSettingsActivity"

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
@@ -81,7 +81,7 @@ public class BlogPreferencesActivity extends AppCompatActivity {
             if (siteSettingsFragment == null) {
                 siteSettingsFragment = new SiteSettingsFragment();
                 siteSettingsFragment.setArguments(getIntent().getExtras());
-                getFragmentManager().beginTransaction()
+                fragmentManager.beginTransaction()
                         .replace(android.R.id.content, siteSettingsFragment, KEY_SETTINGS_FRAGMENT)
                         .commit();
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsActivity.java
@@ -1,22 +1,18 @@
 package org.wordpress.android.ui.prefs;
 
+import android.app.Fragment;
 import android.app.FragmentManager;
 import android.os.Bundle;
-import android.preference.Preference;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
-import org.wordpress.android.R;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.passcodelock.PasscodePreferenceFragment;
 
 public class SettingsActivity extends AppCompatActivity {
     private static final String KEY_SETTINGS_FRAGMENT = "settings-fragment";
     private static final String KEY_PASSCODE_FRAGMENT = "passcode-fragment";
-
-    private SettingsFragment mSettingsFragment;
-    private PasscodePreferenceFragment mPasscodePreferenceFragment;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -26,61 +22,21 @@ public class SettingsActivity extends AppCompatActivity {
             actionBar.setHomeButtonEnabled(true);
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
-        setContentView(R.layout.settings_activity);
 
         FragmentManager fragmentManager = getFragmentManager();
-        if (savedInstanceState == null) {
+        Fragment settingsFragment = fragmentManager.findFragmentByTag(KEY_SETTINGS_FRAGMENT);
+        Fragment passcodeFragment = fragmentManager.findFragmentByTag(KEY_PASSCODE_FRAGMENT);
+        if (settingsFragment == null || passcodeFragment == null) {
             Bundle passcodeArgs = new Bundle();
             passcodeArgs.putBoolean(PasscodePreferenceFragment.KEY_SHOULD_INFLATE, false);
-            mSettingsFragment = new SettingsFragment();
-            mPasscodePreferenceFragment = new PasscodePreferenceFragment();
-            mPasscodePreferenceFragment.setArguments(passcodeArgs);
+            settingsFragment = new SettingsFragment();
+            passcodeFragment = new PasscodePreferenceFragment();
+            passcodeFragment.setArguments(passcodeArgs);
 
             fragmentManager.beginTransaction()
-                    .add(R.id.fragment_container, mSettingsFragment)
-                    .add(R.id.fragment_container, mPasscodePreferenceFragment)
+                    .replace(android.R.id.content, passcodeFragment, KEY_PASSCODE_FRAGMENT)
+                    .add(android.R.id.content, settingsFragment, KEY_SETTINGS_FRAGMENT)
                     .commit();
-        } else {
-            mSettingsFragment = (SettingsFragment)
-                    fragmentManager.getFragment(savedInstanceState, KEY_SETTINGS_FRAGMENT);
-            mPasscodePreferenceFragment = (PasscodePreferenceFragment)
-                    fragmentManager.getFragment(savedInstanceState, KEY_PASSCODE_FRAGMENT);
-        }
-    }
-
-    @Override
-    public void onSaveInstanceState(Bundle savedInstanceState) {
-        super.onSaveInstanceState(savedInstanceState);
-
-        getFragmentManager().putFragment(
-                savedInstanceState, KEY_SETTINGS_FRAGMENT, mSettingsFragment);
-        getFragmentManager().putFragment(
-                savedInstanceState, KEY_PASSCODE_FRAGMENT, mPasscodePreferenceFragment);
-    }
-
-    @Override
-    public void onStart() {
-        super.onStart();
-
-        Preference togglePref =
-                mSettingsFragment.findPreference(getString(org.wordpress.passcodelock.R.string
-                        .pref_key_passcode_toggle));
-        Preference changePref =
-                mSettingsFragment.findPreference(getString(org.wordpress.passcodelock.R.string
-                        .pref_key_change_passcode));
-
-        if (togglePref != null && changePref != null) {
-            mPasscodePreferenceFragment.setPreferences(togglePref, changePref);
-        }
-    }
-
-    @Override
-    public void onBackPressed() {
-        FragmentManager fragmentManager = getFragmentManager();
-        if (fragmentManager.getBackStackEntryCount() > 0) {
-            fragmentManager.popBackStack();
-        } else {
-            super.onBackPressed();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
@@ -53,6 +53,7 @@ public class SettingsFragment extends PreferenceFragment implements OnPreference
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        setRetainInstance(true);
         addPreferencesFromResource(R.xml.settings);
 
         mPreferenceScreen = (PreferenceScreen) findPreference(getActivity().getString(R.string.pref_key_settings_root));


### PR DESCRIPTION
@oguzkocer found an issue with rotating the device on the Account Settings screen where existing dialogs would not be re-created on configuration changes (such as rotation). This PR addresses that problem by saving the fragments during the Activity lifecycle so they don't get re-created.