### PR TITLE
Update Helpshift library to 4.4.0 to fix #3839

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -83,7 +83,7 @@ dependencies {
     compile 'com.android.support:design:23.1.1'
     compile 'com.google.android.gms:play-services-gcm:8.3.0'
     compile 'com.github.chrisbanes.photoview:library:1.2.4'
-    compile 'com.helpshift:android-aar:4.2.0-support'
+    compile 'com.helpshift:android-helpshift-aar:4.4.0'
     compile 'de.greenrobot:eventbus:2.4.0'
     compile 'com.automattic:rest:1.0.2'
     compile 'org.wordpress:graphview:3.4.0'


### PR DESCRIPTION
Hopefully fixes #3839 

From [4.4.0 release notes](https://developers.helpshift.com/android/release-notes/):
> Fix a rare NPE while launching Helpshift screens

