### PR TITLE
Issue/3880 notifications font margin

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -302,7 +302,7 @@ public class NotesAdapter extends CursorRecyclerViewAdapter<NotesAdapter.NoteVie
         @Override
         public void onClick(View v) {
             if (mOnNoteClickListener != null && v.getTag() instanceof String) {
-                mOnNoteClickListener.onClickNote(StringUtils.notNullStr((String)v.getTag()));
+                mOnNoteClickListener.onClickNote((String)v.getTag());
             }
         }
     };

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -18,7 +18,6 @@ import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.models.Note;
 import org.wordpress.android.ui.comments.CommentUtils;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
-import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.SqlUtils;
 import org.wordpress.android.util.StringUtils;
@@ -152,7 +151,7 @@ public class NotesAdapter extends CursorRecyclerViewAdapter<NotesAdapter.NoteVie
     @Override
     public void onBindViewHolder(NoteViewHolder noteViewHolder, Cursor cursor) {
         final Bucket.ObjectCursor<Note> objectCursor = (Bucket.ObjectCursor<Note>) cursor;
-        final String noteId = objectCursor.getSimperiumKey();
+        noteViewHolder.itemView.setTag(objectCursor.getSimperiumKey());
 
         // Display group header
         Note.NoteTimeGroup timeGroup = Note.getTimeGroupForTimestamp(getLongForColumnName(objectCursor, Note.Schema.TIMESTAMP_INDEX));
@@ -236,18 +235,13 @@ public class NotesAdapter extends CursorRecyclerViewAdapter<NotesAdapter.NoteVie
         boolean isUnread = SqlUtils.sqlToBool(getIntForColumnName(objectCursor, Note.Schema.UNREAD_INDEX));
 
         String noticonCharacter = getStringForColumnName(objectCursor, Note.Schema.NOTICON_INDEX);
-        if (!TextUtils.isEmpty(noticonCharacter)) {
-            noteViewHolder.noteIcon.setText(noticonCharacter);
-            if (commentStatus == CommentStatus.UNAPPROVED) {
-                noteViewHolder.noteIcon.setBackgroundResource(R.drawable.shape_oval_orange);
-            } else if (isUnread) {
-                noteViewHolder.noteIcon.setBackgroundResource(R.drawable.shape_oval_blue_white_stroke);
-            } else {
-                noteViewHolder.noteIcon.setBackgroundResource(R.drawable.shape_oval_grey);
-            }
-            noteViewHolder.noteIcon.setVisibility(View.VISIBLE);
+        noteViewHolder.noteIcon.setText(noticonCharacter);
+        if (commentStatus == CommentStatus.UNAPPROVED) {
+            noteViewHolder.noteIcon.setBackgroundResource(R.drawable.shape_oval_orange);
+        } else if (isUnread) {
+            noteViewHolder.noteIcon.setBackgroundResource(R.drawable.shape_oval_blue_white_stroke);
         } else {
-            noteViewHolder.noteIcon.setVisibility(View.GONE);
+            noteViewHolder.noteIcon.setBackgroundResource(R.drawable.shape_oval_grey);
         }
 
         if (isUnread) {
@@ -255,15 +249,6 @@ public class NotesAdapter extends CursorRecyclerViewAdapter<NotesAdapter.NoteVie
         } else {
             noteViewHolder.itemView.setBackgroundColor(mColorRead);
         }
-
-        noteViewHolder.itemView.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (mOnNoteClickListener != null && noteId != null) {
-                    mOnNoteClickListener.onClickNote(noteId);
-                }
-            }
-        });
     }
 
     public int getPositionForNote(String noteId) {
@@ -285,7 +270,7 @@ public class NotesAdapter extends CursorRecyclerViewAdapter<NotesAdapter.NoteVie
         mOnNoteClickListener = mNoteClickListener;
     }
 
-    static class NoteViewHolder extends RecyclerView.ViewHolder {
+    class NoteViewHolder extends RecyclerView.ViewHolder {
         private final View headerView;
         private final View contentView;
         private final TextView headerText;
@@ -308,6 +293,17 @@ public class NotesAdapter extends CursorRecyclerViewAdapter<NotesAdapter.NoteVie
             imgAvatar = (WPNetworkImageView) view.findViewById(R.id.note_avatar);
             noteIcon = (NoticonTextView) view.findViewById(R.id.note_icon);
             progressBar = view.findViewById(R.id.moderate_progress);
+
+            itemView.setOnClickListener(mOnClickListener);
         }
     }
+
+    private View.OnClickListener mOnClickListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            if (mOnNoteClickListener != null && v.getTag() instanceof String) {
+                mOnNoteClickListener.onClickNote(StringUtils.notNullStr((String)v.getTag()));
+            }
+        }
+    };
 }

--- a/WordPress/src/main/res/drawable/comment_reply_background.xml
+++ b/WordPress/src/main/res/drawable/comment_reply_background.xml
@@ -8,7 +8,7 @@
     <item
         android:left="@dimen/margin_extra_large"
         android:right="@dimen/margin_extra_large"
-        android:top="@dimen/margin_large">
+        android:top="9dp">
         <shape android:shape="rectangle">
             <solid android:color="@color/grey_lighten_30" />
             <padding

--- a/WordPress/src/main/res/layout/note_block_comment_user.xml
+++ b/WordPress/src/main/res/layout/note_block_comment_user.xml
@@ -13,13 +13,13 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:gravity="center_vertical"
         android:orientation="horizontal">
 
         <org.wordpress.android.widgets.WPNetworkImageView
             android:id="@+id/user_avatar"
             android:layout_width="@dimen/avatar_sz_small"
-            android:layout_height="@dimen/avatar_sz_small"
-            android:layout_marginTop="5dp"/>
+            android:layout_height="@dimen/avatar_sz_small" />
 
         <LinearLayout
             android:id="@+id/user_name_wrapper"
@@ -43,8 +43,7 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:layout_marginTop="-2dp">
+                android:orientation="horizontal">
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/user_comment_ago"

--- a/WordPress/src/main/res/layout/note_block_header.xml
+++ b/WordPress/src/main/res/layout/note_block_header.xml
@@ -17,6 +17,7 @@
             android:background="?android:selectableItemBackground"
             android:clickable="true"
             android:orientation="horizontal"
+            android:gravity="center_vertical"
             android:paddingBottom="@dimen/margin_medium"
             android:paddingLeft="@dimen/margin_extra_large"
             android:paddingRight="@dimen/margin_extra_large"
@@ -25,8 +26,7 @@
             <org.wordpress.android.widgets.WPNetworkImageView
                 android:id="@+id/header_avatar"
                 android:layout_width="@dimen/avatar_sz_small"
-                android:layout_height="@dimen/avatar_sz_small"
-                android:layout_marginTop="5dp" />
+                android:layout_height="@dimen/avatar_sz_small" />
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -50,7 +50,6 @@
                     android:id="@+id/header_snippet"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="-2dp"
                     android:ellipsize="end"
                     android:includeFontPadding="false"
                     android:singleLine="true"

--- a/WordPress/src/main/res/layout/note_block_user.xml
+++ b/WordPress/src/main/res/layout/note_block_user.xml
@@ -28,7 +28,7 @@
                 android:layout_height="@dimen/notifications_avatar_sz"
                 android:layout_gravity="center_vertical"
                 android:layout_marginRight="@dimen/notifications_adjusted_font_margin"
-                android:layout_marginEnd="@dimen/notifications_adjusted_font_margin"/>
+                android:layout_marginEnd="@dimen/notifications_adjusted_font_margin" />
 
             <LinearLayout
                 android:layout_width="fill_parent"
@@ -44,6 +44,7 @@
                     android:singleLine="true"
                     android:textSize="@dimen/text_sz_medium"
                     android:textStyle="bold"
+                    android:textColor="@color/grey_dark"
                     tools:text="Bob Ross" />
 
                 <org.wordpress.android.widgets.WPTextView


### PR DESCRIPTION
Fixes #3880

Improvements to some of the notifications layouts to look better with the Roboto font. 

I also made some performance improvements to the notes adapter, the main change was to use one instance of the `onClickListener()` instead of creating one for each item.

To test: Open a notification that displays a user's gravatar. It should be well centered and aligned with the text next to it:

<img width="231" alt="screen shot 2016-03-16 at 11 57 35 am" src="https://cloud.githubusercontent.com/assets/789137/13825109/4d2c47f8-eb6e-11e5-82cf-2ec907381631.png">
