### PR TITLE
Refactor site language selection

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -16,6 +16,7 @@ import android.preference.PreferenceFragment;
 import android.preference.PreferenceScreen;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
+import android.util.Pair;
 import android.util.SparseBooleanArray;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
@@ -834,20 +835,14 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void sortLanguages() {
         if (mLanguagePref == null) return;
-        CharSequence[] languages = mLanguagePref.getEntryValues();
-        String[] entries = createLanguageDisplayStrings(languages);
-        String[] values = new String[entries.length];
-        Arrays.sort(entries);
 
-        for (int i = 0; i < entries.length; ++i) {
-            String[] split = entries[i].split("__");
-            entries[i] = split[0];
-            values[i] = split[1];
-        }
+        Pair<String[], String[]> pair = createSortedLanguageDisplayStrings(mLanguagePref.getEntryValues(), WPPrefUtils.languageLocale(null));
+        String[] sortedEntries = pair.first;
+        String[] sortedValues = pair.second;
 
-        mLanguagePref.setEntryValues(values);
-        mLanguagePref.setEntries(entries);
-        mLanguagePref.setDetails(createLanguageDetailDisplayStrings(values));
+        mLanguagePref.setEntries(sortedEntries);
+        mLanguagePref.setEntryValues(sortedValues);
+        mLanguagePref.setDetails(createLanguageDetailDisplayStrings(sortedValues));
     }
 
     private String getWhitelistSummary(int value) {
@@ -1037,17 +1032,27 @@ public class SiteSettingsFragment extends PreferenceFragment
     /**
      * Generates display strings for given language codes. Used as entries in language preference.
      */
-    private String[] createLanguageDisplayStrings(CharSequence[] languageCodes) {
+    private Pair<String[], String[]> createSortedLanguageDisplayStrings(CharSequence[] languageCodes, Locale locale) {
         if (languageCodes == null || languageCodes.length < 1) return null;
 
-        Locale deviceLocale = WPPrefUtils.languageLocale(null);
         String[] entryStrings = new String[languageCodes.length];
         for (int i = 0; i < languageCodes.length; ++i) {
             entryStrings[i] = StringUtils.capitalize(
-                    getLanguageString(languageCodes[i].toString(), deviceLocale)) + "__" + languageCodes[i];
+                    getLanguageString(languageCodes[i].toString(), locale)) + "__" + languageCodes[i];
         }
 
-        return entryStrings;
+        Arrays.sort(entryStrings);
+
+        String[] sortedEntries = new String[languageCodes.length];
+        String[] sortedValues = new String[languageCodes.length];
+
+        for (int i = 0; i < entryStrings.length; ++i) {
+            String[] split = entryStrings[i].split("__");
+            sortedEntries[i] = split[0];
+            sortedValues[i] = split[1];
+        }
+
+        return new Pair<>(sortedEntries, sortedValues);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -51,10 +51,8 @@ import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPPrefUtils;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 import de.greenrobot.event.EventBus;
@@ -827,7 +825,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (TextUtils.isEmpty(mLanguagePref.getSummary()) ||
                 !newValue.equals(mLanguagePref.getValue())) {
             mLanguagePref.setValue(newValue);
-            String summary = getLanguageString(newValue, WPPrefUtils.languageLocale(newValue));
+            String summary = WPPrefUtils.getLanguageString(newValue, WPPrefUtils.languageLocale(newValue));
             mLanguagePref.setSummary(summary);
             mLanguagePref.refreshAdapter();
         }
@@ -836,13 +834,13 @@ public class SiteSettingsFragment extends PreferenceFragment
     private void sortLanguages() {
         if (mLanguagePref == null) return;
 
-        Pair<String[], String[]> pair = createSortedLanguageDisplayStrings(mLanguagePref.getEntryValues(), WPPrefUtils.languageLocale(null));
+        Pair<String[], String[]> pair = WPPrefUtils.createSortedLanguageDisplayStrings(mLanguagePref.getEntryValues(), WPPrefUtils.languageLocale(null));
         String[] sortedEntries = pair.first;
         String[] sortedValues = pair.second;
 
         mLanguagePref.setEntries(sortedEntries);
         mLanguagePref.setEntryValues(sortedValues);
-        mLanguagePref.setDetails(createLanguageDetailDisplayStrings(sortedValues));
+        mLanguagePref.setDetails(WPPrefUtils.createLanguageDetailDisplayStrings(sortedValues));
     }
 
     private String getWhitelistSummary(int value) {
@@ -1027,66 +1025,6 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private boolean shouldShowListPreference(DetailListPreference preference) {
         return preference != null && preference.getEntries() != null && preference.getEntries().length > 0;
-    }
-
-    /**
-     * Generates display strings for given language codes. Used as entries in language preference.
-     */
-    private Pair<String[], String[]> createSortedLanguageDisplayStrings(CharSequence[] languageCodes, Locale locale) {
-        if (languageCodes == null || languageCodes.length < 1) return null;
-
-        String[] entryStrings = new String[languageCodes.length];
-        for (int i = 0; i < languageCodes.length; ++i) {
-            entryStrings[i] = StringUtils.capitalize(
-                    getLanguageString(languageCodes[i].toString(), locale)) + "__" + languageCodes[i];
-        }
-
-        Arrays.sort(entryStrings);
-
-        String[] sortedEntries = new String[languageCodes.length];
-        String[] sortedValues = new String[languageCodes.length];
-
-        for (int i = 0; i < entryStrings.length; ++i) {
-            String[] split = entryStrings[i].split("__");
-            sortedEntries[i] = split[0];
-            sortedValues[i] = split[1];
-        }
-
-        return new Pair<>(sortedEntries, sortedValues);
-    }
-
-    /**
-     * Generates detail display strings in the currently selected locale. Used as detail text
-     * in language preference dialog.
-     */
-    public String[] createLanguageDetailDisplayStrings(CharSequence[] languageCodes) {
-        if (languageCodes == null || languageCodes.length < 1) return null;
-
-        String[] detailStrings = new String[languageCodes.length];
-        for (int i = 0; i < languageCodes.length; ++i) {
-            detailStrings[i] = StringUtils.capitalize(getLanguageString(
-                    languageCodes[i].toString(), WPPrefUtils.languageLocale(languageCodes[i].toString())));
-        }
-
-        return detailStrings;
-    }
-
-    /**
-     * Return a non-null display string for a given language code.
-     */
-    private String getLanguageString(String languageCode, Locale displayLocale) {
-        if (languageCode == null || languageCode.length() < 2 || languageCode.length() > 6) {
-            return "";
-        }
-
-        Locale languageLocale = WPPrefUtils.languageLocale(languageCode);
-        String displayLanguage = StringUtils.capitalize(languageLocale.getDisplayLanguage(displayLocale));
-        String displayCountry = languageLocale.getDisplayCountry(displayLocale);
-
-        if (!TextUtils.isEmpty(displayCountry)) {
-            return displayLanguage + " (" + displayCountry + ")";
-        }
-        return displayLanguage;
     }
 
     private boolean setupMorePreferenceScreen() {

--- a/WordPress/src/main/java/org/wordpress/android/util/WPPrefUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPPrefUtils.java
@@ -235,6 +235,7 @@ public class WPPrefUtils {
 
         String[] entryStrings = new String[languageCodes.length];
         for (int i = 0; i < languageCodes.length; ++i) {
+            // we use "__" here to sort the language code with the display string, so both arrays are sorted at the same time
             entryStrings[i] = StringUtils.capitalize(
                     getLanguageString(languageCodes[i].toString(), locale)) + "__" + languageCodes[i];
         }
@@ -245,6 +246,7 @@ public class WPPrefUtils {
         String[] sortedValues = new String[languageCodes.length];
 
         for (int i = 0; i < entryStrings.length; ++i) {
+            // now, we can split the sorted array to extract the display string and the language code
             String[] split = entryStrings[i].split("__");
             sortedEntries[i] = split[0];
             sortedValues[i] = split[1];

--- a/WordPress/src/main/java/org/wordpress/android/util/WPPrefUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPPrefUtils.java
@@ -8,6 +8,7 @@ import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceGroup;
 import android.text.TextUtils;
+import android.util.Pair;
 import android.util.TypedValue;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -16,6 +17,7 @@ import org.wordpress.android.widgets.TypefaceCache;
 
 import org.wordpress.android.R;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -223,5 +225,65 @@ public class WPPrefUtils {
         }
 
         return languageMap;
+    }
+
+    /**
+     * Generates display strings for given language codes. Used as entries in language preference.
+     */
+    public static Pair<String[], String[]> createSortedLanguageDisplayStrings(CharSequence[] languageCodes, Locale locale) {
+        if (languageCodes == null || languageCodes.length < 1) return null;
+
+        String[] entryStrings = new String[languageCodes.length];
+        for (int i = 0; i < languageCodes.length; ++i) {
+            entryStrings[i] = StringUtils.capitalize(
+                    getLanguageString(languageCodes[i].toString(), locale)) + "__" + languageCodes[i];
+        }
+
+        Arrays.sort(entryStrings);
+
+        String[] sortedEntries = new String[languageCodes.length];
+        String[] sortedValues = new String[languageCodes.length];
+
+        for (int i = 0; i < entryStrings.length; ++i) {
+            String[] split = entryStrings[i].split("__");
+            sortedEntries[i] = split[0];
+            sortedValues[i] = split[1];
+        }
+
+        return new Pair<>(sortedEntries, sortedValues);
+    }
+
+    /**
+     * Generates detail display strings in the currently selected locale. Used as detail text
+     * in language preference dialog.
+     */
+    public static String[] createLanguageDetailDisplayStrings(CharSequence[] languageCodes) {
+        if (languageCodes == null || languageCodes.length < 1) return null;
+
+        String[] detailStrings = new String[languageCodes.length];
+        for (int i = 0; i < languageCodes.length; ++i) {
+            detailStrings[i] = StringUtils.capitalize(getLanguageString(
+                    languageCodes[i].toString(), WPPrefUtils.languageLocale(languageCodes[i].toString())));
+        }
+
+        return detailStrings;
+    }
+
+    /**
+     * Return a non-null display string for a given language code.
+     */
+    public static String getLanguageString(String languageCode, Locale displayLocale) {
+        if (languageCode == null || languageCode.length() < 2 || languageCode.length() > 6) {
+            return "";
+        }
+
+        Locale languageLocale = WPPrefUtils.languageLocale(languageCode);
+        String displayLanguage = StringUtils.capitalize(languageLocale.getDisplayLanguage(displayLocale));
+        String displayCountry = languageLocale.getDisplayCountry(displayLocale);
+
+        if (!TextUtils.isEmpty(displayCountry)) {
+            return displayLanguage + " (" + displayCountry + ")";
+        }
+        return displayLanguage;
     }
 }


### PR DESCRIPTION
This is a follow up PR on #3734. After chatting with @tonyr59h on Slack, I refactored the language display string generation to always sort the strings. As far as I know, we'll always use the sorted version, so since this will also be used in Account Settings, I thought it'd be better to do it this way. I also moved the helper methods to `WPPrefUtils` for the same reason. My only question right now is: Would it make sense to generate and sort the language strings in an AsnycTask? I worry that it might block the UI.

P.S: I wish we had RxJava as a dependency, it would have been such an easy task to make this run on background :(