### PR TITLE
Add basic info about pulling a subtree library

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ Note: `release/x.y` or `hotfix/x.y.z` will be merged back in `master` after a ne
 
 A number of library dependencies are managed as separate open source projects and are git-subtree'd into the WordPress Android app source tree. Use the following command to updated (pull latest) from their respective repos:
 
-        $ git subtree pull --prefix libs/library_name https://github.com/wordpress-mobile/WordPress-Library_Name-Android.git develop
+        $ git subtree pull --squash --prefix libs/library_name https://github.com/wordpress-mobile/WordPress-Library_Name-Android.git develop
 
 and substitute the `library_name` and `Library_Name` to match the library project. As an example, for the Analytics library use 'analytics' and 'Analytics` respectively.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,22 @@ Note: `release/x.y` or `hotfix/x.y.z` will be merged back in `master` after a ne
 
 [git-flow]: http://nvie.com/posts/a-successful-git-branching-model/
 
+# Subtree'd library projects
+
+A number of library dependencies are managed as separate open source projects and are git-subtree'd into the WordPress Android app source tree. Use the following command to updated (pull latest) from their respective repos:
+
+        $ git subtree pull --prefix libs/library_name https://github.com/wordpress-mobile/WordPress-Library_Name-Android.git develop
+
+and substitute the `library_name` and `Library_Name` to match the library project. As an example, for the Analytics library use 'analytics' and 'Analytics` respectively.
+
+Here are the libraries currently maintained and subtree'd:
+
+* Analytics
+* Editor
+* Networking
+* Stores
+* Utils
+
 # Drawable Resources
 
 The Android build tools now allow drawable resources to be provided exclusively in vector format, PNG's are automatically generated at build time if necessary.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,10 @@ A number of library dependencies are managed as separate open source projects an
 
 and substitute the `library_name` and `Library_Name` to match the library project. As an example, for the Analytics library use 'analytics' and 'Analytics` respectively.
 
+Similarly, issue a `subtree push` to push changes committed to the main app repo, upstream to the library repo:
+
+        $ git subtree push --prefix libs/library_name https://github.com/wordpress-mobile/WordPress-Library_Name-Android.git develop
+
 Here are the libraries currently maintained and subtree'd:
 
 * Analytics


### PR DESCRIPTION
Fixes #3892 

This adds to `CONTRIBUTING.md` the basic git command format to use for pulling the latest changes from the library projects maintained as separate open source projects.