### PR TITLE
Issue/3855 plans not serializable

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlanFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlanFragment.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.plans;
 
 import android.app.Fragment;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.text.Html;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -21,15 +22,14 @@ import org.wordpress.android.ui.plans.models.SitePlan;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.HtmlUtils;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 
 public class PlanFragment extends Fragment {
     private static final String SITE_PLAN = "SITE_PLAN";
-    private static final String PLAN_DETAILS = "PLAN_DETAILS";
 
     private ViewGroup mPlanContainerView;
-
     private SitePlan mSitePlan;
     private Plan mPlanDetails;
 
@@ -44,10 +44,10 @@ public class PlanFragment extends Fragment {
         super.onCreate(savedInstanceState);
         if (savedInstanceState != null) {
             if (savedInstanceState.containsKey(SITE_PLAN)) {
-                mSitePlan = (SitePlan) savedInstanceState.getSerializable(SITE_PLAN);
-            }
-            if (savedInstanceState.containsKey(PLAN_DETAILS)) {
-                mPlanDetails = (Plan) savedInstanceState.getSerializable(PLAN_DETAILS);
+                Serializable serial = savedInstanceState.getSerializable(SITE_PLAN);
+                if (serial instanceof SitePlan) {
+                    setSitePlan((SitePlan) serial);
+                }
             }
         }
     }
@@ -70,7 +70,6 @@ public class PlanFragment extends Fragment {
     @Override
     public void onSaveInstanceState(Bundle outState) {
         outState.putSerializable(SITE_PLAN, mSitePlan);
-        outState.putSerializable(PLAN_DETAILS, mPlanDetails);
         super.onSaveInstanceState(outState);
     }
 
@@ -169,7 +168,7 @@ public class PlanFragment extends Fragment {
         mPlanContainerView.addView(view);
     }
 
-    private void setSitePlan(SitePlan sitePlan) {
+    private void setSitePlan(@NonNull SitePlan sitePlan) {
         mSitePlan = sitePlan;
         mPlanDetails = PlansUtils.getGlobalPlan(mSitePlan.getProductID());
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/models/Plan.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/models/Plan.java
@@ -9,12 +9,11 @@ import org.json.JSONObject;
 import org.wordpress.android.util.JSONUtils;
 import org.wordpress.android.util.StringUtils;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.List;
 
-public class Plan implements Serializable {
+public class Plan {
     private long mProductID;
     private String mProductName;
     private final Hashtable<String, Integer> mPrices = new Hashtable<>();

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/models/PlanFeaturesHighlightSection.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/models/PlanFeaturesHighlightSection.java
@@ -5,6 +5,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 
 /*
@@ -29,7 +30,7 @@ a single section to highlight.
             }
         ],
  */
-public class PlanFeaturesHighlightSection {
+public class PlanFeaturesHighlightSection implements Serializable {
     private String mTitle; // title (if available) of this section
     private ArrayList<String> mItems; // slug of the features to highlight in this section
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/models/PlanFeaturesHighlightSection.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/models/PlanFeaturesHighlightSection.java
@@ -5,7 +5,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 
 /*
@@ -30,7 +29,7 @@ a single section to highlight.
             }
         ],
  */
-public class PlanFeaturesHighlightSection implements Serializable {
+public class PlanFeaturesHighlightSection {
     private String mTitle; // title (if available) of this section
     private ArrayList<String> mItems; // slug of the features to highlight in this section
 


### PR DESCRIPTION
Fixes #3855

To test: Open plans, then background the app. Prior to this fix, the app would crash with a `NotSerializableException`.

The problem was caused by serializing the Plan object (`mPlanDetails`) when saving the fragment state because the Plan contains a "PlanFeaturesHighlightSection" object which didn't implement `Serializable`.

Rather than resolve this by implementing `Serializable` in PlanFeaturesHighlightSection, I chose to stop serializing the Plan object. When the SitePlan is restored, it takes care of loading the correct plan. I decided this was a safer approach due to the downsides of serializing (namely, it leads to issue like this one!).

Needs review: @daniloercoli 
