### PR TITLE
issue/fix-recyclerview-scroll-listener-so-we-can-build

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -350,6 +350,18 @@ public class FilteredRecyclerView extends RelativeLayout {
         mRecyclerView.addItemDecoration(decor);
     }
 
+    public void addOnScrollListener(RecyclerView.OnScrollListener listener) {
+        if (mRecyclerView != null) {
+            mRecyclerView.addOnScrollListener(listener);
+        }
+    }
+
+    public void removeOnScrollListener(RecyclerView.OnScrollListener listener) {
+        if (mRecyclerView != null) {
+            mRecyclerView.removeOnScrollListener(listener);
+        }
+    }
+
     public void hideToolbar(){
         mAppBarLayout.setExpanded(false, true);
     }


### PR DESCRIPTION
Implemented `addOnScrollListener` and `removeOnScrollListener` wrappers in FilteredRecyclerView so we can build again.