### PR TITLE
Hide the "new posts" message when the reader list is scrolled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -47,6 +47,7 @@ import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
+import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
@@ -86,6 +87,7 @@ public class ReaderPostListFragment extends Fragment
     private ReaderPostListType mPostListType;
 
     private int mRestorePosition;
+    private int mHideNewPostsBarOnScrollOffset;
 
     private boolean mIsUpdating;
     private boolean mWasPaused;
@@ -379,6 +381,9 @@ public class ReaderPostListFragment extends Fragment
                 refreshPosts();
             }
         });
+
+        // determine how far the user has to scroll before the "new posts" bar is hidden
+        mHideNewPostsBarOnScrollOffset = DisplayUtils.dpToPx(context, 10);
 
         // view that appears when current tag/blog has no posts - box images in this view are
         // displayed and animated for tags only
@@ -936,7 +941,9 @@ public class ReaderPostListFragment extends Fragment
             @Override
             public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
                 super.onScrolled(recyclerView, dx, dy);
-                hideNewPostsBar();
+                if (dy >= mHideNewPostsBarOnScrollOffset) {
+                    hideNewPostsBar();
+                }
             }
         });
 
@@ -950,6 +957,8 @@ public class ReaderPostListFragment extends Fragment
         }
 
         mIsAnimatingOutNewPostsBar = true;
+
+        // remove the onScrollListener assigned in showNewPostsBar()
         mRecyclerView.clearOnScrollListeners();
 
         Animation.AnimationListener listener = new Animation.AnimationListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -805,7 +805,7 @@ public class ReaderPostListFragment extends Fragment
                 && !isFirstPostVisible()) {
             showNewPostsBar();
         } else if (event.getResult().isNewOrChanged()) {
-            showNewPostsBar(); // TODO: refreshPosts();
+            refreshPosts();
         } else {
             boolean requestFailed = (event.getResult() == ReaderActions.UpdateResult.FAILED);
             setEmptyTitleAndDescription(requestFailed);
@@ -930,6 +930,20 @@ public class ReaderPostListFragment extends Fragment
         return (mNewPostsBar != null && mNewPostsBar.getVisibility() == View.VISIBLE);
     }
 
+    /*
+     * scroll listener assigned to the recycler when the "new posts" bar is shown to hide
+     * it upon scrolling
+     */
+    private final RecyclerView.OnScrollListener mOnScrollListener = new RecyclerView.OnScrollListener() {
+        @Override
+        public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
+            super.onScrolled(recyclerView, dx, dy);
+            if (Math.abs(dy) >= mHideNewPostsBarOnScrollOffsetPx) {
+                hideNewPostsBar();
+            }
+        }
+    };
+
     private void showNewPostsBar() {
         if (!isAdded() || isNewPostsBarShowing()) {
             return;
@@ -939,15 +953,7 @@ public class ReaderPostListFragment extends Fragment
         mNewPostsBar.setVisibility(View.VISIBLE);
 
         // hide the bar when the recycler is scrolled
-        mRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
-            @Override
-            public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
-                super.onScrolled(recyclerView, dx, dy);
-                if (Math.abs(dy) >= mHideNewPostsBarOnScrollOffsetPx) {
-                    hideNewPostsBar();
-                }
-            }
-        });
+        mRecyclerView.addOnScrollListener(mOnScrollListener);
 
         // remove the gap marker if it's showing, since it's no longer valid
         getPostAdapter().removeGapMarker();
@@ -961,7 +967,7 @@ public class ReaderPostListFragment extends Fragment
         mIsAnimatingOutNewPostsBar = true;
 
         // remove the onScrollListener assigned in showNewPostsBar()
-        mRecyclerView.clearOnScrollListeners();
+        mRecyclerView.removeOnScrollListener(mOnScrollListener);
 
         Animation.AnimationListener listener = new Animation.AnimationListener() {
             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -87,7 +87,6 @@ public class ReaderPostListFragment extends Fragment
     private ReaderPostListType mPostListType;
 
     private int mRestorePosition;
-    private int mHideNewPostsBarOnScrollOffset;
 
     private boolean mIsUpdating;
     private boolean mWasPaused;
@@ -96,6 +95,9 @@ public class ReaderPostListFragment extends Fragment
 
     private static boolean mHasPurgedReaderDb;
     private static Date mLastAutoUpdateDt;
+
+    private int mHideNewPostsBarOnScrollOffsetPx;
+    private static final int HIDE_NEW_POSTS_BAR_ON_SCROLL_OFFSET_DP = 10;
 
     private final HistoryStack mTagPreviewHistory = new HistoryStack("tag_preview_history");
 
@@ -383,7 +385,7 @@ public class ReaderPostListFragment extends Fragment
         });
 
         // determine how far the user has to scroll before the "new posts" bar is hidden
-        mHideNewPostsBarOnScrollOffset = DisplayUtils.dpToPx(context, 10);
+        mHideNewPostsBarOnScrollOffsetPx = DisplayUtils.dpToPx(context, HIDE_NEW_POSTS_BAR_ON_SCROLL_OFFSET_DP);
 
         // view that appears when current tag/blog has no posts - box images in this view are
         // displayed and animated for tags only
@@ -941,7 +943,7 @@ public class ReaderPostListFragment extends Fragment
             @Override
             public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
                 super.onScrolled(recyclerView, dx, dy);
-                if (dy >= mHideNewPostsBarOnScrollOffset) {
+                if (dy >= mHideNewPostsBarOnScrollOffsetPx) {
                     hideNewPostsBar();
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.support.design.widget.Snackbar;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.ListPopupWindow;
+import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -357,6 +358,14 @@ public class ReaderPostListFragment extends Fragment
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         final ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.reader_fragment_post_cards, container, false);
         mRecyclerView = (ReaderRecyclerView) rootView.findViewById(R.id.recycler_view);
+
+        mRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
+            @Override
+            public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
+                super.onScrolled(recyclerView, dx, dy);
+                hideNewPostsBar();
+            }
+        });
 
         Context context = container.getContext();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -359,14 +359,6 @@ public class ReaderPostListFragment extends Fragment
         final ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.reader_fragment_post_cards, container, false);
         mRecyclerView = (ReaderRecyclerView) rootView.findViewById(R.id.recycler_view);
 
-        mRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
-            @Override
-            public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
-                super.onScrolled(recyclerView, dx, dy);
-                hideNewPostsBar();
-            }
-        });
-
         Context context = container.getContext();
 
         // add the item decoration (dividers) to the recycler, skipping the first item if the first
@@ -939,6 +931,15 @@ public class ReaderPostListFragment extends Fragment
         AniUtils.startAnimation(mNewPostsBar, R.anim.reader_top_bar_in);
         mNewPostsBar.setVisibility(View.VISIBLE);
 
+        // hide the bar when the recycler is scrolled
+        mRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
+            @Override
+            public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
+                super.onScrolled(recyclerView, dx, dy);
+                hideNewPostsBar();
+            }
+        });
+
         // remove the gap marker if it's showing, since it's no longer valid
         getPostAdapter().removeGapMarker();
     }
@@ -949,6 +950,7 @@ public class ReaderPostListFragment extends Fragment
         }
 
         mIsAnimatingOutNewPostsBar = true;
+        mRecyclerView.clearOnScrollListeners();
 
         Animation.AnimationListener listener = new Animation.AnimationListener() {
             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -805,7 +805,7 @@ public class ReaderPostListFragment extends Fragment
                 && !isFirstPostVisible()) {
             showNewPostsBar();
         } else if (event.getResult().isNewOrChanged()) {
-            refreshPosts();
+            showNewPostsBar(); // TODO: refreshPosts();
         } else {
             boolean requestFailed = (event.getResult() == ReaderActions.UpdateResult.FAILED);
             setEmptyTitleAndDescription(requestFailed);
@@ -943,7 +943,7 @@ public class ReaderPostListFragment extends Fragment
             @Override
             public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
                 super.onScrolled(recyclerView, dx, dy);
-                if (dy >= mHideNewPostsBarOnScrollOffsetPx) {
+                if (Math.abs(dy) >= mHideNewPostsBarOnScrollOffsetPx) {
                     hideNewPostsBar();
                 }
             }


### PR DESCRIPTION
Resolves #3825 - Hides the "new posts" bar at the top of the reader when the list is scrolled. A simple way to test this is to replace [this line](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/3825-reader-hide-new-posts-bully/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java#L806) with `showNewPostsBar();` so the new posts bar appears after every update without refreshing the posts.

cc @roundhill 