### PR TITLE
Fix #3656 - String resource updates and future-proofing

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -40,6 +40,7 @@ import org.wordpress.android.models.Blog;
 import org.wordpress.android.ui.stats.StatsWidgetProvider;
 import org.wordpress.android.ui.stats.datasets.StatsTable;
 import org.wordpress.android.util.AnalyticsUtils;
+import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.CoreEvents;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StringUtils;
@@ -370,6 +371,7 @@ public class SiteSettingsFragment extends PreferenceFragment
             changeEditTextPreferenceValue(mAddressPref, mSiteSettings.getAddress());
         } else if (preference == mLanguagePref) {
             if (!mSiteSettings.setLanguageCode(newValue.toString())) {
+                AppLog.w(AppLog.T.SETTINGS, "Unknown language code " + newValue.toString() + " selected in Site Settings.");
                 ToastUtils.showToast(getActivity(), R.string.site_settings_unknown_language_code_error);
             }
             changeLanguageValue(mSiteSettings.getLanguageCode());

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -369,7 +369,9 @@ public class SiteSettingsFragment extends PreferenceFragment
             mSiteSettings.setAddress(newValue.toString());
             changeEditTextPreferenceValue(mAddressPref, mSiteSettings.getAddress());
         } else if (preference == mLanguagePref) {
-            mSiteSettings.setLanguageCode(newValue.toString());
+            if (!mSiteSettings.setLanguageCode(newValue.toString())) {
+                ToastUtils.showToast(getActivity(), R.string.site_settings_unknown_language_code_error);
+            }
             changeLanguageValue(mSiteSettings.getLanguageCode());
         } else if (preference == mPrivacyPref) {
             mSiteSettings.setPrivacy(Integer.valueOf(newValue.toString()));

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -464,9 +464,12 @@ public abstract class SiteSettingsInterface {
         mSettings.privacy = privacy;
     }
 
-    public void setLanguageCode(String languageCode) {
+    public boolean setLanguageCode(String languageCode) {
+        if (!mLanguageCodes.containsKey(languageCode) ||
+            TextUtils.isEmpty(mLanguageCodes.get(languageCode))) return false;
         mSettings.language = languageCode;
         mSettings.languageId = Integer.valueOf(mLanguageCodes.get(languageCode));
+        return true;
     }
 
     public void setLanguageId(int languageId) {

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -179,6 +179,7 @@
         <item>de</item>
         <item>el</item>
         <item>es</item>
+        <item>es_CL</item>
         <item>fr</item>
         <item>gd</item>
         <item>hi</item>
@@ -187,7 +188,6 @@
         <item>it</item>
         <item>ja</item>
         <item>ko</item>
-        <item>nb</item>
         <item>nl</item>
         <item>pl</item>
         <item>ru</item>
@@ -196,7 +196,6 @@
         <item>uz</item>
         <item>zh_CN</item>
         <item>zh_TW</item>
-        <item>zh_HK</item>
         <item>en_GB</item>
         <item>tr</item>
         <item>eu</item>
@@ -205,20 +204,25 @@
         <item>ar</item>
         <item>ro</item>
         <item>mk</item>
-        <item>en_AU</item>
         <item>sr</item>
         <item>sk</item>
         <item>cy</item>
         <item>da</item>
+        <item>bg</item>
+        <item>sq</item>
+        <item>hr</item>
+        <item>cs</item>
     </string-array>
 
     <!-- Language IDs for WordPress REST call -->
+    <!-- ref https://wpcom.trac.automattic.com/browser/trunk/.config/locales.php -->
     <string-array name="lang_ids" translatable="false">
         <item>1</item>
         <item>79</item>
         <item>15</item>
         <item>17</item>
         <item>19</item>
+        <item>484</item>
         <item>24</item>
         <item>476</item>
         <item>30</item>
@@ -247,5 +251,9 @@
         <item>64</item>
         <item>13</item>
         <item>14</item>
+        <item>6</item>
+        <item>66</item>
+        <item>431</item>
+        <item>11</item>
     </string-array>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -584,6 +584,7 @@
 
     <!-- Errors -->
     <string name="site_settings_unsupported_version_error">Unsupported WordPress version</string>
+    <string name="site_settings_unknown_language_code_error">Language code not recognized</string>
     <string name="site_settings_disconnected_toast">Disconnected, editing disabled.</string>
 
     <!--               -->

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -50,7 +50,7 @@
             android:id="@+id/pref_site_language"
             android:key="@string/pref_key_site_language"
             android:title="@string/site_settings_language_title"
-            android:entries="@array/available_languages"
+            android:entries="@array/language_codes"
             android:entryValues="@array/language_codes"
             app:longClickHint="@string/site_settings_language_hint" />
 

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -16,7 +16,7 @@ import java.util.NoSuchElementException;
 public class AppLog {
     // T for Tag
     public enum T {READER, EDITOR, MEDIA, NUX, API, STATS, UTILS, NOTIFS, DB, POSTS, COMMENTS, THEMES, TESTS, PROFILING,
-        SIMPERIUM, SUGGESTION, MAIN}
+        SIMPERIUM, SUGGESTION, MAIN, SETTINGS}
     public static final String TAG = "WordPress";
     public static final int HEADER_LINE_COUNT = 2;
 


### PR DESCRIPTION
The [language arrays](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/res/values/key_strings.xml#L201) got out of sync and caused an issue due to an unrecognized language code in the SiteSettingsInterface [language map](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java#L215).

I've updated the arrays and added some runtime checks to prevent an issue like this from causing a crash in the future (if arrays get messed up again).

Really wish we didn't have proprietary language ID's...