### PR TITLE
Invalid XML-RPC fault responses crash the app

### DIFF
--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
@@ -319,8 +319,17 @@ public class XMLRPCClient implements XMLRPCClientInterface {
             // no parser.require() here since its called in XMLRPCSerializer.deserialize() below
             // deserialize fault result
             Map<String, Object> map = (Map<String, Object>) XMLRPCSerializer.deserialize(pullParser);
-            String faultString = (String) map.get(TAG_FAULT_STRING);
-            int faultCode = (Integer) map.get(TAG_FAULT_CODE);
+            //Check that required tags are in the response
+            if (!map.containsKey(TAG_FAULT_STRING) || !map.containsKey(TAG_FAULT_CODE)) {
+                throw new XMLRPCException("Bad XMLRPC Fault response received - neither <faultCode> nor <faultString>");
+            }
+            String faultString = String.valueOf(map.get(TAG_FAULT_STRING));
+            int faultCode;
+            try {
+                faultCode = Integer.parseInt(String.valueOf(map.get(TAG_FAULT_CODE)));
+            } catch (NumberFormatException e) {
+                throw new XMLRPCException("Bad XMLRPC Fault response received - <faultCode> value is not an integer");
+            }
             consumeHttpEntity(entity);
             throw new XMLRPCFault(faultString, faultCode);
         } else {

--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
@@ -319,18 +319,18 @@ public class XMLRPCClient implements XMLRPCClientInterface {
             // no parser.require() here since its called in XMLRPCSerializer.deserialize() below
             // deserialize fault result
             Map<String, Object> map = (Map<String, Object>) XMLRPCSerializer.deserialize(pullParser);
+            consumeHttpEntity(entity);
             //Check that required tags are in the response
             if (!map.containsKey(TAG_FAULT_STRING) || !map.containsKey(TAG_FAULT_CODE)) {
-                throw new XMLRPCException("Bad XMLRPC Fault response received - neither <faultCode> nor <faultString>");
+                throw new XMLRPCException("Bad XMLRPC Fault response received - <faultCode> and/or <faultString> missing!");
             }
             String faultString = String.valueOf(map.get(TAG_FAULT_STRING));
             int faultCode;
             try {
                 faultCode = (int) map.get(TAG_FAULT_CODE);
             } catch (NumberFormatException | ClassCastException e) {
-                throw new XMLRPCException("Bad XMLRPC Fault response received - <faultCode> value is not an integer");
+                throw new XMLRPCException("Bad XMLRPC Fault response received - <faultCode> value is not a valid integer");
             }
-            consumeHttpEntity(entity);
             throw new XMLRPCFault(faultString, faultCode);
         } else {
             consumeHttpEntity(entity);

--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCClient.java
@@ -326,8 +326,8 @@ public class XMLRPCClient implements XMLRPCClientInterface {
             String faultString = String.valueOf(map.get(TAG_FAULT_STRING));
             int faultCode;
             try {
-                faultCode = Integer.parseInt(String.valueOf(map.get(TAG_FAULT_CODE)));
-            } catch (NumberFormatException e) {
+                faultCode = (int) map.get(TAG_FAULT_CODE);
+            } catch (NumberFormatException | ClassCastException e) {
                 throw new XMLRPCException("Bad XMLRPC Fault response received - <faultCode> value is not an integer");
             }
             consumeHttpEntity(entity);


### PR DESCRIPTION
Fixes #3841

To test:
Try to pass to the app an invalid XMLRPC Fault response, and it should not crash.