### PR TITLE
Update the release checks script with the recent add of wp.app_license_key to gradle.properties

### DIFF
--- a/tools/release-checks.sh
+++ b/tools/release-checks.sh
@@ -98,7 +98,7 @@ function checkVersions() {
 function checkGradleProperties() {
 	/bin/echo -n "Check WordPress/gradle.properties..."
 	checksum=`cat WordPress/gradle.properties|grep "^wp."|tr "[A-Z]" "[a-z]"|sed "s/ //g"|sort|sha1sum |cut -d- -f1| sed "s/ //g"`
-	known_checksum="e55897c69b6c2e17facb1c9ad4afe45f566eed20"
+	known_checksum="2a9fd98ebd7244da4fa3476cc3acddc37f8d529c"
 	if [ x$checksum != x$known_checksum ]; then
 		pFail
 		exit 5


### PR DESCRIPTION
Checksum updated.

To test: 

1. make sure you have a release ready `gradle.properties` file
2. run 
```bash
cat WordPress/gradle.properties | grep "^wp."|tr "[A-Z]" "[a-z]" \
    | sed "s/ //g" | sort | sha1sum | cut -d- -f1 | sed "s/ //g"
```
3. Verify the checksum.