### PR TITLE
Fixes Blog Posts row blinking animation for API 16

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -49,8 +49,8 @@ import de.greenrobot.event.EventBus;
 public class MySiteFragment extends Fragment
         implements WPMainActivity.OnScrollToTopListener {
 
-    private static final long ALERT_ANIM_OFFSET_MS   = 1000l;
-    private static final long ALERT_ANIM_DURATION_MS = 1000l;
+    private static final long ALERT_ANIM_OFFSET_MS   = 1000L;
+    private static final long ALERT_ANIM_DURATION_MS = 1000L;
     public static final int HIDE_WP_ADMIN_YEAR = 2015;
     public static final int HIDE_WP_ADMIN_MONTH = 9;
     public static final int HIDE_WP_ADMIN_DAY = 7;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -38,7 +38,6 @@ import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.notifications.utils.SimperiumUtils;
 import org.wordpress.android.ui.posts.PromoDialog;
 import org.wordpress.android.ui.prefs.AppPrefs;
-import org.wordpress.android.ui.prefs.AccountSettingsFragment;
 import org.wordpress.android.ui.prefs.AppSettingsFragment;
 import org.wordpress.android.ui.prefs.SiteSettingsFragment;
 import org.wordpress.android.ui.reader.ReaderPostListFragment;
@@ -56,9 +55,6 @@ import org.wordpress.android.util.ProfilingUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.widgets.WPViewPager;
-
-import java.util.List;
-import java.util.Map;
 
 import de.greenrobot.event.EventBus;
 

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -162,30 +162,36 @@
             </LinearLayout>
 
             <!--Blog Posts-->
-            <RelativeLayout
-                android:id="@+id/row_blog_posts"
-                style="@style/MySiteListRowLayout">
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
 
                 <View
                     android:id="@+id/postsGlowBackground"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:alpha="1"
-                    android:background="@drawable/pressed_background_wordpress"
+                    android:background="@color/translucent_grey_lighten_20"
                     android:visibility="invisible" />
 
-                <ImageView
-                    android:id="@+id/my_site_blog_posts_icon"
-                    style="@style/MySiteListRowIcon"
-                    android:src="@drawable/my_site_icon_posts" />
+                <LinearLayout
+                    android:id="@+id/row_blog_posts"
+                    style="@style/MySiteListRowLayout">
 
-                <org.wordpress.android.widgets.WPTextView
-                    android:id="@+id/my_site_blog_posts_text_view"
-                    style="@style/MySiteListRowTextView"
-                    android:layout_toRightOf="@id/my_site_blog_posts_icon"
-                    android:text="@string/my_site_btn_blog_posts" />
+                    <ImageView
+                        android:id="@+id/my_site_blog_posts_icon"
+                        style="@style/MySiteListRowIcon"
+                        android:contentDescription="@string/my_site_btn_blog_posts"
+                        android:src="@drawable/my_site_icon_posts" />
 
-            </RelativeLayout>
+                    <org.wordpress.android.widgets.WPTextView
+                        android:id="@+id/my_site_blog_posts_text_view"
+                        style="@style/MySiteListRowTextView"
+                        android:text="@string/my_site_btn_blog_posts" />
+
+                </LinearLayout>
+
+            </FrameLayout>
 
             <!--Media-->
             <RelativeLayout


### PR DESCRIPTION
Fixes #3662, ref #3663

To test, verify the following on API 16 and any other supported API level:
- [ ] Start a new blog post via the FAB on the My Sites page. Add some text and use the Back button to go back to My Sites. The `Blog Posts` row should blink a couple times to indicate the local draft.
- [ ] Press (tap and hold, not click) the `Blog Posts` row and verify that the background color matches other rows. It will be blue on API 16 and translucent grey on all others.