### PR TITLE
Feature/plans manifest

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -24,8 +24,6 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
-    <uses-permission android:name="com.android.vending.BILLING" />
-
     <!-- GCM all build types configuration -->
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/WordPress/src/zalpha/AndroidManifest.xml
+++ b/WordPress/src/zalpha/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="org.wordpress.android"
-          android:installLocation="auto">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- for now in-app billing is only enabled in zalpha builds -->
     <uses-permission android:name="com.android.vending.BILLING"/>

--- a/WordPress/src/zalpha/AndroidManifest.xml
+++ b/WordPress/src/zalpha/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="org.wordpress.android"
+          android:installLocation="auto">
+
+    <!-- for now in-app billing is only enabled in zalpha builds -->
+    <uses-permission android:name="com.android.vending.BILLING"/>
+
+</manifest>


### PR DESCRIPTION
Adds a separate `zalpha` manifest with the BILLING permission so we can test billing without requiring that permission for non-alpha end users.

cc @daniloercoli 