### PR TITLE
Refactor account settings events

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/Account.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Account.java
@@ -72,6 +72,7 @@ public class Account extends AccountModel {
                 if (jsonObject != null) {
                     updateAccountSettingsFromRestResponse(jsonObject);
                     save();
+                    EventBus.getDefault().post(new PrefsEvents.AccountSettingsPostSuccess());
                 }
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/models/Account.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Account.java
@@ -49,7 +49,7 @@ public class Account extends AccountModel {
                 if (jsonObject != null) {
                     updateAccountSettingsFromRestResponse(jsonObject);
                     save();
-                    EventBus.getDefault().post(new PrefsEvents.MyProfileDetailsChanged());
+                    EventBus.getDefault().post(new PrefsEvents.AccountSettingsFetchSuccess());
                 }
             }
         };
@@ -58,7 +58,7 @@ public class Account extends AccountModel {
             @Override
             public void onErrorResponse(VolleyError volleyError) {
                 AppLog.e(T.API, volleyError);
-                EventBus.getDefault().post(new PrefsEvents.MyProfileDataLoadSaveError(volleyError));
+                EventBus.getDefault().post(new PrefsEvents.AccountSettingsFetchError(volleyError));
             }
         };
 
@@ -80,7 +80,7 @@ public class Account extends AccountModel {
             @Override
             public void onErrorResponse(VolleyError volleyError) {
                 AppLog.e(T.API, volleyError);
-                EventBus.getDefault().post(new PrefsEvents.MyProfileDataLoadSaveError(volleyError));
+                EventBus.getDefault().post(new PrefsEvents.AccountSettingsPostError(volleyError));
             }
         };
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -260,7 +260,7 @@ public class MeFragment extends Fragment {
         }
     }
 
-    public void onEventMainThread(PrefsEvents.MyProfileDetailsChanged event) {
+    public void onEventMainThread(PrefsEvents.AccountSettingsFetchSuccess event) {
         refreshAccountDetails();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileActivity.java
@@ -170,15 +170,21 @@ public class MyProfileActivity extends AppCompatActivity {
         return Account.RestParam.toString(param);
     }
 
-    public void onEventMainThread(PrefsEvents.MyProfileDetailsChanged event) {
+    public void onEventMainThread(PrefsEvents.AccountSettingsFetchSuccess event) {
         if (!isFinishing()) {
             refreshDetails();
         }
     }
 
-    public void onEventMainThread(PrefsEvents.MyProfileDataLoadSaveError event) {
+    public void onEventMainThread(PrefsEvents.AccountSettingsFetchError event) {
         if (!isFinishing()) {
-            ToastUtils.showToast(this, R.string.error_refresh_profile_not_accessible, ToastUtils.Duration.LONG);
+            ToastUtils.showToast(this, R.string.error_fetch_my_profile, ToastUtils.Duration.LONG);
+        }
+    }
+
+    public void onEventMainThread(PrefsEvents.AccountSettingsPostError event) {
+        if (!isFinishing()) {
+            ToastUtils.showToast(this, R.string.error_post_my_profile, ToastUtils.Duration.LONG);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/PrefsEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/PrefsEvents.java
@@ -3,10 +3,16 @@ package org.wordpress.android.ui.prefs;
 import com.android.volley.VolleyError;
 
 public class PrefsEvents {
-    public static class MyProfileDetailsChanged {}
-    public static class MyProfileDataLoadSaveError {
+    public static class AccountSettingsFetchSuccess {}
+    public static class AccountSettingsFetchError {
         public final VolleyError mVolleyError;
-        public MyProfileDataLoadSaveError(VolleyError error) {
+        public AccountSettingsFetchError(VolleyError error) {
+            mVolleyError = error;
+        }
+    }
+    public static class AccountSettingsPostError {
+        public final VolleyError mVolleyError;
+        public AccountSettingsPostError(VolleyError error) {
             mVolleyError = error;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/PrefsEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/PrefsEvents.java
@@ -4,6 +4,7 @@ import com.android.volley.VolleyError;
 
 public class PrefsEvents {
     public static class AccountSettingsFetchSuccess {}
+    public static class AccountSettingsPostSuccess {}
     public static class AccountSettingsFetchError {
         public final VolleyError mVolleyError;
         public AccountSettingsFetchError(VolleyError error) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -935,7 +935,10 @@
     <string name="error_refresh_unauthorized_comments">You don\'t have permission to view or edit comments</string>
     <string name="error_refresh_unauthorized_pages">You don\'t have permission to view or edit pages</string>
     <string name="error_refresh_unauthorized_posts">You don\'t have permission to view or edit posts</string>
-    <string name="error_refresh_profile_not_accessible">Unable to access your profile</string>
+    <string name="error_fetch_my_profile">Couldn\'t retrieve your profile</string>
+    <string name="error_fetch_account_settings">Couldn\'t retrieve your account settings</string>
+    <string name="error_post_my_profile">Couldn\'t save your profile</string>
+    <string name="error_post_my_account_settings">Couldn\'t save your account settings</string>
     <string name="error_generic">An error occurred</string>
     <string name="error_moderate_comment">An error occurred while moderating</string>
     <string name="error_edit_comment">An error occurred while editing the comment</string>


### PR DESCRIPTION
Refactors the names of `/me/settings` events and adds new ones to be used in both "My Profile" and "Account Settings" screens. After #3698 is merged, we discussed it with @mzorz on Slack and thought these changes would be a better fit overall, especially with the new changes coming up in `feature/account-settings` branch.

/cc @nbradbury (since you reviewed the original PR)