### PR TITLE
Issue/3833 reader null tag

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -893,6 +893,10 @@ public class ReaderPostListFragment extends Fragment
             AppLog.i(T.READER, "reader post list > network unavailable, canceled tag update");
             return;
         }
+        if (tag == null) {
+            AppLog.w(T.READER, "null tag passed to updatePostsWithTag");
+            return;
+        }
         AppLog.d(T.READER, "reader post list > updating tag " + tag.getTagNameForLog() + ", updateAction=" + updateAction.name());
         ReaderPostService.startServiceForTag(getActivity(), tag, updateAction);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -428,8 +428,8 @@ public class ReaderPostListFragment extends Fragment
 
             @Override
             public FilterCriteria onRecallSelection() {
-                mCurrentTag = AppPrefs.getReaderTag();
-                return mCurrentTag;
+                ReaderTag tag = AppPrefs.getReaderTag();
+                return tag;
             }
 
             @Override


### PR DESCRIPTION
Fixes #3833 - Problem was caused by the new "FilterRecyclerView" updating the instance variable which stores the current tag for the reader fragment (I reviewed that code and should've noticed this). Also added an extra null check when updating the reader to prevent this type of crash in the future.

cc @kwonye 