### PR TITLE
fix #3807: c2d message permissions conflict

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -220,7 +220,7 @@
             android:parentActivityName=".ui.themes.ThemeBrowserActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
-                android:value="org.wordpress.android.ui.themes.ThemeBrowserActivity" />
+                android:value=".ui.themes.ThemeBrowserActivity" />
         </activity>
 
         <!-- Deep Linking Activity -->

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -30,10 +30,10 @@
 
     <!-- self-defined permission prevents other apps to hijack PNs -->
     <permission
-        android:name="org.wordpress.android.permission.C2D_MESSAGE"
+        android:name="${applicationId}.permission.C2D_MESSAGE"
         android:protectionLevel="signature" />
 
-    <uses-permission android:name="org.wordpress.android.permission.C2D_MESSAGE" />
+    <uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
 
     <uses-feature
         android:name="android.hardware.camera"
@@ -418,8 +418,7 @@
             android:permission="com.google.android.c2dm.permission.SEND">
             <intent-filter>
                 <action android:name="com.google.android.c2dm.intent.RECEIVE" />
-
-                <category android:name="org.wordpress.android" />
+                <category android:name="${applicationId}" />
             </intent-filter>
         </receiver>
 


### PR DESCRIPTION
fix #3807: c2d message permissions conflict

<s>Note: PNs are currently not working with this version: a server side patch is coming soon, I'll remove the "Not Ready for Review" lable when it's merged.</s>