### PR TITLE
Clear the Factories between tests Fixes #3890

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/DefaultMocksInstrumentationTestCase.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/DefaultMocksInstrumentationTestCase.java
@@ -33,4 +33,10 @@ public class DefaultMocksInstrumentationTestCase extends InstrumentationTestCase
         RestClientFactoryTest.setPrefixAllInstances("default");
         XMLRPCFactoryTest.setPrefixAllInstances("default");
     }
+
+    @Override
+    protected void tearDown() throws Exception {
+        FactoryUtils.clearFactories();
+        super.tearDown();
+    }
 }

--- a/WordPress/src/androidTest/java/org/wordpress/android/FactoryUtils.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/FactoryUtils.java
@@ -14,6 +14,15 @@ import org.xmlrpc.android.XMLRPCFactory;
 import java.lang.reflect.Field;
 
 public class FactoryUtils {
+    public static void clearFactories() {
+        // clear factories
+        forceFactoryInjection(XMLRPCFactory.class, null);
+        forceFactoryInjection(RestClientFactory.class, null);
+        forceFactoryInjection(OAuthAuthenticatorFactory.class, null);
+        forceFactoryInjection(SystemServiceFactory.class, null);
+        AppLog.v(T.TESTS, "Null factories set");
+    }
+
     public static void initWithTestFactories() {
         // create test factories
         forceFactoryInjection(XMLRPCFactory.class, new XMLRPCFactoryTest());

--- a/WordPress/src/androidTest/java/org/wordpress/android/PostUploadServiceTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/PostUploadServiceTest.java
@@ -16,12 +16,14 @@ public class PostUploadServiceTest extends ServiceTestCase<PostUploadService> {
 
     public PostUploadServiceTest() {
         super(PostUploadService.class);
-        FactoryUtils.initWithTestFactories();
     }
 
     @Override
     protected void setUp() throws Exception {
         super.setUp();
+
+        FactoryUtils.initWithTestFactories();
+
         String namespace = BuildConfig.FLAVOR.equals("wasabi") ? "org.wordpress.android.beta"
                 : "org.wordpress.android";
         testContext = getContext().createPackageContext(namespace, Context.CONTEXT_IGNORE_SECURITY);
@@ -36,6 +38,12 @@ public class PostUploadServiceTest extends ServiceTestCase<PostUploadService> {
         XMLRPCFactoryTest.sMode = XMLRPCFactoryTest.Mode.CUSTOMIZABLE_XML;
         RestClientFactoryTest.sMode = RestClientFactoryTest.Mode.CUSTOMIZABLE;
         AppLog.v(AppLog.T.TESTS, "Modes set to customizable");
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        FactoryUtils.clearFactories();
+        super.tearDown();
     }
 
     public void testStartable() {

--- a/WordPress/src/androidTest/java/org/wordpress/android/networking/AuthenticatorRequestTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/networking/AuthenticatorRequestTest.java
@@ -17,6 +17,12 @@ public class AuthenticatorRequestTest extends InstrumentationTestCase {
         mAuthenticatorRequest = new AuthenticatorRequest(null, null, restClient, null);
     }
 
+    @Override
+    protected void tearDown() throws Exception {
+        FactoryUtils.clearFactories();
+        super.tearDown();
+    }
+
     public void testExtractSiteIdFromUrl1() {
         String url = "";
         assertEquals(null, mAuthenticatorRequest.extractSiteIdFromUrl(url));

--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/notifications/GCMIntentServiceTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/notifications/GCMIntentServiceTest.java
@@ -28,6 +28,12 @@ public class GCMIntentServiceTest extends ServiceTestCase<GCMMessageService> {
         setupService();
     }
 
+    @Override
+    protected void tearDown() throws Exception {
+        FactoryUtils.clearFactories();
+        super.tearDown();
+    }
+
     public void testShouldCircularizeNoteIcon() {
         GCMMessageService intentService = new GCMMessageService();
 

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/ApiHelperTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/ApiHelperTest.java
@@ -22,13 +22,10 @@ import java.util.concurrent.TimeUnit;
 public class ApiHelperTest extends InstrumentationTestCase {
     protected Context mTargetContext;
 
-    public ApiHelperTest() {
-        super();
-        FactoryUtils.initWithTestFactories();
-    }
-
     @Override
     protected void setUp() {
+        FactoryUtils.initWithTestFactories();
+
         // Clean application state
         mTargetContext = new RenamingDelegatingContext(getInstrumentation().getTargetContext(), "test_");
         TestUtils.clearApplicationState(mTargetContext);
@@ -46,6 +43,7 @@ public class ApiHelperTest extends InstrumentationTestCase {
 
     @Override
     protected void tearDown() {
+        FactoryUtils.clearFactories();
     }
 
     // This test failed before #773 was fixed

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/ApiHelperTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/ApiHelperTest.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.util;
 
 import android.content.Context;
+import android.os.AsyncTask;
 import android.test.InstrumentationTestCase;
 import android.test.RenamingDelegatingContext;
 
@@ -46,6 +47,15 @@ public class ApiHelperTest extends InstrumentationTestCase {
         FactoryUtils.clearFactories();
     }
 
+    private void countDownAfterOtherAsyncTasks(final CountDownLatch countDownLatch) {
+        AsyncTask.SERIAL_EXECUTOR.execute(new Runnable() {
+            @Override
+            public void run() {
+                countDownLatch.countDown();
+            }
+        });
+    }
+
     // This test failed before #773 was fixed
     public void testRefreshBlogContent() throws InterruptedException {
         XMLRPCFactoryTest.setPrefixAllInstances("malformed-software-version");
@@ -55,13 +65,15 @@ public class ApiHelperTest extends InstrumentationTestCase {
             @Override
             public void onSuccess() {
                 assertTrue(true);
-                countDownLatch.countDown();
+                // countDown() after the serially invoked (nested) AsyncTask in RefreshBlogContentTask.
+                countDownAfterOtherAsyncTasks(countDownLatch);
             }
 
             @Override
             public void onFailure(ErrorType errorType, String errorMessage, Throwable throwable) {
                 assertTrue(false);
-                countDownLatch.countDown();
+                // countDown() after the serially invoked (nested) AsyncTask in RefreshBlogContentTask.
+                countDownAfterOtherAsyncTasks(countDownLatch);
             }
         }).execute(false);
         countDownLatch.await(5000, TimeUnit.SECONDS);
@@ -76,13 +88,15 @@ public class ApiHelperTest extends InstrumentationTestCase {
             @Override
             public void onSuccess() {
                 assertTrue(false);
-                countDownLatch.countDown();
+                // countDown() after the serially invoked (nested) AsyncTask in RefreshBlogContentTask.
+                countDownAfterOtherAsyncTasks(countDownLatch);
             }
 
             @Override
             public void onFailure(ErrorType errorType, String errorMessage, Throwable throwable) {
                 assertTrue(true);
-                countDownLatch.countDown();
+                // countDown() after the serially invoked (nested) AsyncTask in RefreshBlogContentTask.
+                countDownAfterOtherAsyncTasks(countDownLatch);
             }
         }).execute(false);
         countDownLatch.await(5000, TimeUnit.SECONDS);

--- a/WordPress/src/androidTest/java/org/wordpress/android/util/ApiHelperTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/ApiHelperTest.java
@@ -75,7 +75,7 @@ public class ApiHelperTest extends InstrumentationTestCase {
                 // countDown() after the serially invoked (nested) AsyncTask in RefreshBlogContentTask.
                 countDownAfterOtherAsyncTasks(countDownLatch);
             }
-        }).execute(false);
+        }).executeOnExecutor(AsyncTask.SERIAL_EXECUTOR, false);
         countDownLatch.await(5000, TimeUnit.SECONDS);
     }
 
@@ -98,7 +98,7 @@ public class ApiHelperTest extends InstrumentationTestCase {
                 // countDown() after the serially invoked (nested) AsyncTask in RefreshBlogContentTask.
                 countDownAfterOtherAsyncTasks(countDownLatch);
             }
-        }).execute(false);
+        }).executeOnExecutor(AsyncTask.SERIAL_EXECUTOR, false);
         countDownLatch.await(5000, TimeUnit.SECONDS);
     }
 


### PR DESCRIPTION
Fixes #3890 

This PR adds `tearDown()` treatment for the use of `FactoryUtils.initWithTestFactories()` in test classes that setup mocked Factories.

Needs review: @maxme 
