### PR TITLE
Take locale into account while sorting languages array

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -835,12 +835,14 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (mLanguagePref == null) return;
 
         Pair<String[], String[]> pair = WPPrefUtils.createSortedLanguageDisplayStrings(mLanguagePref.getEntryValues(), WPPrefUtils.languageLocale(null));
-        String[] sortedEntries = pair.first;
-        String[] sortedValues = pair.second;
+        if (pair != null) {
+            String[] sortedEntries = pair.first;
+            String[] sortedValues = pair.second;
 
-        mLanguagePref.setEntries(sortedEntries);
-        mLanguagePref.setEntryValues(sortedValues);
-        mLanguagePref.setDetails(WPPrefUtils.createLanguageDetailDisplayStrings(sortedValues));
+            mLanguagePref.setEntries(sortedEntries);
+            mLanguagePref.setEntryValues(sortedValues);
+            mLanguagePref.setDetails(WPPrefUtils.createLanguageDetailDisplayStrings(sortedValues));
+        }
     }
 
     private String getWhitelistSummary(int value) {

--- a/WordPress/src/main/java/org/wordpress/android/util/WPPrefUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPPrefUtils.java
@@ -7,6 +7,7 @@ import android.preference.Preference;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceGroup;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Pair;
 import android.util.TypedValue;
@@ -231,6 +232,7 @@ public class WPPrefUtils {
     /**
      * Generates display strings for given language codes. Used as entries in language preference.
      */
+    @Nullable
     public static Pair<String[], String[]> createSortedLanguageDisplayStrings(CharSequence[] languageCodes, Locale locale) {
         if (languageCodes == null || languageCodes.length < 1) return null;
 
@@ -260,6 +262,7 @@ public class WPPrefUtils {
      * Generates detail display strings in the currently selected locale. Used as detail text
      * in language preference dialog.
      */
+    @Nullable
     public static String[] createLanguageDetailDisplayStrings(CharSequence[] languageCodes) {
         if (languageCodes == null || languageCodes.length < 1) return null;
 

--- a/WordPress/src/main/java/org/wordpress/android/util/WPPrefUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPPrefUtils.java
@@ -233,12 +233,13 @@ public class WPPrefUtils {
      * Generates display strings for given language codes. Used as entries in language preference.
      */
     @Nullable
-    public static Pair<String[], String[]> createSortedLanguageDisplayStrings(CharSequence[] languageCodes, Locale locale) {
+    public static Pair<String[], String[]> createSortedLanguageDisplayStrings(CharSequence[] languageCodes,
+                                                                              Locale locale) {
         if (languageCodes == null || languageCodes.length < 1) return null;
 
         ArrayList<String> entryStrings = new ArrayList<>(languageCodes.length);
         for (int i = 0; i < languageCodes.length; ++i) {
-            // we use "__" here to sort the language code with the display string, so both arrays are sorted at the same time
+            // "__" is used to sort the language code with the display string so both arrays are sorted at the same time
             entryStrings.add(i, StringUtils.capitalize(
                     getLanguageString(languageCodes[i].toString(), locale)) + "__" + languageCodes[i]);
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPPrefUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPPrefUtils.java
@@ -13,11 +13,12 @@ import android.util.TypedValue;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import org.wordpress.android.R;
 import org.wordpress.android.widgets.TypefaceCache;
 
-import org.wordpress.android.R;
-
-import java.util.Arrays;
+import java.text.Collator;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -233,21 +234,21 @@ public class WPPrefUtils {
     public static Pair<String[], String[]> createSortedLanguageDisplayStrings(CharSequence[] languageCodes, Locale locale) {
         if (languageCodes == null || languageCodes.length < 1) return null;
 
-        String[] entryStrings = new String[languageCodes.length];
+        ArrayList<String> entryStrings = new ArrayList<>(languageCodes.length);
         for (int i = 0; i < languageCodes.length; ++i) {
             // we use "__" here to sort the language code with the display string, so both arrays are sorted at the same time
-            entryStrings[i] = StringUtils.capitalize(
-                    getLanguageString(languageCodes[i].toString(), locale)) + "__" + languageCodes[i];
+            entryStrings.add(i, StringUtils.capitalize(
+                    getLanguageString(languageCodes[i].toString(), locale)) + "__" + languageCodes[i]);
         }
 
-        Arrays.sort(entryStrings);
+        Collections.sort(entryStrings, Collator.getInstance(locale));
 
         String[] sortedEntries = new String[languageCodes.length];
         String[] sortedValues = new String[languageCodes.length];
 
-        for (int i = 0; i < entryStrings.length; ++i) {
+        for (int i = 0; i < entryStrings.size(); ++i) {
             // now, we can split the sorted array to extract the display string and the language code
-            String[] split = entryStrings[i].split("__");
+            String[] split = entryStrings.get(i).split("__");
             sortedEntries[i] = split[0];
             sortedValues[i] = split[1];
         }


### PR DESCRIPTION
Addresses #3761. To test, change your device's locale to something like `Turkish` and before the change the languages wouldn't be sorted, the special characters will be after `z`, after the change, the sorting should be correct. The test is a bit easier on `feature/account-settings` branch in "Account Settings" page.