### PR TITLE
issue/3694-hightlight-reader-icon

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -302,9 +302,9 @@ public class WPMainActivity extends Activity implements Bucket.Listener<Note> {
     }
 
     public void setReaderTabActive() {
-        if (isFinishing() || mViewPager == null) return;
+        if (isFinishing() || mTabLayout == null) return;
 
-        mViewPager.setCurrentItem(WPMainTabAdapter.TAB_READER);
+        mTabLayout.setSelectedTabPosition(WPMainTabAdapter.TAB_READER);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainTabLayout.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainTabLayout.java
@@ -104,4 +104,18 @@ public class WPMainTabLayout extends TabLayout {
 
         animScale.start();
     }
+
+    private boolean isValidPosition(int position) {
+        return (position >=0 && position < getTabCount());
+    }
+
+    public void setSelectedTabPosition(int position) {
+        if (!isValidPosition(position) || getSelectedTabPosition() == position) {
+            return;
+        }
+        Tab tab = getTabAt(position);
+        if (tab != null) {
+            tab.select();
+        }
+    }
 }


### PR DESCRIPTION
Fix #3694 - make sure reader icon is correctly highlighted when opened from the notification empty view.

A simple way to test this is to replace [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/3694-hightlight-reader-icon/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java#L178) with the one below, so that clicking any note opens the reader:
```
((WPMainActivity) getActivity()).setReaderTabActive();
```