### PR TITLE
Issue/41editor shared link not autolinked

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1134,8 +1134,12 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             }
             // Create an <a href> element around links
             text = AutolinkUtils.autoCreateLinks(text);
-            mEditorFragment.setContent(WPHtml.fromHtml(StringUtils.addPTags(text), this, getPost(),
-                    getMaximumThumbnailWidthForEditor()));
+            if (mEditorFragment instanceof EditorFragment) {
+                mEditorFragment.setContent(text);
+            } else {
+                mEditorFragment.setContent(WPHtml.fromHtml(StringUtils.addPTags(text), this, getPost(),
+                        getMaximumThumbnailWidthForEditor()));
+            }
         }
 
         // Check for shared media


### PR DESCRIPTION
Fixes wordpress-mobile/WordPress-Editor-Android#41
I only fixed the visual editor problem, I won't fix the legacy editor issue (link is not editable).

To test: Try to share a link with the WordPress App using the visual editor

Related to this, I opened a new issue: https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/310