### PR TITLE
Formatting input view on layout changes so as not to rely on child order

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPNumberPicker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPNumberPicker.java
@@ -58,6 +58,7 @@ public class WPNumberPicker extends NumberPicker {
         updateIntitialOffset();
         setVerticalFadingEdgeEnabled(false);
         setHorizontalFadingEdgeEnabled(false);
+        WPPrefUtils.layoutAsNumberPickerSelected(mInputView);
         mInputView.setVisibility(View.INVISIBLE);
     }
 
@@ -66,8 +67,6 @@ public class WPNumberPicker extends NumberPicker {
         if (value < getMinValue()) value = getMinValue();
         if (value > getMaxValue()) value = getMaxValue();
         super.setValue(value);
-        EditText view = (EditText) getChildAt(0);
-        WPPrefUtils.layoutAsNumberPickerSelected(view);
     }
 
     @Override


### PR DESCRIPTION
Fixes #3772. Turns out we had the `EditText` stored already in `mInputView` so there was no need to rely on that view being the first child element in the view tree.