### PR TITLE
Fix #3695 by using original Intent Activity was started with to restart it.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
@@ -189,7 +189,14 @@ public class SettingsFragment extends PreferenceFragment implements OnPreference
                     conf.locale = new Locale(localString);
                 }
                 res.updateConfiguration(conf, dm);
-                mSettings.edit().putString(LANGUAGE_PREF_KEY, localeMap.get(values[position])).apply();
+
+                if (position > 0) {
+                    mSettings.edit().putString(LANGUAGE_PREF_KEY, localeMap.get(values[position])).apply();
+                } else {
+                    // remove custom locale key when original device locale is selected
+                    mSettings.edit().remove(LANGUAGE_PREF_KEY).apply();
+                }
+
 
                 // Track the change only if the user selected a non default Device language. This is only used in
                 // Mixpanel, because we have both the device language and app selected language data in Tracks

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -142,7 +142,12 @@ public class WPActivityUtils {
                 resources.updateConfiguration(conf, resources.getDisplayMetrics());
 
                 if (restart) {
-                    Intent refresh = new Intent(context, context.getClass());
+                    // To restart Activity we want to use original intent it was launched with
+                    Intent refresh = context.getIntent();
+                    if (refresh == null) {
+                        refresh = new Intent(context, context.getClass());
+                    }
+
                     refresh.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
                     context.startActivity(refresh);
                     context.finish();


### PR DESCRIPTION
Fix for #3695.
This issue also might have caused problems at other activities, like Pages, where initial state was passed with intent. 

When locale set to something different then a device's one, it's applied every time on orientation change, and activity is restarted. Issue is fixed by using original intent activity was started with to restart it. 

This brings another problem to attention - when we are manually set locale, activity state is not retained on configuration change. I created a separate issue - #3738