### PR TITLE
Fixing fabric.io maven dependency

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -14,5 +14,5 @@
 [maven_repositories]
   central = https://repo1.maven.org/maven2
   wordpress = http://wordpress-mobile.github.io/WordPress-Android
-  fabric = https://maven.fabric.io/repo
+  fabric = https://maven.fabric.io/public
   m2 = ~/.m2/repository

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -71,7 +71,9 @@ android {
 }
 
 dependencies {
-    compile 'com.crashlytics.sdk.android:crashlytics:2.2.2'
+    compile('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {
+        transitive = true;
+    }
 
     // Provided by maven central
     compile ('org.wordpress:mediapicker:1.2.4') {

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         jcenter()
-        maven { url 'https://maven.fabric.io/repo' }
+        maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.0.0-beta7'
@@ -12,7 +12,7 @@ buildscript {
 repositories {
     jcenter()
     maven { url 'http://wordpress-mobile.github.io/WordPress-Android' }
-    maven { url 'https://maven.fabric.io/repo' }
+    maven { url 'https://maven.fabric.io/public' }
 }
 
 apply plugin: 'com.android.application'


### PR DESCRIPTION
We were using `https://maven.fabric.io/repo` instead of `https://maven.fabric.io/public`. Looks like they locked down `/repo`.

Got this error when trying to build (with repo): 
> Error:Could not GET 'https://maven.fabric.io/repo/io/fabric/tools/gradle/maven-metadata.xml'. Received status code 403 from server: Forbidden

See documentation here: https://docs.fabric.io/android/fabric/integration.html

Also updating Crashlytics to 2.5.5 and matching the transitive property as shown here: https://docs.fabric.io/android/crashlytics/build-tools.html#customizing-your-build-gradle

Needs review: @tonyr59h 