### PR TITLE
Reader: don't scan attachments when picking the featured image

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -7,7 +7,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.ui.reader.models.ReaderBlogIdPostId;
-import org.wordpress.android.ui.reader.utils.ImageSizeMap;
 import org.wordpress.android.ui.reader.utils.ReaderImageScanner;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.DateTimeUtils;
@@ -183,13 +182,8 @@ public class ReaderPost {
                 }
             }
         }
-        // if the post still doesn't have a featured image but we have attachment data, check whether
-        // we can find a suitable featured image from the attachments
-        if (!post.hasFeaturedImage() && post.hasAttachments()) {
-            post.featuredImage = new ImageSizeMap(post.attachmentsJson)
-                    .getLargestImageUrl(ReaderConstants.MIN_FEATURED_IMAGE_WIDTH);
-        }
-        // if we *still* don't have a featured image but the text contains an IMG tag, check whether
+
+        // if we still don't have a featured image but the text contains an IMG tag, check whether
         // we can find a suitable image from the text
         if (!post.hasFeaturedImage() && post.hasText() && post.text.contains("<img")) {
             post.featuredImage = new ReaderImageScanner(post.text, post.isPrivate)


### PR DESCRIPTION
Resolves #3664: Previously, the reader would scan attachments to choose a suitable featured image when one wasn't already provided by the author. However, in some cases the post's content won't contain all of the attachments, which leads to possibly choosing a featured image that isn't in the post.

To avoid this situation, we simply skip scanning attachments when choosing a featured image. So now the featured image is either chosen already by the author, or we choose one based on the largest image in the post's content.

cc: @aerych 