### PR TITLE
Fix #3738 by changing the timing of applyLocale call.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -772,17 +772,6 @@ public class WordPress extends Application {
 
         @Override
         public void onActivityResumed(Activity activity) {
-            // Need to track orientation to apply preferred language on rotation
-            int orientation = activity.getResources().getConfiguration().orientation;
-            boolean shouldRestart =
-                    mOrientation == -1 || mOrientation != orientation || !mClass.equals(activity.getClass());
-
-            if (shouldRestart) {
-                mOrientation = orientation;
-                mClass = activity.getClass();
-            }
-            WPActivityUtils.applyLocale(activity, shouldRestart);
-
             if (mIsInBackground) {
                 // was in background before
                 onAppComesFromBackground();
@@ -795,7 +784,8 @@ public class WordPress extends Application {
         }
 
         @Override
-        public void onActivityCreated(Activity arg0, Bundle arg1) {
+        public void onActivityCreated(Activity activity, Bundle arg1) {
+            WPActivityUtils.applyLocale(activity);
         }
 
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -665,9 +665,6 @@ public class WordPress extends Application {
         boolean mIsInBackground = true;
         boolean mFirstActivityResumed = true;
 
-        private Class<?> mClass;
-        private int mOrientation = -1;
-
         @Override
         public void onConfigurationChanged(final Configuration newConfig) {
         }

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -785,6 +785,7 @@ public class WordPress extends Application {
 
         @Override
         public void onActivityCreated(Activity activity, Bundle arg1) {
+            // If user uses custom locale this is right place to apply it to activity.
             WPActivityUtils.applyLocale(activity);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -206,6 +206,9 @@ public class WordPress extends Application {
         registerActivityLifecycleCallbacks(applicationLifecycleMonitor);
 
         initAnalytics(SystemClock.elapsedRealtime() - startDate);
+
+        // If users uses a custom locale set it on start of application
+        WPActivityUtils.applyLocale(getContext());
     }
 
     private void initAnalytics(final long elapsedTimeOnCreate) {
@@ -667,6 +670,8 @@ public class WordPress extends Application {
 
         @Override
         public void onConfigurationChanged(final Configuration newConfig) {
+            // Reapply locale on configuration change
+            WPActivityUtils.applyLocale(getContext());
         }
 
         @Override
@@ -782,8 +787,6 @@ public class WordPress extends Application {
 
         @Override
         public void onActivityCreated(Activity activity, Bundle arg1) {
-            // If user uses custom locale this is right place to apply it to activity.
-            WPActivityUtils.applyLocale(activity);
         }
 
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -786,7 +786,7 @@ public class WordPress extends Application {
         }
 
         @Override
-        public void onActivityCreated(Activity activity, Bundle arg1) {
+        public void onActivityCreated(Activity arg0, Bundle arg1) {
         }
 
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.app.Fragment;
 import android.content.Context;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -122,7 +121,7 @@ public class WPActivityUtils {
         inputMethodManager.hideSoftInputFromWindow(view.getWindowToken(), 0);
     }
 
-    public static void applyLocale(Activity context, boolean restart) {
+    public static void applyLocale(Activity context) {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
 
         if (sharedPreferences.contains(SettingsFragment.LANGUAGE_PREF_KEY)) {
@@ -140,19 +139,6 @@ public class WPActivityUtils {
                 Configuration conf = resources.getConfiguration();
                 conf.locale = new Locale(locale);
                 resources.updateConfiguration(conf, resources.getDisplayMetrics());
-
-                if (restart) {
-                    // To restart Activity we want to use original intent it was launched with
-                    Intent refresh = context.getIntent();
-                    if (refresh == null) {
-                        refresh = new Intent(context, context.getClass());
-                    }
-
-                    refresh.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
-                    context.startActivity(refresh);
-                    context.finish();
-                    context.overridePendingTransition(0, 0);
-                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.util;
 
-import android.app.Activity;
 import android.app.Dialog;
 import android.app.Fragment;
 import android.content.Context;
@@ -121,7 +120,7 @@ public class WPActivityUtils {
         inputMethodManager.hideSoftInputFromWindow(view.getWindowToken(), 0);
     }
 
-    public static void applyLocale(Activity context) {
+    public static void applyLocale(Context context) {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
 
         if (sharedPreferences.contains(SettingsFragment.LANGUAGE_PREF_KEY)) {


### PR DESCRIPTION
Fixes #3738.

By using application context and applying locale at onCreate and reapplying it on configuration change we can avoid restarting activities.

There is still minor issue remaining with activities that use ActionBar (not Toolbar) and android:label - looks like label is cached somewhere, so when you open this activity, then change language and open it again the title will be in previous language until you rotate device. The old label also persists through app restart. To fix it we'll just have to switch to Toolbar completely (there are only couple of activities left).