### PR TITLE
AppCompat Widgets, Take 2 :)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPButton.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPButton.java
@@ -1,10 +1,10 @@
 package org.wordpress.android.widgets;
 
 import android.content.Context;
+import android.support.v7.widget.AppCompatButton;
 import android.util.AttributeSet;
-import android.widget.Button;
 
-public class WPButton extends Button {
+public class WPButton extends AppCompatButton {
     public WPButton(Context context) {
         super(context, null);
         TypefaceCache.setCustomTypeface(context, this, null);

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPCheckBox.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPCheckBox.java
@@ -1,13 +1,13 @@
 package org.wordpress.android.widgets;
 
 import android.content.Context;
+import android.support.v7.widget.AppCompatCheckBox;
 import android.util.AttributeSet;
-import android.widget.CheckBox;
 
 /**
  * A CheckBox that uses the default font from TypefaceCache
  */
-public class WPCheckBox extends CheckBox {
+public class WPCheckBox extends AppCompatCheckBox {
     public WPCheckBox(Context context) {
         super(context);
         TypefaceCache.setCustomTypeface(context, this, null);

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
@@ -8,11 +8,11 @@ import android.graphics.drawable.ColorDrawable;
 import android.os.AsyncTask;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DrawableRes;
+import android.support.v7.widget.AppCompatImageView;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
-import android.widget.ImageView;
 
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.ImageLoader;
@@ -34,7 +34,7 @@ import java.util.HashSet;
  *  (2) manipulating images before display
  *  (3) automatically retrieving the thumbnail for YouTube & Vimeo videos
  */
-public class WPNetworkImageView extends ImageView {
+public class WPNetworkImageView extends AppCompatImageView {
     public enum ImageType {
         NONE,
         PHOTO,

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPRadioButton.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPRadioButton.java
@@ -1,13 +1,13 @@
 package org.wordpress.android.widgets;
 
 import android.content.Context;
+import android.support.v7.widget.AppCompatRadioButton;
 import android.util.AttributeSet;
-import android.widget.RadioButton;
 
 /**
  * A RadioButton that uses the default font from TypefaceCache
  */
-public class WPRadioButton extends RadioButton {
+public class WPRadioButton extends AppCompatRadioButton {
     public WPRadioButton(Context context) {
         super(context);
         TypefaceCache.setCustomTypeface(context, this, null);

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPTextView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPTextView.java
@@ -2,12 +2,12 @@ package org.wordpress.android.widgets;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.support.v7.widget.AppCompatTextView;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.util.AttributeSet;
-import android.widget.TextView;
 
 import org.wordpress.android.R;
 
@@ -15,7 +15,7 @@ import org.wordpress.android.R;
  * custom TextView used in layouts - enables keeping custom typeface handling in one place (so we
  * avoid having to set the typeface for every single TextView in every single activity)
  */
-public class WPTextView extends TextView {
+public class WPTextView extends AppCompatTextView {
     protected boolean mFixWidowWordEnabled;
 
     public WPTextView(Context context) {


### PR DESCRIPTION
Resolves #3799 - Switches WPButton, WPCheckBox, WPNetworkImageView, WPRadioButton, and WPTextView to AppCompat versions, which:

* Support textAllCaps style attribute which works back to Eclair MR1
* Allow dynamic tint via the background tint methods in ViewCompat
* Allow setting of the background tint using backgroundTint and backgroundTintMode attributes
