### PR TITLE
issue/3696-post-preview-snackbar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,4 +31,4 @@ install:
   - cp WordPress/gradle.properties-example WordPress/gradle.properties
 
 script:
-  - ./gradlew -PdisablePreDex build
+  - ./gradlew -PdisablePreDex assembleVanillaRelease lint || (grep -A20 -B2 'severity="Error"' WordPress/build/outputs/lint-results.xml; exit 1)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -209,8 +209,9 @@ public class PostPreviewActivity extends AppCompatActivity {
         // if both buttons are visible, show them below the message instead of to the right of it
         if (mPost.isLocalChange()) {
             RelativeLayout.LayoutParams paramsMessage = (RelativeLayout.LayoutParams) messageText.getLayoutParams();
-            paramsMessage.removeRule(RelativeLayout.LEFT_OF);
-            paramsMessage.removeRule(RelativeLayout.CENTER_VERTICAL);
+            // passing "0" removes the param (necessary since removeRule() is API 17+)
+            paramsMessage.addRule(RelativeLayout.LEFT_OF, 0);
+            paramsMessage.addRule(RelativeLayout.CENTER_VERTICAL, 0);
             ViewGroup.MarginLayoutParams marginsMessage = (ViewGroup.MarginLayoutParams) messageText.getLayoutParams();
             marginsMessage.bottomMargin = getResources().getDimensionPixelSize(R.dimen.margin_small);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -14,6 +14,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
@@ -203,6 +204,21 @@ public class PostPreviewActivity extends AppCompatActivity {
                     revertPost();
                 }
             });
+        }
+
+        // if both buttons are visible, show them below the message instead of to the right of it
+        if (mPost.isLocalChange()) {
+            RelativeLayout.LayoutParams paramsMessage = (RelativeLayout.LayoutParams) messageText.getLayoutParams();
+            paramsMessage.removeRule(RelativeLayout.LEFT_OF);
+            paramsMessage.removeRule(RelativeLayout.CENTER_VERTICAL);
+            ViewGroup.MarginLayoutParams marginsMessage = (ViewGroup.MarginLayoutParams) messageText.getLayoutParams();
+            marginsMessage.bottomMargin = getResources().getDimensionPixelSize(R.dimen.margin_small);
+
+            ViewGroup buttonsView = (ViewGroup) messageView.findViewById(R.id.layout_buttons);
+            RelativeLayout.LayoutParams paramsButtons = (RelativeLayout.LayoutParams) buttonsView.getLayoutParams();
+            paramsButtons.addRule(RelativeLayout.BELOW, R.id.message_text);
+            ViewGroup.MarginLayoutParams marginsButtons = (ViewGroup.MarginLayoutParams) buttonsView.getLayoutParams();
+            marginsButtons.bottomMargin = getResources().getDimensionPixelSize(R.dimen.margin_large);
         }
 
         // first set message bar to invisible so it takes up space, then animate it in


### PR DESCRIPTION
Fix #3696 - the post preview snackbar has been changed to show the buttons below the message when both buttons are visible.

![device-2016-02-02-055708](https://cloud.githubusercontent.com/assets/3903757/12747498/5342f83a-c972-11e5-9bcf-45be5e95ee92.png)
