### PR TITLE
Hide WP Admin link for newer .com accounts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -82,7 +82,7 @@ public class WordPressDB {
     public static final String COLUMN_NAME_VIDEO_PRESS_SHORTCODE = "videoPressShortcode";
     public static final String COLUMN_NAME_UPLOAD_STATE          = "uploadState";
 
-    private static final int DATABASE_VERSION = 40;
+    private static final int DATABASE_VERSION = 41;
 
     private static final String CREATE_TABLE_BLOGS = "create table if not exists accounts (id integer primary key autoincrement, "
             + "url text, blogName text, username text, password text, imagePlacement text, centerThumbnail boolean, fullSizeImage boolean, maxImageWidth text, maxImageWidthId integer);";
@@ -388,6 +388,9 @@ public class WordPressDB {
                 currentVersion++;
             case 39:
                 AccountTable.migrationAddFirstNameLastNameAboutMeFields(db);
+                currentVersion++;
+            case 40:
+                AccountTable.migrationAddDateFields(db);
                 currentVersion++;
         }
         db.setVersion(DATABASE_VERSION);

--- a/WordPress/src/main/java/org/wordpress/android/datasets/AccountTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/AccountTable.java
@@ -72,7 +72,7 @@ public class AccountTable {
         values.put("first_name", account.getFirstName());
         values.put("last_name", account.getLastName());
         values.put("about_me", account.getAboutMe());
-        values.put("date", account.getDateISO8601());
+        values.put("date", account.getDateCreatedISO8601());
         database.insertWithOnConflict(ACCOUNT_TABLE, null, values, SQLiteDatabase.CONFLICT_REPLACE);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/AccountTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/AccountTable.java
@@ -43,6 +43,10 @@ public class AccountTable {
         db.execSQL("ALTER TABLE " + ACCOUNT_TABLE + " ADD about_me TEXT DEFAULT '';");
     }
 
+    public static void migrationAddDateFields(SQLiteDatabase db) {
+        db.execSQL("ALTER TABLE " + ACCOUNT_TABLE + " ADD date TEXT DEFAULT '';");
+    }
+
     private static void dropTables(SQLiteDatabase db) {
         db.execSQL("DROP TABLE IF EXISTS " + ACCOUNT_TABLE);
     }
@@ -68,6 +72,7 @@ public class AccountTable {
         values.put("first_name", account.getFirstName());
         values.put("last_name", account.getLastName());
         values.put("about_me", account.getAboutMe());
+        values.put("date", account.getDateISO8601());
         database.insertWithOnConflict(ACCOUNT_TABLE, null, values, SQLiteDatabase.CONFLICT_REPLACE);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/AccountTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/AccountTable.java
@@ -6,6 +6,7 @@ import android.database.sqlite.SQLiteDatabase;
 
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Account;
+import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.SqlUtils;
 
 public class AccountTable {
@@ -72,7 +73,7 @@ public class AccountTable {
         values.put("first_name", account.getFirstName());
         values.put("last_name", account.getLastName());
         values.put("about_me", account.getAboutMe());
-        values.put("date", account.getDateCreatedISO8601());
+        values.put("date", DateTimeUtils.javaDateToIso8601(account.getDateCreated()));
         database.insertWithOnConflict(ACCOUNT_TABLE, null, values, SQLiteDatabase.CONFLICT_REPLACE);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/models/Account.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Account.java
@@ -23,6 +23,12 @@ import de.greenrobot.event.EventBus;
  * Class for managing logged in user informations.
  */
 public class Account extends AccountModel {
+
+    public static final int HIDE_WP_ADMIN_YEAR = 2015;
+    public static final int HIDE_WP_ADMIN_MONTH = 9;
+    public static final int HIDE_WP_ADMIN_DAY = 7;
+    public static final String HIDE_WP_ADMIN_GMT_TIME_ZONE = "GMT";
+
     public void fetchAccountDetails() {
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
@@ -102,8 +108,8 @@ public class Account extends AccountModel {
     }
 
     public boolean shouldHideWPAdmin() {
-        GregorianCalendar calendar = new GregorianCalendar(2015, 9, 7);
-        calendar.setTimeZone(TimeZone.getTimeZone("GMT"));
+        GregorianCalendar calendar = new GregorianCalendar(HIDE_WP_ADMIN_YEAR, HIDE_WP_ADMIN_MONTH, HIDE_WP_ADMIN_DAY);
+        calendar.setTimeZone(TimeZone.getTimeZone(HIDE_WP_ADMIN_GMT_TIME_ZONE));
 
         return getDate().after(calendar.getTime());
     }

--- a/WordPress/src/main/java/org/wordpress/android/models/Account.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Account.java
@@ -11,8 +11,6 @@ import org.wordpress.android.ui.prefs.PrefsEvents;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
-import java.util.Calendar;
-import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Map;
 import java.util.TimeZone;
@@ -111,7 +109,7 @@ public class Account extends AccountModel {
         GregorianCalendar calendar = new GregorianCalendar(HIDE_WP_ADMIN_YEAR, HIDE_WP_ADMIN_MONTH, HIDE_WP_ADMIN_DAY);
         calendar.setTimeZone(TimeZone.getTimeZone(HIDE_WP_ADMIN_GMT_TIME_ZONE));
 
-        return getDate().after(calendar.getTime());
+        return getDateCreated().after(calendar.getTime());
     }
 
     public enum RestParam {

--- a/WordPress/src/main/java/org/wordpress/android/models/Account.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Account.java
@@ -21,12 +21,6 @@ import de.greenrobot.event.EventBus;
  * Class for managing logged in user informations.
  */
 public class Account extends AccountModel {
-
-    public static final int HIDE_WP_ADMIN_YEAR = 2015;
-    public static final int HIDE_WP_ADMIN_MONTH = 9;
-    public static final int HIDE_WP_ADMIN_DAY = 7;
-    public static final String HIDE_WP_ADMIN_GMT_TIME_ZONE = "GMT";
-
     public void fetchAccountDetails() {
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
@@ -103,13 +97,6 @@ public class Account extends AccountModel {
 
     public void save() {
         AccountTable.save(this);
-    }
-
-    public boolean shouldHideWPAdmin() {
-        GregorianCalendar calendar = new GregorianCalendar(HIDE_WP_ADMIN_YEAR, HIDE_WP_ADMIN_MONTH, HIDE_WP_ADMIN_DAY);
-        calendar.setTimeZone(TimeZone.getTimeZone(HIDE_WP_ADMIN_GMT_TIME_ZONE));
-
-        return getDateCreated().after(calendar.getTime());
     }
 
     public enum RestParam {

--- a/WordPress/src/main/java/org/wordpress/android/models/Account.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Account.java
@@ -11,9 +11,7 @@ import org.wordpress.android.ui.prefs.PrefsEvents;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
-import java.util.GregorianCalendar;
 import java.util.Map;
-import java.util.TimeZone;
 
 import de.greenrobot.event.EventBus;
 

--- a/WordPress/src/main/java/org/wordpress/android/models/Account.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Account.java
@@ -11,7 +11,11 @@ import org.wordpress.android.ui.prefs.PrefsEvents;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.Map;
+import java.util.TimeZone;
 
 import de.greenrobot.event.EventBus;
 
@@ -95,6 +99,13 @@ public class Account extends AccountModel {
 
     public void save() {
         AccountTable.save(this);
+    }
+
+    public boolean shouldHideWPAdmin() {
+        GregorianCalendar calendar = new GregorianCalendar(2015, 9, 7);
+        calendar.setTimeZone(TimeZone.getTimeZone("GMT"));
+
+        return getDate().after(calendar.getTime());
     }
 
     public enum RestParam {

--- a/WordPress/src/main/java/org/wordpress/android/models/AccountModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/AccountModel.java
@@ -3,6 +3,7 @@ package org.wordpress.android.models;
 import android.text.TextUtils;
 
 import org.json.JSONObject;
+import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.StringUtils;
 
@@ -60,6 +61,8 @@ public class AccountModel {
         Date date = DateTimeUtils.iso8601ToJavaDate(json.optString("date"));
         if (date != null) {
             mDateCreated = date;
+        } else {
+            AppLog.e(AppLog.T.API, "Date could not be found from Account JSON response");
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/models/AccountModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/AccountModel.java
@@ -182,10 +182,6 @@ public class AccountModel {
         return mDateCreated;
     }
 
-    public String getDateCreatedISO8601() {
-        return DateTimeUtils.javaDateToIso8601(mDateCreated);
-    }
-
     public void setDateCreated(Date date) {
         mDateCreated = date;
     }

--- a/WordPress/src/main/java/org/wordpress/android/models/AccountModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/AccountModel.java
@@ -3,7 +3,10 @@ package org.wordpress.android.models;
 import android.text.TextUtils;
 
 import org.json.JSONObject;
+import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.StringUtils;
+
+import java.util.Date;
 
 public class AccountModel {
     // WordPress.com only - data fetched from the REST API endpoint
@@ -20,6 +23,7 @@ public class AccountModel {
     private String mFirstName;
     private String mLastName;
     private String mAboutMe;
+    private Date mDate;
 
     public AccountModel() {
         init();
@@ -39,6 +43,7 @@ public class AccountModel {
         mFirstName = "";
         mLastName = "";
         mAboutMe = "";
+        mDate = new Date();
     }
 
     public void updateFromRestResponse(JSONObject json) {
@@ -51,6 +56,7 @@ public class AccountModel {
         mSiteCount = json.optInt("site_count");
         mVisibleSiteCount = json.optInt("visible_site_count");
         mEmail = json.optString("email");
+        mDate = DateTimeUtils.iso8601ToJavaDate(json.optString("date"));
     }
 
     public void updateAccountSettingsFromRestResponse(JSONObject json) {
@@ -166,5 +172,17 @@ public class AccountModel {
 
     public void setAboutMe(String aboutMe) {
         mAboutMe = aboutMe;
+    }
+
+    public Date getDate() {
+        return mDate;
+    }
+
+    public String getDateISO8601() {
+        return DateTimeUtils.javaDateToIso8601(mDate);
+    }
+
+    public void setDate(Date date) {
+        mDate = date;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/AccountModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/AccountModel.java
@@ -23,7 +23,7 @@ public class AccountModel {
     private String mFirstName;
     private String mLastName;
     private String mAboutMe;
-    private Date mDate;
+    private Date mDateCreated;
 
     public AccountModel() {
         init();
@@ -43,7 +43,7 @@ public class AccountModel {
         mFirstName = "";
         mLastName = "";
         mAboutMe = "";
-        mDate = new Date();
+        mDateCreated = new Date();
     }
 
     public void updateFromRestResponse(JSONObject json) {
@@ -56,7 +56,7 @@ public class AccountModel {
         mSiteCount = json.optInt("site_count");
         mVisibleSiteCount = json.optInt("visible_site_count");
         mEmail = json.optString("email");
-        mDate = DateTimeUtils.iso8601ToJavaDate(json.optString("date"));
+        mDateCreated = DateTimeUtils.iso8601ToJavaDate(json.optString("date"));
     }
 
     public void updateAccountSettingsFromRestResponse(JSONObject json) {
@@ -174,15 +174,15 @@ public class AccountModel {
         mAboutMe = aboutMe;
     }
 
-    public Date getDate() {
-        return mDate;
+    public Date getDateCreated() {
+        return mDateCreated;
     }
 
-    public String getDateISO8601() {
-        return DateTimeUtils.javaDateToIso8601(mDate);
+    public String getDateCreatedISO8601() {
+        return DateTimeUtils.javaDateToIso8601(mDateCreated);
     }
 
-    public void setDate(Date date) {
-        mDate = date;
+    public void setDateCreated(Date date) {
+        mDateCreated = date;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/AccountModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/AccountModel.java
@@ -56,7 +56,11 @@ public class AccountModel {
         mSiteCount = json.optInt("site_count");
         mVisibleSiteCount = json.optInt("visible_site_count");
         mEmail = json.optString("email");
-        mDateCreated = DateTimeUtils.iso8601ToJavaDate(json.optString("date"));
+
+        Date date = DateTimeUtils.iso8601ToJavaDate(json.optString("date"));
+        if (date != null) {
+            mDateCreated = date;
+        }
     }
 
     public void updateAccountSettingsFromRestResponse(JSONObject json) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -39,6 +39,9 @@ import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
 import org.wordpress.android.widgets.WPTextView;
 
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
 import de.greenrobot.event.EventBus;
 
 public class MySiteFragment extends Fragment
@@ -46,6 +49,10 @@ public class MySiteFragment extends Fragment
 
     private static final long ALERT_ANIM_OFFSET_MS   = 1000l;
     private static final long ALERT_ANIM_DURATION_MS = 1000l;
+    public static final int HIDE_WP_ADMIN_YEAR = 2015;
+    public static final int HIDE_WP_ADMIN_MONTH = 9;
+    public static final int HIDE_WP_ADMIN_DAY = 7;
+    public static final String HIDE_WP_ADMIN_GMT_TIME_ZONE = "GMT";
 
     private WPNetworkImageView mBlavatarImageView;
     private WPTextView mBlogTitleTextView;
@@ -340,13 +347,25 @@ public class MySiteFragment extends Fragment
     }
 
     private void toggleAdminVisibility() {
-        Blog blog = WordPress.getCurrentBlog();
-        Account account = AccountHelper.getDefaultAccount();
-        
-        if (blog.isDotcomFlag() && account.shouldHideWPAdmin()) {
+        if (shouldHideWPAdmin()) {
             mAdminView.setVisibility(View.GONE);
         } else {
             mAdminView.setVisibility(View.VISIBLE);
+        }
+    }
+
+    private boolean shouldHideWPAdmin() {
+        Blog blog = WordPress.getCurrentBlog();
+
+        if (!blog.isDotcomFlag()) {
+            return false;
+        } else {
+            Account account = AccountHelper.getDefaultAccount();
+
+            GregorianCalendar calendar = new GregorianCalendar(HIDE_WP_ADMIN_YEAR, HIDE_WP_ADMIN_MONTH, HIDE_WP_ADMIN_DAY);
+            calendar.setTimeZone(TimeZone.getTimeZone(HIDE_WP_ADMIN_GMT_TIME_ZONE));
+
+            return account.getDateCreated().after(calendar.getTime());
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -54,7 +54,7 @@ public class MySiteFragment extends Fragment
     private RelativeLayout mThemesContainer;
     private View mConfigurationHeader;
     private View mSettingsView;
-    private View mAdminView;
+    private LinearLayout mAdminView;
     private View mFabView;
     private LinearLayout mNoSiteView;
     private ScrollView mScrollView;
@@ -133,7 +133,7 @@ public class MySiteFragment extends Fragment
         mThemesContainer = (RelativeLayout) rootView.findViewById(R.id.row_themes);
         mConfigurationHeader = rootView.findViewById(R.id.row_configuration);
         mSettingsView = rootView.findViewById(R.id.row_settings);
-        mAdminView = rootView.findViewById(R.id.row_admin);
+        mAdminView = (LinearLayout) rootView.findViewById(R.id.admin_section);
         mScrollView = (ScrollView) rootView.findViewById(R.id.scroll_view);
         mNoSiteView = (LinearLayout) rootView.findViewById(R.id.no_site_view);
         mNoSiteDrakeImageView = (ImageView) rootView.findViewById(R.id.my_site_no_site_view_drake);
@@ -209,7 +209,7 @@ public class MySiteFragment extends Fragment
             }
         });
 
-        mAdminView.setOnClickListener(new View.OnClickListener() {
+        rootView.findViewById(R.id.row_admin).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 ActivityLauncher.viewBlogAdmin(getActivity(), WordPress.getBlog(mBlogLocalId));

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -20,6 +20,8 @@ import android.widget.ScrollView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.models.Account;
+import org.wordpress.android.models.AccountHelper;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
@@ -52,6 +54,7 @@ public class MySiteFragment extends Fragment
     private RelativeLayout mThemesContainer;
     private View mConfigurationHeader;
     private View mSettingsView;
+    private View mAdminView;
     private View mFabView;
     private LinearLayout mNoSiteView;
     private ScrollView mScrollView;
@@ -130,6 +133,7 @@ public class MySiteFragment extends Fragment
         mThemesContainer = (RelativeLayout) rootView.findViewById(R.id.row_themes);
         mConfigurationHeader = rootView.findViewById(R.id.row_configuration);
         mSettingsView = rootView.findViewById(R.id.row_settings);
+        mAdminView = rootView.findViewById(R.id.row_admin);
         mScrollView = (ScrollView) rootView.findViewById(R.id.scroll_view);
         mNoSiteView = (LinearLayout) rootView.findViewById(R.id.no_site_view);
         mNoSiteDrakeImageView = (ImageView) rootView.findViewById(R.id.my_site_no_site_view_drake);
@@ -205,7 +209,7 @@ public class MySiteFragment extends Fragment
             }
         });
 
-        rootView.findViewById(R.id.row_admin).setOnClickListener(new View.OnClickListener() {
+        mAdminView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 ActivityLauncher.viewBlogAdmin(getActivity(), WordPress.getBlog(mBlogLocalId));
@@ -308,6 +312,8 @@ public class MySiteFragment extends Fragment
         mScrollView.setVisibility(View.VISIBLE);
         mNoSiteView.setVisibility(View.GONE);
 
+        toggleAdminVisibility();
+
         int themesVisibility = ThemeBrowserActivity.isAccessible() ? View.VISIBLE : View.GONE;
         mLookAndFeelHeader.setVisibility(themesVisibility);
         mThemesContainer.setVisibility(themesVisibility);
@@ -331,6 +337,17 @@ public class MySiteFragment extends Fragment
 
         mBlogTitleTextView.setText(blogTitle);
         mBlogSubtitleTextView.setText(homeURL);
+    }
+
+    private void toggleAdminVisibility() {
+        Blog blog = WordPress.getCurrentBlog();
+        Account account = AccountHelper.getDefaultAccount();
+        
+        if (blog.isDotcomFlag() && account.shouldHideWPAdmin()) {
+            mAdminView.setVisibility(View.GONE);
+        } else {
+            mAdminView.setVisibility(View.VISIBLE);
+        }
     }
 
     @Override

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -279,34 +279,43 @@
 
             </RelativeLayout>
 
-            <!--Admin-->
-            <LinearLayout style="@style/MySiteListHeaderLayout">
+            <LinearLayout
+                android:id="@+id/admin_section"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
 
-                <org.wordpress.android.widgets.WPTextView
-                    style="@style/MySiteListHeaderTextView"
-                    android:text="@string/my_site_header_admin" />
+                <!--Admin-->
+                <LinearLayout style="@style/MySiteListHeaderLayout">
 
-                <View style="@style/MySiteListSectionDividerView" />
+                    <org.wordpress.android.widgets.WPTextView
+                        style="@style/MySiteListHeaderTextView"
+                        android:text="@string/my_site_header_admin" />
 
+                    <View style="@style/MySiteListSectionDividerView" />
+
+                </LinearLayout>
+
+                <!--View Admin-->
+                <RelativeLayout
+                    android:id="@+id/row_admin"
+                    style="@style/MySiteListRowLayout">
+
+                    <ImageView
+                        android:id="@+id/my_site_view_admin_icon"
+                        style="@style/MySiteListRowIcon"
+                        android:src="@drawable/my_site_icon_view_admin" />
+
+                    <org.wordpress.android.widgets.WPTextView
+                        android:id="@+id/my_site_view_admin_text_view"
+                        style="@style/MySiteListRowTextView"
+                        android:layout_toRightOf="@id/my_site_view_admin_icon"
+                        android:text="@string/my_site_btn_view_admin" />
+
+                </RelativeLayout>
             </LinearLayout>
 
-            <!--View Admin-->
-            <RelativeLayout
-                android:id="@+id/row_admin"
-                style="@style/MySiteListRowLayout">
 
-                <ImageView
-                    android:id="@+id/my_site_view_admin_icon"
-                    style="@style/MySiteListRowIcon"
-                    android:src="@drawable/my_site_icon_view_admin" />
-
-                <org.wordpress.android.widgets.WPTextView
-                    android:id="@+id/my_site_view_admin_text_view"
-                    style="@style/MySiteListRowTextView"
-                    android:layout_toRightOf="@id/my_site_view_admin_icon"
-                    android:text="@string/my_site_btn_view_admin" />
-
-            </RelativeLayout>
 
             <View
                 android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -293,8 +293,7 @@
             <!--View Admin-->
             <RelativeLayout
                 android:id="@+id/row_admin"
-                style="@style/MySiteListRowLayout"
-                android:layout_marginBottom="@dimen/margin_extra_large">
+                style="@style/MySiteListRowLayout">
 
                 <ImageView
                     android:id="@+id/my_site_view_admin_icon"
@@ -308,6 +307,10 @@
                     android:text="@string/my_site_btn_view_admin" />
 
             </RelativeLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/margin_extra_large" />
 
         </LinearLayout>
 


### PR DESCRIPTION
Addresses #3457 

Testing:
1. With a .com account created before 2015-09-07, click a .com site and see that there is a WP Admin row.
2. With a .com account created after 2015-09-07, click a .com site and see that there is no WP Admin row.
3. With a .com account created before 2015-09-07, click a self-hosted site and see that there is a WP Admin row.
3. With a .com account created after 2015-09-07, click a self-hosted site and see that there is a WP Admin row.

Needs review: @hypest 