### PR TITLE
Fixing soft keyboard show/hide for settings dialogs

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -101,8 +101,7 @@
         <activity
             android:name=".ui.prefs.BlogPreferencesActivity"
             android:theme="@style/CalypsoTheme"
-            android:configChanges="orientation|screenSize"
-            android:windowSoftInputMode="stateHidden"/>
+            android:configChanges="orientation|screenSize"/>
         <activity
             android:name=".ui.prefs.LicensesActivity"
             android:theme="@style/Calypso.NoActionBar" />

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -22,7 +22,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
-import android.view.WindowManager;
+import android.view.WindowManager.LayoutParams;
 import android.widget.AbsListView;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
@@ -902,17 +902,23 @@ public class SiteSettingsFragment extends PreferenceFragment
                     }
                 });
                 builder.setNegativeButton(R.string.cancel, null);
-                AlertDialog alertDialog = builder.create();
+                final AlertDialog alertDialog = builder.create();
                 int spacing = getResources().getDimensionPixelSize(R.dimen.dlp_padding_start);
                 alertDialog.setView(input, spacing, spacing, spacing, 0);
                 alertDialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
+                alertDialog.getWindow().setSoftInputMode(LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+                alertDialog.setOnDismissListener(new DialogInterface.OnDismissListener() {
+                    @Override
+                    public void onDismiss(DialogInterface dialog) {
+                        alertDialog.getWindow().setSoftInputMode(LayoutParams.SOFT_INPUT_STATE_HIDDEN);
+                    }
+                });
                 alertDialog.show();
                 alertDialog.getWindow().setLayout(WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.WRAP_CONTENT);
                 Button positive = alertDialog.getButton(DialogInterface.BUTTON_POSITIVE);
                 Button negative = alertDialog.getButton(DialogInterface.BUTTON_NEGATIVE);
                 if (positive != null) WPPrefUtils.layoutAsFlatButton(positive);
                 if (negative != null) WPPrefUtils.layoutAsFlatButton(negative);
-                WPActivityUtils.showKeyboard(input);
             }
         });
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -885,6 +885,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                         new AlertDialog.Builder(getActivity(), R.style.Calypso_AlertDialog);
                 final EditText input = new EditText(getActivity());
                 WPPrefUtils.layoutAsInput(input);
+                input.setWidth(getResources().getDimensionPixelSize(R.dimen.list_editor_input_max_width));
                 input.setHint(R.string.site_settings_list_editor_input_hint);
                 builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                     @Override
@@ -914,7 +915,6 @@ public class SiteSettingsFragment extends PreferenceFragment
                     }
                 });
                 alertDialog.show();
-                alertDialog.getWindow().setLayout(WindowManager.LayoutParams.MATCH_PARENT, WindowManager.LayoutParams.WRAP_CONTENT);
                 Button positive = alertDialog.getButton(DialogInterface.BUTTON_POSITIVE);
                 Button negative = alertDialog.getButton(DialogInterface.BUTTON_NEGATIVE);
                 if (positive != null) WPPrefUtils.layoutAsFlatButton(positive);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SummaryEditTextPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SummaryEditTextPreference.java
@@ -13,12 +13,12 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
+import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
-import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPPrefUtils;
 
 /**
@@ -39,7 +39,6 @@ public class SummaryEditTextPreference extends EditTextPreference implements Pre
     private int mMaxLines;
     private String mHint;
     private AlertDialog mDialog;
-    private EditText mEditText;
     private int mWhichButtonClicked;
 
     public SummaryEditTextPreference(Context context) {
@@ -123,6 +122,7 @@ public class SummaryEditTextPreference extends EditTextPreference implements Pre
             mDialog.onRestoreInstanceState(state);
         }
         mDialog.setOnDismissListener(this);
+        mDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
         mDialog.show();
 
         Button positive = mDialog.getButton(DialogInterface.BUTTON_POSITIVE);
@@ -134,34 +134,31 @@ public class SummaryEditTextPreference extends EditTextPreference implements Pre
     @Override
     protected void onBindDialogView(final View view) {
         super.onBindDialogView(view);
-
         if (view == null) return;
 
-        mEditText = getEditText();
-        ViewParent oldParent = mEditText.getParent();
+        EditText editText = getEditText();
+        ViewParent oldParent = editText.getParent();
         if (oldParent != view) {
             if (oldParent != null && oldParent instanceof ViewGroup) {
                 ViewGroup groupParent = (ViewGroup) oldParent;
-                groupParent.removeView(mEditText);
+                groupParent.removeView(editText);
                 groupParent.setPadding(groupParent.getPaddingLeft(), 0, groupParent.getPaddingRight(), groupParent.getPaddingBottom());
             }
-            onAddEditTextToDialogView(view, mEditText);
+            onAddEditTextToDialogView(view, editText);
         }
-        WPPrefUtils.layoutAsInput(mEditText);
-        mEditText.setSelection(mEditText.getText().length());
-        WPActivityUtils.showKeyboard(mEditText);
+        WPPrefUtils.layoutAsInput(editText);
+        editText.setSelection(editText.getText().length());
     }
 
     @Override
     public void onClick(DialogInterface dialog, int which) {
-        WPActivityUtils.hideKeyboard(mEditText);
         mWhichButtonClicked = which;
     }
 
     @Override
     public void onDismiss(DialogInterface dialog) {
+        mDialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN);
         onDialogClosed(mWhichButtonClicked == DialogInterface.BUTTON_POSITIVE);
-        mDialog = null;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SummaryEditTextPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SummaryEditTextPreference.java
@@ -135,20 +135,21 @@ public class SummaryEditTextPreference extends EditTextPreference implements Pre
     protected void onBindDialogView(final View view) {
         super.onBindDialogView(view);
 
-        if (view != null) {
-            mEditText = getEditText();
-            ViewParent oldParent = mEditText.getParent();
-            if (oldParent != view) {
-                if (oldParent != null) {
-                    ((ViewGroup) oldParent).removeView(mEditText);
-                }
-                ((View) oldParent).setPadding(((View) oldParent).getPaddingLeft(), 0, ((View) oldParent).getPaddingRight(), ((View) oldParent).getPaddingBottom());
-                onAddEditTextToDialogView(view, mEditText);
+        if (view == null) return;
+
+        mEditText = getEditText();
+        ViewParent oldParent = mEditText.getParent();
+        if (oldParent != view) {
+            if (oldParent != null && oldParent instanceof ViewGroup) {
+                ViewGroup groupParent = (ViewGroup) oldParent;
+                groupParent.removeView(mEditText);
+                groupParent.setPadding(groupParent.getPaddingLeft(), 0, groupParent.getPaddingRight(), groupParent.getPaddingBottom());
             }
-            WPPrefUtils.layoutAsInput(mEditText);
-            mEditText.setSelection(mEditText.getText().length());
-            WPActivityUtils.showKeyboard(mEditText);
+            onAddEditTextToDialogView(view, mEditText);
         }
+        WPPrefUtils.layoutAsInput(mEditText);
+        mEditText.setSelection(mEditText.getText().length());
+        WPActivityUtils.showKeyboard(mEditText);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -9,7 +9,6 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
-import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -32,8 +31,6 @@ import org.wordpress.android.ui.prefs.SettingsFragment;
 import java.util.Locale;
 
 public class WPActivityUtils {
-    private static final long SHOW_KEYBOARD_DELAY = 250;
-
     // Hack! PreferenceScreens don't show the toolbar, so we'll manually add one
     // See: http://stackoverflow.com/a/27455363/309558
     public static void addToolbarToDialog(final Fragment context, final Dialog dialog, String title) {
@@ -101,15 +98,6 @@ public class WPActivityUtils {
             //noinspection deprecation
             window.setStatusBarColor(window.getContext().getResources().getColor(color));
         }
-    }
-
-    public static void showKeyboard(final View view) {
-        (new Handler()).postDelayed(new Runnable() {
-            public void run() {
-                InputMethodManager inputMethodManager = (InputMethodManager) view.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
-                inputMethodManager.toggleSoftInputFromWindow(view.getWindowToken(), InputMethodManager.SHOW_IMPLICIT, 0);
-            }
-        }, SHOW_KEYBOARD_DELAY);
     }
 
     public static void hideKeyboard(final View view) {

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -225,6 +225,7 @@
     <dimen name="related_posts_dialog_padding_right">24dp</dimen>
     <dimen name="related_posts_dialog_padding_bottom">12dp</dimen>
     <dimen name="text_sz_related_post_small">11sp</dimen>
+    <dimen name="list_editor_input_max_width">500dp</dimen>
 
     <!--empty lists-->
     <dimen name="empty_list_button_top_margin">32dp</dimen>


### PR DESCRIPTION
Addresses #3629 by programmatically toggling the keyboard and removing the windowSoftInputMode override for BlogPreferencesActivity in AndroidManifest.

cc @hypest ref #3713