### PR TITLE
Fix #3849 make string arrays untranslatable

### DIFF
--- a/WordPress/lint.xml
+++ b/WordPress/lint.xml
@@ -10,4 +10,5 @@
     </issue>
 
     <issue id="HardcodedText" severity="error" />
+    <issue id="InconsistentArrays" severity="error" />
 </lint>

--- a/WordPress/lint.xml
+++ b/WordPress/lint.xml
@@ -10,5 +10,5 @@
     </issue>
 
     <issue id="HardcodedText" severity="error" />
-    <issue id="InconsistentArrays" severity="error" />
+    <issue id="InconsistentArrays" severity="warning" />
 </lint>

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -418,7 +418,7 @@ public class SiteSettingsFragment extends PreferenceFragment
             updateWhitelistSettings(Integer.parseInt(newValue.toString()));
         } else if (preference == mMultipleLinksPref) {
             mSiteSettings.setMultipleLinks(Integer.parseInt(newValue.toString()));
-            String s = StringUtils.getQuantityString(getActivity(), R.string.site_settings_multiple_links_summary_one,
+            String s = StringUtils.getQuantityString(getActivity(), R.string.site_settings_multiple_links_summary_zero,
                     R.string.site_settings_multiple_links_summary_one,
                     R.string.site_settings_multiple_links_summary_other, mSiteSettings.getMultipleLinks());
             mMultipleLinksPref.setSummary(s);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -722,7 +722,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                 mSiteSettings.getUseCommentWhitelist() ? 0
                         : -1 : 1;
         setDetailListPreferenceValue(mWhitelistPref, String.valueOf(approval), getWhitelistSummary(approval));
-        String s = StringUtils.getQuantityString(getActivity(), R.string.site_settings_multiple_links_summary_one,
+        String s = StringUtils.getQuantityString(getActivity(), R.string.site_settings_multiple_links_summary_zero,
                 R.string.site_settings_multiple_links_summary_one,
                 R.string.site_settings_multiple_links_summary_other, mSiteSettings.getMultipleLinks());
         mMultipleLinksPref.setSummary(s);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -418,10 +418,10 @@ public class SiteSettingsFragment extends PreferenceFragment
             updateWhitelistSettings(Integer.parseInt(newValue.toString()));
         } else if (preference == mMultipleLinksPref) {
             mSiteSettings.setMultipleLinks(Integer.parseInt(newValue.toString()));
-            mMultipleLinksPref.setSummary(getResources()
-                    .getQuantityString(R.plurals.site_settings_multiple_links_summary,
-                            mSiteSettings.getMultipleLinks(),
-                            mSiteSettings.getMultipleLinks()));
+            String s = StringUtils.getQuantityString(getActivity(), R.string.site_settings_multiple_links_summary_one,
+                    R.string.site_settings_multiple_links_summary_one,
+                    R.string.site_settings_multiple_links_summary_other, mSiteSettings.getMultipleLinks());
+            mMultipleLinksPref.setSummary(s);
         } else if (preference == mUsernamePref) {
             mSiteSettings.setUsername(newValue.toString());
             changeEditTextPreferenceValue(mUsernamePref, mSiteSettings.getUsername());
@@ -722,10 +722,10 @@ public class SiteSettingsFragment extends PreferenceFragment
                 mSiteSettings.getUseCommentWhitelist() ? 0
                         : -1 : 1;
         setDetailListPreferenceValue(mWhitelistPref, String.valueOf(approval), getWhitelistSummary(approval));
-        mMultipleLinksPref.setSummary(getResources()
-                .getQuantityString(R.plurals.site_settings_multiple_links_summary,
-                        mSiteSettings.getMultipleLinks(),
-                        mSiteSettings.getMultipleLinks()));
+        String s = StringUtils.getQuantityString(getActivity(), R.string.site_settings_multiple_links_summary_one,
+                R.string.site_settings_multiple_links_summary_one,
+                R.string.site_settings_multiple_links_summary_other, mSiteSettings.getMultipleLinks());
+        mMultipleLinksPref.setSummary(s);
         mUploadAndLinkPref.setChecked(mBlog.isFullSizeImage());
         mIdentityRequiredPreference.setChecked(mSiteSettings.getIdentityRequired());
         mUserAccountRequiredPref.setChecked(mSiteSettings.getUserAccountRequired());

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -380,9 +380,10 @@ public abstract class SiteSettingsInterface {
     public @NonNull String getCloseAfterDescriptionForPeriod(int period) {
         if (mActivity == null) return "";
 
-        if (!getShouldCloseAfter() || period == 0) return mActivity.getString(R.string.never);
+        if (!getShouldCloseAfter()) return mActivity.getString(R.string.never);
 
-        return mActivity.getResources().getQuantityString(R.plurals.days_quantity, period, period);
+        return StringUtils.getQuantityString(mActivity, R.string.never, R.string.days_quantity_one,
+                R.string.days_quantity_other, period);
     }
 
     public int getCommentSorting() {
@@ -446,8 +447,8 @@ public abstract class SiteSettingsInterface {
         }
 
         int count = getPagingCountForDescription();
-        if (count == 0) return mActivity.getString(R.string.none);
-        return mActivity.getResources().getQuantityString(R.plurals.site_settings_paging_summary, count, count);
+        return StringUtils.getQuantityString(mActivity, R.string.none, R.string.site_settings_paging_summary_one,
+                R.string.site_settings_paging_summary_other, count);
     }
 
     public boolean getManualApproval() {
@@ -491,11 +492,10 @@ public abstract class SiteSettingsInterface {
     public @NonNull String getKeysDescription(int count) {
         if (mActivity == null) return "";
 
-        if (count > 0) {
-            return mActivity.getResources().getQuantityString(
-                    R.plurals.site_settings_list_editor_summary, count, count);
-        }
-        return mActivity.getString(R.string.site_settings_list_editor_no_items_text);
+        return StringUtils.getQuantityString(mActivity, R.string.site_settings_list_editor_no_items_text,
+                R.string.site_settings_list_editor_summary_one,
+                R.string.site_settings_list_editor_summary_other, count);
+
     }
 
     public void setTitle(String title) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -422,10 +422,8 @@
     <string name="close_after">Close after</string>
     <string name="oldest_first">Oldest first</string>
     <string name="newest_first">Newest first</string>
-    <plurals name="days_quantity">
-        <item quantity="one">1 day</item>
-        <item quantity="other">%d days</item>
-    </plurals>
+    <string name="days_quantity_one">1 day</string>
+    <string name="days_quantity_other">%d days</string>
 
     <!-- PreferenceCategory Headers -->
     <string name="site_settings_general_header">General</string>
@@ -485,14 +483,10 @@
         <item>@string/detail_approve_auto</item>
     </string-array>
 
-    <plurals name="site_settings_multiple_links_summary">
-        <item quantity="one">Require approval for more than 1 link</item>
-        <item quantity="other">Require approval for more than %d links</item>
-    </plurals>
-    <plurals name="site_settings_paging_summary">
-        <item quantity="one">1 comment per page</item>
-        <item quantity="other">%d comments per page</item>
-    </plurals>
+    <string name="site_settings_multiple_links_summary_one">Require approval for more than 1 link</string>
+    <string name="site_settings_multiple_links_summary_other">Require approval for more than %d links</string>
+    <string name="site_settings_paging_summary_one">1 comment per page</string>
+    <string name="site_settings_paging_summary_other">%d comments per page</string>
 
     <string name="privacy_public">Your site is visible to everyone and may be indexed by search engines</string>
     <string name="privacy_public_not_indexed">Your site is visible to everyone but asks search engines not to index it</string>
@@ -574,10 +568,9 @@
     <string name="site_settings_learn_more_caption">You can override these settings for individual posts.</string>
 
     <!-- List Editors (Blacklist, Hold for Moderation) -->
-    <plurals name="site_settings_list_editor_summary">
-        <item quantity="one">1 item</item>
-        <item quantity="other">%d items</item>
-    </plurals>
+    <string name="site_settings_list_editor_summary_one">1 item</string>
+    <string name="site_settings_list_editor_summary_other">%d items</string>
+
     <string name="site_settings_list_editor_no_items_text">No items</string>
     <string name="site_settings_list_editor_input_hint">Enter a word or phrase</string>
     <string name="site_settings_hold_for_moderation_description">When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be held in the moderation queue. You can enter partial words, so \"press\" will match \"WordPress.\"</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -233,11 +233,15 @@
     <string name="button_revert">Revert</string>
 
     <!-- dropdown filter above post cards -->
-    <string-array name="post_filters_array">
-        <item>Published</item>
-        <item>Drafts</item>
-        <item>Scheduled</item>
-        <item>Trashed</item>
+    <string name="filter_published_posts">Published</string>
+    <string name="filter_draft_posts">Drafts</string>
+    <string name="filter_scheduled_posts">Scheduled</string>
+    <string name="filter_trashed_posts">Trashed</string>
+    <string-array name="post_filters_array" translatable="false">
+        <item>@string/filter_published_posts</item>
+        <item>@string/filter_draft_posts</item>
+        <item>@string/filter_scheduled_posts</item>
+        <item>@string/filter_trashed_posts</item>
     </string-array>
 
     <!-- post view -->
@@ -471,11 +475,16 @@
     <string name="site_settings_whitelist_all_summary">Comments from all users</string>
     <string name="site_settings_whitelist_known_summary">Comments from known users</string>
     <string name="site_settings_whitelist_none_summary" translatable="false">@string/none</string>
-    <string-array name="site_settings_auto_approve_details">
-        <item>Require manual approval for everyone\'s comments.</item>
-        <item>Automatically approve if the user has a previously approved comment.</item>
-        <item>Automatically approve everyone\'s comments.</item>
+
+    <string name="detail_approve_manual">Require manual approval for everyone\'s comments.</string>
+    <string name="detail_approve_auto_if_previously_approved">Automatically approve if the user has a previously approved comment</string>
+    <string name="detail_approve_auto">Automatically approve everyone\'s comments.</string>
+    <string-array name="site_settings_auto_approve_details" translatable="false">
+        <item>@string/detail_approve_manual</item>
+        <item>@string/detail_approve_auto_if_previously_approved</item>
+        <item>@string/detail_approve_auto</item>
     </string-array>
+
     <plurals name="site_settings_multiple_links_summary">
         <item quantity="one">Require approval for more than 1 link</item>
         <item quantity="other">Require approval for more than %d links</item>
@@ -484,17 +493,24 @@
         <item quantity="one">1 comment per page</item>
         <item quantity="other">%d comments per page</item>
     </plurals>
-    <string-array name="privacy_details">
-        <item>Your site is visible to everyone and may be indexed by search engines</item>
-        <item>Your site is visible to everyone but asks search engines not to index it</item>
-        <item>Your site is visible only to you and users you approve</item>
+
+    <string name="privacy_public">Your site is visible to everyone and may be indexed by search engines</string>
+    <string name="privacy_public_not_indexed">Your site is visible to everyone but asks search engines not to index it</string>
+    <string name="privacy_private">Your site is visible only to you and users you approve</string>
+    <string-array name="privacy_details" translatable="false">
+        <item>@string/privacy_public</item>
+        <item>@string/privacy_public_not_indexed</item>
+        <item>@string/privacy_private</item>
     </string-array>
 
     <!-- Preference Entries -->
-    <string-array name="site_settings_auto_approve_entries">
-        <item>No comments</item>
-        <item>Known users\' comments</item>
-        <item>All users</item>
+    <string name="approve_manual">No comments</string>
+    <string name="approve_auto_if_previously_approved">Known users\' comments</string>
+    <string name="approve_auto">All users</string>
+    <string-array name="site_settings_auto_approve_entries" translatable="false">
+        <item>@string/approve_manual</item>
+        <item>@string/approve_auto_if_previously_approved</item>
+        <item>@string/approve_auto</item>
     </string-array>
 
     <string-array name="site_settings_privacy_entries" translatable="false">
@@ -840,27 +856,44 @@
     <string name="notifications_push_summary">Settings for notifications that appear on your device.</string>
     <string name="search_sites">Search sites</string>
     <string name="notifications_no_search_results">No sites matched \'%s\'</string>
-    <string-array name="notifications_blog_settings">
-        <item>Comments on my site</item>
-        <item>Likes on my comments</item>
-        <item>Likes on my posts</item>
-        <item>Site follows</item>
-        <item>Site achievements</item>
-        <item>Username mentions</item>
+
+    <string name="comments_on_my_site">Comments on my site</string>
+    <string name="likes_on_my_comments">Likes on my comments</string>
+    <string name="likes_on_my_posts">Likes on my posts</string>
+    <string name="site_follows">Site follows</string>
+    <string name="site_achievements">Site achievements</string>
+    <string name="username_mentions">Username mentions</string>
+    <string-array name="notifications_blog_settings" translatable="false">
+        <item>@string/comments_on_my_site</item>
+        <item>@string/likes_on_my_comments</item>
+        <item>@string/likes_on_my_posts</item>
+        <item>@string/site_follows</item>
+        <item>@string/site_achievements</item>
+        <item>@string/username_mentions</item>
     </string-array>
-    <string-array name="notifications_other_settings">
-        <item>Replies to my comments</item>
-        <item>Likes on my comments</item>
+
+    <string name="replies_to_my_comments">Replies to my comments</string>
+    <string-array name="notifications_other_settings" translatable="false">
+        <item>@string/replies_to_my_comments</item>
+        <item>@string/likes_on_my_comments</item>
     </string-array>
-    <string-array name="notifications_wpcom_settings">
-        <item>Suggestions</item>
-        <item>Research</item>
-        <item>Community</item>
+
+    <string name="notif_suggestions">Suggestions</string>
+    <string name="notif_research">Research</string>
+    <string name="notif_community">Community</string>
+    <string-array name="notifications_wpcom_settings" translatable="false">
+        <item>@string/notif_suggestions</item>
+        <item>@string/notif_research</item>
+        <item>@string/notif_community</item>
     </string-array>
-    <string-array name="notifications_wpcom_settings_summaries">
-        <item>Tips for getting the most out of WordPress.com.</item>
-        <item>Opportunities to participate in WordPress.com research &amp; surveys.</item>
-        <item>Information on WordPress.com courses and events (online &amp; in-person).</item>
+
+    <string name="notif_tips">Tips for getting the most out of WordPress.com.</string>
+    <string name="notif_surveys">Opportunities to participate in WordPress.com research &amp; surveys.</string>
+    <string name="notif_events">Information on WordPress.com courses and events (online &amp; in-person).</string>
+    <string-array name="notifications_wpcom_settings_summaries" translatable="false">
+        <item>@string/notif_tips</item>
+        <item>@string/notif_surveys</item>
+        <item>@string/notif_events</item>
     </string-array>
 
     <!-- reader -->
@@ -882,17 +915,27 @@
 
 
     <!-- Post Formats -->
-    <string-array name="post_formats_array">
-        <item>Aside</item>
-        <item>Audio</item>
-        <item>Chat</item>
-        <item>Gallery</item>
-        <item>Image</item>
-        <item>Link</item>
-        <item>Quote</item>
-        <item>Standard</item>
-        <item>Status</item>
-        <item>Video</item>
+    <string name="post_format_aside">Aside</string>
+    <string name="post_format_audio">Audio</string>
+    <string name="post_format_chat">Chat</string>
+    <string name="post_format_gallery">Gallery</string>
+    <string name="post_format_image">Image</string>
+    <string name="post_format_link">Link</string>
+    <string name="post_format_quote">Quote</string>
+    <string name="post_format_standard">Standard</string>
+    <string name="post_format_status">Status</string>
+    <string name="post_format_video">Video</string>
+    <string-array name="post_formats_array" translatable="false">
+        <item>@string/post_format_aside</item>
+        <item>@string/post_format_audio</item>
+        <item>@string/post_format_chat</item>
+        <item>@string/post_format_gallery</item>
+        <item>@string/post_format_image</item>
+        <item>@string/post_format_link</item>
+        <item>@string/post_format_quote</item>
+        <item>@string/post_format_standard</item>
+        <item>@string/post_format_status</item>
+        <item>@string/post_format_video</item>
     </string-array>
 
     <!-- Menu Buttons -->
@@ -904,11 +947,15 @@
     <!-- Image Alignment -->
     <string name="image_alignment">Alignment</string>
 
-    <string-array name="alignment_array">
-        <item>None</item>
-        <item>Left</item>
-        <item>Center</item>
-        <item>Right</item>
+    <string name="align_none">None</string>
+    <string name="align_left">Left</string>
+    <string name="align_center">Center</string>
+    <string name="align_right">Right</string>
+    <string-array name="alignment_array" translatable="false">
+        <item>@string/align_none</item>
+        <item>@string/align_left</item>
+        <item>@string/align_center</item>
+        <item>@string/align_right</item>
     </string-array>
 
     <!-- About View -->
@@ -1269,10 +1316,13 @@
     <string name="support">Support</string>
     <string name="active">Active</string>
 
-    <string-array name="themes_filter_array">
-        <item>Free</item>
-        <item>All</item>
-        <item>Premium</item>
+    <string name="theme_free">Free</string>
+    <string name="theme_all">All</string>
+    <string name="theme_premium">Premium</string>
+    <string-array name="themes_filter_array" translatable="false">
+        <item>@string/theme_free</item>
+        <item>@string/theme_all</item>
+        <item>@string/theme_premium</item>
     </string-array>
 
     <string name="title_activity_theme_support">Themes</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -483,6 +483,7 @@
         <item>@string/detail_approve_auto</item>
     </string-array>
 
+    <string name="site_settings_multiple_links_summary_zero">Require approval for more than 0 links</string>
     <string name="site_settings_multiple_links_summary_one">Require approval for more than 1 link</string>
     <string name="site_settings_multiple_links_summary_other">Require approval for more than %d links</string>
     <string name="site_settings_paging_summary_one">1 comment per page</string>

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/StringUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/StringUtils.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.util;
 
+import android.content.Context;
+import android.support.annotation.StringRes;
 import android.text.Html;
 import android.text.TextUtils;
 
@@ -63,7 +65,7 @@ public class StringUtils {
                 String trimmed = asploded[i].trim();
                 if (trimmed.length() > 0) {
                     trimmed = trimmed.replace("<br />", "<br>").replace("<br/>", "<br>").replace("<br>\n", "<br>")
-                                     .replace("\n", "<br>");
+                            .replace("\n", "<br>");
                     wrappedHTML.append("<p>");
                     wrappedHTML.append(trimmed);
                     wrappedHTML.append("</p>");
@@ -186,7 +188,7 @@ public class StringUtils {
             return str;
         }
 
-        return str.substring(0, str.length() -1);
+        return str.substring(0, str.length() - 1);
     }
 
     /*
@@ -223,14 +225,13 @@ public class StringUtils {
      * Used to convert a language code ([lc]_[rc] where lc is language code (en, fr, es, etc...)
      * and rc is region code (zh-CN, zh-HK, zh-TW, etc...) to a displayable string with the languages
      * name.
-     *
+     * <p/>
      * The input string must be between 2 and 6 characters, inclusive. An empty string is returned
      * if that is not the case.
-     *
+     * <p/>
      * If the input string is recognized by {@link Locale} the result of this method is the given
      *
-     * @return
-     *  non-null
+     * @return non-null
      */
     public static String getLanguageString(String languagueCode, Locale displayLocale) {
         if (languagueCode == null || languagueCode.length() < 2 || languagueCode.length() > 6) {
@@ -262,11 +263,11 @@ public class StringUtils {
         for (int i = 0; i < in.length(); i++) {
             current = in.charAt(i); // NOTE: No IndexOutOfBoundsException caught here; it should not happen.
             if ((current == 0x9) ||
-                (current == 0xA) ||
-                (current == 0xD) ||
-                ((current >= 0x20) && (current <= 0xD7FF)) ||
-                ((current >= 0xE000) && (current <= 0xFFFD)) ||
-                ((current >= 0x10000) && (current <= 0x10FFFF))) {
+                    (current == 0xA) ||
+                    (current == 0xD) ||
+                    ((current >= 0x20) && (current <= 0xD7FF)) ||
+                    ((current >= 0xE000) && (current <= 0xFFFD)) ||
+                    ((current >= 0x10000) && (current <= 0x10FFFF))) {
                 out.append(current);
             }
         }
@@ -279,6 +280,7 @@ public class StringUtils {
     public static int stringToInt(String s) {
         return stringToInt(s, 0);
     }
+
     public static int stringToInt(String s, int defaultValue) {
         if (s == null)
             return defaultValue;
@@ -292,6 +294,7 @@ public class StringUtils {
     public static long stringToLong(String s) {
         return stringToLong(s, 0L);
     }
+
     public static long stringToLong(String s, long defaultValue) {
         if (s == null)
             return defaultValue;
@@ -300,5 +303,19 @@ public class StringUtils {
         } catch (NumberFormatException e) {
             return defaultValue;
         }
+    }
+
+    /**
+     * We need this because our translation platform doesn't support plurals.
+     */
+    public static String getQuantityString(Context context, @StringRes int zero, @StringRes int one,
+                                         @StringRes int other, int count) {
+        if (count == 0) {
+            return context.getString(zero);
+        }
+        if (count == 1) {
+            return context.getString(one);
+        }
+        return context.getString(other, count);
     }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/StringUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/StringUtils.java
@@ -306,16 +306,22 @@ public class StringUtils {
     }
 
     /**
-     * We need this because our translation platform doesn't support plurals.
+     * Formats the string for the given quantity, using the given arguments.
+     * We need this because our translation platform doesn't support Android plurals.
+     *
+     * @param zero The desired string identifier to get when quantity is exactly 0
+     * @param one The desired string identifier to get when quantity is exactly 1
+     * @param other The desired string identifier to get when quantity is not (0 or 1)
+     * @param quantity The number used to get the correct string
      */
     public static String getQuantityString(Context context, @StringRes int zero, @StringRes int one,
-                                         @StringRes int other, int count) {
-        if (count == 0) {
+                                           @StringRes int other, int quantity) {
+        if (quantity == 0) {
             return context.getString(zero);
         }
-        if (count == 1) {
+        if (quantity == 1) {
             return context.getString(one);
         }
-        return String.format(context.getString(other), count);
+        return String.format(context.getString(other), quantity);
     }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/StringUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/StringUtils.java
@@ -316,6 +316,6 @@ public class StringUtils {
         if (count == 1) {
             return context.getString(one);
         }
-        return context.getString(other, count);
+        return String.format(context.getString(other), count);
     }
 }


### PR DESCRIPTION
Fix #3849 make string arrays untranslatable

Some arrays were harmless (`post_formats_array` for instance), but I prefer to make them all untranslatable so we won't fall into this problem again if we reuse the array differently.

Lint check (and travis) was failing due to `<issue id="InconsistentArrays" severity="error" />`, so I removed it - I'll add it back when we update 5.2 strings: https://github.com/wordpress-mobile/WordPress-Android/issues/3850