### PR TITLE
Limit usernames and passwords to 254 characters

### DIFF
--- a/WordPress/src/main/res/layout/alert_http_auth.xml
+++ b/WordPress/src/main/res/layout/alert_http_auth.xml
@@ -10,10 +10,12 @@
     <EditText android:id="@+id/http_username"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:maxLength="@integer/max_length_username"
         android:hint="@string/httpuser" />
     <EditText android:id="@+id/http_password"
         android:inputType="textPassword"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:maxLength="@integer/max_length_password"
         android:hint="@string/httppassword" />
 </LinearLayout>

--- a/WordPress/src/main/res/layout/blog_preferences.xml
+++ b/WordPress/src/main/res/layout/blog_preferences.xml
@@ -32,6 +32,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/username"
+                android:maxLength="@integer/max_length_username"
                 android:singleLine="true" />
 
             <org.wordpress.android.widgets.OpenSansEditText
@@ -40,6 +41,7 @@
                 android:layout_height="wrap_content"
                 android:hint="@string/password"
                 android:inputType="textPassword"
+                android:maxLength="@integer/max_length_password"
                 android:singleLine="true" />
 
             <org.wordpress.android.widgets.WPTextView
@@ -54,6 +56,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:singleLine="true"
+                android:maxLength="@integer/max_length_username"
                 android:hint="@string/httpuser" />
 
             <org.wordpress.android.widgets.OpenSansEditText
@@ -62,6 +65,7 @@
                 android:layout_height="wrap_content"
                 android:inputType="textPassword"
                 android:singleLine="true"
+                android:maxLength="@integer/max_length_password"
                 android:hint="@string/httppassword" />
         </LinearLayout>
 

--- a/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
+++ b/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
@@ -114,6 +114,7 @@
             android:layout_height="wrap_content"
             android:textSize="@dimen/text_sz_large"
             android:hint="@string/post_password"
+            android:maxLength="@integer/max_length_password"
             android:inputType="textPassword" />
 
         <ViewStub

--- a/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
+++ b/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
@@ -88,6 +88,7 @@
                     style="@style/WordPress.NUXEditText"
                     android:inputType="textUri"
                     android:hint="@string/username"
+                    android:maxLength="@integer/max_length_username"
                     app:persistenceEnabled="true"/>
 
                 <ImageView
@@ -116,6 +117,7 @@
                     android:inputType="textPassword"
                     style="@style/WordPress.NUXEditText"
                     android:hint="@string/password"
+                    android:maxLength="@integer/max_length_password"
                     android:layout_marginRight="38dp"/>
 
                 <ImageView

--- a/WordPress/src/main/res/layout/signin_fragment.xml
+++ b/WordPress/src/main/res/layout/signin_fragment.xml
@@ -99,6 +99,7 @@
                     android:inputType="textEmailAddress"
                     android:imeOptions="actionNext"
                     android:nextFocusDown="@+id/nux_password"
+                    android:maxLength="@integer/max_length_username"
                     app:persistenceEnabled="true" />
 
                 <ImageView
@@ -128,6 +129,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginRight="38dp"
                     android:hint="@string/password"
+                    android:maxLength="@integer/max_length_password"
                     android:inputType="textPassword" />
 
                 <ImageView

--- a/WordPress/src/main/res/values/integers.xml
+++ b/WordPress/src/main/res/values/integers.xml
@@ -8,8 +8,12 @@
     <integer name="isSW600DP">0</integer>
     <integer name="smallest_width_dp">320</integer>
 
-    <!-- max #chars user can type when adding a new topic to the native reader -->
-    <integer name="reader_max_length_topic_name">96</integer>
+    <!-- max #chars user can type when adding a new topic to the reader -->
+    <integer name="max_length_reader_topic_name">96</integer>
+
+    <!-- max #chars for usernames and passwords -->
+    <integer name="max_length_username">254</integer>
+    <integer name="max_length_password">254</integer>
 
     <!-- MediaPicker -->
     <integer name="num_media_columns">2</integer>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -85,7 +85,7 @@
         <item name="android:inputType">text</item>
         <item name="android:singleLine">true</item>
         <item name="android:imeOptions">actionDone</item>
-        <item name="android:maxLength">@integer/reader_max_length_topic_name</item>
+        <item name="android:maxLength">@integer/max_length_reader_topic_name</item>
     </style>
 
     <!-- images -->

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -67,6 +67,7 @@
             android:key="@string/pref_key_site_username"
             android:title="@string/site_settings_username_title"
             android:enabled="false"
+            android:maxLength="@integer/max_length_username"
             app:summaryLines="1"
             app:maxSummaryLines="2"
             app:longClickHint="@string/site_settings_username_hint" />
@@ -77,6 +78,7 @@
             android:title="@string/site_settings_password_title"
             android:enabled="false"
             android:inputType="textPassword"
+            android:maxLength="@integer/max_length_password"
             app:summaryLines="1"
             app:maxSummaryLines="2"
             app:longClickHint="@string/site_settings_password_hint" />


### PR DESCRIPTION
Resolves #3637 - all username and password EditTexts now have a `maxLength` of 254.