### PR TITLE
Retry to download an image if a download error occured after an upload

### DIFF
--- a/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -994,7 +994,8 @@ ZSSEditor.markImageUploadDone = function(imageNodeIdentifier) {
     // Wrap link around image
     var linkTag = '<a href="' + imageNode.attr("src") + '"></a>';
     imageNode.wrap(linkTag);
-
+    // We invoke the sendImageReplacedCallback with a delay to avoid for
+    // it to be ignored by the webview because of the previous callback being done.
     var thisObj = this;
     setTimeout(function() { thisObj.sendImageReplacedCallback(imageNodeIdentifier);}, 500);
 };

--- a/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -926,9 +926,13 @@ ZSSEditor.replaceLocalImageWithRemoteImage = function(imageNodeIdentifier, remot
         ZSSEditor.callback("callback-input", joinedArguments);
         image.onerror = null;
         image.classList.add("image-loaded");
+        console.log("Image Loaded!");
     }
 
     image.onerror = function () {
+        // Even on an error, we swap the image for the time being - so if the user publishes the post,
+        // it won't reference a local image.
+        imageNode.attr('src', image.src);
         imageNode.addClass("wp-image-" + remoteImageId);
         ZSSEditor.markImageUploadDone(imageNodeIdentifier);
         var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();

--- a/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -949,7 +949,7 @@ ZSSEditor.reloadImage = function(node, nCall) {
         return;
     }
     console.log("Reloading image:", node, nCall);
-    node.onerror = tryToReload(node, nCall + 1);
+    node.onerror = ZSSEditor.tryToReload(node, nCall + 1);
     // Force reloading by updating image src
     node.src = node.src;
 }
@@ -961,7 +961,7 @@ ZSSEditor.tryToReload = function (node, nCall) {
     console.log("Image not loaded:", node, "- image reloading will happen soon.");
     node.onerror = null;
     // reload the image with a variable delay: 500ms, 1000ms, 1500ms, 2000ms, etc.
-    setTimeout(reloadImage, nCall * 500, node, nCall);
+    setTimeout(ZSSEditor.reloadImage, nCall * 500, node, nCall);
 }
 
 /**


### PR DESCRIPTION
Retry to download an image if a download error occured after an upload - workaround to fix wordpress-mobile/WordPress-Editor-Android#300

Previous `onError` implementation seemed weird (`imageNode.attr('src', image.src);`), not sure if it was working. I tried to upload images on private sites, and everything works as expected.