### PR TITLE
Adding an index boundary check to prevent OOB crashes on certain locales

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DetailListPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DetailListPreference.java
@@ -70,6 +70,17 @@ public class DetailListPreference extends ListPreference
     }
 
     @Override
+    public CharSequence getEntry() {
+        int index = findIndexOfValue(getValue());
+        CharSequence[] entries = getEntries();
+
+        if (entries != null && index >= 0 && index < entries.length) {
+            return entries[index];
+        }
+        return null;
+    }
+
+    @Override
     protected void showDialog(Bundle state) {
         Context context = getContext();
         Resources res = context.getResources();


### PR DESCRIPTION
Fixes #3846 

To test:
Make sure your `Automatically approve` setting is set to the last value in the list (`All users`). Reproduces if the selected language (under Account Settings) is Portuguese (pt-BR) and you enter the Site Settings screen -> More -> scroll to bottom. The `Automatically approve` preference should contain 3 values but some translations do not have all the strings in `string-array`'s updated.


Needs review: @maxme 