### PR TITLE
Editor - Drop Post Preview

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -897,8 +897,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
         @Override
         public int getCount() {
-            // Show 3 total pages.
-            return 3;
+            // Show two pages for the visual editor, and add a third page for the EditPostPreviewFragment for legacy
+            return (mShowNewEditor ? 2 : 3);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -850,6 +850,10 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
      * one of the sections/tabs/pages.
      */
     public class SectionsPagerAdapter extends FragmentPagerAdapter {
+        // Show two pages for the visual editor, and add a third page for the EditPostPreviewFragment for legacy
+        private static final int NUM_PAGES_VISUAL_EDITOR = 2;
+        private static final int NUM_PAGES_LEGACY_EDITOR = 3;
+
         public SectionsPagerAdapter(FragmentManager fm) {
             super(fm);
         }
@@ -897,8 +901,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
         @Override
         public int getCount() {
-            // Show two pages for the visual editor, and add a third page for the EditPostPreviewFragment for legacy
-            return (mShowNewEditor ? 2 : 3);
+            return (mShowNewEditor ? NUM_PAGES_VISUAL_EDITOR : NUM_PAGES_LEGACY_EDITOR);
         }
     }
 

--- a/WordPress/src/main/res/menu/edit_post.xml
+++ b/WordPress/src/main/res/menu/edit_post.xml
@@ -2,11 +2,6 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
-        android:id="@+id/menu_preview_post"
-        android:icon="@drawable/ic_remove_red_eye_white_24dp"
-        app:showAsAction="always"
-        android:title="@string/preview"/>
-    <item
         android:id="@+id/menu_post_settings"
         android:icon="@drawable/ic_settings_white_24dp"
         app:showAsAction="always"


### PR DESCRIPTION
Addresses https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/223, dropping the 'post preview' (`EditPostPreviewFragment`) from the ActionBar when using the visual editor:

![223-drop-preview](https://cloud.githubusercontent.com/assets/9613966/13197775/66449892-d7c5-11e5-803e-62600c58d35e.png)