### PR TITLE
Fix ApiHelper timeout value that was way too long

### DIFF
--- a/WordPress/src/main/java/org/xmlrpc/android/ApiHelper.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/ApiHelper.java
@@ -42,7 +42,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.StringReader;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1039,10 +1038,10 @@ public class ApiHelper {
     public static String getResponse(final String stringUrl, int numberOfRedirects) throws SSLHandshakeException {
         RequestFuture<String> future = RequestFuture.newFuture();
         StringRequest request = new StringRequest(stringUrl, future, future);
-        request.setRetryPolicy(new DefaultRetryPolicy(XMLRPCClient.DEFAULT_SOCKET_TIMEOUT, 0, 1));
+        request.setRetryPolicy(new DefaultRetryPolicy(XMLRPCClient.DEFAULT_SOCKET_TIMEOUT_MS, 0, 1));
         WordPress.requestQueue.add(request);
         try {
-            return future.get(XMLRPCClient.DEFAULT_SOCKET_TIMEOUT, TimeUnit.SECONDS);
+            return future.get(XMLRPCClient.DEFAULT_SOCKET_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             AppLog.e(T.API, e);
         } catch (ExecutionException e) {

--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
@@ -62,8 +62,8 @@ import de.greenrobot.event.EventBus;
  */
 
 public class XMLRPCClient implements XMLRPCClientInterface {
-    public static final int DEFAULT_CONNECTION_TIMEOUT = 30000;
-    public static final int DEFAULT_SOCKET_TIMEOUT = 60000;
+    public static final int DEFAULT_CONNECTION_TIMEOUT_MS = 30000;
+    public static final int DEFAULT_SOCKET_TIMEOUT_MS = 60000;
 
     public interface OnBytesUploadedListener {
         public void onBytesUploaded(long uploadedBytes);
@@ -157,8 +157,8 @@ public class XMLRPCClient implements XMLRPCClientInterface {
             }
         }
 
-        HttpConnectionParams.setConnectionTimeout(client.getParams(), DEFAULT_CONNECTION_TIMEOUT);
-        HttpConnectionParams.setSoTimeout(client.getParams(), DEFAULT_SOCKET_TIMEOUT);
+        HttpConnectionParams.setConnectionTimeout(client.getParams(), DEFAULT_CONNECTION_TIMEOUT_MS);
+        HttpConnectionParams.setSoTimeout(client.getParams(), DEFAULT_SOCKET_TIMEOUT_MS);
 
         // Setup HTTP Basic Auth if necessary
         if (usernamePasswordCredentials != null) {


### PR DESCRIPTION
Fixes #3830 by setting the timeout of the GET connection to 60 secs.

