### PR TITLE
Rename invalid url message to invalid blog url to avoid confusion

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -95,7 +95,7 @@ public class WPWebViewActivity extends WebViewActivity {
 
         if (TextUtils.isEmpty(url)) {
             AppLog.e(AppLog.T.UTILS, "Empty or null URL");
-            Toast.makeText(context, context.getResources().getText(R.string.invalid_url_message),
+            Toast.makeText(context, context.getResources().getText(R.string.invalid_blog_url_message),
                     Toast.LENGTH_SHORT).show();
             return;
         }
@@ -121,7 +121,7 @@ public class WPWebViewActivity extends WebViewActivity {
 
         if (TextUtils.isEmpty(url)) {
             AppLog.e(AppLog.T.UTILS, "Empty or null URL");
-            Toast.makeText(context, context.getResources().getText(R.string.invalid_url_message),
+            Toast.makeText(context, context.getResources().getText(R.string.invalid_blog_url_message),
                     Toast.LENGTH_SHORT).show();
             return;
         }
@@ -139,7 +139,7 @@ public class WPWebViewActivity extends WebViewActivity {
 
         if (TextUtils.isEmpty(url)) {
             AppLog.e(AppLog.T.UTILS, "Empty or null URL passed to openUrlByUsingMainWPCOMCredentials");
-            Toast.makeText(context, context.getResources().getText(R.string.invalid_url_message),
+            Toast.makeText(context, context.getResources().getText(R.string.invalid_blog_url_message),
                     Toast.LENGTH_SHORT).show();
             return;
         }
@@ -194,7 +194,7 @@ public class WPWebViewActivity extends WebViewActivity {
 
         if (TextUtils.isEmpty(addressToLoad) || !UrlUtils.isValidUrlAndHostNotNull(addressToLoad)) {
             AppLog.e(AppLog.T.UTILS, "Empty or null or invalid URL passed to WPWebViewActivity");
-            Toast.makeText(this, getText(R.string.invalid_url_message),
+            Toast.makeText(this, getText(R.string.invalid_blog_url_message),
                     Toast.LENGTH_SHORT).show();
             finish();
         }
@@ -205,7 +205,7 @@ public class WPWebViewActivity extends WebViewActivity {
         } else {
             if (TextUtils.isEmpty(authURL) || !UrlUtils.isValidUrlAndHostNotNull(authURL)) {
                 AppLog.e(AppLog.T.UTILS, "Empty or null or invalid auth URL passed to WPWebViewActivity");
-                Toast.makeText(this, getText(R.string.invalid_url_message),
+                Toast.makeText(this, getText(R.string.invalid_blog_url_message),
                         Toast.LENGTH_SHORT).show();
                 finish();
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -852,7 +852,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             endProgress();
             showTwoStepCodeError(messageId);
             return;
-        } else if (messageId == org.wordpress.android.R.string.invalid_url_message) {
+        } else if (messageId == org.wordpress.android.R.string.invalid_blog_url_message) {
             showUrlError(messageId);
             endProgress();
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/FetchBlogListWPOrg.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/FetchBlogListWPOrg.java
@@ -92,7 +92,7 @@ public class FetchBlogListWPOrg extends FetchBlogListAbstract {
         String xmlRpcUrl;
         if (!UrlUtils.isValidUrlAndHostNotNull(baseUrl)) {
             AppLog.e(T.NUX, "invalid URL: " + baseUrl);
-            mErrorMsgId = org.wordpress.android.R.string.invalid_url_message;
+            mErrorMsgId = org.wordpress.android.R.string.invalid_blog_url_message;
             return null;
         }
         URI uri = URI.create(baseUrl);
@@ -132,7 +132,7 @@ public class FetchBlogListWPOrg extends FetchBlogListAbstract {
             // TODO: Hopefully a temporary log - remove it if we find a pattern of failing URLs
             CrashlyticsUtils.setString(ExtraKey.ENTERED_URL, baseUrl);
             CrashlyticsUtils.logException(e, ExceptionType.SPECIFIC, T.NUX);
-            mErrorMsgId = org.wordpress.android.R.string.invalid_url_message;
+            mErrorMsgId = org.wordpress.android.R.string.invalid_blog_url_message;
             return null;
         }
 
@@ -188,7 +188,7 @@ public class FetchBlogListWPOrg extends FetchBlogListAbstract {
         url = UrlUtils.addUrlSchemeIfNeeded(url, false);
 
         if (!URLUtil.isValidUrl(url)) {
-            mErrorMsgId = org.wordpress.android.R.string.invalid_url_message;
+            mErrorMsgId = org.wordpress.android.R.string.invalid_blog_url_message;
             return null;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
@@ -49,7 +49,7 @@ public class ThemeWebActivity extends WPWebViewActivity {
 
         if (TextUtils.isEmpty(url)) {
             AppLog.e(AppLog.T.UTILS, "Empty or null URL passed to openWPCOMURL");
-            Toast.makeText(activity, activity.getResources().getText(R.string.invalid_url_message),
+            Toast.makeText(activity, activity.getResources().getText(R.string.invalid_blog_url_message),
                     Toast.LENGTH_SHORT).show();
             return;
         }

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -557,7 +557,7 @@
 	<string name="auto_sharing_preference_reset">إعادة تعيين إعدادات المشاركة التلقائية</string>
 	<string name="auto_sharing_preference_reset_caused_by_error">المدونة المحددة سلفًا لم تعد مرئية</string>
 	<string name="sdcard_message">بطاقة ذاكرة SD  مطلوبة لرفع ملفات الوسائط</string>
-	<string name="invalid_url_message">تحقق من أن عنوان المدونة المدخل صالح</string>
+	<string name="invalid_blog_url_message">تحقق من أن عنوان المدونة المدخل صالح</string>
 	<string name="error_delete_post">حدث خطأ أثناء حذف الـ  %s</string>
 	<string name="error_refresh_posts">المقالات لايمكن تحديثها في الوقت الحاضر</string>
 	<string name="error_refresh_pages">الصفحات لايمكن تحديثها في الوقت الحاضر</string>

--- a/WordPress/src/main/res/values-az/strings.xml
+++ b/WordPress/src/main/res/values-az/strings.xml
@@ -313,7 +313,7 @@
 	<string name="sdcard_message">Media yükləmək üçün taxılmış SD kart gərəklidir</string>
 	<string name="stats_empty_comments">Hələlik şərh yoxdur</string>
 	<string name="stats_bar_graph_empty">Baxılacaq statistika yoxdur</string>
-	<string name="invalid_url_message">Daxil etdiyiniz bloq URL keçərli olduğunu yoxlayın</string>
+	<string name="invalid_blog_url_message">Daxil etdiyiniz bloq URL keçərli olduğunu yoxlayın</string>
 	<string name="reply_failed">Caavab yazma baş tutmadı</string>
 	<string name="notifications_empty_list">Bildirş yoxdur</string>
 	<string name="error_delete_post">%s silinərkən xəta ilə qarşılaşıldı</string>

--- a/WordPress/src/main/res/values-bg/strings.xml
+++ b/WordPress/src/main/res/values-bg/strings.xml
@@ -349,7 +349,7 @@
 	<string name="comments_empty_list">Няма коментари</string>
 	<string name="wait_until_upload_completes">Изчакай трансфера да завърши</string>
 	<string name="category_automatically_renamed">Категорията %1$s не е валидна. Преименувана е на %2$s,</string>
-	<string name="invalid_url_message">Провери дали зададеният URL е валиден</string>
+	<string name="invalid_blog_url_message">Провери дали зададеният URL е валиден</string>
 	<string name="stats_empty_comments">Няма коментари</string>
 	<string name="error_refresh_pages">Страниците не могат да бъдат обновени в момента</string>
 	<string name="error_refresh_comments">Коментарите не могат да бъдат обновени в момента</string>

--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -566,7 +566,7 @@
 	<string name="blog_name_only_lowercase_letters_and_numbers">Adresa webu může obsahovat pouze malá písmena (a-z) a číslice</string>
 	<string name="auto_sharing_preference_reset_caused_by_error">Dříve vybraný web už není viditelný</string>
 	<string name="blog_name_required">Vlož adresu webu</string>
-	<string name="invalid_url_message">Zkontrolujte platnost zadané adresy webu</string>
+	<string name="invalid_blog_url_message">Zkontrolujte platnost zadané adresy webu</string>
 	<string name="blog_not_found">Nastala chyba při přístupu na tento web</string>
 	<string name="no_site_error">Nemohu se připojit k serveru WordPress</string>
 	<string name="reader_share_link">Odkaz pro sdílení</string>

--- a/WordPress/src/main/res/values-cy/strings.xml
+++ b/WordPress/src/main/res/values-cy/strings.xml
@@ -548,7 +548,7 @@
 	<string name="sdcard_message">Mae angen cerdyn SD gosodedig i lwytho cyfryngau</string>
 	<string name="stats_empty_comments">Dim sylwadau eto</string>
 	<string name="stats_bar_graph_empty">Dim ystadegau gael</string>
-	<string name="invalid_url_message">Gwiriwch fod URL y blog yn ddilys</string>
+	<string name="invalid_blog_url_message">Gwiriwch fod URL y blog yn ddilys</string>
 	<string name="reply_failed">Methodd yr ateb</string>
 	<string name="auto_sharing_preference_reset_caused_by_error">Nid yw\'r blog a ddewiswyd yn flaenorol yn weladwy</string>
 	<string name="auto_sharing_preference_reset">Ailosod gosodiadau awto-rannu</string>

--- a/WordPress/src/main/res/values-da/strings.xml
+++ b/WordPress/src/main/res/values-da/strings.xml
@@ -278,7 +278,7 @@
 	<string name="blog_name_not_allowed">Dette websted er ikke tilladt</string>
 	<string name="email_invalid">Indtast en gyldig e-mailadresse</string>
 	<string name="invalid_email_message">Din e-mailadresse er ikke gyldig</string>
-	<string name="invalid_url_message">Undersøg om bloggens URL er gyldig</string>
+	<string name="invalid_blog_url_message">Undersøg om bloggens URL er gyldig</string>
 	<string name="invalid_password_message">Adgangskoden skal være på mindst fire tegn</string>
 	<string name="auto_sharing_preference_reset_caused_by_error">Tidligere valgte blog er ikke længere synlig</string>
 	<string name="stats_bar_graph_empty">Ingen statistik er tilgængelig</string>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -554,7 +554,7 @@
 	<string name="auto_sharing_preference_reset">Auto-Teilen Einstellungen zurücksetzen</string>
 	<string name="blog_not_found">Beim Aufrufen des Blogs ist ein Fehler aufgetreten</string>
 	<string name="invalid_password_message">Passwort muss aus mindestens 4 Zeichen bestehen</string>
-	<string name="invalid_url_message">Überprüfe ob die eingegebene Blog-URL gültig ist</string>
+	<string name="invalid_blog_url_message">Überprüfe ob die eingegebene Blog-URL gültig ist</string>
 	<string name="nux_cannot_log_in">Wir können dich nicht anmelden</string>
 	<string name="no_site_error">Konnte nicht zur WordPress-Webseite verbinden</string>
 	<string name="blog_name_exists">Diese Webseite existiert bereits</string>

--- a/WordPress/src/main/res/values-el/strings.xml
+++ b/WordPress/src/main/res/values-el/strings.xml
@@ -418,7 +418,7 @@
 	<string name="auto_sharing_preference_reset_caused_by_error">Το ιστολόγιο που επιλέχθηκε προηγουμένως δεν είναι πλέον ορατό</string>
 	<string name="sdcard_message">Απαιτείται προσαρτημένη κάρτα SD για τη μεταφόρτωση πολυμέσων</string>
 	<string name="stats_bar_graph_empty">Δε υπάρχουν διαθέσιμα στατιστικά</string>
-	<string name="invalid_url_message">Ελέγξτε αν το URL του ιστολογίου που δώσατε είναι έγκυρο</string>
+	<string name="invalid_blog_url_message">Ελέγξτε αν το URL του ιστολογίου που δώσατε είναι έγκυρο</string>
 	<string name="reply_failed">Αποτυχία απάντησης</string>
 	<string name="notifications_empty_list">Δεν υπάρχουν ειδοποιήσεις</string>
 	<string name="error_delete_post">Προέκυψε σφάλμα κατά τη διαγραφή του %s</string>

--- a/WordPress/src/main/res/values-en-rAU/strings.xml
+++ b/WordPress/src/main/res/values-en-rAU/strings.xml
@@ -526,7 +526,7 @@
 	<string name="sdcard_message">A mounted SD card is required to upload media</string>
 	<string name="stats_empty_comments">No comments yet</string>
 	<string name="stats_bar_graph_empty">No stats available</string>
-	<string name="invalid_url_message">Check that the blog URL entered is valid</string>
+	<string name="invalid_blog_url_message">Check that the blog URL entered is valid</string>
 	<string name="reply_failed">Reply failed</string>
 	<string name="notifications_empty_list">No notifications</string>
 	<string name="error_delete_post">An error occurred while deleting the %s</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -524,7 +524,7 @@
 	<string name="sdcard_message">A mounted SD card is required to upload media</string>
 	<string name="stats_empty_comments">No comments yet</string>
 	<string name="stats_bar_graph_empty">No stats available</string>
-	<string name="invalid_url_message">Check that the blog URL entered is valid</string>
+	<string name="invalid_blog_url_message">Check that the blog URL entered is valid</string>
 	<string name="reply_failed">Reply failed</string>
 	<string name="notifications_empty_list">No notifications</string>
 	<string name="error_delete_post">An error occurred while deleting the %s</string>

--- a/WordPress/src/main/res/values-es-rCL/strings.xml
+++ b/WordPress/src/main/res/values-es-rCL/strings.xml
@@ -342,7 +342,7 @@
 	<string name="sdcard_message">Se necesita una tarjeta SD montada para subir medios</string>
 	<string name="stats_empty_comments">Aún sin comentarios</string>
 	<string name="stats_bar_graph_empty">Estadísticas no disponibles.</string>
-	<string name="invalid_url_message">Comprueba que la URL del blog que has puesto es válida</string>
+	<string name="invalid_blog_url_message">Comprueba que la URL del blog que has puesto es válida</string>
 	<string name="reply_failed">Respuesta fallida</string>
 	<string name="notifications_empty_list">Sin notificaciones</string>
 	<string name="error_delete_post">Ocurrió un error al eliminar el %s</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -562,7 +562,7 @@
 	<string name="reply_failed">Respuesta fallida</string>
 	<string name="error_refresh_comments">No se pudieron actualizar los comentarios</string>
 	<string name="error_refresh_stats">No se pudieron actualizar las estadísticas</string>
-	<string name="invalid_url_message">Comprueba que la URL del blog que has puesto es válida</string>
+	<string name="invalid_blog_url_message">Comprueba que la URL del blog que has puesto es válida</string>
 	<string name="could_not_remove_account">No se ha podido eliminar el sitio</string>
 	<string name="auto_sharing_preference_reset">Restablecer la configuración para compartir de forma automática</string>
 	<string name="auto_sharing_preference_reset_caused_by_error">El blog seleccionado anteriormente ya no está visible</string>

--- a/WordPress/src/main/res/values-eu/strings.xml
+++ b/WordPress/src/main/res/values-eu/strings.xml
@@ -119,7 +119,7 @@
 	<string name="blog_not_found">Blog honetara sartzean errore bat gertatu da</string>
 	<string name="nux_cannot_log_in">Ezin zaitugu sartu</string>
 	<string name="auto_sharing_preference_reset_caused_by_error">Aurretik hautatutako bloga ez dago eskuragarri dagoeneko</string>
-	<string name="invalid_url_message">Ziurtatu sartutako blogaren URLa zuzena dela</string>
+	<string name="invalid_blog_url_message">Ziurtatu sartutako blogaren URLa zuzena dela</string>
 	<string name="auto_sharing_preference_reset">Hobespenen berrezartzea auto-partekatzen</string>
 	<string name="reply_failed">Erantzunak huts egin du</string>
 	<string name="error_refresh_comments">Iruzkinak ezin izan dira une honetan freskatu</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -522,7 +522,7 @@
 	<string name="auto_sharing_preference_reset_caused_by_error">Le blog sélectionné précédemment n\'est plus visible</string>
 	<string name="sdcard_message">Une carte SD est nécessaire pour charger les médias</string>
 	<string name="stats_bar_graph_empty">Aucune statistique disponible</string>
-	<string name="invalid_url_message">Vérifiez que l\'URL du blog est valide</string>
+	<string name="invalid_blog_url_message">Vérifiez que l\'URL du blog est valide</string>
 	<string name="reply_failed">Échec de la réponse</string>
 	<string name="notifications_empty_list">Aucune notifications</string>
 	<string name="error_delete_post">Une erreur s\'est produite lors de la suppression de %s</string>

--- a/WordPress/src/main/res/values-gd/strings.xml
+++ b/WordPress/src/main/res/values-gd/strings.xml
@@ -292,7 +292,7 @@
 	<string name="error_refresh_posts">Cha b’ urrainn dhuinn na puist ath-nuadhachadh aig an àm seo</string>
 	<string name="error_refresh_pages">Cha b’ urrainn dhuinn na duilleagan ath-nuadhachadh aig an àm seo</string>
 	<string name="error_refresh_notifications">Cha b’ urrainn dhuinn na brathan ath-nuadhachadh aig an àm seo</string>
-	<string name="invalid_url_message">Dèan cinnteach gu bheil URL a’ bhloga seo dligheach</string>
+	<string name="invalid_blog_url_message">Dèan cinnteach gu bheil URL a’ bhloga seo dligheach</string>
 	<string name="reply_failed">Dh’fhàillig an fhreagairt</string>
 	<string name="stats_empty_comments">Chan eil beachd ann fhathast</string>
 	<string name="stats_bar_graph_empty">Chan eil stats ri fhaighinn</string>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -504,7 +504,7 @@
 	<string name="help_center">מרכז עזרה</string>
 	<string name="ssl_certificate_error">אישור SSL לא תקף</string>
 	<string name="ssl_certificate_ask_trust">אם בדרך כלל אתה מתחבר לאתר זה ללא בעיות, ייתכן ששגיאה זו נובעת מכך שמישהו מנסה להתחזות לאתר ולכן אסור לך להמשיך. האם ברצונך בכל זאת לתת אמון באישור?</string>
-	<string name="invalid_url_message">ודא שכתובת ה-URL של האתר שהוזנה תקפה</string>
+	<string name="invalid_blog_url_message">ודא שכתובת ה-URL של האתר שהוזנה תקפה</string>
 	<string name="blog_not_found">אירעה שגיאה בזמן הגישה לאתר זה</string>
 	<string name="could_not_remove_account">לא ניתן היה להסיר את האתר</string>
 	<string name="out_of_memory">זיכרון המכשיר מלא</string>

--- a/WordPress/src/main/res/values-hi/strings.xml
+++ b/WordPress/src/main/res/values-hi/strings.xml
@@ -194,7 +194,7 @@
 	<string name="error_edit_comment">टिप्पणी के संपादन के दौरान एक त्रुटि हुई</string>
 	<string name="error_upload">%s को अपलोड करने के दौरान एक त्रुटि हुई</string>
 	<string name="blog_name_cant_be_used">आप उस साइट पते का उपयोग नहीं कर सकते</string>
-	<string name="invalid_url_message">दर्ज किया गये ब्लॉग यूआरएल की वैधता की जाँच करे</string>
+	<string name="invalid_blog_url_message">दर्ज किया गये ब्लॉग यूआरएल की वैधता की जाँच करे</string>
 	<string name="error_refresh_comments">टिप्पणिया इस समय रिफ्रेश नहीं हो सकती</string>
 	<string name="error_refresh_pages">पृष्ठे इस समय रिफ्रेश नहीं हो सकती</string>
 	<string name="theme_fetch_failed">थीम को प्राप्त करने में असफल</string>

--- a/WordPress/src/main/res/values-hr/strings.xml
+++ b/WordPress/src/main/res/values-hr/strings.xml
@@ -539,7 +539,7 @@
 	<string name="sdcard_message">Za prijenos medijskih zapisa potrebna je montirana SD kartica</string>
 	<string name="stats_empty_comments">Još nema komentara</string>
 	<string name="stats_bar_graph_empty">Nema dostupne statistike</string>
-	<string name="invalid_url_message">Provjerite da je uneseni blog URL ispravan</string>
+	<string name="invalid_blog_url_message">Provjerite da je uneseni blog URL ispravan</string>
 	<string name="error_delete_post">Dogodila se greška prilikom brisanja %s</string>
 	<string name="error_refresh_posts">Trenutno nije moguće osvježiti objave</string>
 	<string name="error_refresh_notifications">Trenutno nije moguće osvježiti obavijesti</string>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -525,7 +525,7 @@
 	<string name="sdcard_message">Kartu SD tambahan diperlukan untuk mengunggah media</string>
 	<string name="stats_empty_comments">Belum ada tanggapan</string>
 	<string name="stats_bar_graph_empty">Belum ada statistik</string>
-	<string name="invalid_url_message">Pastikan URL blog yang dimasukkan itu benar</string>
+	<string name="invalid_blog_url_message">Pastikan URL blog yang dimasukkan itu benar</string>
 	<string name="reply_failed">Gagal mengirim balasan</string>
 	<string name="notifications_empty_list">Tak ada pemberitahuan</string>
 	<string name="error_delete_post">Terjadi galat saat menghapus %s</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -526,7 +526,7 @@
 	<string name="sdcard_message">Occorre una scheda SD per caricare i file</string>
 	<string name="stats_empty_comments">Ancora nessun commento</string>
 	<string name="stats_bar_graph_empty">Nessuna statistica disponibile</string>
-	<string name="invalid_url_message">Verifica la validità dell\'URL del blog immesso</string>
+	<string name="invalid_blog_url_message">Verifica la validità dell\'URL del blog immesso</string>
 	<string name="reply_failed">Impossibile rispondere</string>
 	<string name="notifications_empty_list">Nessuna notifica</string>
 	<string name="error_delete_post">Si è verificato un errore durante l\'eliminazione di %s</string>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -537,7 +537,7 @@
 	<string name="error_refresh_notifications">通知を再読み込みできませんでした</string>
 	<string name="invalid_email_message">無効なメールアドレスです</string>
 	<string name="invalid_password_message">パスワードは4文字以上にしてください</string>
-	<string name="invalid_url_message">入力したブログ URL が正しいか確認してください</string>
+	<string name="invalid_blog_url_message">入力したブログ URL が正しいか確認してください</string>
 	<string name="invalid_username_too_long">ユーザー名は半角で61文字以下にしてください。</string>
 	<string name="invalid_username_too_short">ユーザー名は4文字以上にしてください</string>
 	<string name="no_account">WordPress アカウントが見つかりません。アカウントを追加して、もう一度お試しください。</string>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -559,7 +559,7 @@
 	<string name="out_of_memory">장치 메모리가 부족합니다.</string>
 	<string name="no_site_error">WordPress 사이트에 연결할 수 없습니다 . 잠시 후 다시 시도해 주십시오.</string>
 	<string name="no_network_message">사용 가능한 네트워크가 없습니다. 네트워크에 연결하고 다시 시도하십시오 .</string>
-	<string name="invalid_url_message">입력한 블로그 URL이 올바른지 확인하십시오.</string>
+	<string name="invalid_blog_url_message">입력한 블로그 URL이 올바른지 확인하십시오.</string>
 	<string name="sdcard_message">미디어를 업로드하려면 SD카드가 필요합니다.</string>
 	<string name="no_account">WordPress 계정을 찾을 수 없습니다. 계정을 추가하고 다시 시도하십시오.</string>
 	<string name="cat_name_required">카테고리 이름은 필수 항목입니다.</string>

--- a/WordPress/src/main/res/values-mk/strings.xml
+++ b/WordPress/src/main/res/values-mk/strings.xml
@@ -212,7 +212,7 @@
 	<string name="blog_not_found">Настана грешка додека се достапувше блогот</string>
 	<string name="error_refresh_notifications">Известувањата неможат да се ажурират во моментот</string>
 	<string name="error_refresh_pages">Страниците неможат да се ажурират во моментот</string>
-	<string name="invalid_url_message">Проверете дали блог URL-то е воведно правилно</string>
+	<string name="invalid_blog_url_message">Проверете дали блог URL-то е воведно правилно</string>
 	<string name="error_refresh_posts">Напсите неможат да се ажурират во моментот</string>
 	<string name="blog_name_reserved_but_may_be_available">Ова адреса во моментот е резервирана, но можеби може да биде досптана по неколку денови</string>
 	<string name="gallery_error">Неможе да биде превземена медиата.</string>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -536,7 +536,7 @@
 	<string name="blog_not_found">Er heeft zich een fout voorgedaan tijdens het openen van dit blog</string>
 	<string name="wait_until_upload_completes">Wacht tot de upload is voltooid</string>
 	<string name="stats_bar_graph_empty">Geen statistieken beschikbaar</string>
-	<string name="invalid_url_message">Controleer of de ingevoerde blog-URL geldig is</string>
+	<string name="invalid_blog_url_message">Controleer of de ingevoerde blog-URL geldig is</string>
 	<string name="reply_failed">Reactie mislukt</string>
 	<string name="notifications_empty_list">Geen notificaties</string>
 	<string name="error_delete_post">Er heeft zich een fout voorgedaan bij het verwijderen van %s</string>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -219,7 +219,7 @@
 	<string name="theme_set_failed">Nie udało się włączyć motywu</string>
 	<string name="stats_empty_comments">Brak komentarzy</string>
 	<string name="stats_bar_graph_empty">Statystyki nie są dostępne</string>
-	<string name="invalid_url_message">Sprawdź czy wprowadzony URL bloga jest poprawny</string>
+	<string name="invalid_blog_url_message">Sprawdź czy wprowadzony URL bloga jest poprawny</string>
 	<string name="notifications_empty_list">Brak powiadomień</string>
 	<string name="error_delete_post">Wystąpił błąd podczas usuwania %s</string>
 	<string name="error_refresh_posts">W tej chwili nie można odświeżyć wpisów</string>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -412,7 +412,7 @@
 	<string name="adding_cat_failed">Problema ao adicionar categoria</string>
 	<string name="could_not_remove_account">Não foi possível remover o site</string>
 	<string name="stats_bar_graph_empty">Nenhuma estatística disponível</string>
-	<string name="invalid_url_message">Verifique se a URL do blog inserida é válida</string>
+	<string name="invalid_blog_url_message">Verifique se a URL do blog inserida é válida</string>
 	<string name="error_generic">Ocorreu um erro</string>
 	<string name="error_edit_comment">Ocorreu um erro ao editar o comentário</string>
 	<string name="error_load_comment">Não foi possível carregar o comentário</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -545,7 +545,7 @@
 	<string name="error_refresh_posts">Articolele n-au putut fi reîmprospătate în acest moment</string>
 	<string name="error_delete_post">A apărut o eroare în timpul ștergerii %s</string>
 	<string name="notifications_empty_list">Nicio notificare</string>
-	<string name="invalid_url_message">Verifică dacă URL-ul de blog introdus este valid</string>
+	<string name="invalid_blog_url_message">Verifică dacă URL-ul de blog introdus este valid</string>
 	<string name="reply_failed">Răspuns eșuat</string>
 	<string name="stats_bar_graph_empty">Nicio statistică disponibilă</string>
 	<string name="stats_empty_comments">Niciun comentariu deocamdată</string>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -534,7 +534,7 @@
 	<string name="notifications_empty_list">Нет уведомлений</string>
 	<string name="error_delete_post">Произошла ошибка при удалении %s</string>
 	<string name="stats_bar_graph_empty">Статистика недоступна</string>
-	<string name="invalid_url_message">Проверьте правильность введённой ссылки на блог</string>
+	<string name="invalid_blog_url_message">Проверьте правильность введённой ссылки на блог</string>
 	<string name="error_upload">Произошла ошибка при загрузке %s</string>
 	<string name="invalid_email_message">Ваш адрес email не подходит</string>
 	<string name="invalid_password_message">Пароль должен содержать не меньше 4 знаков</string>

--- a/WordPress/src/main/res/values-sk/strings.xml
+++ b/WordPress/src/main/res/values-sk/strings.xml
@@ -406,7 +406,7 @@
 	<string name="nux_cannot_log_in">Prihlásenie nie je možné</string>
 	<string name="error_delete_post">Počas mazania %s nastala chyba</string>
 	<string name="blog_name_reserved">Táto adresa je obsadená</string>
-	<string name="invalid_url_message">Overte si, či vložená URL adresa je správna</string>
+	<string name="invalid_blog_url_message">Overte si, či vložená URL adresa je správna</string>
 	<string name="out_of_memory">Nedostatok voľného miesta v pamäti</string>
 	<string name="blog_not_found">Počas prístupu k blogu sa vyskytla chyba</string>
 	<string name="error_refresh_notifications">Notifikácie nebolo možné znova načítať</string>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -525,7 +525,7 @@
 	<string name="sdcard_message">Për të ngarkuar media, lypset një kartë SD e montuar</string>
 	<string name="stats_empty_comments">Ende pa komente</string>
 	<string name="stats_bar_graph_empty">S’ka statistika gati</string>
-	<string name="invalid_url_message">Kontrolloni nëse URL-ja e blogut të dhënë është e vlefshme</string>
+	<string name="invalid_blog_url_message">Kontrolloni nëse URL-ja e blogut të dhënë është e vlefshme</string>
 	<string name="reply_failed">Përgjigja dështoi</string>
 	<string name="notifications_empty_list">S’ka njoftime</string>
 	<string name="error_refresh_posts">Postimet s’u rifreskuan dot tani</string>

--- a/WordPress/src/main/res/values-sr/strings.xml
+++ b/WordPress/src/main/res/values-sr/strings.xml
@@ -373,7 +373,7 @@
 	<string name="out_of_memory">Уређај нема доступне меморије</string>
 	<string name="notifications_empty_list">Нема обавештења</string>
 	<string name="reply_failed">Одговарање неуспешно</string>
-	<string name="invalid_url_message">Проверите да ли је унети URL исправан</string>
+	<string name="invalid_blog_url_message">Проверите да ли је унети URL исправан</string>
 	<string name="stats_bar_graph_empty">Нема статистика</string>
 	<string name="stats_empty_comments">Нема коментара</string>
 	<string name="no_site_error">Није могуће повезати се на Вордпрес веб место</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -510,7 +510,7 @@
 	<string name="no_account">Inget WordPress-konto hittat, skapa ett konto och försök igen</string>
 	<string name="stats_empty_comments">Inga kommentarer ännu</string>
 	<string name="stats_bar_graph_empty">Ingen statistik tillgänglig</string>
-	<string name="invalid_url_message">Kontrollera att blogg URL:en är gilltig</string>
+	<string name="invalid_blog_url_message">Kontrollera att blogg URL:en är gilltig</string>
 	<string name="error_generic">Ett fel uppstod</string>
 	<string name="error_downloading_image">Fel vid nedladdning av bild</string>
 	<string name="error_load_comment">Kunde inte ladda kommentaren</string>

--- a/WordPress/src/main/res/values-th/strings.xml
+++ b/WordPress/src/main/res/values-th/strings.xml
@@ -479,7 +479,7 @@
 	<string name="comments_empty_list">ไม่มีความเห็น</string>
 	<string name="stats_empty_comments">ยังไม่มีความเห็น</string>
 	<string name="stats_bar_graph_empty">สถิติยังไม่พร้อมให้ดู</string>
-	<string name="invalid_url_message">ตรวจสอบ URL บล็อกที่ใส่มาว่าใช้งานได้หรือไม่</string>
+	<string name="invalid_blog_url_message">ตรวจสอบ URL บล็อกที่ใส่มาว่าใช้งานได้หรือไม่</string>
 	<string name="reply_failed">การตอบกลับล้มเหลว</string>
 	<string name="notifications_empty_list">ไม่มีการเตือน</string>
 	<string name="gallery_error">ไม่สามารถรับไฟล์สื่อ</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -518,7 +518,7 @@
 	<string name="sdcard_message">Medya yüklemek için takılı SD kart gereklidir</string>
 	<string name="stats_empty_comments">Henüz yorum yok</string>
 	<string name="stats_bar_graph_empty">Erişilebilir istatistikler yok</string>
-	<string name="invalid_url_message">Girdiğiniz blog URL\'sinin geçerli olduğunu kontrol edin</string>
+	<string name="invalid_blog_url_message">Girdiğiniz blog URL\'sinin geçerli olduğunu kontrol edin</string>
 	<string name="reply_failed">Cevaplama başarısız</string>
 	<string name="notifications_empty_list">Bildirim yok</string>
 	<string name="error_delete_post">%s silinirken hata ile karşılaşıldı</string>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -523,7 +523,7 @@
 	<string name="auto_sharing_preference_reset">重置自动分享设置</string>
 	<string name="auto_sharing_preference_reset_caused_by_error">已选定的博客不可用</string>
 	<string name="sdcard_message">上传媒体需要已装载的 SD 卡</string>
-	<string name="invalid_url_message">请检查所输博客 URL 是否有效</string>
+	<string name="invalid_blog_url_message">请检查所输博客 URL 是否有效</string>
 	<string name="reply_failed">回复失败</string>
 	<string name="notifications_empty_list">没有通知</string>
 	<string name="error_delete_post">在删除 %s 时发生了一个错误</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -526,7 +526,7 @@
 	<string name="sdcard_message">需要掛接 SD 卡以上傳媒體</string>
 	<string name="stats_empty_comments">尚無回應</string>
 	<string name="stats_bar_graph_empty">沒有可用的統計</string>
-	<string name="invalid_url_message">檢查輸入的網誌網址是否有效</string>
+	<string name="invalid_blog_url_message">檢查輸入的網誌網址是否有效</string>
 	<string name="reply_failed">回覆失敗</string>
 	<string name="notifications_empty_list">沒有通知</string>
 	<string name="error_delete_post">刪除 %s 時發生錯誤</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -526,7 +526,7 @@
 	<string name="sdcard_message">需要掛接 SD 卡以上傳媒體</string>
 	<string name="stats_empty_comments">尚無回應</string>
 	<string name="stats_bar_graph_empty">沒有可用的統計</string>
-	<string name="invalid_url_message">檢查輸入的網誌網址是否有效</string>
+	<string name="invalid_blog_url_message">檢查輸入的網誌網址是否有效</string>
 	<string name="reply_failed">回覆失敗</string>
 	<string name="notifications_empty_list">沒有通知</string>
 	<string name="error_delete_post">刪除 %s 時發生錯誤</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -755,7 +755,7 @@
     <string name="stats_insights_best_ever">Best Views Ever</string>
 
     <!-- invalid_url -->
-    <string name="invalid_url_message">Check that the blog URL entered is valid</string>
+    <string name="invalid_blog_url_message">Check that the blog URL entered is valid</string>
 
     <!-- post status -->
     <string name="publish_post">Publish</string>


### PR DESCRIPTION
This is the 2nd of Account Settings PRs. It's a very simple change and I am not really sure if I should split this up or not. The only reason I wanted to split it up is, even though simple, it changes 48 files which clutters up main PR. I think it'll just be easier for the reviewer. If I shouldn't split it, please let me know and I'll close the PR and avoid it in the future. Thanks!

Reason for the change: I need an `invalid_url_message` string resource and instead of coming up with a different name I wanted to rename the original one since it says "Check that the blog URL entered is valid".

/cc @astralbodies 

Needs Review: @hypest Up for another one? I promise it'll take less then 2 minutes :)