### PR TITLE
Remove auto sharing and post signature from Account Settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -5,7 +5,6 @@ import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -13,7 +12,6 @@ import android.media.ThumbnailUtils;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.IBinder;
-import android.preference.PreferenceManager;
 import android.provider.MediaStore.Images;
 import android.provider.MediaStore.Video;
 import android.support.v4.app.NotificationCompat;
@@ -280,22 +278,6 @@ public class PostUploadService extends Service {
             }
 
             Map<String, Object> contentStruct = new HashMap<String, Object>();
-
-            if (!mPost.isPage() && mPost.isLocalDraft()) {
-                // add the tagline
-                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(mContext);
-
-                if (prefs.getBoolean(getString(R.string.pref_key_post_sig_enabled), false)) {
-                    String tagline = prefs.getString(getString(R.string.pref_key_post_sig), "");
-                    if (!TextUtils.isEmpty(tagline)) {
-                        String tag = "\n\n<span class=\"post_sig\">" + tagline + "</span>\n\n";
-                        if (TextUtils.isEmpty(moreContent))
-                            descriptionContent += tag;
-                        else
-                            moreContent += tag;
-                    }
-                }
-            }
 
             // Post format
             if (!mPost.isPage()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
@@ -4,7 +4,6 @@ import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.SharedPreferences.Editor;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Bundle;
@@ -25,10 +24,8 @@ import android.widget.ListView;
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
-import org.wordpress.android.ui.ShareIntentReceiverActivity;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AnalyticsUtils;
-import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.widgets.WPEditTextPreference;
 
 import java.util.Arrays;
@@ -73,8 +70,6 @@ public class SettingsFragment extends PreferenceFragment implements OnPreference
                 .setOnPreferenceClickListener(this);
         findPreference(getString(R.string.pref_key_oss_licenses))
                 .setOnPreferenceClickListener(this);
-        findPreference(getString(R.string.pref_key_reset_shared_pref))
-                .setOnPreferenceClickListener(this);
 
         mSettings = PreferenceManager.getDefaultSharedPreferences(getActivity());
 
@@ -107,8 +102,6 @@ public class SettingsFragment extends PreferenceFragment implements OnPreference
             return handleOssPreferenceClick();
         } else if (preferenceKey.equals(getString(R.string.pref_key_language))) {
             return handleLanguagePreferenceClick();
-        } else if (preferenceKey.equals(getString(R.string.pref_key_reset_shared_pref))) {
-            return handleResetAutoSharePreferencesClick();
         }
 
         return false;
@@ -139,16 +132,6 @@ public class SettingsFragment extends PreferenceFragment implements OnPreference
         } else {
             mTaglineTextPreference.setSummary(mTaglineTextPreference.getText());
         }
-    }
-
-    private boolean handleResetAutoSharePreferencesClick() {
-        Editor editor = mSettings.edit();
-        editor.remove(ShareIntentReceiverActivity.SHARE_IMAGE_BLOG_ID_KEY);
-        editor.remove(ShareIntentReceiverActivity.SHARE_IMAGE_ADDTO_KEY);
-        editor.remove(ShareIntentReceiverActivity.SHARE_TEXT_BLOG_ID_KEY);
-        editor.apply();
-        ToastUtils.showToast(getActivity(), R.string.auto_sharing_preference_reset, ToastUtils.Duration.SHORT);
-        return true;
     }
 
     private boolean handleLanguagePreferenceClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
@@ -9,10 +9,8 @@ import android.content.res.Resources;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceClickListener;
-import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
-import android.preference.PreferenceScreen;
 import android.util.DisplayMetrics;
 import android.view.MenuItem;
 import android.view.View;
@@ -83,16 +81,6 @@ public class SettingsFragment extends PreferenceFragment implements OnPreference
         }
 
         return false;
-    }
-
-    private void hideManageNotificationCategory() {
-        PreferenceScreen preferenceScreen =
-                (PreferenceScreen) findPreference(getActivity().getString(R.string.pref_key_settings_root));
-        PreferenceCategory notifs =
-                (PreferenceCategory) findPreference(getActivity().getString(R.string.pref_key_notifications_section));
-        if (preferenceScreen != null && notifs != null) {
-            preferenceScreen.removePreference(notifs);
-        }
     }
 
     public boolean onOptionsItemSelected(MenuItem item) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SettingsFragment.java
@@ -8,7 +8,6 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.preference.Preference;
-import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
@@ -24,9 +23,7 @@ import android.widget.ListView;
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
-import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AnalyticsUtils;
-import org.wordpress.android.widgets.WPEditTextPreference;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -40,29 +37,12 @@ public class SettingsFragment extends PreferenceFragment implements OnPreference
 
     private AlertDialog mDialog;
     private SharedPreferences mSettings;
-    private WPEditTextPreference mTaglineTextPreference;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         addPreferencesFromResource(R.xml.settings);
-
-        OnPreferenceChangeListener preferenceChangeListener = new OnPreferenceChangeListener() {
-            @Override
-            public boolean onPreferenceChange(Preference preference, Object newValue) {
-                if (newValue != null) { // cancelled dismiss keyboard
-                    preference.setSummary(newValue.toString());
-                }
-                ActivityUtils.hideKeyboard(getActivity());
-                return true;
-            }
-        };
-
-        mTaglineTextPreference = (WPEditTextPreference) findPreference(getString(R.string.pref_key_post_sig));
-        if (mTaglineTextPreference != null) {
-            mTaglineTextPreference.setOnPreferenceChangeListener(preferenceChangeListener);
-        }
 
         findPreference(getString(R.string.pref_key_language))
                 .setOnPreferenceClickListener(this);
@@ -72,8 +52,6 @@ public class SettingsFragment extends PreferenceFragment implements OnPreference
                 .setOnPreferenceClickListener(this);
 
         mSettings = PreferenceManager.getDefaultSharedPreferences(getActivity());
-
-        updatePostSignature();
     }
 
     @Override
@@ -123,15 +101,6 @@ public class SettingsFragment extends PreferenceFragment implements OnPreference
                 getActivity().finish();
         }
         return super.onOptionsItemSelected(item);
-    }
-
-    private void updatePostSignature() {
-        if (mTaglineTextPreference.getText() == null || mTaglineTextPreference.getText().equals("")) {
-            mTaglineTextPreference.setSummary(R.string.posted_from);
-            mTaglineTextPreference.setText(getString(R.string.posted_from));
-        } else {
-            mTaglineTextPreference.setSummary(mTaglineTextPreference.getText());
-        }
     }
 
     private boolean handleLanguagePreferenceClick() {

--- a/WordPress/src/main/res/layout/share_intent_receiver_dialog.xml
+++ b/WordPress/src/main/res/layout/share_intent_receiver_dialog.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
               android:layout_gravity="center"
@@ -46,13 +45,6 @@
                 style="@style/DropDownNav.WordPress"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"/>
-
-            <CheckBox
-                android:id="@+id/always_use_checkbox"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/always_use_these_settings_to_share"
-                tools:checked="true"/>
         </LinearLayout>
     </ScrollView>
 

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -16,8 +16,6 @@
     <string name="pref_key_post_sig" translatable="false">wp_pref_post_signature</string>
     <string name="pref_key_passlock_section" translatable="false">wp_passcode_lock_category</string>
     <string name="pref_key_passlock" translatable="false">wp_pref_passlock_enabled</string>
-    <string name="pref_key_shared_pref_section" translatable="false">wp_share_pref</string>
-    <string name="pref_key_reset_shared_pref" translatable="false">wp_reset_share_pref</string>
     <string name="pref_key_privacy_section" translatable="false">wp_privacy</string>
     <string name="pref_key_send_usage" translatable="false">wp_pref_send_usage_stats</string>
     <string name="pref_key_about_section" translatable="false">wp_pref_app_about_section</string>

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -9,8 +9,6 @@
 
     <!-- Preference keys -->
     <string name="pref_key_settings_root" translatable="false">wp_pref_root</string>
-    <string name="pref_key_notifications_section" translatable="false">wp_pref_notifications_category</string>
-    <string name="pref_key_notifications" translatable="false">wp_pref_manage_notifications</string>
     <string name="pref_key_passlock_section" translatable="false">wp_passcode_lock_category</string>
     <string name="pref_key_passlock" translatable="false">wp_pref_passlock_enabled</string>
     <string name="pref_key_privacy_section" translatable="false">wp_privacy</string>

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -11,9 +11,6 @@
     <string name="pref_key_settings_root" translatable="false">wp_pref_root</string>
     <string name="pref_key_notifications_section" translatable="false">wp_pref_notifications_category</string>
     <string name="pref_key_notifications" translatable="false">wp_pref_manage_notifications</string>
-    <string name="pref_key_post_sig_section" translatable="false">wp_post_signature</string>
-    <string name="pref_key_post_sig_enabled" translatable="false">wp_pref_signature_enabled</string>
-    <string name="pref_key_post_sig" translatable="false">wp_pref_post_signature</string>
     <string name="pref_key_passlock_section" translatable="false">wp_passcode_lock_category</string>
     <string name="pref_key_passlock" translatable="false">wp_pref_passlock_enabled</string>
     <string name="pref_key_privacy_section" translatable="false">wp_privacy</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -382,11 +382,6 @@
     <string name="share_action">Share</string>
     <string name="cant_share_no_visible_blog">You can\'t share to WordPress without a visible blog</string>
     <string name="no_account">No WordPress account found, add an account and try again</string>
-    <string name="share_preference_title">Share to WordPress</string>
-    <string name="reset_auto_share_preference">Reset auto-sharing settings</string>
-    <string name="auto_sharing_preference_reset">Auto-sharing settings reset</string>
-    <string name="auto_sharing_preference_reset_caused_by_error">Previously selected blog is no longer visible</string>
-    <string name="always_use_these_settings_to_share">Always use these settings</string>
 
     <!-- file errors -->
     <string name="file_error_create">Couldn\'t create temp file for media upload. Make sure there is enough free space on your device.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -342,10 +342,6 @@
     <string name="post_not_published">Post status isn\'t published</string>
     <string name="page_not_published">Page status isn\'t published</string>
     <string name="view_in_browser">View in browser</string>
-    <string name="post_signature">Post signature</string>
-    <string name="your_signature">Your signature:</string>
-    <string name="add_tagline">Add a signature to new posts</string>
-    <string name="posted_from">Posted from WordPress for Android</string>
     <string name="preview">Preview</string>
     <string name="update_verb">Update</string>
     <string name="sending_content">Uploading %s content</string>

--- a/WordPress/src/main/res/xml/settings.xml
+++ b/WordPress/src/main/res/xml/settings.xml
@@ -5,22 +5,6 @@
     android:key="@string/pref_key_settings_root">
 
     <PreferenceCategory
-        android:title="@string/post_signature"
-        android:key="@string/pref_key_post_sig_section">
-
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="@string/pref_key_post_sig_enabled"
-            android:title="@string/post_signature"
-            android:summary="@string/add_tagline"/>
-
-        <org.wordpress.android.widgets.WPEditTextPreference
-            android:key="@string/pref_key_post_sig"
-            android:title="@string/your_signature" />
-
-    </PreferenceCategory>
-
-    <PreferenceCategory
         android:key="@string/pref_key_passlock_section"
         android:persistent="false"
         android:title="@string/passcode_preference_title">

--- a/WordPress/src/main/res/xml/settings.xml
+++ b/WordPress/src/main/res/xml/settings.xml
@@ -38,18 +38,6 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:key="@string/pref_key_shared_pref_section"
-        android:persistent="false"
-        android:title="@string/share_preference_title">
-
-        <Preference
-            android:key="@string/pref_key_reset_shared_pref"
-            android:persistent="false"
-            android:title="@string/reset_auto_share_preference" />
-
-    </PreferenceCategory>
-
-    <PreferenceCategory
         android:title="@string/preference_privacy"
         android:key="@string/pref_key_privacy_section">
 


### PR DESCRIPTION
Addresses #3752 & #3752. This PR cleans up Account Settings from unused features such as Auto-sharing & Post signature. It also removes some unused code about notifications. The decision to remove these features were made on Slack during Account Settings refactor due to the features not getting used much. This work was originally done in `feature/account-settings` branch but moved to it's own PR to make it easier to remove.

Note: I've done my best to test this and make sure we remove all the resources (strings, layouts etc) related to these features, but if the reviewer can test these out as well, that'd be awesome. Thanks!