### PR TITLE
Update to emailchecker2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: android
 jdk: oraclejdk7
-sudo: false
+sudo: required
 
 notifications:
   # Slack notification on failure (secured token).
@@ -22,6 +22,7 @@ android:
 
 env:
   global:
+    - MALLOC_ARENA_MAX=2
     - GRADLE_OPTS="-XX:MaxPermSize=4g -Xmx4g"
     - ANDROID_SDKS=android-14
     - ANDROID_TARGET=android-14

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -25,6 +25,7 @@ android {
 
     dexOptions {
         jumboMode = true
+        javaMaxHeapSize = "4g"
     }
 
     compileSdkVersion 23

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -14,7 +14,6 @@ repositories {
     jcenter()
     maven { url 'http://wordpress-mobile.github.io/WordPress-Android' }
     maven { url 'https://maven.fabric.io/public' }
-    maven { url "http://dl.bintray.com/wordpress-mobile/maven" }
 }
 
 apply plugin: 'com.android.application'
@@ -96,6 +95,7 @@ dependencies {
     compile 'com.automattic:rest:1.0.3'
     compile 'org.wordpress:graphview:3.4.0'
     compile 'org.wordpress:persistentedittext:1.0.1'
+    compile 'org.wordpress:emailchecker2:1.0.0'
 
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.0'
     androidTestCompile 'org.objenesis:objenesis:2.1'
@@ -107,7 +107,6 @@ dependencies {
     compile 'org.wordpress:drag-sort-listview:0.6.1' // not found in maven central
     compile 'org.wordpress:slidinguppanel:1.0.0' // not found in maven central
     compile 'org.wordpress:passcodelock:1.1.0'
-    compile 'org.wordpress:emailchecker2:1.0.0'
 
     // Simperium
     compile 'com.simperium.android:simperium:0.6.8'

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     repositories {
         jcenter()
         maven { url 'https://maven.fabric.io/public' }
+
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.0.0-beta7'
@@ -13,6 +14,7 @@ repositories {
     jcenter()
     maven { url 'http://wordpress-mobile.github.io/WordPress-Android' }
     maven { url 'https://maven.fabric.io/public' }
+    maven { url "http://dl.bintray.com/wordpress-mobile/maven" }
 }
 
 apply plugin: 'com.android.application'
@@ -104,7 +106,7 @@ dependencies {
     compile 'org.wordpress:drag-sort-listview:0.6.1' // not found in maven central
     compile 'org.wordpress:slidinguppanel:1.0.0' // not found in maven central
     compile 'org.wordpress:passcodelock:1.1.0'
-    compile 'org.wordpress:emailchecker:0.3'
+    compile 'org.wordpress:emailchecker2:1.0.0'
 
     // Simperium
     compile 'com.simperium.android:simperium:0.6.8'

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -95,7 +95,7 @@ dependencies {
     compile 'com.automattic:rest:1.0.3'
     compile 'org.wordpress:graphview:3.4.0'
     compile 'org.wordpress:persistentedittext:1.0.1'
-    compile 'org.wordpress:emailchecker2:1.0.0'
+    compile 'org.wordpress:emailchecker2:1.1.0'
 
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.0'
     androidTestCompile 'org.objenesis:objenesis:2.1'

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -32,7 +32,7 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.UserEmailUtils;
 import org.wordpress.android.widgets.WPTextView;
-import org.wordpress.emailchecker.EmailChecker;
+import org.wordpress.emailchecker2.EmailCheckerKt;
 import org.wordpress.persistentedittext.PersistentEditTextHelper;
 
 import java.util.regex.Matcher;
@@ -46,13 +46,8 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
     private WPTextView mSignupButton;
     private WPTextView mProgressTextSignIn;
     private RelativeLayout mProgressBarSignIn;
-    private EmailChecker mEmailChecker;
     private boolean mEmailAutoCorrected;
     private boolean mAutoCompleteUrl;
-
-    public NewUserFragment() {
-        mEmailChecker = new EmailChecker();
-    }
 
     @Override
     public void afterTextChanged(Editable s) {
@@ -323,7 +318,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
             return;
         }
         final String email = EditTextUtils.getText(mEmailTextField).trim();
-        String suggest = mEmailChecker.suggestDomainCorrection(email);
+        String suggest = EmailCheckerKt.suggestDomainCorrection(email);
         if (suggest.compareTo(email) != 0) {
             mEmailAutoCorrected = true;
             mEmailTextField.setText(suggest);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -32,7 +32,7 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.UserEmailUtils;
 import org.wordpress.android.widgets.WPTextView;
-import org.wordpress.emailchecker2.EmailCheckerKt;
+import org.wordpress.emailchecker2.EmailChecker;
 import org.wordpress.persistentedittext.PersistentEditTextHelper;
 
 import java.util.regex.Matcher;
@@ -318,7 +318,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
             return;
         }
         final String email = EditTextUtils.getText(mEmailTextField).trim();
-        String suggest = EmailCheckerKt.suggestDomainCorrection(email);
+        String suggest = EmailChecker.suggestDomainCorrection(email);
         if (suggest.compareTo(email) != 0) {
             mEmailAutoCorrected = true;
             mEmailTextField.setText(suggest);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -59,7 +59,7 @@ import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.widgets.WPTextView;
-import org.wordpress.emailchecker.EmailChecker;
+import org.wordpress.emailchecker2.EmailCheckerKt;
 import org.xmlrpc.android.ApiHelper;
 
 import java.util.EnumSet;
@@ -103,8 +103,6 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     private ImageView mInfoButton;
     private ImageView mInfoButtonSecondary;
 
-    private final EmailChecker mEmailChecker;
-
     private boolean mSelfHosted;
     private boolean mEmailAutoCorrected;
     private boolean mShouldSendTwoStepSMS;
@@ -115,10 +113,6 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     private String mHttpUsername;
     private String mHttpPassword;
     private Blog mJetpackBlog;
-
-    public SignInFragment() {
-        mEmailChecker = new EmailChecker();
-    }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -318,7 +312,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             return;
         }
         // It looks like an email address, then try to correct it
-        String suggest = mEmailChecker.suggestDomainCorrection(email);
+        String suggest = EmailCheckerKt.suggestDomainCorrection(email);
         if (suggest.compareTo(email) != 0) {
             mEmailAutoCorrected = true;
             mUsernameEditText.setText(suggest);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -59,7 +59,7 @@ import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.widgets.WPTextView;
-import org.wordpress.emailchecker2.EmailCheckerKt;
+import org.wordpress.emailchecker2.EmailChecker;
 import org.xmlrpc.android.ApiHelper;
 
 import java.util.EnumSet;
@@ -312,7 +312,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             return;
         }
         // It looks like an email address, then try to correct it
-        String suggest = EmailCheckerKt.suggestDomainCorrection(email);
+        String suggest = EmailChecker.suggestDomainCorrection(email);
         if (suggest.compareTo(email) != 0) {
             mEmailAutoCorrected = true;
             mUsernameEditText.setText(suggest);


### PR DESCRIPTION
This PR replaces [org.wordpress:emailchecker](https://github.com/wordpress-mobile/EmailChecker) with [org.wordpress:emailchecker2](https://github.com/wordpress-mobile/EmailChecker-Android).

What's new? Nothing, this is the exact same algorithm. Written in Kotlin instead of C++. Side effect: we don't need NDK references, and final apk should be ~300kb lighter.

I published the `.aar` on bintray.

Notes:

* I'm using Package-Level functions on the Kotlin [side](https://github.com/wordpress-mobile/EmailChecker-Android/blob/develop/emailchecker/src/main/java/org/wordpress/emailchecker2/EmailChecker.kt#L49), that why we have the util name on the java side is `EmailCheckerKt`: we can rename it, but that's not important: