### PR TITLE
Feature/58 filter comments by status rest api

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/CommentTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/CommentTable.java
@@ -10,6 +10,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.WordPressDB;
 import org.wordpress.android.models.Comment;
 import org.wordpress.android.models.CommentList;
+import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.SqlUtils;
 import org.wordpress.android.util.StringUtils;
@@ -134,6 +135,33 @@ public class CommentTable {
         String[] args = {Integer.toString(localBlogId)};
         Cursor c = getReadableDb().rawQuery(
                 "SELECT * FROM " + COMMENTS_TABLE + " WHERE blog_id=? ORDER BY published DESC", args);
+
+        try {
+            if (c.moveToFirst()) {
+                do {
+                    Comment comment = getCommentFromCursor(c);
+                    comments.add(comment);
+                } while (c.moveToNext());
+            }
+
+            return comments;
+        } finally {
+            SqlUtils.closeCursor(c);
+        }
+    }
+
+    /**
+     * get comments for a blog that have a specific status
+     * @param localBlogId - unique id in account table for this blog
+     * @param filter - status to filter comments by
+     * @return list of comments for this blog
+     */
+    public static CommentList getCommentsForBlogWithFilter(int localBlogId, CommentStatus filter) {
+        CommentList comments = new CommentList();
+
+        String[] args = {Integer.toString(localBlogId), CommentStatus.toString(filter)};
+        Cursor c = getReadableDb().rawQuery(
+                "SELECT * FROM " + COMMENTS_TABLE + " WHERE blog_id=? AND status=? ORDER BY published DESC", args);
 
         try {
             if (c.moveToFirst()) {

--- a/WordPress/src/main/java/org/wordpress/android/datasets/CommentTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/CommentTable.java
@@ -159,9 +159,11 @@ public class CommentTable {
     public static CommentList getCommentsForBlogWithFilter(int localBlogId, CommentStatus filter) {
         CommentList comments = new CommentList();
 
-        String[] args = {Integer.toString(localBlogId), CommentStatus.toString(filter)};
+        //we need to get the filter values for both XMLrpc and REST api as in the case of a migration where existing data is present on a device,
+        // we still need to be able to filter both values
+        String[] args = {Integer.toString(localBlogId), CommentStatus.toString(filter), CommentStatus.toRESTString(filter)};
         Cursor c = getReadableDb().rawQuery(
-                "SELECT * FROM " + COMMENTS_TABLE + " WHERE blog_id=? AND status=? ORDER BY published DESC", args);
+                "SELECT * FROM " + COMMENTS_TABLE + " WHERE blog_id=? AND (status=? OR status=?)  ORDER BY published DESC", args);
 
         try {
             if (c.moveToFirst()) {

--- a/WordPress/src/main/java/org/wordpress/android/models/CommentList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/CommentList.java
@@ -1,5 +1,10 @@
 package org.wordpress.android.models;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.wordpress.android.WordPress;
+
 import java.util.ArrayList;
 
 public class CommentList extends ArrayList<Comment> {
@@ -86,4 +91,19 @@ public class CommentList extends ArrayList<Comment> {
 
         return true;
     }
+
+    public static CommentList fromJSONV1_1(JSONObject object) throws JSONException {
+        CommentList commentList = new CommentList();
+        if (object == null) {
+            return null;
+        } else {
+            JSONArray comments = (JSONArray) object.getJSONArray("comments");
+            for (int i=0; i < comments.length(); i++){
+                JSONObject commentJson = comments.getJSONObject(i);
+                commentList.add(Comment.fromJSON(commentJson));
+            }
+            return commentList;
+        }
+    }
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/CommentStatus.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/CommentStatus.java
@@ -1,11 +1,24 @@
 package org.wordpress.android.models;
 
+import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+
 public enum CommentStatus {
-    UNKNOWN,
-    UNAPPROVED,
-    APPROVED,
-    TRASH,  // <-- REST only
-    SPAM;
+    UNKNOWN(R.string.unknown),
+    UNAPPROVED(R.string.comment_status_unapproved),
+    APPROVED(R.string.comment_status_approved),
+    TRASH(R.string.comment_status_trash),  // <-- REST only
+    SPAM(R.string.comment_status_spam);
+
+    private final int mLabelResId;
+
+    CommentStatus(int labelResId) {
+        mLabelResId = labelResId;
+    }
+
+    public String getLabel() {
+        return WordPress.getContext().getString(mLabelResId);
+    }
 
     /*
      * returns the string representation of the passed status, as used by the XMLRPC API

--- a/WordPress/src/main/java/org/wordpress/android/models/CommentStatus.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/CommentStatus.java
@@ -54,7 +54,7 @@ public enum CommentStatus {
             case TRASH:
                 return "trash";
             default:
-                return "";
+                return "all";
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/models/CommentStatus.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/CommentStatus.java
@@ -24,6 +24,10 @@ public enum CommentStatus {
      * returns the string representation of the passed status, as used by the XMLRPC API
      */
     public static String toString(CommentStatus status) {
+        if (status == null){
+            return "";
+        }
+
         switch (status) {
             case UNAPPROVED:
                 return "hold";

--- a/WordPress/src/main/java/org/wordpress/android/models/CommentStatus.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/CommentStatus.java
@@ -4,7 +4,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 
 public enum CommentStatus {
-    UNKNOWN(R.string.unknown),
+    UNKNOWN(R.string.comment_status_all),
     UNAPPROVED(R.string.comment_status_unapproved),
     APPROVED(R.string.comment_status_approved),
     TRASH(R.string.comment_status_trash),  // <-- REST only

--- a/WordPress/src/main/java/org/wordpress/android/models/CommentStatus.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/CommentStatus.java
@@ -7,7 +7,7 @@ public enum CommentStatus {
     UNKNOWN(R.string.comment_status_all),
     UNAPPROVED(R.string.comment_status_unapproved),
     APPROVED(R.string.comment_status_approved),
-    TRASH(R.string.comment_status_trash),  // <-- REST only
+    TRASH(R.string.comment_status_trash),
     SPAM(R.string.comment_status_spam);
 
     private final int mLabelResId;
@@ -35,6 +35,8 @@ public enum CommentStatus {
                 return "approve";
             case SPAM:
                 return "spam";
+            case TRASH:
+                return "trash";
             default:
                 return "";
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
@@ -403,8 +403,8 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         }
         @Override
         protected Boolean doInBackground(Void... params) {
-            if (mStatusFilter != null && mStatusFilter.equals(CommentStatus.UNKNOWN) || mStatusFilter == null){
-                tmpComments = CommentTable.getCommentsForBlog(mLocalBlogId);
+            if (mStatusFilter == null){
+                tmpComments = CommentTable.getCommentsForBlogWithFilter(mLocalBlogId, CommentStatus.UNKNOWN);
             } else {
                 tmpComments = CommentTable.getCommentsForBlogWithFilter(mLocalBlogId, mStatusFilter);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
@@ -15,6 +15,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.datasets.CommentTable;
 import org.wordpress.android.models.Comment;
 import org.wordpress.android.models.CommentList;
+import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DateTimeUtils;
@@ -371,11 +372,11 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     /*
      * load comments using an AsyncTask
      */
-    void loadComments() {
+    void loadComments(CommentStatus statusFilter) {
         if (mIsLoadTaskRunning) {
             AppLog.w(AppLog.T.COMMENTS, "load comments task already active");
         } else {
-            new LoadCommentsTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+            new LoadCommentsTask(statusFilter).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
         }
     }
 
@@ -385,6 +386,12 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     private boolean mIsLoadTaskRunning = false;
     private class LoadCommentsTask extends AsyncTask<Void, Void, Boolean> {
         CommentList tmpComments;
+        CommentStatus mStatusFilter;
+
+        public LoadCommentsTask (CommentStatus statusFilter){
+            mStatusFilter = statusFilter;
+        }
+
         @Override
         protected void onPreExecute() {
             mIsLoadTaskRunning = true;
@@ -395,7 +402,12 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         }
         @Override
         protected Boolean doInBackground(Void... params) {
-            tmpComments = CommentTable.getCommentsForBlog(mLocalBlogId);
+            if (mStatusFilter != null && mStatusFilter.equals(CommentStatus.UNKNOWN) || mStatusFilter == null){
+                tmpComments = CommentTable.getCommentsForBlog(mLocalBlogId);
+            } else {
+                tmpComments = CommentTable.getCommentsForBlogWithFilter(mLocalBlogId, mStatusFilter);
+            }
+
             if (mComments.isSameList(tmpComments)) {
                 return false;
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
@@ -359,6 +359,16 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     }
 
     /*
+     * clear all comments
+     */
+    void clearComments() {
+        if (mComments != null){
+            mComments.clear();
+            notifyDataSetChanged();
+        }
+    }
+
+    /*
      * load comments using an AsyncTask
      */
     void loadComments() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
@@ -212,7 +212,8 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         }
 
         // request to load more comments when we near the end
-        if (mOnLoadMoreListener != null && position >= getItemCount()-1) {
+        if (mOnLoadMoreListener != null && position >= getItemCount()-1
+                && position >= CommentsListFragment.COMMENTS_PER_PAGE - 1) {
             mOnLoadMoreListener.onLoadMore();
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -120,7 +120,7 @@ public class CommentsActivity extends AppCompatActivity
                         return;
                     }
 
-                    AppLog.d(AppLog.T.STATS, "NEW STATUS : " + selectedCommentStatus.getLabel());
+                    AppLog.d(AppLog.T.COMMENTS, "NEW STATUS : " + selectedCommentStatus.getLabel());
                     mCurrentCommentStatusType = selectedCommentStatus;
                     AppPrefs.setCommentsStatusFilter(mCurrentCommentStatusType);
                     updateCommentList();

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -48,8 +48,8 @@ public class CommentsActivity extends AppCompatActivity
     private long mSelectedCommentId;
     private final CommentList mTrashedComments = new CommentList();
 
-    private final CommentStatus[] commentStatuses = {CommentStatus.UNKNOWN, CommentStatus.UNAPPROVED, CommentStatus.APPROVED, CommentStatus.TRASH,
-            CommentStatus.SPAM};
+    private final CommentStatus[] commentStatuses = {CommentStatus.UNKNOWN, CommentStatus.UNAPPROVED,
+            CommentStatus.APPROVED, CommentStatus.TRASH, CommentStatus.SPAM};
     private Spinner mSpinner;
     private CommentsStatusSpinnerAdapter mCommentsStatusSpinnerAdapter;
     private CommentStatus mCurrentCommentStatusType = CommentStatus.UNKNOWN;
@@ -111,10 +111,12 @@ public class CommentsActivity extends AppCompatActivity
                         return;
                     }
 
-                    final CommentStatus selectedCommentStatus =  (CommentStatus) mCommentsStatusSpinnerAdapter.getItem(position);
+                    final CommentStatus selectedCommentStatus =
+                            (CommentStatus) mCommentsStatusSpinnerAdapter.getItem(position);
 
                     if (mCurrentCommentStatusType == selectedCommentStatus) {
-                        AppLog.d(AppLog.T.COMMENTS, "The selected STATUS is already active: " + selectedCommentStatus.getLabel());
+                        AppLog.d(AppLog.T.COMMENTS, "The selected STATUS is already active: " +
+                                selectedCommentStatus.getLabel());
                         return;
                     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -48,7 +48,7 @@ public class CommentsActivity extends AppCompatActivity
     private long mSelectedCommentId;
     private final CommentList mTrashedComments = new CommentList();
 
-    private final CommentStatus[] commentStatuses = {CommentStatus.UNKNOWN, CommentStatus.UNAPPROVED, CommentStatus.APPROVED, //CommentStatus.TRASH,
+    private final CommentStatus[] commentStatuses = {CommentStatus.UNKNOWN, CommentStatus.UNAPPROVED, CommentStatus.APPROVED, CommentStatus.TRASH,
             CommentStatus.SPAM};
     private Spinner mSpinner;
     private CommentsStatusSpinnerAdapter mCommentsStatusSpinnerAdapter;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -15,7 +15,6 @@ import android.view.View;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
-import org.wordpress.android.models.BlogPairId;
 import org.wordpress.android.models.Comment;
 import org.wordpress.android.models.CommentList;
 import org.wordpress.android.models.CommentStatus;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -48,7 +48,7 @@ public class CommentsActivity extends AppCompatActivity
     private long mSelectedCommentId;
     private final CommentList mTrashedComments = new CommentList();
 
-    private final CommentStatus[] commentStatuses = {CommentStatus.UNKNOWN, CommentStatus.UNAPPROVED, CommentStatus.APPROVED, CommentStatus.TRASH,
+    private final CommentStatus[] commentStatuses = {CommentStatus.UNKNOWN, CommentStatus.UNAPPROVED, CommentStatus.APPROVED, //CommentStatus.TRASH,
             CommentStatus.SPAM};
     private Spinner mSpinner;
     private CommentsStatusSpinnerAdapter mCommentsStatusSpinnerAdapter;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
+import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.LayoutInflater;
@@ -59,9 +60,11 @@ public class CommentsActivity extends AppCompatActivity
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
-        getSupportActionBar().setDisplayShowTitleEnabled(true);
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-        getSupportActionBar().setTitle(getString(R.string.tab_comments));
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayShowTitleEnabled(false);
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
 
         if (savedInstanceState == null) {
             Fragment commentsListFragment = new CommentsListFragment();

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -31,6 +31,7 @@ import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.comments.CommentsListFragment.OnCommentSelectedListener;
 import org.wordpress.android.ui.notifications.NotificationFragment;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ToastUtils;
@@ -43,6 +44,7 @@ public class CommentsActivity extends AppCompatActivity
     private static final String KEY_SELECTED_COMMENT_ID = "selected_comment_id";
     static final String KEY_AUTO_REFRESHED = "has_auto_refreshed";
     static final String KEY_EMPTY_VIEW_MESSAGE = "empty_view_message";
+    static final String SAVED_COMMENTS_STATUS_TYPE = "saved_comments_status_type";
     private long mSelectedCommentId;
     private final CommentList mTrashedComments = new CommentList();
 
@@ -64,6 +66,13 @@ public class CommentsActivity extends AppCompatActivity
         if (actionBar != null) {
             actionBar.setDisplayShowTitleEnabled(false);
             actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+
+        if (getIntent() != null && getIntent().hasExtra(SAVED_COMMENTS_STATUS_TYPE)) {
+            mCurrentCommentStatusType = (CommentStatus) getIntent().getSerializableExtra(SAVED_COMMENTS_STATUS_TYPE);
+        } else {
+            // Read the value from app preferences here. Default to 0 - All
+            mCurrentCommentStatusType = AppPrefs.getCommentsStatusFilter();
         }
 
         if (savedInstanceState == null) {
@@ -101,7 +110,7 @@ public class CommentsActivity extends AppCompatActivity
 
                     AppLog.d(AppLog.T.STATS, "NEW STATUS : " + selectedCommentStatus.getLabel());
                     mCurrentCommentStatusType = selectedCommentStatus;
-                    //AppPrefs.setCommentStatus(mCurrentCommentStatusType);
+                    AppPrefs.setCommentsStatusFilter(mCurrentCommentStatusType);
                     //updateCommentList();
 
                     //trackCommentsAnalytics();

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -4,14 +4,21 @@ import android.app.Dialog;
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.BaseAdapter;
+import android.widget.Spinner;
+import android.widget.TextView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -38,6 +45,12 @@ public class CommentsActivity extends AppCompatActivity
     private long mSelectedCommentId;
     private final CommentList mTrashedComments = new CommentList();
 
+    private final CommentStatus[] commentStatuses = {CommentStatus.UNKNOWN, CommentStatus.UNAPPROVED, CommentStatus.APPROVED, CommentStatus.TRASH,
+            CommentStatus.SPAM};
+    private Spinner mSpinner;
+    private CommentsStatusSpinnerAdapter mCommentsStatusSpinnerAdapter;
+    private CommentStatus mCurrentCommentStatusType = CommentStatus.UNKNOWN;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -62,6 +75,43 @@ public class CommentsActivity extends AppCompatActivity
 
             mSelectedCommentId = savedInstanceState.getLong(KEY_SELECTED_COMMENT_ID);
         }
+
+        if (mSpinner == null && toolbar != null) {
+            View view = View.inflate(this, R.layout.toolbar_spinner, toolbar);
+            mSpinner = (Spinner) view.findViewById(R.id.action_bar_spinner);
+
+            mCommentsStatusSpinnerAdapter = new CommentsStatusSpinnerAdapter(this, commentStatuses);
+
+            mSpinner.setAdapter(mCommentsStatusSpinnerAdapter);
+            mSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+                @Override
+                public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                    if (isFinishing()) {
+                        return;
+                    }
+                    final CommentStatus selectedCommentStatus =  (CommentStatus) mCommentsStatusSpinnerAdapter.getItem(position);
+
+                    if (mCurrentCommentStatusType == selectedCommentStatus) {
+                        AppLog.d(AppLog.T.COMMENTS, "The selected STATUS is already active: " + selectedCommentStatus.getLabel());
+                        return;
+                    }
+
+                    AppLog.d(AppLog.T.STATS, "NEW STATUS : " + selectedCommentStatus.getLabel());
+                    mCurrentCommentStatusType = selectedCommentStatus;
+                    //AppPrefs.setCommentStatus(mCurrentCommentStatusType);
+                    //updateCommentList();
+
+                    //trackCommentsAnalytics();
+                }
+                @Override
+                public void onNothingSelected(AdapterView<?> parent) {
+                    // nop
+                }
+            });
+        }
+
+        selectCurrentCommentStatusTypeInActionBar();
+
     }
 
     @Override
@@ -318,5 +368,105 @@ public class CommentsActivity extends AppCompatActivity
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    /*
+    * make sure the passed comment status type is the one selected in the actionbar
+    */
+    private void selectCurrentCommentStatusTypeInActionBar() {
+        if (isFinishing()) {
+            return;
+        }
+
+        if (mCommentsStatusSpinnerAdapter == null || mSpinner == null) {
+            return;
+        }
+
+        int position = mCommentsStatusSpinnerAdapter.getIndexOfCommentStatus(mCurrentCommentStatusType);
+
+        if (position > -1 && position != mSpinner.getSelectedItemPosition()) {
+            mSpinner.setSelection(position);
+        }
+    }
+
+    /*
+     * adapter used by the comments status spinner
+     */
+    private class CommentsStatusSpinnerAdapter extends BaseAdapter {
+        private final CommentStatus[] mStatuses;
+        private final LayoutInflater mInflater;
+
+        CommentsStatusSpinnerAdapter(Context context, CommentStatus[] statusesNames) {
+            super();
+            mInflater = (LayoutInflater)context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            mStatuses = statusesNames;
+        }
+
+        @Override
+        public int getCount() {
+            return (mStatuses != null ? mStatuses.length : 0);
+        }
+
+        @Override
+        public Object getItem(int position) {
+            if (position < 0 || position >= getCount())
+                return "";
+            return mStatuses[position];
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            final View view;
+            if (convertView == null) {
+                view = mInflater.inflate(R.layout.toolbar_spinner_item, parent, false);
+            } else {
+                view = convertView;
+            }
+
+            final TextView text = (TextView) view.findViewById(R.id.text);
+            CommentStatus selectedTimeframe = (CommentStatus)getItem(position);
+            text.setText(selectedTimeframe.getLabel());
+            return view;
+        }
+
+        @Override
+        public View getDropDownView(int position, View convertView, ViewGroup parent) {
+            CommentStatus selectedTimeframe = (CommentStatus)getItem(position);
+            final TagViewHolder holder;
+
+            if (convertView == null) {
+                convertView = mInflater.inflate(R.layout.toolbar_spinner_dropdown_item, parent, false);
+                holder = new TagViewHolder(convertView);
+                convertView.setTag(holder);
+            } else {
+                holder = (TagViewHolder) convertView.getTag();
+            }
+
+            holder.textView.setText(selectedTimeframe.getLabel());
+            return convertView;
+        }
+
+        private class TagViewHolder {
+            private final TextView textView;
+            TagViewHolder(View view) {
+                textView = (TextView) view.findViewById(R.id.text);
+            }
+        }
+
+        public int getIndexOfCommentStatus(CommentStatus tm) {
+            int pos = 0;
+            for (int i = 0; i < mStatuses.length; i++) {
+                if (mStatuses[i] == tm) {
+                    pos = i;
+                    return pos;
+                }
+            }
+            return pos;
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -53,6 +53,7 @@ public class CommentsActivity extends AppCompatActivity
     private Spinner mSpinner;
     private CommentsStatusSpinnerAdapter mCommentsStatusSpinnerAdapter;
     private CommentStatus mCurrentCommentStatusType = CommentStatus.UNKNOWN;
+    private boolean mSelectingRememeberedStatusTypeOnCreate = false;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -96,6 +97,7 @@ public class CommentsActivity extends AppCompatActivity
 
             mCommentsStatusSpinnerAdapter = new CommentsStatusSpinnerAdapter(this, commentStatuses);
 
+            mSelectingRememeberedStatusTypeOnCreate = true;
             mSpinner.setAdapter(mCommentsStatusSpinnerAdapter);
             mSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
                 @Override
@@ -103,6 +105,12 @@ public class CommentsActivity extends AppCompatActivity
                     if (isFinishing()) {
                         return;
                     }
+
+                    if (mSelectingRememeberedStatusTypeOnCreate){
+                        mSelectingRememeberedStatusTypeOnCreate = false;
+                        return;
+                    }
+
                     final CommentStatus selectedCommentStatus =  (CommentStatus) mCommentsStatusSpinnerAdapter.getItem(position);
 
                     if (mCurrentCommentStatusType == selectedCommentStatus) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -76,7 +76,9 @@ public class CommentsActivity extends AppCompatActivity
         }
 
         if (savedInstanceState == null) {
-            Fragment commentsListFragment = new CommentsListFragment();
+            CommentsListFragment commentsListFragment = new CommentsListFragment();
+            // initialize comment status filter first time
+            commentsListFragment.setCommentStatusFilter(mCurrentCommentStatusType);
             getFragmentManager().beginTransaction()
                     .add(R.id.layout_fragment_container, commentsListFragment, getString(R.string
                             .fragment_tag_comment_list))
@@ -111,7 +113,7 @@ public class CommentsActivity extends AppCompatActivity
                     AppLog.d(AppLog.T.STATS, "NEW STATUS : " + selectedCommentStatus.getLabel());
                     mCurrentCommentStatusType = selectedCommentStatus;
                     AppPrefs.setCommentsStatusFilter(mCurrentCommentStatusType);
-                    //updateCommentList();
+                    updateCommentList();
 
                     //trackCommentsAnalytics();
                 }
@@ -244,6 +246,7 @@ public class CommentsActivity extends AppCompatActivity
         CommentsListFragment listFragment = getListFragment();
         if (listFragment != null) {
             listFragment.setRefreshing(true);
+            listFragment.setCommentStatusFilter(mCurrentCommentStatusType);
             listFragment.updateComments(false);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -225,6 +225,7 @@ public class CommentsListFragment extends Fragment {
                         updateComments(false);
                     }
                 });
+
         return view;
     }
 
@@ -661,4 +662,5 @@ public class CommentsListFragment extends Fragment {
             mActionMode = null;
         }
     }
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -66,7 +66,7 @@ public class CommentsListFragment extends Fragment {
     private EmptyViewMessageType mEmptyViewMessageType = EmptyViewMessageType.NO_CONTENT;
     private CommentStatus mCommentStatusFilter;
 
-    private static final String COMMENTS_PER_PAGE = "30";
+    public static final int COMMENTS_PER_PAGE = 30;
 
     private CommentAdapter getAdapter() {
         if (mAdapter == null) {
@@ -406,9 +406,9 @@ public class CommentsListFragment extends Fragment {
         if (loadMore) {
             int numExisting = getAdapter().getItemCount();
             params.put("offset", Integer.toString(numExisting));
-            params.put("number", COMMENTS_PER_PAGE);
+            params.put("number", Integer.toString(COMMENTS_PER_PAGE));
         } else {
-            params.put("number", COMMENTS_PER_PAGE);
+            params.put("number", Integer.toString(COMMENTS_PER_PAGE));
         }
 
         if (mCommentStatusFilter != null){

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -19,24 +19,29 @@ import android.view.ViewGroup;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import com.android.volley.VolleyError;
+import com.wordpress.rest.RestRequest;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.datasets.CommentTable;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.models.Comment;
 import org.wordpress.android.models.CommentList;
 import org.wordpress.android.models.CommentStatus;
+import org.wordpress.android.networking.RestClientUtils;
 import org.wordpress.android.ui.EmptyViewMessageType;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.VolleyUtils;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper.RefreshListener;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 import org.wordpress.android.widgets.RecyclerItemDecoration;
-import org.xmlrpc.android.ApiHelper;
-import org.xmlrpc.android.ApiHelper.ErrorType;
-import org.xmlrpc.android.XMLRPCFault;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -50,7 +55,6 @@ public class CommentsListFragment extends Fragment {
     private boolean mIsUpdatingComments = false;
     private boolean mCanLoadMoreComments = true;
     boolean mHasAutoRefreshedComments = false;
-    private boolean mHasCheckedDeletedComments = false;
 
     private ProgressBar mProgressLoadMore;
     private SwipeToRefreshHelper mSwipeToRefreshHelper;
@@ -61,9 +65,7 @@ public class CommentsListFragment extends Fragment {
     private EmptyViewMessageType mEmptyViewMessageType = EmptyViewMessageType.NO_CONTENT;
     private CommentStatus mCommentStatusFilter;
 
-    private UpdateCommentsTask mUpdateCommentsTask;
-
-    private static final int COMMENTS_PER_PAGE = 30;
+    private static final String COMMENTS_PER_PAGE = "30";
 
     private CommentAdapter getAdapter() {
         if (mAdapter == null) {
@@ -369,7 +371,7 @@ public class CommentsListFragment extends Fragment {
      * get latest comments from server, or pass loadMore=true to get comments beyond the
      * existing ones
      */
-    void updateComments(boolean loadMore) {
+    void updateComments(final boolean loadMore) {
         if (mIsUpdatingComments) {
             AppLog.w(AppLog.T.COMMENTS, "update comments task already running");
             return;
@@ -383,8 +385,110 @@ public class CommentsListFragment extends Fragment {
 
         updateEmptyView(EmptyViewMessageType.LOADING);
 
-        mUpdateCommentsTask = new UpdateCommentsTask(loadMore, mCommentStatusFilter);
-        mUpdateCommentsTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        mIsUpdatingComments = true;
+        if (loadMore) {
+            showLoadingProgress();
+        }
+
+        if (!isAdded()) {
+            //return null;
+            return;
+        }
+
+        final Blog blog = WordPress.getCurrentBlog();
+        if (blog == null) {
+//            mErrorType = ErrorType.INVALID_CURRENT_BLOG;
+//            return null;
+            return;
+        }
+
+        Map<String, String> params = new HashMap<>();
+        if (loadMore) {
+            int numExisting = getAdapter().getItemCount();
+            params.put("offset", Integer.toString(numExisting));
+            params.put("number", COMMENTS_PER_PAGE);
+        } else {
+            params.put("number", COMMENTS_PER_PAGE);
+        }
+
+        if (mCommentStatusFilter != null){
+            //if this is UNKNOWN that means show ALL, i.e., do not apply filter
+            if (!mCommentStatusFilter.equals(CommentStatus.UNKNOWN)){
+                params.put("status", CommentStatus.toRESTString(mCommentStatusFilter));
+            }
+        }
+
+        WordPress.getRestClientUtilsV1_1().getComments(String.valueOf(blog.getRemoteBlogId()), params,
+                new RestClientUtils.FluxProxyListener<CommentList>() {
+                    @Override
+                    public CommentList onSave(JSONObject response) {
+                        AppLog.d(AppLog.T.API, "Received onSave signal to Categories REST request.");
+                        CommentList comments = null;
+                        try {
+                            comments = CommentList.fromJSONV1_1(response);
+                            if (comments != null){
+                                int localBlogId = blog.getLocalTableBlogId();
+                                CommentTable.saveComments(localBlogId, comments);
+                            }
+                        } catch (JSONException ex){
+                            AppLog.d(AppLog.T.API, "Error parsing WP.com comments:" + ex.getMessage());
+                            ToastUtils.showToast(getActivity(), getString(R.string.error_refresh_comments));
+                            updateEmptyView(EmptyViewMessageType.GENERIC_ERROR);
+                            return null;
+                        }
+
+                        return comments;
+                    }
+
+                    @Override
+                    public void onDataReady(CommentList comments) {
+                        AppLog.d(AppLog.T.API, "Received onDataReady signal to Categories REST request.");
+
+                        boolean isRefreshing = mSwipeToRefreshHelper.isRefreshing();
+                        mIsUpdatingComments = false;
+
+                        if (!isAdded()) return;
+
+                        if (loadMore) {
+                            hideLoadingProgress();
+                        }
+                        mSwipeToRefreshHelper.setRefreshing(false);
+
+                        mCanLoadMoreComments = (comments != null && comments.size() > 0);
+
+                        if (!getActivity().isFinishing()) {
+                            if (comments != null && comments.size() > 0) {
+                                getAdapter().loadComments(mCommentStatusFilter);
+                            } else {
+                                if (isRefreshing){
+                                    //if refreshing and no errors, we only want freshest stuff, so clear old data
+                                    getAdapter().clearComments();
+                                }
+                                updateEmptyView(EmptyViewMessageType.NO_CONTENT);
+                            }
+                        }
+                    }
+                }, new RestClientUtils.FluxProxyErrorListener(){
+                    @Override
+                    public void onErrorResponse(VolleyError error) {
+                        mSwipeToRefreshHelper.setRefreshing(false);
+                        AppLog.e(AppLog.T.COMMENTS, VolleyUtils.errStringFromVolleyError(error), error);
+                        int statusCode = VolleyUtils.statusCodeFromVolleyError(error);
+                        switch (statusCode){
+                            case 401:
+                                if (mEmptyView == null || mEmptyView.getVisibility() != View.VISIBLE) {
+                                    ToastUtils.showToast(getActivity(), getString(R.string.error_refresh_unauthorized_comments));
+                                }
+                                updateEmptyView(EmptyViewMessageType.PERMISSION_ERROR);
+                                break;
+                            default:
+                                ToastUtils.showToast(getActivity(), getString(R.string.error_refresh_comments));
+                                updateEmptyView(EmptyViewMessageType.GENERIC_ERROR);
+                                break;
+                        }
+                    }
+                });
+
     }
 
     public void setCommentIsModerating(long commentId, boolean isModerating) {
@@ -397,134 +501,6 @@ public class CommentsListFragment extends Fragment {
         }
     }
 
-    /*
-     * task to retrieve latest comments from server
-     */
-    private class UpdateCommentsTask extends AsyncTask<Void, Void, CommentList> {
-        ErrorType mErrorType = ErrorType.NO_ERROR;
-        final boolean mIsLoadingMore;
-        final CommentStatus mStatusFilter;
-
-        private UpdateCommentsTask(boolean loadMore, CommentStatus statusfilter) {
-            mIsLoadingMore = loadMore;
-            mStatusFilter = statusfilter;
-        }
-
-        @Override
-        protected void onPreExecute() {
-            super.onPreExecute();
-            mIsUpdatingComments = true;
-            if (mIsLoadingMore) {
-                showLoadingProgress();
-            }
-        }
-
-        @Override
-        protected void onCancelled() {
-            super.onCancelled();
-            mIsUpdatingComments = false;
-            mUpdateCommentsTask = null;
-            mSwipeToRefreshHelper.setRefreshing(false);
-        }
-
-        @Override
-        protected CommentList doInBackground(Void... args) {
-            if (!isAdded()) {
-                return null;
-            }
-
-            Blog blog = WordPress.getCurrentBlog();
-            if (blog == null) {
-                mErrorType = ErrorType.INVALID_CURRENT_BLOG;
-                return null;
-            }
-
-            // the first time this is called, make sure comments deleted on server are removed
-            // from the local database
-            if (!mHasCheckedDeletedComments && !mIsLoadingMore) {
-                mHasCheckedDeletedComments = true;
-                ApiHelper.removeDeletedComments(blog);
-            }
-
-            Map<String, Object> hPost = new HashMap<>();
-            if (mIsLoadingMore) {
-                int numExisting = getAdapter().getItemCount();
-                hPost.put("offset", numExisting);
-                hPost.put("number", COMMENTS_PER_PAGE);
-            } else {
-                hPost.put("number", COMMENTS_PER_PAGE);
-            }
-
-            if (mStatusFilter != null){
-                //if this is UNKNOWN that means show ALL, i.e., do not apply filter
-                if (!mStatusFilter.equals(CommentStatus.UNKNOWN)){
-                    hPost.put("status", CommentStatus.toString(mStatusFilter));
-                }
-            }
-
-            Object[] params = { blog.getRemoteBlogId(),
-                                blog.getUsername(),
-                                blog.getPassword(),
-                                hPost };
-            try {
-                return ApiHelper.refreshComments(blog, params);
-            } catch (XMLRPCFault xmlrpcFault) {
-                mErrorType = ErrorType.UNKNOWN_ERROR;
-                if (xmlrpcFault.getFaultCode() == 401) {
-                    mErrorType = ErrorType.UNAUTHORIZED;
-                }
-            } catch (Exception e) {
-                mErrorType = ErrorType.UNKNOWN_ERROR;
-            }
-            return null;
-        }
-
-        protected void onPostExecute(CommentList comments) {
-
-            boolean isRefreshing = mSwipeToRefreshHelper.isRefreshing();
-            mIsUpdatingComments = false;
-            mUpdateCommentsTask = null;
-
-            if (!isAdded()) return;
-
-            if (mIsLoadingMore) {
-                hideLoadingProgress();
-            }
-            mSwipeToRefreshHelper.setRefreshing(false);
-
-            if (isCancelled()) return;
-
-            mCanLoadMoreComments = (comments != null && comments.size() > 0);
-
-            // result will be null on error OR if no more comments exists
-            if (comments == null && !getActivity().isFinishing() && mErrorType != ErrorType.NO_ERROR) {
-                switch (mErrorType) {
-                    case UNAUTHORIZED:
-                        if (mEmptyView == null || mEmptyView.getVisibility() != View.VISIBLE) {
-                            ToastUtils.showToast(getActivity(), getString(R.string.error_refresh_unauthorized_comments));
-                        }
-                        updateEmptyView(EmptyViewMessageType.PERMISSION_ERROR);
-                        return;
-                    default:
-                        ToastUtils.showToast(getActivity(), getString(R.string.error_refresh_comments));
-                        updateEmptyView(EmptyViewMessageType.GENERIC_ERROR);
-                        return;
-                }
-            }
-
-            if (!getActivity().isFinishing()) {
-                if (comments != null && comments.size() > 0) {
-                    getAdapter().loadComments(mStatusFilter);
-                } else {
-                    if (isRefreshing){
-                        //if refreshing and no errors, we only want freshest stuff, so clear old data
-                        getAdapter().clearComments();
-                    }
-                    updateEmptyView(EmptyViewMessageType.NO_CONTENT);
-                }
-            }
-        }
-    }
 
     @Override
     public void onSaveInstanceState(Bundle outState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -179,7 +179,7 @@ public class CommentsListFragment extends Fragment {
             mEmptyViewMessageType = EmptyViewMessageType.NO_CONTENT;
         }
 
-        if (!NetworkUtils.isNetworkAvailable(getActivity())) {
+        if (!NetworkUtils.checkConnection(getActivity())) {
             updateEmptyView(EmptyViewMessageType.NETWORK_ERROR);
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -235,7 +235,7 @@ public class CommentsListFragment extends Fragment {
         super.onResume();
         if (mRecycler.getAdapter() == null) {
             mRecycler.setAdapter(getAdapter());
-            getAdapter().loadComments();
+            getAdapter().loadComments(mCommentStatusFilter);
         }
     }
 
@@ -362,7 +362,7 @@ public class CommentsListFragment extends Fragment {
         // this is called from CommentsActivity when a comment was changed in the detail view,
         // and the change will already be in SQLite so simply reload the comment adapter
         // to show the change
-        getAdapter().loadComments();
+        getAdapter().loadComments(mCommentStatusFilter);
     }
 
     /*
@@ -456,7 +456,7 @@ public class CommentsListFragment extends Fragment {
             if (mStatusFilter != null){
                 //if this is UNKNOWN that means show ALL, i.e., do not apply filter
                 if (!mStatusFilter.equals(CommentStatus.UNKNOWN)){
-                    hPost.put("status", CommentStatus.toRESTString(mStatusFilter));
+                    hPost.put("status", CommentStatus.toString(mStatusFilter));
                 }
             }
 
@@ -512,7 +512,7 @@ public class CommentsListFragment extends Fragment {
 
             if (!getActivity().isFinishing()) {
                 if (comments != null && comments.size() > 0) {
-                    getAdapter().loadComments();
+                    getAdapter().loadComments(mStatusFilter);
                 } else {
                     if (isRefreshing){
                         //if refreshing and no errors, we only want freshest stuff, so clear old data
@@ -549,7 +549,11 @@ public class CommentsListFragment extends Fragment {
                     stringId = R.string.comments_fetching;
                     break;
                 case NO_CONTENT:
-                    stringId = R.string.comments_empty_list;
+                    if (mCommentStatusFilter != null && mCommentStatusFilter.equals(CommentStatus.UNKNOWN) || mCommentStatusFilter == null){
+                        stringId = R.string.comments_empty_list;
+                    } else {
+                        stringId = R.string.comments_empty_list_filtered;
+                    }
                     break;
                 case NETWORK_ERROR:
                     stringId = R.string.no_network_message;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -376,6 +376,8 @@ public class CommentsListFragment extends Fragment {
         } else if (!NetworkUtils.isNetworkAvailable(getActivity())) {
             updateEmptyView(EmptyViewMessageType.NETWORK_ERROR);
             setRefreshing(false);
+            //we're offline, load/refresh whatever we have in our local db
+            getAdapter().loadComments(mCommentStatusFilter);
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -5,6 +5,7 @@ import android.preference.PreferenceManager;
 import android.text.TextUtils;
 
 import org.wordpress.android.WordPress;
+import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.ActivityId;
@@ -49,6 +50,10 @@ public class AppPrefs {
 
         // Store the number of times Stats are loaded without errors. It's used to show the Widget promo dialog.
         STATS_WIDGET_PROMO_ANALYTICS,
+
+        // index of the last active status type in Comments activity
+        COMMENTS_STATUS_TYPE_INDEX,
+
     }
 
     /**
@@ -179,6 +184,25 @@ public class AppPrefs {
         } else {
             prefs().edit()
                     .remove(DeletablePrefKey.STATS_ITEM_INDEX.name())
+                    .apply();
+        }
+    }
+
+    public static CommentStatus getCommentsStatusFilter() {
+        int idx = getInt(DeletablePrefKey.COMMENTS_STATUS_TYPE_INDEX);
+        CommentStatus[] timeframeValues = CommentStatus.values();
+        if (timeframeValues.length < idx) {
+            return timeframeValues[0];
+        } else {
+            return timeframeValues[idx];
+        }
+    }
+    public static void setCommentsStatusFilter(CommentStatus commentstatus) {
+        if (commentstatus != null) {
+            setInt(DeletablePrefKey.COMMENTS_STATUS_TYPE_INDEX, commentstatus.ordinal());
+        } else {
+            prefs().edit()
+                    .remove(DeletablePrefKey.COMMENTS_STATUS_TYPE_INDEX.name())
                     .apply();
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -190,11 +190,11 @@ public class AppPrefs {
 
     public static CommentStatus getCommentsStatusFilter() {
         int idx = getInt(DeletablePrefKey.COMMENTS_STATUS_TYPE_INDEX);
-        CommentStatus[] timeframeValues = CommentStatus.values();
-        if (timeframeValues.length < idx) {
-            return timeframeValues[0];
+        CommentStatus[] commentStatusValues = CommentStatus.values();
+        if (commentStatusValues.length < idx) {
+            return commentStatusValues[0];
         } else {
-            return timeframeValues[idx];
+            return commentStatusValues[idx];
         }
     }
     public static void setCommentsStatusFilter(CommentStatus commentstatus) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -273,6 +273,7 @@
     <string name="comment_status_unapproved">Pending</string>
     <string name="comment_status_spam">Spam</string>
     <string name="comment_status_trash">Trashed</string>
+    <string name="comment_status_all">All</string>
     <string name="edit_comment">Edit comment</string>
     <string name="comments_empty_list">No comments</string>
     <string name="comment_reply_to_user">Reply to %s</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -276,6 +276,7 @@
     <string name="comment_status_all">All</string>
     <string name="edit_comment">Edit comment</string>
     <string name="comments_empty_list">No comments</string>
+    <string name="comments_empty_list_filtered">No comments with this status found</string>
     <string name="comment_reply_to_user">Reply to %s</string>
     <string name="comment_trashed">Comment trashed</string>
     <string name="comment_spammed">Comment marked as spam</string>

--- a/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
+++ b/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
@@ -82,6 +82,39 @@ public class RestClientUtils {
     }
 
     /**
+     * get a list of recent comments
+     * <p/>
+     * https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/comments/
+     */
+    public void getComments(String siteId, Map<String, String> params, final FluxProxyListener listener, FluxProxyErrorListener errorListener) {
+        String path = String.format("sites/%s/comments", siteId);
+        FluxProxyListenerBridge listenerBridge = new FluxProxyListenerBridge(listener);
+        get(path, params, null, listenerBridge, errorListener);
+    }
+
+
+//    /**
+//     * get a list of recent comments
+//     * <p/>
+//     * https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/comments/
+//     */
+//    public void OLDgetComments(String siteId, Map<String, String> params, Listener listener, ErrorListener errorListener) {
+//        String path = String.format("sites/%s/comments", siteId);
+//        get(path, params, null, listener, errorListener);
+//    }
+//
+//    /**
+//     * Get recent comments with default params.
+//     * <p/>
+//     * https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/comments/
+//     */
+//    public void getComments(String siteId, Listener listener, ErrorListener errorListener) {
+//        Map<String, String> params = new HashMap<>();
+//        params.put("number", "40");
+//        getComments(siteId, params, listener, errorListener);
+//    }
+//
+    /**
      * Reply to a comment
      * <p/>
      * https://developer.wordpress.com/docs/api/1/post/sites/%24site/posts/%24post_ID/replies/new/
@@ -346,5 +379,30 @@ public class RestClientUtils {
         request.setRetryPolicy(retryPolicy);
         AuthenticatorRequest authCheck = new AuthenticatorRequest(request, errorListener, mRestClient, mAuthenticator);
         authCheck.send();
+    }
+
+    public interface FluxProxyErrorListener extends ErrorListener {
+    }
+
+    public interface FluxProxyListener<T> {
+        /** Called when a response is received and needs be saved. */
+        public T onSave(JSONObject response);
+        /** Called after onSave() is called and data is ready to be processed */
+        public void onDataReady(T response);
+    }
+
+    private class FluxProxyListenerBridge implements Listener {
+
+        FluxProxyListener mFluxListener = null;
+
+        public FluxProxyListenerBridge(FluxProxyListener fluxListener){
+            mFluxListener = fluxListener;
+        }
+
+        @Override
+        public void onResponse(JSONObject response) {
+            Object result = mFluxListener.onSave(response);
+            mFluxListener.onDataReady(result);
+        }
     }
 }

--- a/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
+++ b/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
@@ -92,28 +92,6 @@ public class RestClientUtils {
         get(path, params, null, listenerBridge, errorListener);
     }
 
-
-//    /**
-//     * get a list of recent comments
-//     * <p/>
-//     * https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/comments/
-//     */
-//    public void OLDgetComments(String siteId, Map<String, String> params, Listener listener, ErrorListener errorListener) {
-//        String path = String.format("sites/%s/comments", siteId);
-//        get(path, params, null, listener, errorListener);
-//    }
-//
-//    /**
-//     * Get recent comments with default params.
-//     * <p/>
-//     * https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/comments/
-//     */
-//    public void getComments(String siteId, Listener listener, ErrorListener errorListener) {
-//        Map<String, String> params = new HashMap<>();
-//        params.put("number", "40");
-//        getComments(siteId, params, listener, errorListener);
-//    }
-//
     /**
      * Reply to a comment
      * <p/>


### PR DESCRIPTION
Addresses #58. Differs from #3691 in that this one uses REST api instead of XML RPC, and deals with a possible migration (i.e. a device running the current released android app, with stuff in its database, updates to this version running REST api for comments).