### PR TITLE
Issue/3668 rotate wpadmin

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/networking/SSLCertsViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/SSLCertsViewActivity.java
@@ -2,7 +2,6 @@ package org.wordpress.android.networking;
 
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
-import android.webkit.WebSettings;
 
 import org.wordpress.android.R;
 import org.wordpress.android.ui.WebViewActivity;
@@ -22,16 +21,22 @@ public class SSLCertsViewActivity extends WebViewActivity {
         if (actionBar != null) {
             actionBar.setDisplayHomeAsUpEnabled(false);
         }
+    }
 
+    @Override
+    protected void readExtras() {
         Bundle extras = getIntent().getExtras();
         if (extras != null && extras.containsKey(CERT_DETAILS_KEYS)) {
             String certDetails = extras.getString(CERT_DETAILS_KEYS);
             StringBuilder sb = new StringBuilder("<html><body>");
             sb.append(certDetails);
             sb.append("</body></html>");
-            WebSettings settings = mWebView.getSettings();
-            settings.setDefaultTextEncodingName("utf-8");
             mWebView.loadDataWithBaseURL(null, sb.toString(), "text/html", "utf-8", null);
         }
+    }
+
+    @Override
+    protected void configureWebView() {
+        mWebView.getSettings().setDefaultTextEncodingName("utf-8");
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/networking/SSLCertsViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/SSLCertsViewActivity.java
@@ -24,7 +24,7 @@ public class SSLCertsViewActivity extends WebViewActivity {
     }
 
     @Override
-    protected void readExtras() {
+    protected void loadContent() {
         Bundle extras = getIntent().getExtras();
         if (extras != null && extras.containsKey(CERT_DETAILS_KEYS)) {
             String certDetails = extras.getString(CERT_DETAILS_KEYS);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ViewSiteActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ViewSiteActivity.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.webkit.WebSettings;
 import android.widget.ProgressBar;
 import android.widget.Toast;
 
@@ -46,6 +47,7 @@ public class ViewSiteActivity extends WebViewActivity {
         mWebView.setWebChromeClient(new WPWebChromeClient(this, (ProgressBar) findViewById(R.id.progress_bar)));
         mWebView.getSettings().setJavaScriptEnabled(true);
         mWebView.getSettings().setDomStorageEnabled(true);
+        mWebView.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/ViewSiteActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ViewSiteActivity.java
@@ -4,13 +4,9 @@ package org.wordpress.android.ui;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.webkit.WebSettings;
-import android.webkit.WebView;
 import android.widget.ProgressBar;
 import android.widget.Toast;
 
@@ -19,8 +15,8 @@ import com.google.gson.reflect.TypeToken;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
-import org.wordpress.android.models.Blog;
 import org.wordpress.android.models.AccountHelper;
+import org.wordpress.android.models.Blog;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.WPWebViewClient;
 import org.wordpress.android.util.helpers.WPWebChromeClient;
@@ -32,43 +28,24 @@ import java.util.Map;
 /**
  * Activity to view the WordPress blog in a WebView
  */
-public class ViewSiteActivity extends AppCompatActivity {
-    /**
-     * Blog for which this activity is loading content.
-     */
-    private Blog mBlog;
-    private WebView mWebView;
-
+public class ViewSiteActivity extends WebViewActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        ActivityId.trackLastActivity(ActivityId.VIEW_SITE);
+    }
 
-        mBlog = WordPress.getCurrentBlog();
-        if (mBlog == null) {
-            Toast.makeText(this, getResources().getText(R.string.blog_not_found),
-                    Toast.LENGTH_SHORT).show();
-            finish();
+    @Override
+    protected void configureWebView() {
+        Blog blog = WordPress.getCurrentBlog();
+        if (blog == null) {
             return;
         }
 
-        setContentView(R.layout.webview);
-
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-        setSupportActionBar(toolbar);
-        getSupportActionBar().setDisplayShowTitleEnabled(true);
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-
-        mWebView = (WebView) findViewById(R.id.webView);
-        mWebView.setWebViewClient(new WPWebViewClient(mBlog));
-        mWebView.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
+        mWebView.setWebViewClient(new WPWebViewClient(blog));
         mWebView.setWebChromeClient(new WPWebChromeClient(this, (ProgressBar) findViewById(R.id.progress_bar)));
         mWebView.getSettings().setJavaScriptEnabled(true);
         mWebView.getSettings().setDomStorageEnabled(true);
-
-        setTitle(StringUtils.unescapeHTML(mBlog.getBlogName()));
-        loadSiteURL();
-
-        ActivityId.trackLastActivity(ActivityId.VIEW_SITE);
     }
 
     @Override
@@ -77,14 +54,22 @@ public class ViewSiteActivity extends AppCompatActivity {
         ActivityLauncher.slideOutToRight(this);
     }
 
-    private void loadSiteURL() {
-        if (mBlog == null) {
+    @Override
+    protected void loadContent() {
+        Blog blog = WordPress.getCurrentBlog();
+        if (blog == null) {
+            Toast.makeText(this, getResources().getText(R.string.blog_not_found),
+                    Toast.LENGTH_SHORT).show();
+            finish();
             return;
         }
+
+        setTitle(StringUtils.unescapeHTML(blog.getBlogName()));
+
         String siteURL = null;
         Gson gson = new Gson();
         Type type = new TypeToken<Map<?, ?>>() { }.getType();
-        Map<?, ?> blogOptions = gson.fromJson(mBlog.getBlogOptions(), type);
+        Map<?, ?> blogOptions = gson.fromJson(blog.getBlogOptions(), type);
         if (blogOptions != null) {
             Map<?, ?> homeURLMap = (Map<?, ?>) blogOptions.get("home_url");
             if (homeURLMap != null) {
@@ -93,14 +78,14 @@ public class ViewSiteActivity extends AppCompatActivity {
         }
         // Try to guess the URL of the site if blogOptions is null (blog not added to the app)
         if (siteURL == null) {
-            siteURL = mBlog.getUrl().replace("/xmlrpc.php", "");
+            siteURL = blog.getUrl().replace("/xmlrpc.php", "");
         }
 
         // Login to the blog and load the specified URL.
-        String authenticationUrl = WPWebViewActivity.getBlogLoginUrl(mBlog);
+        String authenticationUrl = WPWebViewActivity.getBlogLoginUrl(blog);
 
         String postData = WPWebViewActivity.getAuthenticationPostData(
-                authenticationUrl, siteURL, mBlog.getUsername(), mBlog.getPassword(),
+                authenticationUrl, siteURL, blog.getUsername(), blog.getPassword(),
                 AccountHelper.getDefaultAccount().getAccessToken()
         );
 
@@ -148,4 +133,5 @@ public class ViewSiteActivity extends AppCompatActivity {
 
         return super.onOptionsItemSelected(item);
     }
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -159,9 +159,7 @@ public class WPWebViewActivity extends WebViewActivity {
 
     @SuppressLint("SetJavaScriptEnabled")
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
+    protected void configureWebView() {
         mWebView.getSettings().setJavaScriptEnabled(true);
         mWebView.getSettings().setDomStorageEnabled(true);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -160,58 +160,62 @@ public class WPWebViewActivity extends WebViewActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Bundle extras = getIntent().getExtras();
 
-        if (extras == null) {
-            AppLog.e(AppLog.T.UTILS, "No valid parameters passed to WPWebViewActivity");
-            finish();
-            return;
-        }
+        if (savedInstanceState == null) {
+            Bundle extras = getIntent().getExtras();
 
-        if (extras.getInt(LOCAL_BLOG_ID, -1) > -1) {
-            Blog blog = WordPress.getBlog(extras.getInt(LOCAL_BLOG_ID, -1));
-            if (blog == null) {
+            if (extras == null) {
                 AppLog.e(AppLog.T.UTILS, "No valid parameters passed to WPWebViewActivity");
                 finish();
+                return;
             }
-            mWebView.setWebViewClient(new WPWebViewClient(blog));
-        } else {
-            mWebView.setWebViewClient(new WebViewClient());
-        }
-        mWebView.setWebChromeClient(new WPWebChromeClient(this, (ProgressBar) findViewById(R.id.progress_bar)));
-        mWebView.getSettings().setJavaScriptEnabled(true);
-        mWebView.getSettings().setDomStorageEnabled(true);
 
-        String addressToLoad = extras.getString(URL_TO_LOAD);
-        String username = extras.getString(AUTHENTICATION_USER, "");
-        String password = extras.getString(AUTHENTICATION_PASSWD, "");
-        String authURL = extras.getString(AUTHENTICATION_URL);
+            if (extras.getInt(LOCAL_BLOG_ID, -1) > -1) {
+                Blog blog = WordPress.getBlog(extras.getInt(LOCAL_BLOG_ID, -1));
+                if (blog == null) {
+                    AppLog.e(AppLog.T.UTILS, "No valid parameters passed to WPWebViewActivity");
+                    finish();
+                }
+                mWebView.setWebViewClient(new WPWebViewClient(blog));
+            } else {
+                mWebView.setWebViewClient(new WebViewClient());
+            }
+            mWebView.setWebChromeClient(new WPWebChromeClient(this, (ProgressBar) findViewById(R.id.progress_bar)));
 
-        if (TextUtils.isEmpty(addressToLoad) || !UrlUtils.isValidUrlAndHostNotNull(addressToLoad)) {
-            AppLog.e(AppLog.T.UTILS, "Empty or null or invalid URL passed to WPWebViewActivity");
-            Toast.makeText(this, getText(R.string.invalid_url_message),
-                    Toast.LENGTH_SHORT).show();
-            finish();
-        }
+            mWebView.getSettings().setJavaScriptEnabled(true);
+            mWebView.getSettings().setDomStorageEnabled(true);
 
-        if (TextUtils.isEmpty(authURL) && TextUtils.isEmpty(username) && TextUtils.isEmpty(password)) {
-            // Only the URL to load is passed to this activity. Use a the normal loader not authenticated.
-            loadUrl(addressToLoad);
-        } else {
-            if (TextUtils.isEmpty(authURL) || !UrlUtils.isValidUrlAndHostNotNull(authURL)) {
-                AppLog.e(AppLog.T.UTILS, "Empty or null or invalid auth URL passed to WPWebViewActivity");
+            String addressToLoad = extras.getString(URL_TO_LOAD);
+            String username = extras.getString(AUTHENTICATION_USER, "");
+            String password = extras.getString(AUTHENTICATION_PASSWD, "");
+            String authURL = extras.getString(AUTHENTICATION_URL);
+
+            if (TextUtils.isEmpty(addressToLoad) || !UrlUtils.isValidUrlAndHostNotNull(addressToLoad)) {
+                AppLog.e(AppLog.T.UTILS, "Empty or null or invalid URL passed to WPWebViewActivity");
                 Toast.makeText(this, getText(R.string.invalid_url_message),
                         Toast.LENGTH_SHORT).show();
                 finish();
             }
 
-            if (TextUtils.isEmpty(username)) {
-                AppLog.e(AppLog.T.UTILS, "Username empty/null");
-                Toast.makeText(this, getText(R.string.incorrect_credentials), Toast.LENGTH_SHORT).show();
-                finish();
-            }
+            if (TextUtils.isEmpty(authURL) && TextUtils.isEmpty(username) && TextUtils.isEmpty(password)) {
+                // Only the URL to load is passed to this activity. Use a the normal loader not authenticated.
+                loadUrl(addressToLoad);
+            } else {
+                if (TextUtils.isEmpty(authURL) || !UrlUtils.isValidUrlAndHostNotNull(authURL)) {
+                    AppLog.e(AppLog.T.UTILS, "Empty or null or invalid auth URL passed to WPWebViewActivity");
+                    Toast.makeText(this, getText(R.string.invalid_url_message),
+                            Toast.LENGTH_SHORT).show();
+                    finish();
+                }
 
-            this.loadAuthenticatedUrl(authURL, addressToLoad, username, password);
+                if (TextUtils.isEmpty(username)) {
+                    AppLog.e(AppLog.T.UTILS, "Username empty/null");
+                    Toast.makeText(this, getText(R.string.incorrect_credentials), Toast.LENGTH_SHORT).show();
+                    finish();
+                }
+
+                this.loadAuthenticatedUrl(authURL, addressToLoad, username, password);
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -160,6 +160,8 @@ public class WPWebViewActivity extends WebViewActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        mWebView.getSettings().setJavaScriptEnabled(true);
+        mWebView.getSettings().setDomStorageEnabled(true);
     }
 
     @SuppressLint("SetJavaScriptEnabled")
@@ -176,7 +178,7 @@ public class WPWebViewActivity extends WebViewActivity {
         if (extras.getInt(LOCAL_BLOG_ID, -1) > -1) {
             Blog blog = WordPress.getBlog(extras.getInt(LOCAL_BLOG_ID, -1));
             if (blog == null) {
-                AppLog.e(AppLog.T.UTILS, "No valid parameters passed to WPWebViewActivity");
+                AppLog.e(AppLog.T.UTILS, "No valid blog passed to WPWebViewActivity");
                 finish();
             }
             mWebView.setWebViewClient(new WPWebViewClient(blog));
@@ -185,9 +187,6 @@ public class WPWebViewActivity extends WebViewActivity {
         }
 
         mWebView.setWebChromeClient(new WPWebChromeClient(this, (ProgressBar) findViewById(R.id.progress_bar)));
-
-        mWebView.getSettings().setJavaScriptEnabled(true);
-        mWebView.getSettings().setDomStorageEnabled(true);
 
         String addressToLoad = extras.getString(URL_TO_LOAD);
         String username = extras.getString(AUTHENTICATION_USER, "");

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -178,7 +178,7 @@ public class WPWebViewActivity extends WebViewActivity {
     }
 
     @Override
-    protected void readExtras() {
+    protected void loadContent() {
         Bundle extras = getIntent().getExtras();
 
         if (extras == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -161,8 +161,22 @@ public class WPWebViewActivity extends WebViewActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
         mWebView.getSettings().setJavaScriptEnabled(true);
         mWebView.getSettings().setDomStorageEnabled(true);
+
+        if (getIntent().hasExtra(LOCAL_BLOG_ID)) {
+            Blog blog = WordPress.getBlog(getIntent().getIntExtra(LOCAL_BLOG_ID, -1));
+            if (blog == null) {
+                AppLog.e(AppLog.T.UTILS, "No valid blog passed to WPWebViewActivity");
+                finish();
+            }
+            mWebView.setWebViewClient(new WPWebViewClient(blog));
+        } else {
+            mWebView.setWebViewClient(new WebViewClient());
+        }
+
+        mWebView.setWebChromeClient(new WPWebChromeClient(this, (ProgressBar) findViewById(R.id.progress_bar)));
     }
 
     @Override
@@ -174,19 +188,6 @@ public class WPWebViewActivity extends WebViewActivity {
             finish();
             return;
         }
-
-        if (extras.getInt(LOCAL_BLOG_ID, -1) > -1) {
-            Blog blog = WordPress.getBlog(extras.getInt(LOCAL_BLOG_ID, -1));
-            if (blog == null) {
-                AppLog.e(AppLog.T.UTILS, "No valid blog passed to WPWebViewActivity");
-                finish();
-            }
-            mWebView.setWebViewClient(new WPWebViewClient(blog));
-        } else {
-            mWebView.setWebViewClient(new WebViewClient());
-        }
-
-        mWebView.setWebChromeClient(new WPWebChromeClient(this, (ProgressBar) findViewById(R.id.progress_bar)));
 
         String addressToLoad = extras.getString(URL_TO_LOAD);
         String username = extras.getString(AUTHENTICATION_USER, "");

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -156,66 +156,69 @@ public class WPWebViewActivity extends WebViewActivity {
         context.startActivity(intent);
     }
 
-    @SuppressLint("SetJavaScriptEnabled")
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+    }
 
-        if (savedInstanceState == null) {
-            Bundle extras = getIntent().getExtras();
+    @SuppressLint("SetJavaScriptEnabled")
+    @Override
+    protected void readExtras() {
+        Bundle extras = getIntent().getExtras();
 
-            if (extras == null) {
+        if (extras == null) {
+            AppLog.e(AppLog.T.UTILS, "No valid parameters passed to WPWebViewActivity");
+            finish();
+            return;
+        }
+
+        if (extras.getInt(LOCAL_BLOG_ID, -1) > -1) {
+            Blog blog = WordPress.getBlog(extras.getInt(LOCAL_BLOG_ID, -1));
+            if (blog == null) {
                 AppLog.e(AppLog.T.UTILS, "No valid parameters passed to WPWebViewActivity");
                 finish();
-                return;
             }
+            mWebView.setWebViewClient(new WPWebViewClient(blog));
+        } else {
+            mWebView.setWebViewClient(new WebViewClient());
+        }
 
-            if (extras.getInt(LOCAL_BLOG_ID, -1) > -1) {
-                Blog blog = WordPress.getBlog(extras.getInt(LOCAL_BLOG_ID, -1));
-                if (blog == null) {
-                    AppLog.e(AppLog.T.UTILS, "No valid parameters passed to WPWebViewActivity");
-                    finish();
-                }
-                mWebView.setWebViewClient(new WPWebViewClient(blog));
-            } else {
-                mWebView.setWebViewClient(new WebViewClient());
-            }
-            mWebView.setWebChromeClient(new WPWebChromeClient(this, (ProgressBar) findViewById(R.id.progress_bar)));
+        mWebView.setWebChromeClient(new WPWebChromeClient(this, (ProgressBar) findViewById(R.id.progress_bar)));
 
-            mWebView.getSettings().setJavaScriptEnabled(true);
-            mWebView.getSettings().setDomStorageEnabled(true);
+        mWebView.getSettings().setJavaScriptEnabled(true);
+        mWebView.getSettings().setDomStorageEnabled(true);
 
-            String addressToLoad = extras.getString(URL_TO_LOAD);
-            String username = extras.getString(AUTHENTICATION_USER, "");
-            String password = extras.getString(AUTHENTICATION_PASSWD, "");
-            String authURL = extras.getString(AUTHENTICATION_URL);
+        String addressToLoad = extras.getString(URL_TO_LOAD);
+        String username = extras.getString(AUTHENTICATION_USER, "");
+        String password = extras.getString(AUTHENTICATION_PASSWD, "");
+        String authURL = extras.getString(AUTHENTICATION_URL);
 
-            if (TextUtils.isEmpty(addressToLoad) || !UrlUtils.isValidUrlAndHostNotNull(addressToLoad)) {
-                AppLog.e(AppLog.T.UTILS, "Empty or null or invalid URL passed to WPWebViewActivity");
+        if (TextUtils.isEmpty(addressToLoad) || !UrlUtils.isValidUrlAndHostNotNull(addressToLoad)) {
+            AppLog.e(AppLog.T.UTILS, "Empty or null or invalid URL passed to WPWebViewActivity");
+            Toast.makeText(this, getText(R.string.invalid_url_message),
+                    Toast.LENGTH_SHORT).show();
+            finish();
+        }
+
+        if (TextUtils.isEmpty(authURL) && TextUtils.isEmpty(username) && TextUtils.isEmpty(password)) {
+            // Only the URL to load is passed to this activity. Use a the normal loader not authenticated.
+            loadUrl(addressToLoad);
+        } else {
+            if (TextUtils.isEmpty(authURL) || !UrlUtils.isValidUrlAndHostNotNull(authURL)) {
+                AppLog.e(AppLog.T.UTILS, "Empty or null or invalid auth URL passed to WPWebViewActivity");
                 Toast.makeText(this, getText(R.string.invalid_url_message),
                         Toast.LENGTH_SHORT).show();
                 finish();
             }
 
-            if (TextUtils.isEmpty(authURL) && TextUtils.isEmpty(username) && TextUtils.isEmpty(password)) {
-                // Only the URL to load is passed to this activity. Use a the normal loader not authenticated.
-                loadUrl(addressToLoad);
-            } else {
-                if (TextUtils.isEmpty(authURL) || !UrlUtils.isValidUrlAndHostNotNull(authURL)) {
-                    AppLog.e(AppLog.T.UTILS, "Empty or null or invalid auth URL passed to WPWebViewActivity");
-                    Toast.makeText(this, getText(R.string.invalid_url_message),
-                            Toast.LENGTH_SHORT).show();
-                    finish();
-                }
-
-                if (TextUtils.isEmpty(username)) {
-                    AppLog.e(AppLog.T.UTILS, "Username empty/null");
-                    Toast.makeText(this, getText(R.string.incorrect_credentials), Toast.LENGTH_SHORT).show();
-                    finish();
-                }
-
-                this.loadAuthenticatedUrl(authURL, addressToLoad, username, password);
+            if (TextUtils.isEmpty(username)) {
+                AppLog.e(AppLog.T.UTILS, "Username empty/null");
+                Toast.makeText(this, getText(R.string.incorrect_credentials), Toast.LENGTH_SHORT).show();
+                finish();
             }
+
+            loadAuthenticatedUrl(authURL, addressToLoad, username, password);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -157,6 +157,7 @@ public class WPWebViewActivity extends WebViewActivity {
     }
 
 
+    @SuppressLint("SetJavaScriptEnabled")
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -164,7 +165,6 @@ public class WPWebViewActivity extends WebViewActivity {
         mWebView.getSettings().setDomStorageEnabled(true);
     }
 
-    @SuppressLint("SetJavaScriptEnabled")
     @Override
     protected void readExtras() {
         Bundle extras = getIntent().getExtras();

--- a/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
@@ -40,12 +40,15 @@ public abstract class WebViewActivity extends AppCompatActivity {
         mWebView = (WebView) findViewById(R.id.webView);
         mWebView.setScrollBarStyle(View.SCROLLBARS_INSIDE_OVERLAY);
 
-        // load URL if one was provided in the intent
         if (savedInstanceState == null) {
-            String url = getIntent().getStringExtra(URL);
-            if (url != null) {
-                loadUrl(url);
-            }
+            readExtras();
+        }
+    }
+
+    protected void readExtras() {
+        String url = getIntent().getStringExtra(URL);
+        if (url != null) {
+            loadUrl(url);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
@@ -2,6 +2,7 @@
 package org.wordpress.android.ui;
 
 import android.os.Bundle;
+import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
@@ -42,17 +43,17 @@ public abstract class WebViewActivity extends AppCompatActivity {
         configureWebView();
 
         if (savedInstanceState == null) {
-            readExtras();
+            loadContent();
         }
     }
 
     /*
-     * load the desired URL from the activity's extras - only done on initial activity creation
-     * (ie: when savedInstanceState = null) since onSaveInstanceState /onRestoreInstanceState
-     * will take care of saving and restoring the correct URL when the activity is recreated.
-     * note that descendants should override this w/o calling super() to load a different URL.
+     * load the desired content - only done on initial activity creation (ie: when savedInstanceState
+     * is null) since onSaveInstanceState() and onRestoreInstanceState() will take care of saving
+     * and restoring the correct URL when the activity is recreated - note that descendants should
+     * override this w/o calling super() to load a different URL.
      */
-    protected void readExtras() {
+    protected void loadContent() {
         String url = getIntent().getStringExtra(URL);
         if (url != null) {
             loadUrl(url);
@@ -94,9 +95,15 @@ public abstract class WebViewActivity extends AppCompatActivity {
         setContentView(R.layout.webview);
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-        setSupportActionBar(toolbar);
-        getSupportActionBar().setDisplayShowTitleEnabled(true);
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        if (toolbar != null) {
+            setSupportActionBar(toolbar);
+        }
+
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayShowTitleEnabled(true);
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
@@ -41,10 +41,24 @@ public abstract class WebViewActivity extends AppCompatActivity {
         mWebView.setScrollBarStyle(View.SCROLLBARS_INSIDE_OVERLAY);
 
         // load URL if one was provided in the intent
-        String url = getIntent().getStringExtra(URL);
-        if (url != null) {
-            loadUrl(url);
+        if (savedInstanceState == null) {
+            String url = getIntent().getStringExtra(URL);
+            if (url != null) {
+                loadUrl(url);
+            }
         }
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        mWebView.saveState(outState);
+        super.onSaveInstanceState(outState);
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+        mWebView.restoreState(savedInstanceState);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
@@ -39,6 +39,7 @@ public abstract class WebViewActivity extends AppCompatActivity {
         // format the page for mobile display
         mWebView = (WebView) findViewById(R.id.webView);
         mWebView.setScrollBarStyle(View.SCROLLBARS_INSIDE_OVERLAY);
+        configureWebView();
 
         if (savedInstanceState == null) {
             readExtras();
@@ -96,6 +97,14 @@ public abstract class WebViewActivity extends AppCompatActivity {
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayShowTitleEnabled(true);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    }
+
+    /*
+     * descendants should override this to set a WebViewClient, WebChromeClient, and anything
+     * else necessary to configure the webView prior to navigation
+     */
+    protected void configureWebView() {
+        // noop
     }
 
     private void pauseWebView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
@@ -45,6 +45,12 @@ public abstract class WebViewActivity extends AppCompatActivity {
         }
     }
 
+    /*
+     * load the desired URL from the activity's extras - only done on initial activity creation
+     * (ie: when savedInstanceState = null) since onSaveInstanceState /onRestoreInstanceState
+     * will take care of saving and restoring the correct URL when the activity is recreated.
+     * note that descendants should override this w/o calling super() to load a different URL.
+     */
     protected void readExtras() {
         String url = getIntent().getStringExtra(URL);
         if (url != null) {
@@ -52,12 +58,18 @@ public abstract class WebViewActivity extends AppCompatActivity {
         }
     }
 
+    /*
+     * save the webView state with the bundle so it can be restored
+     */
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         mWebView.saveState(outState);
         super.onSaveInstanceState(outState);
     }
 
+    /*
+     * restore the webView state saved above
+     */
     @Override
     protected void onRestoreInstanceState(Bundle savedInstanceState) {
         super.onRestoreInstanceState(savedInstanceState);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/LicensesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/LicensesActivity.java
@@ -16,7 +16,7 @@ public class LicensesActivity extends WebViewActivity {
     }
 
     @Override
-    protected void readExtras() {
+    protected void loadContent() {
         loadUrl("file:///android_asset/licenses.html");
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/LicensesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/LicensesActivity.java
@@ -13,7 +13,10 @@ public class LicensesActivity extends WebViewActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setTitle(getResources().getText(R.string.open_source_licenses));
+    }
 
+    @Override
+    protected void readExtras() {
         loadUrl("file:///android_asset/licenses.html");
     }
 }


### PR DESCRIPTION
Resolved #3668 by:

1. Having WebViewActivity save & restore the webView state, which retains the current URL
2. Only loading the desired URL on initial creation (ie: when `savedInstanceState` is null) so it doesn't reload upon rotation

Note that this problem wasn't specific to "View Admin" - it happened everywhere a WebViewActivity was used.