### PR TITLE
Issue/3858 plans adapter refactor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlanFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlanFragment.java
@@ -36,6 +36,7 @@ public class PlanFragment extends Fragment {
     public static PlanFragment newInstance(SitePlan sitePlan) {
         PlanFragment fragment = new PlanFragment();
         fragment.setSitePlan(sitePlan);
+        AppLog.d(AppLog.T.PLANS, "PlanFragment newInstance");
         return fragment;
     }
 
@@ -175,17 +176,5 @@ public class PlanFragment extends Fragment {
 
     public SitePlan getSitePlan() {
         return mSitePlan;
-    }
-
-    private static final String UNICODE_CHECKMARK = "\u2713";
-    String getTitle() {
-        if (mSitePlan == null || mPlanDetails == null) {
-            AppLog.w(AppLog.T.PLANS, "empty plan data in fragment getTitle");
-            return "";
-        } else if (mSitePlan.isCurrentPlan()) {
-            return UNICODE_CHECKMARK + " " + mPlanDetails.getProductNameShort();
-        } else {
-            return mPlanDetails.getProductNameShort();
-        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
@@ -363,7 +363,7 @@ public class PlansActivity extends AppCompatActivity {
             });
         } catch (NullPointerException e) {
             // will happen when play store isn't available on device
-            AppLog.e(AppLog.T.PLANS, e);
+            //AppLog.e(AppLog.T.PLANS, e);
             AppLog.w(AppLog.T.PLANS, "Unable to start IAB helper");
         }
     }
@@ -375,7 +375,7 @@ public class PlansActivity extends AppCompatActivity {
             } catch (IllegalArgumentException e) {
                 // this can happen if the IAB helper was created but failed to bind to its service
                 // when started, which will occur on emulators
-                AppLog.e(AppLog.T.PLANS, e);
+                //AppLog.e(AppLog.T.PLANS, e);
             }
             mIabHelper = null;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.plans;
 
 import android.animation.Animator;
 import android.annotation.TargetApi;
-import android.app.Fragment;
 import android.app.FragmentManager;
 import android.content.Intent;
 import android.graphics.Point;
@@ -125,12 +124,7 @@ public class PlansActivity extends AppCompatActivity {
     }
 
     private void updatePurchaseUI(int position) {
-        Fragment fragment = getPageAdapter().getItem(position);
-        if (!(fragment instanceof PlanFragment)) {
-            return;
-        }
-
-        SitePlan sitePlan = ((PlanFragment) fragment).getSitePlan();
+        SitePlan sitePlan = getPageAdapter().getSitePlan(position);
         Plan globalPlan = PlansUtils.getGlobalPlan(sitePlan.getProductID());
         if (globalPlan == null) {
             AppLog.w(AppLog.T.PLANS, "unable to match global plan " + sitePlan.getProductID());

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
@@ -9,7 +9,6 @@ import android.graphics.Point;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.design.widget.TabLayout;
-import android.support.v13.app.FragmentPagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -58,7 +57,7 @@ public class PlansActivity extends AppCompatActivity {
     private int mViewpagerPosSelected = NO_PREV_POS_SELECTED_VIEWPAGER;
 
     private WPViewPager mViewPager;
-    private PlansPageAdapter mPageAdapter;
+    private PlansPagerAdapter mPageAdapter;
     private TabLayout mTabLayout;
 
     private IabHelper mIabHelper;
@@ -249,47 +248,6 @@ public class PlansActivity extends AppCompatActivity {
         progress.setVisibility(View.VISIBLE);
     }
 
-    private class PlansPageAdapter extends FragmentPagerAdapter {
-        private final List<Fragment> mFragments;
-
-        PlansPageAdapter(FragmentManager fm, List<Fragment> fragments) {
-            super(fm);
-            mFragments = fragments;
-        }
-
-        @Override
-        public CharSequence getPageTitle(int position) {
-            if (mFragments != null && isValidPosition(position)) {
-                return ((PlanFragment)mFragments.get(position)).getTitle();
-            }
-            return super.getPageTitle(position);
-        }
-
-        @Override
-        public Fragment getItem(int position) {
-            return mFragments.get(position);
-        }
-
-        @Override
-        public int getCount() {
-            return mFragments.size();
-        }
-
-        public boolean isValidPosition(int position) {
-            return (position >= 0 && position < getCount());
-        }
-
-        public int getPositionOfPlan(long planID) {
-            for (int i = 0; i < getCount(); i++) {
-                PlanFragment fragment = (PlanFragment) getItem(i);
-                if (fragment.getSitePlan().getProductID() == planID) {
-                    return  i;
-                }
-            }
-            return -1;
-        }
-    }
-
     @Override
     protected void onResume() {
         super.onResume();
@@ -321,7 +279,7 @@ public class PlansActivity extends AppCompatActivity {
         super.onSaveInstanceState(outState);
     }
 
-    private PlansPageAdapter getPageAdapter() {
+    private PlansPagerAdapter getPageAdapter() {
         if (mPageAdapter == null) {
             List<Fragment> fragments = new ArrayList<>();
             if (mAvailablePlans != null) {
@@ -331,7 +289,7 @@ public class PlansActivity extends AppCompatActivity {
             }
 
             FragmentManager fm = getFragmentManager();
-            mPageAdapter = new PlansPageAdapter(fm, fragments);
+            mPageAdapter = new PlansPagerAdapter(fm, fragments);
         }
         return mPageAdapter;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
@@ -174,7 +174,6 @@ public class PlansActivity extends AppCompatActivity {
 
         hideProgress();
 
-        mViewPager.setOffscreenPageLimit(mAvailablePlans.length - 1);
         mViewPager.setAdapter(getPageAdapter());
 
         mTabLayout.setTabMode(TabLayout.MODE_FIXED);

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
@@ -24,6 +24,7 @@ import android.widget.Toast;
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.ui.plans.adapters.PlansPagerAdapter;
 import org.wordpress.android.ui.plans.models.Plan;
 import org.wordpress.android.ui.plans.models.SitePlan;
 import org.wordpress.android.ui.plans.util.IabHelper;

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
@@ -37,7 +37,6 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.widgets.WPViewPager;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -281,15 +280,8 @@ public class PlansActivity extends AppCompatActivity {
 
     private PlansPagerAdapter getPageAdapter() {
         if (mPageAdapter == null) {
-            List<Fragment> fragments = new ArrayList<>();
-            if (mAvailablePlans != null) {
-                for (SitePlan plan : mAvailablePlans) {
-                    fragments.add(PlanFragment.newInstance(plan));
-                }
-            }
-
             FragmentManager fm = getFragmentManager();
-            mPageAdapter = new PlansPagerAdapter(fm, fragments);
+            mPageAdapter = new PlansPagerAdapter(getFragmentManager(), mAvailablePlans);
         }
         return mPageAdapter;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansPagerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansPagerAdapter.java
@@ -7,6 +7,7 @@ import android.support.v13.app.FragmentPagerAdapter;
 import android.util.SparseArray;
 import android.view.ViewGroup;
 
+import org.wordpress.android.ui.plans.models.Plan;
 import org.wordpress.android.ui.plans.models.SitePlan;
 import org.wordpress.android.util.AppLog;
 
@@ -16,22 +17,11 @@ import org.wordpress.android.util.AppLog;
 class PlansPagerAdapter extends FragmentPagerAdapter {
     private final SitePlan[] mSitePlans;
     private final SparseArray<PlanFragment> mFragmentMap = new SparseArray<>();
+    private static final String UNICODE_CHECKMARK = "\u2713";
 
     public PlansPagerAdapter(FragmentManager fm, @NonNull SitePlan[] sitePlans) {
         super(fm);
         mSitePlans = sitePlans.clone();
-    }
-
-    @Override
-    public CharSequence getPageTitle(int position) {
-        if (isValidPosition(position)) {
-            PlanFragment fragment = mFragmentMap.get(position);
-            if (fragment == null) {
-                fragment = getItem(position);
-            }
-            return fragment.getTitle();
-        }
-        return super.getPageTitle(position);
     }
 
     @Override
@@ -55,6 +45,22 @@ class PlansPagerAdapter extends FragmentPagerAdapter {
             }
         }
         return -1;
+    }
+
+    @Override
+    public CharSequence getPageTitle(int position) {
+        if (isValidPosition(position)) {
+            Plan planDetails = PlansUtils.getGlobalPlan(mSitePlans[position].getProductID());
+            if (planDetails == null) {
+                AppLog.w(AppLog.T.PLANS, "plans pager > empty plan details in getPageTitle");
+                return "";
+            } else if (mSitePlans[position].isCurrentPlan()) {
+                return UNICODE_CHECKMARK + " " + planDetails.getProductNameShort();
+            } else {
+                return planDetails.getProductNameShort();
+            }
+        }
+        return super.getPageTitle(position);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansPagerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansPagerAdapter.java
@@ -4,8 +4,6 @@ import android.app.FragmentManager;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.v13.app.FragmentPagerAdapter;
-import android.util.SparseArray;
-import android.view.ViewGroup;
 
 import org.wordpress.android.ui.plans.models.Plan;
 import org.wordpress.android.ui.plans.models.SitePlan;
@@ -16,7 +14,6 @@ import org.wordpress.android.util.AppLog;
  */
 class PlansPagerAdapter extends FragmentPagerAdapter {
     private final SitePlan[] mSitePlans;
-    private final SparseArray<PlanFragment> mFragmentMap = new SparseArray<>();
     private static final String UNICODE_CHECKMARK = "\u2713";
 
     public PlansPagerAdapter(FragmentManager fm, @NonNull SitePlan[] sitePlans) {
@@ -61,21 +58,6 @@ class PlansPagerAdapter extends FragmentPagerAdapter {
             }
         }
         return super.getPageTitle(position);
-    }
-
-    @Override
-    public Object instantiateItem(ViewGroup container, int position) {
-        Object item = super.instantiateItem(container, position);
-        if (item instanceof PlanFragment) {
-            mFragmentMap.put(position, (PlanFragment) item);
-        }
-        return item;
-    }
-
-    @Override
-    public void destroyItem(ViewGroup container, int position, Object object) {
-        mFragmentMap.remove(position);
-        super.destroyItem(container, position, object);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansPagerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansPagerAdapter.java
@@ -1,12 +1,14 @@
 package org.wordpress.android.ui.plans;
 
 import android.app.FragmentManager;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.v13.app.FragmentPagerAdapter;
 import android.util.SparseArray;
 import android.view.ViewGroup;
 
 import org.wordpress.android.ui.plans.models.SitePlan;
+import org.wordpress.android.util.AppLog;
 
 /**
  * ViewPager adapter for the main plans activity
@@ -68,5 +70,23 @@ class PlansPagerAdapter extends FragmentPagerAdapter {
     public void destroyItem(ViewGroup container, int position, Object object) {
         mFragmentMap.remove(position);
         super.destroyItem(container, position, object);
+    }
+
+    @Override
+    public void restoreState(Parcelable state, ClassLoader loader) {
+        // work around "Fragement no longer exists for key" Android bug
+        // https://code.google.com/p/android/issues/detail?id=42601
+        try {
+            AppLog.d(AppLog.T.PLANS, "plans pager > adapter restoreState");
+            super.restoreState(state, loader);
+        } catch (IllegalStateException e) {
+            AppLog.e(AppLog.T.PLANS, e);
+        }
+    }
+
+    @Override
+    public Parcelable saveState() {
+        AppLog.d(AppLog.T.PLANS, "plans pager > adapter saveState");
+        return super.saveState();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansPagerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansPagerAdapter.java
@@ -1,46 +1,45 @@
 package org.wordpress.android.ui.plans;
 
-import android.app.Fragment;
 import android.app.FragmentManager;
 import android.support.annotation.NonNull;
 import android.support.v13.app.FragmentPagerAdapter;
+import android.util.SparseArray;
+import android.view.ViewGroup;
 
 import org.wordpress.android.ui.plans.models.SitePlan;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * ViewPager adapter for the main plans activity
  */
 class PlansPagerAdapter extends FragmentPagerAdapter {
-    private final List<Fragment> mFragments = new ArrayList<>();
     private final SitePlan[] mSitePlans;
+    private final SparseArray<PlanFragment> mFragmentMap = new SparseArray<>();
 
     public PlansPagerAdapter(FragmentManager fm, @NonNull SitePlan[] sitePlans) {
         super(fm);
         mSitePlans = sitePlans.clone();
-        for (SitePlan plan : mSitePlans) {
-            mFragments.add(PlanFragment.newInstance(plan));
-        }
     }
 
     @Override
     public CharSequence getPageTitle(int position) {
-        if (mFragments != null && isValidPosition(position)) {
-            return ((PlanFragment) mFragments.get(position)).getTitle();
+        if (isValidPosition(position)) {
+            PlanFragment fragment = mFragmentMap.get(position);
+            if (fragment == null) {
+                fragment = getItem(position);
+            }
+            return fragment.getTitle();
         }
         return super.getPageTitle(position);
     }
 
     @Override
-    public Fragment getItem(int position) {
-        return mFragments.get(position);
+    public PlanFragment getItem(int position) {
+        return PlanFragment.newInstance(mSitePlans[position]);
     }
 
     @Override
     public int getCount() {
-        return mFragments.size();
+        return mSitePlans.length;
     }
 
     public boolean isValidPosition(int position) {
@@ -49,11 +48,25 @@ class PlansPagerAdapter extends FragmentPagerAdapter {
 
     public int getPositionOfPlan(long planID) {
         for (int i = 0; i < getCount(); i++) {
-            PlanFragment fragment = (PlanFragment) getItem(i);
-            if (fragment.getSitePlan().getProductID() == planID) {
+            if (mSitePlans[i].getProductID() == planID) {
                 return i;
             }
         }
         return -1;
+    }
+
+    @Override
+    public Object instantiateItem(ViewGroup container, int position) {
+        Object item = super.instantiateItem(container, position);
+        if (item instanceof PlanFragment) {
+            mFragmentMap.put(position, (PlanFragment) item);
+        }
+        return item;
+    }
+
+    @Override
+    public void destroyItem(ViewGroup container, int position, Object object) {
+        mFragmentMap.remove(position);
+        super.destroyItem(container, position, object);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansPagerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansPagerAdapter.java
@@ -2,19 +2,27 @@ package org.wordpress.android.ui.plans;
 
 import android.app.Fragment;
 import android.app.FragmentManager;
+import android.support.annotation.NonNull;
 import android.support.v13.app.FragmentPagerAdapter;
 
+import org.wordpress.android.ui.plans.models.SitePlan;
+
+import java.util.ArrayList;
 import java.util.List;
 
 /**
  * ViewPager adapter for the main plans activity
  */
 class PlansPagerAdapter extends FragmentPagerAdapter {
-    private final List<Fragment> mFragments;
+    private final List<Fragment> mFragments = new ArrayList<>();
+    private final SitePlan[] mSitePlans;
 
-    PlansPagerAdapter(FragmentManager fm, List<Fragment> fragments) {
+    public PlansPagerAdapter(FragmentManager fm, @NonNull SitePlan[] sitePlans) {
         super(fm);
-        mFragments = fragments;
+        mSitePlans = sitePlans.clone();
+        for (SitePlan plan : mSitePlans) {
+            mFragments.add(PlanFragment.newInstance(plan));
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansPagerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansPagerAdapter.java
@@ -44,6 +44,13 @@ class PlansPagerAdapter extends FragmentPagerAdapter {
         return -1;
     }
 
+    public SitePlan getSitePlan(int position) {
+        if (isValidPosition(position)) {
+            return mSitePlans[position];
+        }
+        return null;
+    }
+
     @Override
     public CharSequence getPageTitle(int position) {
         if (isValidPosition(position)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansPagerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansPagerAdapter.java
@@ -1,0 +1,51 @@
+package org.wordpress.android.ui.plans;
+
+import android.app.Fragment;
+import android.app.FragmentManager;
+import android.support.v13.app.FragmentPagerAdapter;
+
+import java.util.List;
+
+/**
+ * ViewPager adapter for the main plans activity
+ */
+class PlansPagerAdapter extends FragmentPagerAdapter {
+    private final List<Fragment> mFragments;
+
+    PlansPagerAdapter(FragmentManager fm, List<Fragment> fragments) {
+        super(fm);
+        mFragments = fragments;
+    }
+
+    @Override
+    public CharSequence getPageTitle(int position) {
+        if (mFragments != null && isValidPosition(position)) {
+            return ((PlanFragment) mFragments.get(position)).getTitle();
+        }
+        return super.getPageTitle(position);
+    }
+
+    @Override
+    public Fragment getItem(int position) {
+        return mFragments.get(position);
+    }
+
+    @Override
+    public int getCount() {
+        return mFragments.size();
+    }
+
+    public boolean isValidPosition(int position) {
+        return (position >= 0 && position < getCount());
+    }
+
+    public int getPositionOfPlan(long planID) {
+        for (int i = 0; i < getCount(); i++) {
+            PlanFragment fragment = (PlanFragment) getItem(i);
+            if (fragment.getSitePlan().getProductID() == planID) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansUtils.java
@@ -58,8 +58,6 @@ public class PlansUtils {
         }
     }
 
-
-
     @Nullable
     public static Plan getGlobalPlan(long planId) {
         List<Plan> plans = getGlobalPlans();

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/adapters/PlansPagerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/adapters/PlansPagerAdapter.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.plans.adapters;
 
 import android.app.FragmentManager;
-import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.v13.app.FragmentPagerAdapter;
 
@@ -47,24 +46,6 @@ public class PlansPagerAdapter extends FragmentPagerAdapter {
             }
         }
         return super.getPageTitle(position);
-    }
-
-    @Override
-    public void restoreState(Parcelable state, ClassLoader loader) {
-        // work around "Fragement no longer exists for key" Android bug
-        // https://code.google.com/p/android/issues/detail?id=42601
-        try {
-            AppLog.d(AppLog.T.PLANS, "plans pager > adapter restoreState");
-            super.restoreState(state, loader);
-        } catch (IllegalStateException e) {
-            AppLog.e(AppLog.T.PLANS, e);
-        }
-    }
-
-    @Override
-    public Parcelable saveState() {
-        AppLog.d(AppLog.T.PLANS, "plans pager > adapter saveState");
-        return super.saveState();
     }
 
     public boolean isValidPosition(int position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/adapters/PlansPagerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/adapters/PlansPagerAdapter.java
@@ -33,26 +33,6 @@ public class PlansPagerAdapter extends FragmentPagerAdapter {
         return mSitePlans.length;
     }
 
-    public boolean isValidPosition(int position) {
-        return (position >= 0 && position < getCount());
-    }
-
-    public int getPositionOfPlan(long planID) {
-        for (int i = 0; i < getCount(); i++) {
-            if (mSitePlans[i].getProductID() == planID) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    public SitePlan getSitePlan(int position) {
-        if (isValidPosition(position)) {
-            return mSitePlans[position];
-        }
-        return null;
-    }
-
     @Override
     public CharSequence getPageTitle(int position) {
         if (isValidPosition(position)) {
@@ -85,5 +65,25 @@ public class PlansPagerAdapter extends FragmentPagerAdapter {
     public Parcelable saveState() {
         AppLog.d(AppLog.T.PLANS, "plans pager > adapter saveState");
         return super.saveState();
+    }
+
+    public boolean isValidPosition(int position) {
+        return (position >= 0 && position < getCount());
+    }
+
+    public int getPositionOfPlan(long planID) {
+        for (int i = 0; i < getCount(); i++) {
+            if (mSitePlans[i].getProductID() == planID) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public SitePlan getSitePlan(int position) {
+        if (isValidPosition(position)) {
+            return mSitePlans[position];
+        }
+        return null;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/adapters/PlansPagerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/adapters/PlansPagerAdapter.java
@@ -1,10 +1,12 @@
-package org.wordpress.android.ui.plans;
+package org.wordpress.android.ui.plans.adapters;
 
 import android.app.FragmentManager;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.v13.app.FragmentPagerAdapter;
 
+import org.wordpress.android.ui.plans.PlanFragment;
+import org.wordpress.android.ui.plans.PlansUtils;
 import org.wordpress.android.ui.plans.models.Plan;
 import org.wordpress.android.ui.plans.models.SitePlan;
 import org.wordpress.android.util.AppLog;
@@ -12,7 +14,7 @@ import org.wordpress.android.util.AppLog;
 /**
  * ViewPager adapter for the main plans activity
  */
-class PlansPagerAdapter extends FragmentPagerAdapter {
+public class PlansPagerAdapter extends FragmentPagerAdapter {
     private final SitePlan[] mSitePlans;
     private static final String UNICODE_CHECKMARK = "\u2713";
 


### PR DESCRIPTION
Resolves #3858 - simplifies and optimizes the ViewPager adapter used by plans. Rather than being passed a list of fragments in the constructor and then holding on to them, we instead pass a list of site plans and let the FragmentPagerAdapter handle fragment creation/destruction/restoration.

I also moved the adapter out of the activity, which wasn't entirely necessary but it prevents some of the coupling seen in other areas of the app where a ViewPager is used.

I think this adapter was originally based off code used elsewhere in the app, where it was necessary to retain the list of fragments. But here it isn't needed.

Needs review: @daniloercoli 
