### PR TITLE
Log visual editor JavaScript errors in Crashlytics

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/JavaScriptException.java
+++ b/WordPress/src/main/java/org/wordpress/android/JavaScriptException.java
@@ -1,0 +1,21 @@
+package org.wordpress.android;
+
+public class JavaScriptException extends Throwable {
+    String mFile;
+    int mLine;
+
+    public JavaScriptException(String file, int line, String message) {
+        super(message);
+        mFile = file;
+        mLine = line;
+        fillInStackTrace();
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        setStackTrace(new StackTraceElement[] {
+                new StackTraceElement("JavaScriptException", "", mFile, mLine)
+        });
+        return this;
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -52,6 +52,7 @@ import org.wordpress.android.editor.EditorFragmentAbstract;
 import org.wordpress.android.editor.EditorFragmentAbstract.EditorFragmentListener;
 import org.wordpress.android.editor.EditorFragmentAbstract.TrackableEvent;
 import org.wordpress.android.editor.EditorMediaUploadListener;
+import org.wordpress.android.editor.EditorWebViewAbstract.ErrorListener;
 import org.wordpress.android.editor.ImageSettingsDialogFragment;
 import org.wordpress.android.editor.LegacyEditorFragment;
 import org.wordpress.android.models.AccountHelper;
@@ -80,6 +81,8 @@ import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.AutolinkUtils;
+import org.wordpress.android.util.CrashlyticsUtils;
+import org.wordpress.android.util.CrashlyticsUtils.ExceptionType;
 import org.wordpress.android.util.DeviceUtils;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.MediaUtils;
@@ -107,6 +110,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -2027,6 +2031,22 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     @Override
     public void onEditorFragmentInitialized() {
         fillContentEditorFields();
+        // Set the error listener
+        if (mEditorFragment instanceof EditorFragment) {
+            ((EditorFragment) mEditorFragment).setWebViewErrorListener(new ErrorListener() {
+                @Override
+                public void onJavaScriptError(String sourceFile, int lineNumber, String message) {
+                    CrashlyticsUtils.logException(new Exception(message), ExceptionType.SPECIFIC, T.EDITOR,
+                            String.format(Locale.US, "%s:%d: %s", sourceFile, lineNumber, message));
+                }
+
+                @Override
+                public void onJavaScriptAlert(String url, String message) {
+                    // no op
+                }
+            });
+        }
+
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -42,6 +42,7 @@ import android.webkit.URLUtil;
 import android.widget.Toast;
 
 import org.wordpress.android.Constants;
+import org.wordpress.android.JavaScriptException;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.WordPressDB;
@@ -2036,7 +2037,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             ((EditorFragment) mEditorFragment).setWebViewErrorListener(new ErrorListener() {
                 @Override
                 public void onJavaScriptError(String sourceFile, int lineNumber, String message) {
-                    CrashlyticsUtils.logException(new Exception(message), ExceptionType.SPECIFIC, T.EDITOR,
+                    CrashlyticsUtils.logException(new JavaScriptException(sourceFile, lineNumber, message),
+                            ExceptionType.SPECIFIC, T.EDITOR,
                             String.format(Locale.US, "%s:%d: %s", sourceFile, lineNumber, message));
                 }
 
@@ -2046,7 +2048,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 }
             });
         }
-
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/util/CrashlyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/CrashlyticsUtils.java
@@ -2,6 +2,8 @@ package org.wordpress.android.util;
 
 import com.crashlytics.android.Crashlytics;
 
+import io.fabric.sdk.android.Fabric;
+
 public class CrashlyticsUtils {
     final private static String EXCEPTION_KEY = "exception";
     final private static String TAG_KEY = "tag";
@@ -10,6 +12,9 @@ public class CrashlyticsUtils {
     public enum ExtraKey {IMAGE_ANGLE, IMAGE_WIDTH, IMAGE_HEIGHT, IMAGE_RESIZE_SCALE, NOTE_HTMLDATA, ENTERED_URL}
 
     public static void logException(Throwable tr, ExceptionType exceptionType, AppLog.T tag, String message) {
+        if (!Fabric.isInitialized()) {
+            return;
+        }
         if (tag != null) {
             Crashlytics.setString(TAG_KEY, tag.name());
         }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -32,6 +32,7 @@ import com.android.volley.toolbox.ImageLoader;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.wordpress.android.editor.EditorWebViewAbstract.ErrorListener;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.JSONUtils;
@@ -1209,6 +1210,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                     }
                 }
         }
+    }
+
+    public void setWebViewErrorListener(ErrorListener errorListener) {
+        mWebView.setErrorListener(errorListener);
     }
 
     private void updateVisualEditorFields() {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -165,7 +165,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 mWebView.post(new Runnable() {
                     @Override
                     public void run() {
-                        mWebView.execJavaScriptFromString("ZSSEditor.refreshVisibleViewportSize();");
+                        mWebView.execJavaScriptFromString("try {ZSSEditor.refreshVisibleViewportSize();} catch (e) " +
+                                "{console.log(e)}");
                     }
                 });
             }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebViewAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebViewAbstract.java
@@ -9,6 +9,7 @@ import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.view.View;
 import android.webkit.ConsoleMessage;
+import android.webkit.ConsoleMessage.MessageLevel;
 import android.webkit.JsResult;
 import android.webkit.URLUtil;
 import android.webkit.WebChromeClient;
@@ -19,6 +20,7 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.HTTPUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.UrlUtils;
@@ -36,6 +38,7 @@ public abstract class EditorWebViewAbstract extends WebView {
 
     private OnImeBackListener mOnImeBackListener;
     private AuthHeaderRequestListener mAuthHeaderRequestListener;
+    private ErrorListener mErrorListener;
     private JsCallbackReceiver mJsCallbackReceiver;
 
     private Map<String, String> mHeaderMap = new HashMap<>();
@@ -65,7 +68,7 @@ public abstract class EditorWebViewAbstract extends WebView {
 
             @Override
             public void onReceivedError(WebView view, int errorCode, String description, String failingUrl) {
-                AppLog.e(AppLog.T.EDITOR, description);
+                AppLog.e(T.EDITOR, description);
             }
 
             @TargetApi(Build.VERSION_CODES.LOLLIPOP)
@@ -96,7 +99,7 @@ public abstract class EditorWebViewAbstract extends WebView {
                         return new WebResourceResponse(conn.getContentType(), conn.getContentEncoding(),
                                 conn.getInputStream());
                     } catch (IOException e) {
-                        AppLog.e(AppLog.T.EDITOR, e);
+                        AppLog.e(T.EDITOR, e);
                     }
                 }
 
@@ -128,7 +131,7 @@ public abstract class EditorWebViewAbstract extends WebView {
                         return new WebResourceResponse(conn.getContentType(), conn.getContentEncoding(),
                                 conn.getInputStream());
                     } catch (IOException e) {
-                        AppLog.e(AppLog.T.EDITOR, e);
+                        AppLog.e(T.EDITOR, e);
                     }
                 }
 
@@ -139,13 +142,23 @@ public abstract class EditorWebViewAbstract extends WebView {
         this.setWebChromeClient(new WebChromeClient() {
             @Override
             public boolean onConsoleMessage(@NonNull ConsoleMessage cm) {
-                AppLog.d(AppLog.T.EDITOR, cm.message() + " -- From line " + cm.lineNumber() + " of " + cm.sourceId());
+                if (cm.messageLevel() == MessageLevel.ERROR) {
+                    if (mErrorListener != null) {
+                        mErrorListener.onJavaScriptError(cm.sourceId(), cm.lineNumber(), cm.message());
+                    }
+                    AppLog.e(T.EDITOR, cm.message() + " -- From line " + cm.lineNumber() + " of " + cm.sourceId());
+                } else {
+                    AppLog.d(T.EDITOR, cm.message() + " -- From line " + cm.lineNumber() + " of " + cm.sourceId());
+                }
                 return true;
             }
 
             @Override
             public boolean onJsAlert(WebView view, String url, String message, JsResult result) {
-                AppLog.d(AppLog.T.EDITOR, message);
+                AppLog.d(T.EDITOR, message);
+                if (mErrorListener != null) {
+                    mErrorListener.onJavaScriptAlert(url, message);
+                }
                 return true;
             }
         });
@@ -164,6 +177,7 @@ public abstract class EditorWebViewAbstract extends WebView {
 
     /**
      * Handles events that should be triggered when the WebView is hidden or is shown to the user
+     *
      * @param visible the new visibility status of the WebView
      */
     public void notifyVisibilityChanged(boolean visible) {
@@ -207,7 +221,16 @@ public abstract class EditorWebViewAbstract extends WebView {
         mHeaderMap.put(name, value);
     }
 
+    public void setErrorListener(ErrorListener errorListener) {
+        mErrorListener = errorListener;
+    }
+
     public interface AuthHeaderRequestListener {
         String onAuthHeaderRequested(String url);
+    }
+
+    public interface ErrorListener {
+        void onJavaScriptError(String sourceFile, int lineNumber, String message);
+        void onJavaScriptAlert(String url, String message);
     }
 }


### PR DESCRIPTION
Fix wordpress-mobile/WordPress-Editor-Android#288

We're using a WebClient callback to catch JS (and other) errors (`onConsoleMessage`), we could have a better stack trace if we were catching real exceptions from the JS code and call a Java callback from these catch, but that seems unecessary.

Purpose of this is mainly to count JS errors or find specific device errors we wouldn't have caught during testing.

Note: Crashlytics is only enabled in release build types (flavor independant).