### PR TITLE
Mark image upload failed - get error message from XMLRPC

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaEvents.java
@@ -17,9 +17,14 @@ public class MediaEvents {
     public static class MediaUploadFailed {
         public final String mLocalMediaId;
         public final String mErrorMessage;
-        MediaUploadFailed(String localMediaId, String errorMessage) {
+        public final boolean mIsGenericMessage;
+        MediaUploadFailed(String localMediaId, String errorMessage, boolean isGenericMessage) {
             mLocalMediaId = localMediaId;
             mErrorMessage = errorMessage;
+            mIsGenericMessage = isGenericMessage;
+        }
+        MediaUploadFailed(String localMediaId, String errorMessage) {
+            this(localMediaId, errorMessage, false);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1718,7 +1718,11 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     public void onEventMainThread(MediaEvents.MediaUploadFailed event) {
         AnalyticsTracker.track(Stat.EDITOR_UPLOAD_MEDIA_FAILED);
         if (mEditorMediaUploadListener != null) {
-            mEditorMediaUploadListener.onMediaUploadFailed(event.mLocalMediaId);
+            if (event.mIsGenericMessage) {
+                mEditorMediaUploadListener.onMediaUploadFailed(event.mLocalMediaId, getString(R.string.tap_to_try_again));
+            } else {
+                mEditorMediaUploadListener.onMediaUploadFailed(event.mLocalMediaId, event.mErrorMessage);
+            }
         }
     }
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -838,7 +838,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             @Override
             public void run() {
                 mWebView.execJavaScriptFromString("ZSSEditor.markImageUploadFailed(" + mediaId + ", '"
-                        + errorMessage + "');");
+                        + errorMessage.replace("'", "\\'").replace("\"", "\\\"") + "');");
                 mFailedMediaIds.add(mediaId);
                 mUploadingMediaIds.remove(mediaId);
             }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -833,11 +833,12 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     }
 
     @Override
-    public void onMediaUploadFailed(final String mediaId) {
+    public void onMediaUploadFailed(final String mediaId, final String errorMessage) {
         mWebView.post(new Runnable() {
             @Override
             public void run() {
-                mWebView.execJavaScriptFromString("ZSSEditor.markImageUploadFailed(" + mediaId + ");");
+                mWebView.execJavaScriptFromString("ZSSEditor.markImageUploadFailed(" + mediaId + ", '"
+                        + errorMessage + "');");
                 mFailedMediaIds.add(mediaId);
                 mUploadingMediaIds.remove(mediaId);
             }
@@ -883,7 +884,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
                 // If there are images that are still in progress (because the editor exited before they completed),
                 // set them to failed, so the user can restart them (otherwise they will stay stuck in 'uploading' mode)
-                mWebView.execJavaScriptFromString("ZSSEditor.markAllUploadingImagesAsFailed();");
+                mWebView.execJavaScriptFromString("ZSSEditor.markAllUploadingImagesAsFailed('"
+                        + getString(R.string.tap_to_try_again) + "');");
 
                 // Update the list of failed media uploads
                 mWebView.execJavaScriptFromString("ZSSEditor.getFailedImages();");
@@ -1275,11 +1277,6 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         @JavascriptInterface
         public String getStringEdit() {
             return mContext.getString(R.string.edit);
-        }
-
-        @JavascriptInterface
-        public String getStringTapToRetry() {
-            return mContext.getString(R.string.tap_to_try_again);
         }
 
         @JavascriptInterface

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUploadListener.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUploadListener.java
@@ -3,6 +3,6 @@ package org.wordpress.android.editor;
 public interface EditorMediaUploadListener {
     void onMediaUploadSucceeded(String localId, String remoteId, String remoteUrl);
     void onMediaUploadProgress(String localId, float progress);
-    void onMediaUploadFailed(String localId);
+    void onMediaUploadFailed(String localId, String errorMessage);
     void onGalleryMediaUploadSucceeded(long galleryId, String remoteId, int remaining);
 }

--- a/libs/editor/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
+++ b/libs/editor/example/src/main/java/org/wordpress/example/EditorExampleActivity.java
@@ -246,7 +246,8 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
                         count += 0.1;
                     }
 
-                    ((EditorMediaUploadListener) mEditorFragment).onMediaUploadFailed(mediaId);
+                    ((EditorMediaUploadListener) mEditorFragment).onMediaUploadFailed(mediaId,
+                            getString(R.string.tap_to_try_again));
 
                     mFailedUploads.put(mediaId, mediaUrl);
                 } catch (InterruptedException e) {

--- a/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -867,7 +867,7 @@ ZSSEditor.insertLocalImage = function(imageNodeIdentifier, localImageUrl) {
     }
 
     var imgContainerStart = '<span id="' + imageContainerIdentifier + '" class="' + imgContainerClass
-                            + '" contenteditable="false" data-failed="' + nativeState.getStringTapToRetry() + '">';
+                            + '" contenteditable="false">';
     var imgContainerEnd = '</span>';
     var image = '<img data-wpid="' + imageNodeIdentifier + '" src="' + localImageUrl + '" alt="" />';
     var html = imgContainerStart + progressElement + image + imgContainerEnd;
@@ -1055,7 +1055,7 @@ ZSSEditor.markImageUploadFailed = function(imageNodeIdentifier, message) {
  *
  *  @param      imageNodeIdentifier     This is a unique ID provided by the caller.
  */
-ZSSEditor.unmarkImageUploadFailed = function(imageNodeIdentifier, message) {
+ZSSEditor.unmarkImageUploadFailed = function(imageNodeIdentifier) {
     var imageNode = this.getImageNodeWithIdentifier(imageNodeIdentifier);
     if (imageNode.length != 0){
         imageNode.removeClass('failed');
@@ -1079,7 +1079,7 @@ ZSSEditor.unmarkImageUploadFailed = function(imageNodeIdentifier, message) {
 /**
  *  @brief      Marks all in-progress images as failed to upload
  */
-ZSSEditor.markAllUploadingImagesAsFailed = function() {
+ZSSEditor.markAllUploadingImagesAsFailed = function(message) {
     var html = ZSSEditor.getField("zss_field_content").getHTML();
     var tmp = document.createElement( "div" );
     var tmpDom = $( tmp ).html( html );
@@ -1088,7 +1088,7 @@ ZSSEditor.markAllUploadingImagesAsFailed = function() {
     for(var i = 0; i < matches.size(); i++) {
         var mediaId = matches[i].getAttribute("data-wpid");
         if (mediaId != null) {
-            ZSSEditor.markImageUploadFailed(mediaId);
+            ZSSEditor.markImageUploadFailed(mediaId, message);
         }
     }
 };
@@ -1367,7 +1367,7 @@ ZSSEditor.markVideoUploadFailed = function(videoNodeIdentifier, message) {
  *
  *  @param      VideoNodeIdentifier     This is a unique ID provided by the caller.
  */
-ZSSEditor.unmarkVideoUploadFailed = function(videoNodeIdentifier, message) {
+ZSSEditor.unmarkVideoUploadFailed = function(videoNodeIdentifier) {
     var videoNode = this.getVideoNodeWithIdentifier(videoNodeIdentifier);
     if (videoNode.length != 0){
         videoNode.removeClass('failed');


### PR DESCRIPTION
* Get localized error message from XMLRPC.
* Show a generic message in other cases (Network unreachable for instance), we could check for network availability before upload.
* Moved some logic from `MediaUploadService` to `ApiHelper`.


fix wordpress-mobile/WordPress-Editor-Android#285
fix wordpress-mobile/WordPress-Editor-Android#286