### PR TITLE
Translations Update for 5.0 release

### DIFF
--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">الحجم الأصلي</string>
+	<string name="about_me_hint">كلمات قليلة عنك...</string>
+	<string name="public_display_name_hint">سيكون اسم العرض افتراضيًا لاسم المستخدم الخاص بك إذا لم يتم تعيينه</string>
+	<string name="about_me">نبذة عني</string>
+	<string name="public_display_name">اسم العرض العام</string>
+	<string name="my_profile">ملفي الشخصي</string>
+	<string name="first_name">الاسم الأول</string>
+	<string name="last_name">اسم العائلة</string>
+	<string name="site_privacy_public_desc">السماح لمحركات البحث بفهرسة هذا الموقع</string>
+	<string name="site_privacy_hidden_desc">منع محركات البحث من فهرسة هذا الموقع</string>
+	<string name="site_privacy_private_desc">أود أن يكون موقعي خاصًا، مرئيًا فقط للمستخدمين الذين أختارهم</string>
+	<string name="cd_related_post_preview_image">صورة معاينة المقالة ذات الصلة</string>
+	<string name="error_post_remote_site_settings">تعذر حفظ معلومات الموقع</string>
+	<string name="error_fetch_remote_site_settings">تعذر استرداد معلومات الموقع</string>
+	<string name="error_media_upload_connection">حدث خطأ في الاتصال أثناء رفع ملفات الوسائط</string>
+	<string name="site_settings_disconnected_toast">غير متصل، التحرير مُعطّل.</string>
+	<string name="site_settings_unsupported_version_error">إصدار وردبرس غير مدعوم</string>
+	<string name="site_settings_multiple_links_dialog_description">يلزم موافقة على التعليقات التي تتضمن أكثر من هذا العدد من الروابط.</string>
+	<string name="site_settings_close_after_dialog_switch_text">إغلاق تلقائي</string>
+	<string name="site_settings_close_after_dialog_description">إغلاق تلقائي للتعليقات على المقالات.</string>
+	<string name="site_settings_paging_dialog_description">تحديد مناقشات التعليقات في صفحات متعددة.</string>
+	<string name="site_settings_paging_dialog_header">التعليقات لكل صفحة</string>
+	<string name="site_settings_close_after_dialog_title">إغلاق التعليق</string>
+	<string name="site_settings_blacklist_description">عندما يحتوي تعليق على أي من هذه الكلمات في محتواه أو اسمه أو عنوان URL أو عنوان البريد الإلكتروني أو بروتوكول IP الخاص به، سيتم وضع علامة عليه باعتباره تعليقًا مزعجًا. يمكنك إدخال كلمات غير مكتملة، إذ ستطابق كلمة "برس" كلمة "وردبرس".</string>
+	<string name="site_settings_hold_for_moderation_description">عندما يحتوي تعليق على أي من هذه الكلمات في محتواه أو اسمه أو عنوان URL أو عنوان البريد الإلكتروني أو بروتوكول IP الخاص به، سيتم حجزه في قائمة انتظار الإدارة. يمكنك إدخال كلمات غير مكتملة، إذ ستطابق كلمة "برس" كلمة "وردبرس".</string>
+	<string name="site_settings_list_editor_input_hint">أدخل كلمة أو عبارة</string>
+	<string name="site_settings_list_editor_no_items_text">لا توجد عناصر</string>
+	<string name="site_settings_learn_more_caption">يمكنك تجاوز هذه الإعدادات للمقالات الفردية.</string>
+	<string name="site_settings_rp_preview3_site">في "الترقية"</string>
+	<string name="site_settings_rp_preview3_title">نطاق الترقية: فيديوبرس لحفلات الزفاف</string>
+	<string name="site_settings_rp_preview2_site">في "التطبيقات"</string>
+	<string name="site_settings_rp_preview2_title">تجري حاليًا صيانة تطبيق وردبرس للأندرويد</string>
+	<string name="site_settings_rp_preview1_site">في "الجوال"</string>
+	<string name="site_settings_rp_preview1_title">تحديث iPhone/iPad كبير متوفر الآن</string>
+	<string name="site_settings_rp_show_images_title">عرض الصور</string>
+	<string name="site_settings_rp_show_header_title">عرض الترويسة</string>
+	<string name="site_settings_rp_switch_summary">تعرض المقالات ذات الصلة المحتوى ذا الصلة من موقعك أسفل مقالاتك.</string>
+	<string name="site_settings_rp_switch_title">عرض المقالات ذات الصلة</string>
+	<string name="site_settings_delete_site_hint">يُزيل بيانات موقعك من التطبيق</string>
+	<string name="site_settings_blacklist_hint">يتم وضع علامة على التعليقات التي تتطابق مع عامل التصفية باعتبارها بريدًا مزعجًا</string>
+	<string name="site_settings_moderation_hold_hint">يتم وضع التعليقات التي تتطابق مع عامل التصفية في قائمة انتظار الإدارة</string>
+	<string name="site_settings_multiple_links_hint">يتجاهل حد الرابط من المستخدمين المعروفين</string>
+	<string name="site_settings_whitelist_hint">يجب أن يملك صاحب التعليق تعليقات سابقة</string>
+	<string name="site_settings_user_account_required_hint">يجب على الزوار التسجيل ليتمكنوا من التعليق</string>
+	<string name="site_settings_identity_required_hint">يجب على كاتب التعليق كتابة الاسم والبريد الإلكتروني</string>
+	<string name="site_settings_manual_approval_hint">يجب الموافقة على التعليق يدويًا</string>
+	<string name="site_settings_paging_hint">عرض التعليقات في أجزاء من الحجم المحدد</string>
+	<string name="site_settings_threading_hint">السماح للتعليقات المتداخلة بالوصول إلى عمق معين</string>
+	<string name="site_settings_sort_by_hint">يحدد الترتيب الذي تُعرض به التعليقات</string>
+	<string name="site_settings_close_after_hint">إيقاف التعليقات بعد وقت محدد</string>
+	<string name="site_settings_receive_pingbacks_hint">السماح بتنبيهات الروابط من المدونات الأخرى</string>
+	<string name="site_settings_send_pingbacks_hint">محاولة التنبيه بوجود أي مدونات مرتبطة بالمقالة</string>
+	<string name="site_settings_allow_comments_hint">السماح للقرّاء بنشر التعليقات</string>
+	<string name="site_settings_discussion_hint">عرض إعدادات المناقشة على موقعك وتغييرها</string>
+	<string name="site_settings_more_hint">عرض جميع إعدادات المناقشة المتوفرة</string>
+	<string name="site_settings_related_posts_hint">إظهار المقالات ذات الصلة أو إخفاؤها في القارئ</string>
+	<string name="site_settings_upload_and_link_image_hint">التمكين لرفع صورة بالحجم الكامل دائمًا</string>
+	<string name="site_settings_image_width_hint">تغيير حجم الصور في المقالات إلى هذا العرض</string>
+	<string name="site_settings_format_hint">يُعيّن تنسيق مقالة جديدة</string>
+	<string name="site_settings_category_hint">تعيين فئة مقالة جديدة</string>
+	<string name="site_settings_location_hint">إضافة بيانات الموقع إلى مقالاتك تلقائيًا</string>
+	<string name="site_settings_password_hint">تغيير كلمة مرورك</string>
+	<string name="site_settings_username_hint">حساب المستخدم الحالي</string>
+	<string name="site_settings_language_hint">اللغة التي تُكتب بها هذه المدونة في الأصل.</string>
+	<string name="site_settings_privacy_hint">التحكم في من يمكنه رؤية موقعك</string>
+	<string name="site_settings_address_hint">تغيير عنوانك غير مدعوم حاليًا</string>
+	<string name="site_settings_tagline_hint">وصف موجز أو عبارة جذابة يراد بها وصف مدونتك</string>
+	<string name="site_settings_title_hint">بكلمات قليلة، اكتب نبذة موجزة عن هذا الموقع</string>
+	<string name="site_settings_whitelist_known_summary">تعليقات من مستخدمين معروفين</string>
+	<string name="site_settings_whitelist_all_summary">تعليقات من جميع المستخدمين</string>
+	<string name="site_settings_threading_summary">مستويات %d</string>
+	<string name="site_settings_privacy_private_summary">خاص</string>
+	<string name="site_settings_privacy_hidden_summary">مخفي</string>
+	<string name="site_settings_delete_site_title">حذف الموقع</string>
+	<string name="site_settings_privacy_public_summary">عام</string>
+	<string name="site_settings_blacklist_title">قائمة الحظر</string>
+	<string name="site_settings_moderation_hold_title">احتجاز من أجل الإدارة</string>
+	<string name="site_settings_multiple_links_title">الروابط في التعليقات</string>
+	<string name="site_settings_whitelist_title">الموافقة تلقائيًا</string>
+	<string name="site_settings_threading_title">مؤشر الترابط</string>
+	<string name="site_settings_paging_title">ترقيم الصفحات</string>
+	<string name="site_settings_sort_by_title">فرز حسب</string>
+	<string name="site_settings_account_required_title">يجب على المستخدمين تسجيل الدخول</string>
+	<string name="site_settings_identity_required_title">لا بد من تضمين الاسم والبريد الإلكتروني</string>
+	<string name="site_settings_receive_pingbacks_title">تلقي تنبيهات</string>
+	<string name="site_settings_send_pingbacks_title">إرسال تنبيهات</string>
+	<string name="site_settings_allow_comments_title">السماح بالتعليقات</string>
+	<string name="site_settings_default_format_title">التنسيق الافتراضي</string>
+	<string name="site_settings_default_category_title">الفئة الافتراضية</string>
+	<string name="site_settings_location_title">تمكين الموقع</string>
+	<string name="site_settings_address_title">العنوان</string>
+	<string name="site_settings_title_title">عنوان الموقع</string>
+	<string name="site_settings_tagline_title">الشعار</string>
+	<string name="site_settings_this_device_header">هذا الجهاز</string>
+	<string name="site_settings_discussion_new_posts_header">الإعدادات الافتراضية للمقالات الجديدة</string>
+	<string name="site_settings_account_header">الحساب</string>
+	<string name="site_settings_writing_header">كتابة</string>
+	<string name="newest_first">الأحدث أولاً</string>
+	<string name="site_settings_general_header">عام</string>
+	<string name="discussion">مناقشة</string>
+	<string name="privacy">الخصوصية</string>
+	<string name="related_posts">المقالات ذات الصلة</string>
+	<string name="comments">التعليقات</string>
+	<string name="close_after">إغلاق بعد</string>
+	<string name="oldest_first">الأقدم أولاً</string>
+	<string name="media_error_no_permission_upload">ليست لديك الصلاحية اللازمة لرفع ملفات الوسائط إلى هذا الموقع</string>
+	<string name="never">أبدًا</string>
+	<string name="unknown">غير معروف</string>
 	<string name="reader_err_get_post_not_found">لم تعد هذه المقالة موجودة</string>
 	<string name="reader_err_get_post_not_authorized">لست مخولاً لعرض هذه المقالة</string>
 	<string name="reader_err_get_post_generic">يتعذر استرجاع هذه المقالة</string>
@@ -124,14 +232,12 @@
 	<string name="trashed">أُضيف إلى سلة المهملات</string>
 	<string name="button_back">رجوع</string>
 	<string name="page_deleted">تم حذف الصفحة</string>
-	<string name="button_more">المزيد</string>
 	<string name="button_stats">إحصاءات</string>
 	<string name="button_trash">سلة المهملات</string>
 	<string name="button_preview">معاينة</string>
 	<string name="button_view">عرض</string>
 	<string name="button_edit">تحرير</string>
 	<string name="button_publish">نشر</string>
-	<string name="button_delete">حذف</string>
 	<string name="my_site_no_sites_view_subtitle">هل ترغب في إضافة واحد؟</string>
 	<string name="my_site_no_sites_view_title">ليس لديك أي مواقع وردبرس حتى الآن.</string>
 	<string name="my_site_no_sites_view_drake">رسم توضيحي</string>
@@ -170,7 +276,6 @@
 	<string name="my_site_btn_switch_site">تبديل الموقع</string>
 	<string name="my_site_header_publish">نشر</string>
 	<string name="my_site_btn_blog_posts">مقالات المدونة</string>
-	<string name="my_site_btn_comments">التعليقات</string>
 	<string name="my_site_header_look_and_feel">الشكل والطابع</string>
 	<string name="my_site_btn_site_settings">الإعدادات</string>
 	<string name="my_site_header_configuration">التكوين</string>
@@ -221,6 +326,8 @@
 	<string name="add_to_post">إضافة مقالة</string>
 	<string name="take_photo">خذ صورة</string>
 	<string name="device">جهاز</string>
+	<string name="media_details_label_file_name">اسم الملف</string>
+	<string name="media_details_label_file_type">نوع الملف</string>
 	<string name="toast_err_post_uploading">يتعذر فتح مقالة أثناء رفعها</string>
 	<string name="posts_fetching">جار إحضار المقالات…</string>
 	<string name="media_fetching">جار إحضار الوسائط…</string>
@@ -256,7 +363,6 @@
 	<string name="stats_views">مشاهدات</string>
 	<string name="stats_timeframe_years">سنوات</string>
 	<string name="stats_pagination_label">الصفحة %1$s من %2$s</string>
-	<string name="stats_comments">تعليقات</string>
 	<string name="stats_likes">إعجابات</string>
 	<string name="stats_view_followers">متابعون</string>
 	<string name="stats_view_countries">البلاد</string>
@@ -332,13 +438,13 @@
 	<string name="reader_label_comment_count_single">تعليق واحد</string>
 	<string name="reader_label_comments_closed">التعليقات مغلقة</string>
 	<string name="reader_label_comments_on">تعليقات على</string>
-	<string name="reader_title_comments">تعليقات</string>
 	<string name="reader_title_photo_viewer">%1$d من %2$d</string>
 	<string name="error_publish_empty_post">يتعذر نشر مقالة فارغة</string>
 	<string name="error_refresh_unauthorized_posts">ليس لديك الإذن اللازم لعرض المقالات أو تحريرها</string>
 	<string name="error_refresh_unauthorized_pages">ليس لديك الإذن اللازم لعرض الصفحات أو تحريرها</string>
 	<string name="error_refresh_unauthorized_comments">ليس لديك الإذن اللازم لعرض التعليقات أو تحريرها</string>
 	<string name="older_month">أقدم من شهر</string>
+	<string name="more">المزيد</string>
 	<string name="older_two_days">أقدم من يومين</string>
 	<string name="older_last_week">أقدم من أسبوع</string>
 	<string name="stats_no_blog">يتعذر تحميل الإحصاءات للمدونة المطلوبة</string>
@@ -644,12 +750,10 @@
 	<string name="stats_view_clicks">النقرات</string>
 	<string name="stats_timeframe_yesterday">الأمس</string>
 	<string name="stats_timeframe_today">اليوم</string>
-	<string name="stats_view_comments">التعليقات</string>
 	<string name="stats_view_tags_and_categories">الوسوم و التصنيفات</string>
 	<string name="stats_entry_posts_and_pages">العنوان</string>
 	<string name="stats_entry_country">الدولة</string>
 	<string name="stats_totals_clicks">النقرات</string>
-	<string name="stats_totals_comments">التعليقات</string>
 	<string name="unattached">غير مرفق</string>
 	<string name="custom_date">تاريخ مخصص</string>
 	<string name="media_add_popup_capture_photo">التقط صورة</string>
@@ -775,7 +879,6 @@
 	<string name="reply">الرد</string>
 	<string name="yes">نعم</string>
 	<string name="no">لا</string>
-	<string name="tab_comments">تعليقات</string>
 	<string name="preview">معاينة</string>
 	<string name="add">أضف</string>
 	<string name="category_refresh_error">خطأ في تحديث القسم</string>
@@ -826,6 +929,33 @@
 		<item>قياسي</item>
 		<item>حالة</item>
 		<item>فيديو</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>سيكون موقعك مرئيًا للجميع ويمكن فهرسته بواسطة محركات البحث</item>
+		<item>سيكون موقعك مرئيًا للجميع مع مطالبة محركات البحث بعدم فهرسته في الوقت نفسه</item>
+		<item>سيكون موقعك مرئيًا لك وللمستخدمين الذين توافق عليهم فقط</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>يتطلب موافقة يدوية لتعليقات الجميع.</item>
+		<item>موافقة تلقائية إذا كان لدى المستخدم تعليق تمت الموافقة عليه مسبقًا.</item>
+		<item>موافقة تلقائية على تعليقات الجميع.</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>لا توجد تعليقات</item>
+		<item>تعليقات المستخدمين المعروفة</item>
+		<item>جميع المستخدمين</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>بلا</item>
+		<item>مستويان</item>
+		<item>المستويات الثلاثة</item>
+		<item>المستويات الأربعة</item>
+		<item>المستويات الخمسة</item>
+		<item>المستويات الستة</item>
+		<item>المستويات السبعة</item>
+		<item>المستويات الثمانية</item>
+		<item>المستويات التسعة</item>
+		<item>المستويات العشرة</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>مجاني</item>

--- a/WordPress/src/main/res/values-az/strings.xml
+++ b/WordPress/src/main/res/values-az/strings.xml
@@ -23,14 +23,12 @@
 	<string name="post_trashed">Yazını zibil qutusuna göndər</string>
 	<string name="button_back">Geri</string>
 	<string name="page_deleted">Səhifə silindi</string>
-	<string name="button_more">Daha çox</string>
 	<string name="button_stats">Statistikalar</string>
 	<string name="button_trash">Zibil qutusu</string>
 	<string name="button_preview">Önizləmə</string>
 	<string name="button_view">Bax</string>
 	<string name="button_edit">Redaktə et</string>
 	<string name="button_publish">Dərc et</string>
-	<string name="button_delete">Sil</string>
 	<string name="trashed">Zibil qutusuna göndərildi</string>
 	<string name="stats_no_activity_this_period">Bu dövrə aid aktivlik yoxdur</string>
 	<string name="my_site_no_sites_view_subtitle">Bir ədədini əlavə etmək istərdinizmi?</string>
@@ -71,7 +69,6 @@
 	<string name="my_site_btn_switch_site">Saytı Dəyişdir</string>
 	<string name="my_site_btn_blog_posts">Bloq Yazıları</string>
 	<string name="my_site_btn_site_settings">Parametrlər</string>
-	<string name="my_site_btn_comments">Şərhlər</string>
 	<string name="my_site_header_look_and_feel">Əsas Görünüş</string>
 	<string name="my_site_header_publish">Dərc et</string>
 	<string name="my_site_header_configuration">Konfiqurasiya</string>
@@ -203,7 +200,6 @@
 	<string name="stats_view_followers">İzləyici</string>
 	<string name="stats_view_countries">Ölkələr</string>
 	<string name="stats_likes">Bəyənmə</string>
-	<string name="stats_comments">Şərh</string>
 	<string name="stats_pagination_label">Səhifə %1$s / %2$s</string>
 	<string name="stats_timeframe_years">İl</string>
 	<string name="stats_views">Baxış</string>
@@ -227,7 +223,6 @@
 	<string name="reader_label_comment_count_single">Bir şərh</string>
 	<string name="reader_label_comments_closed">Şərhlər bağlıdır</string>
 	<string name="reader_label_comments_on">Şərh</string>
-	<string name="reader_title_comments">Şərh</string>
 	<string name="reader_title_photo_viewer">%1$d / %2$d</string>
 	<string name="error_refresh_unauthorized_posts">Yazıya baxmağa və ya onu redaktə etməyə izniniz yoxdur</string>
 	<string name="select_a_blog">WordPress saytı seç</string>
@@ -244,6 +239,7 @@
 	<string name="error_refresh_unauthorized_pages">Səhifələrə baxma və ya redaktə etmə izniniz yoxdur</string>
 	<string name="error_refresh_unauthorized_comments">Şərhlərə baxma və ya redaktə etmə izniniz yoxdur</string>
 	<string name="older_month">Bir aydan əski</string>
+	<string name="more">Daha çox</string>
 	<string name="older_two_days">2 gündən əski</string>
 	<string name="older_last_week">1 həftədən əski</string>
 	<string name="stats_no_blog">İstənən bloq üçün statistiklar yüklənmir</string>
@@ -534,7 +530,6 @@
 	<string name="media_edit_description_text">Açıqlama</string>
 	<string name="share_action">Göndər</string>
 	<string name="stats_view_tags_and_categories">Etiketlər və Kateqoriyalar</string>
-	<string name="stats_view_comments">Şərhlər</string>
 	<string name="stats_entry_authors">Müəllif</string>
 	<string name="stats_entry_posts_and_pages">Başlıq</string>
 	<string name="all">Tamamı</string>
@@ -547,7 +542,6 @@
 	<string name="stats_entry_country">Ölkə</string>
 	<string name="stats_entry_tags_and_categories">Bəhs</string>
 	<string name="stats_entry_referrers">Yönləndirmə</string>
-	<string name="stats_totals_comments">Şərhlər</string>
 	<string name="media_gallery_type">Növ</string>
 	<string name="menu_search">Axtar</string>
 	<string name="media_edit_caption_text">Başlıq</string>
@@ -633,7 +627,6 @@
 	<string name="app_title">Android üçün WordPress</string>
 	<string name="tos">Xidmət Şərtləri</string>
 	<string name="about">Haqqında</string>
-	<string name="max_thumbnail_px_width">Mövcud təsvirin genişliyi</string>
 	<string name="image_alignment">Mövqeləndirmə</string>
 	<string name="refresh">Təzələ</string>
 	<string name="untitled">Başlıqsız</string>
@@ -668,7 +661,6 @@
 	<string name="no">Xeyr</string>
 	<string name="yes">Bəli</string>
 	<string name="reply">Cavabla</string>
-	<string name="tab_comments">Şərhlər</string>
 	<string name="error">Xəta</string>
 	<string name="cancel">İmtina</string>
 	<string name="save">Qeyd et</string>

--- a/WordPress/src/main/res/values-bg/strings.xml
+++ b/WordPress/src/main/res/values-bg/strings.xml
@@ -69,7 +69,6 @@
 	<string name="days_ago">преди %d дни</string>
 	<string name="yesterday">Вчера</string>
 	<string name="connectionbar_no_connection">Няма връзка</string>
-	<string name="button_delete">Изтриване</string>
 	<string name="stats_no_activity_this_period">За този период няма дейности</string>
 	<string name="page_trashed">Страницата е изпратена към кошчето</string>
 	<string name="button_stats">Статистика</string>
@@ -82,7 +81,6 @@
 	<string name="page_deleted">Страницата е изтрита</string>
 	<string name="trashed">Изхвърлени</string>
 	<string name="button_back">Назад</string>
-	<string name="button_more">Още</string>
 	<string name="button_edit">Редактиране</string>
 	<string name="my_site_no_sites_view_subtitle">Добавяне на един?</string>
 	<string name="my_site_no_sites_view_title">Все още нямате сайтове на WordPress.</string>
@@ -120,7 +118,6 @@
 	<string name="site_picker_title">Избор на сайт</string>
 	<string name="my_site_btn_view_site">Преглед на сайта</string>
 	<string name="my_site_btn_switch_site">Превключване на сайта</string>
-	<string name="my_site_btn_comments">Коментари</string>
 	<string name="my_site_btn_site_settings">Настройки</string>
 	<string name="my_site_header_look_and_feel">Изглед</string>
 	<string name="my_site_header_publish">Публикуване</string>
@@ -213,7 +210,6 @@
 	<string name="stats_empty_video">Няма преглеждани видеа</string>
 	<string name="stats_totals_publicize">Последователи</string>
 	<string name="stats_entry_clicks_link">Връзка</string>
-	<string name="stats_comments">Коментари</string>
 	<string name="stats_followers_months">%1$d месеца</string>
 	<string name="stats_view_followers">Последователи</string>
 	<string name="stats_other_recent_stats_label">Други скорошни статистики</string>
@@ -287,7 +283,6 @@
 	<string name="signing_out">Излизане...</string>
 	<string name="older_month">По-стари от месец</string>
 	<string name="comment_trashed">Коментарът беше изтрит</string>
-	<string name="reader_title_comments">Коментари</string>
 	<string name="reader_label_comments_closed">Коментарите са изключени</string>
 	<string name="reader_title_photo_viewer">%1$d от %2$d</string>
 	<string name="comment">Коментар</string>
@@ -601,11 +596,9 @@
 	<string name="media_edit_description_hint">Добави описание</string>
 	<string name="media_edit_success">Обновено</string>
 	<string name="stats_timeframe_today">Днес</string>
-	<string name="stats_view_comments">Коментари</string>
 	<string name="stats_view_visitors_and_views">Посетители и разглеждания</string>
 	<string name="stats_entry_authors">Автор</string>
 	<string name="stats_timeframe_months">Месеци</string>
-	<string name="stats_totals_comments">Коментари</string>
 	<string name="stats_totals_plays">Гледания</string>
 	<string name="passcode_preference_title">ПИН ключ</string>
 	<string name="passcode_turn_off">Изключи ПИН ключ</string>
@@ -688,7 +681,6 @@
 	<string name="tos">Условия за ползване</string>
 	<string name="app_title">WordPress за Android</string>
 	<string name="about">Относно</string>
-	<string name="max_thumbnail_px_width">Широчина на изображение по подразбиране</string>
 	<string name="image_alignment">Подравняване</string>
 	<string name="refresh">Презареждане</string>
 	<string name="untitled">Неозаглавен</string>
@@ -722,7 +714,6 @@
 	<string name="blogs">Блогове</string>
 	<string name="select_photo">Избор на изображение от галерията</string>
 	<string name="no">Не</string>
-	<string name="tab_comments">Коментари</string>
 	<string name="error">Грешка</string>
 	<string name="cancel">Отказ</string>
 	<string name="yes">Да</string>

--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -1,9 +1,117 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">Originální velikost</string>
+	<string name="about_me_hint">Osobní informace</string>
+	<string name="about_me">O mě</string>
+	<string name="public_display_name_hint">Zobrazované jméno bude vaše uživatelské jméno, pokud nenastavíte jiné</string>
+	<string name="public_display_name">Veřejně zobrazovat jako</string>
+	<string name="my_profile">Můj profil</string>
+	<string name="first_name">Jméno</string>
+	<string name="last_name">Příjmení</string>
+	<string name="site_privacy_public_desc">Povolit indexování tohoto webu</string>
+	<string name="site_privacy_hidden_desc">Zakázat indexování tohoto webu</string>
+	<string name="site_privacy_private_desc">Přeji si aby byl můj web soukromý, viditelný pouze uživatelům, které si sám zvolím.</string>
+	<string name="cd_related_post_preview_image">Náhledový obrázek souvisejících obrázků</string>
+	<string name="error_post_remote_site_settings">Nepodařilo se uložit informace o stránce</string>
+	<string name="error_fetch_remote_site_settings">Nepodařilo se získat informace o stránce</string>
+	<string name="error_media_upload_connection">Během nahrávání mediálního souboru, nastala chyba připojení</string>
+	<string name="site_settings_disconnected_toast">Odpojeno, úpravy vypnuty.</string>
+	<string name="site_settings_unsupported_version_error">Nepodporovaná verze WordPress</string>
+	<string name="site_settings_multiple_links_dialog_description">Vyžadovat schválení pro komentáře, které obsahují více než tento počet odkazů.</string>
+	<string name="site_settings_close_after_dialog_switch_text">Uzavřít automaticky</string>
+	<string name="site_settings_close_after_dialog_description">Automaticky uzavře komentáře k článkům.</string>
+	<string name="site_settings_paging_dialog_description">Rozdělit vlákna komentářů do více stránek.</string>
+	<string name="site_settings_paging_dialog_header">Komentářů na stránku</string>
+	<string name="site_settings_close_after_dialog_title">Uzavřít komentování</string>
+	<string name="site_settings_blacklist_description">Pokud komentář obsahuje jakékoliv z těchto slov ve svém obsahu, jméně, URL, e-mailu, nebo IP, bude označen jako spam. Můžete také zadat části slov, takže podmínce "press" bude odpovídat "WordPress".</string>
+	<string name="site_settings_hold_for_moderation_description">Pokud komentář obsahuje jakékoliv z těchto slov ve svém obsahu, jméně, URL, e-mailu, nebo IP, tento komentář bude pozdržen a moderován. Můžete také zadat části slov, takže podmínce "press" bude odpovídat "WordPress".</string>
+	<string name="site_settings_list_editor_input_hint">Zadejte slovo nebo frázi</string>
+	<string name="site_settings_list_editor_no_items_text">Žádné položky</string>
+	<string name="site_settings_learn_more_caption">Tato nastavení můžete přepsat pro jednotlivé příspěvky.</string>
+	<string name="site_settings_rp_preview3_site">v "aktualizaci"</string>
+	<string name="site_settings_rp_preview3_title">Zaměření upgradu: VideoPress pro svatby</string>
+	<string name="site_settings_rp_preview2_site">v "Aplikaci"</string>
+	<string name="site_settings_rp_preview2_title">Aplikace WordPress pro Android má vylepšený vzhled</string>
+	<string name="site_settings_rp_preview1_site">v "Mobilu"</string>
+	<string name="site_settings_rp_preview1_title">Velký iPhone/iPad dostává nyní aktualizaci</string>
+	<string name="site_settings_rp_show_images_title">Zobrazit obrázky</string>
+	<string name="site_settings_rp_show_header_title">Zobrazit hlavičku</string>
+	<string name="site_settings_rp_switch_summary">Podobné příspěvky zobrazí relevantní obsah vašeho webu, přímo pod příspěvky.</string>
+	<string name="site_settings_rp_switch_title">Zobrazit podobné příspěvky</string>
+	<string name="site_settings_delete_site_hint">Odstraní vaše data o webu z aplikace</string>
+	<string name="site_settings_blacklist_hint">Komentáře odpovídající filtru jsou označeny jako spam</string>
+	<string name="site_settings_moderation_hold_hint">Komentáře odpovídající filtru jsou přesunuty do fronty pro moderaci</string>
+	<string name="site_settings_multiple_links_hint">Ignorovat limit množství odkazů pro známé uživatele</string>
+	<string name="site_settings_whitelist_hint">Autor komentáře musí mít dříve schválený komentář</string>
+	<string name="site_settings_user_account_required_hint">Pro přidávání komentářů, musí být uživatelé registrovaní a přihlášeni</string>
+	<string name="site_settings_identity_required_hint">Autor komentáře musí vyplnit své jméno a e-mail</string>
+	<string name="site_settings_manual_approval_hint">Komentáře musí být ručně schváleny</string>
+	<string name="site_settings_paging_hint">Zobrazovat komentáře v bloku o specifické velikosti</string>
+	<string name="site_settings_threading_hint">Povolit neslušné komentáře do určité hloubky</string>
+	<string name="site_settings_sort_by_hint">Určuje v jakém pořadí jsou komentáře zobrazovány</string>
+	<string name="site_settings_close_after_hint">Po určeném čase zakázat komentáře</string>
+	<string name="site_settings_receive_pingbacks_hint">Povolit odkazy z ostatních webů</string>
+	<string name="site_settings_send_pingbacks_hint">Pokusit se informovat veškeré weby propojené s daným článkem</string>
+	<string name="site_settings_allow_comments_hint">Umožnit čtenářům přidávat komentáře</string>
+	<string name="site_settings_discussion_hint">Prohlédněte a změňte si nastavení vašich webových diskusí</string>
+	<string name="site_settings_more_hint">Zobrazit veškerá dostupná nastavení diskusí</string>
+	<string name="site_settings_related_posts_hint">Zobrazte nebo skryjte podobné příspěvky ve čtečce</string>
+	<string name="site_settings_upload_and_link_image_hint">Povolte pokud chcete vždy nahrávat plnou velikost obrázků</string>
+	<string name="site_settings_image_width_hint">Změní velikost obrázků v příspěvcích na tuto šířku</string>
+	<string name="site_settings_format_hint">Nastaví nový formát příspěvku</string>
+	<string name="site_settings_category_hint">Nastaví novou kategorii příspěvku</string>
+	<string name="site_settings_location_hint">Automaticky vkládat data polohy do vašich příspěvků</string>
+	<string name="site_settings_password_hint">Změňte si své heslo</string>
+	<string name="site_settings_username_hint">Aktuální uživatelský účet</string>
+	<string name="site_settings_language_hint">Jazyk, kterým je tento web psán je</string>
+	<string name="site_settings_privacy_hint">Řídí kdo může zobrazit váš web</string>
+	<string name="site_settings_address_hint">Změna vaší adresy momentálně není k dispozici</string>
+	<string name="site_settings_tagline_hint">Několika slovy popište, čím se budete na webu zabývat.</string>
+	<string name="site_settings_title_hint">Několika slovy popište, čím se budete na webu zabývat</string>
+	<string name="site_settings_whitelist_known_summary">Komentáře pro známé uživatele</string>
+	<string name="site_settings_whitelist_all_summary">Komentáře pro všechny uživatele</string>
+	<string name="site_settings_threading_summary">%d úrovní</string>
+	<string name="site_settings_privacy_private_summary">Soukromé</string>
+	<string name="site_settings_privacy_hidden_summary">Skrytý</string>
+	<string name="site_settings_delete_site_title">Smazat stránku</string>
+	<string name="site_settings_privacy_public_summary">Publikovat</string>
+	<string name="site_settings_blacklist_title">Černá listina</string>
+	<string name="site_settings_moderation_hold_title">Podržet pro moderaci</string>
+	<string name="site_settings_multiple_links_title">Odkazy v komentářích</string>
+	<string name="site_settings_whitelist_title">Schválit automaticky</string>
+	<string name="site_settings_threading_title">Posloupnosti</string>
+	<string name="site_settings_paging_title">Stránkování</string>
+	<string name="site_settings_sort_by_title">Řadit dle</string>
+	<string name="site_settings_account_required_title">Uživatel musí být přihlášen</string>
+	<string name="site_settings_identity_required_title">Musí obsahovat jméno a e-mail</string>
+	<string name="site_settings_receive_pingbacks_title">Přijímat pingbacky</string>
+	<string name="site_settings_send_pingbacks_title">Odesílat pingbacky</string>
+	<string name="site_settings_allow_comments_title">Povolit komentáře</string>
+	<string name="site_settings_default_format_title">Výchozí formát</string>
+	<string name="site_settings_default_category_title">Výchozí kategorie</string>
+	<string name="site_settings_location_title">Povolit polohu</string>
+	<string name="site_settings_address_title">Adresa</string>
+	<string name="site_settings_tagline_title">Popis webu</string>
+	<string name="site_settings_title_title">Nadpis webu</string>
+	<string name="site_settings_this_device_header">Toto zařízení</string>
+	<string name="site_settings_discussion_new_posts_header">Výchozí pro nové příspěvky</string>
+	<string name="site_settings_writing_header">Psaní</string>
+	<string name="site_settings_account_header">Účet</string>
+	<string name="site_settings_general_header">Obecné</string>
+	<string name="newest_first">Nejnovější první</string>
+	<string name="discussion">Diskuse</string>
+	<string name="privacy">Soukromí</string>
+	<string name="comments">Komentáře</string>
+	<string name="related_posts">Související příspěvky</string>
+	<string name="oldest_first">Starší první</string>
+	<string name="close_after">Uzavřít po</string>
+	<string name="media_error_no_permission_upload">Nemáte oprávnění pro nahrávání mediálních souborů na tento web</string>
+	<string name="never">Nikdy</string>
+	<string name="unknown">Neznámý</string>
 	<string name="reader_err_get_post_not_found">Tento příspěvek již neexistuje</string>
 	<string name="reader_err_get_post_not_authorized">Nemáte oprávnění prozobrazení tohoto příspěvku</string>
 	<string name="reader_err_get_post_generic">Nelze načíst tento příspěvek</string>
-	<string name="blog_name_no_spaced_allowed">Adresa stránky nesmí obsahovat mezery</string>
+	<string name="blog_name_no_spaced_allowed">Adresa webu nesmí obsahovat mezery</string>
 	<string name="invalid_username_no_spaces">Uživatelské jméno nemůže obsahovat mezery</string>
 	<string name="reader_empty_followed_blogs_no_recent_posts_description">Stránky, které sledujete v poslední době neměly žádné příspěvky</string>
 	<string name="reader_empty_followed_blogs_no_recent_posts_title">Žádné nedávné příspěvky</string>
@@ -12,7 +120,7 @@
 	<string name="media_details_copy_url">Kopírovat URL adresu</string>
 	<string name="media_details_label_date_uploaded">Nahráno</string>
 	<string name="media_details_label_date_added">Přidáno</string>
-	<string name="selected_theme">Vybrat šablonu</string>
+	<string name="selected_theme">Vybraná šablona</string>
 	<string name="could_not_load_theme">Šablonu nejde načíst</string>
 	<string name="theme_activation_error">Nastala neočekávaná chyba. Šablonu se nepodařilo aktivovat</string>
 	<string name="theme_by_author_prompt_append">od %1$s</string>
@@ -20,9 +128,9 @@
 	<string name="theme_try_and_customize">Vyzkoušet a upravit</string>
 	<string name="theme_done">HOTOVO</string>
 	<string name="theme_support">Podpora</string>
-	<string name="theme_details">Detail</string>
 	<string name="theme_view">Zobrazit</string>
-	<string name="theme_manage_site">SPRAVOVAT STRÁNKU</string>
+	<string name="theme_details">Podrobnosti</string>
+	<string name="theme_manage_site">SPRAVOVAT WEB</string>
 	<string name="theme_activate">Aktivovat</string>
 	<string name="title_activity_theme_support">Šablony</string>
 	<string name="customize">Přizpůsobit</string>
@@ -54,17 +162,17 @@
 	<string name="notifications_empty_view_reader">Zobrazit čtečku</string>
 	<string name="unread">Nepřečtené</string>
 	<string name="notifications_empty_action_followers_likes">Všimněte si: komentujte příspěvky které jste četli.</string>
-	<string name="notifications_empty_action_comments">Připojte se ke konverzaci: komentujte příspěvky z blogů, které sledujete.</string>
+	<string name="notifications_empty_action_comments">Připojte se ke konverzaci: komentujte příspěvky z webů, které sledujete.</string>
 	<string name="notifications_empty_action_unread">Začněte konverzaci: napište nový příspěvek.</string>
-	<string name="notifications_empty_action_all">Buďte aktivní! Komentujte příspěvky z blogů, které sledujete.</string>
+	<string name="notifications_empty_action_all">Buďte aktivní! Komentujte příspěvky z webů, které sledujete.</string>
 	<string name="notifications_empty_likes">Žádné nové liky...zatím.</string>
 	<string name="notifications_empty_followers">Žádný nový sledující...zatím.</string>
 	<string name="notifications_empty_comments">Žádné nové komentáře...zatím.</string>
 	<string name="notifications_empty_unread">Všechny jsou přečtené.</string>
 	<string name="stats_widget_error_jetpack_no_blogid">Prosím získejte Statistiky v aplikaci, a zkuste později přidat widget</string>
 	<string name="stats_widget_error_readd_widget">Prosím odstraňte widget a později jej znovu přidejte</string>
-	<string name="stats_widget_error_no_visible_blog">Statistiky nemohou být přístupné bez viditelného blogu</string>
-	<string name="stats_widget_error_no_permissions">Váš účet WordPress.com nemá přístup k tomuto blogu</string>
+	<string name="stats_widget_error_no_visible_blog">Statistiky nemohou být přístupné bez viditelného webu</string>
+	<string name="stats_widget_error_no_permissions">Váš účet WordPress.com nemá přístup k tomuto webu</string>
 	<string name="stats_widget_error_no_account">Přihlaste se prosím do WordPress účtu</string>
 	<string name="stats_widget_error_generic">Nelze načíst statistiku</string>
 	<string name="stats_widget_loading_data">Načítám data...</string>
@@ -74,7 +182,7 @@
 	<string name="add_media_permission_required">Je vyžadován souhlas k přidání souborů</string>
 	<string name="access_media_permission_required">Je vyžadován souhlas pro přístup k souborům</string>
 	<string name="stats_enable_rest_api_in_jetpack">Povolte modul JSON API v Jetpacku, k náhledu vašich statistik.</string>
-	<string name="error_open_list_from_notification">Tento příspěvek nebo stránka, byl zveřejněn na jiné webové stránce</string>
+	<string name="error_open_list_from_notification">Tento příspěvek nebo stránka, byl zveřejněn na jiném webu</string>
 	<string name="reader_short_comment_count_multi">%s komentářů</string>
 	<string name="reader_short_comment_count_one">1 komentář</string>
 	<string name="reader_label_submit_comment">Publikovat</string>
@@ -104,13 +212,13 @@
 	<string name="email">E-mail</string>
 	<string name="app_notifications">Upozornění aplikace</string>
 	<string name="notifications_tab">Karta oznámení</string>
-	<string name="notifications_comments_other_blogs">Komentáře na ostatních stránkách</string>
+	<string name="notifications_comments_other_blogs">Komentáře na ostatních webech</string>
 	<string name="notifications_wpcom_updates">Aktualizace WordPress.com</string>
 	<string name="notifications_other">Ostatní</string>
 	<string name="notifications_account_emails">E-mail od WordPress.com</string>
-	<string name="notifications_account_emails_summary">Budeme vždy odeslat důležité e-maily týkající se vašeho účtu, ale můžete získat některé zajímavé bonusy.</string>
+	<string name="notifications_account_emails_summary">Budeme vždy odesílat důležité e-maily týkající se vašeho účtu, ale můžete také získat některé zajímavé bonusy.</string>
 	<string name="your_sites">Vaše stránky</string>
-	<string name="notifications_sights_and_sounds">Památky a zvuky</string>
+	<string name="notifications_sights_and_sounds">Notifikační upozornění</string>
 	<string name="stats_insights_latest_post_trend">Bylo to %1$s od %2$s publikován. Zde je návod, jak byl příspěvek doposud upravován...</string>
 	<string name="stats_insights_latest_post_summary">Přehled posledních příspěvků</string>
 	<string name="button_revert">Vrátit</string>
@@ -119,7 +227,6 @@
 	<string name="connectionbar_no_connection">Bez připojení</string>
 	<string name="button_back">Zpět</string>
 	<string name="button_publish">Publikovat</string>
-	<string name="button_delete">Odstranit</string>
 	<string name="button_edit">Upravit</string>
 	<string name="button_view">Zobrazit</string>
 	<string name="page_trashed">Stránka byla přesunuta do koše</string>
@@ -129,20 +236,19 @@
 	<string name="button_stats">Statistiky</string>
 	<string name="button_trash">Koš</string>
 	<string name="button_preview">Náhled</string>
-	<string name="button_more">Více</string>
 	<string name="trashed">Přesunuto do koše</string>
 	<string name="stats_no_activity_this_period">Žádná aktivita v tomto období</string>
 	<string name="my_site_no_sites_view_subtitle">Chtěli byste přidat jednu?</string>
-	<string name="my_site_no_sites_view_title">Nemáte ještě žádné WordPress stránky.</string>
+	<string name="my_site_no_sites_view_title">Zatím nemáte žádný web WordPress.</string>
 	<string name="my_site_no_sites_view_drake">Ilustrace</string>
-	<string name="reader_toast_err_follow_blog_not_authorized">Nemáte oprávnění pro přístup k tomuto blogu</string>
+	<string name="reader_toast_err_follow_blog_not_authorized">Nemáte oprávnění pro přístup k tomuto webu</string>
 	<string name="reader_toast_err_follow_blog_not_found">Web nebyl nalezen</string>
 	<string name="undo">Zpět</string>
 	<string name="tabbar_accessibility_label_me">Já</string>
 	<string name="tabbar_accessibility_label_my_site">Moje stránky</string>
 	<string name="passcodelock_prompt_message">Zadej PIN</string>
 	<string name="editor_toast_changes_saved">Změny byly uloženy</string>
-	<string name="push_auth_expired">Žádost vypršela. Přihlašte se znovu přes WordPress.com </string>
+	<string name="push_auth_expired">Žádost vypršela. Přihlaste se znovu přes WordPress.com </string>
 	<string name="ignore">Ignorovat</string>
 	<string name="stats_insights_most_popular_percent_views">%1$d%% shlédnutí</string>
 	<string name="stats_insights_best_ever">Nejlepší shlédnutí</string>
@@ -163,28 +269,27 @@
 	<string name="site_picker_create_dotcom">Vytvořit web na WordPress.com</string>
 	<string name="site_picker_add_self_hosted">Přidat vlastní WordPress web</string>
 	<string name="site_picker_add_site">Přidat web</string>
-	<string name="site_picker_edit_visibility">Ukázat/skrýt stránky</string>
+	<string name="site_picker_edit_visibility">Zobrazitt/skrýt stránky</string>
 	<string name="site_picker_title">Vybrat web</string>
 	<string name="my_site_btn_switch_site">Přepnout web</string>
 	<string name="my_site_btn_view_admin">Zobrazit administraci</string>
 	<string name="my_site_btn_view_site">Zobrazit web</string>
 	<string name="my_site_header_publish">Publikovat</string>
 	<string name="my_site_btn_site_settings">Nastavení</string>
-	<string name="my_site_btn_comments">Komentáře</string>
 	<string name="my_site_btn_blog_posts">Příspěvky</string>
 	<string name="my_site_header_look_and_feel">Vzhled</string>
 	<string name="my_site_header_admin">Administrace</string>
 	<string name="my_site_header_configuration">Nastavení</string>
 	<string name="reader_label_new_posts_subtitle">Klepněte pro jejich zobrazení</string>
-	<string name="notifications_account_required">Přihlašte se přes WordPress.com kvůli notifikacím</string>
+	<string name="notifications_account_required">Přihlaste se přes WordPress.com kvůli notifikacím</string>
 	<string name="stats_unknown_author">Neznámý autor</string>
-	<string name="signout">Odpojeno</string>
 	<string name="image_added">Obrázek byl přidán</string>
+	<string name="signout">Odpojit</string>
 	<string name="hide">Skrýt</string>
 	<string name="select_all">Vybrat vše</string>
-	<string name="show">Ukázat</string>
 	<string name="deselect_all">Zrušit výběr</string>
 	<string name="sign_out_wpcom_confirm">Po odpojení se vám z účtu vymažou všechny @%s  WordPress.com údaje z tohoto zařízení, včetně lokálních konceptů a změn.</string>
+	<string name="show">Zobrazit</string>
 	<string name="select_from_new_picker">Nový vícenásobný výběr</string>
 	<string name="no_device_images">Žádné obrázky</string>
 	<string name="no_blog_videos">Žádná videa</string>
@@ -218,11 +323,11 @@
 	<string name="invalid_verification_code">Neplatný ověřovací kód</string>
 	<string name="two_step_footer_button">Odeslat kód pomocí SMS</string>
 	<string name="two_step_sms_sent">Zkontrolujte si své SMSky pro ověřovací kód.</string>
-	<string name="sign_in_jetpack">Přihlašte se k účtu Wordpress.com pro připojení k Jetpacku.</string>
-	<string name="auth_required">Pro pokračování, se přihlašte ještě jednou.</string>
 	<string name="two_step_footer_label">Zadejte kód z ověřovací aplikace</string>
 	<string name="media_details_label_file_type">Typ souboru</string>
 	<string name="media_details_label_file_name">Název souboru</string>
+	<string name="sign_in_jetpack">Přihlaste se k účtu WordPress.com pro připojení k Jetpacku.</string>
+	<string name="auth_required">Pro pokračování, se přihlaste ještě jednou.</string>
 	<string name="comments_fetching">Načítám komentáře...</string>
 	<string name="pages_fetching">Načítám stránky...</string>
 	<string name="toast_err_post_uploading">Při nahrávání nelze příspěvek otevřít</string>
@@ -255,7 +360,6 @@
 	<string name="stats_views">Zobrazení</string>
 	<string name="stats_timeframe_years">Roky</string>
 	<string name="stats_pagination_label">Stránka %1$s do %2$s</string>
-	<string name="stats_comments">Komentáře</string>
 	<string name="stats_likes">To se mi líbí</string>
 	<string name="stats_view_countries">Země</string>
 	<string name="stats_view_videos">Videa</string>
@@ -292,9 +396,7 @@
 	<string name="stats_followers_total_wpcom">Počet odběratelů WordPress.com: %1$s</string>
 	<string name="stats_comments_total_comments_followers">Celkový počet článků s odběrateli: %1$s</string>
 	<string name="stats_empty_video">Žádná přehraná videa</string>
-	<string name="stats_empty_tags_and_categories_desc">Získejte přehled nejpopulárnějších témat na stránce podle příspěvků z uplynulého týdne.</string>
 	<string name="stats_entry_publicize">Služba</string>
-	<string name="stats_empty_followers_desc">Sledujte celkový počet odběratelů a dobu odběru vaší stránky.</string>
 	<string name="stats_empty_publicize_desc">Sledujte celkový počet odběratelů přicházejících ze sociálních sítí prostřednictvím propagace.</string>
 	<string name="stats_empty_video_desc">Jestli jste nahráli videa pomocí VideoPressu, zjistíte kolikrát byla videa zobrazena.</string>
 	<string name="stats_empty_comments_desc">Jestli na své stránce povolíte komentáře, můžete sledovat nejaktivnější komentátory a na základě posledních 1000 komentářů zjistit, jaký obsah podněcuje živou diskuzi.</string>
@@ -309,7 +411,9 @@
 	<string name="stats_empty_clicks_desc">Pokud váš obsah obsahuje odkazy na jiné stránky, podívejte se, na které návštěvníci nejvíce klikají.</string>
 	<string name="stats_empty_referrers_desc">Zjistěte více o viditelnosti stránky prostřednictvím webových stránek a vyhledávačů, které zvyšují její návštěvnost</string>
 	<string name="stats_empty_top_posts_desc">Zjistěte, co je váš nejúspěšnější obsah a zkontrolujte, jak se daří jednotlivým příspěvkům a stránkám v průběhu času.</string>
-	<string name="stats_empty_geoviews_desc">Podívejte se na seznam zemí, které produkují vaší stránce nejvyšší návštěvnost.</string>
+	<string name="stats_empty_followers_desc">Sledujte celkový počet odběratelů a dobu odběru vašeho webu.</string>
+	<string name="stats_empty_tags_and_categories_desc">Získejte přehled nejpopulárnějších témat na webu podle příspěvků z uplynulého týdne.</string>
+	<string name="stats_empty_geoviews_desc">Podívejte se na seznam zemí, které produkují vašemu webu nejvyšší návštěvnost.</string>
 	<string name="ssl_certificate_details">Detaily</string>
 	<string name="sure_to_remove_account">Smazat web?</string>
 	<string name="media_gallery_date_range">Zobraz média od %1$s do %2$s</string>
@@ -320,14 +424,11 @@
 	<string name="confirm_delete_multi_media">Odstranit zvolené položky?</string>
 	<string name="confirm_delete_media">Odstranit zvolenou položku?</string>
 	<string name="reader_title_photo_viewer">%1$d z %2$d</string>
-	<string name="reader_title_comments">Komentáře</string>
 	<string name="reader_label_comments_closed">Komentáře jsou uzavřené</string>
 	<string name="reader_label_comment_count_single">Jeden komentář</string>
 	<string name="reader_label_like">To se mi líbí</string>
-	<string name="new_blog_wpcom_created">WordPress.com blog vytvořen!</string>
 	<string name="signing_out">Odhlásit se </string>
 	<string name="reader_empty_comments">Žádné komentáře</string>
-	<string name="reader_empty_followed_blogs_title">Zatím nesledujete žádné stránky</string>
 	<string name="reader_label_comment_count_multi">%,d komentářů</string>
 	<string name="reader_label_view_original">Zobrazit původní článek</string>
 	<string name="reader_label_comments_on">Komentáře k</string>
@@ -349,7 +450,6 @@
 	<string name="nux_help_description">Pro odpovědi na časté dotazy navštivte naše centrum nápovědy nebo fórum</string>
 	<string name="reader_empty_posts_in_tag">Neexistuje žádný příspěvek s tímto štítkem</string>
 	<string name="stats_no_blog">Statistiky pro daný web nebylo možné načíst</string>
-	<string name="select_a_blog">Vybrat stránku WordPress</string>
 	<string name="sending_content">Nahrávání obsahu %s</string>
 	<string name="posts_empty_list">Žádné příspěvky. Přejete si nějaký vytvořit?</string>
 	<string name="pages_empty_list">Žádné stránky. Přejete si nějakou vytvořit?</string>
@@ -357,16 +457,20 @@
 	<string name="agree_terms_of_service">Založením účtu souhlasíte s našimi %1$sPodmínkami používání služby%2$s</string>
 	<string name="mnu_comment_liked">Líbilo se mi</string>
 	<string name="create_new_blog_wpcom">Vytvořit web na WordPress.com</string>
+	<string name="more">Více</string>
+	<string name="new_blog_wpcom_created">WordPress.com web byl vytvořen!</string>
+	<string name="select_a_blog">Vybrat web WordPress</string>
+	<string name="reader_empty_followed_blogs_title">Zatím nesledujete žádné weby</string>
 	<string name="reader_toast_err_generic">Nepodařilo se provést tuto akci</string>
 	<string name="reader_toast_blog_blocked">Příspěvky z tohoto webu se již nebudou zobrazovat</string>
 	<string name="reader_toast_err_block_blog">Nepodařilo se zablokovat tento web</string>
 	<string name="reader_menu_block_blog">Zablokovat tento web</string>
-	<string name="hs__conversation_header">Chat podporován</string>
-	<string name="hs__new_conversation_header">Chat podporován</string>
 	<string name="contact_us">Kontaktujte nás</string>
 	<string name="hs__conversation_detail_error">Popište problém, který vidíte</string>
 	<string name="hs__username_blank_error">Zadejte platné jméno</string>
 	<string name="hs__invalid_email_error">Zadejte platnou e-mailovou adresu</string>
+	<string name="hs__new_conversation_header">Chat podpory</string>
+	<string name="hs__conversation_header">Chat podpory</string>
 	<string name="current_location">Současná poloha</string>
 	<string name="add_location">Přidat polohu</string>
 	<string name="your_signature">Váš podpis:</string>
@@ -399,29 +503,25 @@
 	<string name="forums">Diskusní fórum</string>
 	<string name="help_center">Centrum nápovědy</string>
 	<string name="ssl_certificate_error">Neplatný SSL certifikát</string>
-	<string name="ssl_certificate_ask_trust">Pokud se k těmto stránkám obvykle připojuješ bez problémů, pak tato chyba znamená, že se někdo snaží podvrhnout identitu a neměl bys pokračovat. Chceš přesto důvěřovat tomuto certifikátu?</string>
+	<string name="ssl_certificate_ask_trust">Pokud se k tomuto webu obvykle připojujete bez problémů, pak tato chyba znamená, že se někdo snaží podvrhnout vaši identitu a neměli byste dále pokračovat. Chcete i přesto důvěřovat tomuto certifikátu?</string>
 	<string name="out_of_memory">Nedostatek paměti v zařízení</string>
 	<string name="no_network_message">Není dostupná žádná síť</string>
 	<string name="gallery_error">Multimediální položka nemohla být stažena</string>
-	<string name="blog_not_found">Nastala chyba při přístupu na tento blog</string>
 	<string name="wait_until_upload_completes">Čekej dokud neskončí nahrávání</string>
 	<string name="theme_fetch_failed">Chyba při získávání motivů</string>
 	<string name="theme_set_failed">Chyba při nastavení motivu</string>
 	<string name="theme_auth_error_message">Ujisti se, že máš práva k nastavení motivu</string>
 	<string name="comments_empty_list">Žádný komentář</string>
 	<string name="mnu_comment_unspam">Není spam</string>
-	<string name="no_site_error">Nemohu se připojit na WordPress server</string>
 	<string name="adding_cat_failed">Chyba při přidávání kategorie</string>
 	<string name="adding_cat_success">Kategorie úspěšně přidána</string>
 	<string name="cat_name_required">Jméno kategorie musí být vyplněno</string>
 	<string name="category_automatically_renamed">Jméno kategorie %1$s není platné. Bylo změněno na %2$s.</string>
 	<string name="no_account">Nebyl nalezen žádný WordPress účet. Přidej účet a zkus znovu</string>
 	<string name="auto_sharing_preference_reset">Reset nastavení automatického sdílení </string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Dříve vybraný blog už není viditelný</string>
 	<string name="sdcard_message">Pro nahrání media musí být připojená SD karta</string>
 	<string name="stats_empty_comments">Žádné komentáře</string>
 	<string name="stats_bar_graph_empty">Statistika není dostupná</string>
-	<string name="invalid_url_message">Zkontroluj, že vložená adresa blogu je platná</string>
 	<string name="reply_failed">Odpověď se nezdařila</string>
 	<string name="notifications_empty_list">Žádná oznámení</string>
 	<string name="error_delete_post">Nastala chyba při mazání %s</string>
@@ -451,22 +551,24 @@
 	<string name="username_exists">Toto uživatelské jméno již existuje</string>
 	<string name="email_exists">Tato emailová adresa je již používána</string>
 	<string name="username_reserved_but_may_be_available">Toto uživatelské jméno je momentálně rezervované, ale může být dostupné během pár dnů</string>
-	<string name="blog_name_required">Vlož adresu blogu</string>
-	<string name="blog_name_not_allowed">Tato adresa blogu není dovolena</string>
-	<string name="blog_name_must_be_at_least_four_characters">Adresa blogu musí obsahovat alespoň 4 znaky</string>
-	<string name="blog_name_must_be_less_than_sixty_four_characters">Adresa blogu musí být kratší než 64 znaků</string>
-	<string name="blog_name_contains_invalid_characters">Adresa blogu nesmí obsahovat znak "_"</string>
-	<string name="blog_name_cant_be_used">Nemůžeš použít tuto adresu blogu</string>
-	<string name="blog_name_only_lowercase_letters_and_numbers">Adresa blogu může obsahovat pouze malá písmena (a-z) a číslice</string>
-	<string name="blog_name_exists">Tento blog už existuje</string>
-	<string name="blog_name_reserved">Tento blog je rezervován</string>
-	<string name="blog_name_reserved_but_may_be_available">Tento blog je momentálně rezervován ale může být dostupný během pár dnů</string>
-	<string name="username_or_password_incorrect">Vložené uživatelské jméno a heslo nejsou správné</string>
 	<string name="nux_cannot_log_in">Nemohli jsme tě přihlásit</string>
 	<string name="could_not_remove_account">Nelze odstranit web</string>
 	<string name="error_moderate_comment">Nastala chyba při moderování</string>
-	<string name="add_account_blog_url">Zadej URL blogu</string>
-	<string name="wordpress_blog">WordPress blog</string>
+	<string name="username_or_password_incorrect">Vložené uživatelské jméno nebo heslo je neplatné</string>
+	<string name="blog_name_cant_be_used">Nemůžeš použít tuto adresu webu</string>
+	<string name="blog_name_must_be_less_than_sixty_four_characters">Adresa webu musí být kratší než 64 znaků</string>
+	<string name="blog_name_reserved">Tento web je rezervován</string>
+	<string name="blog_name_reserved_but_may_be_available">Tento web je momentálně rezervován ale může být dostupný během pár dnů</string>
+	<string name="blog_name_exists">Tento web již existuje</string>
+	<string name="blog_name_not_allowed">Tato adresa webu není povolena</string>
+	<string name="blog_name_must_be_at_least_four_characters">Adresa webu musí obsahovat alespoň 4 znaky</string>
+	<string name="blog_name_contains_invalid_characters">Adresa webu nesmí obsahovat znak "_"</string>
+	<string name="blog_name_only_lowercase_letters_and_numbers">Adresa webu může obsahovat pouze malá písmena (a-z) a číslice</string>
+	<string name="auto_sharing_preference_reset_caused_by_error">Dříve vybraný web už není viditelný</string>
+	<string name="blog_name_required">Vlož adresu webu</string>
+	<string name="invalid_url_message">Zkontrolujte platnost zadané adresy webu</string>
+	<string name="blog_not_found">Nastala chyba při přístupu na tento web</string>
+	<string name="no_site_error">Nemohu se připojit k serveru WordPress</string>
 	<string name="reader_share_link">Odkaz pro sdílení</string>
 	<string name="view_site">Zobrazit stránku</string>
 	<string name="new_media">Nahrát soubor</string>
@@ -495,7 +597,6 @@
 	<string name="add_comment">Přidat komentář</string>
 	<string name="post_format">Formát příspěvku</string>
 	<string name="remove_account">Odstranit web</string>
-	<string name="xmlrpc_error">Nelze se připojit. Vlož celou cestu k xmlrpc.php na svém blogu a zkus znovu.</string>
 	<string name="select_categories">Vyber kategorie</string>
 	<string name="account_details">Detaily účtu</string>
 	<string name="edit_post">Uprav článek</string>
@@ -510,7 +611,6 @@
 	<string name="hint_comment_content">Komentář</string>
 	<string name="content_required">Je vyžadován komentář</string>
 	<string name="toast_comment_unedited">Komentář nebyl změněn</string>
-	<string name="blog_removed_successfully">Stránka byla úspěšně odstraněna</string>
 	<string name="comment_added">Komentář byl úspěšně přidán</string>
 	<string name="view_in_browser">Zobrazit v prohlížeči</string>
 	<string name="add_new_category">Přidat novou rubriku</string>
@@ -568,13 +668,17 @@
 	<string name="post_not_published">Příspěvek není zveřejněn</string>
 	<string name="page_not_published">Stránka není zveřejněna</string>
 	<string name="site_address">Vaše vlastní adresa (URL)</string>
+	<string name="wordpress_blog">WordPress web</string>
+	<string name="xmlrpc_error">Nelze se připojit. Vlož celou cestu k xmlrpc.php na svém webu a zkus znovu.</string>
+	<string name="add_account_blog_url">Zadej URL webu</string>
+	<string name="blog_removed_successfully">Web byl úspěšně odstraněn</string>
 	<string name="share_url_page">Sdílení stránky</string>
 	<string name="deleting_page">Mazání stránky</string>
 	<string name="deleting_post">Smazat příspěvek</string>
 	<string name="share_url_post">Sdílet příspěvek</string>
 	<string name="share_link">Sdílet odkaz</string>
 	<string name="creating_your_account">Vytvářím váš účet</string>
-	<string name="creating_your_site">Vytvářím vaše stránky</string>
+	<string name="creating_your_site">Vytvářím vaši stránku</string>
 	<string name="reader_empty_posts_in_tag_updating">Načítám příspěvky...</string>
 	<string name="error_refresh_media">Nastal chyba při aktualizaci knihovny médií. Zkuste to prosím později.</string>
 	<string name="video">Video</string>
@@ -603,7 +707,7 @@
 	<string name="password_invalid">Potřebujete bezpečnější heslo. Ujistěte se, že používáte více než 7 znaků, kombinujete velká a malá písmena, čísla, nebo speciální znaky.</string>
 	<string name="nux_welcome_create_account">Vytvořit účet</string>
 	<string name="nux_oops_not_selfhosted_blog">Přihlásit se k WordPress.com</string>
-	<string name="nux_add_selfhosted_blog">Přidejte vlastní stránku</string>
+	<string name="nux_add_selfhosted_blog">Přidejte vlastní web</string>
 	<string name="nux_tutorial_get_started_title">Můžeme začít!</string>
 	<string name="reader_btn_share">Sdílet</string>
 	<string name="username_invalid">Špatné uživatelské jméno</string>
@@ -637,12 +741,10 @@
 	<string name="stats_entry_posts_and_pages">Nadpis</string>
 	<string name="stats_entry_tags_and_categories">Téma</string>
 	<string name="stats_totals_views">Zobrazení</string>
-	<string name="stats_totals_comments">Komentáře</string>
 	<string name="stats_timeframe_days">Dny</string>
 	<string name="stats_timeframe_months">Měsíce</string>
 	<string name="media_gallery_image_order_reverse">Obrátit</string>
 	<string name="media_gallery_type_slideshow">Slideshow</string>
-	<string name="stats_view_comments">Komentáře</string>
 	<string name="stats_timeframe_today">Dnes</string>
 	<string name="stats_timeframe_yesterday">Včera</string>
 	<string name="images">Obrázky</string>
@@ -711,7 +813,7 @@
 	<string name="error_media_upload">Došlo k chybě během nahrávání médií</string>
 	<string name="publish_date">Publikovat</string>
 	<string name="content_description_add_media">Přidat média</string>
-	<string name="post_content">Obsah článku (tapněte pro přidání textu, videa nebo obrázku)</string>
+	<string name="post_content">Obsah článku (klepněte pro přidání textu a mediálního souboru)</string>
 	<string name="incorrect_credentials">Nesprávné uživatelské jméno nebo heslo.</string>
 	<string name="password">Heslo</string>
 	<string name="username">Uživatelské jméno</string>
@@ -750,11 +852,11 @@
 	<string name="settings">Nastavení</string>
 	<string name="today">Dnes</string>
 	<string name="share_url">Sdílej adresu</string>
-	<string name="quickpress_window_title">Vyberte blog pro zkrácený odkaz QuickPress</string>
 	<string name="quickpress_add_error">Název zkráceného odkazu nemůže být prázdný</string>
-	<string name="publish_post">Veřejné</string>
+	<string name="quickpress_window_title">Vyberte web pro zkrácený odkaz QuickPress</string>
 	<string name="draft">Koncept</string>
 	<string name="post_private">Soukromé</string>
+	<string name="publish_post">Publikováno</string>
 	<string name="upload_full_size_image">Nahrát a odkazovat na plný obrázek</string>
 	<string name="title">Název</string>
 	<string name="tags_separate_with_commas">Tagy (oddělte tagy čárkami)</string>
@@ -769,9 +871,8 @@
 	<string name="media">Media</string>
 	<string name="delete">Vymazat</string>
 	<string name="none">Žádný</string>
-	<string name="blogs">Blogy</string>
+	<string name="blogs">Weby</string>
 	<string name="select_photo">Vyberte fotografii z galerie</string>
-	<string name="tab_comments">Komentáře</string>
 	<string name="reply">Odpovědět</string>
 	<string name="preview">Náhled</string>
 	<string name="on">na</string>
@@ -790,11 +891,11 @@
 		<item>Vpravo</item>
 	</string-array>
 	<string-array name="notifications_blog_settings">
-		<item>Komentářů na mé stránce</item>
+		<item>Komentářů na mém webu</item>
 		<item>To se mi líbí k mým komentářům</item>
 		<item>To se mi líbí k mým příspěvkům</item>
-		<item>Sledující stránky</item>
-		<item>Úspěchy stránky</item>
+		<item>Sledující weby</item>
+		<item>Úspěchy webu</item>
 		<item>V uživatelském jménu zmiňujete</item>
 	</string-array>
 	<string-array name="notifications_other_settings">
@@ -828,6 +929,33 @@
 		<item>Standardní</item>
 		<item>Stav</item>
 		<item>Video</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>Váš web je viditelný pro všechny a může být indexován vyhledávači</item>
+		<item>Váš web je viditelný pro všechny, ale žádá vyhledávače aby jej neindexovali</item>
+		<item>Váš web je viditelný pouze pro vás a pro vámi schválené uživatele</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>Manuálně schvalovat veškeré komentáře.</item>
+		<item>Automaticky schválit komentář, pokud už autor napsal alespoň jeden schválený komentář.</item>
+		<item>Automaticky schvalovat veškeré komentáře.</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>Žádné komentáře</item>
+		<item>Komentáře známých uživatelů</item>
+		<item>Všichni uživatelé</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>Žádné</item>
+		<item>Dvě úrovně</item>
+		<item>Tři úrovně</item>
+		<item>Čtyři úrovně</item>
+		<item>Pět úrovní</item>
+		<item>Šest úrovní</item>
+		<item>Sedm úrovní</item>
+		<item>Osm úrovní</item>
+		<item>Devět úrovní</item>
+		<item>Deset úrovní</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>Zdarma</item>

--- a/WordPress/src/main/res/values-cy/strings.xml
+++ b/WordPress/src/main/res/values-cy/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">Maint Gwreiddiol</string>
+	<string name="about_me_hint">Ychydig o eiriau amdanoch chi…</string>
+	<string name="public_display_name_hint">Bydd yr enw dangos yn defnyddio eich enw defnyddiwr os yw wedi ei osod</string>
+	<string name="about_me">Amdanaf fi</string>
+	<string name="public_display_name">Enw dangos cyhoeddus</string>
+	<string name="my_profile">Fy Mhroffil</string>
+	<string name="first_name">Enw cyntaf</string>
+	<string name="last_name">Enw olaf</string>
+	<string name="site_privacy_public_desc">Caniatáu i beiriannau chwilio fynegeio\'r wefan</string>
+	<string name="site_privacy_hidden_desc">Annog peiriannau chwilio i beidio mynegeio\'r wefan</string>
+	<string name="site_privacy_private_desc">Hoffwn i fy ngwefan fod yn breifat, yn weladwy yn unig i ddefnyddwyr rwy\'n eu dewis</string>
+	<string name="cd_related_post_preview_image">Delwedd sy\'n perthyn ar ôl y rhagolwg</string>
+	<string name="error_post_remote_site_settings">Methu cadw manylion y wefan</string>
+	<string name="error_fetch_remote_site_settings">Methu estyn manylion y wefan</string>
+	<string name="error_media_upload_connection">Digwyddodd gwall cysylltu wrth lwytho\'r cyfrwng</string>
+	<string name="site_settings_disconnected_toast">Datgysylltwyd, analluogwyd y golygu.</string>
+	<string name="site_settings_unsupported_version_error">Fersiwn o WordPress sydd heb ei gynnal</string>
+	<string name="site_settings_multiple_links_dialog_description">Bydd angen cymeradwyaeth ar gyfer sylwadau sy\'n cynnwys mwy na\'r nifer yma o ddolenni.</string>
+	<string name="site_settings_close_after_dialog_switch_text">Cau\'n awtomatig</string>
+	<string name="site_settings_close_after_dialog_description">Cau\'r sylwadau ar erthyglau yn awtomatig.</string>
+	<string name="site_settings_paging_dialog_description">Torri\'r edefyn sylw i dudalennau lluosog.</string>
+	<string name="site_settings_paging_dialog_header">Sylwadau fesul tudalen</string>
+	<string name="site_settings_close_after_dialog_title">Cau sylwadau</string>
+	<string name="site_settings_blacklist_description">Pan fydd sylw yn cynnwys unrhyw un o\'r geiriau hyn yn ei gynnwys, enw, URL, e-bost, neu IP, bydd yn cael ei farcio fel sbam. Gallwch gynnig geiriau rhannol, felly bydd "press" yn canfod "WordPress"</string>
+	<string name="site_settings_hold_for_moderation_description">Pan fydd sylw yn cynnwys unrhyw un o\'r geiriau hyn yn ei gynnwys, enw, URL, e-bost neu IP, bydd yn cael ei gadw yn y rhes cymedroli. Gallwch gynnig geiriau rhannol, felly bydd "press" yn canfod "WordPress"</string>
+	<string name="site_settings_list_editor_input_hint">Teipiwch air neu ymadrodd</string>
+	<string name="site_settings_list_editor_no_items_text">Dim eitemau</string>
+	<string name="site_settings_learn_more_caption">Gallwch diystyru\'r gosodiadau hyn ar gyfer cofnodion unigol.</string>
+	<string name="site_settings_rp_preview3_site">yn "Diweddariad"</string>
+	<string name="site_settings_rp_preview3_title">Canolbwynt Diweddaru: VideoPress ar gyfer Priodasau</string>
+	<string name="site_settings_rp_preview2_site">yn "Apiau"</string>
+	<string name="site_settings_rp_preview2_title">Mae Ap WordPress Android yn Derbyn Adnewyddiad Sylweddol</string>
+	<string name="site_settings_rp_preview1_site">yn "Symudol"</string>
+	<string name="site_settings_rp_preview1_title">Diweddariad iPhone/iPad Mawr Nawr ar Gael</string>
+	<string name="site_settings_rp_show_images_title">Dangos Delweddau</string>
+	<string name="site_settings_rp_show_header_title">Dangos Pennyn</string>
+	<string name="site_settings_rp_switch_summary">Mae Cofnodion Perthynol yn dangos cynnwys perthnasol o\'ch gwefan islaw eich cofnodion.</string>
+	<string name="site_settings_rp_switch_title">Dangos Cofnodion sy\'n Perthyn</string>
+	<string name="site_settings_delete_site_hint">Dileu data eich gwefan o\'r ap</string>
+	<string name="site_settings_blacklist_hint">Mae sylwadau sy\'n cyfateb i hidl yn cael eu marcio fel sbam</string>
+	<string name="site_settings_moderation_hold_hint">Mae sylwadau sy\'n cyfateb i hidl yn cael gosod yn y rhes cymedroli</string>
+	<string name="site_settings_multiple_links_hint">Anwybyddu terfyn dolen gan ddefnyddwyr hysbys</string>
+	<string name="site_settings_whitelist_hint">Rhaid i awdur y sylw fod wedi cyfrannu sylw cymeradwy yn y gorffennol</string>
+	<string name="site_settings_user_account_required_hint">Rhaid i ddefnyddwyr fod wedi\'u cofrestru ac wedi mewngofnodi cyn cynnig sylw</string>
+	<string name="site_settings_identity_required_hint">Rhaid i awdur sylw rhoi enw ac e-bost</string>
+	<string name="site_settings_manual_approval_hint">Rhaid i sylwadau gael eu cymeradwyo â llaw</string>
+	<string name="site_settings_paging_hint">Dangos sylwadau mewn darnau o faint penodol</string>
+	<string name="site_settings_threading_hint">Caniatáu sylwadau nythog i ddyfnder penodol</string>
+	<string name="site_settings_sort_by_hint">Pennu\'r drefn mae\'r sylwadau yn cael eu dangos</string>
+	<string name="site_settings_close_after_hint">Peidio â chaniatáu sylwadau ar ôl amser penodol</string>
+	<string name="site_settings_receive_pingbacks_hint">Caniatáu hysbysiadau dolenni o flogiau eraill</string>
+	<string name="site_settings_send_pingbacks_hint">Ceisio hysbysu unrhyw flogiau sy\'n cael eu cysylltu atyn nhw yn yr erthygl</string>
+	<string name="site_settings_allow_comments_hint">Caniatáu darllenwyr i gofnodi sylwadau</string>
+	<string name="site_settings_discussion_hint">Gweld a newid gosodiadau trafodaethau ar eich gwefannau</string>
+	<string name="site_settings_more_hint">Gweld pob gosodiad trafodaeth sydd ar gael</string>
+	<string name="site_settings_related_posts_hint">Dangos neu guddio cofnodion cysylltiedig yn y darllenydd</string>
+	<string name="site_settings_upload_and_link_image_hint">Galluogi llwytho delwedd maint llawn bob tro</string>
+	<string name="site_settings_image_width_hint">Newid maint delweddau mewn cofnodion i\'r lled hwn</string>
+	<string name="site_settings_format_hint">Gosod fformat cofnod newydd</string>
+	<string name="site_settings_category_hint">Gosod categori cofnod newydd</string>
+	<string name="site_settings_location_hint">Ychwanegu data lleoliad yn awtomatig at eich cofnodion</string>
+	<string name="site_settings_password_hint">Newid eich cyfrinair</string>
+	<string name="site_settings_username_hint">Cyfrif y defnyddiwr cyfredol</string>
+	<string name="site_settings_language_hint">Yr iaith mae\'r blog yn cael ei ysgrifennu ynddi yn bennaf</string>
+	<string name="site_settings_privacy_hint">Rheoli pwy sy\'n gallu gweld eich gwefan</string>
+	<string name="site_settings_address_hint">Nid yw newid eich cyfeiriad yn cael ei gynnal ar hyn o bryd</string>
+	<string name="site_settings_tagline_hint">Disgrifiad byr neu ymadrodd bachog i ddisgrifio eich blog</string>
+	<string name="site_settings_title_hint">Mewn ychydig eiriau, yn esboniwch beth yw natur y wefan hon</string>
+	<string name="site_settings_whitelist_known_summary">Sylwadau gan ddefnyddwyr hysbys</string>
+	<string name="site_settings_whitelist_all_summary">Sylwadau gan pob defnyddiwr</string>
+	<string name="site_settings_threading_summary">%d lefel</string>
+	<string name="site_settings_privacy_private_summary">Preifat</string>
+	<string name="site_settings_privacy_hidden_summary">Cudd</string>
+	<string name="site_settings_delete_site_title">Dileu Gwefan</string>
+	<string name="site_settings_privacy_public_summary">Cyhoeddus</string>
+	<string name="site_settings_blacklist_title">Rhestr ddu</string>
+	<string name="site_settings_moderation_hold_title">Dal ar gyfer Cymedroli</string>
+	<string name="site_settings_multiple_links_title">Dolenni mewn sylwadau</string>
+	<string name="site_settings_whitelist_title">Gymeradwyo\'n Awtomatig</string>
+	<string name="site_settings_threading_title">Edafu</string>
+	<string name="site_settings_paging_title">Tudalennu</string>
+	<string name="site_settings_sort_by_title">Trefnu yn ôl</string>
+	<string name="site_settings_account_required_title">Rhaid llofnodi defnyddwyr</string>
+	<string name="site_settings_identity_required_title">Rhaid cynnwys enw ac e-bost</string>
+	<string name="site_settings_receive_pingbacks_title">Derbyn Hysbysiad Cyfeirio</string>
+	<string name="site_settings_send_pingbacks_title">Anfon Hysbysiadau Cyfeirio</string>
+	<string name="site_settings_allow_comments_title">Caniatáu Sylwadau</string>
+	<string name="site_settings_default_format_title">Fformat Rhagosodedig</string>
+	<string name="site_settings_default_category_title">Categori Rhagosodedig</string>
+	<string name="site_settings_location_title">Galluogi Lleoliad</string>
+	<string name="site_settings_address_title">Cyfeiriad</string>
+	<string name="site_settings_title_title">Teitl y Wefan</string>
+	<string name="site_settings_tagline_title">Llinell Tag</string>
+	<string name="site_settings_this_device_header">Y ddyfais hon</string>
+	<string name="site_settings_discussion_new_posts_header">Rhagosodiadau ar gyfer cofnodion ewydd</string>
+	<string name="site_settings_account_header">Cyfrif</string>
+	<string name="site_settings_writing_header">Ysgrifennu</string>
+	<string name="newest_first">Diweddaraf yn gyntaf</string>
+	<string name="site_settings_general_header">Cyfredinol</string>
+	<string name="discussion">Trafodaeth</string>
+	<string name="privacy">Preifatrwydd</string>
+	<string name="related_posts">Cofnodion sy\'n Perthyn</string>
+	<string name="comments">Sylwadau</string>
+	<string name="close_after">Cau ar ôl</string>
+	<string name="oldest_first">Hynaf yn gyntaf</string>
+	<string name="media_error_no_permission_upload">Nid oes gennych ganiatâd i lwytho cyfrwng i\'r wefan</string>
+	<string name="never">Byth</string>
+	<string name="unknown">Anhysbys</string>
 	<string name="reader_err_get_post_not_found">Nid yw\'r cofnod yma\'n bodoli bellach</string>
 	<string name="reader_err_get_post_not_authorized">Nid ydych wedi eich awdurdodi i weld y cofnod hwn</string>
 	<string name="reader_err_get_post_generic">Methu estyn y cofnod hwn</string>
@@ -14,8 +122,8 @@
 	<string name="media_details_label_date_added">Ychwanegwyd</string>
 	<string name="selected_theme">Thema Dewiswyd</string>
 	<string name="could_not_load_theme">Methu llwytho\'r thema</string>
-	<string name="theme_activation_error">Aeth rhywbeth o\'i le</string>
-	<string name="theme_by_author_prompt_append">gan %1$s</string>
+	<string name="theme_activation_error">Aeth rhywbeth o\'i le. Methu cychwyn y thema</string>
+	<string name="theme_by_author_prompt_append"> gan %1$s</string>
 	<string name="theme_prompt">Diolch am ddewis %1$s</string>
 	<string name="theme_try_and_customize">Defnyddio a Chyfaddasu</string>
 	<string name="theme_view">Golwg</string>
@@ -53,8 +161,8 @@
 	<string name="search_sites">Chwilio gwefannau</string>
 	<string name="notifications_empty_view_reader">Gweld y Darllennydd</string>
 	<string name="unread">Deb ei ddarllen</string>
-	<string name="notifications_empty_action_followers_likes">Denu sylw: rhowch sylw ar gofnod rydych wedi ei ddarllen</string>
-	<string name="notifications_empty_action_comments">Ymunwch â sgwrs: rhowch sylw ar flogiau rydych yn eu dilyn</string>
+	<string name="notifications_empty_action_followers_likes">Denu sylw: rhowch sylw ar gofnod rydych wedi ei ddarllen.</string>
+	<string name="notifications_empty_action_comments">Ymunwch â sgwrs: rhowch sylw ar flogiau rydych yn eu dilyn.</string>
 	<string name="notifications_empty_action_unread">Ail-gynnwch sgwrs: ysgrifennwch gofnod newydd.</string>
 	<string name="notifications_empty_action_all">Byddwch egniol! Rhowch sylwadau ar flogiau rydych yn eu dilyn.</string>
 	<string name="notifications_empty_likes">Dim hoffi newydd i\'w dangos...eto.</string>
@@ -62,18 +170,18 @@
 	<string name="notifications_empty_comments">Dim sylwadau newydd...eto.</string>
 	<string name="notifications_empty_unread">Wedi dal i fyny!</string>
 	<string name="stats_widget_error_jetpack_no_blogid">Ewch i\'r Ystadegau yn yr ap a cheisio ychwanegu\'r teclyn yn hwyrach</string>
-	<string name="stats_widget_error_readd_widget">Tynnwch y teclyn a\'i ychwanegu eto.</string>
+	<string name="stats_widget_error_readd_widget">Tynnwch y teclyn a\'i ychwanegu eto</string>
 	<string name="stats_widget_error_no_visible_blog">Nid oes modd mynd i\'r Ystadegau heb flog gweladwy</string>
-	<string name="stats_widget_error_no_permissions">Nid yw eich cyfrif WordPress.com yn cael mynediad i\'r Ystadegau ar y blog.</string>
+	<string name="stats_widget_error_no_permissions">Nid yw eich cyfrif WordPress.com yn cael mynediad i\'r Ystadegau ar y blog</string>
 	<string name="stats_widget_error_no_account">Mewngofnodwch i WordPress</string>
 	<string name="stats_widget_error_generic">Methu llwytho\'r Ystadegau</string>
-	<string name="stats_widget_loading_data">Llwytho data...</string>
+	<string name="stats_widget_loading_data">Llwytho data…</string>
 	<string name="stats_widget_name_for_blog">Ystadegau %1$s Heddiw</string>
 	<string name="stats_widget_name">Ystadegau Heddiw WordPress</string>
 	<string name="add_location_permission_required">Caniatâd angenrheidiol er mwyn ychwanegu lleoliad</string>
 	<string name="add_media_permission_required">Caniatâd angenrheidiol er mwyn ychwanegu cyfrwng</string>
 	<string name="access_media_permission_required">Caniatâd angenrheidiol er mwyn cael mynediad at gyfrwng</string>
-	<string name="stats_enable_rest_api_in_jetpack">I weld eich ystadegau, galluogwch y modiwl  JSON API yn Jetpack.</string>
+	<string name="stats_enable_rest_api_in_jetpack">I weld eich ystadegau, galluogwch y modiwl JSON API yn Jetpack.</string>
 	<string name="error_open_list_from_notification">Cafodd y cofnod neu dudalen hwn ei gyhoeddi ar wefan arall</string>
 	<string name="reader_short_comment_count_multi">%s Sylw</string>
 	<string name="reader_short_comment_count_one">1 Sylw</string>
@@ -124,13 +232,11 @@
 	<string name="stats_no_activity_this_period">Dim gweithgaredd yn ystod y cyfnod hwn</string>
 	<string name="button_back">Nôl</string>
 	<string name="page_deleted">Dilëwyd y dudalen</string>
-	<string name="button_more">Rhagor</string>
 	<string name="button_stats">Ystadegau</string>
 	<string name="button_trash">Sbwriel</string>
 	<string name="button_edit">Golygu</string>
 	<string name="button_preview">Rhagolwg</string>
 	<string name="button_view">Gweld</string>
-	<string name="button_delete">Dileu</string>
 	<string name="button_publish">Cyhoeddi</string>
 	<string name="my_site_no_sites_view_subtitle">Hoffech chi ychwanegu un?</string>
 	<string name="my_site_no_sites_view_title">Nid oes gennych wefannau WordPress eto.</string>
@@ -172,7 +278,6 @@
 	<string name="my_site_header_publish">Cyhoeddi</string>
 	<string name="my_site_btn_blog_posts">Cofnodion Blog</string>
 	<string name="my_site_btn_site_settings">Gosodiadau</string>
-	<string name="my_site_btn_comments">Sylwadau</string>
 	<string name="reader_label_new_posts_subtitle">Tapio i\'w dangos</string>
 	<string name="my_site_header_admin">Gweinyddu</string>
 	<string name="my_site_header_configuration">Ffurfweddiad</string>
@@ -257,11 +362,9 @@
 	<string name="stats_empty_tags_and_categories_desc">Derbyn trosolwg o\'r pynciau mwyaf poblogaidd ar eich gwefan, yn ôl y prif gofnodion yn ystod yr wythnos diwethaf.</string>
 	<string name="stats_empty_referrers_desc">Dysgu rhagor am welededd eich gwefan drwy edrych ar y gwefannau a pheiriannau chwilio sy\'n anfon y mwyaf o draffig atoch</string>
 	<string name="stats_other_recent_stats_label">Ystadegau Diweddar Eraill</string>
-	<string name="themes_fetching">Estyn themâu</string>
 	<string name="stats_timeframe_years">Blwyddyn</string>
 	<string name="stats_views">Golwg</string>
 	<string name="stats_visitors">Ymwelwyr</string>
-	<string name="stats_comments">Sylwadau</string>
 	<string name="stats_entry_clicks_link">Dolen</string>
 	<string name="stats_view_top_posts_and_pages">Cofnod a Thudalen</string>
 	<string name="stats_view_videos">Fideos</string>
@@ -310,6 +413,7 @@
 	<string name="stats_for">Ystadegau %s</string>
 	<string name="stats_view_all">Gweld y cyfan</string>
 	<string name="stats_view">Gweld</string>
+	<string name="themes_fetching">Estyn themâu…</string>
 	<string name="ssl_certificate_details">Manylion</string>
 	<string name="confirm_delete_media">Dileu\'r eitem hon?</string>
 	<string name="sure_to_remove_account">Tynnu\'r blog?</string>
@@ -337,13 +441,13 @@
 	<string name="select_a_blog">Dewis gwefan WordPress</string>
 	<string name="stats_no_blog">Nid oedd modd llwytho ystadegau\'r blog dan sylw</string>
 	<string name="older_last_week">Mwy nag wythnos</string>
+	<string name="more">Rhagor</string>
 	<string name="error_refresh_unauthorized_comments">Nid oes gennych ganiatâd i weld na golygu sylwadau</string>
 	<string name="error_refresh_unauthorized_pages">Nid oes gennych ganiatâd i weld na golygu tudalennau</string>
 	<string name="error_refresh_unauthorized_posts">Nid oes gennych ganiatâd i weld na golygu cofnodion</string>
 	<string name="error_publish_empty_post">Methu cyhoeddi cofnod gwag</string>
 	<string name="reader_title_photo_viewer">%1$d o %2$d</string>
 	<string name="reader_label_comments_on">Sylwadau ar</string>
-	<string name="reader_title_comments">Sylwadau</string>
 	<string name="reader_label_comments_closed">Mae\'r sylwadau wedi cau</string>
 	<string name="reader_label_comment_count_single">Un sylw</string>
 	<string name="reader_label_like">Hoffi</string>
@@ -354,9 +458,9 @@
 	<string name="create_new_blog_wpcom">Creu blog WordPress.com</string>
 	<string name="nux_help_description">Ewch i\'n canolfan gymorth i gael atebion i\'r cwestiynnau mwyaf cyffredin neu i\'n fforymau i ofyn rhai newydd</string>
 	<string name="browse_our_faq_button">Porwch ein Cwestiynnau Cyffredin</string>
-	<string name="faq_button">Cwestiynnau cyffredin</string>
 	<string name="reader_empty_posts_liked">Nid ydych wedi hoffi unrhyw gofnod</string>
 	<string name="reader_empty_followed_blogs_title">Nid ydych yn dilyn unrhyw wefan hyd yn hyn</string>
+	<string name="faq_button">Cwestiynnau Cyffredin</string>
 	<string name="reader_toast_err_generic">Methu cyflawni\'r weithred hon</string>
 	<string name="reader_toast_err_block_blog">Methu rhwystro\'r blog hwn</string>
 	<string name="reader_toast_blog_blocked">Ni fydd cofnodion o\'r blog yn cael eu dangos bellach</string>
@@ -645,7 +749,6 @@
 	<string name="passcode_manage">Rheoli clo PIN</string>
 	<string name="menu_search">Chwilio</string>
 	<string name="stats_totals_plays">Chwarae</string>
-	<string name="stats_totals_comments">Sylwadau</string>
 	<string name="stats_totals_clicks">Cliciau</string>
 	<string name="stats_totals_views">Golwg</string>
 	<string name="stats_entry_referrers">Cyfeiriwr</string>
@@ -658,7 +761,6 @@
 	<string name="stats_timeframe_yesterday">Ddoe</string>
 	<string name="stats_timeframe_days">Diwrnod</string>
 	<string name="stats_timeframe_today">Heddiw</string>
-	<string name="stats_view_comments">Sylwadau</string>
 	<string name="stats_view_referrers">Cyfeirwyr</string>
 	<string name="stats_view_clicks">Cliciau</string>
 	<string name="stats_view_visitors_and_views">Ymwelwyr a Golygon</string>
@@ -738,7 +840,7 @@
 	<string name="tos">Amodau Gwasanaeth</string>
 	<string name="app_title">WordPress ar gyfer Android</string>
 	<string name="about">Ynghylch</string>
-	<string name="max_thumbnail_px_width">Lled rhagosodedig y ddelwedd</string>
+	<string name="max_thumbnail_px_width">Lled Rhagosodedig y Ddelwedd</string>
 	<string name="image_alignment">Alinio</string>
 	<string name="refresh">Adnewyddu</string>
 	<string name="untitled">Dideitl</string>
@@ -778,7 +880,6 @@
 	<string name="save">Cadw</string>
 	<string name="add">Ychwanegu</string>
 	<string name="category_refresh_error">Gwall adnewyddu categori</string>
-	<string name="tab_comments">Sylwadau</string>
 	<string name="preview">Rhagolwg</string>
 	<string name="cancel">Diddymu</string>
 	<string name="error">Gwall</string>
@@ -808,7 +909,7 @@
 	</string-array>
 	<string-array name="notifications_wpcom_settings_summaries">
 		<item>Cyngor ar sut i gael y gorau o WordPress.com.</item>
-		<item>Cyfleoedd i gymryd rhan mewn ymchwil ac arolygon WordPress.com</item>
+		<item>Cyfleoedd i gymryd rhan mewn ymchwil ac arolygon WordPress.com.</item>
 		<item>Gwybodaeth am gyrsiau a digwyddiadau WordPress.com (ar-lein ac mewn person).</item>
 	</string-array>
 	<string-array name="post_filters_array">
@@ -828,6 +929,33 @@
 		<item>Safonol</item>
 		<item>Statws</item>
 		<item>Fideo</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>Mae eich gwefan yn weladwy i bawb, ac o bosib wedi ei fynegeio gan beiriannau chwilio</item>
+		<item>Mae eich gwefan yn weladwy i bawb, ond mae\'n gofyn i beiriannau chwilio i beidio mynegeio eich gwefan</item>
+		<item>Mae eich gwefan yn weladwy i chi yn unig a defnyddwyr rydych wedi eu cymeradwyo</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>Bydd angen cymeradwyaeth â llaw ar gyfer sylwadau pawb.</item>
+		<item>Cymeradwyo\'n awtomatig os yw\'r defnyddiwr eisoes wedi cael sylw wedi ei gymeradwyo.</item>
+		<item>Cymeradwyo\'n awtomatig sylwadau pawb.</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>Dim sylwadau</item>
+		<item>Sylwadau defnyddwyr hysbys</item>
+		<item>Pob defnyddiwr</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>Dim</item>
+		<item>Dwy lefel</item>
+		<item>Tair lefel</item>
+		<item>Pedair lefel</item>
+		<item>Pum lefel</item>
+		<item>Chwe lefel</item>
+		<item>Saith lefel</item>
+		<item>Wyth lefel</item>
+		<item>Naw lefel</item>
+		<item>Deg lefel</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>Am Ddim</item>

--- a/WordPress/src/main/res/values-da/strings.xml
+++ b/WordPress/src/main/res/values-da/strings.xml
@@ -32,7 +32,6 @@
 	<string name="my_site_header_publish">Udgiv</string>
 	<string name="my_site_header_look_and_feel">Udseende</string>
 	<string name="my_site_btn_blog_posts">Blogindlæg</string>
-	<string name="my_site_btn_comments">Kommentarer</string>
 	<string name="my_site_header_admin">Administrator</string>
 	<string name="my_site_header_configuration">Konfiguration</string>
 	<string name="notifications_account_required">Log ind på WordPress.com for notifikationer</string>
@@ -124,7 +123,6 @@
 	<string name="stats_views">Visninger</string>
 	<string name="stats_timeframe_years">År</string>
 	<string name="stats_pagination_label">Side %1$s af %2$s</string>
-	<string name="stats_comments">Kommentarer</string>
 	<string name="stats_totals_followers">Siden</string>
 	<string name="stats_empty_clicks_title">Ingen klik registreret</string>
 	<string name="stats_empty_video">Ingen videoer afspillet</string>
@@ -181,6 +179,7 @@
 	<string name="comment_reply_to_user">Besvar %s</string>
 	<string name="older_month">Ældre end en måned</string>
 	<string name="signing_out">Logger ud...</string>
+	<string name="more">Mere</string>
 	<string name="older_two_days">Ældre end 2 dage</string>
 	<string name="comment_trashed">Kommentar slettet</string>
 	<string name="comment">Kommentar</string>
@@ -200,7 +199,6 @@
 	<string name="reader_label_comment_count_single">En kommentar</string>
 	<string name="reader_label_comments_closed">Der er lukket for kommentarer</string>
 	<string name="reader_label_comments_on">Kommentarer slået til</string>
-	<string name="reader_title_comments">Kommentarer</string>
 	<string name="reader_title_photo_viewer">%1$d af %2$d</string>
 	<string name="error_publish_empty_post">Kan ikke udgive omt indlæg</string>
 	<string name="error_refresh_unauthorized_posts">Du har ikke tilladelse til at vise eller redigere indlæg</string>
@@ -494,7 +492,6 @@
 	<string name="stats_entry_tags_and_categories">Emne</string>
 	<string name="stats_entry_country">Land</string>
 	<string name="stats_entry_posts_and_pages">Titel</string>
-	<string name="stats_view_comments">Kommentarer</string>
 	<string name="stats_timeframe_today">I dag</string>
 	<string name="stats_timeframe_yesterday">I går</string>
 	<string name="stats_timeframe_days">Dage</string>
@@ -513,7 +510,6 @@
 	<string name="theme_activating_button">Aktiverer</string>
 	<string name="post_excerpt">Uddrag</string>
 	<string name="share_action_title">Tilføj til ...</string>
-	<string name="stats_totals_comments">Kommentarer</string>
 	<string name="stats_totals_plays">Afspilninger</string>
 	<string name="menu_search">Søg</string>
 	<string name="passcode_change_passcode">Ændr PIN</string>
@@ -560,7 +556,6 @@
 	<string name="app_title">WordPress til Android</string>
 	<string name="tos">Brugskrav</string>
 	<string name="about">Om</string>
-	<string name="max_thumbnail_px_width">Standard billedbredde</string>
 	<string name="image_alignment">Justering</string>
 	<string name="refresh">Genindlæs</string>
 	<string name="untitled">Ikke-navngivet</string>
@@ -600,7 +595,6 @@
 	<string name="reply">Svar</string>
 	<string name="no">Nej</string>
 	<string name="yes">Ja</string>
-	<string name="tab_comments">Kommentarer</string>
 	<string name="category_refresh_error">Kategori opdateringsfejl</string>
 	<string name="on">på</string>
 	<string name="preview">Forhåndsvis</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">Originalgröße</string>
+	<string name="about_me_hint">Ein paar Infos über dich ...</string>
+	<string name="about_me">Über mich</string>
+	<string name="public_display_name_hint">Wenn du keinen Anzeigenamen festlegst, wird standardmäßig dein Benutzername verwendet.</string>
+	<string name="public_display_name">Öffentlich angezeigter Name</string>
+	<string name="my_profile">Mein Profil</string>
+	<string name="first_name">Vorname</string>
+	<string name="last_name">Nachname</string>
+	<string name="site_privacy_public_desc">Suchmaschinen erlauben, diese Website zu indexieren</string>
+	<string name="site_privacy_hidden_desc">Suchmaschinen daran hindern, diese Website zu indexieren</string>
+	<string name="site_privacy_private_desc">Meine Website soll privat und nur für von mir ausgewählte Benutzer sichtbar sein.</string>
+	<string name="cd_related_post_preview_image">Vorschaubild für ähnlichen Beitrag</string>
+	<string name="error_post_remote_site_settings">Website-Info konnte nicht gespeichert werden</string>
+	<string name="error_fetch_remote_site_settings">Website-Info konnte nicht abgerufen werden</string>
+	<string name="error_media_upload_connection">Beim Hochladen von Medien ist ein Verbindungsfehler aufgetreten.</string>
+	<string name="site_settings_disconnected_toast">Die Verbindung wurde getrennt, die Bearbeitung ist deaktiviert.</string>
+	<string name="site_settings_unsupported_version_error">Nicht unterstützte WordPress-Version</string>
+	<string name="site_settings_multiple_links_dialog_description">Kommentare mit mehr Links als hier angegeben müssen genehmigt werden.</string>
+	<string name="site_settings_close_after_dialog_switch_text">Automatisch schließen</string>
+	<string name="site_settings_close_after_dialog_description">Kommentare zu Artikeln automatisch schließen.</string>
+	<string name="site_settings_paging_dialog_description">Kommentar-Threads auf mehrere Seiten aufteilen.</string>
+	<string name="site_settings_paging_dialog_header">Kommentare pro Seite</string>
+	<string name="site_settings_close_after_dialog_title">Kommentarbereich schließen</string>
+	<string name="site_settings_blacklist_description">Wenn ein Kommentar eines dieser Wörter im Inhalt, Namen, in der URL, E-Mail-Adresse oder IP-Adresse enthält, wird er als Spam gekennzeichnet. Du kannst auch Teilbegriffe eingeben. So wird beispielsweise bei Eingabe von „press“ als Ergebnis „WordPress“ angezeigt.</string>
+	<string name="site_settings_hold_for_moderation_description">Wenn ein Kommentar eines dieser Wörter im Inhalt, Namen, in der URL, E-Mail-Adresse oder IP-Adresse enthält, wird er in die Warteschlange zur Freischaltung verschoben. Du kannst auch Teilbegriffe eingeben. So wird beispielsweise bei Eingabe von „press“ als Ergebnis „WordPress“ angezeigt.</string>
+	<string name="site_settings_list_editor_input_hint">Gib ein Wort oder einen Begriff ein.</string>
+	<string name="site_settings_list_editor_no_items_text">Keine Einträge</string>
+	<string name="site_settings_learn_more_caption">Für individuelle Beiträge kannst du die Einstellungen auch ausschalten.</string>
+	<string name="site_settings_rp_preview3_site">unter „Upgrade“</string>
+	<string name="site_settings_rp_preview3_title">Schwerpunkt des Upgrades: VideoPress für Hochzeiten</string>
+	<string name="site_settings_rp_preview2_site">unter „Apps“</string>
+	<string name="site_settings_rp_preview2_title">Die WordPress-App für Android wurde umfassend überarbeitet.</string>
+	<string name="site_settings_rp_preview1_site">unter „Mobil“</string>
+	<string name="site_settings_rp_preview1_title">Umfangreiches iPhone/iPad-Update jetzt verfügbar</string>
+	<string name="site_settings_rp_show_images_title">Bilder anzeigen</string>
+	<string name="site_settings_rp_show_header_title">Header anzeigen</string>
+	<string name="site_settings_rp_switch_summary">Als „Ähnliche Beiträge“ werden relevante Inhalte von deiner Website unter deinen Beiträgen angezeigt.</string>
+	<string name="site_settings_rp_switch_title">„Ähnliche Beiträge“ anzeigen</string>
+	<string name="site_settings_delete_site_hint">Entfernt deine Website-Daten von der App</string>
+	<string name="site_settings_blacklist_hint">Kommentare, die einem Filterkriterium entsprechen, werden als Spam gekennzeichnet.</string>
+	<string name="site_settings_moderation_hold_hint">Kommentare, die einem Filterkriterium entsprechen, werden in die Warteschlange zur Freischaltung verschoben.</string>
+	<string name="site_settings_multiple_links_hint">Bei bekannten Benutzern wird die Beschränkung der Linkanzahl ignoriert.</string>
+	<string name="site_settings_whitelist_hint">Der Autor muss bereits einen genehmigten Kommentar geschrieben haben.</string>
+	<string name="site_settings_user_account_required_hint">Benutzer müssen zum Kommentieren registriert und angemeldet sein.</string>
+	<string name="site_settings_identity_required_hint">Benutzer müssen zum Kommentieren Name und E-Mail-Adresse angeben.</string>
+	<string name="site_settings_manual_approval_hint">Kommentare müssen manuell genehmigt werden.</string>
+	<string name="site_settings_paging_hint">Kommentare in Blöcken mit einer festgelegten Größe anzeigen</string>
+	<string name="site_settings_threading_hint">Verschachtelte Kommentare bis zu einer bestimmten Anzahl zulassen</string>
+	<string name="site_settings_sort_by_hint">Legt fest, in welcher Reihenfolge die Kommentare angezeigt werden</string>
+	<string name="site_settings_close_after_hint">Nach dem angegebenen Zeitpunkt sind keine Kommentare mehr zulässig.</string>
+	<string name="site_settings_receive_pingbacks_hint">Link-Benachrichtigungen von anderen Blogs zulassen</string>
+	<string name="site_settings_send_pingbacks_hint">Versuchen, alle in dem Artikel verlinkten Blogs zu benachrichtigen</string>
+	<string name="site_settings_allow_comments_hint">Lesern erlauben, Kommentare zu veröffentlichen</string>
+	<string name="site_settings_discussion_hint">Diskussionseinstellungen für deine Websites anzeigen und ändern</string>
+	<string name="site_settings_more_hint">Alle verfügbaren Diskussionseinstellungen anzeigen</string>
+	<string name="site_settings_related_posts_hint">Ähnliche Beiträge im Reader anzeigen oder ausblenden</string>
+	<string name="site_settings_upload_and_link_image_hint">Aktivieren, damit Bilder immer in voller Größe hochgeladen werden</string>
+	<string name="site_settings_image_width_hint">Größe von Bildern in Beiträgen auf diese Breite ändern</string>
+	<string name="site_settings_format_hint">Legt ein neues Beitragsformat fest</string>
+	<string name="site_settings_category_hint">Legt eine neue Beitragskategorie fest</string>
+	<string name="site_settings_location_hint">Zu deinen Beiträgen automatisch Ortsangaben hinzufügen</string>
+	<string name="site_settings_password_hint">Dein Passwort ändern</string>
+	<string name="site_settings_username_hint">Aktuelles Benutzerkonto</string>
+	<string name="site_settings_language_hint">Sprache, in der dieses Blog vornehmlich geschrieben wird.</string>
+	<string name="site_settings_privacy_hint">Steuert, wer deine Website sehen kann</string>
+	<string name="site_settings_address_hint">Adressänderungen werden aktuell nicht unterstützt.</string>
+	<string name="site_settings_tagline_hint">Eine kurze Beschreibung oder ein treffender Spruch, um dein Blog zu beschreiben</string>
+	<string name="site_settings_title_hint">Erkläre in ein paar Worten, worum es auf deiner Website geht.</string>
+	<string name="site_settings_whitelist_known_summary">Kommentare von bekannten Benutzern</string>
+	<string name="site_settings_whitelist_all_summary">Kommentare von allen Benutzern</string>
+	<string name="site_settings_threading_summary">%d Ebenen</string>
+	<string name="site_settings_privacy_private_summary">Privat</string>
+	<string name="site_settings_privacy_hidden_summary">Versteckt</string>
+	<string name="site_settings_delete_site_title">Website löschen</string>
+	<string name="site_settings_privacy_public_summary">Öffentlich</string>
+	<string name="site_settings_blacklist_title">Sperrliste</string>
+	<string name="site_settings_moderation_hold_title">Zur Freischaltung überprüfen</string>
+	<string name="site_settings_multiple_links_title">Links in Kommentaren</string>
+	<string name="site_settings_whitelist_title">Automatisch genehmigen</string>
+	<string name="site_settings_paging_title">Seitennummerierung</string>
+	<string name="site_settings_threading_title">Verschachtelung</string>
+	<string name="site_settings_sort_by_title">Sortieren nach</string>
+	<string name="site_settings_account_required_title">Benutzer müssen angemeldet sein.</string>
+	<string name="site_settings_identity_required_title">Name und E-Mail-Adresse erforderlich</string>
+	<string name="site_settings_receive_pingbacks_title">Pingbacks erhalten</string>
+	<string name="site_settings_send_pingbacks_title">Pingbacks senden</string>
+	<string name="site_settings_allow_comments_title">Kommentare zulassen</string>
+	<string name="site_settings_default_format_title">Standardformat</string>
+	<string name="site_settings_default_category_title">Standardkategorie</string>
+	<string name="site_settings_location_title">Ort aktivieren</string>
+	<string name="site_settings_address_title">Adresse</string>
+	<string name="site_settings_title_title">Website-Titel</string>
+	<string name="site_settings_tagline_title">Untertitel</string>
+	<string name="site_settings_this_device_header">Auf diesem Gerät</string>
+	<string name="site_settings_discussion_new_posts_header">Standardeinstellungen für neue Beiträge</string>
+	<string name="site_settings_account_header">Konto</string>
+	<string name="site_settings_writing_header">Schreiben</string>
+	<string name="site_settings_general_header">Allgemein</string>
+	<string name="newest_first">Neuester zuerst</string>
+	<string name="comments">Kommentare</string>
+	<string name="discussion">Diskussionen</string>
+	<string name="privacy">Datenschutz</string>
+	<string name="related_posts">Ähnliche Beiträge</string>
+	<string name="close_after">Schließen nach</string>
+	<string name="oldest_first">Ältester zuerst</string>
+	<string name="media_error_no_permission_upload">Du bist nicht berechtigt, Medien auf diese Website hochzuladen.</string>
+	<string name="never">Nie</string>
+	<string name="unknown">Unbekannt</string>
 	<string name="reader_err_get_post_not_found">Dieser Beitrag ist nicht mehr vorhanden</string>
 	<string name="reader_err_get_post_not_authorized">Du hast nicht die erforderlichen Rechte diesen Beitrag anzusehen</string>
 	<string name="reader_err_get_post_generic">Konnte den Beitrag nicht empfangen</string>
@@ -120,12 +228,10 @@
 	<string name="post_deleted">Beitrag gelöscht</string>
 	<string name="button_back">Zurück</string>
 	<string name="page_deleted">Seite gelöscht</string>
-	<string name="button_more">Mehr</string>
 	<string name="button_preview">Vorschau</string>
 	<string name="button_view">Anzeigen</string>
 	<string name="button_edit">Bearbeiten</string>
 	<string name="button_publish">Veröffentlichen</string>
-	<string name="button_delete">Löschen</string>
 	<string name="page_trashed">Seite in den Papierkorb verschoben</string>
 	<string name="post_trashed">Beitrag in den Papierkorb verschoben</string>
 	<string name="stats_no_activity_this_period">Keine Aktivitäten in diesem Zeitraum</string>
@@ -172,7 +278,6 @@
 	<string name="my_site_header_look_and_feel">Erscheinungsbild</string>
 	<string name="my_site_btn_blog_posts">Blogbeiträge</string>
 	<string name="my_site_btn_site_settings">Einstellungen</string>
-	<string name="my_site_btn_comments">Kommentare</string>
 	<string name="my_site_header_admin">Admin</string>
 	<string name="reader_label_new_posts_subtitle">Berühren zum Anzeigen</string>
 	<string name="my_site_header_configuration">Einrichtung</string>
@@ -258,7 +363,6 @@
 	<string name="stats_visitors">Besucher</string>
 	<string name="stats_view_countries">Länder</string>
 	<string name="stats_likes">Gefällt mir</string>
-	<string name="stats_comments">Kommentare</string>
 	<string name="stats_entry_followers">Follower</string>
 	<string name="stats_totals_publicize">Follower</string>
 	<string name="stats_entry_clicks_link">Link</string>
@@ -334,13 +438,13 @@
 	<string name="reader_label_comment_count_single">Ein Kommentar</string>
 	<string name="reader_label_comments_closed">Kommentare sind geschlossen</string>
 	<string name="reader_label_comments_on">Kommentare zu</string>
-	<string name="reader_title_comments">Kommentare</string>
 	<string name="reader_title_photo_viewer">%1$d von %2$d</string>
 	<string name="error_publish_empty_post">Leerer Beitrag kann nicht veröffentlicht werden</string>
 	<string name="error_refresh_unauthorized_posts">Du hast keine Berechtigung Beiträge anzusehen oder zu bearbeiten</string>
 	<string name="error_refresh_unauthorized_pages">Du hast keine Berechtigung Seiten anzusehen oder zu bearbeiten</string>
 	<string name="error_refresh_unauthorized_comments">Du hast keine Berechtigung Kommentare anzusehen oder zu bearbeiten</string>
 	<string name="older_month">Älter als ein Monat</string>
+	<string name="more">Mehr</string>
 	<string name="older_two_days">Älter als zwei Tage</string>
 	<string name="older_last_week">Älter als eine Woche</string>
 	<string name="stats_no_blog">Statistiken konnten nicht geladen werden für den angefragten Blog</string>
@@ -652,7 +756,6 @@
 	<string name="stats_timeframe_weeks">Wochen</string>
 	<string name="stats_timeframe_months">Monate</string>
 	<string name="stats_totals_clicks">Klicks</string>
-	<string name="stats_totals_comments">Kommentare</string>
 	<string name="media_gallery_type">Typ</string>
 	<string name="media_edit_title_text">Titel</string>
 	<string name="media_edit_caption_text">Beschriftung</string>
@@ -660,7 +763,6 @@
 	<string name="stats_view_clicks">Klicks</string>
 	<string name="stats_view_tags_and_categories">Tags &amp; Kategorien</string>
 	<string name="stats_view_referrers">Referrer</string>
-	<string name="stats_view_comments">Kommentare</string>
 	<string name="stats_entry_posts_and_pages">Titel</string>
 	<string name="stats_entry_tags_and_categories">Thema</string>
 	<string name="stats_entry_authors">Autor</string>
@@ -771,7 +873,6 @@
 	<string name="none">Nichts</string>
 	<string name="blogs">Blogs</string>
 	<string name="select_photo">Wähle ein Foto von der Galerie</string>
-	<string name="tab_comments">Kommentare</string>
 	<string name="reply">Antworten</string>
 	<string name="preview">Vorschau</string>
 	<string name="on">zu</string>
@@ -828,6 +929,33 @@
 		<item>Standard</item>
 		<item>Status</item>
 		<item>Video</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>Deine Website ist für alle sichtbar. Suchmaschinen dürfen sie indexieren.</item>
+		<item>Deine Website ist für alle sichtbar. Suchmaschinen werden aufgefordert, sie nicht zu indexieren.</item>
+		<item>Deine Website ist nur für dich und freigegebene Nutzer sichtbar.</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>Alle Kommentare müssen manuell genehmigt werden.</item>
+		<item>Automatisch genehmigen, wenn bereits andere Kommentare des Benutzers genehmigt wurden</item>
+		<item>Alle Kommentare automatisch genehmigen</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>Keine Kommentare</item>
+		<item>Kommentare bekannter Benutzer</item>
+		<item>Alle Benutzer</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>Deaktiviert</item>
+		<item>Zwei Ebenen</item>
+		<item>Drei Ebenen</item>
+		<item>Vier Ebenen</item>
+		<item>Fünf Ebenen</item>
+		<item>Sechs Ebenen</item>
+		<item>Sieben Ebenen</item>
+		<item>Acht Ebenen</item>
+		<item>Neun Ebenen</item>
+		<item>Zehn Ebenen</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>Kostenlos</item>

--- a/WordPress/src/main/res/values-el/strings.xml
+++ b/WordPress/src/main/res/values-el/strings.xml
@@ -112,14 +112,12 @@
 	<string name="trashed">Διαγραμμένα</string>
 	<string name="button_back">Πίσω</string>
 	<string name="page_deleted">Σελίδα διαγράφηκε</string>
-	<string name="button_more">Περισσότερα</string>
 	<string name="button_stats">Στατιστικά</string>
 	<string name="button_trash">Διαγραφή</string>
 	<string name="button_preview">Προεπισκόπηση</string>
 	<string name="button_view">Προβολή</string>
 	<string name="button_edit">Αλλαγή</string>
 	<string name="button_publish">Δημοσίευση</string>
-	<string name="button_delete">Διαγραφή</string>
 	<string name="my_site_no_sites_view_subtitle">Θα θέλατε να προσθέσετε ένα;</string>
 	<string name="my_site_no_sites_view_title">Δεν έχετε κανένα ιστότοπο WordPress ακόμα.</string>
 	<string name="my_site_no_sites_view_drake">Απεικόνιση</string>
@@ -157,7 +155,6 @@
 	<string name="my_site_btn_view_admin">Προβολή Διαχείρισης</string>
 	<string name="site_picker_title">Επιλογή ιστότοπου</string>
 	<string name="my_site_btn_site_settings">Ρυθμίσεις</string>
-	<string name="my_site_btn_comments">Σχόλια</string>
 	<string name="my_site_btn_blog_posts">Ιστολόγημα</string>
 	<string name="my_site_header_look_and_feel">Κοίτα και Νιώσε</string>
 	<string name="my_site_header_publish">Δημοσιεύω</string>
@@ -249,7 +246,6 @@
 	<string name="stats_view_videos">Βίντεο</string>
 	<string name="stats_view_publicize">Δημοσιοποίηση</string>
 	<string name="stats_likes">Likes</string>
-	<string name="stats_comments">Σχόλια</string>
 	<string name="stats_timeframe_years">Χρόνια</string>
 	<string name="stats_views">Προβολές</string>
 	<string name="stats_visitors">Επισκέπτες</string>
@@ -310,7 +306,6 @@
 	<string name="older_two_days">Παλιότερο από 2 μέρες</string>
 	<string name="older_last_week">Παλιότερο από 1 βδομάδα</string>
 	<string name="comment">Σχόλιο</string>
-	<string name="reader_title_comments">Σχόλια</string>
 	<string name="faq_button">FAQ</string>
 	<string name="reader_label_like">Like</string>
 	<string name="mnu_comment_liked">Liked</string>
@@ -647,7 +642,6 @@
 	<string name="stats_view_visitors_and_views">Επισκέπτες και Προβολές</string>
 	<string name="stats_view_clicks">Κλικ</string>
 	<string name="stats_view_tags_and_categories">Ετικέτες και Κατηγορίες</string>
-	<string name="stats_view_comments">Σχόλια</string>
 	<string name="stats_timeframe_today">Σήμερα</string>
 	<string name="stats_timeframe_yesterday">Χθες</string>
 	<string name="theme_set_success">Το θέμα ορίστηκε επιτυχώς</string>
@@ -671,7 +665,6 @@
 	<string name="stats_totals_views">Εμφανίσεις</string>
 	<string name="stats_totals_clicks">Κλικ</string>
 	<string name="stats_totals_plays">Αναπαραγωγές</string>
-	<string name="stats_totals_comments">Σχόλια</string>
 	<string name="menu_search">Αναζήτηση</string>
 	<string name="passcode_manage">Διαχείριση κλειδώματος PIN</string>
 	<string name="passcode_enter_passcode">Πληκτρολογήστε το PIN σας</string>
@@ -724,7 +717,6 @@
 	<string name="tos">Όροι Χρήσης</string>
 	<string name="app_title">WordPress για Android</string>
 	<string name="about">Σχετικά</string>
-	<string name="max_thumbnail_px_width">Προεπιλεγμένο πλάτος εικόνας</string>
 	<string name="image_alignment">Στοίχιση</string>
 	<string name="refresh">Ανανέωση</string>
 	<string name="untitled">Χωρίς τίτλο</string>
@@ -765,7 +757,6 @@
 	<string name="cancel">Ακύρωση</string>
 	<string name="save">Αποθήκευση</string>
 	<string name="add">Πρόσθεση</string>
-	<string name="tab_comments">Σχόλια</string>
 	<string name="category_refresh_error">Σφάλμα ανανέωσης κατηγοριών</string>
 	<string name="on">ενεργό</string>
 	<string name="notification_settings">Ρυθμίσεις Ειδοποιήσεων</string>

--- a/WordPress/src/main/res/values-en-rAU/strings.xml
+++ b/WordPress/src/main/res/values-en-rAU/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">Original Size</string>
+	<string name="about_me_hint">A few words about you…</string>
+	<string name="public_display_name_hint">Display name will default to your username if it is not set</string>
+	<string name="about_me">About me</string>
+	<string name="public_display_name">Public display name</string>
+	<string name="my_profile">My Profile</string>
+	<string name="first_name">First name</string>
+	<string name="last_name">Last name</string>
+	<string name="site_privacy_public_desc">Allow search engines to index this site</string>
+	<string name="site_privacy_hidden_desc">Discourage search engines from indexing this site</string>
+	<string name="site_privacy_private_desc">I would like my site to be private, visible only to users I choose</string>
+	<string name="cd_related_post_preview_image">Related post preview image</string>
+	<string name="error_post_remote_site_settings">Couldn\'t save site info</string>
+	<string name="error_fetch_remote_site_settings">Couldn\'t retrieve site info</string>
+	<string name="error_media_upload_connection">A connection error occurred while uploading media</string>
+	<string name="site_settings_disconnected_toast">Disconnected, editing disabled.</string>
+	<string name="site_settings_unsupported_version_error">Unsupported WordPress version</string>
+	<string name="site_settings_multiple_links_dialog_description">Require approval for comments that include more than this number of links.</string>
+	<string name="site_settings_close_after_dialog_switch_text">Automatically close</string>
+	<string name="site_settings_close_after_dialog_description">Automatically close comments on articles.</string>
+	<string name="site_settings_paging_dialog_description">Break comment threads into multiple pages.</string>
+	<string name="site_settings_paging_dialog_header">Comments per page</string>
+	<string name="site_settings_close_after_dialog_title">Close commenting</string>
+	<string name="site_settings_blacklist_description">When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be marked as spam. You can enter partial words, so "press" will match "WordPress."</string>
+	<string name="site_settings_hold_for_moderation_description">When a comment contains any of these words in its content, name, URL, email, or IP, it will be held in the moderation queue. You can enter partial words, so "press" will match "WordPress."</string>
+	<string name="site_settings_list_editor_input_hint">Enter a word or phrase</string>
+	<string name="site_settings_list_editor_no_items_text">No items</string>
+	<string name="site_settings_learn_more_caption">You can override these settings for individual posts.</string>
+	<string name="site_settings_rp_preview3_site">in "Upgrade"</string>
+	<string name="site_settings_rp_preview3_title">Upgrade Focus: VideoPress For Weddings</string>
+	<string name="site_settings_rp_preview2_site">in "Apps"</string>
+	<string name="site_settings_rp_preview2_title">The WordPress for Android App Gets a Big Facelift</string>
+	<string name="site_settings_rp_preview1_site">in "Mobile"</string>
+	<string name="site_settings_rp_preview1_title">Big iPhone/iPad Update Now Available</string>
+	<string name="site_settings_rp_show_images_title">Show Images</string>
+	<string name="site_settings_rp_show_header_title">Show Header</string>
+	<string name="site_settings_rp_switch_summary">Related Posts displays relevant content from your site below your posts.</string>
+	<string name="site_settings_rp_switch_title">Show Related Posts</string>
+	<string name="site_settings_delete_site_hint">Removes your site data from the app</string>
+	<string name="site_settings_blacklist_hint">Comments that match a filter are marked as spam</string>
+	<string name="site_settings_moderation_hold_hint">Comments that match a filter are put in the moderation queue</string>
+	<string name="site_settings_multiple_links_hint">Ignores link limit from known users</string>
+	<string name="site_settings_whitelist_hint">Comment author must have a previously approved comment</string>
+	<string name="site_settings_user_account_required_hint">Users must be registered and logged in to comment</string>
+	<string name="site_settings_identity_required_hint">Comment author must fill out name and email</string>
+	<string name="site_settings_manual_approval_hint">Comments must be manually approved</string>
+	<string name="site_settings_paging_hint">Display comments in chunks of a specified size</string>
+	<string name="site_settings_threading_hint">Allow nested comments to a certain depth</string>
+	<string name="site_settings_sort_by_hint">Determines the order comments are displayed</string>
+	<string name="site_settings_close_after_hint">Disallow comments after the specified time</string>
+	<string name="site_settings_receive_pingbacks_hint">Allow link notifications from other blogs</string>
+	<string name="site_settings_send_pingbacks_hint">Attempt to notify any blogs linked to from the article</string>
+	<string name="site_settings_allow_comments_hint">Allow readers to post comments</string>
+	<string name="site_settings_discussion_hint">View and change your sites discussion settings</string>
+	<string name="site_settings_more_hint">View all available Discussion settings</string>
+	<string name="site_settings_related_posts_hint">Show or hide related posts in reader</string>
+	<string name="site_settings_upload_and_link_image_hint">Enable to always upload the fullsize image</string>
+	<string name="site_settings_image_width_hint">Resizes images in posts to this width</string>
+	<string name="site_settings_format_hint">Sets new post format</string>
+	<string name="site_settings_category_hint">Sets new post category</string>
+	<string name="site_settings_location_hint">Automatically add location data to your posts</string>
+	<string name="site_settings_password_hint">Change your password</string>
+	<string name="site_settings_username_hint">Current user account</string>
+	<string name="site_settings_language_hint">Language this blog is primarily written in</string>
+	<string name="site_settings_privacy_hint">Controls who can see your site</string>
+	<string name="site_settings_address_hint">Changing your address is not currently supported</string>
+	<string name="site_settings_tagline_hint">A short description or catchy phrase to describe your blog</string>
+	<string name="site_settings_title_hint">In a few words, explain what this site is about</string>
+	<string name="site_settings_whitelist_known_summary">Comments from known users</string>
+	<string name="site_settings_whitelist_all_summary">Comments from all users</string>
+	<string name="site_settings_threading_summary">%d levels</string>
+	<string name="site_settings_privacy_private_summary">Private</string>
+	<string name="site_settings_privacy_hidden_summary">Hidden</string>
+	<string name="site_settings_delete_site_title">Delete Site</string>
+	<string name="site_settings_privacy_public_summary">Public</string>
+	<string name="site_settings_blacklist_title">Blacklist</string>
+	<string name="site_settings_moderation_hold_title">Hold for Moderation</string>
+	<string name="site_settings_multiple_links_title">Links in comments</string>
+	<string name="site_settings_whitelist_title">Automatically approve</string>
+	<string name="site_settings_threading_title">Threading</string>
+	<string name="site_settings_paging_title">Paging</string>
+	<string name="site_settings_sort_by_title">Sort by</string>
+	<string name="site_settings_account_required_title">Users must be signed in</string>
+	<string name="site_settings_identity_required_title">Must include name and email</string>
+	<string name="site_settings_receive_pingbacks_title">Receive Pingbacks</string>
+	<string name="site_settings_send_pingbacks_title">Send Pingbacks</string>
+	<string name="site_settings_allow_comments_title">Allow Comments</string>
+	<string name="site_settings_default_format_title">Default Format</string>
+	<string name="site_settings_default_category_title">Default Category</string>
+	<string name="site_settings_location_title">Enable Location</string>
+	<string name="site_settings_address_title">Address</string>
+	<string name="site_settings_title_title">Site Title</string>
+	<string name="site_settings_tagline_title">Tagline</string>
+	<string name="site_settings_this_device_header">This device</string>
+	<string name="site_settings_discussion_new_posts_header">Defaults for new posts</string>
+	<string name="site_settings_account_header">Account</string>
+	<string name="site_settings_writing_header">Writing</string>
+	<string name="newest_first">Newest first</string>
+	<string name="site_settings_general_header">General</string>
+	<string name="discussion">Discussion</string>
+	<string name="privacy">Privacy</string>
+	<string name="related_posts">Related Posts</string>
+	<string name="comments">Comments</string>
+	<string name="close_after">Close after</string>
+	<string name="oldest_first">Oldest first</string>
+	<string name="media_error_no_permission_upload">You don\'t have permission to upload media to the site</string>
+	<string name="never">Never</string>
+	<string name="unknown">Unknown</string>
 	<string name="reader_err_get_post_not_found">This post no longer exists</string>
 	<string name="reader_err_get_post_not_authorized">You\'re not authorised to view this post</string>
 	<string name="reader_err_get_post_generic">Unable to retrieve this post</string>
@@ -117,13 +225,11 @@
 	<string name="days_ago">%d days ago</string>
 	<string name="yesterday">Yesterday</string>
 	<string name="connectionbar_no_connection">No connection</string>
-	<string name="button_delete">Delete</string>
 	<string name="button_publish">Publish</string>
 	<string name="button_view">View</string>
 	<string name="button_edit">Edit</string>
 	<string name="button_trash">Trash</string>
 	<string name="button_preview">Preview</string>
-	<string name="button_more">More</string>
 	<string name="button_stats">Stats</string>
 	<string name="trashed">Trashed</string>
 	<string name="button_back">Back</string>
@@ -170,7 +276,6 @@
 	<string name="my_site_btn_view_admin">View Admin</string>
 	<string name="my_site_header_publish">Publish</string>
 	<string name="my_site_header_look_and_feel">Look and Feel</string>
-	<string name="my_site_btn_comments">Comments</string>
 	<string name="my_site_btn_site_settings">Settings</string>
 	<string name="my_site_btn_blog_posts">Blog Posts</string>
 	<string name="my_site_header_admin">Admin</string>
@@ -256,7 +361,6 @@
 	<string name="stats_views">Views</string>
 	<string name="stats_pagination_label">Page %1$s of %2$s</string>
 	<string name="stats_timeframe_years">Years</string>
-	<string name="stats_comments">Comments</string>
 	<string name="stats_likes">Likes</string>
 	<string name="stats_view_countries">Countries</string>
 	<string name="stats_view_publicize">Publicize</string>
@@ -334,13 +438,13 @@
 	<string name="reader_label_comment_count_single">One comment</string>
 	<string name="reader_label_comments_closed">Comments are closed</string>
 	<string name="reader_label_comments_on">Comments on</string>
-	<string name="reader_title_comments">Comments</string>
 	<string name="reader_title_photo_viewer">%1$d of %2$d</string>
 	<string name="error_publish_empty_post">Can\'t publish an empty post</string>
 	<string name="error_refresh_unauthorized_posts">You don\'t have permission to view or edit posts</string>
 	<string name="error_refresh_unauthorized_pages">You don\'t have permission to view or edit pages</string>
 	<string name="error_refresh_unauthorized_comments">You don\'t have permission to view or edit comments</string>
 	<string name="older_month">Older than a month</string>
+	<string name="more">More</string>
 	<string name="older_two_days">Older than 2 days</string>
 	<string name="older_last_week">Older than a week</string>
 	<string name="stats_no_blog">Stats couldn\'t be loaded for the required blog</string>
@@ -671,7 +775,6 @@
 	<string name="stats_view_visitors_and_views">Visitors and Views</string>
 	<string name="stats_view_clicks">Clicks</string>
 	<string name="stats_view_referrers">Referrers</string>
-	<string name="stats_view_comments">Comments</string>
 	<string name="stats_timeframe_today">Today</string>
 	<string name="stats_timeframe_yesterday">Yesterday</string>
 	<string name="stats_timeframe_days">Days</string>
@@ -685,7 +788,6 @@
 	<string name="stats_totals_views">Views</string>
 	<string name="stats_totals_clicks">Clicks</string>
 	<string name="stats_totals_plays">Plays</string>
-	<string name="stats_totals_comments">Comments</string>
 	<string name="menu_search">Search</string>
 	<string name="passcode_manage">Manage PIN lock</string>
 	<string name="passcode_enter_passcode">Enter your PIN</string>
@@ -738,7 +840,7 @@
 	<string name="tos">Terms of Service</string>
 	<string name="app_title">WordPress for Android</string>
 	<string name="about">About</string>
-	<string name="max_thumbnail_px_width">Default image width</string>
+	<string name="max_thumbnail_px_width">Default Image Width</string>
 	<string name="image_alignment">Alignment</string>
 	<string name="refresh">Refresh</string>
 	<string name="untitled">Untitled</string>
@@ -776,7 +878,6 @@
 	<string name="save">Save</string>
 	<string name="add">Add</string>
 	<string name="category_refresh_error">Category refresh error</string>
-	<string name="tab_comments">Comments</string>
 	<string name="preview">Preview</string>
 	<string name="on">on</string>
 	<string name="reply">Reply</string>
@@ -828,6 +929,33 @@
 		<item>Standard</item>
 		<item>Status</item>
 		<item>Video</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>Your site is visible to everyone and may be indexed by search engines</item>
+		<item>Your site is visible to everyone but asks search engines not to index it</item>
+		<item>Your site is visible only to you and users you approve</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>Require manual approval for everyone\'s comments.</item>
+		<item>Automatically approve if the user has a previously approved comment.</item>
+		<item>Automatically approve everyone\'s comments.</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>No comments</item>
+		<item>Known users\' comments</item>
+		<item>All users</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>None</item>
+		<item>Two levels</item>
+		<item>Three levels</item>
+		<item>Four levels</item>
+		<item>Five levels</item>
+		<item>Six levels</item>
+		<item>Seven levels</item>
+		<item>Eight levels</item>
+		<item>Nine levels</item>
+		<item>Ten levels</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>Free</item>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -4,7 +4,6 @@
 	<string name="about_me_hint">A few words about you…</string>
 	<string name="about_me">About me</string>
 	<string name="public_display_name_hint">Display name will default to your username if it is not set</string>
-	<string name="public_display_name_hint">Display name will default to your username if it is not set</string>
 	<string name="public_display_name">Public display name</string>
 	<string name="first_name">First name</string>
 	<string name="last_name">Last name</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -1,5 +1,114 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">Original Size</string>
+	<string name="about_me_hint">A few words about you…</string>
+	<string name="about_me">About me</string>
+	<string name="public_display_name_hint">Display name will default to your username if it is not set</string>
+	<string name="public_display_name_hint">Display name will default to your username if it is not set</string>
+	<string name="public_display_name">Public display name</string>
+	<string name="first_name">First name</string>
+	<string name="last_name">Last name</string>
+	<string name="my_profile">My Profile</string>
+	<string name="site_privacy_public_desc">Allow search engines to index this site</string>
+	<string name="site_privacy_hidden_desc">Discourage search engines from indexing this site</string>
+	<string name="site_privacy_private_desc">I would like my site to be private, visible only to users I choose</string>
+	<string name="cd_related_post_preview_image">Related post preview image</string>
+	<string name="error_post_remote_site_settings">Couldn\'t save site info</string>
+	<string name="error_fetch_remote_site_settings">Couldn\'t retrieve site info</string>
+	<string name="error_media_upload_connection">A connection error occurred while uploading media</string>
+	<string name="site_settings_disconnected_toast">Disconnected, editing disabled.</string>
+	<string name="site_settings_unsupported_version_error">Unsupported WordPress version</string>
+	<string name="site_settings_multiple_links_dialog_description">Require approval for comments that include more than this number of links.</string>
+	<string name="site_settings_close_after_dialog_switch_text">Automatically close</string>
+	<string name="site_settings_close_after_dialog_description">Automatically close comments on articles.</string>
+	<string name="site_settings_paging_dialog_description">Break comment threads into multiple pages.</string>
+	<string name="site_settings_paging_dialog_header">Comments per page</string>
+	<string name="site_settings_close_after_dialog_title">Close commenting</string>
+	<string name="site_settings_blacklist_description">When a comment contains any of these words in its content, name, URL, email, or IP, it will be marked as spam. You can enter partial words, so "press" will match "WordPress."</string>
+	<string name="site_settings_hold_for_moderation_description">When a comment contains any of these words in its content, name, URL, email, or IP, it will be held in the moderation queue. You can enter partial words, so "press" will match "WordPress."</string>
+	<string name="site_settings_list_editor_input_hint">Enter a word or phrase</string>
+	<string name="site_settings_list_editor_no_items_text">No items</string>
+	<string name="site_settings_learn_more_caption">You can override these settings for individual posts.</string>
+	<string name="site_settings_rp_preview3_site">in "Upgrade"</string>
+	<string name="site_settings_rp_preview3_title">Upgrade Focus: VideoPress For Weddings</string>
+	<string name="site_settings_rp_preview2_site">in "Apps"</string>
+	<string name="site_settings_rp_preview2_title">The WordPress for Android App Gets a Big Facelift</string>
+	<string name="site_settings_rp_preview1_site">in "Mobile"</string>
+	<string name="site_settings_rp_preview1_title">Big iPhone/iPad Update Now Available</string>
+	<string name="site_settings_rp_show_images_title">Show Images</string>
+	<string name="site_settings_rp_show_header_title">Show Header</string>
+	<string name="site_settings_rp_switch_summary">Related Posts displays relevant content from your site below your posts.</string>
+	<string name="site_settings_rp_switch_title">Show Related Posts</string>
+	<string name="site_settings_delete_site_hint">Removes your site data from the app</string>
+	<string name="site_settings_blacklist_hint">Comments that match a filter are marked as spam</string>
+	<string name="site_settings_moderation_hold_hint">Comments that match a filter are put in the moderation queue</string>
+	<string name="site_settings_multiple_links_hint">Ignores link limit from known users</string>
+	<string name="site_settings_whitelist_hint">Comment author must have a previously approved comment</string>
+	<string name="site_settings_user_account_required_hint">Users must be registered and logged in to comment</string>
+	<string name="site_settings_identity_required_hint">Comment author must fill out name and e-mail</string>
+	<string name="site_settings_manual_approval_hint">Comments must be manually approved</string>
+	<string name="site_settings_paging_hint">Display comments in chunks of a specified size</string>
+	<string name="site_settings_threading_hint">Allow nested comments to a certain depth</string>
+	<string name="site_settings_sort_by_hint">Determines the order comments are displayed</string>
+	<string name="site_settings_close_after_hint">Disallow comments after the specified time</string>
+	<string name="site_settings_receive_pingbacks_hint">Allow link notifications from other blogs</string>
+	<string name="site_settings_send_pingbacks_hint">Attempt to notify any blogs linked to from the article</string>
+	<string name="site_settings_allow_comments_hint">Allow readers to post comments</string>
+	<string name="site_settings_discussion_hint">View and change your sites discussion settings</string>
+	<string name="site_settings_more_hint">View all available Discussion settings</string>
+	<string name="site_settings_related_posts_hint">Show or hide related posts in reader</string>
+	<string name="site_settings_upload_and_link_image_hint">Enable to always upload the fullsize image</string>
+	<string name="site_settings_image_width_hint">Resizes images in posts to this width</string>
+	<string name="site_settings_format_hint">Sets new post format</string>
+	<string name="site_settings_category_hint">Sets new post category</string>
+	<string name="site_settings_location_hint">Automatically add location data to your posts</string>
+	<string name="site_settings_password_hint">Change your password</string>
+	<string name="site_settings_username_hint">Current user account</string>
+	<string name="site_settings_language_hint">Language this blog is primarily written in</string>
+	<string name="site_settings_privacy_hint">Controls who can see your site</string>
+	<string name="site_settings_address_hint">Changing your address is not currently supported</string>
+	<string name="site_settings_tagline_hint">A short description or catchy phrase to describe your blog</string>
+	<string name="site_settings_title_hint">In a few words, explain what this site is about</string>
+	<string name="site_settings_whitelist_known_summary">Comments from known users</string>
+	<string name="site_settings_whitelist_all_summary">Comments from all users</string>
+	<string name="site_settings_threading_summary">%d levels</string>
+	<string name="site_settings_privacy_private_summary">Private</string>
+	<string name="site_settings_privacy_hidden_summary">Hidden</string>
+	<string name="site_settings_delete_site_title">Delete Site</string>
+	<string name="site_settings_privacy_public_summary">Public</string>
+	<string name="site_settings_blacklist_title">Blacklist</string>
+	<string name="site_settings_moderation_hold_title">Hold for Moderation</string>
+	<string name="site_settings_multiple_links_title">Links in comments</string>
+	<string name="site_settings_whitelist_title">Automatically approve</string>
+	<string name="site_settings_paging_title">Paging</string>
+	<string name="site_settings_threading_title">Threading</string>
+	<string name="site_settings_sort_by_title">Sort by</string>
+	<string name="site_settings_account_required_title">Users must be signed in</string>
+	<string name="site_settings_identity_required_title">Must include name and email</string>
+	<string name="site_settings_receive_pingbacks_title">Receive Pingbacks</string>
+	<string name="site_settings_send_pingbacks_title">Send Pingbacks</string>
+	<string name="site_settings_allow_comments_title">Allow Comments</string>
+	<string name="site_settings_default_format_title">Default Format</string>
+	<string name="site_settings_default_category_title">Default Category</string>
+	<string name="site_settings_location_title">Enable Location</string>
+	<string name="site_settings_address_title">Address</string>
+	<string name="site_settings_title_title">Site Title</string>
+	<string name="site_settings_tagline_title">Tagline</string>
+	<string name="site_settings_this_device_header">This device</string>
+	<string name="site_settings_discussion_new_posts_header">Defaults for new posts</string>
+	<string name="site_settings_account_header">Account</string>
+	<string name="site_settings_writing_header">Writing</string>
+	<string name="site_settings_general_header">General</string>
+	<string name="newest_first">Newest first</string>
+	<string name="close_after">Close after</string>
+	<string name="comments">Comments</string>
+	<string name="discussion">Discussion</string>
+	<string name="oldest_first">Oldest first</string>
+	<string name="privacy">Privacy</string>
+	<string name="related_posts">Related Posts</string>
+	<string name="media_error_no_permission_upload">You don\'t have permission to upload media to the site</string>
+	<string name="never">Never</string>
+	<string name="unknown">Unknown</string>
 	<string name="reader_err_get_post_not_found">This post no longer exists</string>
 	<string name="reader_err_get_post_not_authorized">You\'re not authorised to view this post</string>
 	<string name="reader_err_get_post_generic">Unable to retrieve this post</string>
@@ -123,14 +232,12 @@
 	<string name="stats_no_activity_this_period">No activity this period</string>
 	<string name="button_back">Back</string>
 	<string name="page_deleted">Page deleted</string>
-	<string name="button_more">More</string>
 	<string name="button_stats">Stats</string>
 	<string name="button_trash">Bin</string>
 	<string name="button_preview">Preview</string>
 	<string name="button_view">View</string>
 	<string name="button_edit">Edit</string>
 	<string name="button_publish">Publish</string>
-	<string name="button_delete">Delete</string>
 	<string name="trashed">Binned</string>
 	<string name="my_site_no_sites_view_subtitle">Would you like to add one?</string>
 	<string name="my_site_no_sites_view_title">You don\'t have any WordPress sites yet.</string>
@@ -170,7 +277,6 @@
 	<string name="my_site_btn_switch_site">Switch Site</string>
 	<string name="my_site_btn_blog_posts">Blog Posts</string>
 	<string name="my_site_btn_site_settings">Settings</string>
-	<string name="my_site_btn_comments">Comments</string>
 	<string name="my_site_header_look_and_feel">Look and Feel</string>
 	<string name="my_site_header_publish">Publish</string>
 	<string name="my_site_header_configuration">Configuration</string>
@@ -302,7 +408,6 @@
 	<string name="stats_view_followers">Followers</string>
 	<string name="stats_view_countries">Countries</string>
 	<string name="stats_likes">Likes</string>
-	<string name="stats_comments">Comments</string>
 	<string name="stats_pagination_label">Page %1$s of %2$s</string>
 	<string name="stats_timeframe_years">Years</string>
 	<string name="stats_views">Views</string>
@@ -334,13 +439,13 @@
 	<string name="reader_label_comment_count_single">One comment</string>
 	<string name="reader_label_comments_closed">Comments are closed</string>
 	<string name="reader_label_comments_on">Comments on</string>
-	<string name="reader_title_comments">Comments</string>
 	<string name="reader_title_photo_viewer">%1$d of %2$d</string>
 	<string name="error_publish_empty_post">Can\'t publish an empty post</string>
 	<string name="error_refresh_unauthorized_posts">You don\'t have permission to view or edit posts</string>
 	<string name="error_refresh_unauthorized_pages">You don\'t have permission to view or edit pages</string>
 	<string name="error_refresh_unauthorized_comments">You don\'t have permission to view or edit comments</string>
 	<string name="older_month">Older than a month</string>
+	<string name="more">More</string>
 	<string name="older_two_days">Older than 2 days</string>
 	<string name="older_last_week">Older than a week</string>
 	<string name="stats_no_blog">Stats couldn\'t be loaded for the required blog</string>
@@ -658,7 +763,6 @@
 	<string name="media_no_video_message">Get the VideoPress upgrade to upload video!</string>
 	<string name="stats_view_clicks">Clicks</string>
 	<string name="stats_view_referrers">Referrers</string>
-	<string name="stats_view_comments">Comments</string>
 	<string name="stats_timeframe_today">Today</string>
 	<string name="stats_timeframe_yesterday">Yesterday</string>
 	<string name="stats_timeframe_days">Days</string>
@@ -672,7 +776,6 @@
 	<string name="stats_totals_views">Views</string>
 	<string name="stats_totals_clicks">Clicks</string>
 	<string name="stats_totals_plays">Plays</string>
-	<string name="stats_totals_comments">Comments</string>
 	<string name="media_edit_failure">Failed to update</string>
 	<string name="themes_details_label">Details</string>
 	<string name="themes_features_label">Features</string>
@@ -738,7 +841,7 @@
 	<string name="tos">Terms of Service</string>
 	<string name="app_title">WordPress for Android</string>
 	<string name="about">About</string>
-	<string name="max_thumbnail_px_width">Default image width</string>
+	<string name="max_thumbnail_px_width">Default Image Width</string>
 	<string name="image_alignment">Alignment</string>
 	<string name="refresh">Refresh</string>
 	<string name="untitled">Untitled</string>
@@ -776,7 +879,6 @@
 	<string name="save">Save</string>
 	<string name="add">Add</string>
 	<string name="category_refresh_error">Category refresh error</string>
-	<string name="tab_comments">Comments</string>
 	<string name="preview">Preview</string>
 	<string name="on">on</string>
 	<string name="reply">Reply</string>
@@ -828,6 +930,32 @@
 		<item>Standard</item>
 		<item>Status</item>
 		<item>Video</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>Your site is visible to everyone and may be indexed by search engines</item>
+		<item>Your site is visible to everyone but asks search engines not to index it</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>Require manual approval for everyone\'s comments.</item>
+		<item>Automatically approve if the user has a previously approved comment.</item>
+		<item>Automatically approve everyone\'s comments.</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>No comments</item>
+		<item>Known users\' comments</item>
+		<item>All users</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>None</item>
+		<item>Two levels</item>
+		<item>Three levels</item>
+		<item>Four levels</item>
+		<item>Five levels</item>
+		<item>Six levels</item>
+		<item>Seven levels</item>
+		<item>Eight levels</item>
+		<item>Nine levels</item>
+		<item>Ten levels</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>Free</item>

--- a/WordPress/src/main/res/values-es-rCL/strings.xml
+++ b/WordPress/src/main/res/values-es-rCL/strings.xml
@@ -53,14 +53,12 @@
 	<string name="trashed">En la papelera</string>
 	<string name="button_back">Atrás</string>
 	<string name="page_deleted">Página borrada</string>
-	<string name="button_more">Más</string>
 	<string name="button_stats">Estadísticas</string>
 	<string name="button_trash">Papelera</string>
 	<string name="button_preview">Vista previa</string>
 	<string name="button_view">Ver</string>
 	<string name="button_edit">Editar</string>
 	<string name="button_publish">Publicar</string>
-	<string name="button_delete">Borrar</string>
 	<string name="my_site_no_sites_view_subtitle">¿Quieres añadir uno?</string>
 	<string name="my_site_no_sites_view_title">Aún no tienes ningún sitio WordPress.</string>
 	<string name="my_site_no_sites_view_drake">Ilustración</string>
@@ -99,7 +97,6 @@
 	<string name="my_site_btn_view_admin">Ver Administrador</string>
 	<string name="my_site_btn_blog_posts">Entradas del blog</string>
 	<string name="my_site_btn_site_settings">Preferencias</string>
-	<string name="my_site_btn_comments">Comentarios</string>
 	<string name="my_site_header_look_and_feel">Aspecto</string>
 	<string name="my_site_header_publish">Publicar</string>
 	<string name="my_site_header_configuration">Configuración</string>
@@ -135,6 +132,8 @@
 	<string name="media_picker_title">Selecciona medio</string>
 	<string name="take_photo">Sacar una foto</string>
 	<string name="take_video">Grabar un vídeo</string>
+	<string name="media_details_label_file_name">Nombre del archivo:</string>
+	<string name="media_details_label_file_type">Tipo de archivo:</string>
 	<string name="error_publish_no_network">No se puede publicar mientras no haya conexión. Guardado como borrador.</string>
 	<string name="editor_toast_invalid_path">Ruta de archivo no válida</string>
 	<string name="verification_code">Código de verificación</string>
@@ -226,7 +225,6 @@
 	<string name="stats_view_followers">Seguidores</string>
 	<string name="stats_view_countries">Países</string>
 	<string name="stats_likes">Me gusta</string>
-	<string name="stats_comments">Comentarios</string>
 	<string name="stats_pagination_label">Página %1$s de %2$s</string>
 	<string name="stats_timeframe_years">Años</string>
 	<string name="stats_views">Vistas</string>
@@ -261,7 +259,6 @@
 	<string name="reader_label_comment_count_single">Un comentario</string>
 	<string name="reader_label_comments_closed">Los comentarios están cerrados</string>
 	<string name="reader_label_comments_on">Comentarios en</string>
-	<string name="reader_title_comments">Comentarios</string>
 	<string name="reader_title_photo_viewer">%1$d de %2$d</string>
 	<string name="error_publish_empty_post">No se puede publicar una entrada vacía.</string>
 	<string name="error_refresh_unauthorized_posts">No tienes permiso para ver o editar entradas.</string>
@@ -592,7 +589,6 @@
 	<string name="stats_view_clicks">Clics</string>
 	<string name="stats_view_tags_and_categories">Etiquetas y categorías</string>
 	<string name="stats_view_referrers">Referentes</string>
-	<string name="stats_view_comments">Comentarios</string>
 	<string name="stats_timeframe_today">Hoy</string>
 	<string name="stats_timeframe_yesterday">Ayer</string>
 	<string name="stats_timeframe_days">Días</string>
@@ -606,7 +602,6 @@
 	<string name="stats_totals_views">Vistas</string>
 	<string name="stats_totals_clicks">Clics</string>
 	<string name="stats_totals_plays">Juegos</string>
-	<string name="stats_totals_comments">Comentarios</string>
 	<string name="menu_search">Buscar</string>
 	<string name="passcode_manage">Administrar el PIN de bloqueo</string>
 	<string name="passcode_enter_passcode">Introduce tu PIN</string>
@@ -663,7 +658,6 @@
 	<string name="app_title">WordPress para Android</string>
 	<string name="tos">Términos de Servicio</string>
 	<string name="about">Acerca de</string>
-	<string name="max_thumbnail_px_width">Ancho de imagen por defecto</string>
 	<string name="image_alignment">Alineamiento</string>
 	<string name="refresh">Refrescar</string>
 	<string name="untitled">Sin Título</string>
@@ -701,7 +695,6 @@
 	<string name="save">Guardar</string>
 	<string name="add">Añadir</string>
 	<string name="category_refresh_error">Error de actualización de categorías</string>
-	<string name="tab_comments">Comentarios</string>
 	<string name="preview">Vista previa</string>
 	<string name="on">en</string>
 	<string name="reply">Responder</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">Tamaño original</string>
+	<string name="about_me_hint">Algunas palabras sobre ti...</string>
+	<string name="about_me">Sobre mí</string>
+	<string name="public_display_name_hint">El nombre público mostrará por defecto el nombre de usuario si no está establecido</string>
+	<string name="public_display_name">Nombre que se mostrará públicamente</string>
+	<string name="my_profile">Mi perfil</string>
+	<string name="first_name">Nombre</string>
+	<string name="last_name">Apellido</string>
+	<string name="site_privacy_public_desc">Permitir a los motores de búsqueda indexar este sitio</string>
+	<string name="site_privacy_hidden_desc">Disuadir a los motores de búsqueda de indexar este sitio</string>
+	<string name="site_privacy_private_desc">Me gustaría que mi sitio fuese privado, visible únicamente a los usuarios que yo elija</string>
+	<string name="cd_related_post_preview_image">Imagen de vista previa de entradas relacionadas</string>
+	<string name="error_post_remote_site_settings">No pudo guardar la información del sitio</string>
+	<string name="error_fetch_remote_site_settings">No pudo recuperar la información del sitio</string>
+	<string name="error_media_upload_connection">Se ha producido un error de conexión mientras subía multimedia</string>
+	<string name="site_settings_disconnected_toast">Desconectado, la edición se ha desactivado</string>
+	<string name="site_settings_unsupported_version_error">Versión de WordPress no soportada</string>
+	<string name="site_settings_multiple_links_dialog_description">Requiere aprobación para los comentarios que incluyen más de este número de enlaces.</string>
+	<string name="site_settings_close_after_dialog_switch_text">Cierra automáticamente</string>
+	<string name="site_settings_close_after_dialog_description">Cierra automáticamente los comentarios en artículos</string>
+	<string name="site_settings_paging_dialog_description">Rompe los hilos de comentarios en múltiples páginas</string>
+	<string name="site_settings_paging_dialog_header">Comentarios por página</string>
+	<string name="site_settings_close_after_dialog_title">Cerrar los comentarios</string>
+	<string name="site_settings_blacklist_description">Cuando un comentario contenga alguna de estas palabras en su contenido, nombre, URL, correo electrónico o IP, será marcado como spam. Puedes introducir palabras parciales, así "press" coincidirá con "WordPress."</string>
+	<string name="site_settings_hold_for_moderation_description">Cuando un comentario contenga alguna de las estas palabras en su contenido, nombre, URL, correo electrónico o IP, será puesto en la cola para moderar. Puedes introducir palabras parciales, así "press" coincidirá como "Wordpress"</string>
+	<string name="site_settings_list_editor_input_hint">Introduce una palabra o frase</string>
+	<string name="site_settings_list_editor_no_items_text">Sin elementos</string>
+	<string name="site_settings_learn_more_caption">Puedes sobreescribir esta configuración para entradas individuales</string>
+	<string name="site_settings_rp_preview3_site">en "Mejora"</string>
+	<string name="site_settings_rp_preview3_title">Novedades: VideoPress para bodas</string>
+	<string name="site_settings_rp_preview2_site">en "Aplicaciones"</string>
+	<string name="site_settings_rp_preview2_title">La aplicación WordPress para Android consigue un gran lavado de cara</string>
+	<string name="site_settings_rp_preview1_site">en "Móvil"</string>
+	<string name="site_settings_rp_preview1_title">Gran actualización disponible ahora para iPhone/iPad</string>
+	<string name="site_settings_rp_show_images_title">Mostrar imágenes</string>
+	<string name="site_settings_rp_show_header_title">Mostrar cabecera</string>
+	<string name="site_settings_rp_switch_summary">Las entradas relacionadas muestran contenido relevante de tu sitio debajo de las entradas.</string>
+	<string name="site_settings_rp_switch_title">Mostrar entradas relacionadas</string>
+	<string name="site_settings_delete_site_hint">Borra los datos de tu sitio de la aplicación</string>
+	<string name="site_settings_blacklist_hint">Los comentarios que coinciden con un filtro, son marcados como spam</string>
+	<string name="site_settings_moderation_hold_hint">Los comentarios que coinciden con un filtro, son puestos en la cola para moderar</string>
+	<string name="site_settings_multiple_links_hint">Ignorar límite de enlaces de usuarios conocidos</string>
+	<string name="site_settings_whitelist_hint">El autor de un comentario debe tener aprobado un comentario previo</string>
+	<string name="site_settings_user_account_required_hint">Los usuarios deben estar registrados e iniciar sesión para comentar</string>
+	<string name="site_settings_identity_required_hint">El autor de un comentario debe rellenar el nombre y correo eléctronico</string>
+	<string name="site_settings_manual_approval_hint">Los comentarios deben aprobarse manualmente</string>
+	<string name="site_settings_paging_hint">Mostrar los comentarios en pedazos de un tamaño especificado</string>
+	<string name="site_settings_threading_hint">Permitir comentarios anidados hasta cierto nivel</string>
+	<string name="site_settings_sort_by_hint">Determina el orden de los comentarios mostrados</string>
+	<string name="site_settings_close_after_hint">No permitir los comentarios después de un tiempo</string>
+	<string name="site_settings_receive_pingbacks_hint">Permitir notificaciones de enlace de otros sitios</string>
+	<string name="site_settings_send_pingbacks_hint">Intenta notificar cualquier sitio enlazado desde el artículo</string>
+	<string name="site_settings_allow_comments_hint">Permitir a los lectores publicar comentarios</string>
+	<string name="site_settings_discussion_hint">Ver y cambiar la configuración de discusiones de tu sitio</string>
+	<string name="site_settings_more_hint">Ver todos los ajustes disponibles de las discusiones</string>
+	<string name="site_settings_related_posts_hint">Mostrar u ocultar entradas relacionadas en el lector</string>
+	<string name="site_settings_upload_and_link_image_hint">Habilitar que siempre suba la imagen a tamaño completo</string>
+	<string name="site_settings_image_width_hint">Redimensionar imágenes en las entradas a esta anchura</string>
+	<string name="site_settings_format_hint">Establece formato para nuevas entradas</string>
+	<string name="site_settings_category_hint">Establece categoría para nuevas entradas</string>
+	<string name="site_settings_location_hint">Añadir ubicación a tus entradas automáticamente</string>
+	<string name="site_settings_password_hint">Cambiar tu contraseña</string>
+	<string name="site_settings_username_hint">Cuenta del usuario actual</string>
+	<string name="site_settings_language_hint">Idioma en el que está escrito este blog</string>
+	<string name="site_settings_privacy_hint">Controla quien puede ver tu sitio</string>
+	<string name="site_settings_address_hint">El cambio de dirección no está soportado en este momento</string>
+	<string name="site_settings_tagline_hint">Una descripción corta o frase ingeniosa que describa tu blog</string>
+	<string name="site_settings_title_hint">En pocas palabras, explica sobre que es este sitio</string>
+	<string name="site_settings_whitelist_known_summary">Comentarios de usuarios conocidos</string>
+	<string name="site_settings_whitelist_all_summary">Comentarios de todos los usuarios</string>
+	<string name="site_settings_threading_summary">%d niveles</string>
+	<string name="site_settings_privacy_private_summary">Privado</string>
+	<string name="site_settings_privacy_hidden_summary">Oculto</string>
+	<string name="site_settings_privacy_public_summary">Público</string>
+	<string name="site_settings_delete_site_title">Borrar el sitio</string>
+	<string name="site_settings_blacklist_title">Lista negra</string>
+	<string name="site_settings_moderation_hold_title">Mantener para moderación</string>
+	<string name="site_settings_multiple_links_title">Enlaces en comentarios</string>
+	<string name="site_settings_whitelist_title">Aprobar automáticamente</string>
+	<string name="site_settings_paging_title">Paginación</string>
+	<string name="site_settings_threading_title">Comentarios anidados</string>
+	<string name="site_settings_sort_by_title">Ordenar por</string>
+	<string name="site_settings_account_required_title">Los usuarios deben iniciar sesión</string>
+	<string name="site_settings_identity_required_title">Deben ser incluidos el nombre y correo electrónico</string>
+	<string name="site_settings_receive_pingbacks_title">Recibe pingbacks</string>
+	<string name="site_settings_send_pingbacks_title">Envía pingbacks</string>
+	<string name="site_settings_allow_comments_title">Permitir comentarios</string>
+	<string name="site_settings_default_format_title">Formato por defecto</string>
+	<string name="site_settings_default_category_title">Categoría por defecto</string>
+	<string name="site_settings_location_title">Permitir la ubicación</string>
+	<string name="site_settings_address_title">Dirección</string>
+	<string name="site_settings_title_title">Título del sitio</string>
+	<string name="site_settings_tagline_title">Lema</string>
+	<string name="site_settings_this_device_header">Este dispositivo</string>
+	<string name="site_settings_discussion_new_posts_header">Por defecto para nuevas entradas</string>
+	<string name="site_settings_account_header">Cuenta</string>
+	<string name="site_settings_writing_header">Escribiendo</string>
+	<string name="site_settings_general_header">General</string>
+	<string name="newest_first">Nuevos primero</string>
+	<string name="comments">Comentarios</string>
+	<string name="privacy">Privacidad</string>
+	<string name="oldest_first">Antiguos primero</string>
+	<string name="discussion">Discusión</string>
+	<string name="related_posts">Entradas relacionadas</string>
+	<string name="close_after">Cerrar después de</string>
+	<string name="media_error_no_permission_upload">No tienes permisos para subir multimedia al sitio</string>
+	<string name="never">Nunca</string>
+	<string name="unknown">Desconocido</string>
 	<string name="reader_err_get_post_not_found">Esta entrada ya no existe</string>
 	<string name="reader_err_get_post_not_authorized">No estás autorizado a ver esta entrada</string>
 	<string name="reader_err_get_post_generic">No se pudo cargar esta entrada</string>
@@ -124,14 +232,12 @@
 	<string name="trashed">En la papelera</string>
 	<string name="button_back">Atrás</string>
 	<string name="page_deleted">Página borrada</string>
-	<string name="button_more">Más</string>
 	<string name="button_stats">Estadísticas</string>
 	<string name="button_trash">Papelera</string>
 	<string name="button_preview">Vista previa</string>
 	<string name="button_view">Ver</string>
 	<string name="button_edit">Editar</string>
 	<string name="button_publish">Publicar</string>
-	<string name="button_delete">Borrar</string>
 	<string name="my_site_no_sites_view_subtitle">¿Quieres añadir uno?</string>
 	<string name="my_site_no_sites_view_title">Aún no tienes ningún sitio WordPress.</string>
 	<string name="my_site_no_sites_view_drake">Ilustración</string>
@@ -172,7 +278,6 @@
 	<string name="my_site_btn_blog_posts">Entradas del blog</string>
 	<string name="my_site_btn_site_settings">Preferencias</string>
 	<string name="my_site_header_publish">Publicar</string>
-	<string name="my_site_btn_comments">Comentarios</string>
 	<string name="reader_label_new_posts_subtitle">Toca para mostrarlos</string>
 	<string name="my_site_header_admin">Administración</string>
 	<string name="my_site_header_configuration">Configuración</string>
@@ -256,7 +361,6 @@
 	<string name="stats_views">Vistas</string>
 	<string name="stats_timeframe_years">Años</string>
 	<string name="stats_pagination_label">Página %1$s de %2$s</string>
-	<string name="stats_comments">Comentarios</string>
 	<string name="stats_view_countries">Países</string>
 	<string name="stats_likes">Me gusta</string>
 	<string name="stats_view_followers">Seguidores</string>
@@ -332,13 +436,13 @@
 	<string name="reader_label_comment_count_single">Un comentario</string>
 	<string name="reader_label_comments_closed">Los comentarios están cerrados</string>
 	<string name="reader_label_comments_on">Comentarios en</string>
-	<string name="reader_title_comments">Comentarios</string>
 	<string name="reader_title_photo_viewer">%1$d de %2$d</string>
 	<string name="error_publish_empty_post">No se puede publicar una entrada vacía.</string>
 	<string name="error_refresh_unauthorized_posts">No tienes permiso para ver o editar entradas.</string>
 	<string name="error_refresh_unauthorized_pages">No tienes permiso para ver o editar páginas.</string>
 	<string name="error_refresh_unauthorized_comments">No tienes permiso para ver o editar comentarios.</string>
 	<string name="older_month">Hace más de 1 mes</string>
+	<string name="more">Más</string>
 	<string name="older_two_days">Hace más de 2 días</string>
 	<string name="older_last_week">Hace más de 1 semana</string>
 	<string name="stats_no_blog">No se han podido cargar las estadísticas del blog solicitado</string>
@@ -691,9 +795,7 @@
 	<string name="media_edit_description_hint">Escribe una descripción aquí</string>
 	<string name="media_edit_failure">No se pudo actualizar</string>
 	<string name="themes_features_label">Características</string>
-	<string name="stats_view_comments">Comentarios</string>
 	<string name="stats_totals_views">Vistas</string>
-	<string name="stats_totals_comments">Comentarios</string>
 	<string name="media_gallery_image_order_reverse">Inverso</string>
 	<string name="stats">Estadísticas</string>
 	<string name="upload">Subir</string>
@@ -738,7 +840,6 @@
 	<string name="version">Versión</string>
 	<string name="tos">Términos del servicio</string>
 	<string name="about">Acerca de</string>
-	<string name="max_thumbnail_px_width">Ancho de imagen por defecto</string>
 	<string name="image_alignment">Alineamiento</string>
 	<string name="refresh">Refrescar</string>
 	<string name="untitled">Sin Título</string>
@@ -776,7 +877,6 @@
 	<string name="save">Guardar</string>
 	<string name="add">Añadir</string>
 	<string name="category_refresh_error">Error de actualización de categorías</string>
-	<string name="tab_comments">Comentarios</string>
 	<string name="preview">Vista previa</string>
 	<string name="reply">Responder</string>
 	<string name="yes">Sí</string>
@@ -828,6 +928,33 @@
 		<item>Estándar</item>
 		<item>Estatus</item>
 		<item>Vídeo</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>Tu sitio es visible para todos y puede ser indexado por los motores de búsqueda</item>
+		<item>Tu sitio es visible para todos pero pide a los motores de búsqueda no ser indexados</item>
+		<item>Tu sitio es visible únicamente por ti y por lo usuarios que apruebes</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>Requiere aprobación manual para los comentarios de todos</item>
+		<item>Aprobar si el usuario tiene algún comentario aprobado previamente</item>
+		<item>Aprobar los comentarios de todos automáticamente</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>Sin comentarios</item>
+		<item>Comentarios de usuarios conocidos</item>
+		<item>Todos los usuarios</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>Ninguna</item>
+		<item>Dos niveles</item>
+		<item>Tres niveles</item>
+		<item>Cuatro niveles</item>
+		<item>Cinco niveles</item>
+		<item>Seis niveles</item>
+		<item>Siete niveles</item>
+		<item>Ocho niveles</item>
+		<item>Nueve niveles</item>
+		<item>Diez niveles</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>Gratuito</item>

--- a/WordPress/src/main/res/values-eu/strings.xml
+++ b/WordPress/src/main/res/values-eu/strings.xml
@@ -6,14 +6,12 @@
 	<string name="post_deleted">Bidalketa ezabatua</string>
 	<string name="button_back">Itzuli</string>
 	<string name="page_deleted">Orrialdea ezabatua</string>
-	<string name="button_more">Gehiago</string>
 	<string name="button_stats">Estatistikak</string>
 	<string name="button_trash">Zaborra</string>
 	<string name="button_preview">Aurreikusi</string>
 	<string name="button_view">Ikusi</string>
 	<string name="button_edit">Editatu</string>
 	<string name="button_publish">Argitaratu</string>
-	<string name="button_delete">Ezabatu</string>
 	<string name="my_site_no_sites_view_subtitle">Gehitu nahi diozu bat?</string>
 	<string name="my_site_no_sites_view_title">Oraindik ez duzu WordPress gunerik.</string>
 	<string name="reader_toast_err_follow_blog_not_found">Ezin izan da blog hori aurkitu</string>
@@ -32,7 +30,6 @@
 	<string name="my_site_btn_switch_site">Aldatu gunez</string>
 	<string name="my_site_header_look_and_feel">Itxura</string>
 	<string name="my_site_header_publish">Argitaratu</string>
-	<string name="my_site_btn_comments">Iruzkinak</string>
 	<string name="my_site_btn_site_settings">Hobespenak</string>
 	<string name="my_site_header_configuration">Konfigurazioa</string>
 	<string name="my_site_header_admin">Administratzailea</string>
@@ -63,7 +60,7 @@
 	<string name="media_gallery_date_range">Erakutsi mediak  %1$s(e)tik %2$s(e)ra</string>
 	<string name="sure_to_remove_account">Ezabatu gune hau?</string>
 	<string name="signing_out">Saioa ixten...</string>
-	<string name="reader_title_comments">Iruzkinak</string>
+	<string name="more">Gehiago</string>
 	<string name="reader_label_comments_closed">Iruzkinak itxita daude</string>
 	<string name="reader_label_comment_count_single">Iruzkin bat</string>
 	<string name="reader_label_comment_count_multi">%,d iruzkin</string>
@@ -363,7 +360,6 @@
 	<string name="stats_view_visitors_and_views">Bisitariak eta ikuspegiak</string>
 	<string name="stats_totals_clicks">Klikak</string>
 	<string name="themes_features_label">Ezaugarriak</string>
-	<string name="stats_view_comments">Iruzkinak</string>
 	<string name="stats_totals_views">Ikuspegiak</string>
 	<string name="themes">Itxurak</string>
 	<string name="media_add_popup_capture_photo">Argazkia atera</string>
@@ -377,7 +373,6 @@
 	<string name="stats_view_tags_and_categories">Etiketak eta kategoriak</string>
 	<string name="stats_entry_referrers">Erreferentzia</string>
 	<string name="stats_entry_authors">Egilea</string>
-	<string name="stats_totals_comments">Iruzkinak</string>
 	<string name="passcode_set">Ezarri PINa</string>
 	<string name="passcode_preference_title">PINa blokeatu</string>
 	<string name="passcode_manage">Kudeatu PIN blokeatzea</string>
@@ -425,7 +420,6 @@
 	<string name="tos">Zerbitzu-baldintzak</string>
 	<string name="app_title">WordPress Android-erako</string>
 	<string name="about">Honi buruz</string>
-	<string name="max_thumbnail_px_width">Defektuzko irudi zabalera</string>
 	<string name="image_alignment">Lerrokatzea</string>
 	<string name="refresh">Freskatu</string>
 	<string name="untitled">Izenbururik gabe</string>
@@ -462,7 +456,6 @@
 	<string name="cancel">Ezeztatu</string>
 	<string name="save">Gorde</string>
 	<string name="add">Gehitu</string>
-	<string name="tab_comments">Iruzkinak</string>
 	<string name="reply">Erantzun</string>
 	<string name="no">Ez</string>
 	<string name="yes">Bai</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">Taille originale</string>
+	<string name="about_me_hint">Quelques mots à propos de vous...</string>
+	<string name="about_me">À propos de moi</string>
+	<string name="public_display_name_hint">Le nom d\'affichage par défaut est votre nom d\'utilisateur s\'il n\'est pas défini.</string>
+	<string name="public_display_name">Public</string>
+	<string name="first_name">Prénom</string>
+	<string name="last_name">Nom</string>
+	<string name="my_profile">Mon profil</string>
+	<string name="site_privacy_public_desc">Permettre aux moteurs de recherche d’indexer votre site</string>
+	<string name="site_privacy_hidden_desc">Demander aux moteurs de recherche de ne pas indexer ce site</string>
+	<string name="site_privacy_private_desc">Je veux que mon site soit privé, visible seulement aux utilisateurs choisis.</string>
+	<string name="cd_related_post_preview_image">Prévisualisation de l\'image de l\'article connexe</string>
+	<string name="error_post_remote_site_settings">Impossible d\'enregistrer les infos du site</string>
+	<string name="error_fetch_remote_site_settings">Impossible de retrouver les infos du site</string>
+	<string name="error_media_upload_connection">Désolé, une erreur est survenue pendant l\'envoi du média</string>
+	<string name="site_settings_disconnected_toast">Déconnecté, modification désactivée.</string>
+	<string name="site_settings_unsupported_version_error">Version de WordPress non supportée</string>
+	<string name="site_settings_multiple_links_dialog_description">Approbation requise pour les commentaires incluant plus de liens que ce nombre.</string>
+	<string name="site_settings_close_after_dialog_switch_text">Fermer automatiquement</string>
+	<string name="site_settings_close_after_dialog_description">Fermer automatiquement les commentaires.</string>
+	<string name="site_settings_paging_dialog_description">Scinder les fils de commentaires en pages multiples.</string>
+	<string name="site_settings_paging_dialog_header">Commentaires par page</string>
+	<string name="site_settings_close_after_dialog_title">Fermer les commentaires</string>
+	<string name="site_settings_blacklist_description">Quand un commentaire contient un de ces mots dans son contenu, nom, URL, email ou IP, il sera marqué en spam. Vous pouvez saisir des mots partiels, ainsi "press" correspondra à "WordPress".</string>
+	<string name="site_settings_hold_for_moderation_description">Quand un commentaire contient un de ces mots dans son contenu, nom, URL, email ou IP, il sera déposé dans la file de modération. Vous pouvez saisir des mots partiels, ainsi "press" correspondra à "WordPress". </string>
+	<string name="site_settings_list_editor_input_hint">Entrez un mot ou une phrase</string>
+	<string name="site_settings_list_editor_no_items_text">0 éléments</string>
+	<string name="site_settings_learn_more_caption">Vous pouvez substituer ces paramètres pour les articles individuels.</string>
+	<string name="site_settings_rp_preview3_site">dans "Mise à jour"</string>
+	<string name="site_settings_rp_preview3_title">Mise en avant de l\'option : VideoPress pour les mariages</string>
+	<string name="site_settings_rp_preview2_site">dans "Apps"</string>
+	<string name="site_settings_rp_preview2_title">WordPress pour Android App a subi un gros lifting</string>
+	<string name="site_settings_rp_preview1_site">Dans "Mobile"</string>
+	<string name="site_settings_rp_preview1_title">Grosse mise à jour iPhone/iPad disponible.</string>
+	<string name="site_settings_rp_show_images_title">Afficher les images</string>
+	<string name="site_settings_rp_show_header_title">Afficher l\'en-tête</string>
+	<string name="site_settings_rp_switch_summary">Les articles similaires affichent du contenu pertinent de votre site sous les articles.</string>
+	<string name="site_settings_rp_switch_title">Afficher les articles similaires</string>
+	<string name="site_settings_delete_site_hint">Supprime les données de votre site de l\'application</string>
+	<string name="site_settings_blacklist_hint">Les commentaires qui correspondent à un filtrer son marqués comme indésirables</string>
+	<string name="site_settings_moderation_hold_hint">Les commentaires qui correspondent à un filtre sont mis dans la file d\'attente de modération</string>
+	<string name="site_settings_multiple_links_hint">Ignore la limite de liens pour les utilisateurs connus</string>
+	<string name="site_settings_whitelist_hint">L&amp;rsquo;auteur d&amp;rsquo;un commentaire doit avoir déjà au moins un commentaire approuvé</string>
+	<string name="site_settings_user_account_required_hint">Les utilisateurs doivent être enregistrés et connectés pour commenter</string>
+	<string name="site_settings_identity_required_hint">L&amp;rsquo;auteur d&amp;rsquo;un commentaire doit renseigner son nom et son adresse de messagerie</string>
+	<string name="site_settings_manual_approval_hint">Les commentaires doivent être approuvés manuellement</string>
+	<string name="site_settings_paging_hint">Afficher les commentaires en morceaux d\'une taille spécifiée.</string>
+	<string name="site_settings_threading_hint">Permettre les commentaires imbriqués à un certain niveau</string>
+	<string name="site_settings_sort_by_hint">Détermine l\'ordre d\'affichage des commentaires</string>
+	<string name="site_settings_close_after_hint">Interdire les commentaires après l\'heure indiquée</string>
+	<string name="site_settings_receive_pingbacks_hint">Autoriser les liens de notifications depuis les autres sites</string>
+	<string name="site_settings_send_pingbacks_hint">Tenter de notifier les sites liés depuis le contenu des articles</string>
+	<string name="site_settings_allow_comments_hint">Autoriser les lecteurs à publier des commentaires</string>
+	<string name="site_settings_discussion_hint">Voir et modifier les réglages de discussion de votre site</string>
+	<string name="site_settings_more_hint">Voir tous les réglages de discussion disponibles</string>
+	<string name="site_settings_related_posts_hint">Afficher ou cacher les articles similaires dans le lecteur</string>
+	<string name="site_settings_upload_and_link_image_hint">Activez pour toujours mettre en ligne l\'image en pleine grandeur</string>
+	<string name="site_settings_image_width_hint">Redimensionner les images dans les articles dans cette largeur. </string>
+	<string name="site_settings_format_hint">Configure le nouveau format d&amp;rsquo;article</string>
+	<string name="site_settings_category_hint">Configure la nouvelle catégorie d\'articles</string>
+	<string name="site_settings_location_hint">Automatiquement ajouter les données de localisation pour vos articles.</string>
+	<string name="site_settings_password_hint">Changez votre mot de passe</string>
+	<string name="site_settings_username_hint">Compte utilisateur actuel</string>
+	<string name="site_settings_language_hint">La langue d\'écriture de ce blog est principalement en</string>
+	<string name="site_settings_privacy_hint">Contrôler qui peut voir votre site.</string>
+	<string name="site_settings_address_hint">Changer votre adresse n\'est actuellement pas supporté.</string>
+	<string name="site_settings_tagline_hint">Une brève description ou une phrase accrocheuse pour décrire votre blog</string>
+	<string name="site_settings_title_hint">En quelques mots, décrivez la raison d&amp;rsquo;être de ce site.</string>
+	<string name="site_settings_whitelist_known_summary">Commentaires des utilisateurs anonymes</string>
+	<string name="site_settings_whitelist_all_summary">Commentaires de tous les utilisateurs</string>
+	<string name="site_settings_threading_summary">%d niveaux</string>
+	<string name="site_settings_privacy_private_summary">Privé</string>
+	<string name="site_settings_privacy_hidden_summary">Caché</string>
+	<string name="site_settings_delete_site_title">Supprimer le site</string>
+	<string name="site_settings_privacy_public_summary">Public</string>
+	<string name="site_settings_blacklist_title">Liste noire</string>
+	<string name="site_settings_moderation_hold_title">Garder en modération</string>
+	<string name="site_settings_multiple_links_title">Liens dans les commentaires</string>
+	<string name="site_settings_whitelist_title">Approuver automatiquement</string>
+	<string name="site_settings_paging_title">Pagination</string>
+	<string name="site_settings_threading_title">Fil de discussions</string>
+	<string name="site_settings_sort_by_title">Trier par</string>
+	<string name="site_settings_account_required_title">Les utilisateurs doivent être connectés</string>
+	<string name="site_settings_identity_required_title">Doit inclure le nom et l\'email</string>
+	<string name="site_settings_receive_pingbacks_title">Recevoir les pings</string>
+	<string name="site_settings_send_pingbacks_title">Envoi des pings</string>
+	<string name="site_settings_allow_comments_title">Autoriser les commentaires</string>
+	<string name="site_settings_default_format_title">Format par défaut</string>
+	<string name="site_settings_default_category_title">Catégorie par défaut</string>
+	<string name="site_settings_location_title">Activer la localisation</string>
+	<string name="site_settings_address_title">Adresse</string>
+	<string name="site_settings_title_title">Titre du site</string>
+	<string name="site_settings_tagline_title">Slogan</string>
+	<string name="site_settings_this_device_header">Cet appareil</string>
+	<string name="site_settings_discussion_new_posts_header">Par défaut pour les nouveaux articles</string>
+	<string name="site_settings_account_header">Compte</string>
+	<string name="site_settings_writing_header">Écriture</string>
+	<string name="newest_first">Récents en premier</string>
+	<string name="site_settings_general_header">Général</string>
+	<string name="discussion">Discussion</string>
+	<string name="related_posts">Articles similaires</string>
+	<string name="comments">Commentaires</string>
+	<string name="oldest_first"> Anciens en Premier</string>
+	<string name="privacy">Vie privée</string>
+	<string name="close_after">Fermer après</string>
+	<string name="media_error_no_permission_upload">Vous n&amp;rsquo;avez pas l&amp;rsquo;autorisation de mettre en ligne des fichiers média sur ce site</string>
+	<string name="never">Jamais</string>
+	<string name="unknown">Inconnu</string>
 	<string name="reader_err_get_post_not_found">Cet article n’existe plus</string>
 	<string name="reader_err_get_post_not_authorized">Vous n’avez pas les droits nécessaires pour voir cet article</string>
 	<string name="reader_err_get_post_generic">Impossible de retrouver cet article</string>
@@ -121,14 +229,12 @@
 	<string name="page_trashed">Page envoyée à la corbeille</string>
 	<string name="post_trashed">Article envoyé à la corbeille</string>
 	<string name="page_deleted">Page supprimée</string>
-	<string name="button_more">Plus</string>
 	<string name="button_stats">Stats</string>
 	<string name="button_trash">Corbeille</string>
 	<string name="button_preview">Aperçu</string>
 	<string name="button_view">Vue</string>
 	<string name="button_edit">Editer</string>
 	<string name="button_publish">Publier</string>
-	<string name="button_delete">Supprimer</string>
 	<string name="post_deleted">Article supprimé</string>
 	<string name="stats_no_activity_this_period">Pas d\'activité durant cette période</string>
 	<string name="button_back">Retour</string>
@@ -170,7 +276,6 @@
 	<string name="my_site_btn_view_admin">Afficher l\'Admin</string>
 	<string name="my_site_header_publish">Publier</string>
 	<string name="my_site_header_look_and_feel">Personnaliser</string>
-	<string name="my_site_btn_comments">Commentaires</string>
 	<string name="my_site_btn_site_settings">Réglages</string>
 	<string name="my_site_btn_blog_posts">Articles</string>
 	<string name="my_site_header_admin">Admin</string>
@@ -212,7 +317,6 @@
 	<string name="editor_toast_invalid_path">Chemin de fichier invalide</string>
 	<string name="error_publish_no_network">Impossible de publier quand il n\'y a pas de connexion. Brouillon sauvegardé.</string>
 	<string name="device">Appareil</string>
-	<string name="media_details_label_file_type">Type de fichier:</string>
 	<string name="tab_title_site_videos">Videos du site</string>
 	<string name="tab_title_site_images">Images du site</string>
 	<string name="tab_title_device_videos">Vidéos de l\'appareil</string>
@@ -222,7 +326,8 @@
 	<string name="media_picker_title">Sélectionner un média</string>
 	<string name="add_to_post">Ajouter à l\'article</string>
 	<string name="language">Langue</string>
-	<string name="media_details_label_file_name">Nom de fichier :</string>
+	<string name="media_details_label_file_name">Nom de fichier</string>
+	<string name="media_details_label_file_type">Type de fichier</string>
 	<string name="posts_fetching">Récupération des articles…</string>
 	<string name="media_fetching">Récupération des médias…</string>
 	<string name="stats_view_search_terms">Termes de Recherche</string>
@@ -256,7 +361,6 @@
 	<string name="stats_views">Visites</string>
 	<string name="stats_timeframe_years">Années</string>
 	<string name="stats_pagination_label">Page %1$s de %2$s</string>
-	<string name="stats_comments">Commentaires</string>
 	<string name="stats_view_countries">Pays</string>
 	<string name="stats_likes">Aime</string>
 	<string name="stats_view_publicize">Publicize</string>
@@ -334,13 +438,13 @@
 	<string name="reader_label_comment_count_single">Un commentaire</string>
 	<string name="reader_label_comments_closed">Les commentaires sont fermés</string>
 	<string name="reader_label_comments_on">Commentaires sur</string>
-	<string name="reader_title_comments">Commentaires</string>
 	<string name="reader_title_photo_viewer">%1$d sur %2$d</string>
 	<string name="error_publish_empty_post">Impossible de publier un article vide</string>
 	<string name="error_refresh_unauthorized_posts">Vous n\'avez pas la permission de voir ou éditer les articles</string>
 	<string name="error_refresh_unauthorized_pages">Vous n\'avez pas la permission de voir ou éditer les pages</string>
 	<string name="error_refresh_unauthorized_comments">Vous n\'avez pas la permission de voir ou éditer les commentaires</string>
 	<string name="older_month">Plus d\'un mois</string>
+	<string name="more">Plus</string>
 	<string name="older_two_days">Plus de 2 jours</string>
 	<string name="older_last_week">Plus d\'une semaine</string>
 	<string name="stats_no_blog">Les statistiques ne peuvent pas être chargée pour ce blog</string>
@@ -503,7 +607,6 @@
 	<string name="upload_failed">Échec du chargement</string>
 	<string name="horizontal_alignment">Alignement horizontal</string>
 	<string name="link_enter_url_text">Texte du lien (optionnel)</string>
-	<string name="comment_status_trash">À la corbeille</string>
 	<string name="trash">Corbeille</string>
 	<string name="saving_changes">Enregistrement des modifications</string>
 	<string name="sure_to_cancel_edit_comment">Annuler l\'édition de ce commentaire ?</string>
@@ -568,6 +671,7 @@
 	<string name="remove_account">Supprimer le site</string>
 	<string name="blog_removed_successfully">Site supprimé avec succès</string>
 	<string name="notifications_empty_all">Pas (encore) de notifications.</string>
+	<string name="comment_status_trash">À la Corbeille</string>
 	<string name="deleting_page">Suppression de la page</string>
 	<string name="deleting_post">Suppression de l\'article</string>
 	<string name="share_url_page">Partager la page</string>
@@ -616,8 +720,6 @@
 	<string name="reader_btn_follow">Suivre</string>
 	<string name="reader_label_added_tag">%s Ajouté</string>
 	<string name="reader_label_removed_tag">%s Retiré</string>
-	<string name="reader_toast_err_tag_exists">Vous suivez déjà ce tag</string>
-	<string name="reader_toast_err_tag_invalid">Ce n\'est pas un tag valide</string>
 	<string name="reader_toast_err_share_intent">Impossible de partager</string>
 	<string name="reader_toast_err_view_image">Impossible de voir l\'image</string>
 	<string name="reader_toast_err_url_intent">Impossible d\'ouvrir %s</string>
@@ -633,6 +735,8 @@
 	<string name="reader_btn_unfollow">Abonné</string>
 	<string name="media_add_new_media_gallery">Créer une galerie</string>
 	<string name="reader_hint_comment_on_comment">Répondre au commentaire…</string>
+	<string name="reader_toast_err_tag_invalid">Ce n’est pas une étiquette valide</string>
+	<string name="reader_toast_err_tag_exists">Vous suivez déjà cette étiquette</string>
 	<string name="themes">Thèmes</string>
 	<string name="media_gallery_image_order_random">Aléatoire</string>
 	<string name="media_gallery_type">Catégorie</string>
@@ -651,14 +755,11 @@
 	<string name="passcode_re_enter_passcode">Re-entrer votre code PIN</string>
 	<string name="passcode_change_passcode">Changer le code PIN</string>
 	<string name="passcode_set">Code PIN changé</string>
-	<string name="stats_view_referrers">Référants</string>
-	<string name="stats_view_comments">Commentaires</string>
 	<string name="stats_timeframe_today">Aujourd\'hui</string>
 	<string name="stats_timeframe_yesterday">Hier</string>
 	<string name="stats_timeframe_days">Jours</string>
 	<string name="stats_timeframe_weeks">Semaines</string>
 	<string name="stats_timeframe_months">Mois</string>
-	<string name="stats_view_clicks">Clicks</string>
 	<string name="media_no_video_title">VideoPress indisponible</string>
 	<string name="media_gallery_type_slideshow">Diaporama</string>
 	<string name="media_gallery_type_circles">Cercles</string>
@@ -672,7 +773,6 @@
 	<string name="theme_activate_button">Activer</string>
 	<string name="theme_activating_button">Activation</string>
 	<string name="stats_view_visitors_and_views">Visiteurs et Vues</string>
-	<string name="stats_view_tags_and_categories">Tags et Catégories</string>
 	<string name="stats_entry_country">Pays</string>
 	<string name="stats_entry_posts_and_pages">Titre</string>
 	<string name="stats_entry_tags_and_categories">Sujet</string>
@@ -687,7 +787,6 @@
 	<string name="stats_totals_views">Vues</string>
 	<string name="stats_totals_clicks">Clicks</string>
 	<string name="stats_totals_plays">Vues</string>
-	<string name="stats_totals_comments">Commentaires</string>
 	<string name="theme_auth_error_title">Impossible de récupérer les thèmes</string>
 	<string name="post_excerpt">Extrait</string>
 	<string name="share_action_title">Ajouter à ...</string>
@@ -696,6 +795,9 @@
 	<string name="media_edit_failure">Échec de mise à jour</string>
 	<string name="theme_set_success">Le thème a bien été sélectionné !</string>
 	<string name="passcode_turn_off">Désactiver le code PIN</string>
+	<string name="stats_view_clicks">Clics</string>
+	<string name="stats_view_tags_and_categories">Étiquettes et Catégories</string>
+	<string name="stats_view_referrers">Référents</string>
 	<string name="upload">Envoyer</string>
 	<string name="sign_in">Se connecter</string>
 	<string name="notifications">Notifications</string>
@@ -707,7 +809,7 @@
 	<string name="post_signature">Signature des articles</string>
 	<string name="add_tagline">Ajouter une signature aux articles</string>
 	<string name="httppassword">Mot de passe HTTP</string>
-	<string name="httpuser">Nom d\'utilisateur HTTP</string>
+	<string name="httpuser">Nom d’utilisateur HTTP</string>
 	<string name="error_media_upload">Désolé, une erreur est survenue pendant l\'envoi du média</string>
 	<string name="publish_date">Publié le</string>
 	<string name="content_description_add_media">Ajouter média</string>
@@ -738,9 +840,9 @@
 	<string name="tos">Conditions d\'utilisation</string>
 	<string name="app_title">WordPress pour Android</string>
 	<string name="about">A propos</string>
-	<string name="max_thumbnail_px_width">Largeur d\'image par défaut</string>
+	<string name="max_thumbnail_px_width">Largeur d\'iImage par défaut</string>
 	<string name="image_alignment">Alignement</string>
-	<string name="refresh">Rafraîchir</string>
+	<string name="refresh">Rafraichir</string>
 	<string name="untitled">Sans titre</string>
 	<string name="post_id">Article</string>
 	<string name="page_id">Page</string>
@@ -758,7 +860,7 @@
 	<string name="upload_full_size_image">Envoyer l\'image et ajouter un lien vers la taille originale</string>
 	<string name="title">Titre</string>
 	<string name="categories">Catégories</string>
-	<string name="tags_separate_with_commas">Tags (séparez les tags par des virgules)</string>
+	<string name="tags_separate_with_commas">Étiquettes (séparez les par des virgules)</string>
 	<string name="notification_vibrate">Vibrer</string>
 	<string name="notification_blink">Faire clignoter le voyant de notification</string>
 	<string name="notification_sound">Faire retentir la sonnerie</string>
@@ -776,7 +878,6 @@
 	<string name="save">Enregistrer</string>
 	<string name="add">Ajouter</string>
 	<string name="category_refresh_error">Erreur de rafraîchissement de catégorie</string>
-	<string name="tab_comments">Commentaires</string>
 	<string name="preview">Prévisualisation</string>
 	<string name="on">sur</string>
 	<string name="reply">Répondre</string>
@@ -828,6 +929,33 @@
 		<item>Standard</item>
 		<item>État</item>
 		<item>Vidéo</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>Votre site est visible par tous et peut-être être indexé par les moteurs de recherche</item>
+		<item>Votre site est visible par tous, mais demande aux moteurs de recherche de ne pas l\'indexer</item>
+		<item>Votre site est visible uniquement pour vous et les utilisateurs que  vous approuvez</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>Les commentaires doivent être approuvés manuellement.</item>
+		<item>L’auteur d’un commentaire doit avoir déjà au moins un commentaire approuvé.</item>
+		<item>Approuver automatiquement</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>0 Commentaires</item>
+		<item>Commentaires des utilisateurs connus</item>
+		<item>Tous les utilisateurs</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>Aucun</item>
+		<item>Deux niveaux</item>
+		<item>Trois niveaux</item>
+		<item>Quatre niveaux</item>
+		<item>Cinq niveaux</item>
+		<item>Six niveaux</item>
+		<item>Sept niveaux</item>
+		<item>Huit niveaux</item>
+		<item>Neuf niveaux</item>
+		<item>Dix niveaux</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>Gratuit</item>

--- a/WordPress/src/main/res/values-gd/strings.xml
+++ b/WordPress/src/main/res/values-gd/strings.xml
@@ -32,7 +32,6 @@
 	<string name="site_picker_title">Tagh làrach</string>
 	<string name="my_site_header_publish">Foillsich</string>
 	<string name="my_site_header_look_and_feel">Coltas</string>
-	<string name="my_site_btn_comments">Beachdan</string>
 	<string name="my_site_btn_site_settings">Roghainnean</string>
 	<string name="my_site_btn_blog_posts">Puist bloga</string>
 	<string name="my_site_header_admin">Rianachd</string>
@@ -113,7 +112,6 @@
 	<string name="stats_comments_total_comments_followers">Puist air fad aig a bheil luchd-leantainn phost: %1$s</string>
 	<string name="stats_visitors">Aoighean</string>
 	<string name="stats_views">Seallaidhean</string>
-	<string name="stats_comments">Beachdan</string>
 	<string name="stats_pagination_label">Duilleag %1$s à %2$s</string>
 	<string name="stats_timeframe_years">Bliadhna</string>
 	<string name="stats_view_countries">Dùthchannan</string>
@@ -200,7 +198,6 @@
 	<string name="error_publish_empty_post">Cha ghabh post bàn fhoillseachadh</string>
 	<string name="reader_title_photo_viewer">%1$d de %2$d</string>
 	<string name="reader_label_comments_on">Beachdan air</string>
-	<string name="reader_title_comments">Beachdan</string>
 	<string name="reader_label_comments_closed">Tha na beachdan dùinte</string>
 	<string name="reader_label_comment_count_single">Aon bheachd</string>
 	<string name="reader_label_like">’S toil</string>
@@ -521,7 +518,6 @@
 	<string name="stats_view_clicks">Briogaidhean</string>
 	<string name="stats_view_tags_and_categories">Tagaichean ⁊ roinnean-seòrsa</string>
 	<string name="stats_view_referrers">Ath-threòraichean</string>
-	<string name="stats_view_comments">Beachdan</string>
 	<string name="stats_timeframe_today">An-diugh</string>
 	<string name="stats_timeframe_yesterday">An-dè</string>
 	<string name="stats_timeframe_days">Làithean</string>
@@ -536,7 +532,6 @@
 	<string name="stats_totals_views">Seallaidhean</string>
 	<string name="stats_totals_clicks">Briogaidhean</string>
 	<string name="stats_totals_plays">Air a chluich</string>
-	<string name="stats_totals_comments">Beachdan</string>
 	<string name="menu_search">Lorg</string>
 	<string name="passcode_enter_passcode">Cuir a-steach am PIN agad</string>
 	<string name="passcode_re_enter_passcode">Cuir a-steach am PIN agad a-rithist</string>
@@ -588,7 +583,6 @@
 	<string name="tos">Teirmichean na seirbheise</string>
 	<string name="app_title">WordPress airson Android</string>
 	<string name="about">Mu dheidhinn</string>
-	<string name="max_thumbnail_px_width">Leud bunaiteach an deilbh</string>
 	<string name="image_alignment">Co-thaobhadh</string>
 	<string name="refresh">Ath-nuadhaich</string>
 	<string name="untitled">Gun tiotal</string>
@@ -625,7 +619,6 @@
 	<string name="cancel">Sguir dheth</string>
 	<string name="save">Sàbhail</string>
 	<string name="add">Cuir ris</string>
-	<string name="tab_comments">Beachdan</string>
 	<string name="preview">Ro-shealladh</string>
 	<string name="on"> </string>
 	<string name="reply">Freagair</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">גודל מקורי</string>
+	<string name="about_me_hint">תיאור אישי בכמה מילים…</string>
+	<string name="public_display_name_hint">אם לא יוגדר אחרת, שם המשתמש שלך ישמש כשם תצוגה בברירת מחדל</string>
+	<string name="about_me">מי אני</string>
+	<string name="public_display_name">שם תצוגה ציבורי</string>
+	<string name="my_profile">הפרופיל שלי</string>
+	<string name="first_name">שם פרטי</string>
+	<string name="last_name">שם משפחה</string>
+	<string name="site_privacy_public_desc">לאפשר למנועי חיפוש לצרף את האתר לאינדקס</string>
+	<string name="site_privacy_hidden_desc">למנוע ממנועי חיפוש לצרף את האתר לאינדקס</string>
+	<string name="site_privacy_private_desc">אני רוצה שהאתר שלי יהיה פרטי וגלוי רק למשתמשים שאבחר</string>
+	<string name="cd_related_post_preview_image">תמונת תצוגה מקדימה של פוסט קשור</string>
+	<string name="error_post_remote_site_settings">לא הצלחנו לשמור את פרטי האתר</string>
+	<string name="error_fetch_remote_site_settings">לא הצלחנו לאחזר את פרטי האתר</string>
+	<string name="error_media_upload_connection">ארעה שגיאת חיבור במהלך העלאת המדיה</string>
+	<string name="site_settings_disconnected_toast">מנותק, עריכה מושבתת.</string>
+	<string name="site_settings_unsupported_version_error">גרסת WordPress לא נתמכת</string>
+	<string name="site_settings_multiple_links_dialog_description">דרוש אישור לתגובות שכוללות כמות קישורים גבוהה מזו.</string>
+	<string name="site_settings_close_after_dialog_switch_text">סגירה אוטומטית</string>
+	<string name="site_settings_close_after_dialog_description">סגירת תגובות אוטומטית במאמרים.</string>
+	<string name="site_settings_paging_dialog_description">חלוקת שרשורי תגובות למספר עמודים.</string>
+	<string name="site_settings_paging_dialog_header">תגובות לעמוד</string>
+	<string name="site_settings_close_after_dialog_title">סגור לתגובות</string>
+	<string name="site_settings_blacklist_description">תגובה שתכיל מילה מהמילים הללו בתוכן שלה, בשם, בכתובת, באימייל או ב-IP תסומן כתגובת זבל. אפשר להשתמש גם בחלקי מילים, כך ש-"press" תתאים למילה "WordPress".</string>
+	<string name="site_settings_hold_for_moderation_description">תגובה שתכיל מילה מהמילים הללו בתוכן שלה, בשם, בכתובת האתר, באימייל או ב-IP תישמר בתור המנהל. אפשר להשתמש גם בחלקי מילים, כך ש-"press" תתאים למילה "WordPress".</string>
+	<string name="site_settings_list_editor_input_hint">הזנת מילה או ביטוי</string>
+	<string name="site_settings_list_editor_no_items_text">אין פריטים</string>
+	<string name="site_settings_learn_more_caption">אפשר לעקוף הגדרות אלה בפוסטים נפרדים.</string>
+	<string name="site_settings_rp_preview3_site">תחת \'שדרוג\'</string>
+	<string name="site_settings_rp_preview3_title">המלצת שדרוג: VideoPress לחתונות</string>
+	<string name="site_settings_rp_preview2_site">תחת \'אפליקציות\'</string>
+	<string name="site_settings_rp_preview2_title">אפליקציית WordPress ל-Android עברה \'מתיחת פנים\' רצינית</string>
+	<string name="site_settings_rp_preview1_site">תחת \'נייד\'</string>
+	<string name="site_settings_rp_preview1_title">עדכון גדול ל-iPhone/‏iPad זמין עכשיו</string>
+	<string name="site_settings_rp_show_images_title">הצגת תמונות</string>
+	<string name="site_settings_rp_show_header_title">הצגת כותרת</string>
+	<string name="site_settings_rp_switch_summary">פוסטים קשורים מציגים תוכן רלוונטי מהאתר שלך, מתחת לפוסטים שלך.</string>
+	<string name="site_settings_rp_switch_title">הצג תכנים באותו נושא</string>
+	<string name="site_settings_delete_site_hint">מסיר את נתוני האתר שלך מהאפליקציה</string>
+	<string name="site_settings_blacklist_hint">תגובות שתואמות למסנן מסומנות כתגובות זבל</string>
+	<string name="site_settings_moderation_hold_hint">תגובות שתואמות למסנן עוברות לתור לאישור</string>
+	<string name="site_settings_multiple_links_hint">מתעלם ממגבלת קישורים אצל משתמשים מוכרים</string>
+	<string name="site_settings_whitelist_hint">המגיב הוא מישהו שתגובתו אושרה בעבר</string>
+	<string name="site_settings_user_account_required_hint">כדי להגיב יש להירשם לאתר ולהתחבר למערכת</string>
+	<string name="site_settings_identity_required_hint">המגיבים חייבים לכתוב את שמם ואת כתובת האימייל שלהם</string>
+	<string name="site_settings_manual_approval_hint">תגובות חייבות לעבור אישור ידני</string>
+	<string name="site_settings_paging_hint">הצגת כמות מוגדרת של תגובות</string>
+	<string name="site_settings_threading_hint">מאפשר שרשור תגובות עד עומק מסוים</string>
+	<string name="site_settings_sort_by_hint">קובע את סדר הצגת התגובות</string>
+	<string name="site_settings_close_after_hint">לא מאפשר הוספת תגובות אחרי פרק זמן מוגדר</string>
+	<string name="site_settings_receive_pingbacks_hint">מאפשר קבלת הודעות עם קישורים מבלוגים אחרים</string>
+	<string name="site_settings_send_pingbacks_hint">מנסה לשלוח הודעה לכל בלוג שהמאמר מקשר אליו</string>
+	<string name="site_settings_allow_comments_hint">מאפשר לקוראים לפרסם תגובות</string>
+	<string name="site_settings_discussion_hint">הצגה ושינוי של הגדרות הדיון באתרים שלך</string>
+	<string name="site_settings_more_hint">הצגת כל הגדרות הדיון הזמינות</string>
+	<string name="site_settings_related_posts_hint">הצגה/הסתרה של פוסטים קשורים ב-Reader</string>
+	<string name="site_settings_upload_and_link_image_hint">מאפשר תמיד להעלות תמונה בגודל מלא</string>
+	<string name="site_settings_image_width_hint">שינוי גודל של תמונות בפוסטים לרוחב זה</string>
+	<string name="site_settings_format_hint">הגדרת סוג פוסט חדש</string>
+	<string name="site_settings_category_hint">הגדרת קטגוריית פוסט חדשה</string>
+	<string name="site_settings_location_hint">הוספה אוטומטית של נתוני מיקום לפוסטים שלך</string>
+	<string name="site_settings_password_hint">שינוי סיסמה</string>
+	<string name="site_settings_username_hint">חשבון משתמש נוכחי</string>
+	<string name="site_settings_language_hint">השפה עיקרית בה כתוב בלוג זה</string>
+	<string name="site_settings_privacy_hint">מגדיר מי יכול לראות את האתר שלך</string>
+	<string name="site_settings_address_hint">האפשרות לשינוי כתובת לא נתמכת כרגע</string>
+	<string name="site_settings_tagline_hint">תיאור קצר או ביטוי קולע שמתארים את הבלוג שלך</string>
+	<string name="site_settings_title_hint">במספר מילים, הסבר במה עוסק האתר</string>
+	<string name="site_settings_whitelist_known_summary">תגובות ממשתמשים מוכרים</string>
+	<string name="site_settings_whitelist_all_summary">תגובות מכל המשתמשים</string>
+	<string name="site_settings_threading_summary">%d רמות</string>
+	<string name="site_settings_privacy_private_summary">פרטי</string>
+	<string name="site_settings_privacy_hidden_summary">מוסתר</string>
+	<string name="site_settings_delete_site_title">מחיקת אתר</string>
+	<string name="site_settings_privacy_public_summary">ציבורי</string>
+	<string name="site_settings_blacklist_title">רשימה שחורה</string>
+	<string name="site_settings_moderation_hold_title">המתנה לניהול</string>
+	<string name="site_settings_multiple_links_title">קישורים בתגובות</string>
+	<string name="site_settings_whitelist_title">אישור אוטומטי</string>
+	<string name="site_settings_threading_title">שרשור</string>
+	<string name="site_settings_paging_title">עימוד</string>
+	<string name="site_settings_sort_by_title">מיון לפי</string>
+	<string name="site_settings_account_required_title">משתמשים חייבים להתחבר</string>
+	<string name="site_settings_identity_required_title">חובה לציין שם ואימייל</string>
+	<string name="site_settings_receive_pingbacks_title">קבלת פינגבאקים</string>
+	<string name="site_settings_send_pingbacks_title">שליחת פינגבאקים</string>
+	<string name="site_settings_allow_comments_title">אפשר תגובות</string>
+	<string name="site_settings_default_format_title">סוג ברירת מחדל</string>
+	<string name="site_settings_default_category_title">קטגוריית ברירת מחדל</string>
+	<string name="site_settings_location_title">אפשר מיקום</string>
+	<string name="site_settings_address_title">כתובת</string>
+	<string name="site_settings_title_title">שם האתר</string>
+	<string name="site_settings_tagline_title">תיאור האתר</string>
+	<string name="site_settings_this_device_header">מכשיר זה</string>
+	<string name="site_settings_discussion_new_posts_header">ברירות מחדל עבור פוסטים חדשים</string>
+	<string name="site_settings_account_header">חשבון</string>
+	<string name="site_settings_writing_header">כתיבה</string>
+	<string name="site_settings_general_header">כללי</string>
+	<string name="newest_first">חדשים תחילה</string>
+	<string name="discussion">דיון</string>
+	<string name="privacy">פרטיות</string>
+	<string name="comments">תגובות</string>
+	<string name="close_after">סגור אחרי</string>
+	<string name="related_posts">באותו נושא</string>
+	<string name="oldest_first">ישנים תחילה</string>
+	<string name="media_error_no_permission_upload">אין לך הרשאה להעלות מדיה לאתר</string>
+	<string name="never">לעולם לא</string>
+	<string name="unknown">לא ידוע</string>
 	<string name="reader_err_get_post_not_found">הפוסט כבר לא קיים</string>
 	<string name="reader_err_get_post_not_authorized">אינך רשאי לראות פוסט זה</string>
 	<string name="reader_err_get_post_generic">לא ניתן לאחזר פוסט זה</string>
@@ -124,14 +232,12 @@
 	<string name="trashed">הועבר לפח</string>
 	<string name="button_back">חזרה</string>
 	<string name="page_deleted">העמוד נמחק</string>
-	<string name="button_more">עוד</string>
 	<string name="button_stats">נתונים סטטיסטיים</string>
 	<string name="button_trash">פח</string>
 	<string name="button_preview">תצוגה מקדימה</string>
 	<string name="button_view">הצגה</string>
 	<string name="button_edit">עריכה</string>
 	<string name="button_publish">פרסום</string>
-	<string name="button_delete">מחיקה</string>
 	<string name="my_site_no_sites_view_subtitle">האם תרצה להוסיף אחד?</string>
 	<string name="my_site_no_sites_view_title">עדיין אין לך אתרי וורדפרס.</string>
 	<string name="my_site_no_sites_view_drake">אילוסטרציה</string>
@@ -170,7 +276,6 @@
 	<string name="my_site_btn_view_site">הצגת אתר</string>
 	<string name="my_site_header_publish">פרסום</string>
 	<string name="my_site_header_look_and_feel">סגנון</string>
-	<string name="my_site_btn_comments">תגובות</string>
 	<string name="my_site_btn_site_settings">הגדרות</string>
 	<string name="my_site_btn_blog_posts">פוסטים בבלוג</string>
 	<string name="my_site_header_admin">מנהל מערכת</string>
@@ -258,7 +363,6 @@
 	<string name="stats_timeframe_years">שנים</string>
 	<string name="stats_views">צפיות</string>
 	<string name="stats_pagination_label">עמוד %1$s מתוך %2$s</string>
-	<string name="stats_comments">תגובות</string>
 	<string name="stats_likes"> לייקים</string>
 	<string name="stats_view_countries">מדינות</string>
 	<string name="stats_view_followers">עוקבים</string>
@@ -325,11 +429,11 @@
 	<string name="reader_empty_posts_in_tag">אין פוסטים עם התגית הזו</string>
 	<string name="reader_label_comment_count_multi">%,d תגובות</string>
 	<string name="reader_label_view_original">לצפות בפוסט המקורי</string>
-	<string name="reader_title_comments">תגובות</string>
 	<string name="reader_label_comment_count_single">תגובה אחת</string>
 	<string name="reader_label_comments_on">תגובות מופעלות</string>
 	<string name="reader_label_comments_closed">תגובות לא מופעלות</string>
 	<string name="error_publish_empty_post">לא ניתן לפרסם פוסט ריק</string>
+	<string name="more">עוד</string>
 	<string name="error_refresh_unauthorized_pages">אין לך הרשאה לערוך או לצפות בעמודים</string>
 	<string name="error_refresh_unauthorized_posts">אין לך הרשאה לערוך או לצפות בפוסטים</string>
 	<string name="reader_title_photo_viewer">%1$d מתוך %2$d</string>
@@ -671,7 +775,6 @@
 	<string name="stats_view_visitors_and_views">מבקרים וצפיות</string>
 	<string name="stats_view_clicks">קליקים</string>
 	<string name="stats_view_referrers">הפניות</string>
-	<string name="stats_view_comments">תגובות</string>
 	<string name="stats_timeframe_today">היום</string>
 	<string name="stats_timeframe_yesterday">אתמול</string>
 	<string name="stats_timeframe_days">ימים</string>
@@ -685,7 +788,6 @@
 	<string name="stats_totals_views">צפיות</string>
 	<string name="stats_totals_clicks">קליקים</string>
 	<string name="stats_totals_plays">ניגונים</string>
-	<string name="stats_totals_comments">תגובות</string>
 	<string name="menu_search">חיפוש</string>
 	<string name="passcode_manage">ניהול חסימה בקוד אישי</string>
 	<string name="passcode_enter_passcode">הקלד את הקוד האישי שלך</string>
@@ -738,7 +840,7 @@
 	<string name="tos">תנאי שימוש</string>
 	<string name="app_title">וורדפרס עבור אנדרואיד</string>
 	<string name="about">אודות</string>
-	<string name="max_thumbnail_px_width">בררת המחדל לרוחב תמונה</string>
+	<string name="max_thumbnail_px_width">ברירת מחדל לרוחב תמונה</string>
 	<string name="image_alignment">יישור</string>
 	<string name="refresh">רענון</string>
 	<string name="untitled">ללא כותרת</string>
@@ -778,7 +880,6 @@
 	<string name="cancel">בטל</string>
 	<string name="error">שגיאה</string>
 	<string name="on">ב</string>
-	<string name="tab_comments">תגובות</string>
 	<string name="category_refresh_error">שגיאה ברענון קטגוריות</string>
 	<string name="reply">תגובה</string>
 	<string name="preview">תצוגה מקדימה</string>
@@ -828,6 +929,33 @@
 		<item>רגיל</item>
 		<item>סטטוס</item>
 		<item>וידאו</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>האתר שלך גלוי לכולם ומנועי חיפוש יכולים לצרף אותו לאינדקס</item>
+		<item>האתר שלך גלוי לכולם אבל שולח בקשה למנועי חיפוש לא לצרף אותו לאינדקס</item>
+		<item>האתר גלוי רק לך ולמשתמשים שאישרת</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>אישור ידני דרוש לתגובות מכולם.</item>
+		<item>אישור אוטומטי אם תגובה קודמת של המשתמש אושרה.</item>
+		<item>אישור אוטומטי של תגובות מכולם.</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>אין תגובות</item>
+		<item>תגובות של משתמשים מוכרים</item>
+		<item>כל המשתמשים</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>ללא</item>
+		<item>שתי רמות</item>
+		<item>שלוש רמות</item>
+		<item>ארבע רמות</item>
+		<item>חמש רמות</item>
+		<item>שש רמות</item>
+		<item>שבע רמות</item>
+		<item>שמונה רמות</item>
+		<item>תשע רמות</item>
+		<item>עשר רמות</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>חינם</item>

--- a/WordPress/src/main/res/values-hi/strings.xml
+++ b/WordPress/src/main/res/values-hi/strings.xml
@@ -48,7 +48,6 @@
 	<string name="button_preview">पूर्वावलोकन</string>
 	<string name="button_view">देखें</string>
 	<string name="button_publish">प्रकाशित करें</string>
-	<string name="button_delete">हटाएँ</string>
 	<string name="button_edit">संपादित करें</string>
 	<string name="post_trashed">पोस्ट ट्रैश में भेज दिया गया</string>
 	<string name="page_trashed">पृष्ठ ट्रैश में भेज दिया गया</string>
@@ -66,7 +65,6 @@
 	<string name="site_picker_add_self_hosted">सेल्फ-होस्टेड साइट डाले </string>
 	<string name="site_picker_edit_visibility">साइट्स दिखाए या छिपाये</string>
 	<string name="site_picker_add_site">साईट जोड़े</string>
-	<string name="my_site_btn_comments">टिप्पणियाँ</string>
 	<string name="my_site_header_publish">प्रकाशित</string>
 	<string name="my_site_btn_blog_posts">ब्लॉग पोस्ट्स</string>
 	<string name="my_site_header_admin">एडमिन</string>
@@ -106,7 +104,6 @@
 	<string name="stats_followers_a_month">एक महीना</string>
 	<string name="stats_followers_a_year">एक साल</string>
 	<string name="stats_followers_email_selector">ई-मेल</string>
-	<string name="stats_comments">टिप्पणियाँ</string>
 	<string name="stats_followers_an_hour_ago">एक घंटा पहले</string>
 	<string name="stats_entry_top_commenter">लेखक</string>
 	<string name="stats_entry_followers">प्रसंशक</string>
@@ -123,7 +120,6 @@
 	<string name="reader_title_photo_viewer">%1$d का %2$d</string>
 	<string name="comment">टिप्पणी</string>
 	<string name="comment_trashed">टिप्पणी ट्रैश किया गया</string>
-	<string name="reader_title_comments">टिप्पणियाँ</string>
 	<string name="reader_label_comments_on">पर टिप्पणियाँ</string>
 	<string name="reader_menu_block_blog">इस ब्लॉग को ब्लॉक करे</string>
 	<string name="reader_toast_err_block_blog">इस ब्लॉग को ब्लॉक करने में असमर्थ</string>
@@ -398,8 +394,6 @@
 	<string name="reader_hint_comment_on_comment">टिप्पणी का जवाब दे...</string>
 	<string name="create_account_wpcom">Wordpress.com पे अकाउंट बनाये|</string>
 	<string name="all">सभी</string>
-	<string name="stats_view_comments">टिप्पणियां</string>
-	<string name="stats_totals_comments">टिप्पणियां</string>
 	<string name="stats_entry_country">देश</string>
 	<string name="stats_entry_authors">लेखक</string>
 	<string name="media_edit_title_text">शीर्षक</string>
@@ -534,7 +528,6 @@
 	<string name="blogs">ब्लॉग</string>
 	<string name="select_photo">गैलरी से एक तस्वीर को चुने </string>
 	<string name="add"> जोड़े</string>
-	<string name="tab_comments">टिप्पणियां</string>
 	<string name="cancel">रद्द करें</string>
 	<string name="error">त्रुटि</string>
 	<string name="no">नहीं</string>

--- a/WordPress/src/main/res/values-hr/strings.xml
+++ b/WordPress/src/main/res/values-hr/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">Originalna veličina</string>
+	<string name="about_me_hint">Nekoliko riječi o vama...</string>
+	<string name="about_me">O meni</string>
+	<string name="public_display_name_hint">Prikazano ime biti će vaše korisničko ime, ako drugo nije postavljeno</string>
+	<string name="public_display_name">Javno prikazano ime</string>
+	<string name="my_profile">Moj profil</string>
+	<string name="first_name">Ime</string>
+	<string name="last_name">Prezime</string>
+	<string name="site_privacy_public_desc">Dopusti pretraživačima da indeksiraju web stranicu</string>
+	<string name="site_privacy_hidden_desc">Obeshrabri pretraživače da indeksiraju web stranicu</string>
+	<string name="site_privacy_private_desc">Želim da je moja stranica privatna, vidljiva samo korisnicima koje odaberem</string>
+	<string name="cd_related_post_preview_image">Predpregled slika srodnih objava</string>
+	<string name="error_post_remote_site_settings">Nije moguće snimiti info o web stranici</string>
+	<string name="error_fetch_remote_site_settings">Nije moguće dohvatiti info o web stranici</string>
+	<string name="error_media_upload_connection">Tijekom prijenosa medijskoga zapisa dogodila se greška u spajanju</string>
+	<string name="site_settings_disconnected_toast">Odspojeno, uređivanje onemogućeno</string>
+	<string name="site_settings_unsupported_version_error">WordPress inačica koja nije podržana</string>
+	<string name="site_settings_multiple_links_dialog_description">Potrebno odobrenje za komentare koji sadrže više od ovog broja komentara.</string>
+	<string name="site_settings_close_after_dialog_switch_text">Automatski zatvori</string>
+	<string name="site_settings_close_after_dialog_description">Automatski zatvori komentare na člancima</string>
+	<string name="site_settings_paging_dialog_description">Prijelom niza komentara u više stranica.</string>
+	<string name="site_settings_paging_dialog_header">Komentara po stranici</string>
+	<string name="site_settings_close_after_dialog_title">Zatvori komentiranje</string>
+	<string name="site_settings_blacklist_description">Kada komentar sadrži bilo koju od ovih riječi u svom sadržaju, imenu, URL-u, e-pošti, ili IP-u, biti će označen kao spam. Možete unijeti dijelove riječi, tako da će &amp;#8220;press&amp;#8221; odgovarati i riječi &amp;#8220;WordPress&amp;#8221;.</string>
+	<string name="site_settings_hold_for_moderation_description">Kada komentar sadrži bilo koju od ovih riječi u svom sadržaju, imenu, URL-u, e-pošti, ili IP-u, biti će označen kao spam. Možete unijeti dijelove riječi, tako da će &amp;#8220;press&amp;#8221; odgovarati i riječi &amp;#8220;WordPress&amp;#8221;.</string>
+	<string name="site_settings_list_editor_input_hint">Unesite riječi ili frazu</string>
+	<string name="site_settings_list_editor_no_items_text">Nema stavki</string>
+	<string name="site_settings_learn_more_caption">Možete zaobići ove postavke na individualnim objavama.</string>
+	<string name="site_settings_rp_preview3_site">u "Nadogradnji"</string>
+	<string name="site_settings_rp_preview3_title">Fokus nadogradnje: VideoPress za vjenčanja</string>
+	<string name="site_settings_rp_preview2_site">u "Aplikacijama"</string>
+	<string name="site_settings_rp_preview2_title">WordPress for Android aplikacija dobila redizajn</string>
+	<string name="site_settings_rp_preview1_site">u "Mobilnom"</string>
+	<string name="site_settings_rp_preview1_title">Veliko iPhone/iPad ažuriranje sada dostupno</string>
+	<string name="site_settings_rp_show_images_title">Prikaži slike</string>
+	<string name="site_settings_rp_show_header_title">Prikaži zaglavlje</string>
+	<string name="site_settings_rp_switch_summary">Srodne objave prikazuju srodni sadržaj sa vaše stranice ispod vaših objava.</string>
+	<string name="site_settings_rp_switch_title">Prikaži srodne objave</string>
+	<string name="site_settings_delete_site_hint">Uklonite svoju web stranicu iz aplikacije</string>
+	<string name="site_settings_blacklist_hint">Komentari koji odgovaraju filteru označeni su kao spam</string>
+	<string name="site_settings_moderation_hold_hint">Komentari koji odgovaraju filteru stavljeni su na čekanje</string>
+	<string name="site_settings_multiple_links_hint">Ignoriranje limita poveznica od poznatih korisnika</string>
+	<string name="site_settings_whitelist_hint">Autor komentara mora imati prethodno odobreni komentar</string>
+	<string name="site_settings_user_account_required_hint">Korisnici moraju biti registrirani i prijavljeni kako bi objavili komentare</string>
+	<string name="site_settings_identity_required_hint">Autor komentara mora popuniti ime i adresu e-pošte</string>
+	<string name="site_settings_manual_approval_hint">Komentari moraju biti manualno odobreni</string>
+	<string name="site_settings_paging_hint">Prikaži komentare u grupama određene veličine</string>
+	<string name="site_settings_threading_hint">Dopusti ugniježđene komentare do određenog nivoa</string>
+	<string name="site_settings_sort_by_hint">Određuje kojim poretkom su prikazani komentari</string>
+	<string name="site_settings_close_after_hint">Onemogući komentare nakon određenog vremena</string>
+	<string name="site_settings_receive_pingbacks_hint">Dopusti obavijesti o poveznicama sa drugih blogova</string>
+	<string name="site_settings_send_pingbacks_hint">Pokušaj obavijestiti sve blogove prema kojim postoji poveznica u objavi</string>
+	<string name="site_settings_allow_comments_hint">Dopusti čitateljima da objave komentare</string>
+	<string name="site_settings_discussion_hint">Pregledajte i promijenite postavke rasprave na web stranici</string>
+	<string name="site_settings_more_hint">Pregledajte sve dostupne postavke resprave</string>
+	<string name="site_settings_related_posts_hint">Prikažite ili sakrijte srodne objave u čitaču</string>
+	<string name="site_settings_upload_and_link_image_hint">Omogućite da se uvijek prenose slike u punoj veličini</string>
+	<string name="site_settings_image_width_hint">Redimenzionirajte slike u objavama na ovu širinu</string>
+	<string name="site_settings_format_hint">Postavlja novi format objave</string>
+	<string name="site_settings_category_hint">Postavlja novu kategoriju objave</string>
+	<string name="site_settings_location_hint">Automatski dodaj podatke o lokaciji mojim objavama</string>
+	<string name="site_settings_password_hint">Promijenite svoju lozinku</string>
+	<string name="site_settings_username_hint">Trenutni korisnički račun</string>
+	<string name="site_settings_language_hint">Jezik na kojem je primarno pisan ovaj blog</string>
+	<string name="site_settings_privacy_hint">Kontrolira tko može vidjeti vašu web stranicu</string>
+	<string name="site_settings_address_hint">Promjena vaše adrese trenutno nije podržana</string>
+	<string name="site_settings_tagline_hint">Kratki opis ili pamtljiva fraza koja opisuje vaš blog</string>
+	<string name="site_settings_title_hint">U nekoliko riječi, objasnite o čemu govori ova web stranice.</string>
+	<string name="site_settings_whitelist_known_summary">Komentari od nepoznatih korisnika</string>
+	<string name="site_settings_whitelist_all_summary">Komentari svih korisnika</string>
+	<string name="site_settings_threading_summary">%d nivoa</string>
+	<string name="site_settings_privacy_private_summary">Privatno</string>
+	<string name="site_settings_privacy_hidden_summary">Skriveno</string>
+	<string name="site_settings_delete_site_title">Obriši web stranicu</string>
+	<string name="site_settings_privacy_public_summary">Javno</string>
+	<string name="site_settings_blacklist_title">Crna lista</string>
+	<string name="site_settings_moderation_hold_title">Zadržati za moderaciju</string>
+	<string name="site_settings_multiple_links_title">Poveznice u komentarima</string>
+	<string name="site_settings_whitelist_title">Automatsko odobravanje</string>
+	<string name="site_settings_threading_title">Grananje</string>
+	<string name="site_settings_paging_title">Paging</string>
+	<string name="site_settings_sort_by_title">Sortiraj po</string>
+	<string name="site_settings_account_required_title">Korisnici moraju biti prijavljeni</string>
+	<string name="site_settings_identity_required_title">Morate uključiti i ima i adresu e-pošte</string>
+	<string name="site_settings_receive_pingbacks_title">Primanje povratnih pingova</string>
+	<string name="site_settings_send_pingbacks_title">Slanje povratnih pingova</string>
+	<string name="site_settings_allow_comments_title">Dopusti komentare</string>
+	<string name="site_settings_default_format_title">Zadani format</string>
+	<string name="site_settings_default_category_title">Zadana kategorija</string>
+	<string name="site_settings_location_title">Omogući lokaciju</string>
+	<string name="site_settings_address_title">Adresa</string>
+	<string name="site_settings_title_title">Naslov web strancie</string>
+	<string name="site_settings_tagline_title">Slogan</string>
+	<string name="site_settings_this_device_header">Ovaj uređaj</string>
+	<string name="site_settings_discussion_new_posts_header">Zadane postavke za nove objave</string>
+	<string name="site_settings_account_header">Račun</string>
+	<string name="site_settings_writing_header">Pisanje</string>
+	<string name="newest_first">Prvo najnoviji</string>
+	<string name="site_settings_general_header">Općenito</string>
+	<string name="discussion">Rasprava</string>
+	<string name="privacy">Privatnost</string>
+	<string name="related_posts">Srodne objave</string>
+	<string name="comments">Komentari</string>
+	<string name="close_after">Zatvori nakon</string>
+	<string name="oldest_first">Prvo najstariji</string>
+	<string name="media_error_no_permission_upload">Nemate dopuštenje za prijenos medijskih zapisa na web stranicu</string>
+	<string name="never">Nikad</string>
+	<string name="unknown">Nepoznato</string>
 	<string name="reader_err_get_post_not_found">Objava više ne postoji</string>
 	<string name="reader_err_get_post_not_authorized">Nemate pravo pristupa pregledavanja ove objave</string>
 	<string name="reader_err_get_post_generic">Nije moguće učitati objavu</string>
@@ -120,12 +228,10 @@
 	<string name="button_view">Pogledaj</string>
 	<string name="button_edit">Uredi</string>
 	<string name="button_publish">Objavi</string>
-	<string name="button_more">Više</string>
 	<string name="page_deleted">Stranica obrisana</string>
 	<string name="page_trashed">Stanica poslana u smeće</string>
 	<string name="post_trashed">Objava poslana u smeće</string>
 	<string name="button_trash">Smeće</string>
-	<string name="button_delete">Obriši</string>
 	<string name="button_back">Nazad</string>
 	<string name="button_stats">Statistika</string>
 	<string name="button_preview">Predpregled</string>
@@ -168,7 +274,6 @@
 	<string name="site_picker_title">Odaberi stranicu</string>
 	<string name="my_site_btn_view_admin">Prikaži Admin</string>
 	<string name="my_site_btn_switch_site">Promjeni web stranicu</string>
-	<string name="my_site_btn_comments">Komentari</string>
 	<string name="my_site_btn_site_settings">Postavke</string>
 	<string name="my_site_header_publish">Objavi</string>
 	<string name="my_site_btn_blog_posts">Blog objave</string>
@@ -275,7 +380,6 @@
 	<string name="stats_view_followers">Sljedbenici</string>
 	<string name="stats_view_countries">Države</string>
 	<string name="stats_likes">Lajkovi</string>
-	<string name="stats_comments">Komentari</string>
 	<string name="stats_view_all">Pogledaj sve</string>
 	<string name="stats_view">Pogledaj</string>
 	<string name="stats_totals_followers">Od</string>
@@ -324,7 +428,6 @@
 	<string name="reader_label_like">Lajk</string>
 	<string name="reader_label_comment_count_single">Komentar</string>
 	<string name="reader_empty_comments">Još nema komentara</string>
-	<string name="reader_empty_posts_in_tag">Nema postova s ovim tagom</string>
 	<string name="reader_label_comment_count_multi">%,d komentara</string>
 	<string name="reader_label_view_original">Pogledaj izvorni članak</string>
 	<string name="mnu_comment_liked">Lajkao</string>
@@ -335,7 +438,6 @@
 	<string name="new_blog_wpcom_created">WordPress.com blog je kreiran!</string>
 	<string name="reader_label_comments_closed">Komentari su zatvoreni</string>
 	<string name="reader_label_comments_on">Komentari o</string>
-	<string name="reader_title_comments">Komentari</string>
 	<string name="reader_title_photo_viewer">%1$d od %2$d</string>
 	<string name="error_publish_empty_post">Nije moguće objaviti praznu objavu</string>
 	<string name="error_refresh_unauthorized_posts">Nemate dopuštenje za pregled ili uređivanje objava</string>
@@ -357,6 +459,8 @@
 	<string name="browse_our_faq_button">Pregledajte naš ČPP (FAQ)</string>
 	<string name="agree_terms_of_service">Kreiranjem računa pristajete na fascinantne %1$sUvjeti pružanja usluge%2$s</string>
 	<string name="stats_no_blog">Nije moguće učitati statistiku za navedeni blog</string>
+	<string name="more">Više</string>
+	<string name="reader_empty_posts_in_tag">Nema objava s ovom oznakom</string>
 	<string name="reader_toast_err_generic">Nije moguće izvesti tu akciju</string>
 	<string name="reader_toast_err_block_blog">Nije moguće blokirati ovaj blog</string>
 	<string name="reader_toast_blog_blocked">Objave sa ovog bloga više neće biti prikazane</string>
@@ -643,11 +747,9 @@
 	<string name="stats_entry_referrers">Preporučitelj</string>
 	<string name="stats_totals_views">Pregleda</string>
 	<string name="stats_totals_clicks">Klikova</string>
-	<string name="stats_totals_comments">Komentari</string>
 	<string name="menu_search">Pretraživanje</string>
 	<string name="stats_view_referrers">Preporučitelji</string>
 	<string name="stats_timeframe_today">Danas</string>
-	<string name="stats_view_comments">Komentari</string>
 	<string name="stats_timeframe_yesterday">Jučer</string>
 	<string name="theme_activate_button">Aktiviraj</string>
 	<string name="media_edit_success">Ažuriran</string>
@@ -718,14 +820,14 @@
 	<string name="reader">Čitač</string>
 	<string name="no_network_title">Nema dostupne mreže</string>
 	<string name="width">Širina</string>
-	<string name="posts">Postovi</string>
 	<string name="anonymous">Anonimno</string>
 	<string name="page">Stranica</string>
-	<string name="post">Post</string>
 	<string name="pages">Stranice</string>
 	<string name="caption">Opis (opcionalan)</string>
 	<string name="featured">Upotrijebi kao istaknutu sliku</string>
-	<string name="featured_in_post">Uključi sliku u sadržaj posta</string>
+	<string name="posts">Objave</string>
+	<string name="featured_in_post">Uključi sliku u sadržaj objave</string>
+	<string name="post">Objava</string>
 	<string name="ok">OK</string>
 	<string name="blogusername">blogusername</string>
 	<string name="upload_scaled_image">Prenesi i poveži do dimenzionirane slike</string>
@@ -742,8 +844,8 @@
 	<string name="image_alignment">Poravnanje</string>
 	<string name="refresh">Osvježi</string>
 	<string name="untitled">Nenaslovljeno</string>
-	<string name="post_id">Post</string>
 	<string name="page_id">Stranica</string>
+	<string name="post_id">Objava</string>
 	<string name="post_password">Lozinka (opcionalno)</string>
 	<string name="immediately">Odmah</string>
 	<string name="quickpress_add_alert_title">Postavi naziv prečaca</string>
@@ -773,7 +875,6 @@
 	<string name="select_photo">Odaberi sliku iz galerije</string>
 	<string name="error">Pogreška</string>
 	<string name="add">Dodaj</string>
-	<string name="tab_comments">Komentari</string>
 	<string name="reply">Odgovori</string>
 	<string name="yes">Da</string>
 	<string name="no">Ne</string>
@@ -828,6 +929,33 @@
 		<item>Članak</item>
 		<item>Status</item>
 		<item>Video</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>Vaša web stranica je vidljiva svima, i pretraživači će ju indeksirati</item>
+		<item>Vaša web stranica je vidljiva svima, ali traži od pretraživača da ju ne indeksiraju</item>
+		<item>Vaša web stranica je vidljiva samo vama i korisnicima koje odobrite</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>Manualno odobravanje svih komentara.</item>
+		<item>Automatski odobri ako korisnik ima prethodno odobren komentar</item>
+		<item>Automatski odobri sve komentare</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>Nema komentara</item>
+		<item>Komentari poznatih korisnika</item>
+		<item>Svi korisnici</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>Ništa</item>
+		<item>Dva nivoa</item>
+		<item>Tri nivoa</item>
+		<item>Četiri nivoa</item>
+		<item>Pet nivoa</item>
+		<item>Šest nivoa</item>
+		<item>Sedam nivoa</item>
+		<item>Osam nivoa</item>
+		<item>Devet nivoa</item>
+		<item>Deset nivoa</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>Besplatno</item>

--- a/WordPress/src/main/res/values-hu/strings.xml
+++ b/WordPress/src/main/res/values-hu/strings.xml
@@ -18,6 +18,7 @@
 	<string name="error_refresh_unauthorized_pages">Az oldalak megtekintéséhez vagy szerkesztéséhez nincs megfelelő jogosultság</string>
 	<string name="error_refresh_unauthorized_comments">A hozzászólások megtekintéséhez vagy szerkesztéséhez nincs megfelelő jogosultság</string>
 	<string name="older_month">Egy hónapnál régebbi</string>
+	<string name="more">Bövebben</string>
 	<string name="older_two_days">2 napnál régebbi</string>
 	<string name="older_last_week">Egy hétnél régebbi</string>
 	<string name="pages_empty_list">Még nincs egy oldal sem. Létrehozzunk egyet?</string>
@@ -117,7 +118,6 @@
 	<string name="media_edit_success">Frissítve</string>
 	<string name="theme_activating_button">Aktiválás</string>
 	<string name="post_excerpt">Kivonat</string>
-	<string name="stats_view_comments">Hozzászólások</string>
 	<string name="stats_view_referrers">Hivatkozások</string>
 	<string name="stats_timeframe_today">Ma</string>
 	<string name="stats_timeframe_yesterday">Tegnap</string>
@@ -128,7 +128,6 @@
 	<string name="stats_entry_authors">Szerző</string>
 	<string name="themes_details_label">Részletek</string>
 	<string name="themes_features_label">Funkciók</string>
-	<string name="stats_totals_comments">Hozzászólás</string>
 	<string name="media_gallery_type_squares">Négyzetek</string>
 	<string name="theme_activate_button">Bekapcsolás</string>
 	<string name="media_gallery_type_circles">Körök</string>
@@ -207,7 +206,6 @@
 	<string name="version">verzió</string>
 	<string name="app_title">WordPress for Android</string>
 	<string name="about">Névjegy</string>
-	<string name="max_thumbnail_px_width">Alapértelmezett kép szélesség</string>
 	<string name="image_alignment">Kép igazítás</string>
 	<string name="refresh">Frissítés</string>
 	<string name="untitled">Cím nélküli</string>
@@ -245,7 +243,6 @@
 	<string name="save">Mentés</string>
 	<string name="add">Hozzáad</string>
 	<string name="category_refresh_error">Kategóriák frissítése sikertelen</string>
-	<string name="tab_comments">Hozzászólások</string>
 	<string name="on"> -</string>
 	<string name="reply">Válasz</string>
 	<string name="yes">Igen</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">Ukuran Asli</string>
+	<string name="about_me_hint">Beberapa kata tentang Anda...</string>
+	<string name="about_me">Tentang saya</string>
+	<string name="public_display_name_hint">Nama tampilan secara default akan menjadi nama pengguna Anda bila tidak diatur</string>
+	<string name="public_display_name">Nama tampilan publik</string>
+	<string name="my_profile">Profil Saya</string>
+	<string name="first_name">Nama depan</string>
+	<string name="last_name">Nama belakang</string>
+	<string name="site_privacy_public_desc">Izinkan mesin pencari untuk mengindeks situs ini</string>
+	<string name="site_privacy_hidden_desc">Larang mesin pencari untuk mengindeks situs ini</string>
+	<string name="site_privacy_private_desc">Saya ingin situs saya menjadi privat, hanya terlihat oleh pengguna yang saya pilih</string>
+	<string name="cd_related_post_preview_image">Gambar pratinjau pos terkait</string>
+	<string name="error_post_remote_site_settings">Tidak dapat menyimpan info situs</string>
+	<string name="error_fetch_remote_site_settings">Tidak dapat mengambil info situs</string>
+	<string name="error_media_upload_connection">Terjadi kesalahan koneksi saat mengunggah media</string>
+	<string name="site_settings_disconnected_toast">Terputus, penyuntingan dinonaktifkan.</string>
+	<string name="site_settings_unsupported_version_error">Versi WordPress tidak didukung</string>
+	<string name="site_settings_multiple_links_dialog_description">Minta persetujuan untuk komentar yang memiliki lebih dari jumlah tautan ini.</string>
+	<string name="site_settings_close_after_dialog_switch_text">Tutup secara otomatis</string>
+	<string name="site_settings_close_after_dialog_description">Tutup komentar secara otomatis di artikel.</string>
+	<string name="site_settings_paging_dialog_description">Bagi utas komentar ke dalam beberapa halaman.</string>
+	<string name="site_settings_paging_dialog_header">Komentar per halaman</string>
+	<string name="site_settings_close_after_dialog_title">Tutup komentar</string>
+	<string name="site_settings_blacklist_description">Saat komentar memuat kata-kata berikut dalam isi, nama, tautan, email, atau IP, maka akan ditandai sebagai spam. Anda bisa menuliskan bagian kata, jadi "press" akan cocok dengan "WordPress."</string>
+	<string name="site_settings_hold_for_moderation_description">Saat komentar memuat kata-kata berikut dalam isi, nama, tautan, email, atau IP, maka akan tertunda dalam antrean moderasi. Anda bisa menuliskan bagian kata, jadi "press" akan cocok dengan "WordPress."</string>
+	<string name="site_settings_list_editor_input_hint">Masukkan kata atau kalimat</string>
+	<string name="site_settings_list_editor_no_items_text">Tidak ada item</string>
+	<string name="site_settings_learn_more_caption">Anda dapat mengubah pengaturan ini untuk pos individual.</string>
+	<string name="site_settings_rp_preview3_site">dalam "Upgrade"</string>
+	<string name="site_settings_rp_preview3_title">Fokus Upgrade: VideoPress For Weddings</string>
+	<string name="site_settings_rp_preview2_site">dalam "Applikasi"</string>
+	<string name="site_settings_rp_preview2_title">Applikasi WordPress untuk Android Melakukan Perubahan Besar</string>
+	<string name="site_settings_rp_preview1_site">dalam "Mobile"</string>
+	<string name="site_settings_rp_preview1_title">Pembaruan Besar untuk iPhone/iPad Kini Tersedia</string>
+	<string name="site_settings_rp_show_images_title">Tampilkan Gambar</string>
+	<string name="site_settings_rp_show_header_title">Tampilkan Header</string>
+	<string name="site_settings_rp_switch_summary">Pos terkait menampilkan konten yang relevan dari situs Anda di bawah pos Anda.</string>
+	<string name="site_settings_rp_switch_title">Tampilkan Pos Terkait</string>
+	<string name="site_settings_delete_site_hint">Hapus data situs Anda dari aplikasi</string>
+	<string name="site_settings_blacklist_hint">Komentar yang cocok dengan filter ditandai sebagai spam</string>
+	<string name="site_settings_moderation_hold_hint">Komentar yang cocok dengan filter akan menunggu antrean moderasi</string>
+	<string name="site_settings_multiple_links_hint">Abaikan batasan tautan untuk pengguna yang dikenal</string>
+	<string name="site_settings_whitelist_hint">Penulis komentar harus mempunyai komentar yang sudah disetujui sebelumnya</string>
+	<string name="site_settings_user_account_required_hint">Pengguna harus sudah terdaftar dan masuk untuk memberi komentar</string>
+	<string name="site_settings_identity_required_hint">Penulis komentar harus memasukkan nama dan email</string>
+	<string name="site_settings_manual_approval_hint">Komentar harus disetujui secara manual</string>
+	<string name="site_settings_paging_hint">Tampilkan komentar dalam beberapa bagian dengan ukuran spesifik</string>
+	<string name="site_settings_threading_hint">Izinkan komentar cabang sampai kedalaman tertentu</string>
+	<string name="site_settings_sort_by_hint">Tentukan urutan komentar yang ditampilkan</string>
+	<string name="site_settings_close_after_hint">Larang komentar setelah waktu yang ditentukan</string>
+	<string name="site_settings_receive_pingbacks_hint">Perbolehkan pemberitahuan tautan dari blog lain</string>
+	<string name="site_settings_send_pingbacks_hint">Upayakan memberi notifikasi ke blog lain yang tertaut dari artikel</string>
+	<string name="site_settings_allow_comments_hint">Perbolehkan pembaca untuk menulis komentar</string>
+	<string name="site_settings_discussion_hint">Tampilkan dan ubah pengaturan diskusi situs</string>
+	<string name="site_settings_more_hint">Tampilkan semua pengaturan Diskusi yang ada</string>
+	<string name="site_settings_related_posts_hint">Tampilkan atau sembunyikan pos terkait di pembaca</string>
+	<string name="site_settings_upload_and_link_image_hint">Perbolehkan untuk selalu mengirim gambar dalam ukuran asli</string>
+	<string name="site_settings_image_width_hint">Ubah ukuran gambar dalam pos ke lebar berikut</string>
+	<string name="site_settings_format_hint">Tentukan format pos baru</string>
+	<string name="site_settings_category_hint">Tentukan kategori pos baru</string>
+	<string name="site_settings_location_hint">Tambahkan secara otomatis data lokasi ke pos Anda</string>
+	<string name="site_settings_password_hint">Ubah kata sandi Anda</string>
+	<string name="site_settings_username_hint">Akun pengguna saat ini</string>
+	<string name="site_settings_language_hint">Bahasa yang dipakai dalam blog mayoritas adalah</string>
+	<string name="site_settings_privacy_hint">Kontrol siapa saja yang dapat melihat situs Anda</string>
+	<string name="site_settings_address_hint">Mengubah alamat Anda saat ini tidak dimungkinkan</string>
+	<string name="site_settings_tagline_hint">Deskripsi pendek atau kalimat unik untuk menggambarkan blog Anda</string>
+	<string name="site_settings_title_hint">Dalam beberapa kata, jelaskan mengenai situs ini</string>
+	<string name="site_settings_whitelist_known_summary">Komentar dari user yang dikenal</string>
+	<string name="site_settings_whitelist_all_summary">Komentar dari semua pengguna</string>
+	<string name="site_settings_threading_summary">%d level</string>
+	<string name="site_settings_privacy_private_summary">Privat</string>
+	<string name="site_settings_privacy_hidden_summary">Tersembunyi</string>
+	<string name="site_settings_delete_site_title">Hapus Situs</string>
+	<string name="site_settings_privacy_public_summary">Publik</string>
+	<string name="site_settings_blacklist_title">Daftar hitam</string>
+	<string name="site_settings_moderation_hold_title">Menunggu untuk Moderasi</string>
+	<string name="site_settings_multiple_links_title">Tautan dalam komentar</string>
+	<string name="site_settings_whitelist_title">Otomatis disetujui</string>
+	<string name="site_settings_threading_title">Rangkaian</string>
+	<string name="site_settings_paging_title">Penomoran halaman</string>
+	<string name="site_settings_sort_by_title">Urut berdasar</string>
+	<string name="site_settings_account_required_title">Pengguna harus sudah masuk</string>
+	<string name="site_settings_identity_required_title">Harus menyertakan nama dan email</string>
+	<string name="site_settings_receive_pingbacks_title">Terima Ping Balik</string>
+	<string name="site_settings_send_pingbacks_title">Kirim Ping Balik</string>
+	<string name="site_settings_allow_comments_title">Izinkan Komentar</string>
+	<string name="site_settings_default_format_title">Format Baku</string>
+	<string name="site_settings_default_category_title">Kategori Baku</string>
+	<string name="site_settings_location_title">Aktifkan Lokasi</string>
+	<string name="site_settings_address_title">Alamat</string>
+	<string name="site_settings_title_title">Judul Situs</string>
+	<string name="site_settings_tagline_title">Slogan</string>
+	<string name="site_settings_this_device_header">Perangkat ini</string>
+	<string name="site_settings_discussion_new_posts_header">Baku untuk pos baru</string>
+	<string name="site_settings_account_header">Akun</string>
+	<string name="site_settings_writing_header">Tulisan</string>
+	<string name="site_settings_general_header">Umum</string>
+	<string name="newest_first">Terbaru terlebih dahulu</string>
+	<string name="discussion">Diskusi</string>
+	<string name="privacy">Privasi</string>
+	<string name="related_posts">Pos Terkait</string>
+	<string name="comments">Komentar</string>
+	<string name="close_after">Tutup setelah</string>
+	<string name="oldest_first">Paling lama terlebih dahulu</string>
+	<string name="media_error_no_permission_upload">Anda tidak memiliki izin untuk menambahkan media ke dalam situs</string>
+	<string name="never">Tidak pernah</string>
+	<string name="unknown">Tidak diketahui</string>
 	<string name="reader_err_get_post_not_found">Pos ini tidak ada lagi</string>
 	<string name="reader_err_get_post_not_authorized">Anda tidak diizinkan melihat pos ini</string>
 	<string name="reader_err_get_post_generic">Gagal mengambil pos ini</string>
@@ -122,14 +230,12 @@
 	<string name="trashed">Dibuang</string>
 	<string name="button_back">Kembali</string>
 	<string name="page_deleted">Halaman dihapus</string>
-	<string name="button_more">Lainnya</string>
 	<string name="button_stats">Statistik</string>
 	<string name="button_trash">Buang</string>
 	<string name="button_preview">Pratinjau</string>
 	<string name="button_view">Lihat</string>
 	<string name="button_edit">Sunting</string>
 	<string name="button_publish">Terbitkan</string>
-	<string name="button_delete">Hapus</string>
 	<string name="post_deleted">Pos dihapus</string>
 	<string name="post_trashed">Pos dibuang ke tong sampah</string>
 	<string name="my_site_no_sites_view_subtitle">Mau menambahkan satu?</string>
@@ -171,7 +277,6 @@
 	<string name="my_site_header_look_and_feel">Tampilan dan Nuansa</string>
 	<string name="my_site_header_publish">Terbitkan</string>
 	<string name="my_site_btn_site_settings">Pengaturan</string>
-	<string name="my_site_btn_comments">Komentar</string>
 	<string name="my_site_btn_blog_posts">Pos Blog</string>
 	<string name="reader_label_new_posts_subtitle">Ketuk untuk menampilkannya</string>
 	<string name="my_site_header_admin">Admin</string>
@@ -290,7 +395,6 @@
 	<string name="stats_timeframe_years">Tahun</string>
 	<string name="stats_views">Tampilan</string>
 	<string name="stats_pagination_label">Halaman %1$s dari %2$s</string>
-	<string name="stats_comments">Komentar</string>
 	<string name="stats_entry_clicks_link">Tautan</string>
 	<string name="stats_entry_top_commenter">Penulis</string>
 	<string name="stats_entry_publicize">Layanan</string>
@@ -334,13 +438,13 @@
 	<string name="reader_label_comment_count_single">Satu komentar</string>
 	<string name="reader_label_comments_closed">Komentar ditutup</string>
 	<string name="reader_label_comments_on">Komentar pada</string>
-	<string name="reader_title_comments">Komentar</string>
 	<string name="reader_title_photo_viewer">%1$d dari %2$d</string>
 	<string name="error_publish_empty_post">Tidak dapat menerbitkan pos kosong</string>
 	<string name="error_refresh_unauthorized_posts">Anda tidak memiliki izin untuk melihat atau menyunting pos</string>
 	<string name="error_refresh_unauthorized_pages">Anda tidak memiliki izin untuk melihat atau menyunting halaman</string>
 	<string name="error_refresh_unauthorized_comments">Anda tidak memiliki izin untuk melihat atau menyunting komentar</string>
 	<string name="older_month">Lebih dari satu bulan</string>
+	<string name="more">Lainnya</string>
 	<string name="older_two_days">Lebih dari 2 hari</string>
 	<string name="older_last_week">Lebih dari satu minggu</string>
 	<string name="stats_no_blog">Statistik tidak dapat dimuat untuk blog yang diminta</string>
@@ -666,7 +770,6 @@
 	<string name="stats_view_clicks">Klik</string>
 	<string name="stats_view_tags_and_categories">Tag &amp; Kategori</string>
 	<string name="stats_view_referrers">Pengacu</string>
-	<string name="stats_view_comments">Komentar</string>
 	<string name="stats_timeframe_today">Hari Ini</string>
 	<string name="stats_timeframe_yesterday">Kemarin</string>
 	<string name="post_excerpt">Rangkuman</string>
@@ -677,7 +780,6 @@
 	<string name="stats_totals_views">Tampilan</string>
 	<string name="stats_totals_clicks">Klik</string>
 	<string name="stats_totals_plays">Pemutaran</string>
-	<string name="stats_totals_comments">Komentar</string>
 	<string name="stats_timeframe_days">Hari</string>
 	<string name="stats_timeframe_weeks">Minggu</string>
 	<string name="stats_timeframe_months">Bulan</string>
@@ -738,7 +840,7 @@
 	<string name="app_title">WordPress untuk Android</string>
 	<string name="tos">Syarat Layanan</string>
 	<string name="about">Tentang</string>
-	<string name="max_thumbnail_px_width">Lebar bawaan gambar</string>
+	<string name="max_thumbnail_px_width">Lebar Gambar Baku</string>
 	<string name="image_alignment">Penjajaran</string>
 	<string name="refresh">Segarkan</string>
 	<string name="untitled">Tanpa judul</string>
@@ -771,7 +873,6 @@
 	<string name="none">Tiada</string>
 	<string name="blogs">Blog</string>
 	<string name="select_photo">Pilih sebuah foto dari galeri</string>
-	<string name="tab_comments">Komentar</string>
 	<string name="reply">Balasan</string>
 	<string name="preview">Pratinjau</string>
 	<string name="on">pada</string>
@@ -828,6 +929,33 @@
 		<item>Standar</item>
 		<item>Status</item>
 		<item>Video</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>Situs Anda dapat terlihat oleh semua dan mesin pencari bisa mengindeksnya</item>
+		<item>Situs Anda dapat terlihat oleh semua orang tetapi mesin pencari tidak akan mengindeksnya</item>
+		<item>Situs Anda hanya terlihat oleh Anda dan pengguna yang sudah Anda setujui</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>Diperlukan persetujuan manual untuk semua komentar.</item>
+		<item>Secara otomatis menyetujui jika pengguna sudah pernah disetujui komentarnya.</item>
+		<item>Secara otomatis menyetujui semua komentar</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>Belum ada komentar</item>
+		<item>Komentar pengguna yang diketahui</item>
+		<item>Semua pengguna</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>Tidak ada</item>
+		<item>Dua Level</item>
+		<item>Tiga Level</item>
+		<item>Empat Level</item>
+		<item>Lima Level</item>
+		<item>Enam Level</item>
+		<item>Tujuh Level</item>
+		<item>Delapan Level</item>
+		<item>Sembilan Level</item>
+		<item>Sepuluh Level</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>Gratis</item>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">Dimensioni originali</string>
+	<string name="about_me_hint">Alcune informazioni su di te…</string>
+	<string name="public_display_name_hint">Se non viene impostato, il nome visualizzato coinciderà con il nome utente per impostazione predefinita</string>
+	<string name="about_me">Informazioni su di me</string>
+	<string name="public_display_name">Nome visualizzato (pubblico)</string>
+	<string name="my_profile">Il mio profilo</string>
+	<string name="first_name">Nome</string>
+	<string name="last_name">Cognome</string>
+	<string name="site_privacy_public_desc">Permetti ai motori di ricerca di indicizzare questo sito</string>
+	<string name="site_privacy_hidden_desc">Scoraggia i motori di ricerca ad effettuare l\'indicizzazione di questo sito</string>
+	<string name="site_privacy_private_desc">Vorrei che il mio sito fosse privato, visibile solo agli utenti scelti da me</string>
+	<string name="cd_related_post_preview_image">Immagine di anteprima dell\'articolo correlato</string>
+	<string name="error_post_remote_site_settings">Impossibile salvare le informazioni del sito</string>
+	<string name="error_fetch_remote_site_settings">Impossibile recuperare le informazioni del sito</string>
+	<string name="error_media_upload_connection">Si è verificato un errore di connessione durante il caricamento dei contenuti multimediali</string>
+	<string name="site_settings_disconnected_toast">Disconnesso. Modifica disabilitata.</string>
+	<string name="site_settings_unsupported_version_error">Versione di WordPress non supportata</string>
+	<string name="site_settings_multiple_links_dialog_description">Richiedi l\'approvazione per i commenti che includono un numero di link superiore a quello specificato.</string>
+	<string name="site_settings_close_after_dialog_switch_text">Chiudi automaticamente</string>
+	<string name="site_settings_close_after_dialog_description">Chiudi automaticamente i commenti sugli articoli.</string>
+	<string name="site_settings_paging_dialog_description">Suddividi il flusso dei commenti in più pagine.</string>
+	<string name="site_settings_paging_dialog_header">Commenti per pagina</string>
+	<string name="site_settings_close_after_dialog_title">Chiudi commenti</string>
+	<string name="site_settings_blacklist_description">Quando un commento contiene una di queste parole nel testo, nel nome, nell\'URL, nell\'e-mail o nell\'IP, verrà contrassegnato come spam. Puoi inserire parzialmente le parole, per cui "press" corrisponderà a "WordPress".</string>
+	<string name="site_settings_hold_for_moderation_description">Quando un commento contiene una di queste parole nel testo, nel nome, nell\'URL, nell\'e-mail o nell\'IP, verrà inserito nella coda di moderazione. Puoi inserire parzialmente le parole, per cui "press" corrisponderà a "WordPress".</string>
+	<string name="site_settings_list_editor_input_hint">Inserisci una parola o una frase</string>
+	<string name="site_settings_list_editor_no_items_text">Nessun elemento</string>
+	<string name="site_settings_learn_more_caption">Puoi sovrascrivere queste impostazioni per i singoli articoli.</string>
+	<string name="site_settings_rp_preview3_site">in "Upgrade"</string>
+	<string name="site_settings_rp_preview3_title">Punti principali dell\'aggiornamento: VideoPress per matrimoni</string>
+	<string name="site_settings_rp_preview2_site">in "App"</string>
+	<string name="site_settings_rp_preview2_title">Grande rinnovamento di WordPress per l\'app Android</string>
+	<string name="site_settings_rp_preview1_site">in "Mobile"</string>
+	<string name="site_settings_rp_preview1_title">Grande aggiornamento per iPhone/iPad ora disponibile</string>
+	<string name="site_settings_rp_show_images_title">Mostra le immagini</string>
+	<string name="site_settings_rp_show_header_title">Mostra l\'intestazione</string>
+	<string name="site_settings_rp_switch_summary">Articoli correlati visualizza contenuti pertinenti del tuo sito sotto i tuoi articoli.</string>
+	<string name="site_settings_rp_switch_title">Mostra gli articoli correlati</string>
+	<string name="site_settings_delete_site_hint">Rimuovi i dati del sito dall\'app</string>
+	<string name="site_settings_blacklist_hint">I commenti che corrispondono a un filtro vengono contrassegnati come spam</string>
+	<string name="site_settings_moderation_hold_hint">I commenti che corrispondono a un filtro vengono inseriti nella coda di moderazione</string>
+	<string name="site_settings_multiple_links_hint">Ignora limite di link da utenti conosciuti</string>
+	<string name="site_settings_whitelist_hint">L\'autore del commento deve avere un commento già approvato in precedenza</string>
+	<string name="site_settings_user_account_required_hint">Gli utenti devono essere registrati ed aver effettuato l\'accesso per poter inviare commenti</string>
+	<string name="site_settings_identity_required_hint">L\'autore del commento deve inserire nome e indirizzo e-mail</string>
+	<string name="site_settings_manual_approval_hint">I commenti devono essere approvati manualmente</string>
+	<string name="site_settings_paging_hint">Visualizza commenti in parti di dimensioni specifiche</string>
+	<string name="site_settings_threading_hint">Consenti commenti nidificati per una data profondità</string>
+	<string name="site_settings_sort_by_hint">Determina l\'ordine in cui i commenti vengono visualizzati</string>
+	<string name="site_settings_close_after_hint">Rifiuta i commenti dopo l\'orario specificato</string>
+	<string name="site_settings_receive_pingbacks_hint">Consenti notifiche link da altri blog</string>
+	<string name="site_settings_send_pingbacks_hint">Tenta di notificare tutti i blog che hanno un link nell\'articolo</string>
+	<string name="site_settings_allow_comments_hint">Consenti ai lettori di pubblicare commenti</string>
+	<string name="site_settings_discussion_hint">Visualizza e modifica le impostazioni di discussione del sito</string>
+	<string name="site_settings_more_hint">Visualizza tutte le impostazioni di discussione disponibili</string>
+	<string name="site_settings_related_posts_hint">Mostra o nascondi gli articoli correlati nel lettore</string>
+	<string name="site_settings_upload_and_link_image_hint">Consenti sempre di caricare l\'immagine completa</string>
+	<string name="site_settings_image_width_hint">Ridimensiona le immagini negli articoli secondo questa larghezza</string>
+	<string name="site_settings_format_hint">Imposta nuovo formato articolo</string>
+	<string name="site_settings_category_hint">Imposta nuova categoria articolo</string>
+	<string name="site_settings_location_hint">Aggiungi automaticamente i dati sulla posizione agli articoli</string>
+	<string name="site_settings_password_hint">Modifica la password</string>
+	<string name="site_settings_username_hint">Account utente attuale</string>
+	<string name="site_settings_language_hint">Lingua in cui questo blog è scritto prevalentemente</string>
+	<string name="site_settings_privacy_hint">Controlla chi può vedere questo sito</string>
+	<string name="site_settings_address_hint">La modifica dell\'indirizzo non è attualmente supportata</string>
+	<string name="site_settings_tagline_hint">Una breve descrizione o una frase accattivante per descrivere il tuo blog</string>
+	<string name="site_settings_title_hint">Spiega in poche parole l\'argomento del sito</string>
+	<string name="site_settings_whitelist_known_summary">Commenti da utenti conosciuti</string>
+	<string name="site_settings_whitelist_all_summary">Commenti da tutti gli utenti</string>
+	<string name="site_settings_threading_summary">%d livelli</string>
+	<string name="site_settings_privacy_private_summary">Privato</string>
+	<string name="site_settings_privacy_hidden_summary">Nascosto</string>
+	<string name="site_settings_delete_site_title">Elimina sito</string>
+	<string name="site_settings_privacy_public_summary">Pubblico</string>
+	<string name="site_settings_blacklist_title">Blacklist</string>
+	<string name="site_settings_moderation_hold_title">Sottoponi a moderazione</string>
+	<string name="site_settings_multiple_links_title">Link nei commenti</string>
+	<string name="site_settings_whitelist_title">Approva automaticamente</string>
+	<string name="site_settings_paging_title">Paginazione</string>
+	<string name="site_settings_threading_title">Flusso</string>
+	<string name="site_settings_sort_by_title">Ordina per</string>
+	<string name="site_settings_account_required_title">Gli utenti devono essere registrati</string>
+	<string name="site_settings_identity_required_title">Devono includere nome ed e-mail</string>
+	<string name="site_settings_receive_pingbacks_title">Ricevi pingback</string>
+	<string name="site_settings_send_pingbacks_title">Invia pingback</string>
+	<string name="site_settings_allow_comments_title">Consenti commenti</string>
+	<string name="site_settings_default_format_title">Formato predefinito</string>
+	<string name="site_settings_default_category_title">Categoria predefinita</string>
+	<string name="site_settings_location_title">Abilita posizione</string>
+	<string name="site_settings_address_title">Indirizzo</string>
+	<string name="site_settings_title_title">Titolo sito</string>
+	<string name="site_settings_tagline_title">Tagline</string>
+	<string name="site_settings_this_device_header">Questo dispositivo</string>
+	<string name="site_settings_discussion_new_posts_header">Impostazioni predefinite per nuovi articoli</string>
+	<string name="site_settings_account_header">Account</string>
+	<string name="site_settings_writing_header">Scrittura</string>
+	<string name="newest_first">Prima i più recenti</string>
+	<string name="site_settings_general_header">Generali</string>
+	<string name="discussion">Discussione</string>
+	<string name="privacy">Privacy</string>
+	<string name="related_posts">Articoli correlati</string>
+	<string name="comments">Commenti</string>
+	<string name="close_after">Chiudi dopo</string>
+	<string name="oldest_first">Prima i meno recenti</string>
+	<string name="media_error_no_permission_upload">Non disponi delle autorizzazioni per caricare contenuti multimediali sul sito</string>
+	<string name="never">Mai</string>
+	<string name="unknown">Sconosciuto</string>
 	<string name="reader_err_get_post_not_found">Questo articolo non esiste più</string>
 	<string name="reader_err_get_post_not_authorized">Non disponi del permesso per visualizzare questo articolo</string>
 	<string name="reader_err_get_post_generic">Impossibile recuperare questo articolo</string>
@@ -124,14 +232,12 @@
 	<string name="trashed">Cestinato</string>
 	<string name="button_back">Indietro</string>
 	<string name="page_deleted">Pagina cancellata</string>
-	<string name="button_more">Altro</string>
 	<string name="button_stats">Statistiche</string>
 	<string name="button_trash">Cestino</string>
 	<string name="button_preview">Anteprima</string>
 	<string name="button_view">Visualizza</string>
 	<string name="button_edit">Modifica</string>
 	<string name="button_publish">Pubblica</string>
-	<string name="button_delete">Cancella</string>
 	<string name="my_site_no_sites_view_subtitle">Vuoi aggiungerne uno?</string>
 	<string name="my_site_no_sites_view_title">No hai ancora nessun sito WordPress</string>
 	<string name="my_site_no_sites_view_drake">Illustrazione</string>
@@ -170,7 +276,6 @@
 	<string name="my_site_btn_view_admin">Visualizza l\'amministrazione</string>
 	<string name="my_site_header_look_and_feel">Aspetto</string>
 	<string name="my_site_header_publish">Pubblica</string>
-	<string name="my_site_btn_comments">Commenti</string>
 	<string name="my_site_btn_site_settings">Impostazioni</string>
 	<string name="my_site_btn_blog_posts">Articoli blog</string>
 	<string name="my_site_header_admin">Amministrazione</string>
@@ -284,7 +389,6 @@
 	<string name="stats_visitors">Visitatori</string>
 	<string name="stats_pagination_label">Pagina %1$s di %2$s</string>
 	<string name="stats_timeframe_years">Anni</string>
-	<string name="stats_comments">Commenti</string>
 	<string name="stats_view_countries">Paesi</string>
 	<string name="stats_view_videos">Video</string>
 	<string name="stats_entry_clicks_link">Link</string>
@@ -334,13 +438,13 @@
 	<string name="reader_label_comment_count_single">Un commento</string>
 	<string name="reader_label_comments_closed">I commenti sono chiusi</string>
 	<string name="reader_label_comments_on">Commenti su</string>
-	<string name="reader_title_comments">Commenti</string>
 	<string name="reader_title_photo_viewer">%1$d di %2$d</string>
 	<string name="error_publish_empty_post">Non è possibile pubblicare un articolo vuoto</string>
 	<string name="error_refresh_unauthorized_posts">Non disponi del permesso di visualizzare o modificare gli articoli</string>
 	<string name="error_refresh_unauthorized_pages">Non disponi del permesso di visualizzare o modificare le pagine</string>
 	<string name="error_refresh_unauthorized_comments">Non disponi del permesso di visualizzare o modificare i commenti</string>
 	<string name="older_month">Più vecchio di un mese</string>
+	<string name="more">Altro</string>
 	<string name="older_two_days">Più vecchio di 2 giorni</string>
 	<string name="older_last_week">Più vecchio di una settimana</string>
 	<string name="stats_no_blog">Non è possibile caricare le statistiche per il blog indicato</string>
@@ -647,14 +751,12 @@
 	<string name="theme_set_success">Tema impostato con successo!</string>
 	<string name="share_action_title">Aggiungi a...</string>
 	<string name="stats_view_tags_and_categories">Tag &amp; Categorie</string>
-	<string name="stats_view_comments">Commenti</string>
 	<string name="stats_timeframe_today">Oggi</string>
 	<string name="stats_timeframe_yesterday">Ieri</string>
 	<string name="stats_timeframe_days">Giorni</string>
 	<string name="stats_timeframe_weeks">Settimane</string>
 	<string name="stats_totals_views">Visualizzazioni</string>
 	<string name="stats_totals_clicks">Click</string>
-	<string name="stats_totals_comments">Commenti</string>
 	<string name="media_gallery_image_order_random">Casuale</string>
 	<string name="media_gallery_image_order_reverse">Invertito</string>
 	<string name="media_gallery_type">Tipo</string>
@@ -777,7 +879,6 @@
 	<string name="no">No</string>
 	<string name="error">Errore</string>
 	<string name="category_refresh_error">Errore durante l\'aggiornamento delle categorie</string>
-	<string name="tab_comments">Commenti</string>
 	<string name="preview">Anteprima</string>
 	<string name="on">on</string>
 	<string name="yes">Sì</string>
@@ -828,6 +929,33 @@
 		<item>Predefinito</item>
 		<item>Stato</item>
 		<item>Video</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>Il tuo sito è visibile a chiunque e può essere indicizzato dai motori di ricerca</item>
+		<item>Il tuo sito è visibile a chiunque, ma chiede ai motori di ricerca di non indicizzarlo</item>
+		<item>Il tuo sito è visibile solo a te e agli utenti che approvi</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>Richiedi l\'approvazione manuale per i commenti di tutti gli utenti.</item>
+		<item>Approva automaticamente se l\'utente ha approvato un commento in precedenza.</item>
+		<item>Approva automaticamente i commenti di tutti gli utenti.</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>Nessun commento</item>
+		<item>Commenti di utenti conosciuti</item>
+		<item>Tutti gli utenti</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>Nessuno</item>
+		<item>Due livelli</item>
+		<item>Tre livelli</item>
+		<item>Quattro livelli</item>
+		<item>Cinque livelli</item>
+		<item>Sei livelli</item>
+		<item>Sette livelli</item>
+		<item>Otto livelli</item>
+		<item>Nove livelli</item>
+		<item>Dieci livelli</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>Gratuito</item>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">元のサイズ</string>
+	<string name="about_me_hint">簡単な自己紹介</string>
+	<string name="about_me">自己紹介</string>
+	<string name="public_display_name_hint">表示名が設定されていない場合、デフォルトでユーザー名が指定されます</string>
+	<string name="public_display_name">公開表示名</string>
+	<string name="my_profile">プロフィール</string>
+	<string name="first_name">名</string>
+	<string name="last_name">姓</string>
+	<string name="site_privacy_public_desc">検索エンジンによるサイトのインデックスを許可する</string>
+	<string name="site_privacy_hidden_desc">検索エンジンがサイトをインデックスしないようにする</string>
+	<string name="site_privacy_private_desc">サイトを非公開にし、選択したユーザーにのみ表示する</string>
+	<string name="cd_related_post_preview_image">関連記事のプレビュー画像</string>
+	<string name="error_post_remote_site_settings">サイト情報を保存できませんでした</string>
+	<string name="error_fetch_remote_site_settings">サイト情報を取得できませんでした</string>
+	<string name="error_media_upload_connection">メディアのアップロード中に接続エラーが発生しました</string>
+	<string name="site_settings_disconnected_toast">接続が中断されたため編集を無効化しました。</string>
+	<string name="site_settings_unsupported_version_error">サポートされていない WordPress バージョン</string>
+	<string name="site_settings_multiple_links_dialog_description">この数より多くのリンクがコメントに含まれる場合、承認が必要です。</string>
+	<string name="site_settings_close_after_dialog_switch_text">自動的に閉じる</string>
+	<string name="site_settings_close_after_dialog_description">記事のコメントを自動的に閉じます。</string>
+	<string name="site_settings_paging_dialog_description">コメントスレッドを複数のページに分けます。</string>
+	<string name="site_settings_paging_dialog_header">1ページあたりのコメント数</string>
+	<string name="site_settings_close_after_dialog_title">コメントを閉じます</string>
+	<string name="site_settings_blacklist_description">コメントの本文、名前、URL、メール、IP にこれらの語のいずれかが含まれている場合、スパムとしてマークされます。語句の一部を入力できます。例えば、「press」は「WordPress」に一致します。</string>
+	<string name="site_settings_hold_for_moderation_description">コメントの本文、名前、URL、メール、IP にこれらの語のいずれかが含まれている場合、承認待ちになります。語句の一部を入力できます。例えば、「press」は「WordPress」に一致します。</string>
+	<string name="site_settings_list_editor_input_hint">単語やフレーズを入力してください</string>
+	<string name="site_settings_list_editor_no_items_text">項目なし</string>
+	<string name="site_settings_learn_more_caption">これらの設定は投稿ごとに上書きできます。</string>
+	<string name="site_settings_rp_preview3_site">「アップグレード」カテゴリー</string>
+	<string name="site_settings_rp_preview3_title">アップグレードフォーカス: ウェディング向け VideoPress</string>
+	<string name="site_settings_rp_preview2_site">「アプリ」カテゴリー</string>
+	<string name="site_settings_rp_preview2_title">WordPress for Android アプリが大幅リニューアル</string>
+	<string name="site_settings_rp_preview1_site">「モバイル」カテゴリー</string>
+	<string name="site_settings_rp_preview1_title">iPhone/iPad の大幅なアップデートが利用できるようになりました</string>
+	<string name="site_settings_rp_show_images_title">画像を表示</string>
+	<string name="site_settings_rp_show_header_title">ヘッダーを表示</string>
+	<string name="site_settings_rp_switch_summary">「関連記事」は投稿の下にサイト内の関連コンテンツを表示します。</string>
+	<string name="site_settings_rp_switch_title">関連記事を表示</string>
+	<string name="site_settings_delete_site_hint">サイトのデータをアプリから削除します</string>
+	<string name="site_settings_blacklist_hint">フィルターに一致するコメントはスパムとしてマークされます</string>
+	<string name="site_settings_moderation_hold_hint">フィルターに一致するコメントは承認待ちになります</string>
+	<string name="site_settings_multiple_links_hint">既知のユーザーからのリンク制限を無視します</string>
+	<string name="site_settings_whitelist_hint">すでに承認されたコメントの投稿者のコメントを許可し、それ以外のコメントを承認待ちにする</string>
+	<string name="site_settings_user_account_required_hint">ユーザー登録してログインしたユーザーのみコメントをつけられるようにする</string>
+	<string name="site_settings_identity_required_hint">コメントの際、名前とメールアドレスの入力を必須にする</string>
+	<string name="site_settings_manual_approval_hint">コメントを手動で承認する必要があります</string>
+	<string name="site_settings_paging_hint">コメントを指定したサイズに分けて表示します</string>
+	<string name="site_settings_threading_hint">指定の深さまで入れ子コメントを許可します</string>
+	<string name="site_settings_sort_by_hint">コメントを表示する順番を決定します</string>
+	<string name="site_settings_close_after_hint">指定した時間後のコメントを許可しません</string>
+	<string name="site_settings_receive_pingbacks_hint">他のブログからのリンク通知を許可します</string>
+	<string name="site_settings_send_pingbacks_hint">この投稿に含まれるすべてのリンクへの通知を試みる</string>
+	<string name="site_settings_allow_comments_hint">読者からのコメントの投稿を許可します</string>
+	<string name="site_settings_discussion_hint">サイトのディスカッション設定を表示して変更します</string>
+	<string name="site_settings_more_hint">使用可能なディスカッション設定をすべて表示します</string>
+	<string name="site_settings_related_posts_hint">Reader で関連記事を表示または非表示にします</string>
+	<string name="site_settings_upload_and_link_image_hint">常時フルサイズ画像でのアップロードを有効にします</string>
+	<string name="site_settings_image_width_hint">投稿の画像のサイズを幅に合わせて変更します</string>
+	<string name="site_settings_format_hint">新しい投稿のフォーマットを設定します</string>
+	<string name="site_settings_category_hint">新しい投稿のカテゴリーを設定します</string>
+	<string name="site_settings_location_hint">位置データを投稿に自動的に追加します</string>
+	<string name="site_settings_password_hint">パスワードを変更します</string>
+	<string name="site_settings_username_hint">現在のユーザーアカウント</string>
+	<string name="site_settings_language_hint">ブログを書くときに使う主な言語</string>
+	<string name="site_settings_privacy_hint">サイトを閲覧できるユーザーを管理します</string>
+	<string name="site_settings_address_hint">アドレスの変更は現在サポートされていません</string>
+	<string name="site_settings_tagline_hint">ブログの簡単な説明やブログを表す魅力的なフレーズ</string>
+	<string name="site_settings_title_hint">このサイトを短い文章で説明してください</string>
+	<string name="site_settings_whitelist_known_summary">既知のユーザーからのコメント</string>
+	<string name="site_settings_whitelist_all_summary">すべてのユーザーからのコメント</string>
+	<string name="site_settings_threading_summary">%d階層</string>
+	<string name="site_settings_privacy_private_summary">プライベート</string>
+	<string name="site_settings_privacy_hidden_summary">非表示</string>
+	<string name="site_settings_delete_site_title">サイトを削除</string>
+	<string name="site_settings_privacy_public_summary">一般公開</string>
+	<string name="site_settings_blacklist_title">ブラックリスト</string>
+	<string name="site_settings_moderation_hold_title">承認待ち</string>
+	<string name="site_settings_multiple_links_title">コメント内のリンク</string>
+	<string name="site_settings_whitelist_title">自動で承認</string>
+	<string name="site_settings_paging_title">ページ送り</string>
+	<string name="site_settings_threading_title">スレッド化</string>
+	<string name="site_settings_sort_by_title">並び替え</string>
+	<string name="site_settings_account_required_title">ユーザーのログインを必須にする</string>
+	<string name="site_settings_identity_required_title">名前とメールを必須にする</string>
+	<string name="site_settings_receive_pingbacks_title">ピンバックを受け取る</string>
+	<string name="site_settings_send_pingbacks_title">ピンバックを送信</string>
+	<string name="site_settings_allow_comments_title">コメントを許可</string>
+	<string name="site_settings_default_format_title">デフォルトのフォーマット</string>
+	<string name="site_settings_default_category_title">デフォルトカテゴリー</string>
+	<string name="site_settings_location_title">位置情報を有効化</string>
+	<string name="site_settings_address_title">住所</string>
+	<string name="site_settings_title_title">サイトのタイトル</string>
+	<string name="site_settings_tagline_title">キャッチフレーズ</string>
+	<string name="site_settings_this_device_header">このデバイス</string>
+	<string name="site_settings_discussion_new_posts_header">新しい投稿のデフォルト</string>
+	<string name="site_settings_account_header">アカウント</string>
+	<string name="site_settings_writing_header">投稿設定</string>
+	<string name="newest_first">最新のものを先頭表示</string>
+	<string name="site_settings_general_header">一般</string>
+	<string name="discussion">ディスカッション</string>
+	<string name="privacy">プライバシー</string>
+	<string name="related_posts">関連記事</string>
+	<string name="comments">コメント</string>
+	<string name="close_after">特定の日付に終了:</string>
+	<string name="oldest_first">最も古いものを先頭表示</string>
+	<string name="media_error_no_permission_upload">このサイトにメディアをアップロードする権限がありません</string>
+	<string name="never">なし</string>
+	<string name="unknown">不明</string>
 	<string name="reader_err_get_post_not_found">この投稿は存在しません</string>
 	<string name="reader_err_get_post_not_authorized">この投稿を表示する権限がありません</string>
 	<string name="reader_err_get_post_generic">この投稿を取得できません</string>
@@ -124,14 +232,12 @@
 	<string name="trashed">ゴミ箱移動済み</string>
 	<string name="button_back">戻る</string>
 	<string name="page_deleted">ページを削除しました</string>
-	<string name="button_more">続き</string>
 	<string name="button_stats">統計情報</string>
 	<string name="button_trash">ゴミ箱</string>
 	<string name="button_preview">プレビュー</string>
 	<string name="button_view">表示</string>
 	<string name="button_edit">編集</string>
 	<string name="button_publish">公開</string>
-	<string name="button_delete">削除</string>
 	<string name="my_site_no_sites_view_subtitle">追加しますか ?</string>
 	<string name="my_site_no_sites_view_title">まだ WordPress サイトがありません。</string>
 	<string name="my_site_no_sites_view_drake">イラスト</string>
@@ -170,7 +276,6 @@
 	<string name="site_picker_title">サイトを選択</string>
 	<string name="my_site_btn_blog_posts">ブログ投稿</string>
 	<string name="my_site_btn_site_settings">設定</string>
-	<string name="my_site_btn_comments">コメント</string>
 	<string name="my_site_header_look_and_feel">ルックアンドフィール</string>
 	<string name="my_site_header_publish">公開</string>
 	<string name="my_site_header_configuration">設定</string>
@@ -266,7 +371,6 @@
 	<string name="stats_visitors">サイト訪問者</string>
 	<string name="stats_timeframe_years">年</string>
 	<string name="stats_pagination_label">%1$sページ目 (%2$sページ中)</string>
-	<string name="stats_comments">コメント</string>
 	<string name="stats_view_videos">動画</string>
 	<string name="stats_view_publicize">パブリサイズ共有 </string>
 	<string name="stats_view_followers">フォロワー</string>
@@ -332,12 +436,12 @@
 	<string name="reader_label_like">いいね</string>
 	<string name="reader_label_comments_closed">コメントは停止中です。</string>
 	<string name="reader_label_comments_on">次の投稿へのコメント:</string>
-	<string name="reader_title_comments">コメント</string>
 	<string name="reader_title_photo_viewer">%1$d/%2$d</string>
 	<string name="error_publish_empty_post">空の投稿はできません。</string>
 	<string name="error_refresh_unauthorized_posts">投稿の表示/編集の権限がありません。</string>
 	<string name="error_refresh_unauthorized_pages">ページの表示/編集の権限がありません。</string>
 	<string name="error_refresh_unauthorized_comments">コメントの表示/編集の権限がありません。</string>
+	<string name="more">続き</string>
 	<string name="stats_no_blog">要求されたブログの統計を読み込めませんでした。</string>
 	<string name="select_a_blog">WordPress のサイトを選択してください。</string>
 	<string name="sending_content">%s のコンテンツをアップロードしています</string>
@@ -665,7 +769,6 @@
 	<string name="stats_totals_views">表示</string>
 	<string name="stats_totals_clicks">クリック数</string>
 	<string name="stats_totals_plays">再生回数</string>
-	<string name="stats_totals_comments">コメント</string>
 	<string name="menu_search">検索</string>
 	<string name="media_add_popup_capture_photo">写真を撮影</string>
 	<string name="media_add_popup_capture_video">動画を撮影</string>
@@ -673,7 +776,6 @@
 	<string name="themes_details_label">詳細</string>
 	<string name="themes_features_label">機能</string>
 	<string name="stats_view_referrers">リファラ</string>
-	<string name="stats_view_comments">コメント</string>
 	<string name="media_edit_failure">更新に失敗しました</string>
 	<string name="media_edit_description_hint">説明を入力</string>
 	<string name="media_edit_caption_hint">キャプションを入力</string>
@@ -771,7 +873,6 @@
 	<string name="none">なし</string>
 	<string name="blogs">ブログ</string>
 	<string name="select_photo">ギャラリーから写真を選択</string>
-	<string name="tab_comments">コメント</string>
 	<string name="reply">返信する</string>
 	<string name="preview">プレビュー</string>
 	<string name="on">オン</string>
@@ -828,6 +929,33 @@
 		<item>標準</item>
 		<item>ステータス</item>
 		<item>動画</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>誰でもサイトを表示可能にし、検索エンジンによるインデックスを許可する</item>
+		<item>誰でもサイトを表示可能にし、検索エンジンによるインデックスは回避する</item>
+		<item>自身と承認したユーザーのみがサイトを表示可能</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>すべてのコメントで、手動の承認が必要です。</item>
+		<item>ユーザーのコメントが以前に承認されている場合、自動的に承認します。</item>
+		<item>すべてのコメントを自動的に承認します。</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>コメントはありません</item>
+		<item>既知のユーザーのコメント</item>
+		<item>すべてのユーザー</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>なし</item>
+		<item>2階層</item>
+		<item>3階層</item>
+		<item>4階層</item>
+		<item>5階層</item>
+		<item>6階層</item>
+		<item>7階層</item>
+		<item>8階層</item>
+		<item>9階層</item>
+		<item>10階層</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>無料</item>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">원래 크기</string>
+	<string name="about_me_hint">사용자에 대한 몇 가지 정보...</string>
+	<string name="public_display_name_hint">대화명을 설정하지 않을 경우 기본적으로 사용자명으로 설정됩니다.</string>
+	<string name="about_me">내 소개</string>
+	<string name="public_display_name">공개 이름</string>
+	<string name="my_profile">내 프로필</string>
+	<string name="first_name">이름</string>
+	<string name="last_name">성</string>
+	<string name="site_privacy_public_desc">검색 엔진이 이 사이트 검색을 허용하기</string>
+	<string name="site_privacy_hidden_desc">검색 엔진이 이 사이트 검색 차단하기</string>
+	<string name="site_privacy_private_desc">사이트를 비공개로 설정하고 제가 선택하는 사용자만 볼 수 있도록 하고 싶습니다.</string>
+	<string name="cd_related_post_preview_image">관련 글 미리보기 이미지</string>
+	<string name="error_post_remote_site_settings">사이트 정보를 저장할 수 없습니다.</string>
+	<string name="error_fetch_remote_site_settings">사이트 정보를 가져올 수 없습니다.</string>
+	<string name="error_media_upload_connection">미디어를 업로드하는 동안 연결 오류가 발생했습니다.</string>
+	<string name="site_settings_disconnected_toast">연결 해제되어 편집이 비활성화되었습니다.</string>
+	<string name="site_settings_unsupported_version_error">지원되지 않는 워드프레스 버전</string>
+	<string name="site_settings_multiple_links_dialog_description">이 링크 수보다 링크가 많이 포함된 댓글에 대한 승인이 필요합니다.</string>
+	<string name="site_settings_close_after_dialog_switch_text">자동으로 닫기</string>
+	<string name="site_settings_close_after_dialog_description">글에 대한 댓글을 자동으로 닫습니다.</string>
+	<string name="site_settings_paging_dialog_description">댓글 스레드를 여러 페이지로 나눕니다.</string>
+	<string name="site_settings_paging_dialog_header">페이지당 댓글 수</string>
+	<string name="site_settings_close_after_dialog_title">댓글 닫기</string>
+	<string name="site_settings_blacklist_description">댓글의 내용이나 이름, URL, 이메일, IP에 아래 단어가 들어있으면 스팸으로 처리됩니다. 단어의 일부만 입력해도 됩니다. "프레스"라고 입력하면 "워드프레스"로 인식될 수 있습니다.</string>
+	<string name="site_settings_hold_for_moderation_description">댓글의 내용, 이름, URL, 이메일 또는 IP에 아래 단어가 들어 있으면 중재 대기열에 보관됩니다. 단어의 일부만 입력해도 됩니다. "프레스"라고 입력하면 "워드프레스"로 인식될 수 있습니다.</string>
+	<string name="site_settings_list_editor_input_hint">단어 또는 구절을 입력하세요.</string>
+	<string name="site_settings_list_editor_no_items_text">아이템 없음</string>
+	<string name="site_settings_learn_more_caption">개별 글에 대해 이러한 설정을 우선 적용할 수 있습니다.</string>
+	<string name="site_settings_rp_preview3_site">"업그레이드"에서</string>
+	<string name="site_settings_rp_preview3_title">업그레이드 핵심: 웨딩용 VideoPress</string>
+	<string name="site_settings_rp_preview2_site">"앱"에서</string>
+	<string name="site_settings_rp_preview2_title">대대적으로 업데이트된 Android 앱용 WordPress</string>
+	<string name="site_settings_rp_preview1_site">"모바일"에서</string>
+	<string name="site_settings_rp_preview1_title">iPhone/iPad 업데이트 지금 이용 가능</string>
+	<string name="site_settings_rp_show_images_title">이미지 보이기</string>
+	<string name="site_settings_rp_show_header_title">헤더 표시</string>
+	<string name="site_settings_rp_switch_summary">관련 글에는 글 아래에 있는 사이트의 관련 콘텐츠가 표시됩니다.</string>
+	<string name="site_settings_rp_switch_title">관련 글 표시</string>
+	<string name="site_settings_delete_site_hint">앱에서 사이트 데이터를 제거합니다.</string>
+	<string name="site_settings_blacklist_hint">필터와 일치하는 댓글은 스팸으로 표시됩니다.</string>
+	<string name="site_settings_moderation_hold_hint">필터와 일치하는 댓글은 중재 대기열에 배치됩니다.</string>
+	<string name="site_settings_multiple_links_hint">알려진 사용자의 링크 제한을 무시합니다.</string>
+	<string name="site_settings_whitelist_hint">댓글을 쓴 사람이 예전에 댓글이 승인된 적이 있어야 합니다.</string>
+	<string name="site_settings_user_account_required_hint">가입하여 로그인한 사용자만 댓글을 남길 수 있습니다.</string>
+	<string name="site_settings_identity_required_hint">댓글을 쓴 사람의 이름과 이메일을 꼭 남겨야 합니다.</string>
+	<string name="site_settings_manual_approval_hint">댓글은 수동으로 승인되어야 합니다.</string>
+	<string name="site_settings_paging_hint">지정된 크기 단위로 댓글 표시</string>
+	<string name="site_settings_threading_hint">특정 깊이로 계층형 댓글 허용</string>
+	<string name="site_settings_sort_by_hint">댓글이 표시되는 순서를 결정합니다.</string>
+	<string name="site_settings_close_after_hint">지정된 시간 이후 댓글을 허용하지 않음</string>
+	<string name="site_settings_receive_pingbacks_hint">다른 블로그의 링크 알림 허용</string>
+	<string name="site_settings_send_pingbacks_hint">글에서 링크한 블로그에 링크 사실을 알림</string>
+	<string name="site_settings_allow_comments_hint">독자가 댓글을 게시할 수 있도록 허용</string>
+	<string name="site_settings_discussion_hint">사이트 토론 설정 보기 및 변경</string>
+	<string name="site_settings_more_hint">사용 가능한 모든 토론 설정 보기</string>
+	<string name="site_settings_related_posts_hint">리더에서 관련 글 표시 또는 숨기기</string>
+	<string name="site_settings_upload_and_link_image_hint">항상 최대 크기 이미지를 업로드할 수 있도록 허용</string>
+	<string name="site_settings_image_width_hint">글의 이미지를 이 폭으로 크기 조정합니다.</string>
+	<string name="site_settings_format_hint">새 글 형식을 설정합니다.</string>
+	<string name="site_settings_category_hint">새 글 카테고리를 설정합니다.</string>
+	<string name="site_settings_location_hint">글에 자동으로 위치 데이터 추가</string>
+	<string name="site_settings_password_hint">비밀번호 변경</string>
+	<string name="site_settings_username_hint">현재 사용자 계정</string>
+	<string name="site_settings_language_hint">이 블로그의 기본 언어</string>
+	<string name="site_settings_privacy_hint">사이트를 볼 수 있는 사용자를 제어합니다.</string>
+	<string name="site_settings_address_hint">현재 주소 변경은 지원되지 않습니다.</string>
+	<string name="site_settings_tagline_hint">블로그를 설명하는 간단한 설명이나 기억하기 쉬운 구절</string>
+	<string name="site_settings_title_hint">이 사이트가 추구하는 것에 관해 짧게 쓰세요.</string>
+	<string name="site_settings_whitelist_known_summary">알려진 사용자의 댓글</string>
+	<string name="site_settings_whitelist_all_summary">모든 사용자의 댓글</string>
+	<string name="site_settings_threading_summary">%d개 레벨</string>
+	<string name="site_settings_privacy_private_summary">비공개</string>
+	<string name="site_settings_privacy_hidden_summary">숨김</string>
+	<string name="site_settings_delete_site_title">사이트 삭제</string>
+	<string name="site_settings_privacy_public_summary">공개</string>
+	<string name="site_settings_blacklist_title">블랙리스트</string>
+	<string name="site_settings_moderation_hold_title">중재를 위해 보관</string>
+	<string name="site_settings_multiple_links_title">댓글의 링크</string>
+	<string name="site_settings_whitelist_title">자동으로 승인</string>
+	<string name="site_settings_threading_title">스레딩</string>
+	<string name="site_settings_paging_title">페이징</string>
+	<string name="site_settings_sort_by_title">정렬 기준</string>
+	<string name="site_settings_account_required_title">사용자가 로그인해야 합니다.</string>
+	<string name="site_settings_identity_required_title">이름과 이메일을 포함해야 합니다.</string>
+	<string name="site_settings_receive_pingbacks_title">핑백 받기</string>
+	<string name="site_settings_send_pingbacks_title">핑백 보내기</string>
+	<string name="site_settings_allow_comments_title">댓글 허용</string>
+	<string name="site_settings_default_format_title">기본 형식</string>
+	<string name="site_settings_default_category_title">기본 카테고리</string>
+	<string name="site_settings_location_title">위치 활성화</string>
+	<string name="site_settings_address_title">주소</string>
+	<string name="site_settings_title_title">사이트 제목</string>
+	<string name="site_settings_tagline_title">태그라인</string>
+	<string name="site_settings_this_device_header">이 기기</string>
+	<string name="site_settings_discussion_new_posts_header">새 글에 대한 기본값</string>
+	<string name="site_settings_account_header">계정</string>
+	<string name="site_settings_writing_header">쓰기</string>
+	<string name="newest_first">최근 댓글 먼저</string>
+	<string name="site_settings_general_header">일반</string>
+	<string name="discussion">토론</string>
+	<string name="privacy">개인 정보</string>
+	<string name="related_posts">관련 글</string>
+	<string name="comments">댓글</string>
+	<string name="close_after">다음 시간 후에 닫기:</string>
+	<string name="oldest_first">오래된 항목 먼저</string>
+	<string name="media_error_no_permission_upload">미디어를 사이트에 업로드하는 권한이 없습니다.</string>
+	<string name="never">절대</string>
+	<string name="unknown">알 수 없음</string>
 	<string name="reader_err_get_post_not_found">이 글은 더 이상 존재하지 않습니다.</string>
 	<string name="reader_err_get_post_not_authorized">이 글을 볼 권한이 없습니다.</string>
 	<string name="reader_err_get_post_generic">이 글을 가져올 수 없습니다.</string>
@@ -124,14 +232,12 @@
 	<string name="trashed">삭제됨</string>
 	<string name="button_back">돌아가기</string>
 	<string name="page_deleted">페이지 삭제됨</string>
-	<string name="button_more">더</string>
 	<string name="button_stats">통계</string>
 	<string name="button_trash">휴지통</string>
 	<string name="button_preview">미리 보기</string>
 	<string name="button_view">보기</string>
 	<string name="button_edit">편집</string>
 	<string name="button_publish">발행</string>
-	<string name="button_delete">삭제</string>
 	<string name="my_site_no_sites_view_subtitle">더 추가하시겠습니까?</string>
 	<string name="my_site_no_sites_view_title">아직 WordPress사이트를 등록하지 않았습니다.</string>
 	<string name="my_site_no_sites_view_drake">Illustration</string>
@@ -171,7 +277,6 @@
 	<string name="my_site_header_publish">게시</string>
 	<string name="my_site_header_look_and_feel">모양과 느낌</string>
 	<string name="my_site_btn_site_settings">설정</string>
-	<string name="my_site_btn_comments">댓글</string>
 	<string name="my_site_btn_blog_posts">블로그 글</string>
 	<string name="my_site_header_admin">관리자</string>
 	<string name="reader_label_new_posts_subtitle">눌러서 표시</string>
@@ -221,6 +326,8 @@
 	<string name="two_step_sms_sent">확인 코드 문자 메시지가 왔는지 확인하세요.</string>
 	<string name="sign_in_jetpack">워드프레스닷컴 계정에 로그인하여 젯팩에 연결하세요.</string>
 	<string name="auth_required">계속하려면 다시 로그인하세요.</string>
+	<string name="media_details_label_file_name">파일명</string>
+	<string name="media_details_label_file_type">파일형식</string>
 	<string name="stats_empty_search_terms_desc">방문자들이 내 사이트를 찾기 위해 검색한 용어를 확인하여 검색 트래픽에 대해 자세히 알아보세요.</string>
 	<string name="stats_empty_search_terms">기록된 검색어 없음</string>
 	<string name="error_notification_open">알림을 열 수 없음</string>
@@ -253,7 +360,6 @@
 	<string name="stats_timeframe_years">년</string>
 	<string name="stats_views">조회수</string>
 	<string name="stats_visitors">방문자</string>
-	<string name="stats_comments">댓글</string>
 	<string name="stats_pagination_label">%1$s/%2$s 페이지</string>
 	<string name="stats_view_videos">비디오</string>
 	<string name="stats_view_publicize">배포 기능</string>
@@ -333,13 +439,13 @@
 	<string name="reader_label_comment_count_single">1개의 댓글</string>
 	<string name="reader_label_comments_closed">댓글을 남길 수 없습니다.</string>
 	<string name="reader_label_comments_on">댓글:</string>
-	<string name="reader_title_comments">댓글</string>
 	<string name="reader_title_photo_viewer">%1$d/%2$d</string>
 	<string name="error_publish_empty_post">빈 게시물은 게시할 수 없습니다.</string>
 	<string name="error_refresh_unauthorized_posts">게시물을 확인 또는 편집할 권한이 없습니다.</string>
 	<string name="error_refresh_unauthorized_pages">페이지를 확인 또는 편집할 권한이 없습니다.</string>
 	<string name="error_refresh_unauthorized_comments">댓글을 확인 또는 편집할 권한이 없습니다.</string>
 	<string name="older_month">1개월 이전</string>
+	<string name="more">더</string>
 	<string name="older_two_days">2일 이전</string>
 	<string name="older_last_week">1주일 이전</string>
 	<string name="stats_no_blog">요청한 블로그에 대해 통계 자료를 로드할 수 없습니다.</string>
@@ -643,7 +749,6 @@
 	<string name="theme_activating_button">활성화 중</string>
 	<string name="stats_view_clicks">클릭 수</string>
 	<string name="stats_view_tags_and_categories">태그 &amp; 카테고리</string>
-	<string name="stats_view_comments">댓글</string>
 	<string name="stats_timeframe_today">오늘</string>
 	<string name="stats_timeframe_yesterday">어제</string>
 	<string name="stats_timeframe_weeks">주</string>
@@ -653,7 +758,6 @@
 	<string name="menu_search">검색</string>
 	<string name="share_action">공유</string>
 	<string name="stats">통계</string>
-	<string name="stats_totals_comments">댓글</string>
 	<string name="stats_entry_posts_and_pages">제목</string>
 	<string name="media_gallery_type_squares">사각 타일</string>
 	<string name="media_gallery_type_tiled">타일 모자이크</string>
@@ -736,7 +840,7 @@
 	<string name="tos">이용 약관</string>
 	<string name="app_title">WordPress for Android</string>
 	<string name="about">소개</string>
-	<string name="max_thumbnail_px_width">표준 이미지 폭</string>
+	<string name="max_thumbnail_px_width">기본 이미지 너비</string>
 	<string name="image_alignment">배치</string>
 	<string name="refresh">다시 로드</string>
 	<string name="untitled">제목 미설정</string>
@@ -775,7 +879,6 @@
 	<string name="cancel">취소</string>
 	<string name="save">저장</string>
 	<string name="add">추가</string>
-	<string name="tab_comments">댓글</string>
 	<string name="preview">미리보기</string>
 	<string name="reply">회신</string>
 	<string name="on">선택</string>
@@ -826,6 +929,33 @@
 		<item>표준</item>
 		<item>상태</item>
 		<item>동영상</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>사이트가 모든 사람에게 공개되며 검색 엔진이 검색할 수 있습니다.</item>
+		<item>사이트가 모든 사람에게 공개되지만 검색 엔진에 사이트가 검색되지 않도록 요청합니다.</item>
+		<item>사이트가 본인과 본인이 승인한 사용자에게만 공개됩니다.</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>모든 사람의 댓글에 대한 수동 승인이 필요합니다.</item>
+		<item>사용자가 이전에 댓글을 승인한 경우 자동으로 승인합니다.</item>
+		<item>모든 사람의 댓글을 자동으로 승인합니다.</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>댓글 없음</item>
+		<item>알려진 사용자의 댓글</item>
+		<item>모든 사용자</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>없음</item>
+		<item>2개 레벨</item>
+		<item>3개 레벨</item>
+		<item>4개 레벨</item>
+		<item>5개 레벨</item>
+		<item>6개 레벨</item>
+		<item>7개 레벨</item>
+		<item>8개 레벨</item>
+		<item>9개 레벨</item>
+		<item>10개 레벨</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>무료</item>

--- a/WordPress/src/main/res/values-mk/strings.xml
+++ b/WordPress/src/main/res/values-mk/strings.xml
@@ -63,7 +63,6 @@
 	<string name="stats_totals_followers">Од</string>
 	<string name="stats_followers_a_year">Година</string>
 	<string name="stats_followers_total_wpcom">Вкупен број на WordPress.com следбеници: %1$s</string>
-	<string name="stats_comments">Коментари</string>
 	<string name="stats_entry_top_commenter">Автор</string>
 	<string name="stats_view">Прегледи</string>
 	<string name="stats_other_recent_stats_label">Други последни статистики</string>
@@ -93,12 +92,12 @@
 	<string name="reader_label_comments_closed">Коментари затворени</string>
 	<string name="reader_label_comments_on">Коментари на</string>
 	<string name="error_refresh_unauthorized_pages">Немате дозвола за гледање или уредување на страници</string>
-	<string name="reader_title_comments">Коментари</string>
 	<string name="error_refresh_unauthorized_comments">Немате дозвола за гледање или уредување на коментари</string>
 	<string name="error_refresh_unauthorized_posts">Немате дозвола за гледање или уредување на написи</string>
 	<string name="error_publish_empty_post">Неможе да се објави празен напис</string>
 	<string name="reader_title_photo_viewer">%1$d of %2$d</string>
 	<string name="older_month">Постари од месец</string>
+	<string name="more">Повеќе</string>
 	<string name="older_two_days">Постари од 2 дена</string>
 	<string name="older_last_week">Постари од седмица</string>
 	<string name="stats_no_blog">Статиска неможе да се покаже за побараниот блог</string>
@@ -413,7 +412,6 @@
 	<string name="passcode_turn_on">Вклучете го PIN заклучувањето</string>
 	<string name="stats_totals_views">Прегледи</string>
 	<string name="stats_totals_clicks">Кликнувања</string>
-	<string name="stats_totals_comments">Коментари</string>
 	<string name="theme_activating_button">Активирање</string>
 	<string name="theme_set_success">Темата е поставена успешно!</string>
 	<string name="theme_auth_error_title">Неуспешно преземање на теми</string>
@@ -423,7 +421,6 @@
 	<string name="stats">Статистики</string>
 	<string name="stats_view_visitors_and_views">Посетители и прегледи</string>
 	<string name="stats_view_clicks">Кликнувања</string>
-	<string name="stats_view_comments">Коментари</string>
 	<string name="all">Сите</string>
 	<string name="media_edit_failure">Неуспешно качување</string>
 	<string name="themes_details_label">Детали</string>
@@ -483,7 +480,6 @@
 	<string name="version">Верзија</string>
 	<string name="app_title">WordPress за Андроид</string>
 	<string name="about">За нас</string>
-	<string name="max_thumbnail_px_width">Стандардна ширина на сликата</string>
 	<string name="image_alignment">Усогласување</string>
 	<string name="refresh">Освежи</string>
 	<string name="untitled">Без наслов</string>
@@ -521,7 +517,6 @@
 	<string name="save">Зачувај</string>
 	<string name="add">Додај</string>
 	<string name="category_refresh_error">Грешка при освежување на категориите</string>
-	<string name="tab_comments">Коментари</string>
 	<string name="on">на</string>
 	<string name="reply">Одговори</string>
 	<string name="yes">Да</string>

--- a/WordPress/src/main/res/values-nb/strings.xml
+++ b/WordPress/src/main/res/values-nb/strings.xml
@@ -15,13 +15,11 @@
 	<string name="post_deleted">Innlegg slettet</string>
 	<string name="button_back">Tilbake</string>
 	<string name="page_deleted">Side slettet</string>
-	<string name="button_more">Mer</string>
 	<string name="button_stats">Statistikk</string>
 	<string name="button_preview">Forhåndsvis</string>
 	<string name="button_view">Vis</string>
 	<string name="button_edit">Rediger</string>
 	<string name="button_publish">Publiser</string>
-	<string name="button_delete">Slett</string>
 	<string name="button_trash">Papirkurv</string>
 	<string name="page_trashed">Siden er lagt i papirkurven</string>
 	<string name="stats_no_activity_this_period">Ingen aktivitet i denne perioden</string>
@@ -41,7 +39,6 @@
 	<string name="me_btn_login_logout">Logg inn/Logg ut</string>
 	<string name="me_connect_to_wordpress_com">Koble til WordPress.com</string>
 	<string name="my_site_btn_view_site">Vis nettsted</string>
-	<string name="my_site_btn_comments">Kommentarer</string>
 	<string name="my_site_header_publish">Publiser</string>
 	<string name="my_site_btn_site_settings">Innstillinger</string>
 	<string name="my_site_header_admin">Admin</string>
@@ -99,7 +96,6 @@
 	<string name="stats_view_all">Vis alle</string>
 	<string name="stats_view">Vis</string>
 	<string name="stats_followers_email_selector">E-post</string>
-	<string name="stats_comments">Kommentarer</string>
 	<string name="stats_pagination_label">Side %1$s av %2$s</string>
 	<string name="stats_timeframe_years">År</string>
 	<string name="stats_view_followers">Følgere</string>
@@ -134,7 +130,6 @@
 	<string name="confirm_delete_multi_media">Slette valgte elementer?</string>
 	<string name="confirm_delete_media">Slette valgt element?</string>
 	<string name="reader_label_comment_count_single">En kommentar</string>
-	<string name="reader_title_comments">Kommentarer</string>
 	<string name="comment">Kommentar</string>
 	<string name="comment_trashed">Kommentar slettet</string>
 	<string name="reader_title_photo_viewer">%1$d av %2$d</string>
@@ -307,7 +302,6 @@
 	<string name="stats_totals_views">Visninger</string>
 	<string name="stats_totals_clicks">Klikk</string>
 	<string name="stats_totals_plays">Avspillinger</string>
-	<string name="stats_totals_comments">Kommentarer</string>
 	<string name="unattached">Uten vedlegg</string>
 	<string name="media_add_popup_capture_video">Ta opp video</string>
 	<string name="media_gallery_type_squares">Kvadratisk</string>
@@ -320,7 +314,6 @@
 	<string name="stats_view_clicks">Klikk</string>
 	<string name="stats_view_tags_and_categories">Stikkord og kategorier</string>
 	<string name="stats_view_referrers">Henvisninger</string>
-	<string name="stats_view_comments">Kommentarer</string>
 	<string name="stats_timeframe_today">Idag</string>
 	<string name="stats_entry_referrers">Henvisninger</string>
 	<string name="passcode_manage">Håndter PIN kode</string>
@@ -374,7 +367,6 @@
 	<string name="tos">Lisens</string>
 	<string name="app_title">WordPress for Android</string>
 	<string name="about">Om</string>
-	<string name="max_thumbnail_px_width">Standardbredde for bilder</string>
 	<string name="image_alignment">Justering</string>
 	<string name="refresh">Oppdater</string>
 	<string name="untitled">Uten tittel</string>
@@ -411,7 +403,6 @@
 	<string name="reply">Svar</string>
 	<string name="on">på</string>
 	<string name="preview">Forhåndsvisning</string>
-	<string name="tab_comments">Kommentarer</string>
 	<string name="cancel">Avbryt</string>
 	<string name="save">Lagre</string>
 	<string name="add">Legg til</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">Oorspronkelijke grootte</string>
+	<string name="about_me_hint">Enkele woorden over jou…</string>
+	<string name="public_display_name_hint">De weergavenaam is standaard je gebruikersnaam, tenzij hij anders is ingesteld</string>
+	<string name="about_me">Over mij</string>
+	<string name="public_display_name">Openbare weergavenaam</string>
+	<string name="my_profile">Mijn Profiel</string>
+	<string name="first_name">Voornaam</string>
+	<string name="last_name">Achternaam</string>
+	<string name="site_privacy_public_desc">Laat zoekmachines deze site indexeren</string>
+	<string name="site_privacy_hidden_desc">Laat zoekmachines deze site niet indexeren</string>
+	<string name="site_privacy_private_desc">Ik wil dat mijn site privé blijft en dat ik zelf kies voor wie hij zichtbaar is</string>
+	<string name="cd_related_post_preview_image">Voorbeeldafbeelding van gerelateerd bericht bekijken</string>
+	<string name="error_post_remote_site_settings">Kan site-informatie niet opslaan</string>
+	<string name="error_fetch_remote_site_settings">Kan site-informatie niet ophalen</string>
+	<string name="error_media_upload_connection">Er is een verbindingsfout opgetreden bij het uploaden van media</string>
+	<string name="site_settings_disconnected_toast">Niet verbonden, bijwerken uitgeschakeld.</string>
+	<string name="site_settings_unsupported_version_error">Niet-ondersteunde versie van WordPress</string>
+	<string name="site_settings_multiple_links_dialog_description">Vereist goedkeuring voor reacties die meer dan dit aantal koppelingen bevatten.</string>
+	<string name="site_settings_close_after_dialog_switch_text">Automatisch afsluiten</string>
+	<string name="site_settings_close_after_dialog_description">Sluit reacties op artikelen automatisch af.</string>
+	<string name="site_settings_paging_dialog_description">Deel reacties in threads op in meerdere pagina\'s.</string>
+	<string name="site_settings_paging_dialog_header">Reacties per pagina</string>
+	<string name="site_settings_close_after_dialog_title">Reacties afsluiten</string>
+	<string name="site_settings_blacklist_description">Wanneer een reactie een van deze woorden bevat in de inhoud, naam, URL, e-mailadres of IP-adres, wordt het gemarkeerd als spam. Ook delen van woorden worden gevonden, dus "press" levert ook "WordPress" op als resultaat.</string>
+	<string name="site_settings_hold_for_moderation_description">Wanneer een reactie een van deze woorden bevat in de inhoud, naam, URL, het e-mailadres of IP-adres, wordt hij in de wachtrij voor moderatie gezet. Ook delen van woorden worden gevonden, dus "press" levert ook "WordPress" op als resultaat.</string>
+	<string name="site_settings_list_editor_input_hint">Voer een woord of zinsdeel in</string>
+	<string name="site_settings_list_editor_no_items_text">Geen items</string>
+	<string name="site_settings_learn_more_caption">Je kunt deze instellingen ongedaan maken voor individuele berichten.</string>
+	<string name="site_settings_rp_preview3_site">in "Upgrade"</string>
+	<string name="site_settings_rp_preview3_title">Upgradefocus: VideoPress voor bruiloften</string>
+	<string name="site_settings_rp_preview2_site">in "Apps"</string>
+	<string name="site_settings_rp_preview2_title">De WordPress voor Android-app krijgt een grote update</string>
+	<string name="site_settings_rp_preview1_site">in "Mobiel"</string>
+	<string name="site_settings_rp_preview1_title">Grote update voor iPhone/iPad nu beschikbaar</string>
+	<string name="site_settings_rp_show_images_title">Afbeeldingen weergeven</string>
+	<string name="site_settings_rp_show_header_title">Koptekst weergeven</string>
+	<string name="site_settings_rp_switch_summary">Gerelateerde berichten geeft relevante content van je site weer onder je berichten.</string>
+	<string name="site_settings_rp_switch_title">Gerelateerde berichten weergeven</string>
+	<string name="site_settings_delete_site_hint">Verwijder je sitegegevens van de app</string>
+	<string name="site_settings_blacklist_hint">Reacties die overeenkomen met een filter worden als spam gemarkeerd</string>
+	<string name="site_settings_moderation_hold_hint">Reacties die overeenkomen met een filter worden in de wachtrij voor moderatie gezet</string>
+	<string name="site_settings_multiple_links_hint">Negeert koppelingslimiet van bekende gebruikers</string>
+	<string name="site_settings_whitelist_hint">De reactie-auteur moet eerder een goedgekeurde reactie hebben geplaatst</string>
+	<string name="site_settings_user_account_required_hint">Gebruikers moeten geregistreerd en ingelogd zijn om een reactie te plaatsen</string>
+	<string name="site_settings_identity_required_hint">De reactie-auteur moet zijn of haar naam en e-mailadres invullen</string>
+	<string name="site_settings_manual_approval_hint">Reacties moeten handmatig worden goedgekeurd</string>
+	<string name="site_settings_paging_hint">Geef reacties weer in delen van een specifieke grootte</string>
+	<string name="site_settings_threading_hint">Geneste reacties toestaan tot een bepaalde diepte</string>
+	<string name="site_settings_sort_by_hint">Bepaalt de volgorde waarin reacties worden weergegeven</string>
+	<string name="site_settings_close_after_hint">Reacties niet meer toestaan na bepaalde tijd</string>
+	<string name="site_settings_receive_pingbacks_hint">Koppelingsmeldingen van andere blogs toestaan</string>
+	<string name="site_settings_send_pingbacks_hint">Probeer een melding te maken op alle blogs waaraan het artikel is gekoppeld</string>
+	<string name="site_settings_allow_comments_hint">Toestaan dat lezers reacties plaatsen</string>
+	<string name="site_settings_discussion_hint">Geef discussie-instellingen van je site weer en wijzig ze</string>
+	<string name="site_settings_more_hint">Geef alle beschikbare discussie-instellingen weer</string>
+	<string name="site_settings_related_posts_hint">Toon of verberg alle gerelateerde berichten in de reader</string>
+	<string name="site_settings_upload_and_link_image_hint">Inschakelen dat de afbeelding altijd op volledige grootte wordt geüpload</string>
+	<string name="site_settings_image_width_hint">De afmeting van afbeeldingen in berichten wijzigen naar deze breedte</string>
+	<string name="site_settings_format_hint">Een nieuwe post format instellen</string>
+	<string name="site_settings_category_hint">Een nieuwe berichtcategorie instellen</string>
+	<string name="site_settings_location_hint">Automatisch locatiegegevens aan je berichten toevoegen</string>
+	<string name="site_settings_password_hint">Wijzig je wachtwoord</string>
+	<string name="site_settings_username_hint">Huidig gebruikersaccount</string>
+	<string name="site_settings_language_hint">Taal waarin deze blog voornamelijk is geschreven</string>
+	<string name="site_settings_privacy_hint">Beheert wie je site kan zien</string>
+	<string name="site_settings_address_hint">Het wijzigen van je adres wordt momenteel niet ondersteund</string>
+	<string name="site_settings_tagline_hint">Een korte beschrijving of een pakkende zin om je blog te omschrijven</string>
+	<string name="site_settings_title_hint">Leg in een paar woorden uit waar deze site over gaat</string>
+	<string name="site_settings_whitelist_known_summary">Reacties van bekende gebruikers</string>
+	<string name="site_settings_whitelist_all_summary">Reacties van alle gebruikers</string>
+	<string name="site_settings_threading_summary">%d niveaus</string>
+	<string name="site_settings_privacy_private_summary">Privé</string>
+	<string name="site_settings_privacy_hidden_summary">Verborgen</string>
+	<string name="site_settings_delete_site_title">Site verwijderen</string>
+	<string name="site_settings_privacy_public_summary">Openbaar</string>
+	<string name="site_settings_blacklist_title">Blacklist</string>
+	<string name="site_settings_moderation_hold_title">In de wacht zetten voor moderatie</string>
+	<string name="site_settings_multiple_links_title">Koppelingen in reacties</string>
+	<string name="site_settings_whitelist_title">Automatisch goedkeuren</string>
+	<string name="site_settings_threading_title">Weergave threads</string>
+	<string name="site_settings_paging_title">Weergave pagina\'s</string>
+	<string name="site_settings_sort_by_title">Sorteren op</string>
+	<string name="site_settings_account_required_title">Gebruikers moeten aangemeld zijn</string>
+	<string name="site_settings_identity_required_title">Moet naam en e-mail bevatten</string>
+	<string name="site_settings_receive_pingbacks_title">Pingbacks ontvangen</string>
+	<string name="site_settings_send_pingbacks_title">Pingbacks verzenden</string>
+	<string name="site_settings_allow_comments_title">Reacties toestaan</string>
+	<string name="site_settings_default_format_title">Standaard indeling</string>
+	<string name="site_settings_default_category_title">Standaard categorie</string>
+	<string name="site_settings_location_title">Locatie inschakelen</string>
+	<string name="site_settings_address_title">Adres</string>
+	<string name="site_settings_title_title">Sitetitel</string>
+	<string name="site_settings_tagline_title">Slogan</string>
+	<string name="site_settings_this_device_header">Dit apparaat</string>
+	<string name="site_settings_discussion_new_posts_header">Standaardinstellingen voor nieuwe berichten</string>
+	<string name="site_settings_account_header">Account</string>
+	<string name="site_settings_writing_header">Schrijven</string>
+	<string name="newest_first">Nieuwste eerst</string>
+	<string name="site_settings_general_header">Algemeen</string>
+	<string name="discussion">Reacties</string>
+	<string name="privacy">Privacy</string>
+	<string name="related_posts">Gerelateerde berichten</string>
+	<string name="comments">Commentaar</string>
+	<string name="close_after">Hierna sluiten</string>
+	<string name="oldest_first">Oudste eerst</string>
+	<string name="media_error_no_permission_upload">Je hebt geen toestemming om media naar de site te uploaden</string>
+	<string name="never">Nooit</string>
+	<string name="unknown">Onbekend</string>
 	<string name="reader_err_get_post_not_found">Dit bericht bestaat niet meer</string>
 	<string name="reader_err_get_post_not_authorized">Je hebt geen rechten om dit bericht te lezen</string>
 	<string name="reader_err_get_post_generic">Kan dit bericht niet ophalen</string>
@@ -117,14 +225,12 @@
 	<string name="days_ago">%d dagen geleden</string>
 	<string name="yesterday">Gisteren</string>
 	<string name="connectionbar_no_connection">Geen verbinging</string>
-	<string name="button_delete">Verwijderen</string>
 	<string name="button_publish">Publiceren</string>
 	<string name="post_deleted">Bericht verwijderd</string>
 	<string name="post_trashed">Bericht naar de prullenbak verplaatst</string>
 	<string name="page_trashed">Pagina naar de prullenbak verplaatst.</string>
 	<string name="button_back">Terug</string>
 	<string name="page_deleted">Pagina verwijderd</string>
-	<string name="button_more">Meer</string>
 	<string name="button_stats">Statistieken</string>
 	<string name="button_trash">Prullenbak</string>
 	<string name="button_edit">Bewerken</string>
@@ -170,7 +276,6 @@
 	<string name="my_site_btn_view_site">Bekijk site</string>
 	<string name="my_site_header_publish">Publiceren</string>
 	<string name="my_site_header_look_and_feel">Look and feel</string>
-	<string name="my_site_btn_comments">Reacties</string>
 	<string name="my_site_btn_blog_posts">Blogberichten</string>
 	<string name="my_site_btn_site_settings">Instellingen</string>
 	<string name="reader_label_new_posts_subtitle">Tik om ze te tonen</string>
@@ -221,6 +326,8 @@
 	<string name="two_step_sms_sent">Kijk in je sms\'jes voor de verificatiecode.</string>
 	<string name="sign_in_jetpack">Meld je aan bij je WordPress.com account om verbinding te maken met Jetpack.</string>
 	<string name="auth_required">Meld je opnieuw aan om door te gaan.</string>
+	<string name="media_details_label_file_name">Bestandsnaam</string>
+	<string name="media_details_label_file_type">Bestandstype</string>
 	<string name="posts_fetching">Fetching posts…</string>
 	<string name="media_fetching">Fetching media…</string>
 	<string name="pages_fetching">Fetching pages…</string>
@@ -252,7 +359,6 @@
 	<string name="stats_comments_total_comments_followers">Totaalaantal berichten met reactievolgers: %1$s</string>
 	<string name="stats_visitors">Bezoekers</string>
 	<string name="stats_likes">Waarderingen</string>
-	<string name="stats_comments">Reacties</string>
 	<string name="stats_pagination_label">Pagina %1$s van %2$s</string>
 	<string name="stats_timeframe_years">Jaren</string>
 	<string name="stats_views">Weergaven</string>
@@ -328,7 +434,6 @@
 	<string name="reader_empty_posts_in_tag">Geen berichten met deze tag</string>
 	<string name="reader_label_view_original">Bekijk oorspronkelijk artikel</string>
 	<string name="reader_label_like">Like</string>
-	<string name="reader_title_comments">Reacties</string>
 	<string name="reader_label_comments_on">Reacties op</string>
 	<string name="error_refresh_unauthorized_posts">Je hebt geen rechten om berichten te bekijken of te bewerken</string>
 	<string name="reader_title_photo_viewer">%1$d van %2$d</string>
@@ -338,6 +443,7 @@
 	<string name="comment">Reactie</string>
 	<string name="comment_trashed">Reactie verwijderd</string>
 	<string name="older_month">Ouder dan een maand</string>
+	<string name="more">Meer</string>
 	<string name="older_two_days">Ouder dan 2 dagen</string>
 	<string name="older_last_week">Ouder dan een week</string>
 	<string name="select_a_blog">Selecteer een WordPress site</string>
@@ -668,7 +774,6 @@
 	<string name="stats_totals_views">Views</string>
 	<string name="stats_totals_clicks">Kliks</string>
 	<string name="stats_totals_plays">Afgespeeld</string>
-	<string name="stats_totals_comments">Reacties</string>
 	<string name="passcode_preference_title">PIN slot</string>
 	<string name="passcode_turn_off">Zet PIN slot uit</string>
 	<string name="passcode_turn_on">Zet PIN slot uit</string>
@@ -691,7 +796,6 @@
 	<string name="stats_timeframe_months">Maanden</string>
 	<string name="stats_timeframe_yesterday">Gisteren</string>
 	<string name="stats_view_referrers">Top auteurs</string>
-	<string name="stats_view_comments">Reacties</string>
 	<string name="stats_timeframe_today">Vandaag</string>
 	<string name="media_gallery_type_tiled">Tegels</string>
 	<string name="upload">Upload</string>
@@ -736,7 +840,7 @@
 	<string name="tos">Eindgebruikersovereenkomst</string>
 	<string name="app_title">WordPress voor Android</string>
 	<string name="about">Over</string>
-	<string name="max_thumbnail_px_width">Standaard breedte afbeelding</string>
+	<string name="max_thumbnail_px_width">Standaardbreedte van afbeelding</string>
 	<string name="image_alignment">Uitlijning </string>
 	<string name="refresh">Vernieuw</string>
 	<string name="untitled">Zonder titel</string>
@@ -774,7 +878,6 @@
 	<string name="reply">Beantwoord</string>
 	<string name="on">aan</string>
 	<string name="add">Voeg toe</string>
-	<string name="tab_comments">Reacties</string>
 	<string name="error">Fout</string>
 	<string name="cancel">Annuleer </string>
 	<string name="save">Bewaar</string>
@@ -826,6 +929,33 @@
 		<item>Standaard</item>
 		<item>Status</item>
 		<item>Video</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>Je site kan door iedereen worden bekeken en kan worden geïndexeerd door zoekmachines</item>
+		<item>Je site kan door iedereen worden bekeken, maar wordt niet geïndexeerd door zoekmachines</item>
+		<item>Je site is alleen zichtbaar voor jou en gebruikers die je goedkeurt</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>Vereist handmatige goedkeuring voor de reacties van iedereen.</item>
+		<item>Keur de reactie automatisch goed indien de gebruiker eerder een goedgekeurde reactie heeft geplaatst.</item>
+		<item>Keur de reacties van iedereen automatisch goed.</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>Geen reacties</item>
+		<item>Reacties van bekende gebruikers</item>
+		<item>Alle gebruikers</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>Geen</item>
+		<item>Twee niveaus</item>
+		<item>Drie niveaus</item>
+		<item>Vier niveaus</item>
+		<item>Vijf niveaus</item>
+		<item>Zes niveaus</item>
+		<item>Zeven niveaus</item>
+		<item>Acht niveaus</item>
+		<item>Negen niveaus</item>
+		<item>Tien niveaus</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>Gratis</item>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -70,7 +70,6 @@
 	<string name="stats_visitors">Odwiedzających</string>
 	<string name="stats_pagination_label">Strona %1$s z %2$s</string>
 	<string name="stats_timeframe_years">Lata</string>
-	<string name="stats_comments">Komentarze</string>
 	<string name="stats_view_countries">Kraje</string>
 	<string name="stats_likes">Polubienia</string>
 	<string name="stats_view_followers">Śledzący</string>
@@ -137,7 +136,7 @@
 	<string name="reader_label_view_original">Zobacz oryginalny artykuł</string>
 	<string name="reader_label_like">Lubię to</string>
 	<string name="reader_label_comment_count_single">Jeden komentarz</string>
-	<string name="reader_title_comments">Komentarze</string>
+	<string name="more">Więcej</string>
 	<string name="create_new_blog_wpcom">Stwórz blog na WordPress.com</string>
 	<string name="reader_title_photo_viewer">%1$d z %2$d</string>
 	<string name="error_publish_empty_post">Nie można opublikować pustego wpisu</string>
@@ -458,7 +457,6 @@
 	<string name="stats_view_visitors_and_views">Odwiedzający i wyświetlenia</string>
 	<string name="stats_view_clicks">Kliknięcia</string>
 	<string name="stats_view_tags_and_categories">Tagi i kategorie</string>
-	<string name="stats_view_comments">Komentarze</string>
 	<string name="stats_timeframe_today">Dzisiaj</string>
 	<string name="stats_timeframe_yesterday">Wczoraj</string>
 	<string name="stats_timeframe_days">Dni</string>
@@ -471,7 +469,6 @@
 	<string name="stats_totals_views">Wizyty</string>
 	<string name="stats_totals_clicks">Kliknięcia</string>
 	<string name="stats_totals_plays">Odtworzenia</string>
-	<string name="stats_totals_comments">Komentarze</string>
 	<string name="menu_search">Szukaj</string>
 	<string name="passcode_enter_passcode">Podaj swój PIN</string>
 	<string name="passcode_enter_old_passcode">Podaj swój stary PIN</string>
@@ -539,7 +536,6 @@
 	<string name="app_title">WordPress dla Androida</string>
 	<string name="tos">Warunki korzystania</string>
 	<string name="about">O nas</string>
-	<string name="max_thumbnail_px_width">Domyślna szerokość obrazu</string>
 	<string name="image_alignment">Wyrównanie</string>
 	<string name="refresh">Odśwież</string>
 	<string name="untitled">Bez tytułu</string>
@@ -576,7 +572,6 @@
 	<string name="yes">Tak</string>
 	<string name="no">Nie</string>
 	<string name="on">na</string>
-	<string name="tab_comments">Komentarze</string>
 	<string name="category_refresh_error">Błąd odświeżania kategorii</string>
 	<string name="cancel">Anuluj</string>
 	<string name="save">Zapisz</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -1,5 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="about_me">Sobre mim</string>
+	<string name="first_name">Nome</string>
+	<string name="last_name">Sobrenome</string>
+	<string name="my_profile">Meu perfil</string>
+	<string name="error_post_remote_site_settings">Não foi possível salvar as informações do site</string>
+	<string name="reader_err_get_post_not_found">Este post não existe mais</string>
+	<string name="reader_err_get_post_not_authorized">Você não possui autorização para ver este post</string>
+	<string name="reader_err_get_post_generic">Falha ao carregar esse post</string>
+	<string name="blog_name_no_spaced_allowed">O endereço do site não pode conter espaços</string>
+	<string name="invalid_username_no_spaces">O nome de usuário não pode conter espaços</string>
+	<string name="reader_empty_followed_blogs_no_recent_posts_description">Os sites que você segue não publicaram nada recentemente</string>
+	<string name="reader_empty_followed_blogs_no_recent_posts_title">Não há posts recentes</string>
+	<string name="edit_media">Editar mídia</string>
+	<string name="media_details_copy_url_toast">A URL foi copiada para a área de transferência</string>
+	<string name="media_details_copy_url">Copiar URL</string>
+	<string name="media_details_label_date_uploaded">Upload completo</string>
+	<string name="media_details_label_date_added">Adicionada</string>
 	<string name="selected_theme">Tema selecionado</string>
 	<string name="could_not_load_theme">Não foi possível carregar o tema</string>
 	<string name="theme_activation_error">Algo deu errado. Não foi possível ativar o tema</string>
@@ -112,14 +129,12 @@
 	<string name="trashed">Na lixeira</string>
 	<string name="button_back">Voltar</string>
 	<string name="page_deleted">Página excluída</string>
-	<string name="button_more">Mais</string>
 	<string name="button_stats">Estatísticas</string>
 	<string name="button_trash">Enviar para a lixeira</string>
 	<string name="button_preview">Visualizar</string>
 	<string name="button_view">Exibir</string>
 	<string name="button_edit">Editar</string>
 	<string name="button_publish">Publicar</string>
-	<string name="button_delete">Excluir</string>
 	<string name="my_site_no_sites_view_subtitle">Deseja adicionar um?</string>
 	<string name="my_site_no_sites_view_title">Você ainda não possui nenhum site do WordPress.</string>
 	<string name="my_site_no_sites_view_drake">Ilustração</string>
@@ -159,7 +174,6 @@
 	<string name="my_site_btn_blog_posts">Posts do blog</string>
 	<string name="my_site_btn_site_settings">Configurações</string>
 	<string name="my_site_header_look_and_feel">Aparência</string>
-	<string name="my_site_btn_comments">Comentários</string>
 	<string name="my_site_header_publish">Publicar</string>
 	<string name="my_site_header_admin">Painel</string>
 	<string name="reader_label_new_posts_subtitle">Toque para mostrar</string>
@@ -239,7 +253,6 @@
 	<string name="reader_page_recommended_blogs">Talvez você goste destes sites</string>
 	<string name="stats_comments_total_comments_followers">Total de posts com comentários de seguidores: %1$s</string>
 	<string name="stats_visitors">Visitantes</string>
-	<string name="stats_comments">Comentários</string>
 	<string name="stats_pagination_label">Página %1$s de %2$s</string>
 	<string name="stats_timeframe_years">Anos</string>
 	<string name="stats_views">Visualizações</string>
@@ -317,13 +330,13 @@
 	<string name="reader_label_comment_count_single">Um comentário</string>
 	<string name="reader_label_comments_closed">Os comentários estão desativados</string>
 	<string name="reader_label_comments_on">Comentários sobre</string>
-	<string name="reader_title_comments">Comentários</string>
 	<string name="reader_title_photo_viewer">%1$d de %2$d</string>
 	<string name="error_publish_empty_post">Não é possível publicar um post em branco</string>
 	<string name="error_refresh_unauthorized_posts">Você não tem permissão para visualizar ou editar posts</string>
 	<string name="error_refresh_unauthorized_pages">Você não tem permissão para visualizar ou editar páginas</string>
 	<string name="error_refresh_unauthorized_comments">Você não tem permissão para visualizar ou editar comentários</string>
 	<string name="older_month">Há mais de um mês</string>
+	<string name="more">Mais</string>
 	<string name="older_two_days">Há mais de 2 dias</string>
 	<string name="older_last_week">Há mais de uma semana</string>
 	<string name="stats_no_blog">Não foi possível carregar as estatísticas do blog</string>
@@ -636,7 +649,6 @@
 	<string name="share_action_title">Adicionar para...</string>
 	<string name="stats_view_tags_and_categories">Tags e Categorias</string>
 	<string name="stats_view_clicks">Cliques</string>
-	<string name="stats_view_comments">Comentários</string>
 	<string name="stats_timeframe_today">Hoje</string>
 	<string name="stats_view_referrers">Referências</string>
 	<string name="stats_timeframe_yesterday">Ontem</string>
@@ -651,7 +663,6 @@
 	<string name="stats_totals_clicks">Cliques</string>
 	<string name="stats_entry_referrers">Referências</string>
 	<string name="stats_totals_plays">Tocados</string>
-	<string name="stats_totals_comments">Comentários</string>
 	<string name="media_gallery_type_squares">Quadrados</string>
 	<string name="media_gallery_type_circles">Circulos</string>
 	<string name="media_gallery_type_slideshow">Slideshow</string>
@@ -724,7 +735,6 @@
 	<string name="tos">Termos de Serviço</string>
 	<string name="app_title">WordPress para Android</string>
 	<string name="about">Sobre</string>
-	<string name="max_thumbnail_px_width">Largura padrão de imagem</string>
 	<string name="image_alignment">Alinhamento</string>
 	<string name="refresh">Atualizar</string>
 	<string name="untitled">Sem Título</string>
@@ -763,7 +773,6 @@
 	<string name="cancel">Cancelar</string>
 	<string name="save">Salvar</string>
 	<string name="add">Adicionar</string>
-	<string name="tab_comments">Comentários</string>
 	<string name="category_refresh_error">Erro na atualização da categoria</string>
 	<string name="on">em</string>
 	<string name="reply">Responder</string>
@@ -814,6 +823,10 @@
 		<item>Padrão</item>
 		<item>Status</item>
 		<item>Vídeo</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>Seu site está visível para todos e pode ser indexado por mecanismos de busca</item>
+		<item>Seu site está visível para todos mas solicita aos mecanismos de busca para não indexá-lo</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>Gratuito</item>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">Mărime originală</string>
+	<string name="about_me_hint">Câteva cuvinte despre tine...</string>
+	<string name="public_display_name_hint">Numele afișat va fi implicit numele utilizator dacă nu este setat</string>
+	<string name="about_me">Despre mine</string>
+	<string name="public_display_name">Numele afișat public</string>
+	<string name="my_profile">Profilul meu</string>
+	<string name="first_name">Prenume</string>
+	<string name="last_name">Nume</string>
+	<string name="site_privacy_public_desc">Permite motoarelor de căutare să indexeze acest sit</string>
+	<string name="site_privacy_hidden_desc">Descurajează motoarele de căutare de la indexarea acestui sit</string>
+	<string name="site_privacy_private_desc">Aș vrea ca situl meu să fie privat, vizibil doar utilizatorilor pe care i-am ales</string>
+	<string name="cd_related_post_preview_image">Imagine previzualizare articol similar</string>
+	<string name="error_post_remote_site_settings">N-am putut salva informațiile despre sit</string>
+	<string name="error_fetch_remote_site_settings">N-am putut primi informațiile despre sit</string>
+	<string name="error_media_upload_connection">A apărut o eroare în timp ce se încărca media</string>
+	<string name="site_settings_disconnected_toast">Deconectat, editare invalidată.</string>
+	<string name="site_settings_unsupported_version_error">Versiune de WordPress nesuportată</string>
+	<string name="site_settings_multiple_links_dialog_description">Necesită aprobarea pentru comentarii ce includ mai mult decât acest număr de legături.</string>
+	<string name="site_settings_close_after_dialog_switch_text">Închidere automată</string>
+	<string name="site_settings_close_after_dialog_description">Închide automat comentariile articolelor.</string>
+	<string name="site_settings_paging_dialog_description">Împarte firele de comentarii în mai multe pagini.</string>
+	<string name="site_settings_paging_dialog_header">Comentarii per pagină</string>
+	<string name="site_settings_close_after_dialog_title">Închidere comentare</string>
+	<string name="site_settings_blacklist_description">Când un comentariu conține oricare dintre aceste cuvinte în conținutul său, în nume, URL, email sau IP, va fi marcat ca spam. Poți introduce cuvinte parțiale, așa că "press" se va potrivi și pentru "WordPress".</string>
+	<string name="site_settings_hold_for_moderation_description">Când un comentariu conține oricare dintre aceste cuvinte în conținutul său, în nume, URL, email sau IP, va fi reținut în coada de moderare. Poți introduce cuvinte parțiale, așa că "press" se va potrivi și pentru "WordPress".</string>
+	<string name="site_settings_list_editor_input_hint">Introdu un cuvânt sau frază</string>
+	<string name="site_settings_list_editor_no_items_text">Niciun element</string>
+	<string name="site_settings_learn_more_caption">Poți suprascrie aceste setări pentru fiecare articol.</string>
+	<string name="site_settings_rp_preview3_site">în "Actualizare"</string>
+	<string name="site_settings_rp_preview3_title">Focalizare actualizare: VideoPress pentru nunți</string>
+	<string name="site_settings_rp_preview2_site">în "Applicații"</string>
+	<string name="site_settings_rp_preview2_title">Aplicația WordPress pentru Android a primit o mare actualizare a aspectului</string>
+	<string name="site_settings_rp_preview1_site">în "Mobile"</string>
+	<string name="site_settings_rp_preview1_title">Este disponibilă o importantă actualizare pentru iPhone/iPad</string>
+	<string name="site_settings_rp_show_images_title">Arată imaginile</string>
+	<string name="site_settings_rp_show_header_title">Arată antetul</string>
+	<string name="site_settings_rp_switch_summary">Articole similare afișează conținut relevant de pe situl tău sub articolele tale.</string>
+	<string name="site_settings_rp_switch_title">Arată articolele similare</string>
+	<string name="site_settings_delete_site_hint">Înlătură datele sitului tău din aplicație</string>
+	<string name="site_settings_blacklist_hint">Comentariile care corespund unui filtru sunt marcate ca spam</string>
+	<string name="site_settings_moderation_hold_hint">Comentariile care corespund unui filtru sunt puse în coada de moderare</string>
+	<string name="site_settings_multiple_links_hint">Ignoră limita de legături pentru utilizatorii cunoscuți</string>
+	<string name="site_settings_whitelist_hint">Autorul comentariului trebuie să mai aibă un comentariu anterior aprobat</string>
+	<string name="site_settings_user_account_required_hint">Utilizatorul trebuie să fie înregistrat și autentificat pentru a comenta</string>
+	<string name="site_settings_identity_required_hint">Autorul comentariului trebuie să completeze numele și emailul său</string>
+	<string name="site_settings_manual_approval_hint">Comentariile trebuie să fie aprobate manual</string>
+	<string name="site_settings_paging_hint">Afișează comentariile în tranșe de o anumită mărime</string>
+	<string name="site_settings_threading_hint">Permite imbricarea comentariilor până la un anumit nivel</string>
+	<string name="site_settings_sort_by_hint">Determinarea ordinii afișării comentariilor</string>
+	<string name="site_settings_close_after_hint">Interzicere comentarii după un anumit timp</string>
+	<string name="site_settings_receive_pingbacks_hint">Permite notificări despre legături de la alte bloguri</string>
+	<string name="site_settings_send_pingbacks_hint">Încearcă să notifici orice bloguri cu legături din articol</string>
+	<string name="site_settings_allow_comments_hint">Permite cititorilor să publice comentarii</string>
+	<string name="site_settings_discussion_hint">Vezi și modifică setările pentru discuții ale siturilor tale</string>
+	<string name="site_settings_more_hint">Vezi toate setările disponibile pentru discuții</string>
+	<string name="site_settings_related_posts_hint">Arată sau ascunde articolele similare în cititor</string>
+	<string name="site_settings_upload_and_link_image_hint">Validează ca întotdeauna imaginile să fie încărcate la dimensiune completă</string>
+	<string name="site_settings_image_width_hint">Rescalează imaginile în articole la această lățime</string>
+	<string name="site_settings_format_hint">Setare format nou de articol</string>
+	<string name="site_settings_category_hint">Setare categorie nouă de articol</string>
+	<string name="site_settings_location_hint">Adaugă automat informații despre locație articolelor tale</string>
+	<string name="site_settings_password_hint">Schimbă parola ta</string>
+	<string name="site_settings_username_hint">Contul utilizator curent</string>
+	<string name="site_settings_language_hint">Limba principală în care se scrie pe blogul tău</string>
+	<string name="site_settings_privacy_hint">Controlează cine poate vedea situl tău</string>
+	<string name="site_settings_address_hint">Schimbarea adresei nu este încă suportată</string>
+	<string name="site_settings_tagline_hint">O scurtă descriere sau o frază de impact pentru a descrie blogul tău</string>
+	<string name="site_settings_title_hint">Explică, în câteva cuvinte, despre ce este acest sit</string>
+	<string name="site_settings_whitelist_known_summary">Comentarii de la utilizatori necunoscuți</string>
+	<string name="site_settings_whitelist_all_summary">Comentarii de la toți utilizatorii</string>
+	<string name="site_settings_threading_summary">%d nivele</string>
+	<string name="site_settings_privacy_private_summary">Privat</string>
+	<string name="site_settings_privacy_hidden_summary">Ascuns</string>
+	<string name="site_settings_delete_site_title">Șterge sit</string>
+	<string name="site_settings_privacy_public_summary">Public</string>
+	<string name="site_settings_blacklist_title">Lista neagră</string>
+	<string name="site_settings_moderation_hold_title">Reținere pentru moderare</string>
+	<string name="site_settings_multiple_links_title">Legături și comentarii</string>
+	<string name="site_settings_whitelist_title">Aprobare automată</string>
+	<string name="site_settings_threading_title">Fire de discuție</string>
+	<string name="site_settings_paging_title">Paginare</string>
+	<string name="site_settings_sort_by_title">Sortează după</string>
+	<string name="site_settings_account_required_title">Utilizatorul trebuie să fie autentificat</string>
+	<string name="site_settings_identity_required_title">Trebuie incluse numele si emailul</string>
+	<string name="site_settings_receive_pingbacks_title">Primire pingback-uri</string>
+	<string name="site_settings_send_pingbacks_title">trimite pingback-uri</string>
+	<string name="site_settings_allow_comments_title">Permite comentariile</string>
+	<string name="site_settings_default_format_title">Format implicit</string>
+	<string name="site_settings_default_category_title">Categorie implicită</string>
+	<string name="site_settings_location_title">Validează locația</string>
+	<string name="site_settings_address_title">Adresă</string>
+	<string name="site_settings_title_title">Titlu sit</string>
+	<string name="site_settings_tagline_title">Slogan</string>
+	<string name="site_settings_this_device_header">Acest dispozitiv</string>
+	<string name="site_settings_discussion_new_posts_header">Implicite pentru articole noi</string>
+	<string name="site_settings_account_header">Cont</string>
+	<string name="site_settings_writing_header">Scriere</string>
+	<string name="newest_first">Cele mai noi la început</string>
+	<string name="site_settings_general_header">Generale</string>
+	<string name="discussion">Discuție</string>
+	<string name="privacy">Confidențialitate</string>
+	<string name="related_posts">Articole similare</string>
+	<string name="comments">Comentarii</string>
+	<string name="close_after">Închise după</string>
+	<string name="oldest_first">Cele mai vechi la început</string>
+	<string name="media_error_no_permission_upload">Nu ai permisiunea de a încărca media pe sit</string>
+	<string name="never">Niciodată</string>
+	<string name="unknown">Necunoscut</string>
 	<string name="reader_err_get_post_not_found">Acest articol nu mai există</string>
 	<string name="reader_err_get_post_not_authorized">Nu ești autorizat să vezi acest articol</string>
 	<string name="reader_err_get_post_generic">Acest articol nu poate fi regăsit</string>
@@ -124,14 +232,12 @@
 	<string name="trashed">Aruncat la gunoi</string>
 	<string name="button_back">Înapoi</string>
 	<string name="page_deleted">Pagină ștearsă</string>
-	<string name="button_more">Mai mult</string>
 	<string name="button_stats">Statistici</string>
 	<string name="button_trash">Gunoi</string>
 	<string name="button_preview">Previzualizare</string>
 	<string name="button_view">Vizualizare</string>
 	<string name="button_edit">Editare</string>
 	<string name="button_publish">Publică</string>
-	<string name="button_delete">Șters</string>
 	<string name="my_site_no_sites_view_subtitle">Vrei să adaugi unul?</string>
 	<string name="my_site_no_sites_view_title">Încă nu ai niciun sit WordPress.</string>
 	<string name="my_site_no_sites_view_drake">Ilustrație</string>
@@ -170,7 +276,6 @@
 	<string name="site_picker_title">Alege sit</string>
 	<string name="my_site_header_publish">Publicare</string>
 	<string name="my_site_header_look_and_feel">Aspect și afect</string>
-	<string name="my_site_btn_comments">Comentarii</string>
 	<string name="my_site_btn_site_settings">Setări</string>
 	<string name="my_site_btn_blog_posts">Articole blog</string>
 	<string name="reader_label_new_posts_subtitle">Atinge pentru a le arăta</string>
@@ -252,7 +357,6 @@
 	<string name="post_uploading">Încărcare</string>
 	<string name="reader_page_recommended_blogs">Situri care s-ar putea să-ți placă</string>
 	<string name="stats_comments_total_comments_followers">Total articole cu urmăritori ai comentarilor: %1$s</string>
-	<string name="stats_comments">Comentarii</string>
 	<string name="stats_views">Vizualizări</string>
 	<string name="stats_likes">Plăcute</string>
 	<string name="stats_view_followers">Urmăritori</string>
@@ -335,13 +439,13 @@
 	<string name="older_two_days">Mai vechi de 2 zile</string>
 	<string name="older_last_week">Mai vechi de o săptămână</string>
 	<string name="older_month">Mai vechi de o lună</string>
+	<string name="more">Mai mult</string>
 	<string name="error_refresh_unauthorized_pages">Nu ai permisiunea de a vedea sau edita pagini</string>
 	<string name="error_refresh_unauthorized_comments">Nu ai permisiunea de a vedea sau edita comentarii</string>
 	<string name="error_refresh_unauthorized_posts">Nu ai permisiunea de a vedea sau edita articole</string>
 	<string name="reader_label_comment_count_single">Un comentariu</string>
 	<string name="reader_label_comments_closed">Comentariile sunt închise</string>
 	<string name="reader_label_comments_on">Comentarii deschise</string>
-	<string name="reader_title_comments">Comentarii</string>
 	<string name="error_publish_empty_post">Nu pot publica un articol gol</string>
 	<string name="reader_label_view_original">Vezi articolul original</string>
 	<string name="reader_label_like">Place</string>
@@ -647,7 +751,6 @@
 	<string name="share_action">Partajare</string>
 	<string name="stats_totals_clicks">Clicuri</string>
 	<string name="stats_totals_plays">Rulări</string>
-	<string name="stats_totals_comments">Comentarii</string>
 	<string name="stats_totals_views">Vizualizări</string>
 	<string name="stats_entry_referrers">Referință</string>
 	<string name="stats_entry_tags_and_categories">Subiect</string>
@@ -661,7 +764,6 @@
 	<string name="stats_view_visitors_and_views">Vizitatori și vizualizări</string>
 	<string name="stats_view_clicks">Clicuri</string>
 	<string name="stats_view_referrers">Referințe</string>
-	<string name="stats_view_comments">Comentarii</string>
 	<string name="stats_timeframe_today">Azi</string>
 	<string name="stats">statistici</string>
 	<string name="share_action_title">Adaug la...</string>
@@ -738,7 +840,7 @@
 	<string name="version">Versiune</string>
 	<string name="tos">Termenii de funcționare a serviciului</string>
 	<string name="about">Despre</string>
-	<string name="max_thumbnail_px_width">Lățime implicită imagine</string>
+	<string name="max_thumbnail_px_width">Lățime imagine implicită</string>
 	<string name="image_alignment">Aliniere</string>
 	<string name="refresh">Reîmprospătare</string>
 	<string name="untitled">Fără titlu</string>
@@ -774,7 +876,6 @@
 	<string name="preview">Previzualizare</string>
 	<string name="reply">Răspunde</string>
 	<string name="on">pornit</string>
-	<string name="tab_comments">Comentarii</string>
 	<string name="yes">Da</string>
 	<string name="no">Nu</string>
 	<string name="error">Eroare</string>
@@ -828,6 +929,33 @@
 		<item>Standard</item>
 		<item>Stare</item>
 		<item>Video</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>Situl tău este vizibil oricui și poate fi indexat de motoarele de căutare</item>
+		<item>Situl tău este vizibil oricui dar cere motoarelor de căutare să nu-l indexeze</item>
+		<item>Situl tău este vizibil doar pentru utilizatorii pe care i-ai aprobat</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>E necesară aprobarea manuală pentru comentariile fiecăruia.</item>
+		<item>Aprobă automat dacă utilizatorul are un comentariu anterior aprobat.</item>
+		<item>Aprobă automat comentariile fiecăruia.</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>Fără comnetarii</item>
+		<item>Comentariile utilizatorilor cunoscuți</item>
+		<item>Toți utilizatorii</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>Niciuna</item>
+		<item>Două nivele</item>
+		<item>Trei nivele</item>
+		<item>Patru nivele</item>
+		<item>Cinci nivele</item>
+		<item>Șase nivele</item>
+		<item>Șapte nivele</item>
+		<item>Opt nivele</item>
+		<item>Nouă nivele</item>
+		<item>Zece nivele</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>Gratis</item>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">Исходный размер</string>
+	<string name="about_me_hint">Несколько слов о себе…</string>
+	<string name="public_display_name_hint">Если отображаемое имя не задано, вместо него по умолчанию используется имя пользователя.</string>
+	<string name="about_me">Обо мне</string>
+	<string name="public_display_name">Отображаемое для всех имя</string>
+	<string name="my_profile">Мой профиль</string>
+	<string name="first_name">Имя</string>
+	<string name="last_name">Фамилия</string>
+	<string name="site_privacy_public_desc">Разрешить поисковым системам индексировать сайт</string>
+	<string name="site_privacy_hidden_desc">Попросить поисковые системы не индексировать сайт</string>
+	<string name="site_privacy_private_desc">Я хочу, чтобы мой блог был частным, а доступ к нему имели только те пользователи, которых я выберу.</string>
+	<string name="cd_related_post_preview_image">Изображение для предварительного просмотра похожих записей</string>
+	<string name="error_post_remote_site_settings">Не удалось сохранить данные сайта.</string>
+	<string name="error_fetch_remote_site_settings">Не удалось получить данные сайта.</string>
+	<string name="error_media_upload_connection">Ошибка подключения при загрузке медиафайла</string>
+	<string name="site_settings_disconnected_toast">Отключено, редактирование невозможно.</string>
+	<string name="site_settings_unsupported_version_error">Неподдерживаемая версия WordPress</string>
+	<string name="site_settings_multiple_links_dialog_description">Включить обязательный этап одобрения для комментариев, которые содержат больше указанного числа ссылок.</string>
+	<string name="site_settings_close_after_dialog_switch_text">Автоматически закрывать обсуждение</string>
+	<string name="site_settings_close_after_dialog_description">Автоматически закрывать обсуждение статей.</string>
+	<string name="site_settings_paging_dialog_description">Выделять ветки комментариев на отдельные страницы.</string>
+	<string name="site_settings_paging_dialog_header">Комментариев на странице:</string>
+	<string name="site_settings_close_after_dialog_title">Закрыть обсуждение</string>
+	<string name="site_settings_blacklist_description">Комментарии, содержащие любые из этих слов в тексте, имени автора, URL-адресе, адресе электронной почты или IP-адресе, будут помечены как спам. Можно вводить фрагменты слов, то есть по слову press будет найдено WordPress.</string>
+	<string name="site_settings_hold_for_moderation_description">Комментарии, содержащие любые из этих слов в тексте, имени автора, URL-адресе, адресе электронной почты или IP-адресе, будут помещены в очередь на модерацию. Можно вводить фрагменты слов, то есть по слову press будет найдено WordPress.</string>
+	<string name="site_settings_list_editor_input_hint">Введите слово или фразу</string>
+	<string name="site_settings_list_editor_no_items_text">Нет элементов</string>
+	<string name="site_settings_learn_more_caption">Можно изменять эти настройки для отдельных записей.</string>
+	<string name="site_settings_rp_preview3_site">в разделе «Обновление»</string>
+	<string name="site_settings_rp_preview3_title">Специальное обновление: VideoPress для свадеб</string>
+	<string name="site_settings_rp_preview2_site">в разделе «Приложения»</string>
+	<string name="site_settings_rp_preview2_title">Грандиозное обновление приложения WordPress для Android</string>
+	<string name="site_settings_rp_preview1_site">в разделе «Для мобильных устройств»</string>
+	<string name="site_settings_rp_preview1_title">Доступно большое обновление для iPhone и iPad</string>
+	<string name="site_settings_rp_show_images_title">Показывать изображения</string>
+	<string name="site_settings_rp_show_header_title">Показывать заголовок</string>
+	<string name="site_settings_rp_switch_summary">В разделе «Похожие записи» под вашими записями отображается соответствующее содержимое с вашего сайта.</string>
+	<string name="site_settings_rp_switch_title">Показывать похожие записи</string>
+	<string name="site_settings_delete_site_hint">Удаление данных вашего сайта из приложения</string>
+	<string name="site_settings_blacklist_hint">Комментарии, соответствующие фильтру, будут помечены как спам.</string>
+	<string name="site_settings_moderation_hold_hint">Комментарии, соответствующие фильтру, будут помещены в очередь на модерацию.</string>
+	<string name="site_settings_multiple_links_hint">Удаление ограничения по числу ссылок, размещаемых известными пользователями</string>
+	<string name="site_settings_whitelist_hint">Автор комментария должен иметь ранее одобренные комментарии.</string>
+	<string name="site_settings_user_account_required_hint">Чтобы оставить комментарий, пользователь должен быть зарегистрирован и авторизован.</string>
+	<string name="site_settings_identity_required_hint">Автор комментария должен указать имя и эл. адрес.</string>
+	<string name="site_settings_manual_approval_hint">Комментарий должен пройти обязательное одобрение.</string>
+	<string name="site_settings_paging_hint">Показ комментариев блоками определенного размера</string>
+	<string name="site_settings_threading_hint">Ограничить максимальный уровень вложенных комментариев</string>
+	<string name="site_settings_sort_by_hint">Определение порядка отображения комментариев</string>
+	<string name="site_settings_close_after_hint">Закрывать обсуждение через определенное время</string>
+	<string name="site_settings_receive_pingbacks_hint">Разрешить уведомления со ссылками из других блогов</string>
+	<string name="site_settings_send_pingbacks_hint">Отправлять уведомления во все блоги, на которые есть ссылки в статье</string>
+	<string name="site_settings_allow_comments_hint">Разрешить читателям оставлять комментарии</string>
+	<string name="site_settings_discussion_hint">Просмотр и изменение настроек ваших сайтов в разделе «Обсуждение»</string>
+	<string name="site_settings_more_hint">Показывать все настройки в разделе «Обсуждение»</string>
+	<string name="site_settings_related_posts_hint">Отображение похожих записей в приложении «Чтиво»</string>
+	<string name="site_settings_upload_and_link_image_hint">Загружать полноразмерные изображения по умолчанию</string>
+	<string name="site_settings_image_width_hint">Изменение ширины изображений в записи</string>
+	<string name="site_settings_format_hint">Добавление нового формата записи</string>
+	<string name="site_settings_category_hint">Добавление новой рубрики для записей</string>
+	<string name="site_settings_location_hint">Автоматически добавлять к записям данные о местоположении</string>
+	<string name="site_settings_password_hint">Изменить пароль</string>
+	<string name="site_settings_username_hint">Использующаяся учетная запись</string>
+	<string name="site_settings_language_hint">Язык, который используется в блоге в первую очередь</string>
+	<string name="site_settings_privacy_hint">Ограничение доступа к вашему блогу</string>
+	<string name="site_settings_address_hint">Изменение адреса пока не поддерживается.</string>
+	<string name="site_settings_tagline_hint"> или удачная фраза, характеризующая ваш блог</string>
+	<string name="site_settings_title_hint">Объясните в нескольких словах, о чем этот блог.</string>
+	<string name="site_settings_whitelist_known_summary">Комментарии известных пользователей</string>
+	<string name="site_settings_whitelist_all_summary">Все комментарии</string>
+	<string name="site_settings_threading_summary">%d уров.</string>
+	<string name="site_settings_privacy_private_summary">Скрытая</string>
+	<string name="site_settings_privacy_hidden_summary">Скрыто</string>
+	<string name="site_settings_delete_site_title">Удалить сайт</string>
+	<string name="site_settings_privacy_public_summary">Открытая</string>
+	<string name="site_settings_blacklist_title">Черный список</string>
+	<string name="site_settings_moderation_hold_title">Отправить на модерацию</string>
+	<string name="site_settings_multiple_links_title">Ссылки в комментариях</string>
+	<string name="site_settings_whitelist_title">Одобрять автоматически</string>
+	<string name="site_settings_threading_title">Ветвление</string>
+	<string name="site_settings_paging_title">Разбиение на страницы</string>
+	<string name="site_settings_sort_by_title">Приоритет сортировки</string>
+	<string name="site_settings_account_required_title">Пользователи должны выполнять вход</string>
+	<string name="site_settings_identity_required_title">Необходимо указывать имя и эл. адрес</string>
+	<string name="site_settings_receive_pingbacks_title">Получать уведомления</string>
+	<string name="site_settings_send_pingbacks_title">Отправлять уведомления</string>
+	<string name="site_settings_allow_comments_title">Разрешить комментарии</string>
+	<string name="site_settings_default_format_title">Основной формат</string>
+	<string name="site_settings_default_category_title">Основная рубрика</string>
+	<string name="site_settings_location_title">Вкл. определение местоположения</string>
+	<string name="site_settings_address_title">Адрес</string>
+	<string name="site_settings_title_title">Название сайта</string>
+	<string name="site_settings_tagline_title">Ключевая фраза</string>
+	<string name="site_settings_this_device_header">На этом устройстве</string>
+	<string name="site_settings_discussion_new_posts_header">Параметры по умолчанию для новых записей</string>
+	<string name="site_settings_account_header">Учетная запись</string>
+	<string name="site_settings_writing_header">Написание</string>
+	<string name="newest_first">Сначала новые</string>
+	<string name="site_settings_general_header">Общие</string>
+	<string name="discussion">Обсуждение</string>
+	<string name="privacy">Политика конфиденциальности</string>
+	<string name="related_posts">Похожие записи</string>
+	<string name="comments">Комментарии</string>
+	<string name="close_after">Закрыть обсуждение через</string>
+	<string name="oldest_first">Сначала старые</string>
+	<string name="media_error_no_permission_upload">У вас нет разрешения на загрузку файлов на этот сайт</string>
+	<string name="never">Никогда</string>
+	<string name="unknown">Неизвестно</string>
 	<string name="reader_err_get_post_not_found">Эта запись больше не существует</string>
 	<string name="reader_err_get_post_not_authorized">У вас нет прав на просмотр этой записи</string>
 	<string name="reader_err_get_post_generic">Не удается загрузить эту запись</string>
@@ -122,14 +230,12 @@
 	<string name="post_trashed">Запись помещена в корзину</string>
 	<string name="stats_no_activity_this_period">Нет активности за указанный период</string>
 	<string name="page_deleted">Страница удалена</string>
-	<string name="button_more">Ещё</string>
 	<string name="button_stats">Статистика</string>
 	<string name="button_trash">Корзина</string>
 	<string name="button_preview">Просмотреть</string>
 	<string name="button_view">Просмотреть</string>
 	<string name="button_edit">Изменить</string>
 	<string name="button_publish">Опубликовать</string>
-	<string name="button_delete">Удалить</string>
 	<string name="trashed">Удалено</string>
 	<string name="button_back">Назад</string>
 	<string name="my_site_no_sites_view_subtitle">Добавить сайт?</string>
@@ -170,7 +276,6 @@
 	<string name="my_site_btn_view_admin">Просмотреть приложение «Администратор»</string>
 	<string name="my_site_header_publish">Опубликовать</string>
 	<string name="my_site_header_look_and_feel">Вид и функции</string>
-	<string name="my_site_btn_comments">Комментарии</string>
 	<string name="my_site_btn_site_settings">Настройки</string>
 	<string name="my_site_btn_blog_posts">Записи в блоге</string>
 	<string name="reader_label_new_posts_subtitle">Нажмите, чтобы показать записи.</string>
@@ -221,6 +326,8 @@
 	<string name="add_to_post">Добавить в запись</string>
 	<string name="language">Язык</string>
 	<string name="device">Устройство</string>
+	<string name="media_details_label_file_name">Имя файла</string>
+	<string name="media_details_label_file_type">Тип файла</string>
 	<string name="stats_empty_search_terms_desc">Узнайте больше о поисковом трафике, просмотрев ключевые слова, которые посетители вашего сайта использовали, чтобы найти его.</string>
 	<string name="comments_fetching">Загрузка комментариев…</string>
 	<string name="pages_fetching">Загрузка страниц…</string>
@@ -254,7 +361,6 @@
 	<string name="stats_timeframe_years">Годы</string>
 	<string name="stats_views">Просмотров</string>
 	<string name="stats_pagination_label">Страница %1$s из %2$s</string>
-	<string name="stats_comments">Комментарии</string>
 	<string name="stats_likes">Любимое</string>
 	<string name="stats_view_videos">Видео</string>
 	<string name="stats_view_publicize">Публикация</string>
@@ -332,13 +438,13 @@
 	<string name="reader_label_comment_count_single">Один комментарий</string>
 	<string name="reader_label_comments_closed">Обсуждение закрыто</string>
 	<string name="reader_label_comments_on">Комментарии включены</string>
-	<string name="reader_title_comments">Комментарии</string>
 	<string name="reader_title_photo_viewer">%1$d из %2$d</string>
 	<string name="error_publish_empty_post">Нельзя опубликовать пустую запись.</string>
 	<string name="error_refresh_unauthorized_posts">У вас нет прав на просмотр или редактирование записей.</string>
 	<string name="error_refresh_unauthorized_pages">У вас нет прав на просмотр или редактирование страниц.</string>
 	<string name="error_refresh_unauthorized_comments">У вас нет прав на просмотр или редактирование комментариев.</string>
 	<string name="older_month">Больше месяца назад</string>
+	<string name="more">Больше</string>
 	<string name="older_two_days">Больше двух дней назад</string>
 	<string name="older_last_week">Больше недели</string>
 	<string name="stats_no_blog">Невозможно загрузить статистику для этого блога.</string>
@@ -642,7 +748,6 @@
 	<string name="stats_entry_country">Страна</string>
 	<string name="stats_timeframe_today">Сегодня</string>
 	<string name="media_edit_description_text">Описание</string>
-	<string name="stats_view_comments">Комментарии</string>
 	<string name="stats">Статистика</string>
 	<string name="media_gallery_image_order_random">Случайный</string>
 	<string name="passcode_enter_old_passcode">Введите ваш старый PIN</string>
@@ -656,7 +761,6 @@
 	<string name="media_gallery_type_slideshow">Показ слайдов</string>
 	<string name="media_gallery_type_circles">Круги</string>
 	<string name="media_gallery_type_tiled">Плитка</string>
-	<string name="stats_totals_comments">Комментарии</string>
 	<string name="stats_view_clicks">Нажатия</string>
 	<string name="share_action_title">Добавить в ...</string>
 	<string name="stats_timeframe_weeks">Недели</string>
@@ -774,7 +878,6 @@
 	<string name="error">Ошибка</string>
 	<string name="save">Сохранить</string>
 	<string name="add">Добавить</string>
-	<string name="tab_comments">Комментарии</string>
 	<string name="on">на</string>
 	<string name="notification_settings">Настройки уведомлений</string>
 	<string name="yes">Да</string>
@@ -826,6 +929,33 @@
 		<item>Стандартный</item>
 		<item>Статус</item>
 		<item>Видео</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>Ваш сайт доступен всем и может индексироваться поисковыми системами.</item>
+		<item>Ваш сайт доступен всем посетителям, но для него выбран параметр «Попросить поисковые системы не индексировать сайт».</item>
+		<item>Ваш сайт доступен только вам и выбранным вами пользователям.</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>Включить обязательный этап одобрения для всех комментариев.</item>
+		<item>Автоматически одобрять комментарии пользователей, у которых есть ранее одобренные комментарии.</item>
+		<item>Автоматически одобрять все комментарии.</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>Нет комментариев</item>
+		<item>Комментарии известных пользователей</item>
+		<item>Все пользователи</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>Нет</item>
+		<item>2 уровня</item>
+		<item>3 уровня</item>
+		<item>4 уровня</item>
+		<item>5 уровней</item>
+		<item>6 уровней</item>
+		<item>7 уровней</item>
+		<item>8 уровней</item>
+		<item>9 уровней</item>
+		<item>10 уровней</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>Бесплатно</item>

--- a/WordPress/src/main/res/values-sk/strings.xml
+++ b/WordPress/src/main/res/values-sk/strings.xml
@@ -119,14 +119,12 @@
 	<string name="button_stats">Štatistiky</string>
 	<string name="button_preview">Náhľad</string>
 	<string name="button_view">Zobraziť</string>
-	<string name="button_more">Viac</string>
 	<string name="page_deleted">Stránka vymazaná</string>
 	<string name="button_back">Späť</string>
 	<string name="trashed">Odstránené</string>
 	<string name="page_trashed">Stránka presunutá do koša</string>
 	<string name="stats_no_activity_this_period">Žiadna činnosť v toto obdobie</string>
 	<string name="button_publish">Zverejniť</string>
-	<string name="button_delete">Vymazať</string>
 	<string name="post_deleted">Článok vymazaný</string>
 	<string name="post_trashed">Článok presunutý do koša</string>
 	<string name="my_site_no_sites_view_subtitle">Prajete si pridať ďalšie?</string>
@@ -166,7 +164,6 @@
 	<string name="my_site_btn_switch_site">Prepnúť webovú stránku</string>
 	<string name="my_site_btn_view_admin">Zobraziť administráciu</string>
 	<string name="my_site_btn_site_settings">Nastavenia</string>
-	<string name="my_site_btn_comments">Komentáre</string>
 	<string name="my_site_header_publish">Zverejniť</string>
 	<string name="my_site_btn_blog_posts">Články blogu</string>
 	<string name="my_site_header_look_and_feel">Vzhľad</string>
@@ -282,7 +279,6 @@
 	<string name="stats_visitors">Návštevníci</string>
 	<string name="stats_views">Zobrazenia</string>
 	<string name="stats_timeframe_years">Roky</string>
-	<string name="stats_comments">Komentáre</string>
 	<string name="stats_view_top_posts_and_pages">Príspevky a stránky</string>
 	<string name="stats_view_countries">Krajiny</string>
 	<string name="stats_view_videos">Videá</string>
@@ -337,7 +333,6 @@
 	<string name="comment_trashed">Komentár bol odstránený</string>
 	<string name="reader_label_view_original">Pozrieť originál článku</string>
 	<string name="error_refresh_unauthorized_posts">Nemáte oprávnenie prezerať alebo upravovať príspevky</string>
-	<string name="reader_title_comments">Komentáre</string>
 	<string name="reader_title_photo_viewer">%1$d z %2$d</string>
 	<string name="reader_label_comments_closed">Už nie je možné pridávať komentáre</string>
 	<string name="reader_label_comment_count_single">jeden komentár</string>
@@ -349,6 +344,7 @@
 	<string name="older_month">Staršie ako mesiac</string>
 	<string name="older_last_week">Staršie ako týždeň</string>
 	<string name="older_two_days">Staršie ako 2 dni</string>
+	<string name="more">Viac</string>
 	<string name="new_blog_wpcom_created">WordPress.com blog bol vytvorený!</string>
 	<string name="reader_empty_followed_blogs_title">Nesledujete zatiaľ žiadne webové stránky</string>
 	<string name="reader_label_like">Lajk</string>
@@ -650,7 +646,6 @@
 	<string name="stats">Štatistiky</string>
 	<string name="media_gallery_image_order_random">Náhodné</string>
 	<string name="all">Všetko</string>
-	<string name="stats_view_comments">Komentáre</string>
 	<string name="stats_timeframe_yesterday">Včera</string>
 	<string name="stats_timeframe_today">Dnes</string>
 	<string name="share_action">Zdielať</string>
@@ -669,7 +664,6 @@
 	<string name="media_edit_description_text">Popis</string>
 	<string name="media_edit_caption_text">Titulok</string>
 	<string name="media_edit_title_text">Nadpis</string>
-	<string name="stats_totals_comments">Komentárov</string>
 	<string name="stats_totals_clicks">Kliknutí</string>
 	<string name="stats_totals_plays">Prehratí</string>
 	<string name="stats_totals_views">Zobrazení</string>
@@ -735,7 +729,6 @@
 	<string name="app_title">WordPress pre Android</string>
 	<string name="tos">Zmluvné podmienky</string>
 	<string name="about">O aplikácii</string>
-	<string name="max_thumbnail_px_width">Predvolená šírka miniatúry</string>
 	<string name="image_alignment">Zarovnanie</string>
 	<string name="refresh">Obnoviť</string>
 	<string name="untitled">Bez názvu</string>
@@ -768,7 +761,6 @@
 	<string name="none">Žiadny</string>
 	<string name="blogs">Blogy</string>
 	<string name="select_photo">Vybrať foografiu z galérie</string>
-	<string name="tab_comments">Komentáre</string>
 	<string name="reply">Odpovedať</string>
 	<string name="preview">Preview</string>
 	<string name="on">na</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">Madhësia Origjinale</string>
+	<string name="about_me_hint">Pak fjalë rreth jush…</string>
+	<string name="public_display_name_hint">Nëse nuk caktohet një i tillë, si emër ekrani do të përdoret emri juaj i përdoruesit</string>
+	<string name="about_me">Rreth meje</string>
+	<string name="public_display_name">Emri i shfaqur botërisht</string>
+	<string name="my_profile">Profili Im</string>
+	<string name="first_name">Emri</string>
+	<string name="last_name">Mbiemri</string>
+	<string name="site_privacy_public_desc">Lejoji motorët e kërkimeve ta indeksojnë këtë sajt</string>
+	<string name="site_privacy_hidden_desc">Kërkoju motorëve të kërkimit të mos e indeksojnë këtë sajt</string>
+	<string name="site_privacy_private_desc">Do të doja që sajti im të jetë privat, i dukshëm vetëm për përdorues që i zgjedh unë</string>
+	<string name="cd_related_post_preview_image">Figurë paraparje postimi të afërt</string>
+	<string name="error_post_remote_site_settings">S&amp;#8217;u ruajtën dot të dhëna sajti</string>
+	<string name="error_fetch_remote_site_settings">S&amp;#8217;u morën dot të dhëna sajti</string>
+	<string name="error_media_upload_connection">Ndodhi një gabim ndërlidhjeje gjatë ngarkimit të medias</string>
+	<string name="site_settings_disconnected_toast">I shkëputur, përpunimet janë të çaktivizuara</string>
+	<string name="site_settings_unsupported_version_error">Version WordPress i pambuluar</string>
+	<string name="site_settings_multiple_links_dialog_description">Kërko miratim për komente që përmbajnë më tepër lidhje se sa kaq.</string>
+	<string name="site_settings_close_after_dialog_switch_text">Mbylli vetvetiu</string>
+	<string name="site_settings_close_after_dialog_description">Mbylli vetvetiu komentet në artikuj.</string>
+	<string name="site_settings_paging_dialog_description">Copëzojini rrjedhat e komenteve në disa faqe.</string>
+	<string name="site_settings_paging_dialog_header">Komente për faqe</string>
+	<string name="site_settings_close_after_dialog_title">Mbylle komentimin</string>
+	<string name="site_settings_blacklist_description">Kur një koment përmban cilëndo nga këto fjalë në lëndën e vet, emrin, URL-në, email-in, ose IP-në e tij, do të shënohet si i padëshiruar. Mund të jepni edhe copa fjalësh, fjala vjen "press" do të ketë efekt edhe për "WordPress."</string>
+	<string name="site_settings_hold_for_moderation_description">Kur një koment përmban cilëndo nga këto fjalë në lëndën e vet, emrin, URL-në, email-in, ose IP-në e tij, do të mbahet në radhën e moderimeve. Mund të jepni edhe copa fjalësh, fjala vjen "press" do të ketë efekt edhe për "WordPress."</string>
+	<string name="site_settings_list_editor_input_hint">Jepni një fjalë ose togfjalësh</string>
+	<string name="site_settings_list_editor_no_items_text">Pa objekte</string>
+	<string name="site_settings_learn_more_caption">Për postime individuale mund t’i anashkaloni këto rregullime.</string>
+	<string name="site_settings_rp_preview3_site">te "Përmirësojeni"</string>
+	<string name="site_settings_rp_preview3_title">Përmirësoni Focus-in: VideoPress Për Dasma</string>
+	<string name="site_settings_rp_preview2_site">te "Aplikacione"</string>
+	<string name="site_settings_rp_preview2_title">Aplikacioni WordPress për Android i Ndërron Pamjen Goxha</string>
+	<string name="site_settings_rp_preview1_site">në "Celular"</string>
+	<string name="site_settings_rp_preview1_title">Gati Tani një Përditësim i Madh për iPhone/iPad</string>
+	<string name="site_settings_rp_show_images_title">Shfaqni Figura</string>
+	<string name="site_settings_rp_show_header_title">Shfaq Kryet</string>
+	<string name="site_settings_rp_switch_summary">Postimet e Afërta shfaqin nën postimet tuaja lëndë të afërt prej sajtit tuaj.</string>
+	<string name="site_settings_rp_switch_title">Shfaq Postime të Afërta</string>
+	<string name="site_settings_delete_site_hint">Heq prej aplikacionit të dhëna mbi sajtin tuaj</string>
+	<string name="site_settings_blacklist_hint">Komentet me përputhje me një filtër shënohen si të padëshiruar </string>
+	<string name="site_settings_moderation_hold_hint">Komentet me përputhje me ndonjë nga filtra vendosen në radhën e moderimit</string>
+	<string name="site_settings_multiple_links_hint">Për përdorues të njohur shpërfille kufirin e lidhjeve</string>
+	<string name="site_settings_whitelist_hint">Autori i komentit duhet të kenë një koment të miratuar më parë</string>
+	<string name="site_settings_user_account_required_hint">Përdoruesit duhet të jenë të regjistruar dhe të kenë bërë hyrjen</string>
+	<string name="site_settings_identity_required_hint">Autori i komentit duhet të plotësojë emrin dhe email-in</string>
+	<string name="site_settings_manual_approval_hint">Komentet duhet të miratohen dorazi</string>
+	<string name="site_settings_paging_hint">Shfaq komente në copa të madhësisë së dhënë</string>
+	<string name="site_settings_threading_hint">Lejo komente të folezëzuar deri në një nivel të dhënë</string>
+	<string name="site_settings_sort_by_hint">Përcakton rendin sipas të cilit shfaqen komentet</string>
+	<string name="site_settings_close_after_hint">Mos lejo më komente pas një kohe të caktuar</string>
+	<string name="site_settings_receive_pingbacks_hint">Lejo njoftime lidhjesh nga blogje të tjerë</string>
+	<string name="site_settings_send_pingbacks_hint">Përpjekje për të njoftuar cilindo blog me lidhje te artikulli</string>
+	<string name="site_settings_allow_comments_hint">Lejoju lexuesve të postojnë komente</string>
+	<string name="site_settings_discussion_hint">Shihni dhe ndryshoni rregullimet mbi diskutimet në sajtin tuaj</string>
+	<string name="site_settings_more_hint">Shihni krejt rregullimet e mundshme për Diskutimet</string>
+	<string name="site_settings_related_posts_hint">Shfaqni ose fshihni te lexuesi postime të afërta</string>
+	<string name="site_settings_upload_and_link_image_hint">Aktivizojeni që të ngarkohet përherë figura në madhësi të plotë</string>
+	<string name="site_settings_image_width_hint">Figurat në postime ripërmasoji sa kjo gjerësi</string>
+	<string name="site_settings_format_hint">Cakton format të ri postimesh</string>
+	<string name="site_settings_category_hint">Cakton kategori të re postimesh</string>
+	<string name="site_settings_location_hint">Shto vevetiu të dhëna vendi te postimet tuaja</string>
+	<string name="site_settings_password_hint">Ndryshoni fjalëkalimin tuaj</string>
+	<string name="site_settings_username_hint">Llogaria e përdoruesit të tanishëm</string>
+	<string name="site_settings_language_hint">Gjuha në të cilën shkruhet kryesisht në këtë blog</string>
+	<string name="site_settings_privacy_hint">Kontrolloni cilët mund të shohin sajtin tuaj</string>
+	<string name="site_settings_address_hint">Hëpërhë nuk mbulohet ndryshimi i adresës suaj </string>
+	<string name="site_settings_tagline_hint">Një përshkrim i shkurtër ose një togfjalësh ndjellës për të përshkruar blogun tuaj</string>
+	<string name="site_settings_title_hint">Shpjegoni, me pak fjalë, se për çfarë është ky sajt</string>
+	<string name="site_settings_whitelist_known_summary">Komente prej përdoruesish të njohur</string>
+	<string name="site_settings_whitelist_all_summary">Komente prej krejt përdoruesit</string>
+	<string name="site_settings_threading_summary">%d nivele</string>
+	<string name="site_settings_privacy_private_summary">Privat</string>
+	<string name="site_settings_privacy_hidden_summary">I fshehur</string>
+	<string name="site_settings_delete_site_title">Fshije Sajtin</string>
+	<string name="site_settings_privacy_public_summary">Publik</string>
+	<string name="site_settings_blacklist_title">Listë e zezë</string>
+	<string name="site_settings_moderation_hold_title">Mbaje për Moderim</string>
+	<string name="site_settings_multiple_links_title">Lidhje në komente</string>
+	<string name="site_settings_whitelist_title">Miratoji vetvetiu</string>
+	<string name="site_settings_threading_title">Në rrjedha</string>
+	<string name="site_settings_paging_title">Faqosje</string>
+	<string name="site_settings_sort_by_title">Renditini sipas</string>
+	<string name="site_settings_account_required_title">Përdoruesi duhet të ketë bërë hyrjen</string>
+	<string name="site_settings_identity_required_title">Duhet të përfshijë emër dhe email</string>
+	<string name="site_settings_receive_pingbacks_title">Merr Pingback-e</string>
+	<string name="site_settings_send_pingbacks_title">Dërgo Pingback-e</string>
+	<string name="site_settings_allow_comments_title">Lejo Komente</string>
+	<string name="site_settings_default_format_title">Format Parazgjedhje</string>
+	<string name="site_settings_default_category_title">Kategori Parazgjedhje</string>
+	<string name="site_settings_location_title">Aktivizoni Vendndodhje</string>
+	<string name="site_settings_address_title">Adresë</string>
+	<string name="site_settings_title_title">Titull Sajti</string>
+	<string name="site_settings_tagline_title">Përmbledhtas</string>
+	<string name="site_settings_this_device_header">Këtë pajisje</string>
+	<string name="site_settings_discussion_new_posts_header">Parazgjedhje për postime të reja</string>
+	<string name="site_settings_account_header">Llogari</string>
+	<string name="site_settings_writing_header">Shkrim</string>
+	<string name="newest_first">Më të rejat së pari</string>
+	<string name="site_settings_general_header">Të përgjithshme</string>
+	<string name="discussion">Diskutim</string>
+	<string name="privacy">Privatësi</string>
+	<string name="related_posts">Postime të afërt</string>
+	<string name="comments">Komente</string>
+	<string name="close_after">Mbylle pas</string>
+	<string name="oldest_first">Më të vjetrat së pari</string>
+	<string name="media_error_no_permission_upload">S’keni leje të ngarkoni media në këtë sajt</string>
+	<string name="never">Kurrë</string>
+	<string name="unknown">E panjohur</string>
 	<string name="reader_err_get_post_not_found">Ky postim s&amp;#8217;ekziston më</string>
 	<string name="reader_err_get_post_not_authorized">S&amp;#8217;jeni i autorizuar ta shihni këtë postim</string>
 	<string name="reader_err_get_post_generic">S&amp;#8217;arrihet të merret ky postim</string>
@@ -124,14 +232,12 @@
 	<string name="trashed">Të hedhur te hedhurinat</string>
 	<string name="button_back">Mbrapsht</string>
 	<string name="page_deleted">Faqja u fshi</string>
-	<string name="button_more">Më tepër</string>
 	<string name="button_stats">Statistika</string>
 	<string name="button_trash">Hedhurina</string>
 	<string name="button_preview">Paraparje</string>
 	<string name="button_view">Shiheni</string>
 	<string name="button_edit">Përpunojeni</string>
 	<string name="button_publish">Botojeni</string>
-	<string name="button_delete">Fshijeni</string>
 	<string name="my_site_no_sites_view_subtitle">Do të donit të shtoni një të tillë?</string>
 	<string name="my_site_no_sites_view_title">S’keni ende ndonjë sajt WordPress.</string>
 	<string name="my_site_no_sites_view_drake">Ilustrim</string>
@@ -170,7 +276,6 @@
 	<string name="my_site_btn_switch_site">Këmbe Sajt</string>
 	<string name="my_site_btn_blog_posts">Postime Blogu</string>
 	<string name="my_site_btn_site_settings">Rregullime</string>
-	<string name="my_site_btn_comments">Komente</string>
 	<string name="my_site_header_look_and_feel">Pamja dhe Ndjesitë</string>
 	<string name="my_site_header_publish">Botoje</string>
 	<string name="my_site_header_configuration">Formësim</string>
@@ -291,7 +396,6 @@
 	<string name="stats_view_followers">Ndjekës</string>
 	<string name="stats_view_countries">Vende</string>
 	<string name="stats_likes">Pëlqime</string>
-	<string name="stats_comments">Komente</string>
 	<string name="stats_pagination_label">Faqja %1$s nga %2$s</string>
 	<string name="stats_timeframe_years">Vite</string>
 	<string name="stats_views">Parje</string>
@@ -333,7 +437,6 @@
 	<string name="reader_label_comment_count_single">Një koment</string>
 	<string name="reader_label_comments_closed">Komentet janë mbyllur</string>
 	<string name="reader_label_comments_on">Me komentet hapur</string>
-	<string name="reader_title_comments">Komente</string>
 	<string name="error_publish_empty_post">S’botohet dot një postim i zbrazët</string>
 	<string name="error_refresh_unauthorized_posts">S’keni leje të shihni ose të përpunoni postime</string>
 	<string name="error_refresh_unauthorized_pages">S’keni leje të shihni ose të përpunoni faqe</string>
@@ -357,6 +460,7 @@
 	<string name="mnu_comment_liked">U pëlqye</string>
 	<string name="posting_post">Po postohet "%s"</string>
 	<string name="agree_terms_of_service">Duke krijuar një llogari, pajtoheni me %1$sKushtet tërheqëse të Shërbimit%2$s</string>
+	<string name="more">Më tepër</string>
 	<string name="reader_toast_err_generic">I pazoti të kryejë këtë veprim</string>
 	<string name="reader_toast_err_block_blog">I pazoti të bllokojë këtë blog</string>
 	<string name="reader_toast_blog_blocked">Postimet prej këtij blogu s’do të shfaqen më</string>
@@ -668,7 +772,6 @@
 	<string name="stats_view_clicks">Klikime</string>
 	<string name="stats_view_tags_and_categories">Etiketa &amp; Kategori</string>
 	<string name="stats_view_referrers">Referues</string>
-	<string name="stats_view_comments">Komente</string>
 	<string name="stats_timeframe_today">Sot</string>
 	<string name="stats_timeframe_yesterday">Dje</string>
 	<string name="stats_timeframe_days">Ditë</string>
@@ -682,7 +785,6 @@
 	<string name="stats_totals_views">Parje</string>
 	<string name="stats_totals_clicks">Klikime</string>
 	<string name="stats_totals_plays">Luajtje</string>
-	<string name="stats_totals_comments">Komente</string>
 	<string name="menu_search">Kërko</string>
 	<string name="passcode_manage">Administroni kyçje PIN-i</string>
 	<string name="passcode_enter_passcode">Jepni PIN-in tuaj:</string>
@@ -738,7 +840,7 @@
 	<string name="tos">Kushte Shërbimi</string>
 	<string name="app_title">WordPress për Android</string>
 	<string name="about">Rreth</string>
-	<string name="max_thumbnail_px_width">Gjerësi parazgjedhje figure</string>
+	<string name="max_thumbnail_px_width">Gjerësi Parazgjedhje Figure</string>
 	<string name="image_alignment">Drejtim</string>
 	<string name="refresh">Rifresko</string>
 	<string name="untitled">Pa titull</string>
@@ -776,7 +878,6 @@
 	<string name="save">Ruaje</string>
 	<string name="add">Shtoni</string>
 	<string name="category_refresh_error">Gabim rifreskimi kategorish</string>
-	<string name="tab_comments">Komente</string>
 	<string name="preview">Paraparje</string>
 	<string name="on">on</string>
 	<string name="reply">Përgjigjjuni</string>
@@ -828,6 +929,33 @@
 		<item>Standard</item>
 		<item>Gjendje</item>
 		<item>Video</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>Sajti juaj është i dukshëm për këdo dhe mund të indeksohet nga motorë kërkimesh</item>
+		<item>Sajti juaj është i dukshëm për këdo, por kërkon që motorët e kërkimeve të mos e indeksojnë</item>
+		<item>Sajti juaj është i dukshëm vetëm për ju dhe për përdorues që miratoni</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>Kërkoni miratim dorazi për komentet e kujtdo.</item>
+		<item>Miratoje vetvetiu, nëse përdoruesi ka një koment të mëparshëm të miratuar.</item>
+		<item>Mirato vetvetiu komentet e gjithkujt.</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>Pa komente</item>
+		<item>Komente përdoruesish të njohur</item>
+		<item>Krejt përdoruesit</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>Asnjë</item>
+		<item>Dy nivele</item>
+		<item>Tre nivele</item>
+		<item>Katër nivele</item>
+		<item>Pesë nivele</item>
+		<item>Gjashtë nivele</item>
+		<item>Shtatë nivele</item>
+		<item>Tetë nivele</item>
+		<item>Nëntë nivele</item>
+		<item>Dhjetë nivele</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>Falas</item>

--- a/WordPress/src/main/res/values-sr/strings.xml
+++ b/WordPress/src/main/res/values-sr/strings.xml
@@ -50,14 +50,12 @@
 	<string name="trashed">На отпаду</string>
 	<string name="button_back">Назад</string>
 	<string name="page_deleted">Страна је обрисана</string>
-	<string name="button_more">Више</string>
 	<string name="button_stats">Статистике</string>
 	<string name="button_trash">Отпад</string>
 	<string name="button_preview">Предпреглед</string>
 	<string name="button_view">Поглед</string>
 	<string name="button_edit">Уређивање</string>
 	<string name="button_publish">Објављивање</string>
-	<string name="button_delete">Брисање</string>
 	<string name="my_site_no_sites_view_subtitle">Да ли бисте желели да додате једно?</string>
 	<string name="my_site_no_sites_view_title">Још увек немате ниједно Вордпресово веб место.</string>
 	<string name="my_site_no_sites_view_drake">Илустрација</string>
@@ -94,7 +92,6 @@
 	<string name="my_site_btn_view_site">Види веб место</string>
 	<string name="site_picker_title">Одабери веб место</string>
 	<string name="my_site_btn_view_admin">Види управљање</string>
-	<string name="my_site_btn_comments">Коментари</string>
 	<string name="my_site_header_look_and_feel">Изглед и осећај</string>
 	<string name="my_site_header_publish">Објави</string>
 	<string name="my_site_btn_blog_posts">Чланци блога</string>
@@ -195,7 +192,6 @@
 	<string name="stats_visitors">Посетиоци</string>
 	<string name="stats_views">Прегледа</string>
 	<string name="stats_timeframe_years">Година</string>
-	<string name="stats_comments">Коментари</string>
 	<string name="stats_likes">Свиђања</string>
 	<string name="stats_view_countries">Државе</string>
 	<string name="stats_view_followers">Пратиоци</string>
@@ -264,11 +260,11 @@
 	<string name="older_two_days">Старије од два дана</string>
 	<string name="older_last_week">Старије од недељу дана</string>
 	<string name="older_month">Старије од месец дана</string>
+	<string name="more">Више</string>
 	<string name="error_refresh_unauthorized_comments">Немате дозволу да прегледате или уређујете коментаре</string>
 	<string name="error_refresh_unauthorized_posts">Немате дозволу да прегледате или уређујете чланке</string>
 	<string name="error_publish_empty_post">Није могуће објавити празан чланак</string>
 	<string name="reader_title_photo_viewer">%1$d од %2$d</string>
-	<string name="reader_title_comments">Коментари</string>
 	<string name="reader_label_comments_on">Коментарисање је отворено</string>
 	<string name="reader_label_comments_closed">Коментарисање је затворено</string>
 	<string name="reader_label_comment_count_single">Један коментар</string>
@@ -589,7 +585,6 @@
 	<string name="share_action">Подели</string>
 	<string name="share_action_title">Додај на...</string>
 	<string name="theme_set_success">Успешно постављена тема!</string>
-	<string name="stats_totals_comments">Коментари</string>
 	<string name="stats_totals_plays">Пуштања</string>
 	<string name="stats_totals_clicks">Притискања</string>
 	<string name="stats_totals_views">Прегледи</string>
@@ -601,7 +596,6 @@
 	<string name="stats_timeframe_days">Дани</string>
 	<string name="stats_timeframe_today">Данас</string>
 	<string name="stats_entry_referrers">Извор упућивања</string>
-	<string name="stats_view_comments">Коментари</string>
 	<string name="stats_view_referrers">Извори упућивања</string>
 	<string name="media_edit_description_hint">Унесите опис овде</string>
 	<string name="media_edit_caption_hint">Унесите натпис овде</string>
@@ -659,7 +653,6 @@
 	<string name="version">Издање</string>
 	<string name="app_title">Вордпрес за Андроид</string>
 	<string name="about">О</string>
-	<string name="max_thumbnail_px_width">Подразумевана ширина слике</string>
 	<string name="image_alignment">Поравнање</string>
 	<string name="refresh">Освежи</string>
 	<string name="untitled">Без имена</string>
@@ -697,7 +690,6 @@
 	<string name="reply">Одговор</string>
 	<string name="on">укључен</string>
 	<string name="preview">Преглед</string>
-	<string name="tab_comments">Коментари</string>
 	<string name="category_refresh_error">Грешка приликом освежавања категорије</string>
 	<string name="add">Додај</string>
 	<string name="save">Сачувај</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">Originalstorlek</string>
+	<string name="about_me_hint">Ett par ord om dig själv…</string>
+	<string name="public_display_name_hint">Om det inte anges något annat kommer visningsnamnet som standard att vara ditt användarnamn</string>
+	<string name="about_me">Om mig</string>
+	<string name="public_display_name">Offentligt visningsnamn</string>
+	<string name="my_profile">Min profil</string>
+	<string name="first_name">Förnamn</string>
+	<string name="last_name">Efternamn</string>
+	<string name="site_privacy_public_desc">Tillåt att sökmotorer indexerar denna webbplats</string>
+	<string name="site_privacy_hidden_desc">Be att sökmotorer inte indexerar denna webbplats</string>
+	<string name="site_privacy_private_desc">Jag vill att min webbplats ska vara privat och endast tillgänglig för användare som jag själv väljer</string>
+	<string name="cd_related_post_preview_image">Relaterat inlägg förhandsgranskningsbild</string>
+	<string name="error_post_remote_site_settings">Kunde inte spara webbplatsinfo</string>
+	<string name="error_fetch_remote_site_settings">Kunde inte hämta webbplatsinfo</string>
+	<string name="error_media_upload_connection">Ett anslutningsfel uppstod vid uppladdning av media</string>
+	<string name="site_settings_disconnected_toast">Frånkopplad, redigering inaktiverad.</string>
+	<string name="site_settings_unsupported_version_error">WordPress-versionen stöds ej</string>
+	<string name="site_settings_multiple_links_dialog_description">Kräv godkännande för kommentarer som innehåller fler än detta antal länkar.</string>
+	<string name="site_settings_close_after_dialog_switch_text">Stäng automatiskt</string>
+	<string name="site_settings_close_after_dialog_description">Stäng kommentarer om inlägg automatiskt.</string>
+	<string name="site_settings_paging_dialog_description">Dela upp kommentarstrådar i flera sidor.</string>
+	<string name="site_settings_paging_dialog_header">Kommentarer per sida</string>
+	<string name="site_settings_close_after_dialog_title">Stäng kommentarer</string>
+	<string name="site_settings_blacklist_description">När en kommentar innehåller något av dessa ord i innehåll, namn, URL, e-postadress eller IP markeras den som skräppost. Du kan ange delar av ord, så "press" kommer att matcha "Wordpress".</string>
+	<string name="site_settings_hold_for_moderation_description">När en kommentar innehåller något av dessa ord i innehåll, namn, URL, e-postadress eller IP stannar den i granskningskön Du kan ange delar av ord, så "press" kommer att matcha "Wordpress".</string>
+	<string name="site_settings_list_editor_input_hint">Ange ett ord eller en fras</string>
+	<string name="site_settings_list_editor_no_items_text">Inga objekt</string>
+	<string name="site_settings_learn_more_caption">Du kan åsidosätta dessa inställningar för enskilda inlägg.</string>
+	<string name="site_settings_rp_preview3_site">i "Uppgradera"</string>
+	<string name="site_settings_rp_preview3_title">Uppgraderingsfokus: VideoPress för bröllop</string>
+	<string name="site_settings_rp_preview2_site">i "Appar"</string>
+	<string name="site_settings_rp_preview2_title">WordPress för Android får en ansiktslyftning</string>
+	<string name="site_settings_rp_preview1_site">i "Mobilt"</string>
+	<string name="site_settings_rp_preview1_title">Stor iPhone/iPad-uppdatering finns nu tillgänglig</string>
+	<string name="site_settings_rp_show_images_title">Visa bilder</string>
+	<string name="site_settings_rp_show_header_title">Visa sidhuvud</string>
+	<string name="site_settings_rp_switch_summary">Relaterade inlägg visar relevant innehåll från din webbplats nedanför dina inlägg.</string>
+	<string name="site_settings_rp_switch_title">Visa relaterade inlägg</string>
+	<string name="site_settings_delete_site_hint">Tar bort dina webbplatsdata från appen</string>
+	<string name="site_settings_blacklist_hint">Kommentarer som matchar ett filter markeras som skräppost</string>
+	<string name="site_settings_moderation_hold_hint">Kommentarer som matchar ett filter placeras i granskningskön</string>
+	<string name="site_settings_multiple_links_hint">Ignorera länkbegränsningen för kända användare</string>
+	<string name="site_settings_whitelist_hint">Kommentarens författare måste ha en tidigare godkänd kommentar</string>
+	<string name="site_settings_user_account_required_hint">Användare måste vara registrerade och inloggade för att kunna kommentera</string>
+	<string name="site_settings_identity_required_hint">Kommentarens författare måste fylla i namn och e-postadress</string>
+	<string name="site_settings_manual_approval_hint">Kommentarer måste godkännas manuellt</string>
+	<string name="site_settings_paging_hint">Visa kommentarer i stycken av en viss storlek</string>
+	<string name="site_settings_threading_hint">Tillåt staplade kommentarer till ett visst djup</string>
+	<string name="site_settings_sort_by_hint">Avgör i vilken ordning kommentarer visas</string>
+	<string name="site_settings_close_after_hint">Tillåt inte kommentarer efter den angivna tiden</string>
+	<string name="site_settings_receive_pingbacks_hint">Tillåt länknotiser från andra bloggar</string>
+	<string name="site_settings_send_pingbacks_hint">Försök meddela alla bloggar som länkats i inlägget</string>
+	<string name="site_settings_allow_comments_hint">Tillåt att läsare publicerar kommentarer</string>
+	<string name="site_settings_discussion_hint">Visa och ändra dina webbplatsers diskussionsinställningar</string>
+	<string name="site_settings_more_hint">Visa alla tillgängliga diskussionsinställningar</string>
+	<string name="site_settings_related_posts_hint">Visa eller dölj relaterade inlägg i läsaren</string>
+	<string name="site_settings_upload_and_link_image_hint">Aktivera för att alltid ladda upp bilden i fullstorlek</string>
+	<string name="site_settings_image_width_hint">Ändrar bildstorlek i inlägg till denna bredd</string>
+	<string name="site_settings_format_hint">Anger nytt inläggsformat</string>
+	<string name="site_settings_category_hint">Anger ny inläggskategori</string>
+	<string name="site_settings_location_hint">Lägg automatiskt till platsdata i dina inlägg</string>
+	<string name="site_settings_password_hint">Ändra ditt lösenord</string>
+	<string name="site_settings_username_hint">Nuvarande användarkonto</string>
+	<string name="site_settings_language_hint">Det språk som den här bloggen huvudsakligen är skrivet på</string>
+	<string name="site_settings_privacy_hint">Kontrollerar vem som kan se din webbplats</string>
+	<string name="site_settings_address_hint">Ändring av din adress stöds för närvarande inte</string>
+	<string name="site_settings_tagline_hint">En kort beskrivning eller snärtig mening som beskriver din blogg</string>
+	<string name="site_settings_title_hint">Beskriv med några få ord vad denna webbplats handlar om</string>
+	<string name="site_settings_whitelist_known_summary">Kommentarer från kända användare</string>
+	<string name="site_settings_whitelist_all_summary">Kommentarer från alla användare</string>
+	<string name="site_settings_threading_summary">%d nivåer</string>
+	<string name="site_settings_privacy_private_summary">Privat</string>
+	<string name="site_settings_privacy_hidden_summary">Dold</string>
+	<string name="site_settings_delete_site_title">Radera webbplats</string>
+	<string name="site_settings_privacy_public_summary">Offentlig</string>
+	<string name="site_settings_blacklist_title">Svartlista</string>
+	<string name="site_settings_moderation_hold_title">Vänta på granskning</string>
+	<string name="site_settings_multiple_links_title">Länkar i kommentarer</string>
+	<string name="site_settings_whitelist_title">Godkänn automatiskt</string>
+	<string name="site_settings_threading_title">Trådning</string>
+	<string name="site_settings_paging_title">Paginering</string>
+	<string name="site_settings_sort_by_title">Sortera efter</string>
+	<string name="site_settings_account_required_title">Användare måste vara inloggade</string>
+	<string name="site_settings_identity_required_title">Måste inkludera namn och e-postadress</string>
+	<string name="site_settings_receive_pingbacks_title">Ta emot pingbacks</string>
+	<string name="site_settings_send_pingbacks_title">Skicka pingbacks</string>
+	<string name="site_settings_allow_comments_title">Tillåt kommentarer</string>
+	<string name="site_settings_default_format_title">Standardformat</string>
+	<string name="site_settings_default_category_title">Standardkategori</string>
+	<string name="site_settings_location_title">Aktivera plats</string>
+	<string name="site_settings_address_title">Adress</string>
+	<string name="site_settings_title_title">Webbplatsens titel</string>
+	<string name="site_settings_tagline_title">Slogan</string>
+	<string name="site_settings_this_device_header">Denna enhet</string>
+	<string name="site_settings_discussion_new_posts_header">Standard för nya inlägg</string>
+	<string name="site_settings_account_header">Konto</string>
+	<string name="site_settings_writing_header">Skriva</string>
+	<string name="newest_first">Nyast först</string>
+	<string name="site_settings_general_header">Allmänt</string>
+	<string name="discussion">Diskussion</string>
+	<string name="privacy">Integritet</string>
+	<string name="related_posts">Relaterade inlägg</string>
+	<string name="comments">Kommentarer</string>
+	<string name="close_after">Stäng efter</string>
+	<string name="oldest_first">Äldst först</string>
+	<string name="media_error_no_permission_upload">Du har inte tillåtelse att ladda upp media till webbplatsen</string>
+	<string name="never">Aldrig</string>
+	<string name="unknown">Okänd</string>
 	<string name="reader_err_get_post_not_found">Detta inlägg finns inte längre</string>
 	<string name="reader_err_get_post_not_authorized">Du har inte behörighet att se detta inlägg</string>
 	<string name="reader_err_get_post_generic">Kunde inte hämta detta inlägg</string>
@@ -119,11 +227,9 @@
 	<string name="connectionbar_no_connection">Ingen anslutning</string>
 	<string name="stats_no_activity_this_period">Ingen aktivitet denna period</string>
 	<string name="page_deleted">Sidan borttagen</string>
-	<string name="button_more">Mer</string>
 	<string name="button_view">Visa</string>
 	<string name="button_edit">Redigera</string>
 	<string name="button_publish">Publicera</string>
-	<string name="button_delete">Ta bort</string>
 	<string name="trashed">Borttagen</string>
 	<string name="button_back">Tillbaka</string>
 	<string name="button_stats">Statistik</string>
@@ -171,7 +277,6 @@
 	<string name="my_site_btn_blog_posts">Blogginlägg</string>
 	<string name="my_site_header_publish">Publicera</string>
 	<string name="my_site_btn_site_settings">Inställningar </string>
-	<string name="my_site_btn_comments">Kommentarer </string>
 	<string name="my_site_header_look_and_feel">Utseende och känsla</string>
 	<string name="my_site_header_admin">Admin</string>
 	<string name="reader_label_new_posts_subtitle">Knacka för att visa dem</string>
@@ -221,6 +326,8 @@
 	<string name="take_photo">Ta ett foto</string>
 	<string name="device">Enhet</string>
 	<string name="language">Språk</string>
+	<string name="media_details_label_file_name">Filnamn</string>
+	<string name="media_details_label_file_type">Filtyp</string>
 	<string name="posts_fetching">Hämtar inlägg...</string>
 	<string name="media_fetching">Hämtar media...</string>
 	<string name="stats_view_authors">Författare</string>
@@ -254,7 +361,6 @@
 	<string name="stats_visitors">Besökare</string>
 	<string name="stats_pagination_label">Sida %1$s av %2$s</string>
 	<string name="stats_timeframe_years">År</string>
-	<string name="stats_comments">Kommentarer</string>
 	<string name="stats_likes">Gillar</string>
 	<string name="stats_view_countries">Länder</string>
 	<string name="stats_view_publicize">Publicize</string>
@@ -332,13 +438,13 @@
 	<string name="reader_label_comment_count_single">En kommentar</string>
 	<string name="reader_label_comments_closed">Kommentarer inaktiverade</string>
 	<string name="reader_label_comments_on">Kommentarer till</string>
-	<string name="reader_title_comments">Kommentarer</string>
 	<string name="reader_title_photo_viewer">%1$d av %2$d</string>
 	<string name="error_publish_empty_post">Det går inte att publicera ett tomt inlägg</string>
 	<string name="error_refresh_unauthorized_posts">Du saknar behörighet för att visa eller redigera inlägg</string>
 	<string name="error_refresh_unauthorized_pages">Du saknar behörighet för att visa eller redigera sidor</string>
 	<string name="error_refresh_unauthorized_comments">Du saknar behörighet för att visa eller redigera kommentarer</string>
 	<string name="older_month">Äldre än en månad</string>
+	<string name="more">Mer</string>
 	<string name="older_two_days">Äldre än 2 dagar</string>
 	<string name="older_last_week">Äldre än en vecka</string>
 	<string name="stats_no_blog">Statistiken för efterfrågad blogg kunde inte laddas</string>
@@ -669,7 +775,6 @@
 	<string name="stats_view_clicks">Klick</string>
 	<string name="stats_view_tags_and_categories">Etiketter och kategorier</string>
 	<string name="stats_view_referrers">Hänvisningar</string>
-	<string name="stats_view_comments">Kommentarer</string>
 	<string name="stats_timeframe_today">I dag</string>
 	<string name="stats_timeframe_yesterday">I går</string>
 	<string name="stats_timeframe_days">Dagar</string>
@@ -683,7 +788,6 @@
 	<string name="stats_totals_views">Visningar</string>
 	<string name="stats_totals_clicks">Klick</string>
 	<string name="stats_totals_plays">Spelningar</string>
-	<string name="stats_totals_comments">Kommentarer</string>
 	<string name="menu_search">Sök</string>
 	<string name="passcode_manage">Ändra PIN-kodlås</string>
 	<string name="passcode_enter_passcode">Skriv din PIN-kod</string>
@@ -769,7 +873,6 @@
 	<string name="none">Ingen</string>
 	<string name="blogs">Bloggar</string>
 	<string name="select_photo">Välj en bild från galleri</string>
-	<string name="tab_comments">Kommentarer</string>
 	<string name="reply">Svara</string>
 	<string name="cancel">Avbryt</string>
 	<string name="save">Spara</string>
@@ -826,6 +929,33 @@
 		<item>Standard</item>
 		<item>Status</item>
 		<item>Video</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>Din webbplats är synlig för alla och kan indexeras av sökmotorer</item>
+		<item>Din webbplats är synlig för alla, men begär att sökmotorerna inte ska indexera den</item>
+		<item>Din webbplats är bara synlig för dig själv och användare som du godkänner</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>Kräv manuellt godkännande för alla kommentarer.</item>
+		<item>Godkänn automatiskt om användaren har en tidigare godkänd kommentar.</item>
+		<item>Godkänn allas kommentarer automatiskt.</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>Inga kommentarer</item>
+		<item>Kända användares kommentarer</item>
+		<item>Alla användare</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>Ingen</item>
+		<item>Två nivåer</item>
+		<item>Tre nivåer</item>
+		<item>Fyra nivåer</item>
+		<item>Fem nivåer</item>
+		<item>Sex nivåer</item>
+		<item>Sju nivåer</item>
+		<item>Åtta nivåer</item>
+		<item>Nio nivåer</item>
+		<item>Tio nivåer</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>Gratis</item>

--- a/WordPress/src/main/res/values-th/strings.xml
+++ b/WordPress/src/main/res/values-th/strings.xml
@@ -1,5 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">ขนาดต้นฉบับ</string>
+	<string name="about_me">เกี่ยวกับฉัน</string>
+	<string name="public_display_name">ชื่อที่ใช้แสดงในสาธารณะ</string>
+	<string name="my_profile">ประวัติของฉัน</string>
+	<string name="first_name">ชื่อ</string>
+	<string name="last_name">นามสกุล</string>
+	<string name="site_privacy_public_desc">อนุญาตให้เซิร์ชเอ็นจิ้นเก็บหน้าเว็บนี้</string>
+	<string name="site_settings_list_editor_input_hint">ใส่คำหรือวลี</string>
+	<string name="site_settings_list_editor_no_items_text">ไม่มีรายการ</string>
+	<string name="site_settings_password_hint">เปลี่ยนรหัสผ่านของคุณ</string>
+	<string name="site_settings_username_hint">บัญชีผู้ใช้ปัจจุบัน</string>
+	<string name="site_settings_whitelist_all_summary">ความเห็นจากผู้ใช้ทั้งหมด</string>
+	<string name="site_settings_threading_summary">%d ระดับ</string>
+	<string name="site_settings_privacy_private_summary">ส่วนตัว</string>
+	<string name="site_settings_privacy_hidden_summary">ซ่อน</string>
+	<string name="site_settings_delete_site_title">ลบเว็บ</string>
+	<string name="site_settings_privacy_public_summary">สาธารณะ</string>
+	<string name="site_settings_blacklist_title">บัญชีดำ</string>
+	<string name="site_settings_moderation_hold_title">กดค้างเพื่อจัดการ</string>
+	<string name="site_settings_multiple_links_title">ลิงก์ในความเห็น</string>
+	<string name="site_settings_whitelist_title">อนุมัติอัตโนมัติ</string>
+	<string name="site_settings_sort_by_title">เรียงตาม</string>
+	<string name="site_settings_identity_required_title">ต้องประกอบด้วยชื่อและอีเมล</string>
+	<string name="site_settings_receive_pingbacks_title">รับ Pingbacks</string>
+	<string name="site_settings_send_pingbacks_title">ส่ง Pingbacks</string>
+	<string name="site_settings_allow_comments_title">อนุมัติความเห็น</string>
+	<string name="site_settings_default_format_title">รูปแบบค่าเริ่มต้น</string>
+	<string name="site_settings_default_category_title">หมวดหมู่ค่าเริ่มต้น</string>
+	<string name="site_settings_address_title">ที่อยู่</string>
+	<string name="site_settings_title_title">หัวข้อเว็บ</string>
+	<string name="site_settings_tagline_title">คำอธิบาย</string>
+	<string name="site_settings_this_device_header">อุปกรณ์นี้</string>
+	<string name="site_settings_account_header">บัญชี</string>
+	<string name="site_settings_writing_header">การเขียน</string>
+	<string name="newest_first">ใหม่สุดก่อน</string>
+	<string name="site_settings_general_header">ทั่วไป</string>
+	<string name="related_posts">เรื่องที่เกี่ยวข้อง</string>
+	<string name="comments">ความเห็น</string>
+	<string name="discussion">สนทนา</string>
+	<string name="privacy">ส่วนตัว</string>
+	<string name="close_after">ปิดหลังจาก</string>
+	<string name="oldest_first">เก่าสุดก่อน</string>
+	<string name="media_error_no_permission_upload">คุณไม่ได้รับอนุญาตให้อัปโหลดไฟล์สื่อมาที่เว็บนี้</string>
+	<string name="never">ไม่เคย</string>
+	<string name="unknown">ไม่รู้จัก</string>
 	<string name="reader_err_get_post_not_found">ไม่มีเรื่องนี้อยู่อีกแล้ว</string>
 	<string name="reader_err_get_post_not_authorized">คุณไม่มีสิทธิที่จะดูเรื่องนี้</string>
 	<string name="reader_err_get_post_generic">ไม่สามารถดึงข้อมูลเรื่องนี้</string>
@@ -121,14 +166,12 @@
 	<string name="trashed">เปลี่ยนเป็นขยะแล้ว</string>
 	<string name="button_back">กลับไป</string>
 	<string name="page_deleted">ลบหน้าแล้ว</string>
-	<string name="button_more">เพิ่มเติม</string>
 	<string name="button_stats">สถิติ</string>
 	<string name="button_trash">ขยะ</string>
 	<string name="button_preview">ดูก่อน</string>
 	<string name="button_view">ดู</string>
 	<string name="button_edit">แก้ไข</string>
 	<string name="button_publish">เผยแพร่</string>
-	<string name="button_delete">ลบ</string>
 	<string name="post_deleted">ลบหน้าแล้ว</string>
 	<string name="post_trashed">เรื่องที่ส่งไปถังขยะ</string>
 	<string name="page_trashed">หน้าที่ส่งไปถังขยะ</string>
@@ -170,7 +213,6 @@
 	<string name="my_site_btn_view_admin">ดูผู้ควบคุม</string>
 	<string name="my_site_header_publish">เผยแพร่</string>
 	<string name="my_site_header_look_and_feel">หน้าตาและสัมผัส (Look and Feel)</string>
-	<string name="my_site_btn_comments">ความเห็น</string>
 	<string name="my_site_btn_site_settings">ตั้งค่า</string>
 	<string name="my_site_btn_blog_posts">เรื่องบล็อก</string>
 	<string name="my_site_header_admin">ผู้ควบคุม</string>
@@ -303,7 +345,6 @@
 	<string name="stats_views">การดู</string>
 	<string name="stats_timeframe_years">ปี</string>
 	<string name="stats_pagination_label">หน้า %1$s จาก %2$s</string>
-	<string name="stats_comments">ความเห็น</string>
 	<string name="stats_likes">ชื่นชอบ</string>
 	<string name="stats_view_countries">ประเทศ</string>
 	<string name="stats_view_followers">ผู้ติดตาม</string>
@@ -337,13 +378,13 @@
 	<string name="reader_label_comment_count_single">หนึ่งความเห็น</string>
 	<string name="reader_label_comments_closed">ปิดการแสดงความเห็น</string>
 	<string name="reader_label_comments_on">ความเห็นบน</string>
-	<string name="reader_title_comments">ความเห็น</string>
 	<string name="reader_title_photo_viewer">%1$d จาก %2$d</string>
 	<string name="error_publish_empty_post">ไม่สามารถเผยแพร่เรื่องที่ไม่มีเนื้อหา</string>
 	<string name="error_refresh_unauthorized_posts">คุณไม่มีสิทธิ์ดูหรือแก้ไขเรื่อง</string>
 	<string name="error_refresh_unauthorized_pages">คุณไม่มีสิทธิ์ดูหรือแก้ไขหน้า</string>
 	<string name="error_refresh_unauthorized_comments">คุณไม่มีสิทธิ์ดูหรือแก้ไขความเห็น</string>
 	<string name="older_month">เก่ากว่าหนึ่งเดือน</string>
+	<string name="more">กว่า</string>
 	<string name="reader_empty_posts_liked">คุณยังไม่ได้ชื่นชอบเรื่องใด ๆ</string>
 	<string name="faq_button">คำถามที่พบบ่อย</string>
 	<string name="browse_our_faq_button">เรียกดูคำถามที่พบบ่อยของเรา</string>
@@ -645,9 +686,7 @@
 	<string name="stats_totals_views">ดู</string>
 	<string name="stats_totals_clicks">จำนวนที่กด</string>
 	<string name="stats_totals_plays">จำนวนที่เล่น</string>
-	<string name="stats_totals_comments">ความเห็น</string>
 	<string name="stats_view_referrers">ผู้อ้างอิง</string>
-	<string name="stats_view_comments">ความเห็น</string>
 	<string name="stats_timeframe_today">วันนี้</string>
 	<string name="stats_timeframe_yesterday">เมื่อวาน</string>
 	<string name="stats_timeframe_days">วัน</string>
@@ -738,7 +777,7 @@
 	<string name="tos">เงื่อนไขบริการ</string>
 	<string name="app_title">เวิร์ดเพรสสำหรับแอนดรอยด์</string>
 	<string name="about">เกี่ยวกับ</string>
-	<string name="max_thumbnail_px_width">ความกว้างรูปมาตรฐาน</string>
+	<string name="max_thumbnail_px_width">ความกว้างรูปค่าเริ่มต้น</string>
 	<string name="image_alignment">จัดหน้า</string>
 	<string name="refresh">รีเฟรช</string>
 	<string name="untitled">ไม่มีหัวข้อ</string>
@@ -777,7 +816,6 @@
 	<string name="cancel">ยกเลิก</string>
 	<string name="save">บันทึก</string>
 	<string name="add">เพิ่ม</string>
-	<string name="tab_comments">ความเห็น</string>
 	<string name="on">บน</string>
 	<string name="reply">ตอบกลับ</string>
 	<string name="category_refresh_error">โหลดหมวดหมู่อีกครั้งผิดพลาด</string>
@@ -828,6 +866,22 @@
 		<item>ชนิดเรื่องมาตรฐาน</item>
 		<item>ชนิดเรื่องสถานะ</item>
 		<item>ชนิดเรื่องวีดีโอ</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>ไม่มีความเห็น</item>
+		<item>ผู้ใช้ทั้งหมด</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>ไม่มี</item>
+		<item>สองระดับ</item>
+		<item>สามระดับ</item>
+		<item>สี่ระดับ</item>
+		<item>ห้าระดับ</item>
+		<item>หกระดับ</item>
+		<item>เจ็ดระดับ</item>
+		<item>แปดระดับ</item>
+		<item>เก้าระดับ</item>
+		<item>สิบระดับ</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>ฟรี</item>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">Orijinal Boyut</string>
+	<string name="about_me_hint">Hakkınızda birkaç kelime…</string>
+	<string name="public_display_name_hint">Ayarlanmazsa, görünen ad varsayılan olarak kullanıcı adınız şeklinde belirlenir</string>
+	<string name="about_me">Hakkımda</string>
+	<string name="public_display_name">Herkese açık görünen ad</string>
+	<string name="my_profile">Profilim</string>
+	<string name="first_name">Ad</string>
+	<string name="last_name">Soyadı</string>
+	<string name="site_privacy_public_desc">Arama motorlarının bu siteyi endekslemesine izin ver</string>
+	<string name="site_privacy_hidden_desc">Arama motorlarının bu siteyi endekslemesini önle</string>
+	<string name="site_privacy_private_desc">Sitemin sadece seçtiğim kullanıcılara görünecek şekilde özel olmasını istiyorum</string>
+	<string name="cd_related_post_preview_image">İlgili yazı önizleme görseli</string>
+	<string name="error_post_remote_site_settings">Site bilgileri kaydedilemedi</string>
+	<string name="error_fetch_remote_site_settings">Site bilgileri alınamadı</string>
+	<string name="error_media_upload_connection">Medya yüklenirken bağlantı hatası oluştu</string>
+	<string name="site_settings_disconnected_toast">Bağlantı kesik, düzenleme devre dışı.</string>
+	<string name="site_settings_unsupported_version_error">Desteklenmeyen WordPress sürümü</string>
+	<string name="site_settings_multiple_links_dialog_description">Belirtilenden fazla sayıda bağlantı içeren yorumlar için onay iste.</string>
+	<string name="site_settings_close_after_dialog_switch_text">Otomatik olarak kapat</string>
+	<string name="site_settings_close_after_dialog_description">Makalelerdeki yorumları otomatik kapat.</string>
+	<string name="site_settings_paging_dialog_description">Yorum zincirlerini birden çok sayfaya böl.</string>
+	<string name="site_settings_paging_dialog_header">Sayfa başına yorum</string>
+	<string name="site_settings_close_after_dialog_title">Yorumları kapat</string>
+	<string name="site_settings_blacklist_description">Bir yorum içeriğinde, adında, URL’sinde, e-posta ya da IP’sinde bu sözcüklerden biri bulunuyorsa bu yorum, istenmeyen olarak işaretlenecektir. Sözcük parçaları girebilirsiniz; örneğin "press" ifadesi "WordPress" ile eşleşecektir.</string>
+	<string name="site_settings_hold_for_moderation_description">Bir yorumun içeriğinde, adında, URL\'sinde, e-posta ya da IP’sinde bu sözcüklerden biri bulunuyorsa bu yorum, denetim kuyruğuna alınır. Sözcük parçaları girebilirsiniz; örneğin "press" ifadesi "WordPress" ile eşleşecektir.</string>
+	<string name="site_settings_list_editor_input_hint">Bir sözcük veya sözcük grubu girin</string>
+	<string name="site_settings_list_editor_no_items_text">Öge yok</string>
+	<string name="site_settings_learn_more_caption">Bu ayarları yazı özelinde geçersiz kılabilirsiniz.</string>
+	<string name="site_settings_rp_preview3_site">"Yükseltme" içinde</string>
+	<string name="site_settings_rp_preview3_title">Yükseltme Odağı: Düğünler İçin VideoPress</string>
+	<string name="site_settings_rp_preview2_site">"Uygulamalar" içinde</string>
+	<string name="site_settings_rp_preview2_title">Android için WordPress Uygulaması Büyük Bir Görsel Gelişim Yaşadı</string>
+	<string name="site_settings_rp_preview1_site">"Mobil" içinde</string>
+	<string name="site_settings_rp_preview1_title">Büyük iPhone/iPad Güncellemesi İndirilmeye Hazır</string>
+	<string name="site_settings_rp_show_images_title">Görselleri Göster</string>
+	<string name="site_settings_rp_show_header_title">Başlığı Göster</string>
+	<string name="site_settings_rp_switch_summary">Benzer Yazılar, yazılarınızın altında sitenizden ilgili içerikler gösterir.</string>
+	<string name="site_settings_rp_switch_title">Benzer Yazıları Göster</string>
+	<string name="site_settings_delete_site_hint">Sitenizin verilerini uygulamadan kaldırır</string>
+	<string name="site_settings_blacklist_hint">Bir filtre ile eşleşen yorumlar istenmeyen olarak işaretlenir</string>
+	<string name="site_settings_moderation_hold_hint">Bir filtre ile eşleşen yorumlar denetim kuyruğuna alınır</string>
+	<string name="site_settings_multiple_links_hint">Bilinen kullanıcılar için bağlantı sayısı sınırını yoksayar</string>
+	<string name="site_settings_whitelist_hint">Yorum yazarının önceden onaylanmış bir yorumu olmalıdır</string>
+	<string name="site_settings_user_account_required_hint">Kullanıcılar yorum yapmak için kaydolmalı ve oturum açmalılardır</string>
+	<string name="site_settings_identity_required_hint">Yorum yazarı ad ve e-posta alanlarını doldurmalıdır</string>
+	<string name="site_settings_manual_approval_hint">Yorumlar el ile onaylanmalıdır</string>
+	<string name="site_settings_paging_hint">Yorumları belirlenen bir boyuttaki öbekler halinde görüntüle</string>
+	<string name="site_settings_threading_hint">Belli bir seviyeye kadar iç içe yorumlara izin ver</string>
+	<string name="site_settings_sort_by_hint">Yorumların görüntülenme sırasını belirler</string>
+	<string name="site_settings_close_after_hint">Belirtilen zamandan sonra yorumlara izin verme</string>
+	<string name="site_settings_receive_pingbacks_hint">Diğer bloglardan bağlantı bildirimlerine izin ver</string>
+	<string name="site_settings_send_pingbacks_hint">Makalede bağlantı verilen blogları haberdar etmeyi dene</string>
+	<string name="site_settings_allow_comments_hint">Okuyucuların yorum göndermesine izin ver</string>
+	<string name="site_settings_discussion_hint">Sitenizin tartışma ayarlarını görüntüleyin ve değiştirin</string>
+	<string name="site_settings_more_hint">Tüm kullanılabilir Tartışma ayarlarını görüntüle</string>
+	<string name="site_settings_related_posts_hint">Benzer yazıları okuyucuda göster veya sakla</string>
+	<string name="site_settings_upload_and_link_image_hint">Görseli her zaman tam boyutta yüklemeyi etkinleştir</string>
+	<string name="site_settings_image_width_hint">Yazılardaki görüntülerin boyutunu bu genişliğe değiştirir</string>
+	<string name="site_settings_format_hint">Yeni yazı biçimi ayarlar</string>
+	<string name="site_settings_category_hint">Yeni yazı kategorisi ayarlar</string>
+	<string name="site_settings_location_hint">Yazılarınıza otomatik olarak konum verileri ekleyin</string>
+	<string name="site_settings_password_hint">Parolanızı değiştirin</string>
+	<string name="site_settings_username_hint">Geçerli kullanıcı hesabı</string>
+	<string name="site_settings_language_hint">Bu blogun yazıldığı birincil dil</string>
+	<string name="site_settings_privacy_hint">Sitenizi kimlerin görebileceğini kontrol eder</string>
+	<string name="site_settings_address_hint">Adresinizi değiştirme şu anda desteklenmiyor</string>
+	<string name="site_settings_tagline_hint">Blogunuzu anlatan kısa bir açıklama ya da akılda kalıcı bir ifade</string>
+	<string name="site_settings_title_hint">Birkaç kelimeyle bu sitenin ne ile ilgili olduğunu anlatın</string>
+	<string name="site_settings_whitelist_known_summary">Bilinen kullanıcılardan yorumlar</string>
+	<string name="site_settings_whitelist_all_summary">Tüm kullanıcılardan yorumlar</string>
+	<string name="site_settings_threading_summary">%d seviye</string>
+	<string name="site_settings_privacy_private_summary">Özel</string>
+	<string name="site_settings_privacy_hidden_summary">Gizli</string>
+	<string name="site_settings_delete_site_title">Siteyi Sil</string>
+	<string name="site_settings_privacy_public_summary">Herkese Açık</string>
+	<string name="site_settings_blacklist_title">Kara liste</string>
+	<string name="site_settings_moderation_hold_title">Denetleme için tut</string>
+	<string name="site_settings_multiple_links_title">Yorumlardaki bağlantılar</string>
+	<string name="site_settings_whitelist_title">Otomatik olarak onayla</string>
+	<string name="site_settings_threading_title">Yorum zinciri ayarı</string>
+	<string name="site_settings_paging_title">Sayfa ayarı</string>
+	<string name="site_settings_sort_by_title">Sırala</string>
+	<string name="site_settings_account_required_title">Kullanıcılar oturum açmış olmalıdır</string>
+	<string name="site_settings_identity_required_title">Ad ve e-posta adresi içermelidir</string>
+	<string name="site_settings_receive_pingbacks_title">Geri Bildirim Al</string>
+	<string name="site_settings_send_pingbacks_title">Geri Bildirim Gönder</string>
+	<string name="site_settings_allow_comments_title">Yorumlara İzin Ver</string>
+	<string name="site_settings_default_format_title">Varsayılan Biçim</string>
+	<string name="site_settings_default_category_title">Varsayılan Kategori</string>
+	<string name="site_settings_location_title">Konumu Etkinleştir</string>
+	<string name="site_settings_address_title">Adres</string>
+	<string name="site_settings_title_title">Site Başlığı</string>
+	<string name="site_settings_tagline_title">Etiket Satırı</string>
+	<string name="site_settings_this_device_header">Bu cihaz</string>
+	<string name="site_settings_discussion_new_posts_header">Yeni yazılar için varsayılanlar</string>
+	<string name="site_settings_account_header">Hesap</string>
+	<string name="site_settings_writing_header">Yazma</string>
+	<string name="newest_first">İlk en yeni</string>
+	<string name="site_settings_general_header">Genel</string>
+	<string name="discussion">Tartışma</string>
+	<string name="privacy">Gizlilik</string>
+	<string name="related_posts">İlgili Yazılar</string>
+	<string name="comments">Yorumlar</string>
+	<string name="close_after">Şu süreden sonra kapat:</string>
+	<string name="oldest_first">İlk en eski</string>
+	<string name="media_error_no_permission_upload">Siteye medya yükleme izniniz yok</string>
+	<string name="never">Hiçbir zaman</string>
+	<string name="unknown">Bilinmeyen</string>
 	<string name="reader_err_get_post_not_found">Bu yazı artık mevcut değil</string>
 	<string name="reader_err_get_post_not_authorized">Bu yazıyı görüntülemeye yetkili değilsiniz</string>
 	<string name="reader_err_get_post_generic">Bu yazı getirilemiyor</string>
@@ -119,13 +227,11 @@
 	<string name="connectionbar_no_connection">Bağlantı yok</string>
 	<string name="button_back">Geri</string>
 	<string name="page_deleted">Sayfa silindi</string>
-	<string name="button_more">Daha fazla</string>
 	<string name="button_stats">İstatistikler</string>
 	<string name="button_preview">Ön izleme</string>
 	<string name="button_view">Görüntüle</string>
 	<string name="button_edit">Düzenle</string>
 	<string name="button_publish">Yayımla</string>
-	<string name="button_delete">Sil</string>
 	<string name="button_trash">Çöpe taşı</string>
 	<string name="post_deleted">Yazı silindi</string>
 	<string name="trashed">Çöpe taşındı</string>
@@ -171,7 +277,6 @@
 	<string name="my_site_header_look_and_feel">Genel Görünüm</string>
 	<string name="my_site_btn_blog_posts">Blog Yazıları</string>
 	<string name="my_site_btn_site_settings">Ayarlar</string>
-	<string name="my_site_btn_comments">Yorumlar</string>
 	<string name="my_site_header_publish">Yayımla</string>
 	<string name="reader_label_new_posts_subtitle">Göstermek için dokunun</string>
 	<string name="my_site_header_admin">Yönetici</string>
@@ -307,7 +412,6 @@
 	<string name="stats_view_videos">Videolar</string>
 	<string name="stats_entry_clicks_link">Bağlantı</string>
 	<string name="stats_entry_followers">Takipçi</string>
-	<string name="stats_comments">Yorumlar</string>
 	<string name="stats_visitors">Ziyaretçiler</string>
 	<string name="stats_totals_publicize">Takipçiler</string>
 	<string name="ssl_certificate_details">Detaylar</string>
@@ -335,12 +439,12 @@
 	<string name="reader_label_comment_count_single">Bir yorum</string>
 	<string name="reader_label_comments_closed">Yorumlar kapandı</string>
 	<string name="reader_label_comments_on">Yorum yapılan konu:</string>
-	<string name="reader_title_comments">Yorumlar</string>
 	<string name="reader_title_photo_viewer">%1$d / %2$d</string>
 	<string name="error_refresh_unauthorized_posts">Yazıları görüntüleme veya düzenleme izniniz yok</string>
 	<string name="error_refresh_unauthorized_pages">Sayfaları görüntüleme veya düzenleme izniniz yok</string>
 	<string name="error_refresh_unauthorized_comments">Yorumları görüntüleme veya düzenleme izniniz yok</string>
 	<string name="older_month">Bir aydan eski</string>
+	<string name="more">Daha Fazla</string>
 	<string name="older_two_days">2 günden eski</string>
 	<string name="older_last_week">1 haftadan eski</string>
 	<string name="stats_no_blog">İstenen blog için istatistikler yüklenemiyor</string>
@@ -655,7 +759,6 @@
 	<string name="share_action">Paylaş</string>
 	<string name="stats">İstatistikler</string>
 	<string name="stats_view_clicks">Tıklamalar</string>
-	<string name="stats_view_comments">Yorumlar</string>
 	<string name="stats_timeframe_today">Bugün</string>
 	<string name="stats_timeframe_yesterday">Dün</string>
 	<string name="stats_timeframe_days">Günler</string>
@@ -668,7 +771,6 @@
 	<string name="stats_totals_views">Görüntülemeler</string>
 	<string name="stats_totals_clicks">Tıklamalar</string>
 	<string name="stats_totals_plays">Çalınanlar</string>
-	<string name="stats_totals_comments">Yorumlar</string>
 	<string name="menu_search">Ara</string>
 	<string name="passcode_manage">PIN kilidini yönet</string>
 	<string name="passcode_change_passcode">PIN değiştir</string>
@@ -738,7 +840,7 @@
 	<string name="app_title">Android için WordPress</string>
 	<string name="tos">Hizmet Şartları</string>
 	<string name="about">Hakkında</string>
-	<string name="max_thumbnail_px_width">Varsayılan görsel genişliği</string>
+	<string name="max_thumbnail_px_width">Varsayılan Görsel Genişliği</string>
 	<string name="image_alignment">Konumlandırma</string>
 	<string name="refresh">Yenile</string>
 	<string name="untitled">Başlıksız</string>
@@ -775,7 +877,6 @@
 	<string name="cancel">İptal</string>
 	<string name="save">Kaydet</string>
 	<string name="add">Ekle</string>
-	<string name="tab_comments">Yorumlar</string>
 	<string name="preview">Önizleme</string>
 	<string name="on">üstünde</string>
 	<string name="reply">Cevapla</string>
@@ -828,6 +929,33 @@
 		<item>Standard</item>
 		<item>Durum</item>
 		<item>Video</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>Siteniz herkes tarafından görülebilir ve arama motorları tarafından endekslenebilir</item>
+		<item>Siteniz herkes tarafından görülebilir, ancak arama motorlarından kendisini endekslememelerini ister</item>
+		<item>Siteniz sadece siz ve onay verdiğiniz kullanıcılar tarafından görülebilir</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>Herkesin yorumları için el ile onaylama ister.</item>
+		<item>Kullanıcının daha önceden onaylanmış bir yorumu varsa otomatik olarak onayla.</item>
+		<item>Herkesin yorumlarını otomatik olarak onayla.</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>Hiçbir yorum</item>
+		<item>Bilinen kullanıcıların yorumları</item>
+		<item>Tüm kullanıcılar</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>Hiçbiri</item>
+		<item>İki seviye</item>
+		<item>Üç seviye</item>
+		<item>Dört seviye</item>
+		<item>Beş seviye</item>
+		<item>Altı seviye</item>
+		<item>Yedi seviye</item>
+		<item>Sekiz seviye</item>
+		<item>Dokuz seviye</item>
+		<item>On seviye</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>Ücretsiz</item>

--- a/WordPress/src/main/res/values-uz/strings.xml
+++ b/WordPress/src/main/res/values-uz/strings.xml
@@ -82,7 +82,6 @@
 	<string name="stats_view_visitors_and_views">Kirivchular va ko‘rishlar</string>
 	<string name="stats_view_clicks">Bosishlar</string>
 	<string name="stats_view_tags_and_categories">Teg va bo‘limlar</string>
-	<string name="stats_view_comments">Mulohazalar</string>
 	<string name="stats_timeframe_today">Bugun</string>
 	<string name="stats_timeframe_yesterday">Kecha</string>
 	<string name="stats_timeframe_days">Kunlar</string>
@@ -95,7 +94,6 @@
 	<string name="stats_totals_views">Ko‘rishlar</string>
 	<string name="stats_totals_clicks">Bosishlar</string>
 	<string name="stats_totals_plays">Ko‘rishlar</string>
-	<string name="stats_totals_comments">Mulohazalar</string>
 	<string name="custom_date">Ixtiyoriy sana</string>
 	<string name="media_add_popup_capture_photo">Sur‘atga oling</string>
 	<string name="media_add_popup_capture_video">Videoga oling</string>
@@ -156,7 +154,6 @@
 	<string name="tos">Xizmat shartlari</string>
 	<string name="app_title">WordPress for Android</string>
 	<string name="about">Haqida</string>
-	<string name="max_thumbnail_px_width">Asos enlik</string>
 	<string name="image_alignment">Tekislash</string>
 	<string name="refresh">Yangila</string>
 	<string name="untitled">Nomsiz</string>
@@ -193,7 +190,6 @@
 	<string name="cancel">Bekor qilish</string>
 	<string name="add">Qo‘shish</string>
 	<string name="preview">Oldindan ko‘rish</string>
-	<string name="tab_comments">Mulohazalar</string>
 	<string name="category_refresh_error">Bo‘limlarni yangilashda xatolik</string>
 	<string name="error">Xato</string>
 	<string name="save">Saqla</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">原始大小</string>
+	<string name="about_me_hint">有关您的一些字词…</string>
+	<string name="public_display_name_hint">显示名称（如果未设置）将默认为您的用户名</string>
+	<string name="about_me">关于我</string>
+	<string name="public_display_name">公开显示名称</string>
+	<string name="my_profile">我的个人资料</string>
+	<string name="first_name">名字</string>
+	<string name="last_name">姓氏</string>
+	<string name="site_privacy_public_desc">允许搜索引擎将此站点编入索引</string>
+	<string name="site_privacy_hidden_desc">不鼓励搜索引擎将此站点编入索引</string>
+	<string name="site_privacy_private_desc">我希望我的站点保持私密，仅对我选择的用户可见</string>
+	<string name="cd_related_post_preview_image">相关文章预览图片</string>
+	<string name="error_post_remote_site_settings">无法保存站点信息</string>
+	<string name="error_fetch_remote_site_settings">无法检索站点信息</string>
+	<string name="error_media_upload_connection">上传媒体文件时出现连接错误</string>
+	<string name="site_settings_disconnected_toast">已断开连接，编辑已被禁用。</string>
+	<string name="site_settings_unsupported_version_error">不受支持的 WordPress 版本</string>
+	<string name="site_settings_multiple_links_dialog_description">所含链接数超过此数量的评论需要进行审核。</string>
+	<string name="site_settings_close_after_dialog_switch_text">自动关闭</string>
+	<string name="site_settings_close_after_dialog_description">自动关闭文章评论。</string>
+	<string name="site_settings_paging_dialog_description">将评论线程划分到多个页面。</string>
+	<string name="site_settings_paging_dialog_header">每个页面上的评论</string>
+	<string name="site_settings_close_after_dialog_title">关闭评论</string>
+	<string name="site_settings_blacklist_description">如果评论的内容、名称、URL、电子邮件或 IP 中包含其中任意字词，则评论会被标记为垃圾内容。您可输入部分字词，这样，输入“press”将匹配出“WordPress”。</string>
+	<string name="site_settings_hold_for_moderation_description">如果评论的内容、名称、URL、电子邮件或 IP 中包含其中任意字词，则评论会保留在审核队列中。您可输入部分字词，这样，输入“press”将匹配出“WordPress”。</string>
+	<string name="site_settings_list_editor_input_hint">输入一个单词或短语</string>
+	<string name="site_settings_list_editor_no_items_text">无菜单项</string>
+	<string name="site_settings_learn_more_caption">您可以为各篇文章覆盖这些设置。</string>
+	<string name="site_settings_rp_preview3_site">在“升级”中</string>
+	<string name="site_settings_rp_preview3_title">升级重点：婚礼 VideoPress</string>
+	<string name="site_settings_rp_preview2_site">在“应用程序”中</string>
+	<string name="site_settings_rp_preview2_title">Android 版 WordPress 应用程序外观有大变动</string>
+	<string name="site_settings_rp_preview1_site">在“手机”中</string>
+	<string name="site_settings_rp_preview1_title">iPhone/iPad 现在有大更新</string>
+	<string name="site_settings_rp_show_images_title">显示图片</string>
+	<string name="site_settings_rp_show_header_title">显示标题</string>
+	<string name="site_settings_rp_switch_summary">“相关文章”在您的文章下方显示您站点中的相关内容。</string>
+	<string name="site_settings_rp_switch_title">显示相关文章</string>
+	<string name="site_settings_delete_site_hint">从应用程序中删除站点数据</string>
+	<string name="site_settings_blacklist_hint">将与过滤器匹配的评论标记为垃圾内容</string>
+	<string name="site_settings_moderation_hold_hint">将与过滤器匹配的评论置于审核队列</string>
+	<string name="site_settings_multiple_links_hint">忽略来自已知用户的链接限制</string>
+	<string name="site_settings_whitelist_hint">评论作者必须已有审核通过的评论</string>
+	<string name="site_settings_user_account_required_hint">用户必须已注册并登录才能评论</string>
+	<string name="site_settings_identity_required_hint">评论作者必须填写名称和电子邮件</string>
+	<string name="site_settings_manual_approval_hint">评论必须经过人工审核</string>
+	<string name="site_settings_paging_hint">以指定大小的数据块显示评论</string>
+	<string name="site_settings_threading_hint">允许特定深度的嵌套评论</string>
+	<string name="site_settings_sort_by_hint">确定评论的显示顺序</string>
+	<string name="site_settings_close_after_hint">不允许在指定时间后评论</string>
+	<string name="site_settings_receive_pingbacks_hint">允许来自其他博客的链接通知</string>
+	<string name="site_settings_send_pingbacks_hint">尝试通知从文章链接到的任何博客</string>
+	<string name="site_settings_allow_comments_hint">允许阅读者发布评论</string>
+	<string name="site_settings_discussion_hint">查看并更改您的站点讨论设置</string>
+	<string name="site_settings_more_hint">查看所有可用的讨论设置</string>
+	<string name="site_settings_related_posts_hint">在阅读器中显示或隐藏相关文章</string>
+	<string name="site_settings_upload_and_link_image_hint">启用以始终上传完整大小的图片</string>
+	<string name="site_settings_image_width_hint">将文章中的图片大小调整至此宽度</string>
+	<string name="site_settings_format_hint">设置新的文章格式</string>
+	<string name="site_settings_category_hint">设置新的文章类别</string>
+	<string name="site_settings_location_hint">自动为文章添加位置数据</string>
+	<string name="site_settings_password_hint">更改您的密码</string>
+	<string name="site_settings_username_hint">当前用户帐户</string>
+	<string name="site_settings_language_hint">此博客的主要撰写语言</string>
+	<string name="site_settings_privacy_hint">控制可查看站点的人员</string>
+	<string name="site_settings_address_hint">目前不支持更改地址</string>
+	<string name="site_settings_tagline_hint">介绍您的博客的简短说明或夺人眼球的短语</string>
+	<string name="site_settings_title_hint">以简洁的话语介绍此站点的内容</string>
+	<string name="site_settings_whitelist_known_summary">来自已知用户的评论</string>
+	<string name="site_settings_whitelist_all_summary">来自所有用户的评论</string>
+	<string name="site_settings_threading_summary"> 个级别</string>
+	<string name="site_settings_privacy_private_summary">私密</string>
+	<string name="site_settings_privacy_hidden_summary">已隐藏</string>
+	<string name="site_settings_delete_site_title">删除站点</string>
+	<string name="site_settings_privacy_public_summary">公开</string>
+	<string name="site_settings_blacklist_title">黑名单</string>
+	<string name="site_settings_moderation_hold_title">保持审核状态</string>
+	<string name="site_settings_multiple_links_title">评论中的链接</string>
+	<string name="site_settings_whitelist_title">自动审核</string>
+	<string name="site_settings_threading_title">线程</string>
+	<string name="site_settings_paging_title">分页</string>
+	<string name="site_settings_sort_by_title">排序方式</string>
+	<string name="site_settings_account_required_title">用户必须注册</string>
+	<string name="site_settings_identity_required_title">必须包括名称和电子邮件</string>
+	<string name="site_settings_receive_pingbacks_title">接收 Pingback</string>
+	<string name="site_settings_send_pingbacks_title">发送 Pingback</string>
+	<string name="site_settings_allow_comments_title">允许评论</string>
+	<string name="site_settings_default_format_title">默认格式</string>
+	<string name="site_settings_default_category_title">默认类别</string>
+	<string name="site_settings_location_title">启用位置</string>
+	<string name="site_settings_address_title">地址</string>
+	<string name="site_settings_title_title">站点标题</string>
+	<string name="site_settings_tagline_title">标语</string>
+	<string name="site_settings_this_device_header">此设备</string>
+	<string name="site_settings_discussion_new_posts_header">默认用于新文章</string>
+	<string name="site_settings_account_header">帐户</string>
+	<string name="site_settings_writing_header">撰写</string>
+	<string name="newest_first">最新评论在先</string>
+	<string name="site_settings_general_header">常规</string>
+	<string name="discussion">讨论</string>
+	<string name="privacy">隐私</string>
+	<string name="related_posts">相关文章</string>
+	<string name="comments">评论</string>
+	<string name="close_after">在指定天数后关闭</string>
+	<string name="oldest_first">最早评论在先</string>
+	<string name="media_error_no_permission_upload">您无权向此站点上传媒体文件</string>
+	<string name="never">从不</string>
+	<string name="unknown">未知</string>
 	<string name="reader_err_get_post_not_found">此文章不再存在</string>
 	<string name="reader_err_get_post_not_authorized">您不具备查看此文章的权限</string>
 	<string name="reader_err_get_post_generic">无法检索这篇文章</string>
@@ -124,14 +232,12 @@
 	<string name="trashed">已放入回收站</string>
 	<string name="button_back">返回</string>
 	<string name="page_deleted">已删除页面</string>
-	<string name="button_more">更多</string>
 	<string name="button_stats">统计信息</string>
 	<string name="button_trash">放入回收站</string>
 	<string name="button_preview">预览</string>
 	<string name="button_view">查看</string>
 	<string name="button_edit">编辑</string>
 	<string name="button_publish">发布</string>
-	<string name="button_delete">删除</string>
 	<string name="my_site_no_sites_view_subtitle">想要添加一个吗？</string>
 	<string name="my_site_no_sites_view_title">您目前没有任何 WordPress 站点。</string>
 	<string name="my_site_no_sites_view_drake">插图</string>
@@ -170,7 +276,6 @@
 	<string name="my_site_btn_view_site">查看站点</string>
 	<string name="my_site_header_look_and_feel">外观</string>
 	<string name="my_site_header_publish">发布</string>
-	<string name="my_site_btn_comments">评论</string>
 	<string name="my_site_btn_site_settings">设置</string>
 	<string name="my_site_btn_blog_posts">博客文章</string>
 	<string name="reader_label_new_posts_subtitle">轻点以显示文章</string>
@@ -221,6 +326,8 @@
 	<string name="two_step_sms_sent">查收短信查看验证码。</string>
 	<string name="sign_in_jetpack">登录 WordPress.com 帐户来连接 Jetpack。</string>
 	<string name="auth_required">再次登录以继续操作。</string>
+	<string name="media_details_label_file_name">文件名</string>
+	<string name="media_details_label_file_type">文件类型</string>
 	<string name="stats_followers_total_email_paged">正在显示 %1$d - %2$d 位（共 %3$s 位）电子邮件关注者</string>
 	<string name="stats_followers_total_wpcom_paged">正在显示 %1$d - %2$d 位（共 %3$s 位）WordPress.com 关注者</string>
 	<string name="reader_empty_posts_request_failed">无法检索文章</string>
@@ -255,7 +362,6 @@
 	<string name="stats_views">浏览量</string>
 	<string name="stats_visitors">访客</string>
 	<string name="stats_likes">赞</string>
-	<string name="stats_comments">评论</string>
 	<string name="stats_view_followers">关注者</string>
 	<string name="stats_view_countries">国家/地区</string>
 	<string name="stats_view_videos">视频</string>
@@ -332,13 +438,13 @@
 	<string name="reader_label_comment_count_single">1 条评论</string>
 	<string name="reader_label_comments_closed">评论功能被关闭</string>
 	<string name="reader_label_comments_on">评论于</string>
-	<string name="reader_title_comments">评论</string>
 	<string name="reader_title_photo_viewer">%1$d/%2$d</string>
 	<string name="error_publish_empty_post">发布的文章不能为空</string>
 	<string name="error_refresh_unauthorized_posts">您不具备查看或编辑文章的权限</string>
 	<string name="error_refresh_unauthorized_pages">您不具备查看或编辑页面的权限</string>
 	<string name="error_refresh_unauthorized_comments">您不具备查看或编辑评论的权限</string>
 	<string name="older_month">超过一个月</string>
+	<string name="more">更多</string>
 	<string name="older_two_days">超过 2 天</string>
 	<string name="older_last_week">超过 1 周</string>
 	<string name="stats_no_blog">无法加载所需博客的统计信息</string>
@@ -647,7 +753,6 @@
 	<string name="stats_timeframe_days">天</string>
 	<string name="stats_timeframe_weeks">周</string>
 	<string name="stats_timeframe_months">月</string>
-	<string name="stats_view_comments">评论</string>
 	<string name="stats_view_clicks">点击</string>
 	<string name="share_action_title">添加到...</string>
 	<string name="theme_auth_error_title">未能获取主题</string>
@@ -686,7 +791,6 @@
 	<string name="stats_totals_views">浏览次数</string>
 	<string name="stats_totals_clicks">点击数</string>
 	<string name="stats_totals_plays">播放数</string>
-	<string name="stats_totals_comments">评论数</string>
 	<string name="stats_view_visitors_and_views">访问量和浏览量</string>
 	<string name="stats_view_referrers">推荐人</string>
 	<string name="stats_entry_country">国家</string>
@@ -736,7 +840,7 @@
 	<string name="tos">服务条款</string>
 	<string name="app_title">WordPress for Android</string>
 	<string name="about">关于</string>
-	<string name="max_thumbnail_px_width">默认图像宽度</string>
+	<string name="max_thumbnail_px_width">默认图片宽度</string>
 	<string name="image_alignment">对齐</string>
 	<string name="refresh">刷新</string>
 	<string name="untitled">无标题</string>
@@ -774,7 +878,6 @@
 	<string name="save">保存</string>
 	<string name="add">添加</string>
 	<string name="category_refresh_error">分类刷新错误</string>
-	<string name="tab_comments">评论</string>
 	<string name="on">于</string>
 	<string name="reply">回复</string>
 	<string name="yes">是</string>
@@ -826,6 +929,33 @@
 		<item>标准</item>
 		<item>状态</item>
 		<item>视频</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>您的站点对所有人可见，并且可以被搜索引擎编入索引</item>
+		<item>您的站点对所有人可见，但要求搜索引擎不将其编入索引</item>
+		<item>您的站点仅对您以及您审核通过的用户可见</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>每个人的评论都需要进行人工审核。</item>
+		<item>如果用户已有审核通过的评论，则系统将自动审核该用户的其他评论。</item>
+		<item>自动审核每个人的评论。</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>没有评论</item>
+		<item>已知用户的评论</item>
+		<item>所有用户</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>无</item>
+		<item>两个级别</item>
+		<item>三个级别</item>
+		<item>四个级别</item>
+		<item>五个级别</item>
+		<item>六个级别</item>
+		<item>七个级别</item>
+		<item>八个级别</item>
+		<item>九个级别</item>
+		<item>十个级别</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>免费</item>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">原始尺寸</string>
+	<string name="about_me_hint">簡單介紹一下自己…</string>
+	<string name="public_display_name_hint">如果未設定，顯示名稱會預設為你的使用者名稱</string>
+	<string name="about_me">關於我</string>
+	<string name="public_display_name">公開顯示名稱</string>
+	<string name="my_profile">我的個人檔案</string>
+	<string name="first_name">名</string>
+	<string name="last_name">姓</string>
+	<string name="site_privacy_public_desc">允許搜尋引擎將這個網站加入索引</string>
+	<string name="site_privacy_hidden_desc">阻擋搜尋引擎將這個網站加入索引</string>
+	<string name="site_privacy_private_desc">我想要將我的網站設為私人網站，只有我選擇的使用者可看見</string>
+	<string name="cd_related_post_preview_image">相關文章預覽圖片</string>
+	<string name="error_post_remote_site_settings">無法儲存網站資訊</string>
+	<string name="error_fetch_remote_site_settings">無法擷取網站資訊</string>
+	<string name="error_media_upload_connection">上傳媒體時發生連線錯誤</string>
+	<string name="site_settings_disconnected_toast">已中斷連線，編輯功能已停用。</string>
+	<string name="site_settings_unsupported_version_error">不支援的 WordPress 版本</string>
+	<string name="site_settings_multiple_links_dialog_description">如果留言包含的連結超過此數量，留言就必須經過審核。</string>
+	<string name="site_settings_close_after_dialog_switch_text">自動關閉</string>
+	<string name="site_settings_close_after_dialog_description">自動關閉文章的留言功能。</string>
+	<string name="site_settings_paging_dialog_description">將留言串分為數頁。</string>
+	<string name="site_settings_paging_dialog_header">每頁留言數</string>
+	<string name="site_settings_close_after_dialog_title">關閉留言功能</string>
+	<string name="site_settings_blacklist_description">如果留言的內容、名稱、URL、電子郵件或 IP 位址中含有以下文字，該留言將標記為垃圾留言。你也可以輸入字詞的一部分，例如「press」會與「WordPress」相符。</string>
+	<string name="site_settings_hold_for_moderation_description">如果留言的內容、名稱、URL、電子郵件或 IP 位址中含有以下文字，就會被送進審核清單。你也可以輸入字詞的一部分，例如「press」會與「WordPress」相符。</string>
+	<string name="site_settings_list_editor_input_hint">輸入字詞或片語</string>
+	<string name="site_settings_list_editor_no_items_text">無項目</string>
+	<string name="site_settings_learn_more_caption">你可以針對不同的文章覆寫這些設定。</string>
+	<string name="site_settings_rp_preview3_site">在「升級」中</string>
+	<string name="site_settings_rp_preview3_title">升級重點：婚禮適用的 VideoPress</string>
+	<string name="site_settings_rp_preview2_site">在「應用程式」中</string>
+	<string name="site_settings_rp_preview2_title">Android 專用的 WordPress 應用程式已全面翻新</string>
+	<string name="site_settings_rp_preview1_site">在「行動」中</string>
+	<string name="site_settings_rp_preview1_title">有重大的 iPhone/iPad 更新可供使用</string>
+	<string name="site_settings_rp_show_images_title">顯示圖片</string>
+	<string name="site_settings_rp_show_header_title">顯示頁首</string>
+	<string name="site_settings_rp_switch_summary">相關文章會在你的文章下方顯示網站上的相關內容。</string>
+	<string name="site_settings_rp_switch_title">顯示相關文章</string>
+	<string name="site_settings_delete_site_hint">從應用程式移除你的網站資料</string>
+	<string name="site_settings_blacklist_hint">與篩選條件相符的留言將標示為垃圾留言</string>
+	<string name="site_settings_moderation_hold_hint">與篩選條件相符的留言將被送進審核清單</string>
+	<string name="site_settings_multiple_links_hint">忽略已知使用者的連結限制</string>
+	<string name="site_settings_whitelist_hint">先前有經核准的留言才可以發表留言</string>
+	<string name="site_settings_user_account_required_hint">已註冊且登入的使用者才可以發表留言</string>
+	<string name="site_settings_identity_required_hint">輸入名稱和電子郵件後才可以發表留言</string>
+	<string name="site_settings_manual_approval_hint">留言必須經人工核准</string>
+	<string name="site_settings_paging_hint">按照指定的區塊大小顯示留言</string>
+	<string name="site_settings_threading_hint">允許留言達到一定高度後以巢狀顯示</string>
+	<string name="site_settings_sort_by_hint">決定留言顯示順序</string>
+	<string name="site_settings_close_after_hint">不允許在指定的時間後發表留言</string>
+	<string name="site_settings_receive_pingbacks_hint">允許其他網誌在建立連結時傳送通知</string>
+	<string name="site_settings_send_pingbacks_hint">嘗試通知在文章中建立連結的所有網誌</string>
+	<string name="site_settings_allow_comments_hint">允許讀者發表留言</string>
+	<string name="site_settings_discussion_hint">檢視及變更你的網站討論設定</string>
+	<string name="site_settings_more_hint">檢視所有可變更的討論設定</string>
+	<string name="site_settings_related_posts_hint">在讀取器中顯示或隱藏相關文章</string>
+	<string name="site_settings_upload_and_link_image_hint">允許一律上傳完整大小的圖片</string>
+	<string name="site_settings_image_width_hint">將文章中的圖片調整為符合以下寬度</string>
+	<string name="site_settings_format_hint">設定新的文章格式</string>
+	<string name="site_settings_category_hint">設定新的文章類別</string>
+	<string name="site_settings_location_hint">自動將位置資料加到文章中</string>
+	<string name="site_settings_password_hint">變更你的密碼</string>
+	<string name="site_settings_username_hint">目前的使用者帳號</string>
+	<string name="site_settings_language_hint">此網誌主要使用的語言</string>
+	<string name="site_settings_privacy_hint">控制網站存取權限</string>
+	<string name="site_settings_address_hint">目前不支援變更網址</string>
+	<string name="site_settings_tagline_hint">使用簡短的說明或好記的字詞組合來描述你的網誌</string>
+	<string name="site_settings_title_hint">以簡單幾個字說明此網站主題</string>
+	<string name="site_settings_whitelist_known_summary">已知使用者的留言</string>
+	<string name="site_settings_whitelist_all_summary">所有使用者的留言</string>
+	<string name="site_settings_threading_summary">%d 層</string>
+	<string name="site_settings_privacy_private_summary">私密</string>
+	<string name="site_settings_privacy_hidden_summary">隱藏</string>
+	<string name="site_settings_delete_site_title">刪除網站</string>
+	<string name="site_settings_privacy_public_summary">公開</string>
+	<string name="site_settings_blacklist_title">黑名單</string>
+	<string name="site_settings_moderation_hold_title">等待審核</string>
+	<string name="site_settings_multiple_links_title">留言中的連結</string>
+	<string name="site_settings_whitelist_title">自動核准</string>
+	<string name="site_settings_threading_title">階層顯示</string>
+	<string name="site_settings_paging_title">分頁</string>
+	<string name="site_settings_sort_by_title">排序依據</string>
+	<string name="site_settings_account_required_title">使用者必須登入</string>
+	<string name="site_settings_identity_required_title">必須包含名稱和電子郵件</string>
+	<string name="site_settings_receive_pingbacks_title">接收引用通知</string>
+	<string name="site_settings_send_pingbacks_title">傳送引用通知</string>
+	<string name="site_settings_allow_comments_title">允許留言</string>
+	<string name="site_settings_default_format_title">預設格式</string>
+	<string name="site_settings_default_category_title">預設類別</string>
+	<string name="site_settings_location_title">啟用定位</string>
+	<string name="site_settings_address_title">位址</string>
+	<string name="site_settings_title_title">網站標題</string>
+	<string name="site_settings_tagline_title">標語</string>
+	<string name="site_settings_this_device_header">此裝置</string>
+	<string name="site_settings_discussion_new_posts_header">新文章預設設定</string>
+	<string name="site_settings_account_header">帳號</string>
+	<string name="site_settings_writing_header">撰寫</string>
+	<string name="newest_first">最新的在前</string>
+	<string name="site_settings_general_header">一般</string>
+	<string name="discussion">討論</string>
+	<string name="privacy">隱私</string>
+	<string name="related_posts">相關文章</string>
+	<string name="comments">留言</string>
+	<string name="close_after">以下時間後關閉</string>
+	<string name="oldest_first">最舊的在前</string>
+	<string name="media_error_no_permission_upload">你沒有權限，無法上傳媒體檔案至網站</string>
+	<string name="never">從未</string>
+	<string name="unknown">不明</string>
 	<string name="reader_err_get_post_not_found">此文章已不存在</string>
 	<string name="reader_err_get_post_not_authorized">你未獲授權無法檢視此文章</string>
 	<string name="reader_err_get_post_generic">無法擷取此文章</string>
@@ -124,14 +232,12 @@
 	<string name="trashed">已移至垃圾桶</string>
 	<string name="button_back">返回</string>
 	<string name="page_deleted">頁面已刪除</string>
-	<string name="button_more">更多</string>
 	<string name="button_stats">統計</string>
 	<string name="button_trash">垃圾桶</string>
 	<string name="button_preview">預覽</string>
 	<string name="button_view">檢視</string>
 	<string name="button_edit">編輯</string>
 	<string name="button_publish">發表</string>
-	<string name="button_delete">刪除</string>
 	<string name="my_site_no_sites_view_subtitle">你希望加入一個嗎?</string>
 	<string name="my_site_no_sites_view_title">你還沒有任何 WordPress 網站。</string>
 	<string name="my_site_no_sites_view_drake">圖示</string>
@@ -171,7 +277,6 @@
 	<string name="my_site_header_publish">發表</string>
 	<string name="my_site_header_look_and_feel">外觀和風格</string>
 	<string name="my_site_btn_site_settings">設定</string>
-	<string name="my_site_btn_comments">留言</string>
 	<string name="my_site_btn_blog_posts">網誌文章</string>
 	<string name="my_site_header_admin">管理</string>
 	<string name="reader_label_new_posts_subtitle">點選以顯示</string>
@@ -221,6 +326,8 @@
 	<string name="two_step_sms_sent">請查看簡訊是否收到驗證碼。</string>
 	<string name="sign_in_jetpack">登入 WordPress.com 帳號以連結至 Jetpack。</string>
 	<string name="auth_required">再次登入以繼續操作。</string>
+	<string name="media_details_label_file_name">檔案名稱</string>
+	<string name="media_details_label_file_type">檔案類型</string>
 	<string name="media_fetching">正在擷取媒體…</string>
 	<string name="posts_fetching">正在擷取文章…</string>
 	<string name="toast_err_post_uploading">上傳文章時無法加以開啟</string>
@@ -254,7 +361,6 @@
 	<string name="stats_timeframe_years">年</string>
 	<string name="stats_views">點閱數</string>
 	<string name="stats_pagination_label">第 %1$s 頁，共 %2$s 頁</string>
-	<string name="stats_comments">留言</string>
 	<string name="stats_view_countries">國家</string>
 	<string name="stats_likes">按讚數</string>
 	<string name="stats_view_publicize">宣傳</string>
@@ -332,13 +438,13 @@
 	<string name="reader_label_comment_count_single">一則留言</string>
 	<string name="reader_label_comments_closed">留言已關閉</string>
 	<string name="reader_label_comments_on">以下內容的留言：</string>
-	<string name="reader_title_comments">留言</string>
 	<string name="reader_title_photo_viewer">第 %1$d 個，共 %2$d 個</string>
 	<string name="error_publish_empty_post">無法發表空白的文章</string>
 	<string name="error_refresh_unauthorized_posts">你沒有查看或編輯文章的權限</string>
 	<string name="error_refresh_unauthorized_pages">你沒有查看或編輯頁面的權限</string>
 	<string name="error_refresh_unauthorized_comments">你沒有查看或編輯留言的權限</string>
 	<string name="older_month">超過一個月</string>
+	<string name="more">更多</string>
 	<string name="older_two_days">超過 2 天</string>
 	<string name="older_last_week">超過一週</string>
 	<string name="stats_no_blog">無法為所需網誌載入統計</string>
@@ -669,7 +775,6 @@
 	<string name="stats_view_visitors_and_views">訪客和點閱數</string>
 	<string name="stats_view_clicks">點擊率</string>
 	<string name="stats_view_referrers">來源網址</string>
-	<string name="stats_view_comments">回應</string>
 	<string name="stats_timeframe_today">今天</string>
 	<string name="stats_timeframe_yesterday">昨天</string>
 	<string name="stats_timeframe_days">天</string>
@@ -683,7 +788,6 @@
 	<string name="stats_totals_views">點閱數</string>
 	<string name="stats_totals_clicks">點擊率</string>
 	<string name="stats_totals_plays">播放次數</string>
-	<string name="stats_totals_comments">回應</string>
 	<string name="menu_search">搜尋</string>
 	<string name="passcode_manage">管理 PIN 鎖定</string>
 	<string name="passcode_enter_passcode">輸入你的 PIN</string>
@@ -779,7 +883,6 @@
 	<string name="yes">是</string>
 	<string name="no">否</string>
 	<string name="preview">預覽</string>
-	<string name="tab_comments">迴響</string>
 	<string name="notification_settings">通知設定</string>
 	<string-array name="alignment_array">
 		<item>無</item>
@@ -826,6 +929,33 @@
 		<item>標準</item>
 		<item>狀態</item>
 		<item>影片</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>所有人都能看見你的網站，且搜尋引擎可能會將網站加入索引</item>
+		<item>所有人都能看見你的網站，但網站會要求搜尋引擎不要加入索引</item>
+		<item>只有你和經核准的使用者可看見你的網站</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>需要人工審核所有人的留言。</item>
+		<item>如果使用者有已審核的留言，則自動核准。</item>
+		<item>自動核准所有人的留言。</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>無留言</item>
+		<item>已知使用者的留言</item>
+		<item>所有使用者</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>無</item>
+		<item>兩層</item>
+		<item>三層</item>
+		<item>四層</item>
+		<item>五層</item>
+		<item>六層</item>
+		<item>七層</item>
+		<item>八層</item>
+		<item>九層</item>
+		<item>十層</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>免費</item>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -1,5 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="site_settings_image_original_size">原始尺寸</string>
+	<string name="about_me_hint">簡單介紹一下自己…</string>
+	<string name="public_display_name_hint">如果未設定，顯示名稱會預設為你的使用者名稱</string>
+	<string name="about_me">關於我</string>
+	<string name="public_display_name">公開顯示名稱</string>
+	<string name="my_profile">我的個人檔案</string>
+	<string name="first_name">名</string>
+	<string name="last_name">姓</string>
+	<string name="site_privacy_public_desc">允許搜尋引擎將這個網站加入索引</string>
+	<string name="site_privacy_hidden_desc">阻擋搜尋引擎將這個網站加入索引</string>
+	<string name="site_privacy_private_desc">我想要將我的網站設為私人網站，只有我選擇的使用者可看見</string>
+	<string name="cd_related_post_preview_image">相關文章預覽圖片</string>
+	<string name="error_post_remote_site_settings">無法儲存網站資訊</string>
+	<string name="error_fetch_remote_site_settings">無法擷取網站資訊</string>
+	<string name="error_media_upload_connection">上傳媒體時發生連線錯誤</string>
+	<string name="site_settings_disconnected_toast">已中斷連線，編輯功能已停用。</string>
+	<string name="site_settings_unsupported_version_error">不支援的 WordPress 版本</string>
+	<string name="site_settings_multiple_links_dialog_description">如果留言包含的連結超過此數量，留言就必須經過審核。</string>
+	<string name="site_settings_close_after_dialog_switch_text">自動關閉</string>
+	<string name="site_settings_close_after_dialog_description">自動關閉文章的留言功能。</string>
+	<string name="site_settings_paging_dialog_description">將留言串分為數頁。</string>
+	<string name="site_settings_paging_dialog_header">每頁留言數</string>
+	<string name="site_settings_close_after_dialog_title">關閉留言功能</string>
+	<string name="site_settings_blacklist_description">如果留言的內容、名稱、URL、電子郵件或 IP 位址中含有以下文字，該留言將標記為垃圾留言。你也可以輸入字詞的一部分，例如「press」會與「WordPress」相符。</string>
+	<string name="site_settings_hold_for_moderation_description">如果留言的內容、名稱、URL、電子郵件或 IP 位址中含有以下文字，就會被送進審核清單。你也可以輸入字詞的一部分，例如「press」會與「WordPress」相符。</string>
+	<string name="site_settings_list_editor_input_hint">輸入字詞或片語</string>
+	<string name="site_settings_list_editor_no_items_text">無項目</string>
+	<string name="site_settings_learn_more_caption">你可以針對不同的文章覆寫這些設定。</string>
+	<string name="site_settings_rp_preview3_site">在「升級」中</string>
+	<string name="site_settings_rp_preview3_title">升級重點：婚禮適用的 VideoPress</string>
+	<string name="site_settings_rp_preview2_site">在「應用程式」中</string>
+	<string name="site_settings_rp_preview2_title">Android 專用的 WordPress 應用程式已全面翻新</string>
+	<string name="site_settings_rp_preview1_site">在「行動」中</string>
+	<string name="site_settings_rp_preview1_title">有重大的 iPhone/iPad 更新可供使用</string>
+	<string name="site_settings_rp_show_images_title">顯示圖片</string>
+	<string name="site_settings_rp_show_header_title">顯示頁首</string>
+	<string name="site_settings_rp_switch_summary">相關文章會在你的文章下方顯示網站上的相關內容。</string>
+	<string name="site_settings_rp_switch_title">顯示相關文章</string>
+	<string name="site_settings_delete_site_hint">從應用程式移除你的網站資料</string>
+	<string name="site_settings_blacklist_hint">與篩選條件相符的留言將標示為垃圾留言</string>
+	<string name="site_settings_moderation_hold_hint">與篩選條件相符的留言將被送進審核清單</string>
+	<string name="site_settings_multiple_links_hint">忽略已知使用者的連結限制</string>
+	<string name="site_settings_whitelist_hint">先前有經核准的留言才可以發表留言</string>
+	<string name="site_settings_user_account_required_hint">已註冊且登入的使用者才可以發表留言</string>
+	<string name="site_settings_identity_required_hint">輸入名稱和電子郵件後才可以發表留言</string>
+	<string name="site_settings_manual_approval_hint">留言必須經人工核准</string>
+	<string name="site_settings_paging_hint">按照指定的區塊大小顯示留言</string>
+	<string name="site_settings_threading_hint">允許留言達到一定高度後以巢狀顯示</string>
+	<string name="site_settings_sort_by_hint">決定留言顯示順序</string>
+	<string name="site_settings_close_after_hint">不允許在指定的時間後發表留言</string>
+	<string name="site_settings_receive_pingbacks_hint">允許其他網誌在建立連結時傳送通知</string>
+	<string name="site_settings_send_pingbacks_hint">嘗試通知在文章中建立連結的所有網誌</string>
+	<string name="site_settings_allow_comments_hint">允許讀者發表留言</string>
+	<string name="site_settings_discussion_hint">檢視及變更你的網站討論設定</string>
+	<string name="site_settings_more_hint">檢視所有可變更的討論設定</string>
+	<string name="site_settings_related_posts_hint">在讀取器中顯示或隱藏相關文章</string>
+	<string name="site_settings_upload_and_link_image_hint">允許一律上傳完整大小的圖片</string>
+	<string name="site_settings_image_width_hint">將文章中的圖片調整為符合以下寬度</string>
+	<string name="site_settings_format_hint">設定新的文章格式</string>
+	<string name="site_settings_category_hint">設定新的文章類別</string>
+	<string name="site_settings_location_hint">自動將位置資料加到文章中</string>
+	<string name="site_settings_password_hint">變更你的密碼</string>
+	<string name="site_settings_username_hint">目前的使用者帳號</string>
+	<string name="site_settings_language_hint">此網誌主要使用的語言</string>
+	<string name="site_settings_privacy_hint">控制網站存取權限</string>
+	<string name="site_settings_address_hint">目前不支援變更網址</string>
+	<string name="site_settings_tagline_hint">使用簡短的說明或好記的字詞組合來描述你的網誌</string>
+	<string name="site_settings_title_hint">以簡單幾個字說明此網站主題</string>
+	<string name="site_settings_whitelist_known_summary">已知使用者的留言</string>
+	<string name="site_settings_whitelist_all_summary">所有使用者的留言</string>
+	<string name="site_settings_threading_summary">%d 層</string>
+	<string name="site_settings_privacy_private_summary">私密</string>
+	<string name="site_settings_privacy_hidden_summary">隱藏</string>
+	<string name="site_settings_delete_site_title">刪除網站</string>
+	<string name="site_settings_privacy_public_summary">公開</string>
+	<string name="site_settings_blacklist_title">黑名單</string>
+	<string name="site_settings_moderation_hold_title">等待審核</string>
+	<string name="site_settings_multiple_links_title">留言中的連結</string>
+	<string name="site_settings_whitelist_title">自動核准</string>
+	<string name="site_settings_threading_title">階層顯示</string>
+	<string name="site_settings_paging_title">分頁</string>
+	<string name="site_settings_sort_by_title">排序依據</string>
+	<string name="site_settings_account_required_title">使用者必須登入</string>
+	<string name="site_settings_identity_required_title">必須包含名稱和電子郵件</string>
+	<string name="site_settings_receive_pingbacks_title">接收引用通知</string>
+	<string name="site_settings_send_pingbacks_title">傳送引用通知</string>
+	<string name="site_settings_allow_comments_title">允許留言</string>
+	<string name="site_settings_default_format_title">預設格式</string>
+	<string name="site_settings_default_category_title">預設類別</string>
+	<string name="site_settings_location_title">啟用定位</string>
+	<string name="site_settings_address_title">位址</string>
+	<string name="site_settings_title_title">網站標題</string>
+	<string name="site_settings_tagline_title">標語</string>
+	<string name="site_settings_this_device_header">此裝置</string>
+	<string name="site_settings_discussion_new_posts_header">新文章預設設定</string>
+	<string name="site_settings_account_header">帳號</string>
+	<string name="site_settings_writing_header">撰寫</string>
+	<string name="newest_first">最新的在前</string>
+	<string name="site_settings_general_header">一般</string>
+	<string name="discussion">討論</string>
+	<string name="privacy">隱私</string>
+	<string name="related_posts">相關文章</string>
+	<string name="comments">留言</string>
+	<string name="close_after">以下時間後關閉</string>
+	<string name="oldest_first">最舊的在前</string>
+	<string name="media_error_no_permission_upload">你沒有權限，無法上傳媒體檔案至網站</string>
+	<string name="never">從未</string>
+	<string name="unknown">不明</string>
 	<string name="reader_err_get_post_not_found">此文章已不存在</string>
 	<string name="reader_err_get_post_not_authorized">你未獲授權無法檢視此文章</string>
 	<string name="reader_err_get_post_generic">無法擷取此文章</string>
@@ -124,14 +232,12 @@
 	<string name="trashed">已移至垃圾桶</string>
 	<string name="button_back">返回</string>
 	<string name="page_deleted">頁面已刪除</string>
-	<string name="button_more">更多</string>
 	<string name="button_stats">統計</string>
 	<string name="button_trash">垃圾桶</string>
 	<string name="button_preview">預覽</string>
 	<string name="button_view">檢視</string>
 	<string name="button_edit">編輯</string>
 	<string name="button_publish">發表</string>
-	<string name="button_delete">刪除</string>
 	<string name="my_site_no_sites_view_subtitle">你希望加入一個嗎?</string>
 	<string name="my_site_no_sites_view_title">你還沒有任何 WordPress 網站。</string>
 	<string name="my_site_no_sites_view_drake">圖示</string>
@@ -171,7 +277,6 @@
 	<string name="my_site_header_publish">發表</string>
 	<string name="my_site_header_look_and_feel">外觀和風格</string>
 	<string name="my_site_btn_site_settings">設定</string>
-	<string name="my_site_btn_comments">留言</string>
 	<string name="my_site_btn_blog_posts">網誌文章</string>
 	<string name="my_site_header_admin">管理</string>
 	<string name="reader_label_new_posts_subtitle">點選以顯示</string>
@@ -221,6 +326,8 @@
 	<string name="two_step_sms_sent">請查看簡訊是否收到驗證碼。</string>
 	<string name="sign_in_jetpack">登入 WordPress.com 帳號以連結至 Jetpack。</string>
 	<string name="auth_required">再次登入以繼續操作。</string>
+	<string name="media_details_label_file_name">檔案名稱</string>
+	<string name="media_details_label_file_type">檔案類型</string>
 	<string name="media_fetching">正在擷取媒體…</string>
 	<string name="posts_fetching">正在擷取文章…</string>
 	<string name="toast_err_post_uploading">上傳文章時無法加以開啟</string>
@@ -254,7 +361,6 @@
 	<string name="stats_timeframe_years">年</string>
 	<string name="stats_views">點閱數</string>
 	<string name="stats_pagination_label">第 %1$s 頁，共 %2$s 頁</string>
-	<string name="stats_comments">留言</string>
 	<string name="stats_view_countries">國家</string>
 	<string name="stats_likes">按讚數</string>
 	<string name="stats_view_publicize">宣傳</string>
@@ -332,13 +438,13 @@
 	<string name="reader_label_comment_count_single">一則留言</string>
 	<string name="reader_label_comments_closed">留言已關閉</string>
 	<string name="reader_label_comments_on">以下內容的留言：</string>
-	<string name="reader_title_comments">留言</string>
 	<string name="reader_title_photo_viewer">第 %1$d 個，共 %2$d 個</string>
 	<string name="error_publish_empty_post">無法發表空白的文章</string>
 	<string name="error_refresh_unauthorized_posts">你沒有查看或編輯文章的權限</string>
 	<string name="error_refresh_unauthorized_pages">你沒有查看或編輯頁面的權限</string>
 	<string name="error_refresh_unauthorized_comments">你沒有查看或編輯留言的權限</string>
 	<string name="older_month">超過一個月</string>
+	<string name="more">更多</string>
 	<string name="older_two_days">超過 2 天</string>
 	<string name="older_last_week">超過一週</string>
 	<string name="stats_no_blog">無法為所需網誌載入統計</string>
@@ -669,7 +775,6 @@
 	<string name="stats_view_visitors_and_views">訪客和點閱數</string>
 	<string name="stats_view_clicks">點擊率</string>
 	<string name="stats_view_referrers">來源網址</string>
-	<string name="stats_view_comments">回應</string>
 	<string name="stats_timeframe_today">今天</string>
 	<string name="stats_timeframe_yesterday">昨天</string>
 	<string name="stats_timeframe_days">天</string>
@@ -683,7 +788,6 @@
 	<string name="stats_totals_views">點閱數</string>
 	<string name="stats_totals_clicks">點擊率</string>
 	<string name="stats_totals_plays">播放次數</string>
-	<string name="stats_totals_comments">回應</string>
 	<string name="menu_search">搜尋</string>
 	<string name="passcode_manage">管理 PIN 鎖定</string>
 	<string name="passcode_enter_passcode">輸入你的 PIN</string>
@@ -779,7 +883,6 @@
 	<string name="yes">是</string>
 	<string name="no">否</string>
 	<string name="preview">預覽</string>
-	<string name="tab_comments">迴響</string>
 	<string name="notification_settings">通知設定</string>
 	<string-array name="alignment_array">
 		<item>無</item>
@@ -826,6 +929,33 @@
 		<item>標準</item>
 		<item>狀態</item>
 		<item>影片</item>
+	</string-array>
+	<string-array name="privacy_details">
+		<item>所有人都能看見你的網站，且搜尋引擎可能會將網站加入索引</item>
+		<item>所有人都能看見你的網站，但網站會要求搜尋引擎不要加入索引</item>
+		<item>只有你和經核准的使用者可看見你的網站</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_details">
+		<item>需要人工審核所有人的留言。</item>
+		<item>如果使用者有已審核的留言，則自動核准。</item>
+		<item>自動核准所有人的留言。</item>
+	</string-array>
+	<string-array name="site_settings_auto_approve_entries">
+		<item>無留言</item>
+		<item>已知使用者的留言</item>
+		<item>所有使用者</item>
+	</string-array>
+	<string-array name="site_settings_threading_entries">
+		<item>無</item>
+		<item>兩層</item>
+		<item>三層</item>
+		<item>四層</item>
+		<item>五層</item>
+		<item>六層</item>
+		<item>七層</item>
+		<item>八層</item>
+		<item>九層</item>
+		<item>十層</item>
 	</string-array>
 	<string-array name="themes_filter_array">
 		<item>免費</item>


### PR DESCRIPTION
Found a weird duplicated string in en-gb, problem comes from GlotPress (i18n team notified): https://translate.wordpress.org/projects/apps/android/dev/en-gb/default?filters%5Bterm%5D=public_display_name_hint&filters%5Buser_login%5D=&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filter=Filter&sort%5Bby%5D=priority&sort%5Bhow%5D=desc

manually fixed in a6945b9