### PR TITLE
changed empty comments strings to be absolute per CommentStatus type

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -238,7 +238,18 @@ public class CommentsListFragment extends Fragment {
                     if (filter == null || CommentStatus.UNKNOWN.equals(filter)) {
                         return getString(R.string.comments_empty_list);
                     } else {
-                        return getString(R.string.comments_empty_list_filtered, mCommentStatusFilter.getLabel().toLowerCase());
+                        switch (mCommentStatusFilter) {
+                            case APPROVED:
+                                return getString(R.string.comments_empty_list_filtered_approved);
+                            case UNAPPROVED:
+                                return getString(R.string.comments_empty_list_filtered_pending);
+                            case SPAM:
+                                return getString(R.string.comments_empty_list_filtered_spam);
+                            case TRASH:
+                                return getString(R.string.comments_empty_list_filtered_trashed);
+                            default:
+                                return getString(R.string.comments_empty_list);
+                        }
                     }
 
                 } else {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -285,7 +285,10 @@
     <string name="comment_status_all">All</string>
     <string name="edit_comment">Edit comment</string>
     <string name="comments_empty_list">No comments</string>
-    <string name="comments_empty_list_filtered">No %s comments</string>
+    <string name="comments_empty_list_filtered_approved">No Approved comments</string>
+    <string name="comments_empty_list_filtered_pending">No Pending comments</string>
+    <string name="comments_empty_list_filtered_spam">No Spam comments</string>
+    <string name="comments_empty_list_filtered_trashed">No Trashed comments</string>
     <string name="comment_reply_to_user">Reply to %s</string>
     <string name="comment_trashed">Comment trashed</string>
     <string name="comment_spammed">Comment marked as spam</string>


### PR DESCRIPTION
Fixes #3877 

To test: just go to the Comments section and try to find a type of Comment that returns zero items from the server



Needs review: @maxme 

