### PR TITLE
issue/3800-preview-query-param

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -25,9 +25,9 @@ import org.wordpress.android.ui.media.WordPressMediaUtils;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.PostPreviewActivity;
 import org.wordpress.android.ui.posts.PostsListActivity;
+import org.wordpress.android.ui.prefs.AccountSettingsActivity;
 import org.wordpress.android.ui.prefs.BlogPreferencesActivity;
 import org.wordpress.android.ui.prefs.MyProfileActivity;
-import org.wordpress.android.ui.prefs.AccountSettingsActivity;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 import org.wordpress.android.ui.prefs.notifications.NotificationsSettingsActivity;
 import org.wordpress.android.ui.stats.StatsActivity;
@@ -166,9 +166,8 @@ public class ActivityLauncher {
     public static void browsePostOrPage(Context context, Blog blog, Post post) {
         if (blog == null || post == null || TextUtils.isEmpty(post.getPermaLink())) return;
 
-        String url = post.getPermaLink();
-        // Add the preview parameter if the post is not published yet
-        url = UrlUtils.appendUrlParameter(url, "preview", "true");
+        // always add the preview parameter to avoid bumping stats when viewing posts
+        String url = UrlUtils.appendUrlParameter(post.getPermaLink(), "preview", "true");
         WPWebViewActivity.openUrlByUsingBlogCredentials(context, blog, post, url);
     }
 


### PR DESCRIPTION
Resolves #3800 by changing the comment to explain why the `preview` param is always used.