### PR TITLE
Remove videopress check in the media browser and Update translations for 5.2 

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/repo' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta6'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta7'
         classpath 'io.fabric.tools:gradle:1.+'
     }
 }

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories {
         jcenter()
-        maven { url 'https://maven.fabric.io/repo' }
+        maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.0.0-beta7'
@@ -12,7 +12,7 @@ buildscript {
 repositories {
     jcenter()
     maven { url 'http://wordpress-mobile.github.io/WordPress-Android' }
-    maven { url 'https://maven.fabric.io/repo' }
+    maven { url 'https://maven.fabric.io/public' }
 }
 
 apply plugin: 'com.android.application'

--- a/WordPress/lint.xml
+++ b/WordPress/lint.xml
@@ -11,4 +11,5 @@
 
     <issue id="HardcodedText" severity="error" />
     <issue id="InconsistentArrays" severity="error" />
+    <issue id="StringFormatCount" severity="error" />
 </lint>

--- a/WordPress/lint.xml
+++ b/WordPress/lint.xml
@@ -10,5 +10,5 @@
     </issue>
 
     <issue id="HardcodedText" severity="error" />
-    <issue id="InconsistentArrays" severity="warning" />
+    <issue id="InconsistentArrays" severity="error" />
 </lint>

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -32,7 +32,6 @@ import android.widget.ListView;
 import android.widget.PopupWindow;
 import android.widget.Toast;
 
-import org.wordpress.android.Constants;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.FeatureSet;
@@ -48,7 +47,6 @@ import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.widgets.WPAlertDialogFragment;
 import org.xmlrpc.android.ApiHelper;
 import org.xmlrpc.android.ApiHelper.GetFeatures.Callback;
 
@@ -216,28 +214,14 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 adapter.notifyDataSetChanged();
 
-                // Support video only if you are self-hosted or are a dot-com blog with the video
-                // press upgrade
-                boolean selfHosted = !WordPress.getCurrentBlog().isDotcomFlag();
-                boolean isVideoEnabled = selfHosted
-                        || (mFeatureSet != null && mFeatureSet.isVideopressEnabled());
-
                 if (position == 0) {
                     mMediaAddFragment.launchCamera();
                 } else if (position == 1) {
-                    if (isVideoEnabled) {
-                        mMediaAddFragment.launchVideoCamera();
-                    } else {
-                        showVideoPressUpgradeDialog();
-                    }
+                    mMediaAddFragment.launchVideoCamera();
                 } else if (position == 2) {
                     mMediaAddFragment.launchPictureLibrary();
                 } else if (position == 3) {
-                    if (isVideoEnabled) {
-                        mMediaAddFragment.launchVideoLibrary();
-                    } else {
-                        showVideoPressUpgradeDialog();
-                    }
+                    mMediaAddFragment.launchVideoLibrary();
                 }
 
                 mAddMediaPopup.dismiss();
@@ -248,17 +232,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
         mAddMediaPopup = new PopupWindow(layoutView, width, ViewGroup.LayoutParams.WRAP_CONTENT, true);
         mAddMediaPopup.setBackgroundDrawable(new ColorDrawable());
-    }
-
-    private void showVideoPressUpgradeDialog() {
-        FragmentTransaction ft = getFragmentManager().beginTransaction();
-        String title = getString(R.string.media_no_video_title);
-        String message = getString(R.string.media_no_video_message);
-        String infoTitle = getString(R.string.learn_more);
-        String infoURL = Constants.videoPressURL;
-        WPAlertDialogFragment alert = WPAlertDialogFragment.newUrlInfoDialog(title, message, infoTitle, infoURL);
-        ft.add(alert, "alert");
-        ft.commitAllowingStateLoss();
     }
 
     @Override

--- a/WordPress/src/main/res/values-ar/strings.xml
+++ b/WordPress/src/main/res/values-ar/strings.xml
@@ -1,6 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">Deine Kontoeinstellungen konnten nicht gespeichert werden.</string>
+	<string name="post_format_status">الحالة</string>
+	<string name="post_format_video">الفيديو</string>
+	<string name="align_none">بلا</string>
+	<string name="align_left">يسار</string>
+	<string name="align_center">وسط</string>
+	<string name="align_right">يمين</string>
+	<string name="theme_free">مجانًا</string>
+	<string name="theme_all">الكل</string>
+	<string name="theme_premium">Premium</string>
+	<string name="post_format_chat">محادثة</string>
+	<string name="post_format_gallery">معرض</string>
+	<string name="post_format_image">الصورة</string>
+	<string name="post_format_link">الرابط</string>
+	<string name="post_format_quote">اقتباس</string>
+	<string name="post_format_standard">قياسي</string>
+	<string name="notif_events">معلومات حول دورات وردبرس.كوم ومناسباته (على الإنترنت وشخصيًا).</string>
+	<string name="post_format_aside">ملاحظة</string>
+	<string name="post_format_audio">الصوت</string>
+	<string name="notif_surveys">فرص المشاركة في أبحاث وردبرس.كوم واستطلاعاته.</string>
+	<string name="notif_tips">نصائح للحصول على أكبر استفادة من وردبرس.كوم.</string>
+	<string name="notif_community">المجتمع</string>
+	<string name="replies_to_my_comments">الردود على تعليقاتي</string>
+	<string name="notif_suggestions">اقتراحات</string>
+	<string name="notif_research">الأبحاث</string>
+	<string name="site_achievements">إنجازات الموقع</string>
+	<string name="username_mentions">الإشارات إلى اسم المستخدم</string>
+	<string name="likes_on_my_posts">الإعجابات بمقالاتي</string>
+	<string name="site_follows">متابعات للموقع</string>
+	<string name="likes_on_my_comments">الإعجابات بتعليقاتي</string>
+	<string name="comments_on_my_site">التعليقات على موقعي</string>
+	<string name="site_settings_list_editor_summary_other">%d من العناصر</string>
+	<string name="site_settings_list_editor_summary_one">عنصر واحد</string>
+	<string name="approve_auto_if_previously_approved">تعليقات المستخدمين المعروفين</string>
+	<string name="approve_auto">كل المستخدمين</string>
+	<string name="approve_manual">لا توجد تعليقات</string>
+	<string name="site_settings_paging_summary_other">%d من التعليقات في الصفحة</string>
+	<string name="site_settings_paging_summary_one">تعليق واحد في الصفحة</string>
+	<string name="site_settings_multiple_links_summary_other">تلزم الموافقة على أكثر من %d من الروابط</string>
+	<string name="site_settings_multiple_links_summary_one">تلزم الموافقة على أكثر من رابط واحد</string>
+	<string name="site_settings_multiple_links_summary_zero">تلزم الموافقة على أكثر من 0 من الروابط</string>
+	<string name="detail_approve_auto">موافقة تلقائية على تعليقات الجميع.</string>
+	<string name="detail_approve_auto_if_previously_approved">موافقة تلقائية إذا كان لدى المستخدم تعليق تمت الموافقة عليه مسبقًا</string>
+	<string name="detail_approve_manual">تلزم موافقة يدوية على تعليقات الجميع.</string>
+	<string name="filter_trashed_posts">تم وضعها في سلة المهملات</string>
+	<string name="days_quantity_one">يوم واحد</string>
+	<string name="days_quantity_other">%d من الأيام</string>
+	<string name="filter_published_posts">تم النشر</string>
+	<string name="filter_draft_posts">المسودات</string>
+	<string name="filter_scheduled_posts">تمت الجدولة</string>
+	<string name="pending_email_change_snackbar">انقر فوق رابط التحقق في البريد الإلكتروني المرسل إلى %1$s للتأكيد على عنوانك الجديد</string>
+	<string name="primary_site">موقع أساسي</string>
+	<string name="web_address">عنوان الويب</string>
+	<string name="account_settings">‎@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">فشل بعض عمليات رفع الوسائط. يُرجى تجربتها مجددًا أو حذفها.</string>
+	<string name="editor_toast_uploading_please_wait">أنت تقوم حاليًا برفع وسائط. يُرجى الانتظار حتى تكتمل هذه العملية.</string>
+	<string name="error_refresh_comments_showing_older">يتعذر تحديث التعليقات في الوقت الحالي - إظهار تعليقات أقدم</string>
+	<string name="editor_post_settings_set_featured_image">تعيين الصورة المميزة</string>
+	<string name="editor_post_settings_featured_image">الصورة المميزة</string>
+	<string name="new_editor_promo_desc">يتضمن الآن تطبيق وردبرس.كوم الخاص بنظام Android رؤية جديدة رائعة\n المحرر. جرِّبه من خلال إنشاء مقالة جديدة.</string>
+	<string name="new_editor_promo_title">محرر جديد تمامًا</string>
+	<string name="new_editor_promo_button_label">رائع، شكرًا!</string>
+	<string name="visual_editor_enabled">تم تمكين محرر مرئي</string>
+	<string name="editor_content_placeholder">شارك قصتك هنا…</string>
+	<string name="editor_page_title_placeholder">عنوان الصفحة</string>
+	<string name="editor_post_title_placeholder">عنوان المقالة</string>
+	<string name="email_address">عنوان البريد الإلكتروني</string>
+	<string name="preference_show_visual_editor">إظهار محرر مرئي</string>
+	<string name="dlg_sure_to_delete_comments">هل ترغب في إزالة هذه التعليقات نهائيًا؟</string>
+	<string name="preference_editor">المحرر</string>
+	<string name="dlg_sure_to_delete_comment">هل ترغب في إزالة هذا التعليق نهائيًا؟</string>
+	<string name="mnu_comment_delete_permanently">حذف</string>
+	<string name="comment_deleted_permanently">تم حذف تعليق</string>
+	<string name="mnu_comment_untrash">استعادة</string>
+	<string name="comments_empty_list_filtered">لا توجد %s من التعليقات</string>
+	<string name="could_not_load_page">يتعذر تحميل الصفحة</string>
+	<string name="comment_status_all">الكل</string>
+	<string name="interface_language">لغة الواجهة</string>
+	<string name="off">إيقاف تشغيل</string>
+	<string name="about_the_app">حول التطبيق</string>
 	<string name="error_post_my_profile">تعذر حفظ الملف الشخصي</string>
 	<string name="error_fetch_account_settings">Deine Kontoeinstellungen konnten nicht abgerufen werden.</string>
 	<string name="error_fetch_my_profile">Dein Profil konnte nicht abgerufen werden.</string>
@@ -487,12 +565,10 @@
 	<string name="hs__invalid_email_error">أدخل عنوان بريد إلكتروني صالحًا</string>
 	<string name="add_location">أضف مكان</string>
 	<string name="current_location">المكان الحالي</string>
-	<string name="your_signature">توقيعك:</string>
 	<string name="search_location">بحث</string>
 	<string name="search_current_location">حدد</string>
 	<string name="edit_location">تحرير</string>
 	<string name="preference_send_usage_stats">إرسال الإحصائيات</string>
-	<string name="preference_privacy">الخصوصية</string>
 	<string name="preference_send_usage_stats_summary">إرسال إحصائيات الاستخدام تلقائيًا لمساعدتنا في تطوير WordPress للإندرويد</string>
 	<string name="update_verb">تحديث</string>
 	<string name="schedule_verb">جدولة</string>
@@ -568,10 +644,7 @@
 	<string name="theme_set_failed">فشل في تعيين القالب</string>
 	<string name="theme_auth_error_message">تاكد من أن لديك صلاحيات لتعيين القوالب</string>
 	<string name="category_automatically_renamed">اسم التصنيف %1$s  ليس صالحًا . تم اعادة تسميته لـ %2$s.</string>
-	<string name="auto_sharing_preference_reset">إعادة تعيين إعدادات المشاركة التلقائية</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">المدونة المحددة سلفًا لم تعد مرئية</string>
 	<string name="sdcard_message">بطاقة ذاكرة SD  مطلوبة لرفع ملفات الوسائط</string>
-	<string name="invalid_url_message">تحقق من أن عنوان المدونة المدخل صالح</string>
 	<string name="error_delete_post">حدث خطأ أثناء حذف الـ  %s</string>
 	<string name="error_refresh_posts">المقالات لايمكن تحديثها في الوقت الحاضر</string>
 	<string name="error_refresh_pages">الصفحات لايمكن تحديثها في الوقت الحاضر</string>
@@ -686,6 +759,7 @@
 	<string name="comment_status_unapproved">معلق</string>
 	<string name="dlg_unapproving_comments">غير مصدق</string>
 	<string name="notifications_empty_all">ليست هناك تنبيهات…حتى الآن.</string>
+	<string name="invalid_site_url_message">تحقق من أن عنوان URL الذي تم إدخاله في الموقع صحيح</string>
 	<string name="share_url_post">مشاركة المقالة</string>
 	<string name="deleting_page">يتم الان حذف الصفحة</string>
 	<string name="deleting_post">يتم الان حذف المقالة</string>
@@ -696,16 +770,13 @@
 	<string name="reader_empty_posts_in_tag_updating">يتم الآن جلب المقالات ...</string>
 	<string name="error_refresh_media">حدث شيء خطأ عندما كان يتم تحديث مكتبة الوسائط. أعد المحاولة في وقت لاحق.</string>
 	<string name="reader_label_reply">رد</string>
-	<string name="share_preference_title">المشاركة إلى ووردبريس</string>
 	<string name="cant_share_no_visible_blog">لا تستطيع مشاركتها إلى ووردبريس بدون أن تجعل المدونة مرئية</string>
 	<string name="comment_spammed">تم وضع علامة إزعاج على التعليق</string>
 	<string name="video">فيديو</string>
 	<string name="download">تحميل الوسائط</string>
-	<string name="reset_auto_share_preference">إعادة تعيين إعدادات المشاركة التلقائية</string>
 	<string name="reader_likes_you_and_multi">أنت و %,d آخرون أحببتم هذا</string>
 	<string name="reader_likes_multi">%,d أحبوا هذا</string>
 	<string name="reader_toast_err_get_comment">غير قادر على استعادة هذا التعليق</string>
-	<string name="always_use_these_settings_to_share">دائمًا استخدم هذه الإعدادات</string>
 	<string name="account_two_step_auth_enabled">هذا الحساب تبقى عليه اثنتان من خطوات المصادقة. قم بزيارة إعدادات الأمان على ووردبريس.كوم وإنشاء كلمة مرور خاصة بالتطبيقات.</string>
 	<string name="select_time">تحديد الوقت</string>
 	<string name="select_date">تحديد التاريخ</string>
@@ -795,12 +866,10 @@
 	<string name="stats_timeframe_months">الشهور</string>
 	<string name="stats_totals_views">الزيارات</string>
 	<string name="stats_entry_authors">الكاتب</string>
-	<string name="media_no_video_title">فيديوبريس غير متوفر</string>
 	<string name="theme_activating_button">جاري التفعيل</string>
 	<string name="media_edit_failure">فشل التحديث</string>
 	<string name="share_action_title">أضف إلى...</string>
 	<string name="stats_entry_referrers">الإحالات</string>
-	<string name="media_no_video_message">احصل على ترقية فيديوبريس لرفع الفيديو</string>
 	<string name="media_gallery_type_slideshow">عارض الشرائح</string>
 	<string name="share_action">المشاركة</string>
 	<string name="theme_set_success">نجح في جعل الثيم افتراضي</string>
@@ -821,8 +890,6 @@
 	<string name="loading">جاري التحميل...</string>
 	<string name="httppassword">كلمة مرور HTTP</string>
 	<string name="httpuser">اسم مستخدم HTTP</string>
-	<string name="post_signature">توقيع المقالة</string>
-	<string name="add_tagline">أضف توقيعا إلى المقالات الجديدة</string>
 	<string name="error_media_upload">حدث خطأ أثناء رفع ملفات الوسائط</string>
 	<string name="publish_date">نشر</string>
 	<string name="post_content">المحتوى (انقر لإضافة نص ووسائط)</string>
@@ -847,11 +914,9 @@
 	<string name="upload_scaled_image">الرفع والربط بالصورة المحجمة</string>
 	<string name="scheduled">مجدول</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">نشر من تطبيق ووردبريس للأندرويد</string>
 	<string name="version">النسخة</string>
 	<string name="tos">بنود الخدمة</string>
 	<string name="app_title">ووردبريس للآندرويد</string>
-	<string name="about">حول</string>
 	<string name="max_thumbnail_px_width">عرض الصورة الافتراضي</string>
 	<string name="image_alignment">المحاذاة</string>
 	<string name="refresh">تجديد</string>
@@ -896,70 +961,4 @@
 	<string name="category_refresh_error">خطأ في تحديث القسم</string>
 	<string name="on">تشغيل</string>
 	<string name="notification_settings">إعدادات التنبيهات</string>
-	<string-array name="alignment_array">
-		<item>بدون</item>
-		<item>يسار</item>
-		<item>وسط</item>
-		<item>يمين</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>التعليقات على موقعي</item>
-		<item>الإعجابات بتعليقاتي</item>
-		<item>الإعجابات بمقالاتي</item>
-		<item>متابعات للموقع</item>
-		<item>إنجازات الموقع</item>
-		<item>الإشارات إلى اسم المستخدم</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>الردود على تعليقاتي</item>
-		<item>الإعجابات بتعليقاتي</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>اقتراحات</item>
-		<item>الأبحاث</item>
-		<item>المجتمع</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>نصائح للحصول على أكبر استفادة من وردبرس.كوم.</item>
-		<item>فرص المشاركة في أبحاث واستطلاعات وردبرس.كوم.</item>
-		<item>معلومات حول دورات ومناسبات وردبرس.كوم (عبر الإنترنت وشخصيًا).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>تم النشر</item>
-		<item>المسودات</item>
-		<item>تمت الجدولة</item>
-		<item>أُضيف إلى سلة المهملات</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>ملاحظة</item>
-		<item>صوت</item>
-		<item>محادثة</item>
-		<item>معرض</item>
-		<item>صورة</item>
-		<item>رابط</item>
-		<item>اقتباس</item>
-		<item>قياسي</item>
-		<item>حالة</item>
-		<item>فيديو</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>سيكون موقعك مرئيًا للجميع ويمكن فهرسته بواسطة محركات البحث</item>
-		<item>سيكون موقعك مرئيًا للجميع مع مطالبة محركات البحث بعدم فهرسته في الوقت نفسه</item>
-		<item>سيكون موقعك مرئيًا لك وللمستخدمين الذين توافق عليهم فقط</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>يتطلب موافقة يدوية لتعليقات الجميع.</item>
-		<item>موافقة تلقائية إذا كان لدى المستخدم تعليق تمت الموافقة عليه مسبقًا.</item>
-		<item>موافقة تلقائية على تعليقات الجميع.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>لا توجد تعليقات</item>
-		<item>تعليقات المستخدمين المعروفة</item>
-		<item>جميع المستخدمين</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>مجاني</item>
-		<item>الكل</item>
-		<item>الإصدار المميز</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-az/strings.xml
+++ b/WordPress/src/main/res/values-az/strings.xml
@@ -263,11 +263,9 @@
 	<string name="hs__invalid_email_error">Keçərli bir e-poçt ünvanı daxil edin</string>
 	<string name="add_location">Mövqe əlavə edin</string>
 	<string name="current_location">Hazırkı mövqe</string>
-	<string name="your_signature">İmzanız:</string>
 	<string name="search_location">Axtarış</string>
 	<string name="edit_location">Redaktə et</string>
 	<string name="search_current_location">Yerləşdir</string>
-	<string name="preference_privacy">Gizlilik</string>
 	<string name="preference_send_usage_stats">Statistikaları göndər</string>
 	<string name="preference_send_usage_stats_summary">Android üçün WordPress-i inkişaf etdirməyimizə yardımçı olmaq üçün bizə avtomatik olaraq istifadə statistikalarını göndərin. </string>
 	<string name="update_verb">Yenilə</string>
@@ -308,12 +306,9 @@
 	<string name="cat_name_required">Kateqoriya adı vacibdir</string>
 	<string name="category_automatically_renamed">Kateqoriya adı %1$s yararsızdır. Ad %2$s olaraq dəyişdirildi</string>
 	<string name="no_account">WordPress hesabı tapılmadı, bir hesab əlavə edib təkrar yoxlayın</string>
-	<string name="auto_sharing_preference_reset">Avtomatik-paylaşma parametrlərinin sıfırlanması</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Əvvəlki seçilmiş bloq görünmür</string>
 	<string name="sdcard_message">Media yükləmək üçün taxılmış SD kart gərəklidir</string>
 	<string name="stats_empty_comments">Hələlik şərh yoxdur</string>
 	<string name="stats_bar_graph_empty">Baxılacaq statistika yoxdur</string>
-	<string name="invalid_url_message">Daxil etdiyiniz bloq URL keçərli olduğunu yoxlayın</string>
 	<string name="reply_failed">Caavab yazma baş tutmadı</string>
 	<string name="notifications_empty_list">Bildirş yoxdur</string>
 	<string name="error_delete_post">%s silinərkən xəta ilə qarşılaşıldı</string>
@@ -475,9 +470,6 @@
 	<string name="reader_likes_multi">%,d şəxs bunu bəyənir</string>
 	<string name="reader_likes_you_and_multi">Siz və bir digər şəxs %,d bunu bəyənir</string>
 	<string name="reader_toast_err_get_comment">Bu şərhi qəbul etmək mümkün deyil</string>
-	<string name="reset_auto_share_preference">Avto-paylaşma parametrlərini sıfırla</string>
-	<string name="always_use_these_settings_to_share">Hər zaman bu qurulumlardan istifadə edin</string>
-	<string name="share_preference_title">WordPress ilə paylaş</string>
 	<string name="download">Media endirilir</string>
 	<string name="cant_share_no_visible_blog">Görünən bir bloqunuz olmadan WordPress ilə paylaşa bilməzsiniz</string>
 	<string name="select_time">Saat seç</string>
@@ -577,8 +569,6 @@
 	<string name="stats_totals_views">Baxışlar</string>
 	<string name="stats_totals_clicks">Tıklamalar</string>
 	<string name="stats_totals_plays">İfalar</string>
-	<string name="media_no_video_title">VideoPress əlçatmazdır</string>
-	<string name="media_no_video_message">Video yükləmək üçün, VideoPress yenilənmələrini əldə edin!</string>
 	<string name="media_edit_title_text">Başlıq</string>
 	<string name="passcode_re_enter_passcode">PIN kodunu təkrar daxil et</string>
 	<string name="passcode_enter_passcode">PIN kodunu daxil et</string>
@@ -594,8 +584,6 @@
 	<string name="loading">Yüklənir...</string>
 	<string name="httpuser">HTTP istifadəçi adı</string>
 	<string name="httppassword">HTTP parolu</string>
-	<string name="add_tagline">Yeni yazılara bir imza əlavə et</string>
-	<string name="post_signature">Yazı imzası</string>
 	<string name="error_media_upload">Media faylının yüklənməsi zamanı xəta baş verdi.</string>
 	<string name="content_description_add_media">Media əlavə et</string>
 	<string name="post_content">Mühtəviyyat (mətn və media əlavə etmək üçün toxunun)</string>
@@ -620,11 +608,9 @@
 	<string name="scaled_image">Mütənasib təsvirin genişliyi</string>
 	<string name="scheduled">Ertələndi</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Android üçün WordPress ilə göndərilmişdir</string>
 	<string name="version">Versiya</string>
 	<string name="app_title">Android üçün WordPress</string>
 	<string name="tos">Xidmət Şərtləri</string>
-	<string name="about">Haqqında</string>
 	<string name="image_alignment">Mövqeləndirmə</string>
 	<string name="refresh">Təzələ</string>
 	<string name="untitled">Başlıqsız</string>
@@ -667,31 +653,4 @@
 	<string name="category_refresh_error">Kateqoriya təzələnməsi əsnasında xəta baş verdi.</string>
 	<string name="on">tərəfndən</string>
 	<string name="notification_settings">Bildiriş Parametrləri</string>
-	<string-array name="alignment_array">
-		<item>Heç biri</item>
-		<item>Sol</item>
-		<item>Mərkəz</item>
-		<item>Sağ</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Dərc edildi</item>
-		<item>Qaralama</item>
-		<item>Planlandı</item>
-		<item>Zİbil qutusuna göndərildi</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Yan sütun</item>
-		<item>Audio</item>
-		<item>Çat</item>
-		<item>Qalereya</item>
-		<item>Təsvir</item>
-		<item>Bağlantı</item>
-		<item>Kvota</item>
-		<item>Standard</item>
-		<item>Status</item>
-		<item>Video</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-bg/strings.xml
+++ b/WordPress/src/main/res/values-bg/strings.xml
@@ -314,11 +314,9 @@
 	<string name="hs__invalid_email_error">Въведете валидна електронна поща</string>
 	<string name="add_location">Добавете местоположение</string>
 	<string name="current_location">Текущо местоположение</string>
-	<string name="your_signature">Вашият подпис:</string>
 	<string name="search_location">Търсене</string>
 	<string name="edit_location">Редактиране</string>
 	<string name="search_current_location">Местоположение</string>
-	<string name="preference_privacy">Поверителност </string>
 	<string name="preference_send_usage_stats_summary">Автоматично изпращане на статистика за ползването, за да помогнете на развитието на WordPress за Android</string>
 	<string name="preference_send_usage_stats">Изпращане на статистика</string>
 	<string name="update_verb">Актуализиране</string>
@@ -349,7 +347,6 @@
 	<string name="comments_empty_list">Няма коментари</string>
 	<string name="wait_until_upload_completes">Изчакай трансфера да завърши</string>
 	<string name="category_automatically_renamed">Категорията %1$s не е валидна. Преименувана е на %2$s,</string>
-	<string name="invalid_url_message">Провери дали зададеният URL е валиден</string>
 	<string name="stats_empty_comments">Няма коментари</string>
 	<string name="error_refresh_pages">Страниците не могат да бъдат обновени в момента</string>
 	<string name="error_refresh_comments">Коментарите не могат да бъдат обновени в момента</string>
@@ -357,7 +354,6 @@
 	<string name="error_load_comment">Коментарът не можеше да бъде зареден</string>
 	<string name="passcode_wrong_passcode">Грешен ПИН</string>
 	<string name="theme_set_failed">Възникна грешка при смяна на темата</string>
-	<string name="auto_sharing_preference_reset">Нулиране на настройките за автоматично споделяне</string>
 	<string name="adding_cat_success">Категорията е добавена успешно</string>
 	<string name="error_downloading_image">Възникна грешка при извличане на това изображение</string>
 	<string name="invalid_username_too_short">Потребителското име трябва да е по-дълго от 4 символа</string>
@@ -377,7 +373,6 @@
 	<string name="username_reserved_but_may_be_available">Това потребителско име е резервирано в момента, но може да бъде налично в близките дни</string>
 	<string name="blog_not_found">Възникна грешка при достъпване на този блог</string>
 	<string name="error_edit_comment">Възникна грешка при редактирането на коментара</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Предишно избрания блог вече не е видим </string>
 	<string name="no_network_message">Няма налична мрежа</string>
 	<string name="blog_name_exists">Този уебсайт вече съществува</string>
 	<string name="username_required">Въведете потребителско име</string>
@@ -528,11 +523,8 @@
 	<string name="reader_label_reply">Отговор</string>
 	<string name="cant_share_no_visible_blog">Не можете да споделяте към WordPress без видим блог</string>
 	<string name="reader_toast_err_get_comment">Възникна грешка при извличането на този коментар</string>
-	<string name="reset_auto_share_preference">Нулирайте настройките на автоматичното споделяне</string>
 	<string name="download">Сваляне на медиа</string>
 	<string name="comment_spammed">Коментарът е отбелязан като спам</string>
-	<string name="share_preference_title">Споделяне с WordPress</string>
-	<string name="always_use_these_settings_to_share">Винаги тези настройки</string>
 	<string name="validating_site_data">Валидиране на даннитена сайта</string>
 	<string name="validating_user_data">Валидиране на данните на потребителя</string>
 	<string name="account_two_step_auth_enabled">За този профил е активирана двустепенна защита. За да генерирате необходимата парола посетете WordPress.com .</string>
@@ -622,8 +614,6 @@
 	<string name="media_gallery_image_order_random">Произволен</string>
 	<string name="media_gallery_type">Вид</string>
 	<string name="media_gallery_type_tiled">Плочки</string>
-	<string name="media_no_video_title">VideoPress не е наличен</string>
-	<string name="media_no_video_message">Обновете VideoPress за да качите видео!</string>
 	<string name="media_edit_failure">Актуализирането е неуспешно</string>
 	<string name="themes_details_label">Подробности</string>
 	<string name="themes_features_label">Възможности</string>
@@ -647,8 +637,6 @@
 	<string name="follows">Следва</string>
 	<string name="loading">Зареждане...</string>
 	<string name="httppassword">HTTP Парола</string>
-	<string name="post_signature">Подпис на публикациите</string>
-	<string name="add_tagline">Добавяне на подпис към новите публикации</string>
 	<string name="httpuser">Потребител за HTTP</string>
 	<string name="error_media_upload">Грешка при качването на медийния файл</string>
 	<string name="post_content">Съдържание (докосни, за да добавиш текст и снимки)</string>
@@ -674,11 +662,9 @@
 	<string name="scaled_image">Оразмеряване ширината на изображението</string>
 	<string name="scheduled">Планирана</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Публикувано чрез WordPress за Android</string>
 	<string name="version">Версия</string>
 	<string name="tos">Условия за ползване</string>
 	<string name="app_title">WordPress за Android</string>
-	<string name="about">Относно</string>
 	<string name="image_alignment">Подравняване</string>
 	<string name="refresh">Презареждане</string>
 	<string name="untitled">Неозаглавен</string>
@@ -722,50 +708,4 @@
 	<string name="add">Добавяне</string>
 	<string name="preview">Предвариетелен преглед</string>
 	<string name="reply">Отговор</string>
-	<string-array name="alignment_array">
-		<item>Няма</item>
-		<item>Ляво</item>
-		<item>Център</item>
-		<item>Дясно</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Коментара на моя сайт</item>
-		<item>Харесвания на моите коментари</item>
-		<item>Харесвания на моите публикации</item>
-		<item>Последвани сайта</item>
-		<item>Достижения на сайта</item>
-		<item>Споменавания на потребителското име</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Отговори на моите коментари</item>
-		<item>Харесвания на моите коментари</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Предложения</item>
-		<item>Изследване</item>
-		<item>Общност</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Подсказки как да извлечем максима от WordPress.com</item>
-		<item>Възможности за участие в проучванията и изследванията на WordPress.com</item>
-		<item>Информация за курсовете и събитията (онлайн и лице-в-лице) на WordPress.com</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Публикувани</item>
-		<item>Чернови</item>
-		<item>В график</item>
-		<item>Изхвърлени</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Бележка</item>
-		<item>Аудио</item>
-		<item>Чат</item>
-		<item>Галерия</item>
-		<item>Изображение</item>
-		<item>Връзка</item>
-		<item>Цитат</item>
-		<item>Стандартен</item>
-		<item>Състояние</item>
-		<item>Видео</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-cs/strings.xml
+++ b/WordPress/src/main/res/values-cs/strings.xml
@@ -1,6 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">Nelze uložit nastavení účtu</string>
+	<string name="post_format_status">Aktualita</string>
+	<string name="post_format_video">Video</string>
+	<string name="align_none">Žádné</string>
+	<string name="align_left">Doleva</string>
+	<string name="align_center">Na střed</string>
+	<string name="align_right">Doprava</string>
+	<string name="theme_free">Zdarma</string>
+	<string name="theme_all">Vše</string>
+	<string name="theme_premium">Placeno</string>
+	<string name="post_format_gallery">Galerie</string>
+	<string name="post_format_image">Obrázek</string>
+	<string name="post_format_link">Odkaz</string>
+	<string name="post_format_quote">Citace</string>
+	<string name="post_format_standard">Základní</string>
+	<string name="post_format_chat">Chat</string>
+	<string name="post_format_aside">Poznámka</string>
+	<string name="post_format_audio">Zvuk</string>
+	<string name="approve_auto">Všichni uživatelé</string>
+	<string name="approve_manual">Žádné komentáře</string>
+	<string name="site_settings_paging_summary_other">%d komentářů na stránce</string>
+	<string name="site_settings_paging_summary_one">1 komentář na stránce</string>
+	<string name="days_quantity_other">%d dnů</string>
+	<string name="days_quantity_one">1 den</string>
+	<string name="filter_published_posts">Publikováno</string>
+	<string name="filter_draft_posts">Koncepty</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_page_title_placeholder">Název stránky</string>
+	<string name="editor_post_title_placeholder">Název příspěvku</string>
+	<string name="email_address">E-mailová adresa</string>
+	<string name="preference_show_visual_editor">Zobrazit vizuální editor</string>
+	<string name="preference_editor">Editor</string>
+	<string name="mnu_comment_delete_permanently">Smazat</string>
+	<string name="mnu_comment_untrash">Obnovit</string>
+	<string name="comment_status_all">Vše</string>
+	<string name="off">Vypnout</string>
+	<string name="about_the_app">O aplikaci</string>
+	<string name="error_post_account_settings">Nelze uložit nastavení účtu</string>
 	<string name="error_post_my_profile">Nelze uložit váš profil</string>
 	<string name="error_fetch_account_settings">Nelze načíst nastavení účtu</string>
 	<string name="error_fetch_my_profile">Nelze načíst váš profil</string>
@@ -9,6 +45,9 @@
 	<string name="remove">Odstranit</string>
 	<string name="disabled">Deaktivováno</string>
 	<string name="site_settings_image_original_size">Originální velikost</string>
+	<string name="privacy_private">Váš web je viditelný pouze pro vás a pro vámi schválené uživatele</string>
+	<string name="privacy_public_not_indexed">Váš web je viditelný pro všechny, ale žádá vyhledávače aby jej neindexovali</string>
+	<string name="privacy_public">Váš web je viditelný pro všechny a může být indexován vyhledávači</string>
 	<string name="about_me_hint">Osobní informace</string>
 	<string name="about_me">O mě</string>
 	<string name="public_display_name_hint">Zobrazované jméno bude vaše uživatelské jméno, pokud nenastavíte jiné</string>
@@ -481,11 +520,9 @@
 	<string name="hs__conversation_header">Chat podpory</string>
 	<string name="current_location">Současná poloha</string>
 	<string name="add_location">Přidat polohu</string>
-	<string name="your_signature">Váš podpis:</string>
 	<string name="edit_location">Upravit</string>
 	<string name="search_location">Hledat</string>
 	<string name="search_current_location">Lokalizovat</string>
-	<string name="preference_privacy">Soukromé</string>
 	<string name="preference_send_usage_stats_summary">Automaticky odesílat statistiky používání pro zlepšení WordPressu pro Android</string>
 	<string name="preference_send_usage_stats">Odesílat statistiky</string>
 	<string name="update_verb">Aktualizovat</string>
@@ -522,7 +559,6 @@
 	<string name="comments_empty_list">Žádný komentář</string>
 	<string name="mnu_comment_unspam">Není spam</string>
 	<string name="no_account">Nebyl nalezen žádný WordPress účet. Přidej účet a zkus znovu</string>
-	<string name="auto_sharing_preference_reset">Reset nastavení automatického sdílení </string>
 	<string name="sdcard_message">Pro nahrání media musí být připojená SD karta</string>
 	<string name="stats_empty_comments">Žádné komentáře</string>
 	<string name="stats_bar_graph_empty">Statistika není dostupná</string>
@@ -568,7 +604,6 @@
 	<string name="blog_name_must_be_at_least_four_characters">Adresa webu musí obsahovat alespoň 4 znaky</string>
 	<string name="blog_name_contains_invalid_characters">Adresa webu nesmí obsahovat znak "_"</string>
 	<string name="blog_name_only_lowercase_letters_and_numbers">Adresa webu může obsahovat pouze malá písmena (a-z) a číslice</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Dříve vybraný web už není viditelný</string>
 	<string name="blog_name_required">Vlož adresu webu</string>
 	<string name="invalid_url_message">Zkontrolujte platnost zadané adresy webu</string>
 	<string name="blog_not_found">Nastala chyba při přístupu na tento web</string>
@@ -696,10 +731,7 @@
 	<string name="reader_likes_you_and_multi">To se líbí vám a dalším %,d</string>
 	<string name="reader_likes_multi">To se mi líbí (%,d)</string>
 	<string name="reader_toast_err_get_comment">Nepodařilo se získat tento komentář</string>
-	<string name="share_preference_title">Sdílet s WordPressem</string>
 	<string name="cant_share_no_visible_blog">Nemůžete sdílet s WordPressem bez viditelného webu</string>
-	<string name="reset_auto_share_preference">Obnovit volby automatického sdílení</string>
-	<string name="always_use_these_settings_to_share">Vždy použít tato nastavení</string>
 	<string name="select_date">Vyberte datum</string>
 	<string name="pick_photo">Vyberte fotku</string>
 	<string name="pick_video">Vyberte video</string>
@@ -788,7 +820,6 @@
 	<string name="media_add_popup_capture_photo">Zachytit fotografii</string>
 	<string name="media_gallery_type_squares">Čtverce</string>
 	<string name="media_gallery_type_circles">Kruhy</string>
-	<string name="media_no_video_title">VideoPress je nedostupný</string>
 	<string name="stats_view_clicks">Kliknutí</string>
 	<string name="stats_timeframe_weeks">Týdny</string>
 	<string name="unattached">Nepřiřazeno</string>
@@ -801,7 +832,6 @@
 	<string name="media_gallery_type_tiled">Dlaždice</string>
 	<string name="stats_view_visitors_and_views">Návštěvnící a zobrazení</string>
 	<string name="stats_entry_country">Země</string>
-	<string name="media_no_video_message">Získejte VideoPress aktualizaci pro nahrání videa!</string>
 	<string name="stats_totals_clicks">Prokliky</string>
 	<string name="stats_view_referrers">Odkazující</string>
 	<string name="stats_entry_referrers">Odkazující</string>
@@ -813,8 +843,6 @@
 	<string name="more_notifications">a %d dalších.</string>
 	<string name="sign_in">Přihlásit se</string>
 	<string name="loading">Nahrávám...</string>
-	<string name="post_signature">Podpis příspěvku</string>
-	<string name="add_tagline">Připojit podpis k novým příspěvkům</string>
 	<string name="httpuser">HTTP uživ.jméno</string>
 	<string name="httppassword">HTTP heslo</string>
 	<string name="error_media_upload">Došlo k chybě během nahrávání médií</string>
@@ -841,11 +869,9 @@
 	<string name="upload_scaled_image">Nahrát a odkazovat na zmenšený obrázek</string>
 	<string name="scheduled">Načasováno</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Zasláno z WordPressu pro Android</string>
 	<string name="app_title">WordPress pro Android</string>
 	<string name="version">Verze</string>
 	<string name="tos">Podmínky služby</string>
-	<string name="about">O nás</string>
 	<string name="max_thumbnail_px_width">Výchozí šířka obrázku</string>
 	<string name="image_alignment">Zarovnání</string>
 	<string name="refresh">Obnovit</string>
@@ -867,6 +893,7 @@
 	<string name="title">Název</string>
 	<string name="categories">Rubriky</string>
 	<string name="tags_separate_with_commas">Štítky (oddělte štítky čárkami)</string>
+	<string name="dlg_deleting_comments">Odstraňování komentářů</string>
 	<string name="notification_sound">Přehrát zvuk oznámení</string>
 	<string name="notification_blink">Blikat při upozornění</string>
 	<string name="notification_vibrate">Vibrovat</string>
@@ -890,70 +917,4 @@
 	<string name="no">Ne</string>
 	<string name="error">Chyba</string>
 	<string name="category_refresh_error">Chyba obnovení rubrik</string>
-	<string-array name="alignment_array">
-		<item>Žádné</item>
-		<item>Vlevo</item>
-		<item>Doprostřed</item>
-		<item>Vpravo</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Komentářů na mém webu</item>
-		<item>To se mi líbí k mým komentářům</item>
-		<item>To se mi líbí k mým příspěvkům</item>
-		<item>Sledující weby</item>
-		<item>Úspěchy webu</item>
-		<item>V uživatelském jménu zmiňujete</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Počet odpovědí na moje komentáře</item>
-		<item>Počet like na moje komentáře</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Návrhy</item>
-		<item>Výzkum</item>
-		<item>Komunita</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Tipy jak získat co nejvíc z WordPress.com.</item>
-		<item>Příležitost zůčastnit se výzkumu a průzkumů na WordPress.com</item>
-		<item>Informace o kurzech a událostek WordPress.com (online a osobně).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Publikováno</item>
-		<item>Koncepty</item>
-		<item>Naplánováno</item>
-		<item>Přesunuto do koše</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Poznámka</item>
-		<item>Audio</item>
-		<item>Chat</item>
-		<item>Galerie</item>
-		<item>Obrázek</item>
-		<item>Odkaz</item>
-		<item>Citace</item>
-		<item>Standardní</item>
-		<item>Stav</item>
-		<item>Video</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Váš web je viditelný pro všechny a může být indexován vyhledávači</item>
-		<item>Váš web je viditelný pro všechny, ale žádá vyhledávače aby jej neindexovali</item>
-		<item>Váš web je viditelný pouze pro vás a pro vámi schválené uživatele</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>Manuálně schvalovat veškeré komentáře.</item>
-		<item>Automaticky schválit komentář, pokud už autor napsal alespoň jeden schválený komentář.</item>
-		<item>Automaticky schvalovat veškeré komentáře.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>Žádné komentáře</item>
-		<item>Komentáře známých uživatelů</item>
-		<item>Všichni uživatelé</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Zdarma</item>
-		<item>Vše</item>
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-cy/strings.xml
+++ b/WordPress/src/main/res/values-cy/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">Nid oedd modd i ni gadw manylion eich cyfrif</string>
 	<string name="error_post_my_profile">Nid oedd modd cadw eich proffil</string>
 	<string name="error_fetch_account_settings">Methu adfer gosodiadau eich cyfrif</string>
 	<string name="error_fetch_my_profile">Methu adfer eich proffil</string>
@@ -487,11 +486,9 @@
 	<string name="hs__conversation_header">Cefnogaeth drwy sgwrs</string>
 	<string name="add_location">Ychwanegwch leoliad</string>
 	<string name="current_location">Lleoliad cyfredol</string>
-	<string name="your_signature">Eich llofnod:</string>
 	<string name="search_location">Chwilio</string>
 	<string name="edit_location">Golygu</string>
 	<string name="search_current_location">Lleoli</string>
-	<string name="preference_privacy">Preifatrwydd</string>
 	<string name="preference_send_usage_stats">Anfon ystadegau</string>
 	<string name="preference_send_usage_stats_summary">Anfonwch ystadegau defnydd i\'n cynorthwyo i wella WordPress Android</string>
 	<string name="update_verb">Diweddaru</string>
@@ -562,10 +559,7 @@
 	<string name="sdcard_message">Mae angen cerdyn SD gosodedig i lwytho cyfryngau</string>
 	<string name="stats_empty_comments">Dim sylwadau eto</string>
 	<string name="stats_bar_graph_empty">Dim ystadegau gael</string>
-	<string name="invalid_url_message">Gwiriwch fod URL y blog yn ddilys</string>
 	<string name="reply_failed">Methodd yr ateb</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Nid yw\'r blog a ddewiswyd yn flaenorol yn weladwy</string>
-	<string name="auto_sharing_preference_reset">Ailosod gosodiadau awto-rannu</string>
 	<string name="cat_name_required">Mae angen maes enw categori</string>
 	<string name="category_automatically_renamed">Nid yw enw categori %1$s yn ddilys. Mae wedi ei ail-enwi i%2$s.</string>
 	<string name="no_account">Heb ganfod cyfrif WordPress, ychwanegwch cyfrif a cheisiwch eto</string>
@@ -695,9 +689,6 @@
 	<string name="creating_your_account">Creu eich cyfrif</string>
 	<string name="error_refresh_media">Aeth rhywbeth o\'i le wrth adnewyddu\'r llyfrgell cyfryngau. Rhowch gynnig arall arni\'n nes ymlaen.</string>
 	<string name="reader_empty_posts_in_tag_updating">Estyn cofnodion…</string>
-	<string name="always_use_these_settings_to_share">Defnyddiwch y gosodiadau hyn bob tro</string>
-	<string name="reset_auto_share_preference">Ailosod gosodiadau auto-rannu</string>
-	<string name="share_preference_title">Rhannu i WordPress</string>
 	<string name="cant_share_no_visible_blog">Nid oes modd rhannu i WordPress heb flog gweladwy</string>
 	<string name="reader_toast_err_get_comment">Methu adfer y sylw hwn</string>
 	<string name="reader_label_reply">Ateb</string>
@@ -795,9 +786,7 @@
 	<string name="media_edit_title_text">Teitl</string>
 	<string name="media_edit_caption_text">Egluryn</string>
 	<string name="media_edit_description_text">Disgrifiad</string>
-	<string name="media_no_video_message">Estynnwch VideoPress er mwyn llwytho fideo!</string>
 	<string name="media_gallery_type_slideshow">Sioe sleidiau</string>
-	<string name="media_no_video_title">Nid yw VideoPress ar gael</string>
 	<string name="media_gallery_type_circles">Cylchoedd</string>
 	<string name="media_gallery_type_tiled">Teils</string>
 	<string name="media_gallery_type_squares">Sgwariau</string>
@@ -821,8 +810,6 @@
 	<string name="loading">Llwytho…</string>
 	<string name="httppassword">Cyfrinair HTTP</string>
 	<string name="httpuser">Enw defnyddiwr HTTP</string>
-	<string name="post_signature">Llofnod cofnod</string>
-	<string name="add_tagline">Ychwanegu llofnod i gofnodion newydd</string>
 	<string name="error_media_upload">Digwyddodd gwall wrth lwytho\'r cyfrwng</string>
 	<string name="publish_date">Cyhoeddi</string>
 	<string name="content_description_add_media">Ychwanegu cyfrwng</string>
@@ -847,11 +834,9 @@
 	<string name="upload_scaled_image">Llwytho a chysylltu â delwedd graddedig</string>
 	<string name="scheduled">Amserlennwyd</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Cofnod o WordPress ar gyfer Android</string>
 	<string name="version">Fersiwn</string>
 	<string name="tos">Amodau Gwasanaeth</string>
 	<string name="app_title">WordPress ar gyfer Android</string>
-	<string name="about">Ynghylch</string>
 	<string name="max_thumbnail_px_width">Lled Rhagosodedig y Ddelwedd</string>
 	<string name="image_alignment">Alinio</string>
 	<string name="refresh">Adnewyddu</string>
@@ -896,70 +881,4 @@
 	<string name="cancel">Diddymu</string>
 	<string name="error">Gwall</string>
 	<string name="notification_settings">Gosodiadau Hysbysiadau</string>
-	<string-array name="alignment_array">
-		<item>Dim</item>
-		<item>Chwith</item>
-		<item>Canol</item>
-		<item>De</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Sylwadau ar fy ngwefan</item>
-		<item>Hoffi fy sylwadau</item>
-		<item>Hoffi fy nghofnodion</item>
-		<item>Gwefan yn dilyn</item>
-		<item>Cyraeddiadau\'r wefan</item>
-		<item>Crybwylliad enw defnyddiwr</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Atebion i fy sylwadau</item>
-		<item>Hoffi fy sylwadau</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Awgrymiadau</item>
-		<item>Ymchwil</item>
-		<item>Cymuned</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Cyngor ar sut i gael y gorau o WordPress.com.</item>
-		<item>Cyfleoedd i gymryd rhan mewn ymchwil ac arolygon WordPress.com.</item>
-		<item>Gwybodaeth am gyrsiau a digwyddiadau WordPress.com (ar-lein ac mewn person).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Cyhoeddwyd</item>
-		<item>Drafftiau</item>
-		<item>Amserlenwyd</item>
-		<item>Sbwriel</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Neilleb</item>
-		<item>Sain</item>
-		<item>Sgwrs</item>
-		<item>Oriel</item>
-		<item>Delwedd</item>
-		<item>Dolen</item>
-		<item>Dyfynnu</item>
-		<item>Safonol</item>
-		<item>Statws</item>
-		<item>Fideo</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Mae eich gwefan yn weladwy i bawb, ac o bosib wedi ei fynegeio gan beiriannau chwilio</item>
-		<item>Mae eich gwefan yn weladwy i bawb, ond mae\'n gofyn i beiriannau chwilio i beidio mynegeio eich gwefan</item>
-		<item>Mae eich gwefan yn weladwy i chi yn unig a defnyddwyr rydych wedi eu cymeradwyo</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>Bydd angen cymeradwyaeth â llaw ar gyfer sylwadau pawb.</item>
-		<item>Cymeradwyo\'n awtomatig os yw\'r defnyddiwr eisoes wedi cael sylw wedi ei gymeradwyo.</item>
-		<item>Cymeradwyo\'n awtomatig sylwadau pawb.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>Dim sylwadau</item>
-		<item>Sylwadau defnyddwyr hysbys</item>
-		<item>Pob defnyddiwr</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Am Ddim</item>
-		<item>Y Cyfan</item>
-		<item>Premiwm</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-da/strings.xml
+++ b/WordPress/src/main/res/values-da/strings.xml
@@ -216,13 +216,11 @@
 	<string name="contact_us">Kontakt os</string>
 	<string name="current_location">Nuværende placering</string>
 	<string name="add_location">Tilføj placering</string>
-	<string name="your_signature">Din signatur:</string>
 	<string name="search_current_location">Lokaliser</string>
 	<string name="search_location">Søg</string>
 	<string name="edit_location">Rediger</string>
 	<string name="preference_send_usage_stats_summary">Send automatisk brugsstatistik for at hjælpe os med at forbedre WordPress til Android</string>
 	<string name="preference_send_usage_stats">Indsend statistikker</string>
-	<string name="preference_privacy">Privatliv</string>
 	<string name="schedule_verb">Planlæg</string>
 	<string name="update_verb">Opdater</string>
 	<string name="reader_label_followed_blog">Blog fulgt</string>
@@ -259,7 +257,6 @@
 	<string name="blog_name_reserved">Det websted er reserveret</string>
 	<string name="out_of_memory">Enheden er løbet tør for hukommelse</string>
 	<string name="no_network_message">Der er intet netværk tilgængeligt</string>
-	<string name="auto_sharing_preference_reset">Auto-deling indstillinger er nulstillet</string>
 	<string name="sdcard_message">Et SD-kort skal være stukket ind og tilgængeligt for at kunne uploade medier</string>
 	<string name="no_account">Ingen WordPress konto fundet. Tilføj en konto og prøv igen</string>
 	<string name="theme_set_failed">Det lykkedes ikke at indstille temaet på plads</string>
@@ -278,9 +275,7 @@
 	<string name="blog_name_not_allowed">Dette websted er ikke tilladt</string>
 	<string name="email_invalid">Indtast en gyldig e-mailadresse</string>
 	<string name="invalid_email_message">Din e-mailadresse er ikke gyldig</string>
-	<string name="invalid_url_message">Undersøg om bloggens URL er gyldig</string>
 	<string name="invalid_password_message">Adgangskoden skal være på mindst fire tegn</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Tidligere valgte blog er ikke længere synlig</string>
 	<string name="stats_bar_graph_empty">Ingen statistik er tilgængelig</string>
 	<string name="stats_empty_comments">Ingen kommentarer endnu</string>
 	<string name="reply_failed">Svar fejlede</string>
@@ -408,15 +403,12 @@
 	<string name="reader_empty_posts_in_tag_updating">Henter indlæg...</string>
 	<string name="reader_toast_err_get_comment">Kunne ikke hente denne kommentar</string>
 	<string name="reader_likes_multi">%,d personer synes godt om dette</string>
-	<string name="share_preference_title">Del på WordPress</string>
-	<string name="always_use_these_settings_to_share">Brug altid disse indstillinger</string>
 	<string name="video">Video</string>
 	<string name="download">Henter medie</string>
 	<string name="comment_spammed">Kommentar markeret som spam</string>
 	<string name="reader_label_reply">Besvar</string>
 	<string name="reader_likes_you_and_multi">Du og %,d andre personer synes godt om dette</string>
 	<string name="cant_share_no_visible_blog">Du kan ikke dele til WordPress uden en synlig blog</string>
-	<string name="reset_auto_share_preference">Nulstil indstillinger for automatisk deling</string>
 	<string name="reader_toast_err_get_post">Kunne ikke hente dette indlæg</string>
 	<string name="reader_likes_you_and_one">Du og en anden synes godt om dette</string>
 	<string name="validating_user_data">Validerer brugerdata</string>
@@ -458,7 +450,6 @@
 	<string name="nux_tutorial_get_started_title">Kom i gang!</string>
 	<string name="reader_likes_one">En person synes godt om dette</string>
 	<string name="stats_view_tags_and_categories">Tags &amp; kategorier</string>
-	<string name="media_no_video_title">VideoPress utilgængelig</string>
 	<string name="media_edit_caption_hint">Indtast en tekst her</string>
 	<string name="theme_auth_error_title">Kunne ikke hente temaer</string>
 	<string name="stats_entry_referrers">Henviser</string>
@@ -521,8 +512,6 @@
 	<string name="new_notifications">%d nye notifikationer</string>
 	<string name="more_notifications">og %d mere.</string>
 	<string name="loading">Indlæser...</string>
-	<string name="add_tagline">Tilføj en signatur til nye indlæg</string>
-	<string name="post_signature">Indlægssignatur</string>
 	<string name="httppassword">HTTP-adgangskode</string>
 	<string name="httpuser">HTTP-brugernavn</string>
 	<string name="error_media_upload">Der opstod en fejl under overførsel af medie</string>
@@ -549,11 +538,9 @@
 	<string name="scaled_image">Bredde på skalerede billede</string>
 	<string name="scheduled">Planlagt</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Udgivet via WordPress til Android</string>
 	<string name="version">Version</string>
 	<string name="app_title">WordPress til Android</string>
 	<string name="tos">Brugskrav</string>
-	<string name="about">Om</string>
 	<string name="image_alignment">Justering</string>
 	<string name="refresh">Genindlæs</string>
 	<string name="untitled">Ikke-navngivet</string>
@@ -596,21 +583,4 @@
 	<string name="category_refresh_error">Kategori opdateringsfejl</string>
 	<string name="on">på</string>
 	<string name="preview">Forhåndsvis</string>
-	<string-array name="alignment_array">
-		<item>Ingen</item>
-		<item>Venstre</item>
-		<item>Center</item>
-		<item>Højre</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Lyd</item>
-		<item>Chat</item>
-		<item>Galleri</item>
-		<item>Billede</item>
-		<item>Link</item>
-		<item>Citat</item>
-		<item>Standard</item>
-		<item>Status</item>
-		<item>Video</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-de/strings.xml
+++ b/WordPress/src/main/res/values-de/strings.xml
@@ -1,6 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">Deine Kontoeinstellungen konnten nicht gespeichert werden.</string>
+	<string name="post_format_status">Status</string>
+	<string name="post_format_video">Video</string>
+	<string name="align_none">Nichts</string>
+	<string name="align_left">Links</string>
+	<string name="align_center">Zentriert</string>
+	<string name="align_right">Rechts</string>
+	<string name="theme_free">Gratis</string>
+	<string name="theme_all">Alle</string>
+	<string name="theme_premium">Premium</string>
+	<string name="post_format_chat">Chat</string>
+	<string name="post_format_gallery">Galerie</string>
+	<string name="post_format_image">Bild</string>
+	<string name="post_format_link">Link</string>
+	<string name="post_format_quote">Zitat</string>
+	<string name="post_format_standard">Standard</string>
+	<string name="notif_events">Informationen zu WordPress.com-Kursen und -Veranstaltungen (online und vor Ort)</string>
+	<string name="post_format_aside">Kurzmitteilung</string>
+	<string name="post_format_audio">Audio</string>
+	<string name="notif_surveys">Gelegenheiten, an Marktforschung und Befragungen von WordPress.com teilzunehmen</string>
+	<string name="notif_tips">Tipps für die optimale Nutzung von WordPress.com</string>
+	<string name="notif_community">Community</string>
+	<string name="replies_to_my_comments">Antworten auf meine Kommentare</string>
+	<string name="notif_suggestions">Vorschläge</string>
+	<string name="notif_research">Marktforschung</string>
+	<string name="site_achievements">Website-Auszeichnungen</string>
+	<string name="username_mentions">Benutzernamen-Erwähnungen</string>
+	<string name="likes_on_my_posts">Likes für meine Beiträge</string>
+	<string name="site_follows">Website-Follows</string>
+	<string name="likes_on_my_comments">Likes für meine Kommentare</string>
+	<string name="comments_on_my_site">Kommentare auf meiner Website</string>
+	<string name="site_settings_list_editor_summary_other">%d Einträge</string>
+	<string name="site_settings_list_editor_summary_one">1 Eintrag</string>
+	<string name="approve_auto_if_previously_approved">Kommentare bekannter Benutzer</string>
+	<string name="approve_auto">Alle Benutzer</string>
+	<string name="approve_manual">Keine Kommentare</string>
+	<string name="site_settings_paging_summary_other">%d Kommentare pro Seite</string>
+	<string name="site_settings_paging_summary_one">1 Kommentar pro Seite</string>
+	<string name="site_settings_multiple_links_summary_other">Mehr als %d Links müssen genehmigt werden.</string>
+	<string name="site_settings_multiple_links_summary_one">Mehr als 1 Link muss genehmigt werden.</string>
+	<string name="site_settings_multiple_links_summary_zero">Mehr als 0 Links müssen genehmigt werden.</string>
+	<string name="detail_approve_auto">Alle Kommentare automatisch genehmigen</string>
+	<string name="detail_approve_auto_if_previously_approved">Automatisch genehmigen, wenn bereits andere Kommentare des Benutzers genehmigt wurden</string>
+	<string name="detail_approve_manual">Alle Kommentare müssen manuell genehmigt werden.</string>
+	<string name="filter_trashed_posts">Im Papierkorb</string>
+	<string name="days_quantity_one">1 Tag</string>
+	<string name="days_quantity_other">%d Tage</string>
+	<string name="filter_published_posts">Veröffentlicht</string>
+	<string name="filter_draft_posts">Entwürfe</string>
+	<string name="filter_scheduled_posts">Geplant</string>
+	<string name="pending_email_change_snackbar">Klicke auf den Bestätigungslink in der E-Mail, die an %1$s gesendet wurde, um deine neue Adresse zu bestätigen.</string>
+	<string name="primary_site">Primäre Website</string>
+	<string name="web_address">Web-Adresse</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">Einige Medien-Uploads sind fehlgeschlagen. Bitte versuche es erneut oder lösche sie.</string>
+	<string name="editor_toast_uploading_please_wait">Medien werden hochgeladen … Bitte warte, bis der Vorgang abgeschlossen ist.</string>
+	<string name="error_refresh_comments_showing_older">Die Kommentare konnten nicht aktualisiert werden. Es werden ältere Kommentare angezeigt.</string>
+	<string name="editor_post_settings_set_featured_image">Beitragsbild festlegen</string>
+	<string name="editor_post_settings_featured_image">Beitragsbild</string>
+	<string name="new_editor_promo_desc">Die WordPress-App für Android verfügt nun über einen tollen neuen visuellen\n Editor. Probier ihn aus, indem du einen neuen Beitrag erstellst.</string>
+	<string name="new_editor_promo_title">Komplett neuer Editor</string>
+	<string name="new_editor_promo_button_label">Super, danke!</string>
+	<string name="visual_editor_enabled">Visueller Editor aktiviert</string>
+	<string name="editor_content_placeholder">Teile deine Geschichte hier …</string>
+	<string name="editor_page_title_placeholder">Seitentitel</string>
+	<string name="editor_post_title_placeholder">Beitragstitel</string>
+	<string name="email_address">E-Mail-Adresse</string>
+	<string name="preference_show_visual_editor">Visuellen Editor anzeigen</string>
+	<string name="dlg_sure_to_delete_comments">Möchtest du diese Kommentare dauerhaft löschen?</string>
+	<string name="preference_editor">Editor</string>
+	<string name="dlg_sure_to_delete_comment">Möchtest du diesen Kommentar dauerhaft löschen?</string>
+	<string name="mnu_comment_delete_permanently">Löschen</string>
+	<string name="comment_deleted_permanently">Kommentar gelöscht</string>
+	<string name="mnu_comment_untrash">Wiederherstellen</string>
+	<string name="comments_empty_list_filtered">Keine %s Kommentare</string>
+	<string name="could_not_load_page">Seite konnte nicht geladen werden.</string>
+	<string name="comment_status_all">Alle</string>
+	<string name="interface_language">Sprache der Bedienoberfläche</string>
+	<string name="off">Aus</string>
+	<string name="about_the_app">Über die App</string>
 	<string name="error_post_my_profile">Konnte dein Profil nicht speichern</string>
 	<string name="error_fetch_account_settings">Deine Kontoeinstellungen konnten nicht abgerufen werden.</string>
 	<string name="error_fetch_my_profile">Dein Profil konnte nicht abgerufen werden.</string>
@@ -487,11 +565,9 @@
 	<string name="hs__conversation_header">Support-Chat</string>
 	<string name="add_location">Standort hinzufügen</string>
 	<string name="current_location">Aktueller Standort</string>
-	<string name="your_signature">Deine Signatur:</string>
 	<string name="search_location">Suchen</string>
 	<string name="edit_location">Bearbeiten</string>
 	<string name="search_current_location">Lokalisieren</string>
-	<string name="preference_privacy">Privatsphäre</string>
 	<string name="preference_send_usage_stats">Statistiken senden</string>
 	<string name="preference_send_usage_stats_summary">Nutzungsstatistiken automatisch versenden, damit wir WordPress für Android weiter verbessern können</string>
 	<string name="update_verb">Update</string>
@@ -562,13 +638,10 @@
 	<string name="sdcard_message">Eine angeschlossene SD-Karte wird für den Medienupload benötigt</string>
 	<string name="category_automatically_renamed">Kategorie-Name %1$s ist ungültig. Er wurde umbenannt zu %2$s.</string>
 	<string name="wait_until_upload_completes">Warte bis der Upload fertig ist</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Vorher ausgewählter Blog ist nicht mehr sichtbar</string>
 	<string name="error_refresh_comments">Kommentare konnten nicht aktualisiert werden</string>
 	<string name="cat_name_required">Das Feld Kategorie-Name ist erforderlich</string>
-	<string name="auto_sharing_preference_reset">Auto-Teilen Einstellungen zurücksetzen</string>
 	<string name="blog_not_found">Beim Aufrufen des Blogs ist ein Fehler aufgetreten</string>
 	<string name="invalid_password_message">Passwort muss aus mindestens 4 Zeichen bestehen</string>
-	<string name="invalid_url_message">Überprüfe ob die eingegebene Blog-URL gültig ist</string>
 	<string name="nux_cannot_log_in">Wir können dich nicht anmelden</string>
 	<string name="no_site_error">Konnte nicht zur WordPress-Webseite verbinden</string>
 	<string name="blog_name_exists">Diese Webseite existiert bereits</string>
@@ -686,6 +759,7 @@
 	<string name="post_settings">Beitrags-Einstellungen</string>
 	<string name="page_settings">Seiten-Einstellungen</string>
 	<string name="notifications_empty_all">Keine Benachrichtigung bisher.</string>
+	<string name="invalid_site_url_message">Überprüfe, ob die eingegebene Website-URL gültig ist.</string>
 	<string name="deleting_page">Lösche Seite</string>
 	<string name="share_url_post">Beitrag teilen</string>
 	<string name="share_link">Link teilen</string>
@@ -697,14 +771,11 @@
 	<string name="reader_empty_posts_in_tag_updating">Hole Beiträge…</string>
 	<string name="reader_label_reply">Antworten</string>
 	<string name="comment_spammed">Kommentar als Spam markiert</string>
-	<string name="always_use_these_settings_to_share">Immer diese Einstellungen benutzen</string>
 	<string name="video">Video</string>
 	<string name="download">Lade Medien herunter</string>
 	<string name="reader_toast_err_get_comment">Kommentar konnte nicht geladen werden</string>
 	<string name="reader_likes_multi">%d Leuten gefällt dies</string>
-	<string name="share_preference_title">Auf WordPress teilen</string>
 	<string name="cant_share_no_visible_blog">Du kannst nicht auf WordPress teilen ohne einen sichtbaren Blog</string>
-	<string name="reset_auto_share_preference">Einstellungen zum Auto-Teilen resetten</string>
 	<string name="reader_likes_you_and_multi">Dir und %,d anderen gefällt dies</string>
 	<string name="select_time">Zeit auswählen</string>
 	<string name="select_date">Datum auswählen</string>
@@ -797,8 +868,6 @@
 	<string name="passcode_change_passcode">PIN ändern</string>
 	<string name="media_add_popup_capture_photo">Foto aufnehmen</string>
 	<string name="media_add_popup_capture_video">Video aufnehmen</string>
-	<string name="media_no_video_title">VideoPress nicht verfügbar</string>
-	<string name="media_no_video_message">Hol dir das VideoPress Upgrade, um Videos hochzuladen!</string>
 	<string name="theme_set_success">Theme erfolgreich festgelegt!</string>
 	<string name="theme_auth_error_title">Abruf der Themes fehlgeschlagen</string>
 	<string name="stats_view_visitors_and_views">Besucher und Aufrufe</string>
@@ -821,8 +890,6 @@
 	<string name="loading">Lädt...</string>
 	<string name="httpuser">HTTP-Benutzername</string>
 	<string name="httppassword">HTTP-Passwort</string>
-	<string name="post_signature">Beitragssignatur</string>
-	<string name="add_tagline">Eine Signatur zu neuen Beiträgen hinzufügen</string>
 	<string name="error_media_upload">Beim Hochladen von Medien ist ein Fehler aufgetreten</string>
 	<string name="publish_date">Veröffentlichen</string>
 	<string name="content_description_add_media">Medien hinzufügen</string>
@@ -847,11 +914,9 @@
 	<string name="upload_scaled_image">Hochladen und zum skalierten Bild verlinken</string>
 	<string name="scheduled">Geplant</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Veröffentlicht mit WordPress für Android</string>
 	<string name="version">Version</string>
 	<string name="tos">Nutzungsbedingungen</string>
 	<string name="app_title">WordPress für Android</string>
-	<string name="about">Über</string>
 	<string name="max_thumbnail_px_width">Standardbreite für Bilder</string>
 	<string name="image_alignment">Ausrichtung</string>
 	<string name="refresh">Aktualisieren</string>
@@ -896,70 +961,4 @@
 	<string name="error">Fehler</string>
 	<string name="category_refresh_error">Fehler beim Aktualisieren der Kategorien</string>
 	<string name="notification_settings">Benachrichtigungseinstellungen</string>
-	<string-array name="alignment_array">
-		<item>Keine</item>
-		<item>Links</item>
-		<item>Zentriert</item>
-		<item>Rechts</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Kommentare auf meiner Website</item>
-		<item>Likes zu meinen Kommentaren</item>
-		<item>Likes zu meinen Beiträgen</item>
-		<item>Website-Follows</item>
-		<item>Website-Auszeichnungen</item>
-		<item>Benutzernamen-Erwähnungen</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Antworten auf meine Kommentare</item>
-		<item>Likes zu meinen Kommentaren</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Vorschläge</item>
-		<item>Marktforschung</item>
-		<item>Community</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Tipps für die optimale Nutzung von WordPress.com.</item>
-		<item>Gelegenheiten, an Marktforschung und Umfragen von WordPress.com teilzunehmen.</item>
-		<item>Informationen zu WordPress.com-Kursen und -Veranstaltungen (online und vor Ort).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Veröffentlicht</item>
-		<item>Entwürfe</item>
-		<item>Geplant</item>
-		<item>Im Papierkorb</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Kurzmitteilung</item>
-		<item>Audio</item>
-		<item>Chat</item>
-		<item>Galerie</item>
-		<item>Bild</item>
-		<item>Link</item>
-		<item>Zitat</item>
-		<item>Standard</item>
-		<item>Status</item>
-		<item>Video</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Deine Website ist für alle sichtbar. Suchmaschinen dürfen sie indexieren.</item>
-		<item>Deine Website ist für alle sichtbar. Suchmaschinen werden aufgefordert, sie nicht zu indexieren.</item>
-		<item>Deine Website ist nur für dich und freigegebene Nutzer sichtbar.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>Alle Kommentare müssen manuell genehmigt werden.</item>
-		<item>Automatisch genehmigen, wenn bereits andere Kommentare des Benutzers genehmigt wurden</item>
-		<item>Alle Kommentare automatisch genehmigen</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>Keine Kommentare</item>
-		<item>Kommentare bekannter Benutzer</item>
-		<item>Alle Benutzer</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Kostenlos</item>
-		<item>Alle</item>
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-el/strings.xml
+++ b/WordPress/src/main/res/values-el/strings.xml
@@ -286,7 +286,6 @@
 	<string name="stats_entry_search_terms">Όρος αναζήτησης</string>
 	<string name="stats_view_authors">Συγγραφείς</string>
 	<string name="error_notification_open">Αδύνατον να ανοιχτεί η ειδοποίηση</string>
-	<string name="stats_followers_total_email_paged">Κατάδειξη %1$d - %2$d από %3$ς Ακόλουθοι Email</string>
 	<string name="stats_search_terms_unknown_search_terms">Άγνωστοι όροι αναζήτησης</string>
 	<string name="stats_empty_search_terms_desc">Μάθετε περισσότερα για την κίνηση στην αναζήτηση σας εξετάζοντας τους όρους αναζήτησης που χρησιμοποίησαν οι χρήστες για να βρούν το site σας.</string>
 	<string name="reader_empty_posts_request_failed">Αδυναμία φόρτωσης των άρθρων</string>
@@ -294,6 +293,7 @@
 	<string name="posts_fetching">Λήψη άρθρων...</string>
 	<string name="media_fetching">Λήψη πολυμέσων...</string>
 	<string name="stats_followers_total_wpcom_paged">Κατάδειξη %1$d - %2$d από %3$s Ακόλουθοι WordPress.com</string>
+	<string name="stats_followers_total_email_paged">Κατάδειξη %1$d - %2$d από %3$s Ακόλουθοι Email</string>
 	<string name="stats_months_and_years">Μήνες και Χρόνια</string>
 	<string name="reader_page_recommended_blogs">Ιστολόγια που μπορεί να σας αρέσουν</string>
 	<string name="post_uploading">Μεταφόρτωση</string>

--- a/WordPress/src/main/res/values-el/strings.xml
+++ b/WordPress/src/main/res/values-el/strings.xml
@@ -1,5 +1,77 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+	<string name="post_format_status">Κατάσταση</string>
+	<string name="post_format_video">Βίντεο</string>
+	<string name="align_none">Καμία</string>
+	<string name="align_left">Αριστερά</string>
+	<string name="align_center">Κέντρο</string>
+	<string name="align_right">Δεξιά</string>
+	<string name="theme_free">Δωρεάν</string>
+	<string name="theme_all">Όλα</string>
+	<string name="theme_premium">Premium</string>
+	<string name="post_format_chat">Συζήτηση</string>
+	<string name="post_format_gallery">Βιβλιοθήκη πολυμέσων</string>
+	<string name="post_format_image">Εικόνα</string>
+	<string name="post_format_link">Σύνδεσμος</string>
+	<string name="post_format_quote">Παράθεση</string>
+	<string name="post_format_standard">Κανονικό</string>
+	<string name="notif_events">Πληροφορίες για μαθήματα και εκδηλώσεις του WordPress.com (διαδικτυακά και φυσικά).</string>
+	<string name="post_format_audio">Ήχος</string>
+	<string name="notif_surveys">Ευκαιρίες συμμετοχής σε έρευνες και δημοσκοπήσεις του WordPress.com.</string>
+	<string name="notif_tips">Συμβουλές για να αξιοποιήσετε στο μέγιστο το WordPress.com.</string>
+	<string name="notif_community">Κοινότητα</string>
+	<string name="replies_to_my_comments">Απαντήσεις στα σχόλιά μου</string>
+	<string name="notif_suggestions">Προτάσεις</string>
+	<string name="notif_research">Έρευνα</string>
+	<string name="site_achievements">Επιτεύγματα του ιστότοπου</string>
+	<string name="username_mentions">Αναφορές του ονόματος χρήστη</string>
+	<string name="likes_on_my_posts">"Μου αρέσει" στα άρθρα μου</string>
+	<string name="site_follows">Ακόλουθοι ιστότοπου</string>
+	<string name="likes_on_my_comments">"Μου αρέσει" στα σχόλιά μου</string>
+	<string name="comments_on_my_site">Σχόλια στον ιστότοπό μου</string>
+	<string name="site_settings_list_editor_summary_other">%d αντικείμενα</string>
+	<string name="site_settings_list_editor_summary_one">1 αντικείμενο</string>
+	<string name="approve_auto_if_previously_approved">Σχόλια γνωστών χρηστών</string>
+	<string name="approve_auto">Όλοι οι χρήστες</string>
+	<string name="approve_manual">Δεν υπάρχουν σχόλια</string>
+	<string name="site_settings_paging_summary_other">%d σχόλια ανά σελίδα</string>
+	<string name="site_settings_paging_summary_one">1 σχόλιο ανά σελίδα</string>
+	<string name="site_settings_multiple_links_summary_other">Απαιτείται έγκριση για περισσότερους από %d συνδέσμους</string>
+	<string name="site_settings_multiple_links_summary_one">Απαιτείται έγκριση για περισσότερους από 1 σύνδεσμο</string>
+	<string name="site_settings_multiple_links_summary_zero">Απαιτείται έγκριση για περισσότερους από 0 συνδέσμους</string>
+	<string name="detail_approve_auto">Αυτόματη έγκριση όλων των σχολίων</string>
+	<string name="detail_approve_auto_if_previously_approved">Αυτόματη έγκριση αν ο χρήστης έχει προηγούμενο εγκεκριμένο σχόλιο</string>
+	<string name="detail_approve_manual">Απαιτείται χειροκίνητη έγκριση για όλα τα σχόλια.</string>
+	<string name="filter_trashed_posts">Διαγραμμένα</string>
+	<string name="days_quantity_one">1 ημέρα</string>
+	<string name="days_quantity_other">%d ημέρες</string>
+	<string name="filter_published_posts">Δημοσιευμένα</string>
+	<string name="filter_draft_posts">Προσχέδια</string>
+	<string name="filter_scheduled_posts">Προγραμματισμένα</string>
+	<string name="pending_email_change_snackbar">Κάντε κλικ στο σύνδεσμο επιβεβαίωσης στο μήνυμα e-mail που στάλθηκε στο %1$s για να επιβεβαιώσετε τη νέα σας διεύθυνση.</string>
+	<string name="primary_site">Κύριος ιστότοπος</string>
+	<string name="web_address">Διεύθυνση Ιστότοπου</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">Κάποιες μεραφορτώσεις πολυμέσων απέτυχαν. Παρακαλώ δοκιμάστε πάλι ή διαγράψτε τις.</string>
+	<string name="editor_toast_uploading_please_wait">Αυτή τη στιγμή μεταφορτώνετε πολυμέσα. Παρακαλώ περιμένετε μέχρι να ολοκληρωθεί.</string>
+	<string name="error_refresh_comments_showing_older">Δεν ήταν δυνατή η ανανέωση των σχολίων αυτή τη στιγμή - εμφάνιση παλαιότερων σχολίων</string>
+	<string name="editor_post_settings_set_featured_image">Ορισμός προβαλλόμενης εικόνας</string>
+	<string name="editor_post_settings_featured_image">Προβαλλόμενη Εικόνα</string>
+	<string name="new_editor_promo_desc">Η εφαρμογή του WordPress για Android περιλαμβάνει τώρα έναν όμορφο νέο\nεπεξεργαστή. Δοκιμάστε τον δημιουργώντας ένα νέο άρθρο.</string>
+	<string name="new_editor_promo_title">Ολοκαίνουριος επεξεργαστής κειμένου</string>
+	<string name="new_editor_promo_button_label">Σπουδαία, ευχαριστούμε!</string>
+	<string name="visual_editor_enabled">Ο οπτικοποιημένος επεξεργαστής ενεργοποιήθηκε</string>
+	<string name="editor_content_placeholder">Μοιραστείτε την ιστορία σας εδώ...</string>
+	<string name="editor_page_title_placeholder">Τίτλος Σελίδας</string>
+	<string name="editor_post_title_placeholder">Τίτλος Άρθρου</string>
+	<string name="email_address">Διεύθυνση email</string>
+	<string name="preference_show_visual_editor">Προβολή οπτικοποιημένου επεξεργαστή</string>
+	<string name="dlg_sure_to_delete_comments">Να διαγραφούν οριστικά αυτά τα σχόλια;</string>
+	<string name="preference_editor">Επεξεργαστής</string>
+	<string name="dlg_sure_to_delete_comment">Οριστική διαγραφή αυτού του σχολίου;</string>
+	<string name="mnu_comment_delete_permanently">Διαγραφή</string>
+	<string name="comment_deleted_permanently">Το σχόλιο διαγράφηκε</string>
+	<string name="mnu_comment_untrash">Αποκατάσταση</string>
 	<string name="selected_theme">Επιλεγμένο Θέμα</string>
 	<string name="could_not_load_theme">Αποτυχία φόρτωσης θέματος</string>
 	<string name="theme_activation_error">Κάτι πήγε στραβά. Δεν ενεργοποιήθηκε το θέμα</string>
@@ -350,11 +422,9 @@
 	<string name="hs__conversation_header">Συζήτηση υποστήριξης</string>
 	<string name="add_location">Προσθέστε περιοχή</string>
 	<string name="current_location">Τωρινή τοποθεσία</string>
-	<string name="your_signature">Η υπογραφή σας:</string>
 	<string name="search_location">Αναζήτηση</string>
 	<string name="edit_location">Επεξεργασία</string>
 	<string name="search_current_location">Εντοπισμός</string>
-	<string name="preference_privacy">Ιδιωτικότητα </string>
 	<string name="preference_send_usage_stats">Αποστολή στατιστικών</string>
 	<string name="preference_send_usage_stats_summary">Αυτόματη αποστολή στατιστικών στοιχείων χρήσης ώστε να μας βοηθήσετε να βελτιώσουμε το WordPress για το Android</string>
 	<string name="update_verb">Ενημέρωση</string>
@@ -414,11 +484,8 @@
 	<string name="cat_name_required">Απαιτείται το πεδίο ονόματος κατηγορίας</string>
 	<string name="category_automatically_renamed">Το όνομα κατηγορίας %1$s δεν είναι έγκυρο. Έχει μετονομαστεί σε %2$s.</string>
 	<string name="no_account">Δεν βρέθηκε λογαριασμός WordPress, προσθέστε λογαριασμό  και δοκιμάστε ξανά</string>
-	<string name="auto_sharing_preference_reset">Επαναφορά ρυθμίσεων αυτόματου διαμοιρασμού</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Το ιστολόγιο που επιλέχθηκε προηγουμένως δεν είναι πλέον ορατό</string>
 	<string name="sdcard_message">Απαιτείται προσαρτημένη κάρτα SD για τη μεταφόρτωση πολυμέσων</string>
 	<string name="stats_bar_graph_empty">Δε υπάρχουν διαθέσιμα στατιστικά</string>
-	<string name="invalid_url_message">Ελέγξτε αν το URL του ιστολογίου που δώσατε είναι έγκυρο</string>
 	<string name="reply_failed">Αποτυχία απάντησης</string>
 	<string name="notifications_empty_list">Δεν υπάρχουν ειδοποιήσεις</string>
 	<string name="error_delete_post">Προέκυψε σφάλμα κατά τη διαγραφή του %s</string>
@@ -566,9 +633,6 @@
 	<string name="download">Γίνεται μεταφορά πολυμέσων</string>
 	<string name="comment_spammed">Το σχόλιο αυτό έχει σημειωθεί ως ανεπιθύμητο</string>
 	<string name="cant_share_no_visible_blog">Δε μπορείτε να μοιραστείτε στο WordPress χωρίς ένα ορατό ιστολόγιο</string>
-	<string name="share_preference_title">Μοιραστείτε στο WordPress</string>
-	<string name="reset_auto_share_preference">Επαναφορά ρυθμίσεων αυτόματου μοιρασμού</string>
-	<string name="always_use_these_settings_to_share">Να γίνεται πάντοτε χρήση αυτών των ρυθμίσεων</string>
 	<string name="reader_likes_you_and_one">Αυτό αρέσει σε εσάς και ακόμη ένα χρήστη</string>
 	<string name="select_date">Επιλέξτε ημερομηνία</string>
 	<string name="select_time">Επιλέξτε ώρα</string>
@@ -646,8 +710,6 @@
 	<string name="stats_timeframe_yesterday">Χθες</string>
 	<string name="theme_set_success">Το θέμα ορίστηκε επιτυχώς</string>
 	<string name="theme_activating_button">Γίνεται ενεργοποιήση</string>
-	<string name="media_no_video_title">Το VideoPress δεν είναι διαθέσιμο</string>
-	<string name="media_no_video_message">Αναβαθμίστε το VideoPress για να φορτώσετε video!</string>
 	<string name="media_edit_caption_hint">Προσθέστε μια λεζάντα εδώ</string>
 	<string name="theme_auth_error_title">Δε στάθηκε δυνατό να ανακτηθούν τα θέματα.</string>
 	<string name="post_excerpt">Σύνοψη</string>
@@ -682,8 +744,6 @@
 	<string name="more_notifications">και %d ακόμη.</string>
 	<string name="follows">Ακόλουθοι</string>
 	<string name="loading">Φορτώνει...</string>
-	<string name="post_signature">Υπογραφή άρθρου</string>
-	<string name="add_tagline">Προσθήκη υπογραφής στα νέα άρθρα</string>
 	<string name="httpuser">Όνομα χρήστη HTTP</string>
 	<string name="httppassword">Κωδικός χρήστη HTTP</string>
 	<string name="error_media_upload">Ένα σφάλμα συνέβη κατά το ανέβασμα των πολυμέσων</string>
@@ -710,11 +770,9 @@
 	<string name="scaled_image">Νέο πλάτος εικόνας</string>
 	<string name="scheduled">Προγραμματισμένο</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Αναρτήθηκε από το WordPress για το Android</string>
 	<string name="version">Έκδοση</string>
 	<string name="tos">Όροι Χρήσης</string>
 	<string name="app_title">WordPress για Android</string>
-	<string name="about">Σχετικά</string>
 	<string name="image_alignment">Στοίχιση</string>
 	<string name="refresh">Ανανέωση</string>
 	<string name="untitled">Χωρίς τίτλο</string>
@@ -758,55 +816,4 @@
 	<string name="category_refresh_error">Σφάλμα ανανέωσης κατηγοριών</string>
 	<string name="on">ενεργό</string>
 	<string name="notification_settings">Ρυθμίσεις Ειδοποιήσεων</string>
-	<string-array name="alignment_array">
-		<item>Κανένα</item>
-		<item>Αριστερά</item>
-		<item>Κέντρο</item>
-		<item>Δεξιά</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Σχόλια στον ιστότοπό μου</item>
-		<item>"Like" στα σχόλιά μου</item>
-		<item>"Like" στα άρθρα μου</item>
-		<item>Ακολουθούν τον ιστότοπο</item>
-		<item>Επιτεύγματα ιστοτόπου</item>
-		<item>Αναφορές ονόματος χρήστη</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Απαντήσεις στα σχόλιά μου</item>
-		<item>"Like" στα σχόλιά μου</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Προτάσεις</item>
-		<item>Έρευνα</item>
-		<item>Κοινότητα</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Συμβουλές για να πάρετε το μέγιστο από το WordPress.com.</item>
-		<item>Ευκαιρίες για συμμετοχή στις έρευνες και δημοσκοπήσεις του WordPress.com.</item>
-		<item>Πληροφορίες για εκπαίδευση και εκδηλώσεις του WordPress.com (διαδικτυακά και ζωντανά).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Δημοσιευμένα</item>
-		<item>Προσχέδια</item>
-		<item>Προγραμματισμένα</item>
-		<item>Διαγραμμένα</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Πλαϊνό</item>
-		<item>Ήχητικό</item>
-		<item>Συνομιλία</item>
-		<item>Γκαλερί</item>
-		<item>Εικόνα</item>
-		<item>Σύνδεσμος</item>
-		<item>Παράθεση</item>
-		<item>Κλασσικό</item>
-		<item>Κατάσταση</item>
-		<item>Video</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Δωρεάν</item>
-		<item>Όλα</item>
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-en-rAU/strings.xml
+++ b/WordPress/src/main/res/values-en-rAU/strings.xml
@@ -1,6 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">Couldn\'t save your account settings</string>
+	<string name="post_format_status">Status</string>
+	<string name="post_format_video">Video</string>
+	<string name="align_none">None</string>
+	<string name="align_left">Left</string>
+	<string name="align_center">Centre</string>
+	<string name="align_right">Right</string>
+	<string name="theme_free">Free</string>
+	<string name="theme_all">All</string>
+	<string name="theme_premium">Premium</string>
+	<string name="post_format_chat">Chat</string>
+	<string name="post_format_gallery">Gallery</string>
+	<string name="post_format_image">Image</string>
+	<string name="post_format_link">Link</string>
+	<string name="post_format_quote">Quote</string>
+	<string name="post_format_standard">Standard</string>
+	<string name="notif_events">Information on WordPress.com courses and events (online &amp; in-person).</string>
+	<string name="post_format_aside">Aside</string>
+	<string name="post_format_audio">Audio</string>
+	<string name="notif_surveys">Opportunities to participate in WordPress.com research &amp; surveys.</string>
+	<string name="notif_tips">Tips for getting the most out of WordPress.com.</string>
+	<string name="notif_community">Community</string>
+	<string name="replies_to_my_comments">Replies to my comments</string>
+	<string name="notif_suggestions">Suggestions</string>
+	<string name="notif_research">Research</string>
+	<string name="site_achievements">Site achievements</string>
+	<string name="username_mentions">Username mentions</string>
+	<string name="likes_on_my_posts">Likes on my posts</string>
+	<string name="site_follows">Site follows</string>
+	<string name="likes_on_my_comments">Likes on my comments</string>
+	<string name="comments_on_my_site">Comments on my site</string>
+	<string name="site_settings_list_editor_summary_other">%d items</string>
+	<string name="site_settings_list_editor_summary_one">1 item</string>
+	<string name="approve_auto_if_previously_approved">Known users\' comments</string>
+	<string name="approve_auto">All users</string>
+	<string name="approve_manual">No comments</string>
+	<string name="site_settings_paging_summary_other">%d comments per page</string>
+	<string name="site_settings_paging_summary_one">1 comment per page</string>
+	<string name="site_settings_multiple_links_summary_other">Require approval for more than %d links</string>
+	<string name="site_settings_multiple_links_summary_one">Require approval for more than 1 link</string>
+	<string name="site_settings_multiple_links_summary_zero">Require approval for more than 0 links</string>
+	<string name="detail_approve_auto">Automatically approve everyone\'s comments.</string>
+	<string name="detail_approve_auto_if_previously_approved">Automatically approve if the user has a previously approved comment</string>
+	<string name="detail_approve_manual">Require manual approval for everyone\'s comments.</string>
+	<string name="filter_trashed_posts">Trashed</string>
+	<string name="days_quantity_one">1 day</string>
+	<string name="days_quantity_other">%d days</string>
+	<string name="filter_published_posts">Published</string>
+	<string name="filter_draft_posts">Drafts</string>
+	<string name="filter_scheduled_posts">Scheduled</string>
+	<string name="pending_email_change_snackbar">Click the verification link in the email sent to %1$s to confirm your new address</string>
+	<string name="primary_site">Primary site</string>
+	<string name="web_address">Web Address</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">Some media uploads have failed. Please retry them or delete them.</string>
+	<string name="editor_toast_uploading_please_wait">You are currently uploading media. Please wait until this completes.</string>
+	<string name="error_refresh_comments_showing_older">Comments couldn\'t be refreshed at this time - showing older comments</string>
+	<string name="editor_post_settings_set_featured_image">Set Featured Image</string>
+	<string name="editor_post_settings_featured_image">Featured Image</string>
+	<string name="new_editor_promo_desc">The WordPress app for Android now includes a beautiful new visual\n    editor. Try it out by creating a new post.</string>
+	<string name="new_editor_promo_title">Brand new editor</string>
+	<string name="new_editor_promo_button_label">Great, thanks!</string>
+	<string name="visual_editor_enabled">Visual Editor enabled</string>
+	<string name="editor_content_placeholder">Share your story here…</string>
+	<string name="editor_page_title_placeholder">Page Title</string>
+	<string name="editor_post_title_placeholder">Post Title</string>
+	<string name="email_address">Email address</string>
+	<string name="preference_show_visual_editor">Show visual editor</string>
+	<string name="dlg_sure_to_delete_comments">Permanently delete these comments?</string>
+	<string name="preference_editor">Editor</string>
+	<string name="dlg_sure_to_delete_comment">Permanently delete this comment?</string>
+	<string name="mnu_comment_delete_permanently">Delete</string>
+	<string name="comment_deleted_permanently">Comment deleted</string>
+	<string name="mnu_comment_untrash">Restore</string>
+	<string name="comments_empty_list_filtered">No %s comments</string>
+	<string name="could_not_load_page">Could not load page</string>
+	<string name="comment_status_all">All</string>
+	<string name="interface_language">Interface Language</string>
+	<string name="off">Off</string>
+	<string name="about_the_app">About the app</string>
+	<string name="error_post_account_settings">Couldn\'t save your account settings</string>
 	<string name="error_post_my_profile">Couldn\'t save your profile</string>
 	<string name="error_fetch_account_settings">Couldn\'t retrieve your account settings</string>
 	<string name="error_fetch_my_profile">Couldn\'t retrieve your profile</string>
@@ -15,6 +94,9 @@
 	<string name="add_category">Add category</string>
 	<string name="disabled">Disabled</string>
 	<string name="site_settings_image_original_size">Original Size</string>
+	<string name="privacy_private">Your site is visible only to you and users you approve</string>
+	<string name="privacy_public_not_indexed">Your site is visible to everyone but asks search engines not to index it</string>
+	<string name="privacy_public">Your site is visible to everyone and may be indexed by search engines</string>
 	<string name="about_me_hint">A few words about you…</string>
 	<string name="public_display_name_hint">Display name will default to your username if it is not set</string>
 	<string name="about_me">About me</string>
@@ -487,11 +569,9 @@
 	<string name="hs__invalid_email_error">Enter a valid email address</string>
 	<string name="add_location">Add location</string>
 	<string name="current_location">Current location</string>
-	<string name="your_signature">Your signature:</string>
 	<string name="search_location">Search</string>
 	<string name="edit_location">Edit</string>
 	<string name="search_current_location">Locate</string>
-	<string name="preference_privacy">Privacy</string>
 	<string name="preference_send_usage_stats">Send statistics</string>
 	<string name="preference_send_usage_stats_summary">Automatically send usage statistics to help us improve WordPress for Android</string>
 	<string name="update_verb">Update</string>
@@ -535,12 +615,9 @@
 	<string name="cat_name_required">The category name field is required</string>
 	<string name="category_automatically_renamed">Category name %1$s isn\'t valid. It has been renamed to %2$s.</string>
 	<string name="no_account">No WordPress account found, add an account and try again</string>
-	<string name="auto_sharing_preference_reset">Auto-sharing settings reset</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Previously selected blog is no longer visible</string>
 	<string name="sdcard_message">A mounted SD card is required to upload media</string>
 	<string name="stats_empty_comments">No comments yet</string>
 	<string name="stats_bar_graph_empty">No stats available</string>
-	<string name="invalid_url_message">Check that the blog URL entered is valid</string>
 	<string name="reply_failed">Reply failed</string>
 	<string name="notifications_empty_list">No notifications</string>
 	<string name="error_delete_post">An error occurred while deleting the %s</string>
@@ -583,6 +660,7 @@
 	<string name="blog_name_reserved_but_may_be_available">That site is currently reserved but may be available in a couple days</string>
 	<string name="username_or_password_incorrect">The username or password you entered is incorrect</string>
 	<string name="nux_cannot_log_in">We can\'t log you in</string>
+	<string name="invalid_url_message">Check that the URL entered is valid</string>
 	<string name="blog_removed_successfully">Site removed successfully</string>
 	<string name="remove_account">Remove site</string>
 	<string name="xmlrpc_error">Couldn\'t connect. Enter the full path to xmlrpc.php on your site and try again.</string>
@@ -686,6 +764,7 @@
 	<string name="blog_name_invalid">Invalid site address</string>
 	<string name="blog_title_invalid">Invalid site title</string>
 	<string name="notifications_empty_all">No notifications…yet.</string>
+	<string name="invalid_site_url_message">Check that the site URL entered is valid</string>
 	<string name="deleting_page">Deleting page</string>
 	<string name="deleting_post">Deleting post</string>
 	<string name="share_url_post">Share post</string>
@@ -703,9 +782,6 @@
 	<string name="download">Downloading media</string>
 	<string name="comment_spammed">Comment marked as spam</string>
 	<string name="cant_share_no_visible_blog">You can\'t share to WordPress without a visible blog</string>
-	<string name="share_preference_title">Share to WordPress</string>
-	<string name="reset_auto_share_preference">Reset auto-sharing settings</string>
-	<string name="always_use_these_settings_to_share">Always use these settings</string>
 	<string name="select_time">Select time</string>
 	<string name="reader_likes_you_and_one">You and one other like this</string>
 	<string name="select_date">Select date</string>
@@ -766,8 +842,6 @@
 	<string name="media_gallery_type_tiled">Tiled</string>
 	<string name="media_gallery_type_circles">Circles</string>
 	<string name="media_gallery_type_slideshow">Slideshow</string>
-	<string name="media_no_video_title">VideoPress unavailable</string>
-	<string name="media_no_video_message">Get the VideoPress upgrade to upload video!</string>
 	<string name="media_edit_title_text">Title</string>
 	<string name="media_edit_caption_text">Caption</string>
 	<string name="media_edit_description_text">Description</string>
@@ -819,8 +893,6 @@
 	<string name="more_notifications">and %d more.</string>
 	<string name="follows">Follows</string>
 	<string name="loading">Loading…</string>
-	<string name="post_signature">Post signature</string>
-	<string name="add_tagline">Add a signature to new posts</string>
 	<string name="httpuser">HTTP username</string>
 	<string name="httppassword">HTTP password</string>
 	<string name="error_media_upload">An error occurred while uploading media</string>
@@ -847,11 +919,9 @@
 	<string name="scaled_image">Scaled image width</string>
 	<string name="scheduled">Scheduled</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Posted from WordPress for Android</string>
 	<string name="version">Version</string>
 	<string name="tos">Terms of Service</string>
 	<string name="app_title">WordPress for Android</string>
-	<string name="about">About</string>
 	<string name="max_thumbnail_px_width">Default Image Width</string>
 	<string name="image_alignment">Alignment</string>
 	<string name="refresh">Refresh</string>
@@ -873,6 +943,7 @@
 	<string name="title">Title</string>
 	<string name="tags_separate_with_commas">Tags (separate tags with commas)</string>
 	<string name="categories">Categories</string>
+	<string name="dlg_deleting_comments">Deleting comments</string>
 	<string name="notification_blink">Blink notification light</string>
 	<string name="notification_sound">Play notification sound</string>
 	<string name="notification_vibrate">Vibrate</string>
@@ -896,70 +967,4 @@
 	<string name="yes">Yes</string>
 	<string name="no">No</string>
 	<string name="notification_settings">Notification Settings</string>
-	<string-array name="alignment_array">
-		<item>None</item>
-		<item>Left</item>
-		<item>Centre</item>
-		<item>Right</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Comments on my site</item>
-		<item>Likes on my comments</item>
-		<item>Likes on my posts</item>
-		<item>Site follows</item>
-		<item>Site achievements</item>
-		<item>Username mentions</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Replies to my comments</item>
-		<item>Likes on my comments</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Suggestions</item>
-		<item>Research</item>
-		<item>Community</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Tips for getting the most out of WordPress.com.</item>
-		<item>Opportunities to participate in WordPress.com research &amp; surveys.</item>
-		<item>Information on WordPress.com courses and events (online &amp; in-person).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Published</item>
-		<item>Drafts</item>
-		<item>Scheduled</item>
-		<item>Trashed</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Aside</item>
-		<item>Audio</item>
-		<item>Chat</item>
-		<item>Gallery</item>
-		<item>Image</item>
-		<item>Link</item>
-		<item>Quote</item>
-		<item>Standard</item>
-		<item>Status</item>
-		<item>Video</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Your site is visible to everyone and may be indexed by search engines</item>
-		<item>Your site is visible to everyone but asks search engines not to index it</item>
-		<item>Your site is visible only to you and users you approve</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>Require manual approval for everyone\'s comments.</item>
-		<item>Automatically approve if the user has a previously approved comment.</item>
-		<item>Automatically approve everyone\'s comments.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>No comments</item>
-		<item>Known users\' comments</item>
-		<item>All users</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Free</item>
-		<item>All</item>
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -1,6 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">Couldn\'t save your account settings</string>
+	<string name="post_format_status">Status</string>
+	<string name="post_format_video">Video</string>
+	<string name="align_none">None</string>
+	<string name="align_left">Left</string>
+	<string name="align_center">Centre</string>
+	<string name="align_right">Right</string>
+	<string name="theme_free">Free</string>
+	<string name="theme_all">All</string>
+	<string name="theme_premium">Premium</string>
+	<string name="post_format_chat">Chat</string>
+	<string name="post_format_gallery">Gallery</string>
+	<string name="post_format_image">Image</string>
+	<string name="post_format_link">Link</string>
+	<string name="post_format_quote">Quote</string>
+	<string name="post_format_standard">Standard</string>
+	<string name="notif_events">Information on WordPress.com courses and events (online &amp; in-person).</string>
+	<string name="post_format_aside">Aside</string>
+	<string name="post_format_audio">Audio</string>
+	<string name="notif_surveys">Opportunities to participate in WordPress.com research &amp; surveys.</string>
+	<string name="notif_tips">Tips for getting the most out of WordPress.com.</string>
+	<string name="notif_community">Community</string>
+	<string name="replies_to_my_comments">Replies to my comments</string>
+	<string name="notif_suggestions">Suggestions</string>
+	<string name="notif_research">Research</string>
+	<string name="site_achievements">Site achievements</string>
+	<string name="username_mentions">Username mentions</string>
+	<string name="likes_on_my_posts">Likes on my posts</string>
+	<string name="site_follows">Site follows</string>
+	<string name="likes_on_my_comments">Likes on my comments</string>
+	<string name="comments_on_my_site">Comments on my site</string>
+	<string name="site_settings_list_editor_summary_other">%d items</string>
+	<string name="site_settings_list_editor_summary_one">1 item</string>
+	<string name="approve_auto_if_previously_approved">Known users\' comments</string>
+	<string name="approve_auto">All users</string>
+	<string name="approve_manual">No comments</string>
+	<string name="site_settings_paging_summary_other">%d comments per page</string>
+	<string name="site_settings_paging_summary_one">1 comment per page</string>
+	<string name="site_settings_multiple_links_summary_other">Require approval for more than %d links</string>
+	<string name="site_settings_multiple_links_summary_one">Require approval for more than 1 link</string>
+	<string name="site_settings_multiple_links_summary_zero">Require approval for more than 0 links</string>
+	<string name="detail_approve_auto">Automatically approve everyone\'s comments.</string>
+	<string name="detail_approve_auto_if_previously_approved">Automatically approve if the user has a previously approved comment</string>
+	<string name="detail_approve_manual">Require manual approval for everyone\'s comments.</string>
+	<string name="filter_trashed_posts">Trashed</string>
+	<string name="days_quantity_one">1 day</string>
+	<string name="days_quantity_other">%d days</string>
+	<string name="filter_published_posts">Published</string>
+	<string name="filter_draft_posts">Drafts</string>
+	<string name="filter_scheduled_posts">Scheduled</string>
+	<string name="pending_email_change_snackbar">Click the verification link in the email sent to %1$s to confirm your new address</string>
+	<string name="primary_site">Primary site</string>
+	<string name="web_address">Web Address</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">Some media uploads have failed. Please retry them or delete them.</string>
+	<string name="editor_toast_uploading_please_wait">You are currently uploading media. Please wait until this completes.</string>
+	<string name="error_refresh_comments_showing_older">Comments couldn\'t be refreshed at this time - showing older comments</string>
+	<string name="editor_post_settings_set_featured_image">Set Featured Image</string>
+	<string name="editor_post_settings_featured_image">Featured Image</string>
+	<string name="new_editor_promo_desc">The WordPress app for Android now includes a beautiful new visual\n    editor. Try it out by creating a new post.</string>
+	<string name="new_editor_promo_title">Brand new editor</string>
+	<string name="new_editor_promo_button_label">Great, thanks!</string>
+	<string name="visual_editor_enabled">Visual Editor enabled</string>
+	<string name="editor_content_placeholder">Share your story here…</string>
+	<string name="editor_page_title_placeholder">Page Title</string>
+	<string name="editor_post_title_placeholder">Post Title</string>
+	<string name="email_address">Email address</string>
+	<string name="preference_show_visual_editor">Show visual editor</string>
+	<string name="dlg_sure_to_delete_comments">Permanently delete these comments?</string>
+	<string name="preference_editor">Editor</string>
+	<string name="dlg_sure_to_delete_comment">Permanently delete this comment?</string>
+	<string name="mnu_comment_delete_permanently">Delete</string>
+	<string name="comment_deleted_permanently">Comment deleted</string>
+	<string name="mnu_comment_untrash">Restore</string>
+	<string name="comments_empty_list_filtered">No %s comments</string>
+	<string name="could_not_load_page">Could not load page</string>
+	<string name="comment_status_all">All</string>
+	<string name="interface_language">Interface Language</string>
+	<string name="off">Off</string>
+	<string name="about_the_app">About the app</string>
+	<string name="error_post_account_settings">Couldn\'t save your account settings</string>
 	<string name="error_post_my_profile">Couldn\'t save your profile</string>
 	<string name="error_fetch_account_settings">Couldn\'t retrieve your account settings</string>
 	<string name="error_fetch_my_profile">Couldn\'t retrieve your profile</string>
@@ -15,6 +94,9 @@
 	<string name="add_category">Add category</string>
 	<string name="disabled">Disabled</string>
 	<string name="site_settings_image_original_size">Original Size</string>
+	<string name="privacy_private">Your site is visible only to you and users you approve</string>
+	<string name="privacy_public_not_indexed">Your site is visible to everyone but asks search engines not to index it</string>
+	<string name="privacy_public">Your site is visible to everyone and may be indexed by search engines</string>
 	<string name="about_me_hint">A few words about you…</string>
 	<string name="public_display_name_hint">Display name will default to your username if it is not set</string>
 	<string name="about_me">About me</string>
@@ -487,11 +569,9 @@
 	<string name="hs__invalid_email_error">Enter a valid email address</string>
 	<string name="add_location">Add location</string>
 	<string name="current_location">Current location</string>
-	<string name="your_signature">Your signature:</string>
 	<string name="search_location">Search</string>
 	<string name="edit_location">Edit</string>
 	<string name="search_current_location">Locate</string>
-	<string name="preference_privacy">Privacy</string>
 	<string name="preference_send_usage_stats">Send statistics</string>
 	<string name="preference_send_usage_stats_summary">Automatically send usage statistics to help us improve WordPress for Android</string>
 	<string name="update_verb">Update</string>
@@ -535,12 +615,9 @@
 	<string name="cat_name_required">The category name field is required</string>
 	<string name="category_automatically_renamed">Category name %1$s isn\'t valid. It has been renamed to %2$s.</string>
 	<string name="no_account">No WordPress account found, add an account and try again</string>
-	<string name="auto_sharing_preference_reset">Auto-sharing settings reset</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Previously selected blog is no longer visible</string>
 	<string name="sdcard_message">A mounted SD card is required to upload media</string>
 	<string name="stats_empty_comments">No comments yet</string>
 	<string name="stats_bar_graph_empty">No stats available</string>
-	<string name="invalid_url_message">Check that the blog URL entered is valid</string>
 	<string name="reply_failed">Reply failed</string>
 	<string name="notifications_empty_list">No notifications</string>
 	<string name="error_delete_post">An error occurred while deleting the %s</string>
@@ -583,6 +660,7 @@
 	<string name="blog_name_reserved_but_may_be_available">That site is currently reserved but may be available in a couple days</string>
 	<string name="username_or_password_incorrect">The username or password you entered is incorrect</string>
 	<string name="nux_cannot_log_in">We can\'t log you in</string>
+	<string name="invalid_url_message">Check that the URL entered is valid</string>
 	<string name="author_name">Author name</string>
 	<string name="author_email">Author email</string>
 	<string name="author_url">Author URL</string>
@@ -686,6 +764,7 @@
 	<string name="trash_yes">Trash</string>
 	<string name="trash_no">Don\'t trash</string>
 	<string name="trash">Trash</string>
+	<string name="invalid_site_url_message">Check that the site URL entered is valid</string>
 	<string name="deleting_page">Deleting page</string>
 	<string name="deleting_post">Deleting post</string>
 	<string name="share_url_post">Share post</string>
@@ -703,9 +782,6 @@
 	<string name="download">Downloading media</string>
 	<string name="comment_spammed">Comment marked as spam</string>
 	<string name="cant_share_no_visible_blog">You can\'t share to WordPress without a visible blog</string>
-	<string name="share_preference_title">Share to WordPress</string>
-	<string name="reset_auto_share_preference">Reset auto-sharing settings</string>
-	<string name="always_use_these_settings_to_share">Always use these settings</string>
 	<string name="select_time">Select time</string>
 	<string name="reader_likes_you_and_one">You and one other like this</string>
 	<string name="reader_empty_followed_blogs_description">But don\'t worry, just tap the icon at the top right to start exploring!</string>
@@ -766,8 +842,6 @@
 	<string name="media_gallery_type_tiled">Tiled</string>
 	<string name="media_gallery_type_circles">Circles</string>
 	<string name="media_gallery_type_slideshow">Slideshow</string>
-	<string name="media_no_video_title">VideoPress unavailable</string>
-	<string name="media_no_video_message">Get the VideoPress upgrade to upload video!</string>
 	<string name="media_edit_title_text">Title</string>
 	<string name="media_edit_caption_text">Caption</string>
 	<string name="media_edit_description_text">Description</string>
@@ -819,8 +893,6 @@
 	<string name="new_notifications">%d new notifications</string>
 	<string name="more_notifications">and %d more.</string>
 	<string name="loading">Loading…</string>
-	<string name="post_signature">Post signature</string>
-	<string name="add_tagline">Add a signature to new posts</string>
 	<string name="httpuser">HTTP username</string>
 	<string name="httppassword">HTTP password</string>
 	<string name="error_media_upload">An error occurred while uploading media</string>
@@ -847,11 +919,9 @@
 	<string name="scaled_image">Scaled image width</string>
 	<string name="scheduled">Scheduled</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Posted from WordPress for Android</string>
 	<string name="version">Version</string>
 	<string name="tos">Terms of Service</string>
 	<string name="app_title">WordPress for Android</string>
-	<string name="about">About</string>
 	<string name="max_thumbnail_px_width">Default Image Width</string>
 	<string name="image_alignment">Alignment</string>
 	<string name="refresh">Refresh</string>
@@ -873,6 +943,7 @@
 	<string name="title">Title</string>
 	<string name="tags_separate_with_commas">Tags (separate tags with commas)</string>
 	<string name="categories">Categories</string>
+	<string name="dlg_deleting_comments">Deleting comments</string>
 	<string name="notification_blink">Blink notification light</string>
 	<string name="notification_sound">Play notification sound</string>
 	<string name="notification_vibrate">Vibrate</string>
@@ -896,70 +967,4 @@
 	<string name="notification_settings">Notification Settings</string>
 	<string name="yes">Yes</string>
 	<string name="no">No</string>
-	<string-array name="alignment_array">
-		<item>None</item>
-		<item>Left</item>
-		<item>Center</item>
-		<item>Right</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Comments on my site</item>
-		<item>Likes on my comments</item>
-		<item>Likes on my posts</item>
-		<item>Site follows</item>
-		<item>Site achievements</item>
-		<item>Username mentions</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Replies to my comments</item>
-		<item>Likes on my comments</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Suggestions</item>
-		<item>Research</item>
-		<item>Community</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Tips for getting the most out of WordPress.com.</item>
-		<item>Opportunities to participate in WordPress.com research &amp; surveys.</item>
-		<item>Information on WordPress.com courses and events (online &amp; in-person).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Published</item>
-		<item>Drafts</item>
-		<item>Scheduled</item>
-		<item>Trashed</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Aside</item>
-		<item>Audio</item>
-		<item>Chat</item>
-		<item>Gallery</item>
-		<item>Image</item>
-		<item>Link</item>
-		<item>Quote</item>
-		<item>Standard</item>
-		<item>Status</item>
-		<item>Video</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Your site is visible to everyone and may be indexed by search engines</item>
-		<item>Your site is visible to everyone but asks search engines not to index it</item>
-		<item>Your site is visible only to you and users you approve</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>Require manual approval for everyone\'s comments.</item>
-		<item>Automatically approve if the user has a previously approved comment.</item>
-		<item>Automatically approve everyone\'s comments.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>No comments</item>
-		<item>Known users\' comments</item>
-		<item>All users</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Free</item>
-		<item>All</item>
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -1,6 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">Couldn\'t save your account settings</string>
+	<string name="post_format_status">Status</string>
+	<string name="post_format_video">Video</string>
+	<string name="align_none">None</string>
+	<string name="align_left">Left</string>
+	<string name="align_center">Centre</string>
+	<string name="align_right">Right</string>
+	<string name="theme_free">Free</string>
+	<string name="theme_all">All</string>
+	<string name="theme_premium">Premium</string>
+	<string name="post_format_chat">Chat</string>
+	<string name="post_format_gallery">Gallery</string>
+	<string name="post_format_image">Image</string>
+	<string name="post_format_link">Link</string>
+	<string name="post_format_quote">Quote</string>
+	<string name="post_format_standard">Standard</string>
+	<string name="notif_events">Information on WordPress.com courses and events (online &amp; in-person).</string>
+	<string name="post_format_aside">Aside</string>
+	<string name="post_format_audio">Audio</string>
+	<string name="notif_surveys">Opportunities to participate in WordPress.com research &amp; surveys.</string>
+	<string name="notif_tips">Tips for getting the most out of WordPress.com.</string>
+	<string name="notif_community">Community</string>
+	<string name="replies_to_my_comments">Replies to my comments</string>
+	<string name="notif_suggestions">Suggestions</string>
+	<string name="notif_research">Research</string>
+	<string name="site_achievements">Site achievements</string>
+	<string name="username_mentions">Username mentions</string>
+	<string name="likes_on_my_posts">Likes on my posts</string>
+	<string name="site_follows">Site follows</string>
+	<string name="likes_on_my_comments">Likes on my comments</string>
+	<string name="comments_on_my_site">Comments on my site</string>
+	<string name="site_settings_list_editor_summary_other">%d items</string>
+	<string name="site_settings_list_editor_summary_one">1 item</string>
+	<string name="approve_auto_if_previously_approved">Known users\' comments</string>
+	<string name="approve_auto">All users</string>
+	<string name="approve_manual">No comments</string>
+	<string name="site_settings_paging_summary_other">%d comments per page</string>
+	<string name="site_settings_paging_summary_one">1 comment per page</string>
+	<string name="site_settings_multiple_links_summary_other">Require approval for more than %d links</string>
+	<string name="site_settings_multiple_links_summary_one">Require approval for more than 1 link</string>
+	<string name="site_settings_multiple_links_summary_zero">Require approval for more than 0 links</string>
+	<string name="detail_approve_auto">Automatically approve everyone\'s comments.</string>
+	<string name="detail_approve_auto_if_previously_approved">Automatically approve if the user has a previously approved comment</string>
+	<string name="detail_approve_manual">Require manual approval for everyone\'s comments.</string>
+	<string name="filter_trashed_posts">Binned</string>
+	<string name="days_quantity_one">1 day</string>
+	<string name="days_quantity_other">%d days</string>
+	<string name="filter_published_posts">Published</string>
+	<string name="filter_draft_posts">Drafts</string>
+	<string name="filter_scheduled_posts">Scheduled</string>
+	<string name="pending_email_change_snackbar">Click the verification link in the email sent to %1$s to confirm your new address</string>
+	<string name="primary_site">Primary site</string>
+	<string name="web_address">Web Address</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">Some media uploads have failed. Please retry them or delete them.</string>
+	<string name="editor_toast_uploading_please_wait">You are currently uploading media. Please wait until this completes.</string>
+	<string name="error_refresh_comments_showing_older">Comments couldn\'t be refreshed at this time - showing older comments</string>
+	<string name="editor_post_settings_set_featured_image">Set Featured Image</string>
+	<string name="editor_post_settings_featured_image">Featured Image</string>
+	<string name="new_editor_promo_desc">The WordPress app for Android now includes a beautiful new visual\n    editor. Try it out by creating a new post.</string>
+	<string name="new_editor_promo_title">Brand new editor</string>
+	<string name="new_editor_promo_button_label">Great, thanks!</string>
+	<string name="visual_editor_enabled">Visual Editor enabled</string>
+	<string name="editor_content_placeholder">Share your story here…</string>
+	<string name="editor_page_title_placeholder">Page Title</string>
+	<string name="editor_post_title_placeholder">Post Title</string>
+	<string name="email_address">Email address</string>
+	<string name="preference_show_visual_editor">Show visual editor</string>
+	<string name="dlg_sure_to_delete_comments">Permanently delete these comments?</string>
+	<string name="preference_editor">Editor</string>
+	<string name="dlg_sure_to_delete_comment">Permanently delete this comment?</string>
+	<string name="mnu_comment_delete_permanently">Delete</string>
+	<string name="comment_deleted_permanently">Comment deleted</string>
+	<string name="mnu_comment_untrash">Restore</string>
+	<string name="comments_empty_list_filtered">No %s comments</string>
+	<string name="could_not_load_page">Could not load page</string>
+	<string name="comment_status_all">All</string>
+	<string name="interface_language">Interface Language</string>
+	<string name="off">Off</string>
+	<string name="about_the_app">About the app</string>
+	<string name="error_post_account_settings">Couldn\'t save your account settings</string>
 	<string name="error_post_my_profile">Couldn\'t save your profile</string>
 	<string name="error_fetch_account_settings">Couldn\'t retrieve your account settings</string>
 	<string name="error_fetch_my_profile">Couldn\'t retrieve your profile</string>
@@ -15,6 +94,9 @@
 	<string name="remove">Remove</string>
 	<string name="search">Search</string>
 	<string name="site_settings_image_original_size">Original Size</string>
+	<string name="privacy_private">Your site is visible only to you and users you approve</string>
+	<string name="privacy_public_not_indexed">Your site is visible to everyone but asks search engines not to index it</string>
+	<string name="privacy_public">Your site is visible to everyone and may be indexed by search engines</string>
 	<string name="about_me_hint">A few words about you…</string>
 	<string name="about_me">About me</string>
 	<string name="public_display_name_hint">Display name will default to your username if it is not set</string>
@@ -487,11 +569,9 @@
 	<string name="contact_us">Contact us</string>
 	<string name="current_location">Current location</string>
 	<string name="add_location">Add location</string>
-	<string name="your_signature">Your signature:</string>
 	<string name="search_location">Search</string>
 	<string name="edit_location">Edit</string>
 	<string name="search_current_location">Locate</string>
-	<string name="preference_privacy">Privacy</string>
 	<string name="preference_send_usage_stats">Send statistics</string>
 	<string name="preference_send_usage_stats_summary">Automatically send usage statistics to help us improve WordPress for Android</string>
 	<string name="update_verb">Update</string>
@@ -533,12 +613,9 @@
 	<string name="cat_name_required">The category name field is required</string>
 	<string name="category_automatically_renamed">Category name %1$s isn\'t valid. It has been renamed to %2$s.</string>
 	<string name="no_account">No WordPress account found, add an account and try again</string>
-	<string name="auto_sharing_preference_reset">Auto-sharing settings reset</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Previously selected blog is no longer visible</string>
 	<string name="sdcard_message">A mounted SD card is required to upload media</string>
 	<string name="stats_empty_comments">No comments yet</string>
 	<string name="stats_bar_graph_empty">No stats available</string>
-	<string name="invalid_url_message">Check that the blog URL entered is valid</string>
 	<string name="reply_failed">Reply failed</string>
 	<string name="notifications_empty_list">No notifications</string>
 	<string name="error_delete_post">An error occurred while deleting the %s</string>
@@ -583,6 +660,7 @@
 	<string name="nux_cannot_log_in">We can\'t log you in</string>
 	<string name="out_of_memory">Device out of memory</string>
 	<string name="could_not_remove_account">Couldn\'t remove site</string>
+	<string name="invalid_url_message">Check that the URL entered is valid</string>
 	<string name="xmlrpc_error">Couldn\'t connect. Enter the full path to xmlrpc.php on your site and try again.</string>
 	<string name="select_categories">Select categories</string>
 	<string name="account_details">Account details</string>
@@ -686,6 +764,7 @@
 	<string name="http_authorization_required">Authorisation required</string>
 	<string name="mnu_comment_trash">Bin</string>
 	<string name="comment_status_trash">Binned</string>
+	<string name="invalid_site_url_message">Check that the site URL entered is valid</string>
 	<string name="deleting_page">Deleting page</string>
 	<string name="deleting_post">Deleting post</string>
 	<string name="share_url_post">Share post</string>
@@ -702,9 +781,6 @@
 	<string name="video">Video</string>
 	<string name="download">Downloading media</string>
 	<string name="cant_share_no_visible_blog">You can\'t share to WordPress without a visible blog</string>
-	<string name="share_preference_title">Share to WordPress</string>
-	<string name="reset_auto_share_preference">Reset auto-sharing settings</string>
-	<string name="always_use_these_settings_to_share">Always use these settings</string>
 	<string name="comment_spammed">Comment marked as spam</string>
 	<string name="select_time">Select time</string>
 	<string name="reader_likes_you_and_one">You and one other like this</string>
@@ -772,8 +848,6 @@
 	<string name="media_gallery_type_tiled">Tiled</string>
 	<string name="media_gallery_type_circles">Circles</string>
 	<string name="media_gallery_type_slideshow">Slideshow</string>
-	<string name="media_no_video_title">VideoPress unavailable</string>
-	<string name="media_no_video_message">Get the VideoPress upgrade to upload video!</string>
 	<string name="stats_view_clicks">Clicks</string>
 	<string name="stats_view_referrers">Referrers</string>
 	<string name="stats_timeframe_today">Today</string>
@@ -819,8 +893,6 @@
 	<string name="more_notifications">and %d more.</string>
 	<string name="follows">Follows</string>
 	<string name="loading">Loading…</string>
-	<string name="post_signature">Post signature</string>
-	<string name="add_tagline">Add a signature to new posts</string>
 	<string name="httpuser">HTTP username</string>
 	<string name="httppassword">HTTP password</string>
 	<string name="error_media_upload">An error occurred while uploading media</string>
@@ -847,11 +919,9 @@
 	<string name="scaled_image">Scaled image width</string>
 	<string name="scheduled">Scheduled</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Posted from WordPress for Android</string>
 	<string name="version">Version</string>
 	<string name="tos">Terms of Service</string>
 	<string name="app_title">WordPress for Android</string>
-	<string name="about">About</string>
 	<string name="max_thumbnail_px_width">Default Image Width</string>
 	<string name="image_alignment">Alignment</string>
 	<string name="refresh">Refresh</string>
@@ -873,6 +943,7 @@
 	<string name="title">Title</string>
 	<string name="tags_separate_with_commas">Tags (separate tags with commas)</string>
 	<string name="categories">Categories</string>
+	<string name="dlg_deleting_comments">Deleting comments</string>
 	<string name="notification_blink">Blink notification light</string>
 	<string name="notification_sound">Play notification sound</string>
 	<string name="notification_vibrate">Vibrate</string>
@@ -896,70 +967,4 @@
 	<string name="yes">Yes</string>
 	<string name="no">No</string>
 	<string name="notification_settings">Notification Settings</string>
-	<string-array name="alignment_array">
-		<item>None</item>
-		<item>Left</item>
-		<item>Center</item>
-		<item>Right</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Comments on my site</item>
-		<item>Likes on my comments</item>
-		<item>Likes on my posts</item>
-		<item>Site follows</item>
-		<item>Site achievements</item>
-		<item>Username mentions</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Replies to my comments</item>
-		<item>Likes on my comments</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Suggestions</item>
-		<item>Research</item>
-		<item>Community</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Tips for getting the most out of WordPress.com.</item>
-		<item>Opportunities to participate in WordPress.com research &amp; surveys.</item>
-		<item>Information on WordPress.com courses and events (online &amp; in-person).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Published</item>
-		<item>Drafts</item>
-		<item>Scheduled</item>
-		<item>Binned</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Aside</item>
-		<item>Audio</item>
-		<item>Chat</item>
-		<item>Gallery</item>
-		<item>Image</item>
-		<item>Link</item>
-		<item>Quote</item>
-		<item>Standard</item>
-		<item>Status</item>
-		<item>Video</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Your site is visible to everyone and may be indexed by search engines</item>
-		<item>Your site is visible to everyone but asks search engines not to index it</item>
-		<item>Your site is visible only to you and users you approve</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>Require manual approval for everyone\'s comments.</item>
-		<item>Automatically approve if the user has a previously approved comment.</item>
-		<item>Automatically approve everyone\'s comments.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>No comments</item>
-		<item>Known users\' comments</item>
-		<item>All users</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Free</item>
-		<item>All</item>
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-es-rCL/strings.xml
+++ b/WordPress/src/main/res/values-es-rCL/strings.xml
@@ -293,11 +293,9 @@
 	<string name="hs__invalid_email_error">Escribe una dirección de correo electrónico válida</string>
 	<string name="add_location">Añadir localización</string>
 	<string name="current_location">Localización actual</string>
-	<string name="your_signature">Tu firma:</string>
 	<string name="search_location">Búsqueda</string>
 	<string name="edit_location">Editar</string>
 	<string name="search_current_location">Localizar</string>
-	<string name="preference_privacy">Privacidad</string>
 	<string name="preference_send_usage_stats">Enviar estadísticas</string>
 	<string name="preference_send_usage_stats_summary">Enviar automáticamente estadísticas de uso para ayudarnos a mejorar WordPress para Android</string>
 	<string name="update_verb">Actualizar</string>
@@ -337,12 +335,9 @@
 	<string name="adding_cat_success">Categoría agregada correctamente.</string>
 	<string name="cat_name_required">El campo nombre de categoría es necesario</string>
 	<string name="category_automatically_renamed">El nombre de categoría %1$s no es válido. Fue renombrado a %2$s.</string>
-	<string name="auto_sharing_preference_reset">Restablecer la configuración para compartir de forma automática</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">El blog seleccionado anteriormente ya no está visible</string>
 	<string name="sdcard_message">Se necesita una tarjeta SD montada para subir medios</string>
 	<string name="stats_empty_comments">Aún sin comentarios</string>
 	<string name="stats_bar_graph_empty">Estadísticas no disponibles.</string>
-	<string name="invalid_url_message">Comprueba que la URL del blog que has puesto es válida</string>
 	<string name="reply_failed">Respuesta fallida</string>
 	<string name="notifications_empty_list">Sin notificaciones</string>
 	<string name="error_delete_post">Ocurrió un error al eliminar el %s</string>
@@ -507,9 +502,6 @@
 	<string name="video">Vídeo</string>
 	<string name="download">Descargando elemento multimedia</string>
 	<string name="comment_spammed">Comentado marcado como spam</string>
-	<string name="share_preference_title">Compartir en WordPress</string>
-	<string name="reset_auto_share_preference">Reiniciar los ajustes de compartir automaticamente</string>
-	<string name="always_use_these_settings_to_share">Utiliza siempre estos ajustes</string>
 	<string name="cant_share_no_visible_blog">No puedes compartir en WordPress sin un blog visible</string>
 	<string name="reader_empty_followed_blogs_description">No te preocupes, ¡solo tienes que pulsar el icono para empezar a explorar!</string>
 	<string name="select_date">Elegir fecha</string>
@@ -567,7 +559,6 @@
 	<string name="media_gallery_type_tiled">Mosaico</string>
 	<string name="media_gallery_type_circles">Círculos</string>
 	<string name="media_gallery_type_slideshow">Pase de diapositivas </string>
-	<string name="media_no_video_title">VideoPress no disponible</string>
 	<string name="media_edit_title_text">Título</string>
 	<string name="media_edit_caption_text">Leyenda</string>
 	<string name="media_edit_description_text">Descripción</string>
@@ -613,7 +604,6 @@
 	<string name="custom_date">Fecha Personalizada</string>
 	<string name="media_add_popup_capture_photo">Tomar Foto</string>
 	<string name="media_add_popup_capture_video">Capturar Vídeo</string>
-	<string name="media_no_video_message">¡Actualiza VideoPress para subir videos!</string>
 	<string name="stats_view_visitors_and_views">Visitantes y Visualizaciones</string>
 	<string name="passcode_enter_old_passcode">Introduce tu PIN anterior</string>
 	<string name="upload">Subir</string>
@@ -623,8 +613,6 @@
 	<string name="new_notifications">%d nuevas notificaciones</string>
 	<string name="more_notifications">y %d más.</string>
 	<string name="loading">Cargando...</string>
-	<string name="post_signature">Firma de la entrada</string>
-	<string name="add_tagline">Añadir firma a las nuevas entradas</string>
 	<string name="httpuser">Usuario HTTP</string>
 	<string name="httppassword">Contraseña HTTP</string>
 	<string name="error_media_upload">Se ha producido un error al cargar los archivos</string>
@@ -651,11 +639,9 @@
 	<string name="scaled_image">Ancho de la imagen en escala</string>
 	<string name="scheduled">Programado</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Publicado desde WordPress para Android</string>
 	<string name="version">Versión</string>
 	<string name="app_title">WordPress para Android</string>
 	<string name="tos">Términos de Servicio</string>
-	<string name="about">Acerca de</string>
 	<string name="image_alignment">Alineamiento</string>
 	<string name="refresh">Refrescar</string>
 	<string name="untitled">Sin Título</string>
@@ -699,50 +685,4 @@
 	<string name="notification_settings">Ajustes de avisos</string>
 	<string name="yes">Sí</string>
 	<string name="no">No</string>
-	<string-array name="alignment_array">
-		<item>Ninguno</item>
-		<item>Izquierda</item>
-		<item>Centro</item>
-		<item>Derecha</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Comentarios en mi sitio</item>
-		<item>"Me gusta" en mis comentarios</item>
-		<item>"Me gusta" en mis entradas</item>
-		<item>Seguidores del sitio</item>
-		<item>Logros del sitio</item>
-		<item>Menciones del usuario</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Respuestas a mis comentarios</item>
-		<item>"Me gusta" en mis comentarios</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Sugerencias</item>
-		<item>Investigación</item>
-		<item>Comunidad</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Consejos para sacar el máximo provecho de WordPress.com</item>
-		<item>Oportunidades para participar en investigaciones y encuestas de WordPress.com.</item>
-		<item>Información sobre cursos y eventos de WordPress.com (online y presenciales).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Publicados</item>
-		<item>Borradores</item>
-		<item>Programados</item>
-		<item>En la papelera</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Minientrada</item>
-		<item>Audio</item>
-		<item>Chat</item>
-		<item>Galería</item>
-		<item>Imagen</item>
-		<item>Enlace</item>
-		<item>Cita</item>
-		<item>Estándar</item>
-		<item>Estado</item>
-		<item>Vídeo</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -1,6 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">No se pudieron guardar los ajustes de la cuenta</string>
+	<string name="post_format_status">Estado</string>
+	<string name="post_format_video">Video</string>
+	<string name="align_none">Ninguno</string>
+	<string name="align_left">Izquierda</string>
+	<string name="align_center">Centrado</string>
+	<string name="align_right">Derecha</string>
+	<string name="theme_all">Todo</string>
+	<string name="theme_premium">Premium</string>
+	<string name="theme_free">Gratis</string>
+	<string name="post_format_chat">Chat</string>
+	<string name="post_format_gallery">Galería</string>
+	<string name="post_format_image">Imagen</string>
+	<string name="post_format_link">Enlace</string>
+	<string name="post_format_quote">Cita</string>
+	<string name="post_format_standard">Estándar</string>
+	<string name="notif_events">Información sobre cursos y eventos de WordPress.com (online y presenciales).</string>
+	<string name="post_format_audio">Audio</string>
+	<string name="post_format_aside">Minientrada</string>
+	<string name="notif_surveys">Oportunidades para participar en investigaciones y encuestas en WordPress.</string>
+	<string name="notif_tips">Consejos para sacar el máximo partido a WordPress.com</string>
+	<string name="notif_community">Comunidad</string>
+	<string name="replies_to_my_comments">Respuestas a mis comentarios</string>
+	<string name="notif_suggestions">Sugerencias</string>
+	<string name="notif_research">Investigación</string>
+	<string name="site_achievements">Logros del sitio</string>
+	<string name="username_mentions">Menciones del nombre de usuario</string>
+	<string name="likes_on_my_posts">"Me gusta" en mis entradas</string>
+	<string name="site_follows">Seguidores del sitio</string>
+	<string name="likes_on_my_comments">"Me gusta" en mis comentarios</string>
+	<string name="comments_on_my_site">Comentarios en mi sitio</string>
+	<string name="site_settings_list_editor_summary_other">%d elementos</string>
+	<string name="site_settings_list_editor_summary_one">1 elemento</string>
+	<string name="approve_auto_if_previously_approved">Comentarios de usuarios conocidos</string>
+	<string name="approve_auto">Todos los usuarios</string>
+	<string name="approve_manual">Sin comentarios</string>
+	<string name="site_settings_paging_summary_other">%d comentarios por página</string>
+	<string name="site_settings_paging_summary_one">1 comentario por página</string>
+	<string name="site_settings_multiple_links_summary_other">Se necesita aprobación para más de %d enlaces</string>
+	<string name="site_settings_multiple_links_summary_one">Se necesita aprobación para más de 1 enlace</string>
+	<string name="site_settings_multiple_links_summary_zero">Se requiere aprobación para más de 0 enlaces</string>
+	<string name="detail_approve_auto">Aprobar automáticamente los comentarios de todo el mundo.</string>
+	<string name="detail_approve_auto_if_previously_approved">Aprobar automáticamente si el usuario tiene un comentario previamente aprobado</string>
+	<string name="detail_approve_manual">Se requiere aprobación manual de los comentarios de todos.</string>
+	<string name="days_quantity_one">1 día</string>
+	<string name="days_quantity_other">%d días</string>
+	<string name="filter_trashed_posts">En la papelera</string>
+	<string name="filter_published_posts">Publicados</string>
+	<string name="filter_draft_posts">Borradores</string>
+	<string name="filter_scheduled_posts">Planificados</string>
+	<string name="primary_site">Sitio principal</string>
+	<string name="web_address">Dirección web</string>
+	<string name="pending_email_change_snackbar">Haz click en el enlace de verificación del correo electrónica enviado a %1$s para confirmar tu nueva dirección</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">Algunas subidas de archivos multimedia han fallado. Por favor, inténtelo de nuevo o bórrelos.</string>
+	<string name="editor_toast_uploading_please_wait">Actualmente estás subiendo archivos multimedia. Por favor, espera hasta que se complete.</string>
+	<string name="error_refresh_comments_showing_older">No se pudieron actualizar los comentarios ahora mismo - se muestran comentarios antiguos</string>
+	<string name="editor_post_settings_set_featured_image">Fijar la imagen destacada</string>
+	<string name="editor_post_settings_featured_image">Imagen destacada</string>
+	<string name="new_editor_promo_desc">La app de WordPress para Android ahora incluye un nuevo editor visual\nPruébalo creando una nueva entrada.</string>
+	<string name="new_editor_promo_title">El nuevo editor</string>
+	<string name="new_editor_promo_button_label">¡Genial, gracias!</string>
+	<string name="visual_editor_enabled">Editor visual activado</string>
+	<string name="editor_content_placeholder">Comparte tu historia aquí...</string>
+	<string name="editor_page_title_placeholder">Título página</string>
+	<string name="editor_post_title_placeholder">Título entrada</string>
+	<string name="email_address">Correo electrónico</string>
+	<string name="preference_show_visual_editor">Mostrar editor visual</string>
+	<string name="dlg_sure_to_delete_comments">¿Eliminar de forma permanente estos comentarios?</string>
+	<string name="preference_editor">Editor</string>
+	<string name="dlg_sure_to_delete_comment">¿Eliminar de forma permanente este comentario?</string>
+	<string name="mnu_comment_delete_permanently">Eliminar</string>
+	<string name="comment_deleted_permanently">Comentario eliminado</string>
+	<string name="mnu_comment_untrash">Restaurar</string>
+	<string name="comments_empty_list_filtered">Sin %s comentarios</string>
+	<string name="could_not_load_page">No se pudo cargar la página</string>
+	<string name="comment_status_all">Todos</string>
+	<string name="interface_language">Idioma del interface</string>
+	<string name="off">Off</string>
+	<string name="about_the_app">Sobre la app</string>
+	<string name="error_post_account_settings">No se pudieron guardar los ajustes de la cuenta</string>
 	<string name="error_post_my_profile">No se pudo guardar tu perfil</string>
 	<string name="error_fetch_account_settings">No se pudieron recuperar los ajustes de la cuenta</string>
 	<string name="error_fetch_my_profile">No se pudo obtener tu perfil</string>
@@ -15,6 +94,9 @@
 	<string name="search">Buscar</string>
 	<string name="add_category">Añadir categoría</string>
 	<string name="site_settings_image_original_size">Tamaño original</string>
+	<string name="privacy_private">Tu sitio es visible únicamente por ti y por lo usuarios que apruebes</string>
+	<string name="privacy_public_not_indexed">Tu sitio es visible para todos pero pide a los motores de búsqueda no ser indexado</string>
+	<string name="privacy_public">Tu sitio es visible para todos y puede ser indexado por motores de búsqueda</string>
 	<string name="about_me_hint">Algunas palabras sobre ti...</string>
 	<string name="about_me">Sobre mí</string>
 	<string name="public_display_name_hint">El nombre público mostrará por defecto el nombre de usuario si no está establecido</string>
@@ -487,11 +569,9 @@
 	<string name="hs__invalid_email_error">Escribe una dirección de correo electrónico válida</string>
 	<string name="add_location">Añadir localización</string>
 	<string name="current_location">Localización actual</string>
-	<string name="your_signature">Tu firma:</string>
 	<string name="search_location">Búsqueda</string>
 	<string name="edit_location">Editar</string>
 	<string name="search_current_location">Localizar</string>
-	<string name="preference_privacy">Privacidad</string>
 	<string name="preference_send_usage_stats">Enviar estadísticas</string>
 	<string name="preference_send_usage_stats_summary">Enviar automáticamente estadísticas de uso para ayudarnos a mejorar WordPress para Android</string>
 	<string name="update_verb">Actualizar</string>
@@ -576,13 +656,11 @@
 	<string name="reply_failed">Respuesta fallida</string>
 	<string name="error_refresh_comments">No se pudieron actualizar los comentarios</string>
 	<string name="error_refresh_stats">No se pudieron actualizar las estadísticas</string>
-	<string name="invalid_url_message">Comprueba que la URL del blog que has puesto es válida</string>
 	<string name="could_not_remove_account">No se ha podido eliminar el sitio</string>
-	<string name="auto_sharing_preference_reset">Restablecer la configuración para compartir de forma automática</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">El blog seleccionado anteriormente ya no está visible</string>
 	<string name="blog_name_only_lowercase_letters_and_numbers">La dirección solo puede contener letras minúsculas (a-z) y números.</string>
 	<string name="blog_name_reserved_but_may_be_available">Este sitio está reservado actualmente pero es posible que quede libre en un par de días.</string>
 	<string name="nux_cannot_log_in">No se pudo acceder</string>
+	<string name="invalid_url_message">Comprueba que la URL introducida sea válida</string>
 	<string name="edit_post">Editar entrada</string>
 	<string name="add_comment">Añadir comentario</string>
 	<string name="connection_error">Error de conexión</string>
@@ -686,6 +764,7 @@
 	<string name="email_reserved">Esta dirección de correo electrónico ya se ha utilizado. Comprueba si tienes en tu bandeja de entrada un correo de activación. Si no activas ahora el correo, puedes intentarlo dentro de unos días.</string>
 	<string name="notifications_empty_all">No hay notificaciones... todavía.</string>
 	<string name="reader_toast_err_remove_tag">No se pudo eliminar esta etiqueta</string>
+	<string name="invalid_site_url_message">Comprueba que la URL del sitio introducida es válida</string>
 	<string name="deleting_post">Borrando entrada</string>
 	<string name="share_url_post">Compartir entrada</string>
 	<string name="share_url_page">Compartir página</string>
@@ -702,9 +781,6 @@
 	<string name="download">Descargando elemento multimedia</string>
 	<string name="comment_spammed">Comentado marcado como spam</string>
 	<string name="cant_share_no_visible_blog">No se puede compartir en WordPress si no tienes un blog visible</string>
-	<string name="share_preference_title">Compartir en WordPress</string>
-	<string name="reset_auto_share_preference">Reiniciar los ajustes de compartir automaticamente</string>
-	<string name="always_use_these_settings_to_share">Utiliza siempre estos ajustes</string>
 	<string name="reader_toast_err_get_comment">No ha sido posible cargar este comentario</string>
 	<string name="reader_likes_you_and_one">A ti y a otra persona os gusta esto.</string>
 	<string name="select_date">Elegir fecha</string>
@@ -759,7 +835,6 @@
 	<string name="media_add_popup_capture_photo">Tomar foto</string>
 	<string name="media_add_popup_capture_video">Tomar vídeo</string>
 	<string name="media_gallery_type">Tipo</string>
-	<string name="media_no_video_title">VideoPress no disponible</string>
 	<string name="stats_view_tags_and_categories">Etiquetas y categorías</string>
 	<string name="stats_timeframe_today">Hoy</string>
 	<string name="stats_timeframe_yesterday">Ayer</string>
@@ -797,7 +872,6 @@
 	<string name="media_gallery_type_slideshow">Pase de diapositivas </string>
 	<string name="media_gallery_type_tiled">Mosaico</string>
 	<string name="media_gallery_type_circles">Círculos</string>
-	<string name="media_no_video_message">Necesitas comprar VideoPress para subir videos</string>
 	<string name="stats_view_visitors_and_views">Visitantes y Vistas</string>
 	<string name="theme_set_success">¡Tema aplicado con exito!</string>
 	<string name="theme_auth_error_title">Error al recibir temas</string>
@@ -821,8 +895,6 @@
 	<string name="loading">Cargando...</string>
 	<string name="httpuser">Usuario HTTP</string>
 	<string name="httppassword">Contraseña HTTP</string>
-	<string name="post_signature">Firma de la entrada</string>
-	<string name="add_tagline">Añadir firma a las nuevas entradas</string>
 	<string name="error_media_upload">Se ha producido un error al cargar los archivos</string>
 	<string name="publish_date">Publicar</string>
 	<string name="content_description_add_media">Añadir media</string>
@@ -847,11 +919,10 @@
 	<string name="scaled_image">Ancho de la imagen en escala</string>
 	<string name="scheduled">Programado</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Publicado desde WordPress para Android</string>
 	<string name="app_title">WordPress para Android</string>
 	<string name="version">Versión</string>
 	<string name="tos">Términos del servicio</string>
-	<string name="about">Acerca de</string>
+	<string name="max_thumbnail_px_width">Ancho predeterminado de la imagen </string>
 	<string name="image_alignment">Alineamiento</string>
 	<string name="refresh">Refrescar</string>
 	<string name="untitled">Sin Título</string>
@@ -872,6 +943,7 @@
 	<string name="categories">Categorías</string>
 	<string name="title">Título</string>
 	<string name="tags_separate_with_commas">Etiquetas (separa las etiquetas con comas)</string>
+	<string name="dlg_deleting_comments">Eliminando comentarios</string>
 	<string name="notification_vibrate">Vibrar</string>
 	<string name="notification_sound">Notificación sonora</string>
 	<string name="notification_blink">Notificación luminosa</string>
@@ -895,70 +967,4 @@
 	<string name="no">No</string>
 	<string name="on">en</string>
 	<string name="notification_settings">Ajustes de avisos</string>
-	<string-array name="alignment_array">
-		<item>Ninguno</item>
-		<item>Izquierda</item>
-		<item>Centro</item>
-		<item>Derecha</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Comentarios en mi sitio</item>
-		<item>"Me gusta" en mis comentarios</item>
-		<item>"Me gusta" en mis entradas</item>
-		<item>Seguidores del sitio</item>
-		<item>Logros del sitio</item>
-		<item>Menciones del usuario</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Respuestas a mis comentarios</item>
-		<item>"Me gusta" en mis comentarios</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Sugerencias</item>
-		<item>Investigación</item>
-		<item>Comunidad</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Consejos para sacar el máximo provecho de WordPress.com</item>
-		<item>Oportunidades para participar en investigaciones y encuestas de WordPress.com.</item>
-		<item>Información sobre cursos y eventos de WordPress.com (online y presenciales).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Publicados</item>
-		<item>Borradores</item>
-		<item>Programados</item>
-		<item>En la papelera</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Minientrada</item>
-		<item>Audio</item>
-		<item>Chat</item>
-		<item>Galería</item>
-		<item>Imagen</item>
-		<item>Enlace</item>
-		<item>Cita</item>
-		<item>Estándar</item>
-		<item>Estatus</item>
-		<item>Vídeo</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Tu sitio es visible para todos y puede ser indexado por los motores de búsqueda</item>
-		<item>Tu sitio es visible para todos pero pide a los motores de búsqueda no ser indexados</item>
-		<item>Tu sitio es visible únicamente por ti y por lo usuarios que apruebes</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>Requiere aprobación manual para los comentarios de todos</item>
-		<item>Aprobar si el usuario tiene algún comentario aprobado previamente</item>
-		<item>Aprobar los comentarios de todos automáticamente</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>Sin comentarios</item>
-		<item>Comentarios de usuarios conocidos</item>
-		<item>Todos los usuarios</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Gratuito</item>
-		<item>Todos</item>
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-eu/strings.xml
+++ b/WordPress/src/main/res/values-eu/strings.xml
@@ -73,10 +73,8 @@
 	<string name="reader_label_like">Gustukoa</string>
 	<string name="select_a_blog">Aukeratu WordPress gune bat</string>
 	<string name="contact_us">Kontaktatu gurekin</string>
-	<string name="your_signature">Zure sinadura:</string>
 	<string name="edit_location">Editatu</string>
 	<string name="search_location">Bilatu</string>
-	<string name="preference_privacy">Pribatutasuna</string>
 	<string name="preference_send_usage_stats">Bidali estatistikak</string>
 	<string name="preference_send_usage_stats_summary">Bidali erabilera estatistikak automatikoki WordPress Android-erako hobetzen laguntzeko</string>
 	<string name="update_verb">Eguneratu</string>
@@ -118,9 +116,6 @@
 	<string name="wait_until_upload_completes">Itxaron karga osatu bitartean</string>
 	<string name="blog_not_found">Blog honetara sartzean errore bat gertatu da</string>
 	<string name="nux_cannot_log_in">Ezin zaitugu sartu</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Aurretik hautatutako bloga ez dago eskuragarri dagoeneko</string>
-	<string name="invalid_url_message">Ziurtatu sartutako blogaren URLa zuzena dela</string>
-	<string name="auto_sharing_preference_reset">Hobespenen berrezartzea auto-partekatzen</string>
 	<string name="reply_failed">Erantzunak huts egin du</string>
 	<string name="error_refresh_comments">Iruzkinak ezin izan dira une honetan freskatu</string>
 	<string name="error_refresh_stats">Estatistikak ezin izan dira une honetan freskatu </string>
@@ -269,9 +264,6 @@
 	<string name="comment_spammed">Iruzkina spam bezala markatuta</string>
 	<string name="download">Media deskargatzen</string>
 	<string name="reader_likes_multi">%,d pertsonak hau gustuko dute</string>
-	<string name="share_preference_title">Partekatu WordPress-en</string>
-	<string name="reset_auto_share_preference">Automatikoki partekatzeko hobespenak berrezarri</string>
-	<string name="always_use_these_settings_to_share">Erabili beti hobespen hauek</string>
 	<string name="reader_toast_err_get_comment">Ezin izan da iruzkin hau eskuratu</string>
 	<string name="reader_likes_you_and_multi">Zuk eta %,d pertsonak hau gustuko duzue</string>
 	<string name="select_time">Aukeratu ordua</string>
@@ -335,7 +327,6 @@
 	<string name="all">Denak</string>
 	<string name="unattached">Txertatu gabe</string>
 	<string name="media_add_popup_capture_video">Bideoa grabatu</string>
-	<string name="media_no_video_title">VideoPress ez dago eskuragarri</string>
 	<string name="stats_timeframe_today">Gaur</string>
 	<string name="stats_timeframe_yesterday">Atzo</string>
 	<string name="theme_activate_button">Gaitu</string>
@@ -355,7 +346,6 @@
 	<string name="media_gallery_type_tiled">Mosaikoa</string>
 	<string name="media_gallery_type_circles">Zirkuluak</string>
 	<string name="media_gallery_image_order_reverse">Alderantzikatu</string>
-	<string name="media_no_video_message">Bideoak igotzeko VideoPress erosi behar duzu</string>
 	<string name="stats_view_visitors_and_views">Bisitariak eta ikuspegiak</string>
 	<string name="stats_totals_clicks">Klikak</string>
 	<string name="themes_features_label">Ezaugarriak</string>
@@ -386,8 +376,6 @@
 	<string name="note_reply_successful">Erantzuna argitaratuta.</string>
 	<string name="loading">Kargatzen...</string>
 	<string name="httppassword">HTTP pasahitza</string>
-	<string name="post_signature">Bidalketaren sinadura</string>
-	<string name="add_tagline">Gehitu sinadura bidalketa berrietan</string>
 	<string name="httpuser">HTTP erabiltzaile-izena</string>
 	<string name="error_media_upload">Errore bat gertatu da mediak kargatzean</string>
 	<string name="publish_date">Argitaratu</string>
@@ -413,11 +401,9 @@
 	<string name="scaled_image">Irudiaren zabalera eskalan</string>
 	<string name="scheduled">Programatuta</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">WordPress Android-erako erabiliz argitaratua</string>
 	<string name="version">Bertsioa</string>
 	<string name="tos">Zerbitzu-baldintzak</string>
 	<string name="app_title">WordPress Android-erako</string>
-	<string name="about">Honi buruz</string>
 	<string name="image_alignment">Lerrokatzea</string>
 	<string name="refresh">Freskatu</string>
 	<string name="untitled">Izenbururik gabe</string>
@@ -460,26 +446,4 @@
 	<string name="preview">Aurrebista</string>
 	<string name="category_refresh_error">Kategoria eguneraketa errorea</string>
 	<string name="on">en</string>
-	<string-array name="alignment_array">
-		<item>Bat ere ez</item>
-		<item>Ezkerrean</item>
-		<item>Erdian</item>
-		<item>Eskuinean</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Argitaratua</item>
-		<item>Zirriborroak</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Albokoa</item>
-		<item>Audioa</item>
-		<item>Txata</item>
-		<item>Galeria</item>
-		<item>Irudia</item>
-		<item>Esteka</item>
-		<item>Aipua</item>
-		<item>Estandarra</item>
-		<item>Egoera</item>
-		<item>Bideoa</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -1,6 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">Impossible d\'enregistrer vos réglages de compte</string>
+	<string name="post_format_status">État</string>
+	<string name="post_format_video">Vidéo</string>
+	<string name="align_none">Aucun</string>
+	<string name="align_left">Gauche</string>
+	<string name="align_center">Centre</string>
+	<string name="align_right">Droite</string>
+	<string name="theme_free">Gratuit</string>
+	<string name="theme_all">Tous</string>
+	<string name="theme_premium">Premium</string>
+	<string name="post_format_gallery">Galerie</string>
+	<string name="post_format_image">Image</string>
+	<string name="post_format_link">Lien</string>
+	<string name="post_format_quote">Citation</string>
+	<string name="post_format_standard">Standard</string>
+	<string name="post_format_chat">Discussion</string>
+	<string name="notif_events">Information sur les formations et évènements WordPress.com (en ligne ou en personne).</string>
+	<string name="post_format_aside">En passant</string>
+	<string name="post_format_audio">Son</string>
+	<string name="notif_surveys">Opportunités de participer aux recherches et sondages de WordPress.com.</string>
+	<string name="notif_tips">Conseils pour tirer au mieux parti de WordPress.com</string>
+	<string name="notif_community">Communauté</string>
+	<string name="replies_to_my_comments">Réponses à mes commentaires</string>
+	<string name="notif_suggestions">Suggestions</string>
+	<string name="notif_research">Recherche</string>
+	<string name="site_achievements">Accomplissements du site</string>
+	<string name="username_mentions">Mentions de l\'identifiant</string>
+	<string name="likes_on_my_posts">Mentions "J\'aime" sur mes articles</string>
+	<string name="site_follows">Abonnements du site</string>
+	<string name="likes_on_my_comments">Mentions "J\'aime" sur mes commentaires</string>
+	<string name="comments_on_my_site">Commentaires sur mon site</string>
+	<string name="site_settings_list_editor_summary_other">%d éléments</string>
+	<string name="site_settings_list_editor_summary_one">Un élément</string>
+	<string name="approve_auto_if_previously_approved">Commentaires d\'utilisateurs connus</string>
+	<string name="approve_auto">Tous les utilisateurs</string>
+	<string name="approve_manual">Aucun commentaire</string>
+	<string name="site_settings_paging_summary_other">%d commentaires par page</string>
+	<string name="site_settings_paging_summary_one">Un commentaire par page</string>
+	<string name="site_settings_multiple_links_summary_other">Requiert une approbation pour plus de %d liens</string>
+	<string name="site_settings_multiple_links_summary_one">Requiert une approbation pour plus d\'un lien</string>
+	<string name="site_settings_multiple_links_summary_zero">Requiert une approbation pour plus de 0 lien</string>
+	<string name="detail_approve_auto">Approuver automatiquement les commentaires de tout le monde.</string>
+	<string name="detail_approve_auto_if_previously_approved">Approuver automatiquement les commentaires de tous ceux ayant déjà eu un commentaire approuvé</string>
+	<string name="detail_approve_manual">Requiert l\'approbation manuelle des commentaires de tout le monde.</string>
+	<string name="days_quantity_one">Un jour</string>
+	<string name="days_quantity_other">%d jours</string>
+	<string name="filter_trashed_posts">Mis à la Corbeille</string>
+	<string name="filter_published_posts">Publiés</string>
+	<string name="filter_draft_posts">Brouillons</string>
+	<string name="filter_scheduled_posts">Programmés</string>
+	<string name="primary_site">Site principal</string>
+	<string name="web_address">Adresse web</string>
+	<string name="pending_email_change_snackbar">Cliquez sur le lien de vérification de l\'e-mail envoyé à %1$s pour confirmer votre nouvelle adresse.</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">Certaines mises en ligne ont échouées. Veuillez essayer à nouveau ou supprimez les.</string>
+	<string name="editor_toast_uploading_please_wait">Vous êtes actuellement en train de mettre en ligne un média. Veuillez patienter jusqu\'à ce que soit terminé.</string>
+	<string name="error_refresh_comments_showing_older">Les commentaires ne peuvent pas être actualisés en ce moment - affichage des commentaires plus anciens</string>
+	<string name="editor_post_settings_set_featured_image">Définir une image mise à la une</string>
+	<string name="editor_post_settings_featured_image">Image à la une</string>
+	<string name="new_editor_promo_desc">L\'application WordPress for Android inclus un nouveau et superbe éditeur visuel. Essayez-le en créant un nouvel article !</string>
+	<string name="new_editor_promo_title">Tout nouvel éditeur</string>
+	<string name="new_editor_promo_button_label">Super, merci !</string>
+	<string name="visual_editor_enabled">Éditeur visuel activé</string>
+	<string name="editor_content_placeholder">Partagez ici votre histoire...</string>
+	<string name="editor_page_title_placeholder">Titre de la page</string>
+	<string name="editor_post_title_placeholder">Titre de l\'article</string>
+	<string name="email_address">Adresse de messagerie</string>
+	<string name="preference_show_visual_editor">Afficher l\'éditeur visuel</string>
+	<string name="dlg_sure_to_delete_comments">Supprimer définitivement ces commentaires ?</string>
+	<string name="preference_editor">Éditeur</string>
+	<string name="dlg_sure_to_delete_comment">Supprimer définitivement ce commentaire ? </string>
+	<string name="mnu_comment_delete_permanently">Supprimer</string>
+	<string name="mnu_comment_untrash">Restaurer</string>
+	<string name="comment_deleted_permanently">Commentaire supprimé</string>
+	<string name="comments_empty_list_filtered">Pas de commentaires %s</string>
+	<string name="could_not_load_page">Impossible de charger la page</string>
+	<string name="comment_status_all">Tout</string>
+	<string name="interface_language">Langue de l\'interface</string>
+	<string name="off">Off</string>
+	<string name="about_the_app">À propos de l\'application</string>
+	<string name="error_post_account_settings">Impossible d\'enregistrer vos réglages de compte</string>
 	<string name="error_post_my_profile">Impossible d\'enregistrer votre profil</string>
 	<string name="error_fetch_account_settings">Impossible de récupérer vos réglages de compte</string>
 	<string name="error_fetch_my_profile">Impossible de récupérer votre profil</string>
@@ -15,6 +94,9 @@
 	<string name="add_category">Ajouter la catégorie</string>
 	<string name="disabled">Désactivé(e)</string>
 	<string name="site_settings_image_original_size">Taille originale</string>
+	<string name="privacy_private">Votre site est visible uniquement pour vous et les utilisateurs que vous approuvez</string>
+	<string name="privacy_public_not_indexed">Votre site est visible par tous, mais demande aux moteurs de recherche de ne pas l\'indexer</string>
+	<string name="privacy_public">Votre site est visible par tous et peut être indexé par les moteurs de recherche</string>
 	<string name="about_me_hint">Quelques mots à propos de vous...</string>
 	<string name="about_me">À propos de moi</string>
 	<string name="public_display_name_hint">Le nom d\'affichage par défaut est votre nom d\'utilisateur s\'il n\'est pas défini.</string>
@@ -487,11 +569,9 @@
 	<string name="hs__invalid_email_error">Entrer une adresse email valide</string>
 	<string name="add_location">Ajouter localisation</string>
 	<string name="current_location">Localisation courante</string>
-	<string name="your_signature">Votre signature:</string>
 	<string name="search_location">Rechercher</string>
 	<string name="edit_location">Editer</string>
 	<string name="search_current_location">Localiser</string>
-	<string name="preference_privacy">Données personnelles</string>
 	<string name="preference_send_usage_stats">Envoyer statistiques</string>
 	<string name="preference_send_usage_stats_summary">Envoyer automatiquement des statistiques d\'utilisation pour nous aider à améliorer WordPress pour Android</string>
 	<string name="update_verb">Mettre à jour</string>
@@ -532,8 +612,6 @@
 	<string name="cat_name_required">Le champ du nom de catégorie est requis</string>
 	<string name="category_automatically_renamed">Le nom de la catégorie %1$s est invalide. Il a été renommé en %2$s.</string>
 	<string name="no_account">Aucun compte WordPress n\'a été trouvé, ajoutez un compte et réessayez</string>
-	<string name="auto_sharing_preference_reset">Paramètres d\'auto-partage réinitiallisés</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Le blog sélectionné précédemment n\'est plus visible</string>
 	<string name="sdcard_message">Une carte SD est nécessaire pour charger les médias</string>
 	<string name="stats_bar_graph_empty">Aucune statistique disponible</string>
 	<string name="invalid_url_message">Vérifiez que l\'URL du blog est valide</string>
@@ -686,6 +764,7 @@
 	<string name="blog_removed_successfully">Site supprimé avec succès</string>
 	<string name="notifications_empty_all">Pas (encore) de notifications.</string>
 	<string name="comment_status_trash">À la Corbeille</string>
+	<string name="invalid_site_url_message">Vérifiez que l\'URL saisie est valide</string>
 	<string name="deleting_page">Suppression de la page</string>
 	<string name="deleting_post">Suppression de l\'article</string>
 	<string name="share_url_page">Partager la page</string>
@@ -700,11 +779,8 @@
 	<string name="reader_label_reply">Répondre</string>
 	<string name="video">Vidéo</string>
 	<string name="reader_likes_you_and_multi">Vous et %,d personnes aiment ça</string>
-	<string name="share_preference_title">Partager sur WordPress</string>
 	<string name="comment_spammed">Commentaire marqué comme indésirable</string>
 	<string name="download">Téléchargement du média en cours</string>
-	<string name="reset_auto_share_preference">Remettre à zéro les paramètres de partage automatique</string>
-	<string name="always_use_these_settings_to_share">Toujours utiliser ces réglages</string>
 	<string name="cant_share_no_visible_blog">Vous ne pouvez pas partager vers WordPress sans avoir publié au moins un blog.</string>
 	<string name="reader_toast_err_get_post">Impossible de récupérer cet article</string>
 	<string name="select_time">Sélectionner l\'heure</string>
@@ -739,7 +815,6 @@
 	<string name="reader_toast_err_url_intent">Impossible d\'ouvrir %s</string>
 	<string name="reader_empty_followed_tags">Vous ne suivez aucun tag</string>
 	<string name="create_account_wpcom">Créer un compte sur WordPress.com</string>
-	<string name="connecting_wpcom">Connection à WordPress.com</string>
 	<string name="reader_likes_one">Une personne aime ça</string>
 	<string name="reader_likes_only_you">Vous aimez ça</string>
 	<string name="reader_toast_err_comment_failed">Impossible d\'envoyer votre commentaire</string>
@@ -751,6 +826,7 @@
 	<string name="reader_hint_comment_on_comment">Répondre au commentaire…</string>
 	<string name="reader_toast_err_tag_invalid">Ce n’est pas une étiquette valide</string>
 	<string name="reader_toast_err_tag_exists">Vous suivez déjà cette étiquette</string>
+	<string name="connecting_wpcom">Connexion à WordPress.com</string>
 	<string name="themes">Thèmes</string>
 	<string name="media_gallery_image_order_random">Aléatoire</string>
 	<string name="media_gallery_type">Catégorie</string>
@@ -773,7 +849,6 @@
 	<string name="stats_timeframe_days">Jours</string>
 	<string name="stats_timeframe_weeks">Semaines</string>
 	<string name="stats_timeframe_months">Mois</string>
-	<string name="media_no_video_title">VideoPress indisponible</string>
 	<string name="media_gallery_type_slideshow">Diaporama</string>
 	<string name="media_gallery_type_circles">Cercles</string>
 	<string name="media_gallery_type_squares">Carrés</string>
@@ -795,7 +870,6 @@
 	<string name="media_edit_caption_text">Légende</string>
 	<string name="media_edit_description_text">Description</string>
 	<string name="media_edit_title_hint">Entrer un titre</string>
-	<string name="media_no_video_message">Sélectionner l\'option VideoPress pour uploader vos vidéos.</string>
 	<string name="media_gallery_type_tiled">Mosaïque</string>
 	<string name="stats_totals_views">Vues</string>
 	<string name="stats_totals_clicks">Clicks</string>
@@ -819,8 +893,6 @@
 	<string name="more_notifications">et %d autres.</string>
 	<string name="follows">Suit</string>
 	<string name="loading">Chargement…</string>
-	<string name="post_signature">Signature des articles</string>
-	<string name="add_tagline">Ajouter une signature aux articles</string>
 	<string name="httppassword">Mot de passe HTTP</string>
 	<string name="httpuser">Nom d’utilisateur HTTP</string>
 	<string name="error_media_upload">Désolé, une erreur est survenue pendant l\'envoi du média</string>
@@ -847,11 +919,9 @@
 	<string name="upload_scaled_image">Envoyer et lier l\'image à l\'échelle</string>
 	<string name="scheduled">Programmé</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Posté avec Wordpress pour Android</string>
 	<string name="version">Version</string>
 	<string name="tos">Conditions d\'utilisation</string>
 	<string name="app_title">WordPress pour Android</string>
-	<string name="about">A propos</string>
 	<string name="max_thumbnail_px_width">Largeur d\'iImage par défaut</string>
 	<string name="image_alignment">Alignement</string>
 	<string name="refresh">Rafraichir</string>
@@ -873,6 +943,7 @@
 	<string name="title">Titre</string>
 	<string name="categories">Catégories</string>
 	<string name="tags_separate_with_commas">Étiquettes (séparez les par des virgules)</string>
+	<string name="dlg_deleting_comments">Effacement de commentaires en cours</string>
 	<string name="notification_vibrate">Vibrer</string>
 	<string name="notification_blink">Faire clignoter le voyant de notification</string>
 	<string name="notification_sound">Faire retentir la sonnerie</string>
@@ -896,70 +967,4 @@
 	<string name="yes">Oui</string>
 	<string name="no">Non</string>
 	<string name="notification_settings">Paramètres de Notification</string>
-	<string-array name="alignment_array">
-		<item>Aucun</item>
-		<item>Gauche</item>
-		<item>Centre</item>
-		<item>Droite</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Commentaires sur mon site</item>
-		<item>Likes sur mes commentaires</item>
-		<item>Likes sur mes articles</item>
-		<item>Suivi de site</item>
-		<item>Achievements de site</item>
-		<item>Mentions de mon nom d\'utilisateur</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Réponses à mes commentaires</item>
-		<item>Likes sur mes commentaires</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Suggestions</item>
-		<item>Étude</item>
-		<item>Communauté</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Astuces pour tirer le maximum de WordPress.com.</item>
-		<item>Opportunités de participer aux sondages et études WordPress.com.</item>
-		<item>Informations sur les cours et les événement WordPress.com (en ligne &amp; en personne).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Publié</item>
-		<item>Brouillons</item>
-		<item>Programmé</item>
-		<item>À la corbeille</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>En passant</item>
-		<item>Audio</item>
-		<item>Discussion</item>
-		<item>Galerie</item>
-		<item>Image</item>
-		<item>Lien</item>
-		<item>Citation</item>
-		<item>Standard</item>
-		<item>État</item>
-		<item>Vidéo</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Votre site est visible par tous et peut-être être indexé par les moteurs de recherche</item>
-		<item>Votre site est visible par tous, mais demande aux moteurs de recherche de ne pas l\'indexer</item>
-		<item>Votre site est visible uniquement pour vous et les utilisateurs que  vous approuvez</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>Les commentaires doivent être approuvés manuellement.</item>
-		<item>L’auteur d’un commentaire doit avoir déjà au moins un commentaire approuvé.</item>
-		<item>Approuver automatiquement</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>0 Commentaires</item>
-		<item>Commentaires des utilisateurs connus</item>
-		<item>Tous les utilisateurs</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Gratuit</item>
-		<item>Tous</item>
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-gd/strings.xml
+++ b/WordPress/src/main/res/values-gd/strings.xml
@@ -224,13 +224,11 @@
 	<string name="contact_us">Cuir fios thugainn</string>
 	<string name="current_location">An t-ionad làithreach</string>
 	<string name="add_location">Cuir ionad ris</string>
-	<string name="your_signature">An t-earr-sgrìobhadh agad:</string>
 	<string name="search_current_location">Lorg</string>
 	<string name="edit_location">Deasaich</string>
 	<string name="search_location">Lorg</string>
 	<string name="preference_send_usage_stats_summary">Cuir stats cleachdaidh thugainn ach an urrainn dhuinn WordPress airson Android a leasachadh</string>
 	<string name="preference_send_usage_stats">Cuir na stats</string>
-	<string name="preference_privacy">Prìobhaideachd</string>
 	<string name="schedule_verb">Cuir air an sgeideal</string>
 	<string name="update_verb">Ùraich</string>
 	<string name="reader_toast_err_already_follow_blog">Tha thu a’ leantainn a’ bhloga seo mu thràth</string>
@@ -292,13 +290,10 @@
 	<string name="error_refresh_posts">Cha b’ urrainn dhuinn na puist ath-nuadhachadh aig an àm seo</string>
 	<string name="error_refresh_pages">Cha b’ urrainn dhuinn na duilleagan ath-nuadhachadh aig an àm seo</string>
 	<string name="error_refresh_notifications">Cha b’ urrainn dhuinn na brathan ath-nuadhachadh aig an àm seo</string>
-	<string name="invalid_url_message">Dèan cinnteach gu bheil URL a’ bhloga seo dligheach</string>
 	<string name="reply_failed">Dh’fhàillig an fhreagairt</string>
 	<string name="stats_empty_comments">Chan eil beachd ann fhathast</string>
 	<string name="stats_bar_graph_empty">Chan eil stats ri fhaighinn</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Chan eil am bloga a thagh thu roimhe ri fhaicinn tuilleadh</string>
 	<string name="sdcard_message">Feumaidh tu cairt SD a chaidh a mhunntachadh mus urrainn dhut meadhanan a luchdadh suas</string>
-	<string name="auto_sharing_preference_reset">Chaidh roghainnean a’ cho-roinnidh fhèin-obrachail ath-shuidheachadh</string>
 	<string name="category_automatically_renamed">Chan e ainm dligheach airson roinn-seòrsa a tha ann an %1$s. Chaidh %2$s a chur air an àite sin.</string>
 	<string name="no_account">Cha deach cunntas WordPress a lorg, cuir cunntas ris is feuch ris a-rithist</string>
 	<string name="cat_name_required">Tha feum air raon ainm na roinn-seòrsa</string>
@@ -435,9 +430,6 @@
 	<string name="download">A\' luchdadh a-nuas a\' mheadhain</string>
 	<string name="comment_spammed">Chaidh comharra spama a chur ris a\' bheachd</string>
 	<string name="cant_share_no_visible_blog">Chan urrainn dhut co-roinneadh gu WordPress as aonais bloga a tha ri fhaicinn</string>
-	<string name="share_preference_title">Co-roinn gu WordPress</string>
-	<string name="reset_auto_share_preference">Ath-shuidhich roghainnean a\' cho-roinnidh fhèin-obrachail</string>
-	<string name="always_use_these_settings_to_share">Cleachd na roghainnean seo an-còmhnaidh</string>
 	<string name="select_time">Tagh àm</string>
 	<string name="reader_likes_you_and_one">Thuirt thusa agus aonan eile gur toigh leibh seo</string>
 	<string name="select_date">Tagh ceann-là</string>
@@ -495,8 +487,6 @@
 	<string name="media_gallery_type_tiled">Mar leacan</string>
 	<string name="media_gallery_type_circles">Cearcallan</string>
 	<string name="media_gallery_type_slideshow">Taisbeanadh-shleamhnagan</string>
-	<string name="media_no_video_title">Chan eil VideoPress ri làimh</string>
-	<string name="media_no_video_message">Faigh àrdachadh VideoPress gus video a luchdadh suas!</string>
 	<string name="media_edit_title_text">Tiotal</string>
 	<string name="media_edit_caption_text">Caipsean</string>
 	<string name="media_edit_description_text">Tuairisgeul</string>
@@ -548,8 +538,6 @@
 	<string name="new_notifications">%d brath(an) ùra</string>
 	<string name="more_notifications">agus %d a bharrachd.</string>
 	<string name="loading">\'Ga luchdadh…</string>
-	<string name="post_signature">Postaich an t-earr-sgrìobhadh</string>
-	<string name="add_tagline">Cuir earr-sgrìobhaidh ri puist ùra</string>
 	<string name="httpuser">Ainm-cleachdaiche HTTP</string>
 	<string name="httppassword">Facal-faire HTTP</string>
 	<string name="error_media_upload">Thachair mearachd fhad \'s a bha sinn a\' luchdadh suas meadhan</string>
@@ -576,11 +564,9 @@
 	<string name="scaled_image">Leud an deilbh sgèilichte</string>
 	<string name="scheduled">Air an sgeideal</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Air a phostadh o WordPress airson Android</string>
 	<string name="version">Tionndadh</string>
 	<string name="tos">Teirmichean na seirbheise</string>
 	<string name="app_title">WordPress airson Android</string>
-	<string name="about">Mu dheidhinn</string>
 	<string name="image_alignment">Co-thaobhadh</string>
 	<string name="refresh">Ath-nuadhaich</string>
 	<string name="untitled">Gun tiotal</string>
@@ -623,22 +609,4 @@
 	<string name="yes">Tha</string>
 	<string name="no">Chan eil</string>
 	<string name="category_refresh_error">Mearachd le ath-nuadhachadh na roinn-seòrsa</string>
-	<string-array name="alignment_array">
-		<item>Chan eil gin</item>
-		<item>Clì</item>
-		<item>Meadhan</item>
-		<item>Deas</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Aside</item>
-		<item>Fuaim</item>
-		<item>Cabadaich</item>
-		<item>Gailearaidh</item>
-		<item>Dealbh</item>
-		<item>Ceangal</item>
-		<item>Luaidh</item>
-		<item>Stannardach</item>
-		<item>Staid</item>
-		<item>Video</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-he/strings.xml
+++ b/WordPress/src/main/res/values-he/strings.xml
@@ -1,6 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">הגדרות החשבון לא נשמרו</string>
+	<string name="post_format_video">וידאו</string>
+	<string name="align_left">שמאל</string>
+	<string name="align_center">מרכז</string>
+	<string name="align_right">ימין</string>
+	<string name="theme_free">חינם</string>
+	<string name="theme_premium">פרימיום</string>
+	<string name="align_none">ללא</string>
+	<string name="post_format_status">מצב</string>
+	<string name="theme_all">הכול</string>
+	<string name="post_format_chat">צ\'אט</string>
+	<string name="post_format_image">תמונה</string>
+	<string name="post_format_link">קישור</string>
+	<string name="post_format_quote">ציטוט</string>
+	<string name="post_format_gallery">גלריה</string>
+	<string name="post_format_standard">פוסט רגיל</string>
+	<string name="post_format_audio">אודיו</string>
+	<string name="notif_events">מידע על קורסים ואירועים ב-WordPress.com (ברשת ופרונטלי).</string>
+	<string name="post_format_aside">קצרצר</string>
+	<string name="notif_surveys">הזדמנויות להשתתף במחקרים וסקרים של WordPress.com.</string>
+	<string name="notif_tips">טיפים כדי להפיק את המרב מ-WordPress.com.</string>
+	<string name="notif_community">קהילה</string>
+	<string name="notif_suggestions">הצעות</string>
+	<string name="replies_to_my_comments">מענה לתגובות שלי</string>
+	<string name="notif_research">מחקר</string>
+	<string name="site_achievements">הישגי אתר</string>
+	<string name="username_mentions">אזכורים של שם משתמש</string>
+	<string name="likes_on_my_posts">לייקים בפוסטים שלי</string>
+	<string name="site_follows">עוקבים אחרי האתר</string>
+	<string name="likes_on_my_comments">לייקים בתגובות שלי</string>
+	<string name="comments_on_my_site">תגובות באתר שלי</string>
+	<string name="site_settings_list_editor_summary_other">%d פריטים</string>
+	<string name="site_settings_list_editor_summary_one">פריט אחד</string>
+	<string name="approve_auto">כל המשתמשים</string>
+	<string name="approve_auto_if_previously_approved">תגובות של משתמשים מוכרים</string>
+	<string name="approve_manual">אין תגובות</string>
+	<string name="site_settings_paging_summary_other">%d תגובות לעמוד</string>
+	<string name="site_settings_paging_summary_one">תגובה אחת לעמוד</string>
+	<string name="site_settings_multiple_links_summary_other">נדרש אישור עבור יותר מ-%d קישורים</string>
+	<string name="site_settings_multiple_links_summary_one">נדרש אישור עבור יותר מקישור אחד</string>
+	<string name="site_settings_multiple_links_summary_zero">נדרש אישור עבור יותר מ-0 קישורים</string>
+	<string name="detail_approve_auto">אישור אוטומטי של תגובות מכולם.</string>
+	<string name="detail_approve_auto_if_previously_approved">אישור אוטומטי אם תגובה קודמת של המשתמש אושרה</string>
+	<string name="detail_approve_manual">אישור ידני דרוש לתגובות מכולם.</string>
+	<string name="days_quantity_one">יום אחד</string>
+	<string name="days_quantity_other">%d ימים</string>
+	<string name="filter_trashed_posts">הועבר לפח</string>
+	<string name="filter_published_posts">פורסם</string>
+	<string name="filter_draft_posts">טיוטות</string>
+	<string name="filter_scheduled_posts">מתוזמן לפרסום</string>
+	<string name="primary_site">אתר ראשי</string>
+	<string name="pending_email_change_snackbar">יש ללחוץ על הקישור לאימות באימייל שנשלח לכתובת %1$s כדי לאשר את כתובתך החדשה</string>
+	<string name="web_address">כתובת URL</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">מספר העלאות מדיה נכשלו. יש לנסות שוב או למחוק אותן.</string>
+	<string name="editor_toast_uploading_please_wait">מתבצעת כרגע העלאת מדיה על-ידך. יש להמתין להשלמת הפעולה.</string>
+	<string name="error_refresh_comments_showing_older">לא ניתן לרענן תגובות כרגע - מציג תגובות ישנות</string>
+	<string name="editor_post_settings_set_featured_image">קביעת תמונה מרכזית</string>
+	<string name="editor_post_settings_featured_image">תמונה מרכזית</string>
+	<string name="new_editor_promo_desc">אפליקציית WordPress עבור Android כוללת כעת עורך ויזואלי חדש\n ויפהפה. ניתן להתנסות בו על ידי יצירת פוסט חדש.</string>
+	<string name="new_editor_promo_title">עורך חדש ומחודש</string>
+	<string name="new_editor_promo_button_label">נהדר, תודה!</string>
+	<string name="visual_editor_enabled">עורך ויזואלי מופעל</string>
+	<string name="editor_content_placeholder">מומלץ לשתף את הסיפור שלך כאן…</string>
+	<string name="editor_page_title_placeholder">כותרת עמוד</string>
+	<string name="editor_post_title_placeholder">כותרת הפוסט</string>
+	<string name="email_address">כתובת אימייל</string>
+	<string name="preference_show_visual_editor">הצגת עורך ויזואלי</string>
+	<string name="preference_editor">עורך</string>
+	<string name="dlg_sure_to_delete_comments">האם למחוק תגובות אלה לצמיתות?</string>
+	<string name="dlg_sure_to_delete_comment">האם למחוק תגובה זו לצמיתות?</string>
+	<string name="mnu_comment_delete_permanently">מחיקה</string>
+	<string name="comment_deleted_permanently">התגובה נמחקה</string>
+	<string name="mnu_comment_untrash">שחזור</string>
+	<string name="comments_empty_list_filtered">אין תגובות בסטטוס %s</string>
+	<string name="could_not_load_page">לא ניתן היה לטעון את העמוד</string>
+	<string name="comment_status_all">הכול</string>
+	<string name="interface_language">שפת ממשק</string>
+	<string name="off">כיבוי</string>
+	<string name="about_the_app">מידע על האפליקציה</string>
+	<string name="error_post_account_settings">לא ניתן לשמור הגדרות החשבון</string>
 	<string name="error_post_my_profile">הפרופיל לא נשמר</string>
 	<string name="error_fetch_account_settings">לא ניתן לאחזר את הגדרות החשבון שלך</string>
 	<string name="error_fetch_my_profile">לא ניתן לאחזר את הפרופיל שלך</string>
@@ -15,6 +94,9 @@
 	<string name="remove">להסיר</string>
 	<string name="disabled">לא מופעל</string>
 	<string name="site_settings_image_original_size">גודל מקורי</string>
+	<string name="privacy_private">האתר גלוי רק לך ולמשתמשים שאישרת</string>
+	<string name="privacy_public_not_indexed">האתר שלך גלוי לכולם אבל שולח בקשה למנועי חיפוש לא לצרף אותו לאינדקס</string>
+	<string name="privacy_public">האתר שלך גלוי לכולם ומנועי חיפוש יכולים לצרף אותו לאינדקס</string>
 	<string name="about_me_hint">תיאור אישי בכמה מילים…</string>
 	<string name="public_display_name_hint">אם לא יוגדר אחרת, שם המשתמש שלך ישמש כשם תצוגה בברירת מחדל</string>
 	<string name="about_me">מי אני</string>
@@ -487,11 +569,9 @@
 	<string name="hs__invalid_email_error">נא להזין כתובת אימייל</string>
 	<string name="add_location">הוספת מיקום</string>
 	<string name="current_location">מיקום נוכחי</string>
-	<string name="your_signature">החתימה שלך:</string>
 	<string name="search_location">חיפוש</string>
 	<string name="edit_location">עריכה</string>
 	<string name="search_current_location">אתר</string>
-	<string name="preference_privacy">פרטיות</string>
 	<string name="preference_send_usage_stats">שליחת סטטיסטיקות</string>
 	<string name="preference_send_usage_stats_summary">שליחת נתוני שימוש סטטיסטיים שיאפשרו לנו לשפר את WordPress לאנדרויד</string>
 	<string name="update_verb">עדכן</string>
@@ -518,7 +598,6 @@
 	<string name="help_center">מרכז עזרה</string>
 	<string name="ssl_certificate_error">אישור SSL לא תקף</string>
 	<string name="ssl_certificate_ask_trust">אם בדרך כלל אתה מתחבר לאתר זה ללא בעיות, ייתכן ששגיאה זו נובעת מכך שמישהו מנסה להתחזות לאתר ולכן אסור לך להמשיך. האם ברצונך בכל זאת לתת אמון באישור?</string>
-	<string name="invalid_url_message">ודא שכתובת ה-URL של האתר שהוזנה תקפה</string>
 	<string name="blog_not_found">אירעה שגיאה בזמן הגישה לאתר זה</string>
 	<string name="could_not_remove_account">לא ניתן היה להסיר את האתר</string>
 	<string name="out_of_memory">זיכרון המכשיר מלא</string>
@@ -536,7 +615,6 @@
 	<string name="cat_name_required">שם הקטגוריה הוא שדה חובה</string>
 	<string name="category_automatically_renamed">שם הקטגוריה %1$s אינו תקף. הוא שונה ל-%2$s.</string>
 	<string name="no_account">לא נמצא חשבון ב-WordPress, הוסף חשבון ונסה שנית</string>
-	<string name="auto_sharing_preference_reset">איפוס הגדרות שיתוף אוטומטי</string>
 	<string name="sdcard_message">יש לטעון כרטיס SD כדי להעלות קבצים</string>
 	<string name="stats_empty_comments">עדיין אין תגובות</string>
 	<string name="stats_bar_graph_empty">הנתונים הסטטיסטיים לא זמינים</string>
@@ -582,7 +660,7 @@
 	<string name="blog_name_reserved_but_may_be_available">אתר זה שמור כעת אך עשוי להיות זמין בעוד כמה ימים</string>
 	<string name="username_or_password_incorrect">שם המשתמש או הסיסמה שהקלדת שגויים</string>
 	<string name="nux_cannot_log_in">איננו יכולים לחבר אותך</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">האתר שנבחר כבר אינו גלוי</string>
+	<string name="invalid_url_message">ודא שכתובת האתר שהוזנה תקפה</string>
 	<string name="wordpress_blog">אתר ב-WordPress</string>
 	<string name="blog_removed_successfully">האתר הוסר בהצלחה</string>
 	<string name="add_account_blog_url">כתובת האתר</string>
@@ -686,6 +764,7 @@
 	<string name="blog_name_invalid">כתובת אתר לא תקפה</string>
 	<string name="blog_title_invalid">כותרת אתר לא תקפה</string>
 	<string name="notifications_empty_all">אין התראות... עדיין.</string>
+	<string name="invalid_site_url_message">יש לוודא שכתובת ה-URL של האתר שהוזנה תקפה</string>
 	<string name="share_url_post">שתף פוסט</string>
 	<string name="share_url_page">שתף עמוד</string>
 	<string name="share_link">קישור לשיתוף</string>
@@ -702,9 +781,6 @@
 	<string name="reader_label_reply">תשובה</string>
 	<string name="video">וידאו</string>
 	<string name="download">מוריד מדיה</string>
-	<string name="share_preference_title">שתף ב-WordPress</string>
-	<string name="reset_auto_share_preference">אפס הגדרות לשיתוף אוטומטי</string>
-	<string name="always_use_these_settings_to_share">השתמש תמיד בהגדרות אלה</string>
 	<string name="comment_spammed">התגובה סומנה כתגובת זבל</string>
 	<string name="select_time">בחר שעה</string>
 	<string name="reader_likes_you_and_one">אתה ועוד אחד אוהבים את זה</string>
@@ -766,8 +842,6 @@
 	<string name="media_gallery_type_tiled">אריחים</string>
 	<string name="media_gallery_type_circles">עיגולים</string>
 	<string name="media_gallery_type_slideshow">מצגת</string>
-	<string name="media_no_video_title">VideoPress לא זמין</string>
-	<string name="media_no_video_message">שדרג ל-VideoPress כדי להעלות וידאו!</string>
 	<string name="media_edit_title_text">כותרת</string>
 	<string name="media_edit_caption_text">כיתוב</string>
 	<string name="media_edit_description_text">תיאור</string>
@@ -819,8 +893,6 @@
 	<string name="more_notifications">הוסף %d נוספים.</string>
 	<string name="follows">עוקבים</string>
 	<string name="loading">טוען...</string>
-	<string name="post_signature">חתימה</string>
-	<string name="add_tagline">הוסף חתימה לפוסטים חדשים</string>
 	<string name="httpuser">שם משתמש</string>
 	<string name="httppassword">סיסמה</string>
 	<string name="error_media_upload">ארעה שגיאה במהלך העלאת הקובץ.</string>
@@ -847,11 +919,9 @@
 	<string name="upload_scaled_image">העלאה וקישור לתמונה</string>
 	<string name="scheduled">תוזמן</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">פורסם דרך וורדפרס עבור אנדרואיד</string>
 	<string name="version">גרסה</string>
 	<string name="tos">תנאי שימוש</string>
 	<string name="app_title">וורדפרס עבור אנדרואיד</string>
-	<string name="about">אודות</string>
 	<string name="max_thumbnail_px_width">ברירת מחדל לרוחב תמונה</string>
 	<string name="image_alignment">יישור</string>
 	<string name="refresh">רענון</string>
@@ -873,6 +943,7 @@
 	<string name="categories">קטגוריות</string>
 	<string name="tags_separate_with_commas">תגים (יש להפריד בפסיקים)</string>
 	<string name="title">כותרת</string>
+	<string name="dlg_deleting_comments">מוחק תגובות</string>
 	<string name="notification_vibrate">רטט</string>
 	<string name="notification_sound">שמע צליל התראה</string>
 	<string name="notification_blink">האר נורית הודעה</string>
@@ -896,70 +967,4 @@
 	<string name="reply">תגובה</string>
 	<string name="preview">תצוגה מקדימה</string>
 	<string name="notification_settings">הגדרות התראות</string>
-	<string-array name="alignment_array">
-		<item>ללא</item>
-		<item>שמאל</item>
-		<item>מרכז</item>
-		<item>ימין</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>תגובות באתר שלי</item>
-		<item>לייקים בתגובות שלי</item>
-		<item>לייקים בפוסטים שלי</item>
-		<item>עוקבי אתר</item>
-		<item>הישגי אתר</item>
-		<item>איזכורי משתמש</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>מענה לתגובות שלי</item>
-		<item>לייקים לתגובות שלי</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>הצעות</item>
-		<item>חיפוש חוזר</item>
-		<item>קהילה</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>טיפים כדי להפיק את המיטב מוורדפרס.קום.</item>
-		<item>הזדמנות להשתתף במחקר &amp; סקר של וורדפרס.קום.</item>
-		<item>מידע על קורסים ואירועים בוורדפרס.קום (ברשת &amp; פרונטלי).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>פורסם</item>
-		<item>טיוטות</item>
-		<item>מתוזמן לפרסום</item>
-		<item>הועבר לפח</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>הערה</item>
-		<item>אודיו</item>
-		<item>צ\'אט</item>
-		<item>גלריה</item>
-		<item>תמונה</item>
-		<item>קישור</item>
-		<item>ציטוט</item>
-		<item>רגיל</item>
-		<item>סטטוס</item>
-		<item>וידאו</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>האתר שלך גלוי לכולם ומנועי חיפוש יכולים לצרף אותו לאינדקס</item>
-		<item>האתר שלך גלוי לכולם אבל שולח בקשה למנועי חיפוש לא לצרף אותו לאינדקס</item>
-		<item>האתר גלוי רק לך ולמשתמשים שאישרת</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>אישור ידני דרוש לתגובות מכולם.</item>
-		<item>אישור אוטומטי אם תגובה קודמת של המשתמש אושרה.</item>
-		<item>אישור אוטומטי של תגובות מכולם.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>אין תגובות</item>
-		<item>תגובות של משתמשים מוכרים</item>
-		<item>כל המשתמשים</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>חינם</item>
-		<item>הכל</item>
-		<item>פרימיום</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-hi/strings.xml
+++ b/WordPress/src/main/res/values-hi/strings.xml
@@ -133,11 +133,9 @@
 	<string name="contact_us">हमसे संपर्क करें</string>
 	<string name="add_location">स्थान जोड़ें</string>
 	<string name="current_location">वर्तमान स्थान</string>
-	<string name="your_signature">आपका हस्ताक्षर:</string>
 	<string name="search_location">खोज</string>
 	<string name="edit_location">संपादित करें</string>
 	<string name="search_current_location">स्थान निर्धारण करे</string>
-	<string name="preference_privacy">गोपनीयता</string>
 	<string name="preference_send_usage_stats">आंकड़े भेजें</string>
 	<string name="preference_send_usage_stats_summary">स्वचालित रूप से उपयोग के आंकड़े भेज कर हमें एंड्रॉयड के लिए वर्डप्रेस को बेहतर बनाने में मदद करे\n\n</string>
 	<string name="update_verb">अपडेट करे</string>
@@ -226,8 +224,6 @@
 	<string name="category_automatically_renamed">श्रेणी नाम %1$s मान्य नहीं है.यह %2$s में बदल दिया गया है.</string>
 	<string name="error_moderate_comment">मध्यस्थता करते हुए त्रुटि हुई</string>
 	<string name="no_account">कोई वर्डप्रेस खाता नहीं है,एक खाता जोड़े और फिर से प्रयास करे</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">पहले चयनित ब्लॉग अब नहीं दिख रहा है</string>
-	<string name="auto_sharing_preference_reset">स्वत: साझा सेटिंग रीसेट करें</string>
 	<string name="sdcard_message">मीडिया अपलोड करने के लिए एक माउंटेड एसडी कार्ड की आवश्यकता है</string>
 	<string name="add_comment">टिप्पणी जोड़ें</string>
 	<string name="add_new_category">नई श्रेणी जोड़ें</string>
@@ -345,11 +341,8 @@
 	<string name="reader_label_reply">जवाब दें</string>
 	<string name="reader_toast_err_get_comment">इस टिप्पणी को पुनः प्राप्त में असमर्थ</string>
 	<string name="reader_likes_multi">%,d लोगों ने पसंद किया</string>
-	<string name="always_use_these_settings_to_share">हमेशा इन सेटिंग्स का उपयोग करे</string>
 	<string name="reader_likes_you_and_multi">आपने और %,d लोगो ने इसे पसंद किया है</string>
-	<string name="share_preference_title">वर्डप्रेस पर साझा करे</string>
 	<string name="cant_share_no_visible_blog"> आप एक प्रत्यक्ष ब्लॉग के बिना वर्डप्रेस में साझा नहीं कर सकते</string>
-	<string name="reset_auto_share_preference">स्वत: साझा सेटिंग रीसेट करें</string>
 	<string name="comment_spammed">टिप्पणी स्पैम के रूप में चिह्नित </string>
 	<string name="reader_toast_err_get_post">इस संदेश को पुनः प्राप्त में असमर्थ</string>
 	<string name="reader_likes_you_and_one">आपने और एक और ने इसे पसंद किया है</string>
@@ -425,7 +418,6 @@
 	<string name="media_gallery_image_order_reverse">उल्टा</string>
 	<string name="stats_totals_views">देखें गये</string>
 	<string name="passcode_change_passcode">पिन बदलें</string>
-	<string name="media_no_video_title">विडियोप्रेस उपलब्ध नहीं</string>
 	<string name="theme_auth_error_title">थीम को प्राप्त करने में असफल</string>
 	<string name="stats">आँकड़े</string>
 	<string name="theme_set_success">थीम सफलतापूर्वक सेट किया गया!</string>
@@ -445,7 +437,6 @@
 	<string name="post_excerpt">अंश</string>
 	<string name="media_add_popup_capture_photo">छवि कैप्चर करे</string>
 	<string name="media_add_popup_capture_video">विडियो कैप्चर करे</string>
-	<string name="media_no_video_message">विडियो अपलोड करने के लिए VideoPress को अपग्रेड करे</string>
 	<string name="passcode_turn_off">पिन को ऑफ करे</string>
 	<string name="passcode_turn_on">पिन को ऑन करे</string>
 	<string name="passcode_manage">पिन का प्रबंधन करे</string>
@@ -461,8 +452,6 @@
 	<string name="loading">लोड किया जा रहा...</string>
 	<string name="httppassword">एचटीटीपी कूटशब्द</string>
 	<string name="httpuser">एचटीटीपी उपयोगकर्ता नाम</string>
-	<string name="post_signature">पोस्ट हस्ताक्षर</string>
-	<string name="add_tagline">नये पोस्टो पर हस्ताक्षर जोड़ें</string>
 	<string name="error_media_upload">मीडिया अपलोड करने के दौरान एक त्रुटि हुई</string>
 	<string name="content_description_add_media">मीडिया जोड़ें</string>
 	<string name="publish_date">प्रकाशित करे</string>
@@ -487,11 +476,9 @@
 	<string name="scaled_image">बढाये गए छवि की चौड़ाई</string>
 	<string name="scheduled">	नियत किया गया</string>
 	<string name="link_enter_url">यूआरएल</string>
-	<string name="posted_from">एंड्राइड के लिए वर्डप्रेस से प्रकाशित किया गया</string>
 	<string name="version">संस्करण</string>
 	<string name="tos">सेवा की शर्तें</string>
 	<string name="app_title">एंड्राइड के लिए वर्डप्रेस</string>
-	<string name="about">के बारे में</string>
 	<string name="max_thumbnail_px_width">मूलभूत छवि की चौड़ाई</string>
 	<string name="image_alignment">संरेखण</string>
 	<string name="refresh">रिफ्रेश</string>
@@ -535,46 +522,4 @@
 	<string name="save">सहेजें</string>
 	<string name="yes">हां</string>
 	<string name="category_refresh_error">श्रेणी रिफ्रेश त्रुटि</string>
-	<string-array name="alignment_array">
-		<item>कुछ भी नहीं</item>
-		<item>बाएं</item>
-		<item>मध्य</item>
-		<item>दाहिना</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>मेरी साइट पर टिप्पणियाँ </item>
-		<item>साइट की उपलब्धयां</item>
-		<item>उपयोगकर्ता के नाम का उल्लेख</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>मेरी टिप्पणी के उत्तर</item>
-		<item>मेरी टिप्पणियों को पसंद किया</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>सुझाव</item>
-		<item>अनुसंधान</item>
-		<item>समुदाय</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>WordPress.com के अनुसंधान और सर्वे में भाग लेने का मौका।</item>
-		<item>पाठ्यक्रम और घटनाओं (ऑनलाइन और व्यक्तिगत रूप से ) के बारे में Wordpress.com पर जानिये</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>प्रकाशित</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>एसाइड</item>
-		<item>ऑडियो</item>
-		<item>चैट</item>
-		<item>गैलरी</item>
-		<item>छवि</item>
-		<item>कड़ी</item>
-		<item>उद्धरण</item>
-		<item>सामान्य</item>
-		<item>स्थति</item>
-		<item>विडियो</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>सभी</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-hr/strings.xml
+++ b/WordPress/src/main/res/values-hr/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">Neuspjelo snimanje postavki vašeg računa</string>
+	<string name="error_post_account_settings">Neuspjelo snimanje postavki vašeg računa</string>
 	<string name="error_post_my_profile">Neuspjelo snimanje vašeg profila</string>
 	<string name="error_fetch_account_settings">Neuspjelo dohvaćanje postavki vašeg računa</string>
 	<string name="error_fetch_my_profile">Neuspjelo dohvaćanje vašeg profila</string>
@@ -15,6 +15,9 @@
 	<string name="add_category">Dodaj kategoriju</string>
 	<string name="disabled">Onemogući</string>
 	<string name="site_settings_image_original_size">Originalna veličina</string>
+	<string name="privacy_private">Vaša web stranica je vidljiva samo vama i korisnicima koje odobrite</string>
+	<string name="privacy_public_not_indexed">Vaša web stranica je vidljiva svima, ali traži od pretraživača da ju ne indeksiraju</string>
+	<string name="privacy_public">Vaša web stranica je vidljiva svima, i pretraživači će ju indeksirati</string>
 	<string name="about_me_hint">Nekoliko riječi o vama...</string>
 	<string name="about_me">O meni</string>
 	<string name="public_display_name_hint">Prikazano ime biti će vaše korisničko ime, ako drugo nije postavljeno</string>
@@ -487,11 +490,9 @@
 	<string name="hs__conversation_header">Razgovor s podrškom</string>
 	<string name="add_location">Dodaj lokaciju</string>
 	<string name="current_location">Trenutna lokacija</string>
-	<string name="your_signature">Vaš potpis</string>
 	<string name="search_location">Pretraga</string>
 	<string name="edit_location">Uredi</string>
 	<string name="search_current_location">Pronaći</string>
-	<string name="preference_privacy">Privatnost</string>
 	<string name="preference_send_usage_stats">Šalji statistiku</string>
 	<string name="preference_send_usage_stats_summary">Automatski šalji statistiku o korištenju kako bi nam pomogli poboljšati WordPress za Andorid</string>
 	<string name="update_verb">Ažuriraj</string>
@@ -548,12 +549,9 @@
 	<string name="cat_name_required">Polje imena kategorije je obavezno</string>
 	<string name="category_automatically_renamed">Ime kategorije %1$s nije valjano. Preimenovana je u %2$s.</string>
 	<string name="no_account">Nije pronađen WordPress.com račun. Dodajte račun i pokušajte ponovno</string>
-	<string name="auto_sharing_preference_reset">Reset postavki automatskog dijeljenja</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Prethodno odabran blog više nije vidljiv</string>
 	<string name="sdcard_message">Za prijenos medijskih zapisa potrebna je montirana SD kartica</string>
 	<string name="stats_empty_comments">Još nema komentara</string>
 	<string name="stats_bar_graph_empty">Nema dostupne statistike</string>
-	<string name="invalid_url_message">Provjerite da je uneseni blog URL ispravan</string>
 	<string name="error_delete_post">Dogodila se greška prilikom brisanja %s</string>
 	<string name="error_refresh_posts">Trenutno nije moguće osvježiti objave</string>
 	<string name="error_refresh_notifications">Trenutno nije moguće osvježiti obavijesti</string>
@@ -583,6 +581,7 @@
 	<string name="email_invalid">Unesite ispravnu adresu e-pošte</string>
 	<string name="email_not_allowed">Ta adresa e-pošte nije dopuštena</string>
 	<string name="email_exists">Ova adresa e-pošte se već koristi</string>
+	<string name="invalid_url_message">Provjerite da je uneseni URL ispravan</string>
 	<string name="view_site">Pogledaj stranicu</string>
 	<string name="add_new_category">Dodaj novu kategoriju</string>
 	<string name="category_name">Ime kategorije</string>
@@ -695,8 +694,6 @@
 	<string name="creating_your_site">Napravi svoju stranicu</string>
 	<string name="reader_empty_posts_in_tag_updating">Dohvaćanje objava...</string>
 	<string name="error_refresh_media">Nešto je pošlo krivo tijekom osvježavanja medijskih zapisa. Pokušajte ponovno kasnije.</string>
-	<string name="share_preference_title">Dijeljenje na WordPressu</string>
-	<string name="reset_auto_share_preference">Vrati izvorne postavke automatskog dijeljenja</string>
 	<string name="reader_likes_you_and_multi">Vi i %,d drugih se ovo sviđa</string>
 	<string name="reader_likes_multi">%,d ljudi se ovo sviđa</string>
 	<string name="reader_toast_err_get_comment">Nije moguće dohvatiti komentare</string>
@@ -704,7 +701,6 @@
 	<string name="video">Video</string>
 	<string name="download">Preuzimanje medijskih zapisa</string>
 	<string name="comment_spammed">Komentar označen kao spam</string>
-	<string name="always_use_these_settings_to_share">Uvijek koristi ove postavke</string>
 	<string name="cant_share_no_visible_blog">Ne možete dijeliti na WordPressu bez vidljivog bloga</string>
 	<string name="select_date">Odaberi datum</string>
 	<string name="pick_photo">Odaberi sliku</string>
@@ -789,7 +785,6 @@
 	<string name="media_gallery_type_tiled">Pločice</string>
 	<string name="media_gallery_type_circles">Kružnice</string>
 	<string name="media_gallery_type_slideshow">Dijaprojekcija</string>
-	<string name="media_no_video_title">VideoPress nedostupan</string>
 	<string name="media_edit_title_text">Naslov</string>
 	<string name="media_edit_description_text">Opis</string>
 	<string name="media_edit_caption_text">Podnatpis</string>
@@ -810,7 +805,6 @@
 	<string name="passcode_turn_off">Isključi zaključavanje PIN-om</string>
 	<string name="passcode_turn_on">Uključi zaključavanje PIN-om</string>
 	<string name="unattached">Nepriloženo</string>
-	<string name="media_no_video_message">Za prijenos videa kupite VideoPress nadogradnju!</string>
 	<string name="upload">Prijenos</string>
 	<string name="sign_in">Prijavi se</string>
 	<string name="notifications">Obavijesti</string>
@@ -819,8 +813,6 @@
 	<string name="note_reply_successful">Odgovor objavljen</string>
 	<string name="follows">Praćenje</string>
 	<string name="loading">Učitavanje...</string>
-	<string name="post_signature">Potpis objave</string>
-	<string name="add_tagline">Dodajte svoj potpis u nove objave</string>
 	<string name="httppassword">HTTP lozinka</string>
 	<string name="httpuser">HTTP korisničko ime</string>
 	<string name="error_media_upload">Dogodila se greška tijekom prijenosa medijskog zapisa</string>
@@ -847,11 +839,9 @@
 	<string name="scaled_image">Širina dimenzionirane slike</string>
 	<string name="scheduled">Zakazano</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Objavljeno pomoću WordPress za Android</string>
 	<string name="version">Inačica</string>
 	<string name="tos">Uvjeti Korištenja</string>
 	<string name="app_title">WordPress za Android</string>
-	<string name="about">O aplikaciji</string>
 	<string name="max_thumbnail_px_width">Zadana širina slike</string>
 	<string name="image_alignment">Poravnanje</string>
 	<string name="refresh">Osvježi</string>
@@ -873,6 +863,7 @@
 	<string name="title">Naslov</string>
 	<string name="tags_separate_with_commas">Oznake (razdvoji oznake zarezima)</string>
 	<string name="categories">Kategorije</string>
+	<string name="dlg_deleting_comments">Brisanje komentara</string>
 	<string name="notification_blink">Trepereće svjetlo za obavijesti</string>
 	<string name="notification_sound">Reproduciraj zvučnu obavijest </string>
 	<string name="notification_vibrate">Vibracija</string>
@@ -896,70 +887,4 @@
 	<string name="category_refresh_error">Pogreška u osvježavanju kategorija</string>
 	<string name="preview">Pretpregled</string>
 	<string name="notification_settings">Postavke obavijesti</string>
-	<string-array name="alignment_array">
-		<item>Nijedan</item>
-		<item>Lijevo</item>
-		<item>Centar</item>
-		<item>Desno</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Komentari na mojoj stranici</item>
-		<item>Lajkovi na mojim komentarima</item>
-		<item>Lajkovi na mojim objavama</item>
-		<item>Sljedbenici stranice</item>
-		<item>Ostvarenja web stranice</item>
-		<item>Spominjanje korisničkog imena</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Odgovori na moje komentare</item>
-		<item>Lajkovi na moje komentare</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Prijedlozi</item>
-		<item>Istraživanje</item>
-		<item>Zajednica</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Savjeti kako izvući najviše od WordPress.com.</item>
-		<item>Prilika za sudjelovanje u WordPress.com istraživanjima i anketama.</item>
-		<item>Informacije o WordPress.com tečajevima i dogođanjima ( na internetu i osobno).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Objavljeno</item>
-		<item>Nacrti</item>
-		<item>Tempirano</item>
-		<item>Stavljeno u smeće</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Crtica</item>
-		<item>Audio</item>
-		<item>Čavrljanje</item>
-		<item>Galerija</item>
-		<item>Slika</item>
-		<item>Poveznica</item>
-		<item>Citat</item>
-		<item>Članak</item>
-		<item>Status</item>
-		<item>Video</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Vaša web stranica je vidljiva svima, i pretraživači će ju indeksirati</item>
-		<item>Vaša web stranica je vidljiva svima, ali traži od pretraživača da ju ne indeksiraju</item>
-		<item>Vaša web stranica je vidljiva samo vama i korisnicima koje odobrite</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>Manualno odobravanje svih komentara.</item>
-		<item>Automatski odobri ako korisnik ima prethodno odobren komentar</item>
-		<item>Automatski odobri sve komentare</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>Nema komentara</item>
-		<item>Komentari poznatih korisnika</item>
-		<item>Svi korisnici</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Besplatno</item>
-		<item>Sve</item>
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-hu/strings.xml
+++ b/WordPress/src/main/res/values-hu/strings.xml
@@ -35,12 +35,10 @@
 	<string name="hs__conversation_header">Támogató chat</string>
 	<string name="add_location">Hely hozzáadás</string>
 	<string name="current_location">Jelenlegi hely</string>
-	<string name="your_signature">Aláírás:</string>
 	<string name="edit_location">Szerkeszt</string>
 	<string name="search_location">Keresés</string>
 	<string name="search_current_location">Hely meghatározás</string>
 	<string name="preference_send_usage_stats">Statisztika küldés</string>
-	<string name="preference_privacy">Adatvédelem</string>
 	<string name="update_verb">Frissítést</string>
 	<string name="schedule_verb">Időzítés</string>
 	<string name="reader_title_subs">Címkék és blogok</string>
@@ -99,7 +97,6 @@
 	<string name="edit_comment">Hozzászólás szerkesztése</string>
 	<string name="dlg_trashing_comments">Lomtárba küldés</string>
 	<string name="pending_review">Áttekintésre várakozik</string>
-	<string name="always_use_these_settings_to_share">Mindig ezeket a beálitásokat használja</string>
 	<string name="download">Média letöltés folyamatban</string>
 	<string name="media_add_new_media_gallery">Galéria létrehozása</string>
 	<string name="reader_btn_follow">Követés</string>
@@ -130,7 +127,6 @@
 	<string name="media_gallery_type_squares">Négyzetek</string>
 	<string name="theme_activate_button">Bekapcsolás</string>
 	<string name="media_gallery_type_circles">Körök</string>
-	<string name="media_no_video_title">VideoPress nem érhető el</string>
 	<string name="media_edit_caption_hint">A feliratot itt lehet megadni</string>
 	<string name="media_edit_description_hint">A leírást itt lehet megadni</string>
 	<string name="media_edit_failure">A feltöltés nem sikerült</string>
@@ -158,7 +154,6 @@
 	<string name="media_gallery_type_slideshow">Diavetítés</string>
 	<string name="media_gallery_type_tiled">Mozaik</string>
 	<string name="unattached">Független</string>
-	<string name="media_no_video_message">Fizessünk elő VideoPressre a videó feltöltéséhez!</string>
 	<string name="media_edit_title_text">Cím</string>
 	<string name="images">Kép</string>
 	<string name="theme_auth_error_title">Nem sikerült a sablonok betöltése</string>
@@ -171,8 +166,6 @@
 	<string name="new_notifications">%d új értesítés</string>
 	<string name="more_notifications">és %d további.</string>
 	<string name="loading">Betöltés</string>
-	<string name="add_tagline">Aláírás hozzáadása a bejegyzéshez</string>
-	<string name="post_signature">Bejegyzés aláírás</string>
 	<string name="httpuser">HTTP felhasználónév</string>
 	<string name="httppassword">HTTP jelszó</string>
 	<string name="error_media_upload">Hiba történt a média feltöltése közben</string>
@@ -199,11 +192,9 @@
 	<string name="scaled_image">Átméretezett kép szélessége</string>
 	<string name="scheduled">Időzítve</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Ez a bejegyzés WordPress for Android alkalmazással készült</string>
 	<string name="tos">Szolgáltatási feltételek</string>
 	<string name="version">verzió</string>
 	<string name="app_title">WordPress for Android</string>
-	<string name="about">Névjegy</string>
 	<string name="image_alignment">Kép igazítás</string>
 	<string name="refresh">Frissítés</string>
 	<string name="untitled">Cím nélküli</string>
@@ -246,22 +237,4 @@
 	<string name="yes">Igen</string>
 	<string name="no">Nem</string>
 	<string name="preview">Előnézet</string>
-	<string-array name="alignment_array">
-		<item>Nincs</item>
-		<item>Bal</item>
-		<item>Közép</item>
-		<item>Jobb</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Széljegyzet</item>
-		<item>Audió</item>
-		<item>Chat</item>
-		<item>Galéria</item>
-		<item>Kép</item>
-		<item>Hivatkozás</item>
-		<item>Idézet</item>
-		<item>Általános</item>
-		<item>Állapot</item>
-		<item>Videó</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-id/strings.xml
+++ b/WordPress/src/main/res/values-id/strings.xml
@@ -1,6 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">Tidak dapat menyimpan pengaturan akun Anda</string>
+	<string name="post_format_status">Status</string>
+	<string name="post_format_video">Video</string>
+	<string name="align_none">Tidak Ada</string>
+	<string name="align_left">Kiri</string>
+	<string name="align_center">Tengah</string>
+	<string name="align_right">Kanan</string>
+	<string name="theme_free">Gratis</string>
+	<string name="theme_all">Semua</string>
+	<string name="theme_premium">Premium</string>
+	<string name="post_format_chat">Obrolan</string>
+	<string name="post_format_gallery">Galeri</string>
+	<string name="post_format_image">Gambar</string>
+	<string name="post_format_link">Tautan</string>
+	<string name="post_format_quote">Kutipan</string>
+	<string name="post_format_standard">Standar</string>
+	<string name="notif_events">Informasi tentang kursus dan acara WordPress.com (online &amp; tatap muka).</string>
+	<string name="post_format_aside">Ke samping</string>
+	<string name="post_format_audio">Audio</string>
+	<string name="notif_surveys">Kesempatan untuk berpartisipasi dalam riset &amp; survei WordPress.com.</string>
+	<string name="notif_tips">Kiat untuk mendapat maksimal dari WordPress.com.</string>
+	<string name="notif_community">Komunitas</string>
+	<string name="replies_to_my_comments">Balas komentar saya</string>
+	<string name="notif_suggestions">Saran</string>
+	<string name="notif_research">Riset</string>
+	<string name="site_achievements">Prestasi situs</string>
+	<string name="username_mentions">Penyebutan nama pengguna</string>
+	<string name="likes_on_my_posts">Suka pada pos saya</string>
+	<string name="site_follows">Pengikut Situs</string>
+	<string name="likes_on_my_comments">Suka pada komentar saya</string>
+	<string name="comments_on_my_site">Komentar di situs saya</string>
+	<string name="site_settings_list_editor_summary_other">%d items</string>
+	<string name="site_settings_list_editor_summary_one">1 item</string>
+	<string name="approve_auto_if_previously_approved">Komentar pengguna yang diketahui</string>
+	<string name="approve_auto">Semua pengguna</string>
+	<string name="approve_manual">Tak ada komentar</string>
+	<string name="site_settings_paging_summary_other">%d komentar per halaman</string>
+	<string name="site_settings_paging_summary_one">1 komentar per halaman</string>
+	<string name="site_settings_multiple_links_summary_other">Minta persetujuan untuk lebih dari %d tautan</string>
+	<string name="site_settings_multiple_links_summary_one">Minta persetujuan untuk lebih dari 1 tautan</string>
+	<string name="site_settings_multiple_links_summary_zero">Minta persetujuan untuk lebih dari 0 tautan</string>
+	<string name="detail_approve_auto">Otomatis setujui komentar semua orang.</string>
+	<string name="detail_approve_auto_if_previously_approved">Otomatis setujui jika pengguna memiliki komentar yang disetujui sebelumnya</string>
+	<string name="detail_approve_manual">Wajibkan persetujuan manual untuk komentar semua orang.</string>
+	<string name="filter_trashed_posts">Dibuang</string>
+	<string name="days_quantity_one">1 hari</string>
+	<string name="days_quantity_other">%d hari</string>
+	<string name="filter_published_posts">Diterbitkan</string>
+	<string name="filter_draft_posts">Draf</string>
+	<string name="filter_scheduled_posts">Terjadwal</string>
+	<string name="pending_email_change_snackbar">Klik tautan verifikasi di email yang dikirimkan ke %1$s untuk mengonfirmasi alamat baru Anda</string>
+	<string name="primary_site">Situs Utama</string>
+	<string name="web_address">Alamat Web</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">Gagal mengunggah beberapa media. Harap coba lagi atau hapus.</string>
+	<string name="editor_toast_uploading_please_wait">Saat ini Anda sedang mengunggah media. Harap tunggu hingga selesai.</string>
+	<string name="error_refresh_comments_showing_older">Komentar tidak dapat disegarkan pada saat ini - menunjukkan komentar lama</string>
+	<string name="editor_post_settings_set_featured_image">Atur Gambar Unggulan</string>
+	<string name="editor_post_settings_featured_image">Gambar Unggulan</string>
+	<string name="new_editor_promo_desc">Aplikasi WordPress untuk Android sekarang berisi visual baru yang cantik\n penyunting Cobalah dengan membuat pos baru.</string>
+	<string name="new_editor_promo_title">Penyunting baru</string>
+	<string name="new_editor_promo_button_label">Bagus, terima kasih!</string>
+	<string name="visual_editor_enabled">Editor Visual diaktifkan</string>
+	<string name="editor_content_placeholder">Editor Visual diaktifkan</string>
+	<string name="editor_page_title_placeholder">Judul Halaman</string>
+	<string name="editor_post_title_placeholder">Judul Kiriman</string>
+	<string name="email_address">Alamat email</string>
+	<string name="preference_show_visual_editor">Tampilkan editor visual</string>
+	<string name="dlg_sure_to_delete_comments">Hapus komentar ini secara permanen?</string>
+	<string name="preference_editor">Penyunting</string>
+	<string name="dlg_sure_to_delete_comment">Hapus komentar ini secara permanen?</string>
+	<string name="mnu_comment_delete_permanently">Hapus</string>
+	<string name="comment_deleted_permanently">Komentar dihapus</string>
+	<string name="mnu_comment_untrash">Pulihkan</string>
+	<string name="comments_empty_list_filtered">Tidak ada %s komentar</string>
+	<string name="could_not_load_page">Tidak dapat memuat halaman</string>
+	<string name="comment_status_all">Semua</string>
+	<string name="interface_language">Bahasa Antarmuka</string>
+	<string name="off">Nonaktif</string>
+	<string name="about_the_app">Tentang aplikasi</string>
 	<string name="error_post_my_profile">Tidak dapat menyimpan profil Anda</string>
 	<string name="error_fetch_account_settings">Tidak dapat mengambil pengaturan akun Anda</string>
 	<string name="error_fetch_my_profile">Tidak dapat mengambil profil Anda</string>
@@ -487,11 +565,9 @@
 	<string name="hs__invalid_email_error">Masukkan sebuah alamat email yang sah</string>
 	<string name="current_location">Lokasi saat ini</string>
 	<string name="add_location">Tambahkan lokasi</string>
-	<string name="your_signature">Tanda tangan Anda:</string>
 	<string name="search_location">Cari</string>
 	<string name="edit_location">Sunting</string>
 	<string name="search_current_location">Temukan</string>
-	<string name="preference_privacy">Privasi</string>
 	<string name="preference_send_usage_stats">Kirim statistik</string>
 	<string name="preference_send_usage_stats_summary">Secara otomatis mengirim statistik penggunaan untuk membantu kami meningkatkan WordPress untuk Android</string>
 	<string name="update_verb">Mutakhirkan</string>
@@ -534,12 +610,9 @@
 	<string name="cat_name_required">Nama kategori wajib diisi</string>
 	<string name="category_automatically_renamed">Nama kategori %1$s tidak sah. Sudah diubah menjadi %2$s.</string>
 	<string name="no_account">Akun WordPress tidak ditemukan, masukkan akun dan coba lagi</string>
-	<string name="auto_sharing_preference_reset">Atur ulang pengaturan berbagi-otomatis</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Blog yang dipilih sebelumnya tak lagi terlihat</string>
 	<string name="sdcard_message">Kartu SD tambahan diperlukan untuk mengunggah media</string>
 	<string name="stats_empty_comments">Belum ada tanggapan</string>
 	<string name="stats_bar_graph_empty">Belum ada statistik</string>
-	<string name="invalid_url_message">Pastikan URL blog yang dimasukkan itu benar</string>
 	<string name="reply_failed">Gagal mengirim balasan</string>
 	<string name="notifications_empty_list">Tak ada pemberitahuan</string>
 	<string name="error_delete_post">Terjadi galat saat menghapus %s</string>
@@ -686,6 +759,7 @@
 	<string name="blog_removed_successfully">Situs berhasil dihapus</string>
 	<string name="remove_account">Hapus situs</string>
 	<string name="notifications_empty_all">Belum ada pemberitahuan...sampai sekarang.</string>
+	<string name="invalid_site_url_message">Pastikan URL situs yang dimasukkan sudah valid</string>
 	<string name="deleting_page">Menghapus laman</string>
 	<string name="deleting_post">Menghapus pos</string>
 	<string name="share_url_post">Bagikan pos</string>
@@ -701,9 +775,6 @@
 	<string name="reader_label_reply">Balas</string>
 	<string name="video">Video</string>
 	<string name="download">Mengunduh media</string>
-	<string name="share_preference_title">Bagikan ke WordPress</string>
-	<string name="reset_auto_share_preference">Reset pengaturan berbagi otomatis</string>
-	<string name="always_use_these_settings_to_share">Selalu gunakan pengaturan ini</string>
 	<string name="cant_share_no_visible_blog">Anda tidak bisa berbagi ke WordPress tanpa satupun blog yang terlihat oleh publik</string>
 	<string name="comment_spammed">Komentar ditandai sebagai spam</string>
 	<string name="select_time">Pilih waktu</string>
@@ -758,8 +829,6 @@
 	<string name="unattached">Tidak terlampir</string>
 	<string name="media_add_popup_capture_photo">Ambil foto</string>
 	<string name="media_add_popup_capture_video">Rekam video</string>
-	<string name="media_no_video_title">VideoPress tak tersedia</string>
-	<string name="media_no_video_message">Dapatkan upgrade VideoPress untuk mengunggah video!</string>
 	<string name="media_edit_title_text">Judul</string>
 	<string name="media_edit_caption_text">Subjudul</string>
 	<string name="media_edit_description_text">Deskripsi</string>
@@ -819,8 +888,6 @@
 	<string name="sign_in">Log masuk</string>
 	<string name="follows">Mengikuti</string>
 	<string name="loading">Memuat...</string>
-	<string name="post_signature">Kirim tandatangan</string>
-	<string name="add_tagline">Tambahkan sebuah tandatangan dalam tulisan baru</string>
 	<string name="httpuser">Nama pengguna HTTP</string>
 	<string name="httppassword">Kata sandi HTTP</string>
 	<string name="error_media_upload">Ada masalah ketika mengunggah media</string>
@@ -847,11 +914,9 @@
 	<string name="scaled_image">Lebar gambar terskala</string>
 	<string name="scheduled">Dijadwalkan</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Ditulis dari WordPress untuk Android</string>
 	<string name="version">Versi</string>
 	<string name="app_title">WordPress untuk Android</string>
 	<string name="tos">Syarat Layanan</string>
-	<string name="about">Tentang</string>
 	<string name="max_thumbnail_px_width">Lebar Gambar Baku</string>
 	<string name="image_alignment">Penjajaran</string>
 	<string name="refresh">Segarkan</string>
@@ -896,70 +961,4 @@
 	<string name="error">Galat</string>
 	<string name="category_refresh_error">Gagal memuat ulang Kategori</string>
 	<string name="notification_settings">Pengaturan Pemberitahuan</string>
-	<string-array name="alignment_array">
-		<item>Tak ada</item>
-		<item>Kiri</item>
-		<item>Tengah</item>
-		<item>Kanan</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Komentar di situs saya</item>
-		<item>Suka pada komentar saya</item>
-		<item>Suka pada pos saya</item>
-		<item>Pengikut Situs</item>
-		<item>Prestasi situs</item>
-		<item>Penyebutan nama pengguna</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Balas komentar saya</item>
-		<item>Suka pada komentar saya</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Saran</item>
-		<item>Riset</item>
-		<item>Komunitas</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Kiat untuk mendapat maksimal dari WordPress.com.</item>
-		<item>Kesempatan untuk berpartisipasi dalam riset &amp; survei WordPress.com.</item>
-		<item>Informasi tentang kursus dan acara WordPress.com (online &amp; tatap muka).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Diterbitkan</item>
-		<item>Draf</item>
-		<item>Terjadwal</item>
-		<item>Dibuang</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Di samping</item>
-		<item>Audio</item>
-		<item>Chat</item>
-		<item>Galeri</item>
-		<item>Gambar</item>
-		<item>Taut</item>
-		<item>Kutip</item>
-		<item>Standar</item>
-		<item>Status</item>
-		<item>Video</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Situs Anda dapat terlihat oleh semua dan mesin pencari bisa mengindeksnya</item>
-		<item>Situs Anda dapat terlihat oleh semua orang tetapi mesin pencari tidak akan mengindeksnya</item>
-		<item>Situs Anda hanya terlihat oleh Anda dan pengguna yang sudah Anda setujui</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>Diperlukan persetujuan manual untuk semua komentar.</item>
-		<item>Secara otomatis menyetujui jika pengguna sudah pernah disetujui komentarnya.</item>
-		<item>Secara otomatis menyetujui semua komentar</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>Belum ada komentar</item>
-		<item>Komentar pengguna yang diketahui</item>
-		<item>Semua pengguna</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Gratis</item>
-		<item>Semua</item>
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -1,6 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">Impossibile salvare le impostazioni dell\'account</string>
+	<string name="post_format_status">Stato</string>
+	<string name="post_format_video">Video</string>
+	<string name="align_none">Nessuno</string>
+	<string name="align_left">Sinistra</string>
+	<string name="align_center">Centro</string>
+	<string name="align_right">Destra</string>
+	<string name="theme_free">Gratuito</string>
+	<string name="theme_all">Tutti</string>
+	<string name="theme_premium">Premium</string>
+	<string name="post_format_chat">Chat</string>
+	<string name="post_format_gallery">Galleria</string>
+	<string name="post_format_image">Immagine</string>
+	<string name="post_format_link">Link</string>
+	<string name="post_format_quote">Citazione</string>
+	<string name="post_format_standard">Standard</string>
+	<string name="notif_events">Informazioni sui corsi e sugli eventi di WordPress.com (online e di persona).</string>
+	<string name="post_format_aside">Digressione</string>
+	<string name="post_format_audio">Audio</string>
+	<string name="notif_surveys">Opportunità di partecipare ai sondaggi e alle ricerche di WordPress.com.</string>
+	<string name="notif_tips">Suggerimenti per utilizzare al meglio WordPress.com.</string>
+	<string name="notif_community">Comunità</string>
+	<string name="replies_to_my_comments">Risposte ai miei commenti</string>
+	<string name="notif_suggestions">Suggerimenti</string>
+	<string name="notif_research">Ricerca</string>
+	<string name="site_achievements">Obiettivi del sito</string>
+	<string name="username_mentions">Riferimenti al nome utente</string>
+	<string name="likes_on_my_posts">Mi piace per i miei articoli</string>
+	<string name="site_follows">Segui del sito</string>
+	<string name="likes_on_my_comments">Mi piace per i miei commenti</string>
+	<string name="comments_on_my_site">Commenti sul mio sito</string>
+	<string name="site_settings_list_editor_summary_other">%d elementi</string>
+	<string name="site_settings_list_editor_summary_one">1 elemento</string>
+	<string name="approve_auto">Tutti gli utenti</string>
+	<string name="approve_auto_if_previously_approved">Commenti di utenti conosciuti</string>
+	<string name="approve_manual">Nessun commento</string>
+	<string name="site_settings_paging_summary_other">%d commenti per pagina</string>
+	<string name="site_settings_paging_summary_one">1 commento per pagina</string>
+	<string name="site_settings_multiple_links_summary_other">Richiedi l\'approvazione per più di %d link</string>
+	<string name="site_settings_multiple_links_summary_one">Richiedi l\'approvazione per più di 1 link</string>
+	<string name="site_settings_multiple_links_summary_zero">Richiedi l\'approvazione per più di 0 link</string>
+	<string name="detail_approve_auto">Approva automaticamente i commenti di tutti gli utenti.</string>
+	<string name="detail_approve_auto_if_previously_approved">Approva automaticamente se l\'utente ha approvato un commento in precedenza</string>
+	<string name="detail_approve_manual">Richiedi l\'approvazione manuale per i commenti di tutti gli utenti.</string>
+	<string name="days_quantity_other">%d giorni</string>
+	<string name="days_quantity_one">1 giorno</string>
+	<string name="filter_trashed_posts">Eliminati</string>
+	<string name="filter_published_posts">Pubblicati</string>
+	<string name="filter_draft_posts">Bozze</string>
+	<string name="filter_scheduled_posts">Programmati</string>
+	<string name="pending_email_change_snackbar">Fai clic sul link di verifica nell\'e-mail inviata a %1$s per confermare il tuo nuovo indirizzo</string>
+	<string name="primary_site">Sito principale</string>
+	<string name="web_address">Indirizzo web</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">Alcuni caricamenti di file multimediali non sono riusciti. Riprova a effettuarli o eliminali.</string>
+	<string name="editor_toast_uploading_please_wait">Al momento stai caricando file multimediali. Attendi il termine dell\'operazione.</string>
+	<string name="error_refresh_comments_showing_older">Impossibile aggiornare i commenti in questo momento, vengono visualizzati i commenti precedenti</string>
+	<string name="editor_post_settings_set_featured_image">Imposta immagine in primo piano</string>
+	<string name="editor_post_settings_featured_image">Immagine in primo piano</string>
+	<string name="new_editor_promo_desc">L\'app WordPress per Android ora include un nuovo bellissimo editor\n visuale. Provalo creando un nuovo articolo.</string>
+	<string name="new_editor_promo_title">Un editor completamente nuovo</string>
+	<string name="new_editor_promo_button_label">Fantastico, grazie!</string>
+	<string name="visual_editor_enabled">Editor visuale abilitato</string>
+	<string name="editor_content_placeholder">Condividi la tua storia qui...</string>
+	<string name="editor_page_title_placeholder">Titolo della pagina</string>
+	<string name="editor_post_title_placeholder">Titolo dell\'articolo</string>
+	<string name="email_address">Indirizzo e-mail</string>
+	<string name="preference_show_visual_editor">Mostra editor visuale</string>
+	<string name="dlg_sure_to_delete_comments">Eliminare in modo permanente questi commenti?</string>
+	<string name="preference_editor">Editor</string>
+	<string name="dlg_sure_to_delete_comment">Eliminare in modo permanente questo commento?</string>
+	<string name="mnu_comment_delete_permanently">Elimina</string>
+	<string name="mnu_comment_untrash">Ripristina</string>
+	<string name="comment_deleted_permanently">Commento eliminato</string>
+	<string name="comments_empty_list_filtered">Nessun commento %s</string>
+	<string name="could_not_load_page">Impossibile caricare la pagina</string>
+	<string name="comment_status_all">Tutti</string>
+	<string name="interface_language">Lingua dell\'interfaccia</string>
+	<string name="off">Disattivata</string>
+	<string name="about_the_app">Info sull\'app</string>
+	<string name="error_post_account_settings">Impossibile salvare le impostazioni del tuo account</string>
 	<string name="error_post_my_profile">Impossibile salvare il profilo</string>
 	<string name="error_fetch_account_settings">Impossibile recuperare le impostazioni dell\'account</string>
 	<string name="error_fetch_my_profile">Impossibile recuperare il profilo</string>
@@ -15,6 +94,9 @@
 	<string name="add_category">Aggiungi categoria</string>
 	<string name="disabled">Disattivata</string>
 	<string name="site_settings_image_original_size">Dimensioni originali</string>
+	<string name="privacy_private">Il tuo sito è visibile solo a te e agli utenti che approvi</string>
+	<string name="privacy_public_not_indexed">Il tuo sito è visibile a chiunque, ma chiede ai motori di ricerca di non indicizzarlo</string>
+	<string name="privacy_public">Il tuo sito è visibile a chiunque e può essere indicizzato dai motori di ricerca</string>
 	<string name="about_me_hint">Alcune informazioni su di te…</string>
 	<string name="public_display_name_hint">Se non viene impostato, il nome visualizzato coinciderà con il nome utente per impostazione predefinita</string>
 	<string name="about_me">Informazioni su di me</string>
@@ -487,11 +569,9 @@
 	<string name="hs__invalid_email_error">Inserisci un email valida</string>
 	<string name="add_location">Aggiungi una località</string>
 	<string name="current_location">Località corrente</string>
-	<string name="your_signature">La tua firma</string>
 	<string name="search_location">Cerca</string>
 	<string name="edit_location">Modifica</string>
 	<string name="search_current_location">Rintraccia</string>
-	<string name="preference_privacy">Privacy</string>
 	<string name="preference_send_usage_stats">Invia le statistiche</string>
 	<string name="preference_send_usage_stats_summary">Invia automaticamente le statistiche di utilizzo per aiutarci a migliorare WordPress per Android</string>
 	<string name="update_verb">Aggiorna</string>
@@ -535,12 +615,9 @@
 	<string name="cat_name_required">Il campo Nome categoria è obbligatorio</string>
 	<string name="category_automatically_renamed">Il valore del campo Nome categoria %1$s non è valido. È stato rinominato in %2$s.</string>
 	<string name="no_account">Impossibile trovare un account WordPress. Aggiungi un account e riprova</string>
-	<string name="auto_sharing_preference_reset">Reset delle impostazioni di condivisione automatica</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Il blog selezionato in precedenza non è più visibile</string>
 	<string name="sdcard_message">Occorre una scheda SD per caricare i file</string>
 	<string name="stats_empty_comments">Ancora nessun commento</string>
 	<string name="stats_bar_graph_empty">Nessuna statistica disponibile</string>
-	<string name="invalid_url_message">Verifica la validità dell\'URL del blog immesso</string>
 	<string name="reply_failed">Impossibile rispondere</string>
 	<string name="notifications_empty_list">Nessuna notifica</string>
 	<string name="error_delete_post">Si è verificato un errore durante l\'eliminazione di %s</string>
@@ -583,6 +660,7 @@
 	<string name="blog_name_reserved_but_may_be_available">Il sito è attualmente riservato, ma potrebbe essere disponibile tra un paio di giorni</string>
 	<string name="username_or_password_incorrect">Il nome utente o la password immessi non sono corretti</string>
 	<string name="nux_cannot_log_in">Impossibile effettuare l\'accesso</string>
+	<string name="invalid_url_message">Verifica la validità dell\'URL inserita</string>
 	<string name="blog_removed_successfully">Sito rimosso correttamente</string>
 	<string name="remove_account">Rimuovi sito</string>
 	<string name="xmlrpc_error">Impossibile connettersi. Inserisci il percorso completo a xmlrpc.php del tuo sito e riprova.</string>
@@ -686,6 +764,7 @@
 	<string name="blog_name_invalid">Indirizzo del sito non valido</string>
 	<string name="blog_title_invalid">Titolo del sito non valido</string>
 	<string name="notifications_empty_all">Nessuna notifica... per ora.</string>
+	<string name="invalid_site_url_message">Controlla che l\'URL del sito sia valido</string>
 	<string name="deleting_page">Eliminando la pagina</string>
 	<string name="deleting_post">Eliminando l\'articolo</string>
 	<string name="share_url_post">Condividi l\'articolo</string>
@@ -703,9 +782,6 @@
 	<string name="download">Download file multimediale in corso</string>
 	<string name="comment_spammed">Commento contrassegnato come spam</string>
 	<string name="cant_share_no_visible_blog">Non è possibile condividere su WordPress senza un blog visibile</string>
-	<string name="share_preference_title">Condividi su WordPress</string>
-	<string name="reset_auto_share_preference">Resetta le impostazioni di condivisione automatica</string>
-	<string name="always_use_these_settings_to_share">Usa sempre queste impostazioni</string>
 	<string name="select_time">Seleziona orario</string>
 	<string name="reader_likes_you_and_one">Piace a te e a un\'altra persona</string>
 	<string name="select_date">Seleziona data</string>
@@ -757,7 +833,6 @@
 	<string name="custom_date">Data personalizzata</string>
 	<string name="media_add_popup_capture_photo">Scatta una foto</string>
 	<string name="media_add_popup_capture_video">Registra un video</string>
-	<string name="media_no_video_title">VideoPress non disponibile</string>
 	<string name="media_edit_title_text">Titolo</string>
 	<string name="media_edit_description_text">Descrizione</string>
 	<string name="media_edit_title_hint">Inserisci un titolo qui</string>
@@ -801,7 +876,6 @@
 	<string name="stats_entry_authors">Autore</string>
 	<string name="media_gallery_type_squares">Riquadri</string>
 	<string name="stats_entry_tags_and_categories">Argomenti</string>
-	<string name="media_no_video_message">Scarica l\'aggiornamento di VideoPress per caricare dei video!</string>
 	<string name="theme_activating_button">Attivazione</string>
 	<string name="passcode_manage">Gestione blocco PIN</string>
 	<string name="media_gallery_type_slideshow">Visualizza come slideshow</string>
@@ -820,8 +894,6 @@
 	<string name="more_notifications">e altre %d.</string>
 	<string name="loading">Caricamento in corso…</string>
 	<string name="httpuser">HTTP nome utente</string>
-	<string name="post_signature">Firma dell\'articolo</string>
-	<string name="add_tagline">Aggiungi la firma ai nuovi articoli</string>
 	<string name="httppassword">Password HTTP</string>
 	<string name="error_media_upload">Si è verificato un errore durante il caricamento</string>
 	<string name="post_content">Contenuto (tocca per aggiungere testo e file multimediali)</string>
@@ -847,11 +919,9 @@
 	<string name="scaled_image">Larghezza immagine ridimensionata</string>
 	<string name="scheduled">Programmato</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Scritto con WordPress per Android</string>
 	<string name="version">Versione</string>
 	<string name="tos">Condizioni del servizio</string>
 	<string name="app_title">WordPress per Android</string>
-	<string name="about">Informazioni su</string>
 	<string name="max_thumbnail_px_width">Larghezza predefinita immagine</string>
 	<string name="image_alignment">Allineamento</string>
 	<string name="refresh">Aggiorna</string>
@@ -873,6 +943,7 @@
 	<string name="title">Titolo</string>
 	<string name="categories">Categorie</string>
 	<string name="tags_separate_with_commas">Etichette (separate da una virgola)</string>
+	<string name="dlg_deleting_comments">Eliminazione commenti</string>
 	<string name="notification_vibrate">Vibrazione</string>
 	<string name="notification_sound">Esegui notifica sonora</string>
 	<string name="notification_blink">Esegui notifica visiva</string>
@@ -896,70 +967,4 @@
 	<string name="yes">Sì</string>
 	<string name="reply">Rispondi</string>
 	<string name="notification_settings">Impostazioni notifiche</string>
-	<string-array name="alignment_array">
-		<item>Nessuno</item>
-		<item>A sinistra</item>
-		<item>Al centro</item>
-		<item>A destra</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Commenti sul mio sito</item>
-		<item>Mi piace ai miei commenti</item>
-		<item>Mi piace ai miei articoli</item>
-		<item>Seguono il sito</item>
-		<item>Traguardi del sito</item>
-		<item>Menzioni del nome utente</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Repliche ai miei commenti</item>
-		<item>Mi piace ai miei commenti</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Suggerimenti</item>
-		<item>Ricerca</item>
-		<item>Comunità</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Suggerimenti per ottenere il massimo da WordPress.com.</item>
-		<item>Opportunità di partecipare alle ricerche ed ai sondaggi di WordPress.com.</item>
-		<item>Informazioni sui corsi e gli eventi su WordPress.com (online e di persona).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Pubblicato</item>
-		<item>Bozze</item>
-		<item>Programmato</item>
-		<item>Cestinato</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Nota (aside)</item>
-		<item>Audio</item>
-		<item>Chat</item>
-		<item>Galleria</item>
-		<item>Immagine</item>
-		<item>Link</item>
-		<item>Citazione</item>
-		<item>Predefinito</item>
-		<item>Stato</item>
-		<item>Video</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Il tuo sito è visibile a chiunque e può essere indicizzato dai motori di ricerca</item>
-		<item>Il tuo sito è visibile a chiunque, ma chiede ai motori di ricerca di non indicizzarlo</item>
-		<item>Il tuo sito è visibile solo a te e agli utenti che approvi</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>Richiedi l\'approvazione manuale per i commenti di tutti gli utenti.</item>
-		<item>Approva automaticamente se l\'utente ha approvato un commento in precedenza.</item>
-		<item>Approva automaticamente i commenti di tutti gli utenti.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>Nessun commento</item>
-		<item>Commenti di utenti conosciuti</item>
-		<item>Tutti gli utenti</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Gratuito</item>
-		<item>Tutti</item>
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-ja/strings.xml
+++ b/WordPress/src/main/res/values-ja/strings.xml
@@ -1,6 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">アカウント設定を保存できませんでした</string>
+	<string name="post_format_status">ステータス</string>
+	<string name="post_format_video">動画</string>
+	<string name="align_none">なし</string>
+	<string name="align_left">左</string>
+	<string name="align_center">中央</string>
+	<string name="align_right">右</string>
+	<string name="theme_free">無料</string>
+	<string name="theme_all">すべて</string>
+	<string name="theme_premium">プレミアム</string>
+	<string name="post_format_chat">チャット</string>
+	<string name="post_format_gallery">ギャラリー</string>
+	<string name="post_format_image">画像</string>
+	<string name="post_format_link">リンク</string>
+	<string name="post_format_quote">引用</string>
+	<string name="post_format_standard">標準</string>
+	<string name="notif_events">WordPress.com のコースやイベント (オンライン・オフライン) の情報。</string>
+	<string name="post_format_aside">アサイド</string>
+	<string name="post_format_audio">音声ファイル</string>
+	<string name="notif_surveys">WordPress.com の研究・調査に参加する機会。</string>
+	<string name="notif_tips">WordPress.com を最大限に活用するためのヒント。</string>
+	<string name="notif_community">コミュニティ</string>
+	<string name="replies_to_my_comments">自分のコメントへの返信</string>
+	<string name="notif_suggestions">提案</string>
+	<string name="notif_research">リサーチ</string>
+	<string name="site_achievements">サイトの達成記録</string>
+	<string name="username_mentions">ユーザー名メンション</string>
+	<string name="likes_on_my_posts">自分の投稿への「いいね」</string>
+	<string name="site_follows">サイトでフォロー</string>
+	<string name="likes_on_my_comments">自分のコメントへの「いいね」</string>
+	<string name="comments_on_my_site">サイト上のコメント</string>
+	<string name="site_settings_list_editor_summary_other">%d項目</string>
+	<string name="site_settings_list_editor_summary_one">1項目</string>
+	<string name="approve_auto_if_previously_approved">既知のユーザーのコメント</string>
+	<string name="approve_auto">すべてのユーザー</string>
+	<string name="approve_manual">コメントなし</string>
+	<string name="site_settings_paging_summary_other">%d件のコメント (1ページあたり)</string>
+	<string name="site_settings_paging_summary_one">1件のコメント (1ページあたり)</string>
+	<string name="site_settings_multiple_links_summary_other">%dリンク以上の承認が必要です</string>
+	<string name="site_settings_multiple_links_summary_one">2リンク以上の承認が必要です</string>
+	<string name="site_settings_multiple_links_summary_zero">1リンク以上の承認が必要です</string>
+	<string name="detail_approve_auto">すべてのコメントを自動的に承認します。</string>
+	<string name="detail_approve_auto_if_previously_approved">ユーザーのコメントが以前に承認されている場合、自動的に承認します</string>
+	<string name="detail_approve_manual">すべてのコメントで手動の承認が必要です。</string>
+	<string name="filter_trashed_posts">ゴミ箱に移動</string>
+	<string name="days_quantity_one">1日</string>
+	<string name="days_quantity_other">%d日</string>
+	<string name="filter_published_posts">公開済み</string>
+	<string name="filter_draft_posts">下書き</string>
+	<string name="filter_scheduled_posts">予約済み</string>
+	<string name="pending_email_change_snackbar">%1$s へ送信されたメール内の認証リンクをクリックして、新しいアドレスを承認してください。</string>
+	<string name="primary_site">基本のサイト</string>
+	<string name="web_address">ウェブアドレス</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">一部のメディアのアップロードに失敗しました。もう一度お試しいただくか、該当するファイルを削除してください。</string>
+	<string name="editor_toast_uploading_please_wait">メディアをアップロードしています。完了するまで、しばらくお待ちください。</string>
+	<string name="error_refresh_comments_showing_older">現在、コメントを更新することができないため、古いコメントが表示されます。</string>
+	<string name="editor_post_settings_set_featured_image">アイキャッチ画像を設定</string>
+	<string name="editor_post_settings_featured_image">アイキャッチ画像</string>
+	<string name="new_editor_promo_desc">Android 用の WordPress アプリに、美しいビジュアルエディターが\n新たに追加されました。新しい投稿を作って、その機能をお試しください。</string>
+	<string name="new_editor_promo_title">刷新されたエディター</string>
+	<string name="new_editor_promo_button_label">ありがとうございます。</string>
+	<string name="visual_editor_enabled">ビジュアルエディターを有効化しました</string>
+	<string name="editor_content_placeholder">こちらでストーリーを共有してください...</string>
+	<string name="editor_page_title_placeholder">ページタイトル</string>
+	<string name="editor_post_title_placeholder">投稿タイトル</string>
+	<string name="email_address">メールアドレス</string>
+	<string name="preference_show_visual_editor">ビジュアルエディターを表示</string>
+	<string name="dlg_sure_to_delete_comments">これらのコメントを完全に削除しますか ?</string>
+	<string name="preference_editor">編集者</string>
+	<string name="dlg_sure_to_delete_comment">このコメントを完全に削除しますか ?</string>
+	<string name="mnu_comment_delete_permanently">削除</string>
+	<string name="comment_deleted_permanently">コメントを削除しました</string>
+	<string name="mnu_comment_untrash">復元</string>
+	<string name="comments_empty_list_filtered">%s のコメントはありません</string>
+	<string name="could_not_load_page">ページを読み込めません</string>
+	<string name="comment_status_all">すべて</string>
+	<string name="interface_language">管理画面の言語</string>
+	<string name="off">オフ</string>
+	<string name="about_the_app">このアプリについて</string>
 	<string name="error_post_my_profile">プロフィールを保存できませんでした</string>
 	<string name="error_fetch_account_settings">アカウント設定を読み込めませんでした</string>
 	<string name="error_fetch_my_profile">プロフィールを読み込めませんでした</string>
@@ -487,11 +565,9 @@
 	<string name="hs__invalid_email_error">正しいメールアドレスを入力してください</string>
 	<string name="add_location">位置情報を追加</string>
 	<string name="current_location">現在の位置</string>
-	<string name="your_signature">署名:</string>
 	<string name="search_location">検索</string>
 	<string name="edit_location">編集</string>
 	<string name="search_current_location">位置情報取得</string>
-	<string name="preference_privacy">プライバシー</string>
 	<string name="preference_send_usage_stats">統計情報を送信</string>
 	<string name="preference_send_usage_stats_summary">WordPress for Android を改善するため、利用統計情報を自動的に送信する</string>
 	<string name="update_verb">更新</string>
@@ -530,7 +606,6 @@
 	<string name="theme_set_failed">テーマの設定に失敗しました</string>
 	<string name="adding_cat_failed">カテゴリーの追加に失敗しました</string>
 	<string name="adding_cat_success">カテゴリーを追加しました</string>
-	<string name="auto_sharing_preference_reset">自動共有設定リセット</string>
 	<string name="blog_name_cant_be_used">そのサイトアドレスは使えません</string>
 	<string name="blog_name_contains_invalid_characters">サイトアドレスに \'_\' (アンダースコア記号) を含めることはできません</string>
 	<string name="blog_name_must_be_at_least_four_characters">サイトアドレスは4文字以上にしてください。</string>
@@ -551,7 +626,6 @@
 	<string name="error_refresh_notifications">通知を再読み込みできませんでした</string>
 	<string name="invalid_email_message">無効なメールアドレスです</string>
 	<string name="invalid_password_message">パスワードは4文字以上にしてください</string>
-	<string name="invalid_url_message">入力したブログ URL が正しいか確認してください</string>
 	<string name="invalid_username_too_long">ユーザー名は半角で61文字以下にしてください。</string>
 	<string name="invalid_username_too_short">ユーザー名は4文字以上にしてください</string>
 	<string name="no_account">WordPress アカウントが見つかりません。アカウントを追加して、もう一度お試しください。</string>
@@ -574,7 +648,6 @@
 	<string name="username_or_password_incorrect">入力されたユーザー名またはパスワードが間違っています</string>
 	<string name="wait_until_upload_completes">アップロードが完了するまでお待ちください</string>
 	<string name="username_must_include_letters">ユーザー名には必ず英小文字 (a-z) を1つ以上含めてください</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">以前選択したブログは現在非表示になっています</string>
 	<string name="error_refresh_posts">投稿を再読み込みできませんでした</string>
 	<string name="error_refresh_pages">ページを再読み込みできませんでした</string>
 	<string name="error_refresh_comments">コメントを再読み込みできませんでした</string>
@@ -686,6 +759,7 @@
 	<string name="blog_removed_successfully">サイトを削除しました</string>
 	<string name="remove_account">サイトを削除</string>
 	<string name="notifications_empty_all">通知はまだありません。</string>
+	<string name="invalid_site_url_message">入力したサイト URL が正しいか確認してください</string>
 	<string name="deleting_page">ページを削除中</string>
 	<string name="deleting_post">投稿を削除中</string>
 	<string name="share_link">リンクを共有</string>
@@ -699,11 +773,8 @@
 	<string name="download">メディアをダウンロード中</string>
 	<string name="reader_label_reply">返信</string>
 	<string name="video">動画</string>
-	<string name="share_preference_title">WordPress で共有</string>
 	<string name="reader_toast_err_get_comment">このコメントを読み込めません</string>
 	<string name="cant_share_no_visible_blog">公開ブログがないため WordPress で共有できません</string>
-	<string name="reset_auto_share_preference">自動共有設定をリセット</string>
-	<string name="always_use_these_settings_to_share">常にこの設定を使用</string>
 	<string name="reader_likes_you_and_multi">あなたと%,d人が「いいね」をしています。</string>
 	<string name="reader_likes_multi">%,d 人が「いいね」しています。</string>
 	<string name="pick_photo">画像を選択</string>
@@ -803,13 +874,11 @@
 	<string name="passcode_manage">PIN 番号ロック管理</string>
 	<string name="stats_view_tags_and_categories">タグとカテゴリー</string>
 	<string name="stats_view_visitors_and_views">訪問者数・表示回数</string>
-	<string name="media_no_video_title">VideoPress が利用できません</string>
 	<string name="post_excerpt">抜粋</string>
 	<string name="theme_activating_button">有効化中</string>
 	<string name="theme_set_success">テーマの設定を完了しました。</string>
 	<string name="share_action_title">追加先</string>
 	<string name="theme_auth_error_title">テーマ情報の取得に失敗しました</string>
-	<string name="media_no_video_message">動画をアップロードするには VideoPress アップグレードを追加してください。</string>
 	<string name="custom_date">カスタム日付</string>
 	<string name="upload">アップロード</string>
 	<string name="sign_in">ログイン</string>
@@ -819,8 +888,6 @@
 	<string name="more_notifications">あと%d件。</string>
 	<string name="new_notifications">%d件の新しい通知</string>
 	<string name="loading">読込中…</string>
-	<string name="post_signature">投稿の署名</string>
-	<string name="add_tagline">新規投稿に署名を追加</string>
 	<string name="httpuser">HTTP ユーザー名</string>
 	<string name="httppassword">HTTP パスワード</string>
 	<string name="error_media_upload">メディアをアップロードする際にエラーが発生しました</string>
@@ -847,11 +914,9 @@
 	<string name="upload_scaled_image">アップロードしてサイズを変更した画像にリンク</string>
 	<string name="scheduled">予約済み</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">WordPress for Android から投稿</string>
 	<string name="version">バージョン</string>
 	<string name="tos">利用規約</string>
 	<string name="app_title">WordPress for Android</string>
-	<string name="about">紹介</string>
 	<string name="max_thumbnail_px_width">標準の画像幅</string>
 	<string name="image_alignment">配置</string>
 	<string name="refresh">再読み込み</string>
@@ -896,70 +961,4 @@
 	<string name="error">エラー</string>
 	<string name="category_refresh_error">カテゴリーの再読み込みエラー</string>
 	<string name="notification_settings">通知設定</string>
-	<string-array name="alignment_array">
-		<item>なし</item>
-		<item>左</item>
-		<item>中央</item>
-		<item>右</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>サイト上のコメント</item>
-		<item>自分のコメントへの「いいね」</item>
-		<item>自分の投稿への「いいね」</item>
-		<item>サイトでフォロー</item>
-		<item>サイトの達成記録</item>
-		<item>ユーザー名への言及</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>自分のコメントへの返信</item>
-		<item>自分のコメントへの「いいね」</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>提案</item>
-		<item>リサーチ</item>
-		<item>コミュニティ</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>WordPress.com を最大限に活用するためのヒント。</item>
-		<item>WordPress.com の研究・調査に参加する機会。</item>
-		<item>WordPress.com のコースやイベント (オンライン・オフライン) の情報。</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>公開済み</item>
-		<item>下書き</item>
-		<item>予約済み</item>
-		<item>ゴミ箱移動済み</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>アサイド</item>
-		<item>音声</item>
-		<item>チャット</item>
-		<item>ギャラリー</item>
-		<item>画像</item>
-		<item>リンク</item>
-		<item>引用</item>
-		<item>標準</item>
-		<item>ステータス</item>
-		<item>動画</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>誰でもサイトを表示可能にし、検索エンジンによるインデックスを許可する</item>
-		<item>誰でもサイトを表示可能にし、検索エンジンによるインデックスは回避する</item>
-		<item>自身と承認したユーザーのみがサイトを表示可能</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>すべてのコメントで、手動の承認が必要です。</item>
-		<item>ユーザーのコメントが以前に承認されている場合、自動的に承認します。</item>
-		<item>すべてのコメントを自動的に承認します。</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>コメントはありません</item>
-		<item>既知のユーザーのコメント</item>
-		<item>すべてのユーザー</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>無料</item>
-		<item>すべて</item>
-		<item>プレミアム</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-ko/strings.xml
+++ b/WordPress/src/main/res/values-ko/strings.xml
@@ -1,6 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">계정 설정을 저장할 수 없습니다.</string>
+	<string name="post_format_status">상태</string>
+	<string name="post_format_video">비디오</string>
+	<string name="align_none">없음</string>
+	<string name="align_left">왼쪽</string>
+	<string name="align_center">가운데</string>
+	<string name="align_right">오른쪽</string>
+	<string name="theme_free">무료</string>
+	<string name="theme_all">모두</string>
+	<string name="theme_premium">프리미엄</string>
+	<string name="post_format_chat">채팅</string>
+	<string name="post_format_gallery">갤러리</string>
+	<string name="post_format_image">이미지</string>
+	<string name="post_format_link">링크</string>
+	<string name="post_format_quote">인용</string>
+	<string name="post_format_standard">기본</string>
+	<string name="notif_events">워드프레스닷컴 강의 및 이벤트에 대한 정보(온라인 및 직접 만남).</string>
+	<string name="post_format_aside">추가 정보</string>
+	<string name="post_format_audio">오디오</string>
+	<string name="notif_surveys">워드프레스닷컴 리서치 및 설문 조사에 참여할 기회.</string>
+	<string name="notif_tips">워드프레스닷컴을 최대한 활용하기 위한 팁.</string>
+	<string name="notif_community">커뮤니티</string>
+	<string name="replies_to_my_comments">내 댓글에 대한 답글</string>
+	<string name="notif_suggestions">제안</string>
+	<string name="notif_research">리서치</string>
+	<string name="site_achievements">사이트 작성 글</string>
+	<string name="username_mentions">사용자명 멘션</string>
+	<string name="likes_on_my_posts">내 글의 좋아요</string>
+	<string name="site_follows">사이트 팔로우</string>
+	<string name="likes_on_my_comments">내 댓글의 좋아요</string>
+	<string name="comments_on_my_site">내 사이트의 댓글</string>
+	<string name="site_settings_list_editor_summary_other">%d개 항목</string>
+	<string name="site_settings_list_editor_summary_one">1개의 항목</string>
+	<string name="approve_auto_if_previously_approved">알려진 사용자의 댓글</string>
+	<string name="approve_auto">모든 사용자</string>
+	<string name="approve_manual">댓글 없음</string>
+	<string name="site_settings_paging_summary_other">페이지당 댓글 %d개</string>
+	<string name="site_settings_paging_summary_one">페이지당 댓글 1개</string>
+	<string name="site_settings_multiple_links_summary_other">링크가 %d개를 넘는 경우 승인 필요</string>
+	<string name="site_settings_multiple_links_summary_one">링크가 1개를 넘는 경우 승인 필요</string>
+	<string name="site_settings_multiple_links_summary_zero">링크가 0개를 넘는 경우 승인 필요</string>
+	<string name="detail_approve_auto">모든 사람의 댓글을 자동으로 승인합니다.</string>
+	<string name="detail_approve_auto_if_previously_approved">사용자가 이전에 댓글을 승인한 경우 자동으로 승인합니다.</string>
+	<string name="detail_approve_manual">모든 사람의 댓글에 수동 승인이 필요합니다.</string>
+	<string name="filter_trashed_posts">삭제됨</string>
+	<string name="days_quantity_one">1일</string>
+	<string name="days_quantity_other">%d일</string>
+	<string name="filter_published_posts">발행됨</string>
+	<string name="filter_draft_posts">임시글</string>
+	<string name="filter_scheduled_posts">예약됨</string>
+	<string name="pending_email_change_snackbar">새 주소를 확인하려면 %1$s(으)로 전송된 이메일에 있는 확인 링크를 클릭하세요.</string>
+	<string name="primary_site">기본 사이트</string>
+	<string name="web_address">웹 주소</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">일부 미디어 업로드에 실패했습니다. 다시 시도하거나 삭제하세요.</string>
+	<string name="editor_toast_uploading_please_wait">미디어를 업로드 중입니다. 완료될 때까지 기다려 주세요.</string>
+	<string name="error_refresh_comments_showing_older">지금은 댓글을 새로 고칠 수 없습니다. 이전 댓글을 표시 중입니다.</string>
+	<string name="editor_post_settings_set_featured_image">특성 이미지 설정</string>
+	<string name="editor_post_settings_featured_image">특성 이미지</string>
+	<string name="new_editor_promo_desc">Android용 워드프레스 앱에 멋진\n 편집기. 새 글을 작성하면서 사용해 보세요.</string>
+	<string name="new_editor_promo_title">완전히 새로운 편집기</string>
+	<string name="new_editor_promo_button_label">네, 확인했습니다.</string>
+	<string name="visual_editor_enabled">비주얼 편집기 사용 설정됨</string>
+	<string name="editor_content_placeholder">여기서 스토리 공유…</string>
+	<string name="editor_page_title_placeholder">페이지 제목</string>
+	<string name="editor_post_title_placeholder">글 제목</string>
+	<string name="email_address">이메일 주소</string>
+	<string name="preference_show_visual_editor">비주얼 편집기 표시</string>
+	<string name="dlg_sure_to_delete_comments">이 댓글을 영구 삭제하시겠습니까?</string>
+	<string name="preference_editor">편집자</string>
+	<string name="dlg_sure_to_delete_comment">이 댓글을 영구 삭제하시겠습니까?</string>
+	<string name="mnu_comment_delete_permanently">삭제</string>
+	<string name="comment_deleted_permanently">댓글 삭제됨</string>
+	<string name="mnu_comment_untrash">복원</string>
+	<string name="comments_empty_list_filtered">%s 댓글 없음</string>
+	<string name="could_not_load_page">페이지를 로드할 수 없음</string>
+	<string name="comment_status_all">모두</string>
+	<string name="interface_language">인터페이스 언어</string>
+	<string name="off">끔</string>
+	<string name="about_the_app">앱 정보</string>
 	<string name="error_post_my_profile">프로필을 저장할 수 없습니다.</string>
 	<string name="error_fetch_account_settings">계정 설정을 검색할 수 없습니다.</string>
 	<string name="error_fetch_my_profile">프로필을 검색할 수 없습니다.</string>
@@ -487,11 +565,9 @@
 	<string name="hs__invalid_email_error">유효한 이메일 주소를 입력하세요</string>
 	<string name="add_location">위치 추가</string>
 	<string name="current_location">현재 위치</string>
-	<string name="your_signature">당신의 서명:</string>
 	<string name="search_location">검색</string>
 	<string name="edit_location">편집</string>
 	<string name="search_current_location">위치 지정</string>
-	<string name="preference_privacy">프라이버시</string>
 	<string name="preference_send_usage_stats">통계 보내기</string>
 	<string name="preference_send_usage_stats_summary">사용 통계를 자동으로 보내면 안드로이드용 워드프레스를 개선하는데 도움이 됩니다.</string>
 	<string name="update_verb">업데이트</string>
@@ -522,8 +598,6 @@
 	<string name="mnu_comment_unspam">스팸이 아닙니다.</string>
 	<string name="error_refresh_posts">게시물을 다시로드 할 수 없습니다.</string>
 	<string name="error_refresh_comments">댓글을 다시로드 할 수 없습니다 .</string>
-	<string name="auto_sharing_preference_reset">자동 공유 설정을 재설정했습니다.</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">이전에 선택한 블로그는 현재 비공개로 되어 있습니다.</string>
 	<string name="error_refresh_pages">고정 페이지를 다시로드 할 수 없습니다.</string>
 	<string name="error_refresh_notifications">알림을 다시로드 할 수 없습니다.</string>
 	<string name="username_or_password_incorrect">입력된 사용자 이름이나 암호가 잘못되었습니다.</string>
@@ -573,7 +647,6 @@
 	<string name="out_of_memory">장치 메모리가 부족합니다.</string>
 	<string name="no_site_error">WordPress 사이트에 연결할 수 없습니다 . 잠시 후 다시 시도해 주십시오.</string>
 	<string name="no_network_message">사용 가능한 네트워크가 없습니다. 네트워크에 연결하고 다시 시도하십시오 .</string>
-	<string name="invalid_url_message">입력한 블로그 URL이 올바른지 확인하십시오.</string>
 	<string name="sdcard_message">미디어를 업로드하려면 SD카드가 필요합니다.</string>
 	<string name="no_account">WordPress 계정을 찾을 수 없습니다. 계정을 추가하고 다시 시도하십시오.</string>
 	<string name="cat_name_required">카테고리 이름은 필수 항목입니다.</string>
@@ -686,6 +759,7 @@
 	<string name="blog_removed_successfully">사이트가 제거되었습니다.</string>
 	<string name="remove_account">사이트 제거</string>
 	<string name="notifications_empty_all">알림이 없습니다.</string>
+	<string name="invalid_site_url_message">입력한 사이트 URL이 올바른지 확인합니다.</string>
 	<string name="deleting_page">페이지 삭제</string>
 	<string name="deleting_post">글 삭제</string>
 	<string name="share_url_post">글 공유</string>
@@ -699,11 +773,8 @@
 	<string name="download">미디어를 다운로드 중</string>
 	<string name="reader_label_reply">회신</string>
 	<string name="video">동영상</string>
-	<string name="share_preference_title">WordPress 공유</string>
 	<string name="reader_toast_err_get_comment">이 코멘트를 읽을 수 없습니다</string>
 	<string name="cant_share_no_visible_blog">공개 블로그가 없기 때문에 WordPress에 공유 할 수 없습니다</string>
-	<string name="reset_auto_share_preference">자동 공유 설정을 재설정</string>
-	<string name="always_use_these_settings_to_share">항상 이 설정을 사용</string>
 	<string name="reader_likes_you_and_multi">당신에게 %d명이 "좋아요"를 하고 있습니다.</string>
 	<string name="reader_likes_multi">%d명이 "좋아요"를 눌렀습니다.</string>
 	<string name="pick_photo">이미지를 선택</string>
@@ -804,12 +875,10 @@
 	<string name="passcode_enter_passcode">PIN 번호를 입력</string>
 	<string name="passcode_manage">PIN 번호 잠금 관리</string>
 	<string name="stats_view_visitors_and_views">방문자수 · 페이지 뷰</string>
-	<string name="media_no_video_title">VideoPress 를 사용할 수 없습니다</string>
 	<string name="post_excerpt">발췌</string>
 	<string name="theme_set_success">테마 설정을 완료 했습니다.</string>
 	<string name="share_action_title">추가 정보</string>
 	<string name="theme_auth_error_title">테마 정보를 가져오는데 실패했습니다</string>
-	<string name="media_no_video_message">동영상을 업로드하려면 VideoPress 업그레이드를 추가 하십시오.</string>
 	<string name="custom_date">사용자 지정 날짜</string>
 	<string name="upload">업로드</string>
 	<string name="sign_in">로그인</string>
@@ -819,8 +888,6 @@
 	<string name="more_notifications">%d개.</string>
 	<string name="new_notifications">%d개의 새로운 알림</string>
 	<string name="loading">로드 중입니다...</string>
-	<string name="post_signature">리뷰 서명</string>
-	<string name="add_tagline">새 게시물에 서명을 추가</string>
 	<string name="httpuser">HTTP 사용자 이름</string>
 	<string name="httppassword">HTTP 암호</string>
 	<string name="error_media_upload">미디어를 업로드할때 오류가 발생했습니다</string>
@@ -847,11 +914,9 @@
 	<string name="upload_scaled_image">업로드 하여 크기를 조정 한 이미지 링크</string>
 	<string name="scheduled">예약</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">WordPress for Android에서 작성</string>
 	<string name="version">버전</string>
 	<string name="tos">이용 약관</string>
 	<string name="app_title">WordPress for Android</string>
-	<string name="about">소개</string>
 	<string name="max_thumbnail_px_width">기본 이미지 너비</string>
 	<string name="image_alignment">배치</string>
 	<string name="refresh">다시 로드</string>
@@ -896,70 +961,4 @@
 	<string name="on">선택</string>
 	<string name="category_refresh_error">카테고리의 다시 읽기 오류</string>
 	<string name="notification_settings">알림 설정</string>
-	<string-array name="alignment_array">
-		<item>없음</item>
-		<item>왼쪽</item>
-		<item>중앙</item>
-		<item>오른쪽</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>내 사이트의 댓글</item>
-		<item>내 댓글의 좋아요</item>
-		<item>내 게시글의 좋아요</item>
-		<item>사이트 팔로우</item>
-		<item>사이트 작성 글</item>
-		<item>사용자명 멘션</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>내 댓글에 대한 답글</item>
-		<item>내 댓글의 좋아요</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>제안</item>
-		<item>리서치</item>
-		<item>커뮤니티</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>워드프레스닷컴을 최대한 활용하기 위한 팁.</item>
-		<item>워드프레스닷컴 리서치 및 설문 조사에 참여할 기회.</item>
-		<item>워드프레스닷컴 강의 및 이벤트에 대한 정보(온라인 및 직접 만남).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>발행됨</item>
-		<item>임시글</item>
-		<item>예약됨</item>
-		<item>삭제됨</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>곁에</item>
-		<item>음성</item>
-		<item>채팅</item>
-		<item>갤러리</item>
-		<item>이미지</item>
-		<item>링크</item>
-		<item>인용</item>
-		<item>표준</item>
-		<item>상태</item>
-		<item>동영상</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>사이트가 모든 사람에게 공개되며 검색 엔진이 검색할 수 있습니다.</item>
-		<item>사이트가 모든 사람에게 공개되지만 검색 엔진에 사이트가 검색되지 않도록 요청합니다.</item>
-		<item>사이트가 본인과 본인이 승인한 사용자에게만 공개됩니다.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>모든 사람의 댓글에 대한 수동 승인이 필요합니다.</item>
-		<item>사용자가 이전에 댓글을 승인한 경우 자동으로 승인합니다.</item>
-		<item>모든 사람의 댓글을 자동으로 승인합니다.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>댓글 없음</item>
-		<item>알려진 사용자의 댓글</item>
-		<item>모든 사용자</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>무료</item>
-		<item>모두</item>
-		<item>프리미엄</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-mk/strings.xml
+++ b/WordPress/src/main/res/values-mk/strings.xml
@@ -125,11 +125,9 @@
 	<string name="contact_us">Контактирај нè</string>
 	<string name="add_location">Додади локација</string>
 	<string name="current_location">Моментална локација</string>
-	<string name="your_signature">Ваш подпис:</string>
 	<string name="search_location">Пребарувај</string>
 	<string name="edit_location">Уреди</string>
 	<string name="search_current_location">Лоцирај</string>
-	<string name="preference_privacy">Приватност</string>
 	<string name="preference_send_usage_stats">Испрати статистика</string>
 	<string name="preference_send_usage_stats_summary">Автоматски испраќај статистика од употребата да ни помогнеш да го подобриме WordPress за Андроид</string>
 	<string name="update_verb">Ажурирај</string>
@@ -182,9 +180,7 @@
 	<string name="blog_name_must_be_at_least_four_characters">Веб адресата мора да содржи барем 4 знака</string>
 	<string name="no_account">Не е пронајдена WordPress корисничка сметка, додади корисничка сметка и обиди се повторно</string>
 	<string name="blog_name_must_be_less_than_sixty_four_characters">Веб адреста треба да има помалку од 64 знака</string>
-	<string name="auto_sharing_preference_reset">Ресетирање на подесувањата за автоматско споделување</string>
 	<string name="blog_name_contains_invalid_characters">Веб адресата не треба да содржи знак  “_”</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Претходно избраниот блог повеќе не е видлив</string>
 	<string name="blog_name_cant_be_used">Вие не може да ја користите оваа веб адреса</string>
 	<string name="blog_name_exists">Оваа веб адреса веќе постои</string>
 	<string name="blog_name_reserved">Оваа веб адреса е резервирана</string>
@@ -212,7 +208,6 @@
 	<string name="blog_not_found">Настана грешка додека се достапувше блогот</string>
 	<string name="error_refresh_notifications">Известувањата неможат да се ажурират во моментот</string>
 	<string name="error_refresh_pages">Страниците неможат да се ажурират во моментот</string>
-	<string name="invalid_url_message">Проверете дали блог URL-то е воведно правилно</string>
 	<string name="error_refresh_posts">Напсите неможат да се ажурират во моментот</string>
 	<string name="blog_name_reserved_but_may_be_available">Ова адреса во моментот е резервирана, но можеби може да биде досптана по неколку денови</string>
 	<string name="gallery_error">Неможе да биде превземена медиата.</string>
@@ -333,9 +328,6 @@
 	<string name="video">Видео</string>
 	<string name="download">Преземање на медиа</string>
 	<string name="comment_spammed">Коментарот е означен како спам</string>
-	<string name="share_preference_title">Сподели до WordPress</string>
-	<string name="always_use_these_settings_to_share">Секогаш користи ги овие поднесувања</string>
-	<string name="reset_auto_share_preference">Ресетирање на подесувањата за автоматско споделување</string>
 	<string name="pick_photo">Избери фотографија</string>
 	<string name="validating_site_data">Валидирање на податоци за сајт</string>
 	<string name="reader_toast_err_get_post">Неможе да се вчита овој напис</string>
@@ -391,8 +383,6 @@
 	<string name="media_gallery_type_tiled">Плочки</string>
 	<string name="media_gallery_type_circles">Кругови</string>
 	<string name="media_gallery_type_slideshow">Слајдшоу</string>
-	<string name="media_no_video_title">VideoPress не е достапен</string>
-	<string name="media_no_video_message">Преземи го ажурирањето за VideoPress за прикачување на видео!</string>
 	<string name="media_edit_title_text">Наслов</string>
 	<string name="media_edit_caption_text">Наслов</string>
 	<string name="media_edit_description_text">Опис</string>
@@ -446,8 +436,6 @@
 	<string name="note_reply_successful">Одговори на објавено</string>
 	<string name="loading">Вчитување...</string>
 	<string name="httpuser">HTTP корисничко име</string>
-	<string name="post_signature">Потпис на написот</string>
-	<string name="add_tagline">Додади потпис на новите написи</string>
 	<string name="httppassword">HTTP лозинка</string>
 	<string name="error_media_upload">Настана грешка при качување на медиа</string>
 	<string name="publish_date">Објави</string>
@@ -473,11 +461,9 @@
 	<string name="scaled_image">Ширина на прилагодена слика</string>
 	<string name="scheduled">Распоредени</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Објавено од WordPress за Android</string>
 	<string name="tos">Услови за користење</string>
 	<string name="version">Верзија</string>
 	<string name="app_title">WordPress за Андроид</string>
-	<string name="about">За нас</string>
 	<string name="image_alignment">Усогласување</string>
 	<string name="refresh">Освежи</string>
 	<string name="untitled">Без наслов</string>
@@ -520,22 +506,4 @@
 	<string name="yes">Да</string>
 	<string name="no">Не</string>
 	<string name="preview">Преглед</string>
-	<string-array name="alignment_array">
-		<item>Никој</item>
-		<item>Лево</item>
-		<item>Центар</item>
-		<item>Десно</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Настрана</item>
-		<item>Аудио</item>
-		<item>Разговор</item>
-		<item>Галерија</item>
-		<item>Слика</item>
-		<item>Врска</item>
-		<item>Цитат</item>
-		<item>Стандардно</item>
-		<item>Статус</item>
-		<item>Видео</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-nb/strings.xml
+++ b/WordPress/src/main/res/values-nb/strings.xml
@@ -155,11 +155,9 @@
 	<string name="hs__invalid_email_error">Skriv inn en gyldig epost-adresse</string>
 	<string name="add_location">Legg til bosted</string>
 	<string name="current_location">Nåværende bosted</string>
-	<string name="your_signature">Din signatur:</string>
 	<string name="search_location">Søk</string>
 	<string name="edit_location">Rediger</string>
 	<string name="search_current_location">Finn</string>
-	<string name="preference_privacy">Synlighet</string>
 	<string name="preference_send_usage_stats">Send statistikk</string>
 	<string name="preference_send_usage_stats_summary">Send automatisk brukerdata til å forbedre WordPress for Android</string>
 	<string name="update_verb">Oppdater</string>
@@ -236,7 +234,6 @@
 	<string name="reader_likes_multi">%,d personer liker dette</string>
 	<string name="reader_toast_err_get_comment">Kunne ikke hente denne kommentaren</string>
 	<string name="video">Video</string>
-	<string name="share_preference_title">Del med WordPress</string>
 	<string name="pick_photo">Velg bilde</string>
 	<string name="select_date">Velg dato</string>
 	<string name="reader_likes_you_and_one">Du og en annen har likt dette</string>
@@ -272,7 +269,6 @@
 	<string name="media_gallery_type">Type</string>
 	<string name="media_gallery_image_order_random">Tilfeldig</string>
 	<string name="media_gallery_image_order_reverse">Omvendt</string>
-	<string name="media_no_video_title">VideoPress utilgjengelig</string>
 	<string name="media_edit_title_text">Tittel</string>
 	<string name="media_edit_description_text">Beskrivelse</string>
 	<string name="media_edit_success">Oppdatert</string>
@@ -306,7 +302,6 @@
 	<string name="media_gallery_type_squares">Kvadratisk</string>
 	<string name="media_gallery_type_tiled">Flislagt</string>
 	<string name="media_gallery_type_slideshow">Lysbildevisning</string>
-	<string name="media_no_video_message">Oppgrader til VideoPress for å laste opp video!</string>
 	<string name="media_edit_description_hint">Skriv en beskrivelse her</string>
 	<string name="themes_features_label">Funksjoner</string>
 	<string name="stats_view_visitors_and_views">Besøk og visninger</string>
@@ -332,8 +327,6 @@
 	<string name="new_notifications">%d nye varsler</string>
 	<string name="more_notifications">og %d flere.</string>
 	<string name="loading">Laster...</string>
-	<string name="post_signature">Signatur innlegg</string>
-	<string name="add_tagline">Legg til en signatur i nye innlegg</string>
 	<string name="httpuser">HTTP brukernavn</string>
 	<string name="httppassword">HTTP passord</string>
 	<string name="error_media_upload">Det oppsto en feil under opplasting av media.</string>
@@ -360,11 +353,9 @@
 	<string name="scaled_image">Bildebredde</string>
 	<string name="scheduled">Planlagt</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Publisert med WordPress for Android</string>
 	<string name="version">Versjon</string>
 	<string name="tos">Lisens</string>
 	<string name="app_title">WordPress for Android</string>
-	<string name="about">Om</string>
 	<string name="image_alignment">Justering</string>
 	<string name="refresh">Oppdater</string>
 	<string name="untitled">Uten tittel</string>
@@ -408,26 +399,4 @@
 	<string name="no">Nei</string>
 	<string name="error">Feil</string>
 	<string name="category_refresh_error">Feil ved innlasting av kategorier på nytt</string>
-	<string-array name="alignment_array">
-		<item>Ingen</item>
-		<item>Venstre</item>
-		<item>Senter</item>
-		<item>Høyre</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Publisert</item>
-		<item>Kladder</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Tilside</item>
-		<item>Lyd</item>
-		<item>Prat</item>
-		<item>Galleri</item>
-		<item>Bilde</item>
-		<item>Lenke</item>
-		<item>Sitat</item>
-		<item>Standard</item>
-		<item>Status</item>
-		<item>Video</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-nl/strings.xml
+++ b/WordPress/src/main/res/values-nl/strings.xml
@@ -1,6 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">Opslaan van je accountinstellingen mislukt</string>
+	<string name="post_format_status">Status</string>
+	<string name="post_format_video">Video</string>
+	<string name="align_none">Geen</string>
+	<string name="align_left">Links</string>
+	<string name="align_center">Midden</string>
+	<string name="align_right">Rechts</string>
+	<string name="theme_free">Gratis</string>
+	<string name="theme_all">Alle</string>
+	<string name="theme_premium">Premium</string>
+	<string name="post_format_chat">Chat</string>
+	<string name="post_format_gallery">Galerij</string>
+	<string name="post_format_image">Afbeelding</string>
+	<string name="post_format_link">Link</string>
+	<string name="post_format_quote">Citeren</string>
+	<string name="post_format_standard">Standaard</string>
+	<string name="notif_events">Informatie over cursussen en evenementen van WordPress.com (online en op locatie).</string>
+	<string name="post_format_aside">Aside</string>
+	<string name="post_format_audio">Audio</string>
+	<string name="notif_surveys">Mogelijkheden om deel te nemen aan onderzoeken en enquêtes van WordPress.com.</string>
+	<string name="notif_tips">Tips om WordPress.com optimaal te benutten.</string>
+	<string name="notif_community">Community</string>
+	<string name="replies_to_my_comments">Antwoorden op mijn reacties</string>
+	<string name="notif_suggestions">Suggesties</string>
+	<string name="notif_research">Onderzoek</string>
+	<string name="site_achievements">Prestaties voor de site</string>
+	<string name="username_mentions">Vermeldingen van gebruikersnaam</string>
+	<string name="likes_on_my_posts">Likes voor mijn berichten</string>
+	<string name="site_follows">Volgers van site</string>
+	<string name="likes_on_my_comments">Likes voor mijn reacties</string>
+	<string name="comments_on_my_site">Reacties op mijn site</string>
+	<string name="site_settings_list_editor_summary_other">%d items</string>
+	<string name="site_settings_list_editor_summary_one">1 item</string>
+	<string name="approve_auto_if_previously_approved">Reacties van bekende gebruikers</string>
+	<string name="approve_auto">Alle gebruikers</string>
+	<string name="approve_manual">Geen reacties</string>
+	<string name="site_settings_paging_summary_other">%d reacties per pagina</string>
+	<string name="site_settings_paging_summary_one">1 reactie per pagina</string>
+	<string name="site_settings_multiple_links_summary_other">Vereis goedkeuring voor meer dan %d links</string>
+	<string name="site_settings_multiple_links_summary_one">Vereis goedkeuring voor meer dan 1 link</string>
+	<string name="site_settings_multiple_links_summary_zero">Vereis goedkeuring voor meer dan 0 links</string>
+	<string name="detail_approve_auto">Keur de reacties van iedereen automatisch goed.</string>
+	<string name="detail_approve_auto_if_previously_approved">Keur de reactie automatisch goed indien de gebruiker eerder een goedgekeurde reactie heeft geplaatst</string>
+	<string name="detail_approve_manual">Vereist handmatige goedkeuring voor de reacties van iedereen.</string>
+	<string name="filter_trashed_posts">Verwijderd</string>
+	<string name="days_quantity_one">1 dag</string>
+	<string name="days_quantity_other">%d dagen</string>
+	<string name="filter_published_posts">Gepubliceerd</string>
+	<string name="filter_draft_posts">Concepten</string>
+	<string name="filter_scheduled_posts">Gepland</string>
+	<string name="pending_email_change_snackbar">Klik op de link in de verificatiemail die verzonden is naar %1$s om je nieuwe adres te bevestigen</string>
+	<string name="primary_site">Primaire site</string>
+	<string name="web_address">Webadres</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">Enkele media konden niet worden geüpload. Probeer het opnieuw of verwijder ze.</string>
+	<string name="editor_toast_uploading_please_wait">Je bent media aan het uploaden. Wacht totdat dit is afgerond.</string>
+	<string name="error_refresh_comments_showing_older">Reacties konden momenteel niet worden vernieuwd - oudere reacties worden weergegeven</string>
+	<string name="editor_post_settings_set_featured_image">Stel aanbevolen afbeelding in</string>
+	<string name="editor_post_settings_featured_image">Aanbevolen afbeelding</string>
+	<string name="new_editor_promo_desc">De WordPress-app voor Android bevat een prachtige nieuwe visual\n editor. Probeer hem uit door een nieuw bericht te maken.</string>
+	<string name="new_editor_promo_title">Volledig nieuwe editor</string>
+	<string name="new_editor_promo_button_label">Geweldig, bedankt!</string>
+	<string name="visual_editor_enabled">Visual Editor ingeschakeld</string>
+	<string name="editor_content_placeholder">Deel hier je verhaal...</string>
+	<string name="editor_page_title_placeholder">Paginatitel</string>
+	<string name="editor_post_title_placeholder">Berichttitel</string>
+	<string name="email_address">E-mailadres</string>
+	<string name="preference_show_visual_editor">Visual Editor weergeven</string>
+	<string name="dlg_sure_to_delete_comments">Deze reacties permanent verwijderen?</string>
+	<string name="preference_editor">Editor</string>
+	<string name="dlg_sure_to_delete_comment">Deze reactie permanent verwijderen?</string>
+	<string name="mnu_comment_delete_permanently">Verwijderen</string>
+	<string name="comment_deleted_permanently">Reactie verwijderd</string>
+	<string name="mnu_comment_untrash">Herstellen</string>
+	<string name="comments_empty_list_filtered">Geen %s reacties</string>
+	<string name="could_not_load_page">Kan pagina niet laden</string>
+	<string name="comment_status_all">Alle</string>
+	<string name="interface_language">Interface-taal</string>
+	<string name="off">Uit</string>
+	<string name="about_the_app">Over de app</string>
 	<string name="error_post_my_profile">Opslaan van je profiel mislukt</string>
 	<string name="error_fetch_account_settings">Ophalen van je accountinstellingen mislukt</string>
 	<string name="error_fetch_my_profile">Ophalen van je profiel mislukt</string>
@@ -487,11 +565,9 @@
 	<string name="hs__invalid_email_error">Voer een geldig e-mailadres in</string>
 	<string name="add_location">Locatie toevoegen</string>
 	<string name="current_location">Huidige Locatie</string>
-	<string name="your_signature">Je handtekening</string>
 	<string name="search_location">Zoeken</string>
 	<string name="edit_location">Bewerken</string>
 	<string name="search_current_location">Locatie bepalen</string>
-	<string name="preference_privacy">Privacy</string>
 	<string name="preference_send_usage_stats">Verstuur statistieken</string>
 	<string name="preference_send_usage_stats_summary">Stuur automatisch gebruiksstatistieken om ons te helpen WordPress voor Android te verbeteren</string>
 	<string name="update_verb">Bijwerken</string>
@@ -527,8 +603,6 @@
 	<string name="cat_name_required">Het veld Categorienaam is verplicht</string>
 	<string name="category_automatically_renamed">Categorienaam %1$s is ongeldig. De categorie is hernoemd naar %2$s.</string>
 	<string name="no_account">Geen WordPress-account gevonden. Voeg een account toe en probeer het opnieuw</string>
-	<string name="auto_sharing_preference_reset">Instellingen automatisch delen opnieuw instellen</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Eerder geselecteerd blog is niet meer zichtbaar</string>
 	<string name="sdcard_message">Er moet een SD-kaart zijn gekoppeld om media te uploaden</string>
 	<string name="stats_empty_comments">Er zijn nog geen reacties</string>
 	<string name="error_load_comment">Kan de reactie niet laden</string>
@@ -550,7 +624,6 @@
 	<string name="blog_not_found">Er heeft zich een fout voorgedaan tijdens het openen van dit blog</string>
 	<string name="wait_until_upload_completes">Wacht tot de upload is voltooid</string>
 	<string name="stats_bar_graph_empty">Geen statistieken beschikbaar</string>
-	<string name="invalid_url_message">Controleer of de ingevoerde blog-URL geldig is</string>
 	<string name="reply_failed">Reactie mislukt</string>
 	<string name="notifications_empty_list">Geen notificaties</string>
 	<string name="error_delete_post">Er heeft zich een fout voorgedaan bij het verwijderen van %s</string>
@@ -686,6 +759,7 @@
 	<string name="blog_name_invalid">Ongeldig site-adres</string>
 	<string name="blog_title_invalid">Ongeldige sitetitel</string>
 	<string name="notifications_empty_all">Nog geen meldingen.</string>
+	<string name="invalid_site_url_message">Controleer of de ingevoerde site-URL geldig is</string>
 	<string name="share_url_page">Deel pagina</string>
 	<string name="share_url_post">Deel bericht</string>
 	<string name="deleting_page">Verwijderen van pagina</string>
@@ -703,9 +777,6 @@
 	<string name="download">Downloaden van media</string>
 	<string name="comment_spammed">Reactie als spam gemarkeerd</string>
 	<string name="cant_share_no_visible_blog">Je kan niet delen naar WordPress zonder een zichtbare blog</string>
-	<string name="share_preference_title">Deel naar WordPress</string>
-	<string name="reset_auto_share_preference">Reset auto-sharing instellingen</string>
-	<string name="always_use_these_settings_to_share">Gebruik deze instellingen altijd</string>
 	<string name="pick_photo">Selecteer foto</string>
 	<string name="account_two_step_auth_enabled">Voor deze account is authenticatie in twee stappen actief. Bekijk je beveiligingsinstellingen op WordPress.com en genereer een applicatie-specifiek wachtwoord.</string>
 	<string name="pick_video">Selecteer video</string>
@@ -758,7 +829,6 @@
 	<string name="unattached">Niet gekoppeld</string>
 	<string name="custom_date">Aan te passen datum</string>
 	<string name="media_gallery_type_slideshow">Diavoorstelling</string>
-	<string name="media_no_video_title">VideoPress niet beschikbaar</string>
 	<string name="media_edit_title_text">Titel</string>
 	<string name="media_edit_caption_text">Onderschrift</string>
 	<string name="theme_activating_button">Activeren</string>
@@ -797,7 +867,6 @@
 	<string name="passcode_re_enter_passcode">Voer je PIN opnieuw in</string>
 	<string name="passcode_change_passcode">Verander PIN</string>
 	<string name="passcode_set">PIN ingesteld</string>
-	<string name="media_no_video_message">Haal nu VideoPress op om video te uploaden</string>
 	<string name="media_edit_description_text">Beschrijving</string>
 	<string name="media_edit_title_hint">Voer hier een titel in</string>
 	<string name="media_edit_caption_hint">Voer hier een onderschrift in</string>
@@ -821,8 +890,6 @@
 	<string name="loading">Laden...</string>
 	<string name="httpuser">HTTP gebruikersnaam</string>
 	<string name="httppassword">HTTP wachtwoord</string>
-	<string name="post_signature">Bericht handtekening</string>
-	<string name="add_tagline">Voeg een handtekening toe aan nieuwe berichten</string>
 	<string name="error_media_upload">Er is een fout opgetreden tijdens het uploaden van media</string>
 	<string name="publish_date">Publiceer</string>
 	<string name="content_description_add_media">Media toevoegen</string>
@@ -847,11 +914,9 @@
 	<string name="scaled_image">Breedte geschaalde afbeelding</string>
 	<string name="scheduled">Gepland</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Geplaatst met WordPress voor Android</string>
 	<string name="version">Versie</string>
 	<string name="tos">Eindgebruikersovereenkomst</string>
 	<string name="app_title">WordPress voor Android</string>
-	<string name="about">Over</string>
 	<string name="max_thumbnail_px_width">Standaardbreedte van afbeelding</string>
 	<string name="image_alignment">Uitlijning </string>
 	<string name="refresh">Vernieuw</string>
@@ -896,70 +961,4 @@
 	<string name="category_refresh_error">Categorie vernieuwen fout</string>
 	<string name="preview">Voorbeeld</string>
 	<string name="notification_settings">Meldingsinstellingen</string>
-	<string-array name="alignment_array">
-		<item>Geen</item>
-		<item>Links</item>
-		<item>Midden</item>
-		<item>Rechts</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Reacties op mijn site</item>
-		<item>Likes voor mijn reacties</item>
-		<item>Likes voor mijn berichten</item>
-		<item>Volgers van site</item>
-		<item>Prestaties voor de site</item>
-		<item>Vermeldingen van gebruikersnaam</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Antwoorden op mijn reacties</item>
-		<item>Likes voor mijn reacties</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Suggesties</item>
-		<item>Onderzoek</item>
-		<item>Community</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Tips om WordPress.com optimaal te benutten.</item>
-		<item>Mogelijkheden om deel te nemen aan onderzoeken en enquêtes van WordPress.com.</item>
-		<item>Informatie over cursussen en evenementen van WordPress.com (online en op locatie).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Gepuliceerd</item>
-		<item>Concept</item>
-		<item>Ingepland</item>
-		<item>Weggegooid</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Aside</item>
-		<item>Audio</item>
-		<item>Chat</item>
-		<item>Galerij</item>
-		<item>Afbeelding</item>
-		<item>Link</item>
-		<item>Quote</item>
-		<item>Standaard</item>
-		<item>Status</item>
-		<item>Video</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Je site kan door iedereen worden bekeken en kan worden geïndexeerd door zoekmachines</item>
-		<item>Je site kan door iedereen worden bekeken, maar wordt niet geïndexeerd door zoekmachines</item>
-		<item>Je site is alleen zichtbaar voor jou en gebruikers die je goedkeurt</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>Vereist handmatige goedkeuring voor de reacties van iedereen.</item>
-		<item>Keur de reactie automatisch goed indien de gebruiker eerder een goedgekeurde reactie heeft geplaatst.</item>
-		<item>Keur de reacties van iedereen automatisch goed.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>Geen reacties</item>
-		<item>Reacties van bekende gebruikers</item>
-		<item>Alle gebruikers</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Gratis</item>
-		<item>Alles</item>
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -180,13 +180,11 @@
 	<string name="hs__conversation_detail_error">Opisz problem, który zaobserwowano</string>
 	<string name="add_location">Dodaj lokalizację</string>
 	<string name="current_location">Obecna lokalizacja</string>
-	<string name="your_signature">Twój podpis:</string>
 	<string name="search_location">Szukaj</string>
 	<string name="edit_location">Edytuj</string>
 	<string name="search_current_location">Zlokalizuj</string>
 	<string name="preference_send_usage_stats_summary">Automatycznie wysyłaj statystyki użytkowania, by pomóc nam ulepszać WordPressa dla Androida</string>
 	<string name="preference_send_usage_stats">Wysyłaj statystyki</string>
-	<string name="preference_privacy">Prywatność</string>
 	<string name="update_verb">Zaktualizuj</string>
 	<string name="schedule_verb">Zaplanuj</string>
 	<string name="reader_title_subs">Tagi i blogi</string>
@@ -219,7 +217,6 @@
 	<string name="theme_set_failed">Nie udało się włączyć motywu</string>
 	<string name="stats_empty_comments">Brak komentarzy</string>
 	<string name="stats_bar_graph_empty">Statystyki nie są dostępne</string>
-	<string name="invalid_url_message">Sprawdź czy wprowadzony URL bloga jest poprawny</string>
 	<string name="notifications_empty_list">Brak powiadomień</string>
 	<string name="error_delete_post">Wystąpił błąd podczas usuwania %s</string>
 	<string name="error_refresh_posts">W tej chwili nie można odświeżyć wpisów</string>
@@ -241,7 +238,6 @@
 	<string name="blog_name_required">Wpisz adres strony</string>
 	<string name="no_network_message">Brak dostępnej sieci</string>
 	<string name="no_site_error">Nie można nawiązać połączenia ze stroną WordPressa</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Poprzednio wybrany blog nie jest już widoczny</string>
 	<string name="blog_not_found">Wystąpił błąd podczas dostępu do tego bloga</string>
 	<string name="error_refresh_pages">Strony nie mogły zostać odświeżone w tej chwili</string>
 	<string name="error_refresh_notifications">Powiadomienia nie mogły zostać odświeżone w tej chwili</string>
@@ -261,7 +257,6 @@
 	<string name="error_refresh_stats">Statystyki chwilowo nie mogły zostać wyświetlone</string>
 	<string name="blog_name_exists">Witryna o takiej nazwie już istnieje</string>
 	<string name="nux_cannot_log_in">Nie możemy zalogować cię na twoje konto</string>
-	<string name="auto_sharing_preference_reset">Ustawienia automatycznego udostępniania zostały przywrócone do domyślnych</string>
 	<string name="error_downloading_image">Błąd pobierania obrazka</string>
 	<string name="error_load_comment">Nie można było wczytać komentarza</string>
 	<string name="blog_name_must_be_less_than_sixty_four_characters">Adres witryny musi być krótszy niż 64 znaki</string>
@@ -386,9 +381,6 @@
 	<string name="download">Pobieranie mediów</string>
 	<string name="comment_spammed">Komentarz został oznaczony jako spam</string>
 	<string name="cant_share_no_visible_blog">Nie możesz udostępnić do WordPressa bez widocznego bloga</string>
-	<string name="share_preference_title">Udostępnij do WordPressa</string>
-	<string name="reset_auto_share_preference">Zresetuj ustawienia autoudostępniania</string>
-	<string name="always_use_these_settings_to_share">Zawsze używaj tych ustawień</string>
 	<string name="reader_likes_you_and_multi">Ty i %,d innych lubią to</string>
 	<string name="reader_likes_multi">%,d osób lubi to</string>
 	<string name="select_time">Wybierz czas</string>
@@ -474,7 +466,6 @@
 	<string name="passcode_re_enter_passcode">Powtórz swój PIN</string>
 	<string name="passcode_change_passcode">Zmień PIN</string>
 	<string name="passcode_set">Ustaw PIN</string>
-	<string name="media_no_video_message">Zainstaluj VideoPress, aby móc wysyłać pliki wideo!</string>
 	<string name="theme_set_success">Pomyślnie ustawiono motyw!</string>
 	<string name="theme_auth_error_title">Nie udało się pobrać motywów.</string>
 	<string name="images">Obrazy</string>
@@ -482,7 +473,6 @@
 	<string name="media_add_popup_capture_photo">Wykonaj zdjęcie</string>
 	<string name="media_gallery_image_order_reverse">Odwrócona</string>
 	<string name="media_gallery_type_circles">Kręgi</string>
-	<string name="media_no_video_title">Funkcja VideoPress jest niedostępna</string>
 	<string name="media_edit_caption_text">Podpis</string>
 	<string name="theme_activating_button">Aktywowanie</string>
 	<string name="theme_activate_button">Aktywuj</string>
@@ -501,10 +491,8 @@
 	<string name="more_notifications">i %d więcej.</string>
 	<string name="sign_in">Zaloguj się</string>
 	<string name="loading">Ładowanie...</string>
-	<string name="add_tagline">Dodaj podpis do nowych wpisów</string>
 	<string name="httpuser">Nazwa użytkownika protokołu HTTP</string>
 	<string name="httppassword">Hasło protokołu HTTP</string>
-	<string name="post_signature">Podpis</string>
 	<string name="error_media_upload">Napotkano błąd podczas wysyłania multimediów.</string>
 	<string name="publish_date">Opublikuj</string>
 	<string name="post_content">Treść (dotknij, aby dodać tekst i multimedia)</string>
@@ -529,11 +517,9 @@
 	<string name="upload_scaled_image">Załaduj i wprowadź adres do przeskalowanego obrazu</string>
 	<string name="scheduled">Zaplanowane</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Opublikowano przez WordPress dla Androida</string>
 	<string name="version">Wersja</string>
 	<string name="app_title">WordPress dla Androida</string>
 	<string name="tos">Warunki korzystania</string>
-	<string name="about">O nas</string>
 	<string name="image_alignment">Wyrównanie</string>
 	<string name="refresh">Odśwież</string>
 	<string name="untitled">Bez tytułu</string>
@@ -576,22 +562,4 @@
 	<string name="error">Błąd</string>
 	<string name="reply">Odpisz</string>
 	<string name="preview">Podgląd</string>
-	<string-array name="alignment_array">
-		<item>Brak</item>
-		<item>Do lewej</item>
-		<item>Wyśrodkuj</item>
-		<item>Do prawej</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Z boku</item>
-		<item>Audio</item>
-		<item>Czat</item>
-		<item>Galeria</item>
-		<item>Obraz</item>
-		<item>Odnośnik</item>
-		<item>Cytuj</item>
-		<item>Standardowe</item>
-		<item>Status</item>
-		<item>Wideo</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-pt-rBR/strings.xml
+++ b/WordPress/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">Não foi possível salvar as configurações da sua conta</string>
+	<string name="post_format_status">Status</string>
+	<string name="post_format_video">Vídeo</string>
+	<string name="align_none">Nenhum</string>
+	<string name="align_left">À esquerda</string>
+	<string name="align_center">Centralizar</string>
+	<string name="align_right">À direita</string>
+	<string name="theme_free">Gratuito</string>
+	<string name="theme_all">Tudo</string>
+	<string name="theme_premium">Premium</string>
+	<string name="post_format_chat">Chat</string>
+	<string name="post_format_gallery">Galeria</string>
+	<string name="post_format_image">Imagem</string>
+	<string name="post_format_link">Link</string>
+	<string name="post_format_quote">Citação</string>
+	<string name="post_format_standard">Padrão</string>
+	<string name="notif_events">Informações sobre cursos e eventos (online e presenciais) do WordPress.com.</string>
+	<string name="post_format_aside">Notas</string>
+	<string name="post_format_audio">Áudio</string>
+	<string name="notif_surveys">Oportunidades para participar das pesquisas e enquetes do WordPress.com.</string>
+	<string name="notif_tips">Dicas para aproveitar o máximo do WordPress.com</string>
+	<string name="notif_community">Comunidade</string>
+	<string name="replies_to_my_comments">Respostas aos meus comentários</string>
+	<string name="notif_suggestions">Sugestões</string>
+	<string name="notif_research">Pesquisa</string>
+	<string name="site_achievements">Conquistas do site</string>
+	<string name="username_mentions">Menções ao nome de usuário</string>
+	<string name="likes_on_my_posts">Curtidas nos meus posts</string>
+	<string name="site_follows">Seguidores do site</string>
+	<string name="likes_on_my_comments">Curtidas nos meus comentários</string>
+	<string name="comments_on_my_site">Comentários no meu site</string>
+	<string name="site_settings_list_editor_summary_other">%d itens</string>
+	<string name="site_settings_list_editor_summary_one">1 item</string>
+	<string name="approve_auto_if_previously_approved">Comentários de usuários conhecidos</string>
+	<string name="approve_auto">Todos os usuários</string>
+	<string name="approve_manual">Sem comentários</string>
+	<string name="site_settings_paging_summary_other">%d comentários por página</string>
+	<string name="site_settings_paging_summary_one">1 comentário por página</string>
+	<string name="site_settings_multiple_links_summary_other">Exige aprovação para mais de %d links</string>
+	<string name="site_settings_multiple_links_summary_one">Exige aprovação para mais de 1 link</string>
+	<string name="site_settings_multiple_links_summary_zero">Exige aprovação para mais de 0 links</string>
+	<string name="detail_approve_auto">Aprovar automaticamente todos os comentários.</string>
+	<string name="detail_approve_auto_if_previously_approved">Aprovar automaticamente se o usuário tiver um comentário aprovado anteriormente.</string>
+	<string name="detail_approve_manual">Exigir aprovação manual para todos os comentários.</string>
+	<string name="filter_trashed_posts">Na lixeira</string>
+	<string name="days_quantity_one">1 dia</string>
+	<string name="days_quantity_other">%d dias</string>
+	<string name="filter_published_posts">Publicado</string>
+	<string name="filter_draft_posts">Rascunhos</string>
+	<string name="filter_scheduled_posts">Agendado</string>
+	<string name="pending_email_change_snackbar">Clique no link de verificação no email enviado para %1$s para confirmar seu novo endereço</string>
+	<string name="primary_site">Site principal</string>
+	<string name="web_address">Endereço da web</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">Falha ao fazer upload de algumas mídias. Tente fazer o upload novamente ou exclua as mídias.</string>
+	<string name="editor_toast_uploading_please_wait">Você está fazendo upload de mídia no momento. Aguarde até que o processo seja concluído.</string>
+	<string name="error_refresh_comments_showing_older">Não foi possível atualizar os comentários no momento. Comentários mais antigos estão sendo exibidos</string>
+	<string name="editor_post_settings_set_featured_image">Configurar imagem destacada</string>
+	<string name="editor_post_settings_featured_image">Imagem destacada</string>
+	<string name="new_editor_promo_desc">O aplicativo do WordPress para Android agora inclui um belo visual repaginado.\n editor. Experimente criando um novo post.</string>
+	<string name="new_editor_promo_title">Novo editor</string>
+	<string name="new_editor_promo_button_label">Ótimo, obrigado!</string>
+	<string name="visual_editor_enabled">Editor visual ativado</string>
+	<string name="editor_content_placeholder">Compartilhe sua história aqui...</string>
+	<string name="editor_page_title_placeholder">Título da página</string>
+	<string name="editor_post_title_placeholder">Título do post</string>
+	<string name="email_address">Endereço de email</string>
+	<string name="preference_show_visual_editor">Exibir editor visual</string>
+	<string name="dlg_sure_to_delete_comments">Excluir estes comentários permanentemente?</string>
+	<string name="preference_editor">Editor</string>
+	<string name="dlg_sure_to_delete_comment">Excluir este comentário permanentemente?</string>
+	<string name="mnu_comment_delete_permanently">Excluir</string>
+	<string name="comment_deleted_permanently">Comentário excluído</string>
+	<string name="mnu_comment_untrash">Restaurar</string>
+	<string name="comments_empty_list_filtered">Sem comentários %s</string>
+	<string name="could_not_load_page">Não foi possível carregar a página</string>
+	<string name="comment_status_all">Tudo</string>
+	<string name="interface_language">Idioma da interface</string>
+	<string name="off">Desativado</string>
+	<string name="about_the_app">Sobre o aplicativo</string>
 	<string name="error_post_my_profile">Não foi possível salvar seu perfil</string>
 	<string name="error_fetch_account_settings">Não foi possível recuperar as configurações da sua conta</string>
 	<string name="error_fetch_my_profile">Não foi possível recuperar seu perfil</string>
@@ -15,8 +93,10 @@
 	<string name="add_category">Adicionar categoria</string>
 	<string name="disabled">Desativado</string>
 	<string name="site_settings_image_original_size">Tamanho original</string>
+	<string name="about_me_hint">Algumas palavras sobre você...</string>
 	<string name="about_me">Sobre mim</string>
 	<string name="public_display_name_hint">O nome de exibição será o seu nome de usuário se não for configurado</string>
+	<string name="public_display_name">Nome para exibição pública</string>
 	<string name="first_name">Nome</string>
 	<string name="last_name">Sobrenome</string>
 	<string name="my_profile">Meu perfil</string>
@@ -27,9 +107,13 @@
 	<string name="error_post_remote_site_settings">Não foi possível salvar as informações do site</string>
 	<string name="error_fetch_remote_site_settings">Não foi possível recuperar as informações do site</string>
 	<string name="error_media_upload_connection">Ocorreu um erro de conexão durante o envio de mídia</string>
+	<string name="site_settings_disconnected_toast">Sem conexão, edição desabilitada.</string>
+	<string name="site_settings_unsupported_version_error">Versão do WordPress não suportada</string>
 	<string name="site_settings_multiple_links_dialog_description">Exigir aprovação para comentários que incluem mais do que este número de links.</string>
+	<string name="site_settings_close_after_dialog_switch_text">Fechar automaticamente</string>
 	<string name="site_settings_close_after_dialog_description">Encerrar automaticamente comentários nos artigos.</string>
 	<string name="site_settings_paging_dialog_description">Dividir tópicos de comentários em várias páginas.</string>
+	<string name="site_settings_paging_dialog_header">Comentários por página</string>
 	<string name="site_settings_close_after_dialog_title">Encerrar comentários</string>
 	<string name="site_settings_blacklist_description">Quando um comentário tiver uma destas palavras em seu conteúdo, nome, URL, email ou IP, ele será marcado como spam. Você pode inserir partes de palavras, então "press" corresponderá a "WordPress".</string>
 	<string name="site_settings_hold_for_moderation_description">Quando um comentário contiver qualquer uma destas palavras em seu conteúdo, nome, URL, endereço de email ou IP, o mesmo será retido na fila de moderação. Você pode inserir partes de palavras, então "press" corresponderá a "WordPress".</string>
@@ -42,17 +126,22 @@
 	<string name="site_settings_rp_preview2_title">O aplicativo WordPress para Android foi melhorado</string>
 	<string name="site_settings_rp_preview1_site">em "Mobile"</string>
 	<string name="site_settings_rp_preview1_title">Grande atualização para iPhone/iPad disponível</string>
+	<string name="site_settings_rp_show_images_title">Mostrar imagens</string>
+	<string name="site_settings_rp_show_header_title">Mostrar cabeçalho</string>
 	<string name="site_settings_rp_switch_summary">Posts Relacionados exibe conteúdo relevante do seu site abaixo dos seus posts.</string>
+	<string name="site_settings_rp_switch_title">Mostrar posts relacionados</string>
 	<string name="site_settings_delete_site_hint">Remove os dados do seu site do aplicativo</string>
 	<string name="site_settings_blacklist_hint">Comentários que corresponderem a um filtro serão marcados como spam</string>
 	<string name="site_settings_moderation_hold_hint">Comentários que corresponderem a um filtro serão colocados em uma fila de moderação</string>
 	<string name="site_settings_multiple_links_hint">Ignora o limite de links de usuários conhecidos</string>
 	<string name="site_settings_whitelist_hint">O autor do comentário tem que ter um comentário aprovado anteriormente</string>
+	<string name="site_settings_user_account_required_hint">Usuários devem estar registrados e logados para comentar</string>
 	<string name="site_settings_identity_required_hint">O autor do comentário tem que preencher o nome e email</string>
 	<string name="site_settings_manual_approval_hint">Os comentários devem ser aprovados manualmente</string>
 	<string name="site_settings_paging_hint">Exibir comentários em grupos de tamanho especificado</string>
 	<string name="site_settings_threading_hint">Permitir comentários agrupados em uma certa profundidade</string>
 	<string name="site_settings_sort_by_hint">Determina a ordem de exibição dos comentários</string>
+	<string name="site_settings_close_after_hint">Desabilitar comentários após um tempo específico</string>
 	<string name="site_settings_receive_pingbacks_hint">Permitir notificações de link de outros blogs</string>
 	<string name="site_settings_send_pingbacks_hint">Tentar notificar blogs com links a partir do artigo</string>
 	<string name="site_settings_allow_comments_hint">Permitir que leitores publiquem comentários</string>
@@ -64,26 +153,53 @@
 	<string name="site_settings_format_hint">Define o formato do novo post</string>
 	<string name="site_settings_category_hint">Define a categoria do novo post</string>
 	<string name="site_settings_location_hint">Adicionar automaticamente os dados de localização aos posts</string>
+	<string name="site_settings_password_hint">Alterar sua senha</string>
 	<string name="site_settings_username_hint">Conta de usuário atual</string>
 	<string name="site_settings_language_hint">Idioma em que este blog é normalmente escrito</string>
+	<string name="site_settings_privacy_hint">Controle quem pode ver seu site</string>
 	<string name="site_settings_address_hint">No momento, você não pode alterar o endereço</string>
 	<string name="site_settings_tagline_hint">Uma breve descrição ou uma frase de efeito para descrever o seu blog</string>
 	<string name="site_settings_title_hint">Em poucas palavras, explique sobre o que é este site</string>
 	<string name="site_settings_whitelist_known_summary">Comentários de usuários conhecidos</string>
 	<string name="site_settings_whitelist_all_summary">Comentários de todos os usuários</string>
+	<string name="site_settings_threading_summary">%d níveis</string>
+	<string name="site_settings_privacy_private_summary">Privado</string>
+	<string name="site_settings_privacy_hidden_summary">Oculto</string>
+	<string name="site_settings_privacy_public_summary">Público</string>
+	<string name="site_settings_delete_site_title">Excluir site</string>
+	<string name="site_settings_blacklist_title">Lista negra</string>
 	<string name="site_settings_moderation_hold_title">Aguardar moderação</string>
 	<string name="site_settings_multiple_links_title">Links nos comentários</string>
+	<string name="site_settings_whitelist_title">Aprovar automaticamente</string>
 	<string name="site_settings_threading_title">Threading</string>
 	<string name="site_settings_paging_title">Paginação</string>
+	<string name="site_settings_sort_by_title">Ordenar por</string>
 	<string name="site_settings_account_required_title">Os usuários devem estar conectados</string>
 	<string name="site_settings_identity_required_title">É necessário incluir nome e email</string>
 	<string name="site_settings_receive_pingbacks_title">Receber Pingbacks</string>
 	<string name="site_settings_send_pingbacks_title">Enviar Pingbacks</string>
+	<string name="site_settings_allow_comments_title">Habilitar comentários</string>
+	<string name="site_settings_default_format_title">Formato padrão</string>
+	<string name="site_settings_default_category_title">Categoria padrão</string>
+	<string name="site_settings_location_title">Habilitar localização</string>
+	<string name="site_settings_address_title">Endereço</string>
+	<string name="site_settings_title_title">Título do site</string>
 	<string name="site_settings_tagline_title">Tagline</string>
+	<string name="site_settings_this_device_header">Este dispositivo</string>
 	<string name="site_settings_discussion_new_posts_header">Padrões para novos posts</string>
+	<string name="site_settings_writing_header">Escrevendo</string>
+	<string name="site_settings_account_header">Conta</string>
+	<string name="site_settings_general_header">Geral</string>
 	<string name="newest_first">Mais novos primeiro</string>
+	<string name="related_posts">Posts relacionados</string>
+	<string name="comments">Comentários</string>
+	<string name="discussion">Discussão</string>
+	<string name="privacy">Privacidade</string>
 	<string name="close_after">Encerrar após</string>
 	<string name="oldest_first">Mais antigos primeiro</string>
+	<string name="media_error_no_permission_upload">Você não tem permissão para enviar mídia para o site</string>
+	<string name="never">Nunca</string>
+	<string name="unknown">Desconhecido</string>
 	<string name="reader_err_get_post_not_found">Este post não existe mais</string>
 	<string name="reader_err_get_post_not_authorized">Você não possui autorização para ver este post</string>
 	<string name="reader_err_get_post_generic">Falha ao carregar esse post</string>
@@ -302,6 +418,8 @@
 	<string name="tab_title_site_videos">Vídeos do site</string>
 	<string name="tab_title_site_images">Imagens do site</string>
 	<string name="media_picker_title">Selecionar mídia</string>
+	<string name="media_details_label_file_type">Tipo de arquivo</string>
+	<string name="media_details_label_file_name">Nome do arquivo</string>
 	<string name="error_notification_open">Não foi possível abrir a notificação</string>
 	<string name="publisher">Editor:</string>
 	<string name="reader_empty_posts_request_failed">Não foi possível recuperar os posts</string>
@@ -447,11 +565,9 @@
 	<string name="hs__invalid_email_error">Digite um email válido</string>
 	<string name="add_location">Adicionar localização</string>
 	<string name="current_location">Localização atual</string>
-	<string name="your_signature">Sua assinatura:</string>
 	<string name="search_location">Pesquisa</string>
 	<string name="search_current_location">Localizar</string>
 	<string name="edit_location">   Editar</string>
-	<string name="preference_privacy">Privacidade</string>
 	<string name="preference_send_usage_stats">Enviar estatísticas</string>
 	<string name="preference_send_usage_stats_summary">Envie estatísticas de uso automaticamente para nos ajudar a melhorar o WordPress para Android</string>
 	<string name="update_verb">Atualizar</string>
@@ -491,7 +607,6 @@
 	<string name="adding_cat_failed">Problema ao adicionar categoria</string>
 	<string name="could_not_remove_account">Não foi possível remover o site</string>
 	<string name="stats_bar_graph_empty">Nenhuma estatística disponível</string>
-	<string name="invalid_url_message">Verifique se a URL do blog inserida é válida</string>
 	<string name="error_generic">Ocorreu um erro</string>
 	<string name="error_edit_comment">Ocorreu um erro ao editar o comentário</string>
 	<string name="error_load_comment">Não foi possível carregar o comentário</string>
@@ -501,8 +616,6 @@
 	<string name="cat_name_required">O campo de nome da categoria é obrigatório</string>
 	<string name="category_automatically_renamed">O nome da categoria %1$s não é válido. Ela foi renomeada para %2$s.</string>
 	<string name="no_account">Não foi encontrada uma conta WordPress, adicione uma conta e tente novamente</string>
-	<string name="auto_sharing_preference_reset">Configurações de autocompartilhamento redefinidas</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">O blog selecionado previamente não é mais visível</string>
 	<string name="theme_fetch_failed">Falha ao buscar temas</string>
 	<string name="theme_set_failed">Falha ao definir tema</string>
 	<string name="sdcard_message">Um cartão SD montado é necessário para fazer upload de mídia</string>
@@ -646,6 +759,7 @@
 	<string name="blog_name_must_include_letters">O endereço do site deve ter pelo menos uma letra (a-z)</string>
 	<string name="blog_title_invalid">Título do site inválido</string>
 	<string name="notifications_empty_all">Nenhuma notificação... ainda.</string>
+	<string name="invalid_site_url_message">Verifique se a URL do site inserida é válida</string>
 	<string name="deleting_page">Excluindo página</string>
 	<string name="deleting_post">Excluindo post</string>
 	<string name="share_url_post">Compartilhar post</string>
@@ -663,9 +777,6 @@
 	<string name="download">Fazendo download de mídia</string>
 	<string name="comment_spammed">Comentário marcado como spam</string>
 	<string name="cant_share_no_visible_blog">Você não pode compartilhar no WordPress sem um blog visível</string>
-	<string name="share_preference_title">Compartilhar no WordPress</string>
-	<string name="reset_auto_share_preference">Redefinir configurações de auto-compartilhamento</string>
-	<string name="always_use_these_settings_to_share">Sempre usar essa configuração</string>
 	<string name="select_time">Selecione o tempo</string>
 	<string name="reader_likes_you_and_one">Você e mais um gostaram disso</string>
 	<string name="select_date">Selecione a data</string>
@@ -755,7 +866,6 @@
 	<string name="theme_activating_button">Ativando</string>
 	<string name="themes_features_label">Recursos</string>
 	<string name="media_gallery_type_tiled">Mosaico</string>
-	<string name="media_no_video_title">Videopress não esta disponivel</string>
 	<string name="passcode_enter_passcode">Entre seu PIN</string>
 	<string name="passcode_enter_old_passcode">Entre seu PIN antigo</string>
 	<string name="passcode_re_enter_passcode">Entre seu PIN novamente</string>
@@ -769,7 +879,6 @@
 	<string name="passcode_turn_on">Ligar o bloqueio do código PIN</string>
 	<string name="passcode_preference_title">Código PIN</string>
 	<string name="passcode_manage">Gerenciar seu código PIN.</string>
-	<string name="media_no_video_message">Obtenha o VideoPress atualizado para fazer upload de vídeos!</string>
 	<string name="stats_view_visitors_and_views">Visitantes e Visualizações</string>
 	<string name="upload">Enviar</string>
 	<string name="notifications">Notificações</string>
@@ -781,8 +890,6 @@
 	<string name="loading">Carregando...</string>
 	<string name="httpuser">Usuário HTTP</string>
 	<string name="httppassword">Senha HTTP</string>
-	<string name="post_signature">Assinatura</string>
-	<string name="add_tagline">Adicionar uma assinatura a novos posts</string>
 	<string name="error_media_upload">Ocorreu um erro durante o envio de mídia</string>
 	<string name="post_content">Conteúdo (Toque para adicionar texto e mídia)</string>
 	<string name="publish_date">Publicar</string>
@@ -807,11 +914,10 @@
 	<string name="upload_scaled_image">Enviar e link para a imagem redimensionada</string>
 	<string name="scheduled">Agendado</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Publicado do WordPress para Android</string>
 	<string name="version">Versão</string>
 	<string name="tos">Termos de Serviço</string>
 	<string name="app_title">WordPress para Android</string>
-	<string name="about">Sobre</string>
+	<string name="max_thumbnail_px_width">Largura padrão de imagem</string>
 	<string name="image_alignment">Alinhamento</string>
 	<string name="refresh">Atualizar</string>
 	<string name="untitled">Sem Título</string>
@@ -855,66 +961,4 @@
 	<string name="reply">Responder</string>
 	<string name="preview">Pré-visualizar</string>
 	<string name="notification_settings">Configurações de notificações</string>
-	<string-array name="alignment_array">
-		<item>Nenhum</item>
-		<item>Esquerda</item>
-		<item>Centralizado</item>
-		<item>Direita</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Comentários no meu site</item>
-		<item>Curtidas nos meus comentários</item>
-		<item>Curtidas nos meus posts</item>
-		<item>Seguidores do site</item>
-		<item>Conquistas do site</item>
-		<item>Menções ao nome de usuário</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Respostas aos meus comentários</item>
-		<item>Curtidas nos meus comentários</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Sugestões</item>
-		<item>Pesquisa</item>
-		<item>Comunidade</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Dicas para aproveitar ao máximo o WordPress.com.</item>
-		<item>Oportunidades para participar das pesquisas e enquetes do WordPress.com.</item>
-		<item>Informações sobre cursos e eventos (online e presenciais) do WordPress.com.</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Publicado</item>
-		<item>Rascunhos</item>
-		<item>Agendado</item>
-		<item>Na lixeira</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Nota</item>
-		<item>Áudio</item>
-		<item>Chat</item>
-		<item>Galeria</item>
-		<item>Imagem</item>
-		<item>Link</item>
-		<item>Citação</item>
-		<item>Padrão</item>
-		<item>Status</item>
-		<item>Vídeo</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Seu site está visível para todos e pode ser indexado por mecanismos de busca</item>
-		<item>Seu site está visível para todos mas solicita aos mecanismos de busca para não indexá-lo</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>Exigir aprovação manual para todos os comentários.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>Comentários de usuários conhecidos</item>
-		<item>Todos os usuários</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Gratuito</item>
-		<item>Todos</item>
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -1,6 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">N-am putut salva setările tale de cont</string>
+	<string name="post_format_status">Stare</string>
+	<string name="post_format_video">Video</string>
+	<string name="align_none">Niciuna</string>
+	<string name="align_left">Stânga</string>
+	<string name="align_center">Centru</string>
+	<string name="align_right">Dreapta</string>
+	<string name="theme_free">Gratis</string>
+	<string name="theme_all">Toate</string>
+	<string name="theme_premium">Premium</string>
+	<string name="post_format_gallery">Galerie</string>
+	<string name="post_format_image">Imagine</string>
+	<string name="post_format_link">Legătură</string>
+	<string name="post_format_quote">Citat</string>
+	<string name="post_format_standard">Standard</string>
+	<string name="post_format_chat">Discuție</string>
+	<string name="post_format_audio">Audio</string>
+	<string name="post_format_aside">Notă</string>
+	<string name="notif_events">Informații despre cursurile și evenimente WordPress.com (online și în persoană).</string>
+	<string name="notif_surveys">Oportunități de a participa în cercetarea și sondaje WordPress.com.</string>
+	<string name="notif_tips">Sfaturi pentru a profita la maxim de WordPress.com.</string>
+	<string name="notif_community">Comunitate</string>
+	<string name="notif_research">Cercetare</string>
+	<string name="replies_to_my_comments">Răspunsuri la comentariile mele</string>
+	<string name="notif_suggestions">Sugestii</string>
+	<string name="site_achievements">Realizări sit</string>
+	<string name="username_mentions">Mențiuni nume utilizator</string>
+	<string name="likes_on_my_posts">Aprecieri pentru articolele mele</string>
+	<string name="site_follows">Urmăriri sit</string>
+	<string name="likes_on_my_comments">Aprecieri pentru comentariile mele</string>
+	<string name="comments_on_my_site">Comentarii pe situl meu</string>
+	<string name="site_settings_list_editor_summary_other">%d elemente</string>
+	<string name="site_settings_list_editor_summary_one">1 element</string>
+	<string name="approve_auto">Toți utilizatorii</string>
+	<string name="approve_auto_if_previously_approved">Comentariile utilizatorilor cunoscuți</string>
+	<string name="approve_manual">Niciun comentariu</string>
+	<string name="site_settings_paging_summary_other">%d comentarii per pagină</string>
+	<string name="site_settings_paging_summary_one">1 comentariu per pagină</string>
+	<string name="site_settings_multiple_links_summary_other">Necesită aprobare dacă are mai mult de %d legături</string>
+	<string name="site_settings_multiple_links_summary_one">Necesită aprobare dacă are mai mult de o legătură</string>
+	<string name="site_settings_multiple_links_summary_zero">Necesită aprobare dacă are mai mult de 0 legături</string>
+	<string name="detail_approve_auto">Aprobare automată a tuturor comentariilor.</string>
+	<string name="detail_approve_auto_if_previously_approved">Aprobare automată dacă utilizatorul are un comentariu aprobat anterior</string>
+	<string name="detail_approve_manual">Necesită aprobare manuală pentru comentariile oricui.</string>
+	<string name="days_quantity_one">1 zi</string>
+	<string name="days_quantity_other">%d zile</string>
+	<string name="filter_trashed_posts">Aruncat la gunoi</string>
+	<string name="filter_draft_posts">Ciorne</string>
+	<string name="filter_scheduled_posts">Programată</string>
+	<string name="filter_published_posts">Publicat</string>
+	<string name="pending_email_change_snackbar">Dă clic pe legătura de verificare din emailul trimis la %1$s pentru a confirma noua ta adresă</string>
+	<string name="primary_site">Sit primar</string>
+	<string name="web_address">Adresă web</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">Unele actualizări media au eșuat. Te rog reînceacă-le sau șterge-le.</string>
+	<string name="editor_toast_uploading_please_wait">Acum încarci media. Te rog așteaptă până ce asta se termină.</string>
+	<string name="error_refresh_comments_showing_older">Comentariile nu pot fi reîmprospătate acum - sunt arătate comentarii mai vechi</string>
+	<string name="editor_post_settings_set_featured_image">Setează imaginea reprezentativă</string>
+	<string name="editor_post_settings_featured_image">Imagine reprezentativă</string>
+	<string name="new_editor_promo_desc">aplicația WordPress pentru Android include acum un un nou și frumos \neditor vizual. Încearcă-l creând un nou articol.</string>
+	<string name="new_editor_promo_title">Editor nou nouț</string>
+	<string name="new_editor_promo_button_label">Super, mulțumesc!</string>
+	<string name="visual_editor_enabled">Editor vizual validat</string>
+	<string name="editor_content_placeholder">Partajează aici povestea ta...</string>
+	<string name="editor_page_title_placeholder">Titlu pagină</string>
+	<string name="editor_post_title_placeholder">Titlu articol</string>
+	<string name="email_address">Adresă email</string>
+	<string name="preference_show_visual_editor">Arată editorul vizual</string>
+	<string name="dlg_sure_to_delete_comments">Șterg permanent aceste comentarii?</string>
+	<string name="preference_editor">Editor</string>
+	<string name="dlg_sure_to_delete_comment">Șterg permanent acest comentariu?</string>
+	<string name="mnu_comment_delete_permanently">Ștergere</string>
+	<string name="comment_deleted_permanently">Comentariu șters</string>
+	<string name="mnu_comment_untrash">Restaurare</string>
+	<string name="comments_empty_list_filtered">Nu %s cometarii</string>
+	<string name="could_not_load_page">Nu pot încărca pagina</string>
+	<string name="comment_status_all">Tot</string>
+	<string name="interface_language">Limba interfeței</string>
+	<string name="off">Oprit</string>
+	<string name="about_the_app">Despre aplicație</string>
+	<string name="error_post_account_settings">N-am putut salva setările tale de cont</string>
 	<string name="error_post_my_profile">N-am putut salva profilul tău</string>
 	<string name="error_fetch_account_settings">N-am putut aduce setările tale de cont</string>
 	<string name="error_fetch_my_profile">N-am putut aduce profilul tău</string>
@@ -15,6 +94,9 @@
 	<string name="add_category">Adaugă categorie</string>
 	<string name="disabled">Invalidat</string>
 	<string name="site_settings_image_original_size">Mărime originală</string>
+	<string name="privacy_private">Situl tău este vizibil doar pentru tine și pentru utilizatorii pe care i-ai aprobat</string>
+	<string name="privacy_public_not_indexed">Situl tău este vizibil pentru toată lumea, dar cere motoarelor de căutare să nu-l indexeze</string>
+	<string name="privacy_public">Situl tău este vizibil pentru toată lumea și poate fi indexat de motoarele de căutare</string>
 	<string name="about_me_hint">Câteva cuvinte despre tine...</string>
 	<string name="public_display_name_hint">Numele afișat va fi implicit numele utilizator dacă nu este setat</string>
 	<string name="about_me">Despre mine</string>
@@ -487,13 +569,11 @@
 	<string name="contact_us">Contactează-ne</string>
 	<string name="current_location">Locație curentă</string>
 	<string name="add_location">Adaugă locație</string>
-	<string name="your_signature">Semnătura ta:</string>
 	<string name="search_current_location">Localizează</string>
 	<string name="edit_location">Editare</string>
 	<string name="search_location">Caută</string>
 	<string name="preference_send_usage_stats_summary">Trimite automat statistici pentru a ajuta la îmbunătățirea aplicației WordPress pentru Android</string>
 	<string name="preference_send_usage_stats">Trimite statistici</string>
-	<string name="preference_privacy">Confidențialitate</string>
 	<string name="schedule_verb">Programare</string>
 	<string name="update_verb">Actualizează</string>
 	<string name="reader_empty_recommended_blogs">Niciun blog recomandat</string>
@@ -559,13 +639,10 @@
 	<string name="error_refresh_posts">Articolele n-au putut fi reîmprospătate în acest moment</string>
 	<string name="error_delete_post">A apărut o eroare în timpul ștergerii %s</string>
 	<string name="notifications_empty_list">Nicio notificare</string>
-	<string name="invalid_url_message">Verifică dacă URL-ul de blog introdus este valid</string>
 	<string name="reply_failed">Răspuns eșuat</string>
 	<string name="stats_bar_graph_empty">Nicio statistică disponibilă</string>
 	<string name="stats_empty_comments">Niciun comentariu deocamdată</string>
 	<string name="sdcard_message">Este necesar un card SD montat pentru a încărca media</string>
-	<string name="auto_sharing_preference_reset">Resetare setări de auto-partajare </string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Blogul selectat anterior nu mai este vizibil</string>
 	<string name="no_account">Niciun cont WordPress nu a fost găsit, adaugă unul și încearcă din nou</string>
 	<string name="cat_name_required">Câmpul cu numele categoriei este obligatoriu</string>
 	<string name="category_automatically_renamed">Numele categoriei %1$s nu e valid. A fost redenumită %2$s.</string>
@@ -583,6 +660,7 @@
 	<string name="theme_fetch_failed">Am eșuat în aducerea temelor</string>
 	<string name="no_network_message">Nu e nicio rețea disponibilă</string>
 	<string name="out_of_memory">Depășirea memoriei dispozitivului</string>
+	<string name="invalid_url_message">Verifică dacă URL-ul introdus este valid</string>
 	<string name="blog_removed_successfully">Sit înlăturat cu succes</string>
 	<string name="remove_account">Înlătură situl</string>
 	<string name="reader_toast_err_remove_tag">Nu pot șterge această etichetă</string>
@@ -686,6 +764,7 @@
 	<string name="select_categories">Selectează categoriile</string>
 	<string name="xmlrpc_error">Nu mă pot conecta. Introdu calea completă spre xmlrpc.php de pe situl tău și mai încearcă odată.</string>
 	<string name="notifications_empty_all">Nicio notificare... încă.</string>
+	<string name="invalid_site_url_message">Verifică dacă URL-ul de sit introdus e corect</string>
 	<string name="share_url_post">Partajare articol</string>
 	<string name="share_url_page">Partajare pagină</string>
 	<string name="share_link">Partajare legătură</string>
@@ -699,10 +778,7 @@
 	<string name="reader_likes_multi">%,d oameni la fel</string>
 	<string name="reader_label_reply">Răspunde</string>
 	<string name="reader_likes_you_and_multi">Tu și încă %,d alții la fel</string>
-	<string name="always_use_these_settings_to_share">Folosește întotdeauna aceste setări</string>
 	<string name="cant_share_no_visible_blog">Nu poți partaja pe WordPress fără ca blogul să fie vizibil</string>
-	<string name="share_preference_title">Partajare pe WordPress</string>
-	<string name="reset_auto_share_preference">Resetare setări de auto-partajare</string>
 	<string name="reader_toast_err_get_comment">Nu pot să aduc acest comentariu</string>
 	<string name="download">Descarc media</string>
 	<string name="video">Video</string>
@@ -794,9 +870,7 @@
 	<string name="media_edit_caption_text">Text asociat</string>
 	<string name="media_edit_description_text">Descriere</string>
 	<string name="media_edit_title_hint">Introdu aici titlul</string>
-	<string name="media_no_video_message">Fă actualizarea pentru VideoPress pentru a încărca un video!</string>
 	<string name="media_edit_title_text">Titlu</string>
-	<string name="media_no_video_title">VideoPress indisponibil</string>
 	<string name="media_gallery_type_tiled">Placat</string>
 	<string name="media_gallery_type_circles">Cercuri</string>
 	<string name="media_gallery_type_slideshow">Diaporama</string>
@@ -821,8 +895,6 @@
 	<string name="loading">Se încarcă...</string>
 	<string name="httpuser">nume utilizator HTTP</string>
 	<string name="httppassword">parolă HTTP</string>
-	<string name="post_signature">Semnătură articol</string>
-	<string name="add_tagline">Adaugă o semnătură noilor articole</string>
 	<string name="error_media_upload">A apărut o eroare la încărcarea media</string>
 	<string name="content_description_add_media">Adaugă media</string>
 	<string name="publish_date">Publicare</string>
@@ -847,11 +919,9 @@
 	<string name="upload_scaled_image">Încarcă și leagă la imaginea scalată</string>
 	<string name="scheduled">Programat</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Publicat de pe WordPress pentru Android</string>
 	<string name="app_title">WordPress pentru Android</string>
 	<string name="version">Versiune</string>
 	<string name="tos">Termenii de funcționare a serviciului</string>
-	<string name="about">Despre</string>
 	<string name="max_thumbnail_px_width">Lățime imagine implicită</string>
 	<string name="image_alignment">Aliniere</string>
 	<string name="refresh">Reîmprospătare</string>
@@ -873,6 +943,7 @@
 	<string name="categories">Categorii</string>
 	<string name="title">Titlu</string>
 	<string name="tags_separate_with_commas">Etichete (separă etichetele cu virgule)</string>
+	<string name="dlg_deleting_comments">Ștergere comentarii</string>
 	<string name="notification_vibrate">Vibrare</string>
 	<string name="notification_blink">Clipește lumina de notificare</string>
 	<string name="notification_sound">Sunet de notificare</string>
@@ -896,70 +967,4 @@
 	<string name="add">Adaugă</string>
 	<string name="cancel">Anulare</string>
 	<string name="notification_settings">Setări notificare</string>
-	<string-array name="alignment_array">
-		<item>Nimic</item>
-		<item>Stânga</item>
-		<item>Centru</item>
-		<item>Dreapta</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Comentarii pe situl meu</item>
-		<item>Aprecieri la comentariile mele</item>
-		<item>Aprecieri la articolele mele</item>
-		<item>Urmăriri sit</item>
-		<item>Realizările sitului</item>
-		<item>Mențiuni nume utilizator</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Răspunsuri la comentariile mele</item>
-		<item>Aprecieri la comentariile mele</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Sugestii</item>
-		<item>Cercetare</item>
-		<item>Comunitate</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Sfaturi pentru a obține ce este mai bun din WordPress.com.</item>
-		<item>Oportunități de a participa în cercetări și sondaje WordPress.com.</item>
-		<item>Informații despre cursuri și evenimente WordPress.com (on-line &amp; în-persoană).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Publicat</item>
-		<item>Ciorne</item>
-		<item>Planificat</item>
-		<item>Aruncat la gunoi</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Notă</item>
-		<item>Audio</item>
-		<item>Conversație</item>
-		<item>Galerie</item>
-		<item>Imagine</item>
-		<item>Legătură</item>
-		<item>Citat</item>
-		<item>Standard</item>
-		<item>Stare</item>
-		<item>Video</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Situl tău este vizibil oricui și poate fi indexat de motoarele de căutare</item>
-		<item>Situl tău este vizibil oricui dar cere motoarelor de căutare să nu-l indexeze</item>
-		<item>Situl tău este vizibil doar pentru utilizatorii pe care i-ai aprobat</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>E necesară aprobarea manuală pentru comentariile fiecăruia.</item>
-		<item>Aprobă automat dacă utilizatorul are un comentariu anterior aprobat.</item>
-		<item>Aprobă automat comentariile fiecăruia.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>Fără comnetarii</item>
-		<item>Comentariile utilizatorilor cunoscuți</item>
-		<item>Toți utilizatorii</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Gratis</item>
-		<item>Toate</item>
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-ru/strings.xml
+++ b/WordPress/src/main/res/values-ru/strings.xml
@@ -1,6 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">Не удалось сохранить настройки учетной записи.</string>
+	<string name="post_format_status">Статус</string>
+	<string name="post_format_video">Видео</string>
+	<string name="align_none">Нет</string>
+	<string name="align_left">Слева</string>
+	<string name="align_center">По центру</string>
+	<string name="align_right">Справа</string>
+	<string name="theme_free">Бесплатно</string>
+	<string name="theme_all">Все</string>
+	<string name="theme_premium">Премиум</string>
+	<string name="post_format_chat">Чат</string>
+	<string name="post_format_gallery">Галерея</string>
+	<string name="post_format_image">Изображение</string>
+	<string name="post_format_link">Ссылка</string>
+	<string name="post_format_quote">Цитата</string>
+	<string name="post_format_standard">Стандартный</string>
+	<string name="notif_events">Информация об учебных курсах и мероприятиях WordPress.com (очных и онлайн).</string>
+	<string name="post_format_aside">Заметка</string>
+	<string name="post_format_audio">Аудио</string>
+	<string name="notif_surveys">Возможности участия в исследованиях и опросах WordPress.com.</string>
+	<string name="notif_tips">Советы по эффективному использованию WordPress.com.</string>
+	<string name="notif_community">Сообщество</string>
+	<string name="replies_to_my_comments">Ответы на мои комментарии</string>
+	<string name="notif_suggestions">Предложения</string>
+	<string name="notif_research">Исследования</string>
+	<string name="site_achievements">Достижения сайта</string>
+	<string name="username_mentions">Упоминания имени пользователя</string>
+	<string name="likes_on_my_posts">Отметки «Нравится» к моим записям</string>
+	<string name="site_follows">Читатели сайта</string>
+	<string name="likes_on_my_comments">Отметки «Нравится» к моим комментариям</string>
+	<string name="comments_on_my_site">Комментарии на моём сайте</string>
+	<string name="site_settings_list_editor_summary_other">Всего элементов: %d</string>
+	<string name="site_settings_list_editor_summary_one">1 элемент</string>
+	<string name="approve_auto_if_previously_approved">Комментарии известных пользователей</string>
+	<string name="approve_auto">Все пользователи</string>
+	<string name="approve_manual">Нет комментариев</string>
+	<string name="site_settings_paging_summary_other">Количество комментариев на страницу: %d</string>
+	<string name="site_settings_paging_summary_one">1 комментарий на страницу</string>
+	<string name="site_settings_multiple_links_summary_other">Требуется проверка, если количество ссылок превышает %d</string>
+	<string name="site_settings_multiple_links_summary_one">Требуется проверка при наличии более 1 ссылки</string>
+	<string name="site_settings_multiple_links_summary_zero">Требуется проверка при наличии более 0 ссылок</string>
+	<string name="detail_approve_auto">Автоматически одобрять все комментарии.</string>
+	<string name="detail_approve_auto_if_previously_approved">Автоматически одобрять комментарии пользователя, оставившего ранее одобренные комментарии</string>
+	<string name="detail_approve_manual">Включить обязательный этап одобрения для всех комментариев.</string>
+	<string name="filter_trashed_posts">Удален</string>
+	<string name="days_quantity_one">1 день</string>
+	<string name="days_quantity_other">%d дн.</string>
+	<string name="filter_published_posts">Опубликовано</string>
+	<string name="filter_draft_posts">Черновики</string>
+	<string name="filter_scheduled_posts">Запланированные</string>
+	<string name="pending_email_change_snackbar">Нажмите на ссылку в электронном письме, отправленном на %1$s, чтобы подтвердить новый адрес</string>
+	<string name="primary_site">Основной сайт</string>
+	<string name="web_address">Интернет-адрес</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">Не удалось загрузить медиафайлы. Повторите попытку или удалите файлы из очереди.</string>
+	<string name="editor_toast_uploading_please_wait">В данный момент выполняется загрузка медиафайлов. Дождитесь окончания загрузки.</string>
+	<string name="error_refresh_comments_showing_older">Не удалось обновить ленту комментариев — отображены старые комментарии</string>
+	<string name="editor_post_settings_set_featured_image">Настроить избранное изображение</string>
+	<string name="editor_post_settings_featured_image">Избранное изображение</string>
+	<string name="new_editor_promo_desc">Приложение WordPress для Android теперь имеет новое визуальное оформление\n редактор. Попробуйте с его помощью создать новую запись.</string>
+	<string name="new_editor_promo_title">Новый редактор</string>
+	<string name="new_editor_promo_button_label">Спасибо!</string>
+	<string name="visual_editor_enabled">Визуальный редактор включен</string>
+	<string name="editor_content_placeholder">Поделитесь своей историей здесь…</string>
+	<string name="editor_page_title_placeholder">Заголовок страницы</string>
+	<string name="editor_post_title_placeholder">Заголовок записи</string>
+	<string name="email_address">Адрес электронной почты</string>
+	<string name="preference_show_visual_editor">Показать визуальный редактор</string>
+	<string name="dlg_sure_to_delete_comments">Удалить эти комментарии без возможности восстановления?</string>
+	<string name="preference_editor">Редактор</string>
+	<string name="dlg_sure_to_delete_comment">Удалить этот комментарий без возможности восстановления?</string>
+	<string name="mnu_comment_delete_permanently">Удалить</string>
+	<string name="comment_deleted_permanently">Комментарий удалён</string>
+	<string name="mnu_comment_untrash">Восстановить</string>
+	<string name="comments_empty_list_filtered">Нет %s комментариев</string>
+	<string name="could_not_load_page">Не удалось загрузить страницу</string>
+	<string name="comment_status_all">Все</string>
+	<string name="interface_language">Язык интерфейса</string>
+	<string name="off">Выкл.</string>
+	<string name="about_the_app">О приложении</string>
 	<string name="error_post_my_profile">Не удалось сохранить профиль.</string>
 	<string name="error_fetch_account_settings">Не удалось загрузить настройки учетной записи.</string>
 	<string name="error_fetch_my_profile">Не удалось загрузить профиль.</string>
@@ -487,11 +565,9 @@
 	<string name="hs__invalid_email_error">Введите корректный адрес e-mail</string>
 	<string name="add_location">Добавить местоположение</string>
 	<string name="current_location">Текущее местоположение</string>
-	<string name="your_signature">Ваша подпись:</string>
 	<string name="search_location">Поиск</string>
 	<string name="edit_location">Изменить</string>
 	<string name="search_current_location">Найти</string>
-	<string name="preference_privacy">Приватность</string>
 	<string name="preference_send_usage_stats">Отправить статистику</string>
 	<string name="preference_send_usage_stats_summary">Автоматически отправлять статистику использования для улучшения WordPress для Android</string>
 	<string name="update_verb">Обновить</string>
@@ -529,7 +605,6 @@
 	<string name="out_of_memory">Устройству не хватает памяти</string>
 	<string name="gallery_error">Медиа-файл не может быть восстановлен</string>
 	<string name="no_account">Не найдено аккаунта WordPress. Добавьте аккаунт и попробуйте снова</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Ранее выбранный блог изменил статус видимости</string>
 	<string name="error_refresh_posts">Пост не может быть обновлен в данный момент</string>
 	<string name="error_refresh_pages">Страница не может быть обновлена в данный момент</string>
 	<string name="error_refresh_notifications">Уведомление не могут быть обновлены в данный момент</string>
@@ -544,11 +619,9 @@
 	<string name="email_invalid">Введите правильный email адрес</string>
 	<string name="could_not_remove_account">Невозможно удалить сайт</string>
 	<string name="theme_fetch_failed">Ошибка выбора темы.</string>
-	<string name="auto_sharing_preference_reset">Сброс настроек общего доступа</string>
 	<string name="notifications_empty_list">Нет уведомлений</string>
 	<string name="error_delete_post">Произошла ошибка при удалении %s</string>
 	<string name="stats_bar_graph_empty">Статистика недоступна</string>
-	<string name="invalid_url_message">Проверьте правильность введённой ссылки на блог</string>
 	<string name="error_upload">Произошла ошибка при загрузке %s</string>
 	<string name="invalid_email_message">Ваш адрес email не подходит</string>
 	<string name="invalid_password_message">Пароль должен содержать не меньше 4 знаков</string>
@@ -686,6 +759,7 @@
 	<string name="notifications_empty_all">Уведомлений пока нет.</string>
 	<string name="reader_toast_err_add_tag">Не удается добавить эту метку</string>
 	<string name="reader_toast_err_remove_tag">Не удается удалить эту метку</string>
+	<string name="invalid_site_url_message">Убедитесь, что введен допустимый URL-адрес сайта</string>
 	<string name="deleting_page">Удаление страницы</string>
 	<string name="deleting_post">Удаление записи</string>
 	<string name="share_url_post">Поделиться записью</string>
@@ -698,14 +772,11 @@
 	<string name="video">Видео</string>
 	<string name="reader_likes_you_and_multi">Вам и %,d другим понравилось это.</string>
 	<string name="comment_spammed">Комментарий помечен как спам.</string>
-	<string name="always_use_these_settings_to_share">Всегда использовать эти настройки</string>
 	<string name="reader_label_reply">Ответ</string>
 	<string name="reader_likes_multi">Понравилось %,d людям</string>
 	<string name="reader_toast_err_get_comment">Не удается загрузить этот комментарий</string>
 	<string name="download">Загрузить медиа</string>
-	<string name="share_preference_title">Поделиться на WordPress </string>
 	<string name="cant_share_no_visible_blog">Вы не можете поделиться через WordPress без видимого блога</string>
-	<string name="reset_auto_share_preference">Сбросить настройки авто-sharing</string>
 	<string name="select_time">Выберите время</string>
 	<string name="pick_photo">Выберите фото</string>
 	<string name="pick_video">Выберите видео</string>
@@ -805,8 +876,6 @@
 	<string name="post_excerpt">Отрывок</string>
 	<string name="media_edit_description_hint">Введите описание</string>
 	<string name="all">Всё</string>
-	<string name="media_no_video_title">VideoPress недоступен</string>
-	<string name="media_no_video_message">Получить обновление VideoPress для загрузки видео!</string>
 	<string name="media_edit_title_text">Название</string>
 	<string name="media_edit_caption_text">Заголовок</string>
 	<string name="media_edit_title_hint">Введите название</string>
@@ -819,10 +888,8 @@
 	<string name="new_notifications">Новые уведомления: %d</string>
 	<string name="follows">Подписки</string>
 	<string name="loading">Загрузка…</string>
-	<string name="add_tagline">Добавлять подпись к новым записям</string>
 	<string name="httpuser">Имя для HTTP-авторизации</string>
 	<string name="httppassword">Пароль для HTTP-авторизации</string>
-	<string name="post_signature">Подпись для записей</string>
 	<string name="error_media_upload">Произошла ошибка при загрузке медиафайла</string>
 	<string name="publish_date">Опубликовано</string>
 	<string name="content_description_add_media">Добавить медиа</string>
@@ -847,11 +914,9 @@
 	<string name="scaled_image">Ширина уменьшенного изображения</string>
 	<string name="scheduled">Запланировано</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Опубликовано из WordPress для Android</string>
 	<string name="version">Версия</string>
 	<string name="tos">Условия сервиса</string>
 	<string name="app_title">WordPress для Android</string>
-	<string name="about">О программе</string>
 	<string name="max_thumbnail_px_width">Ширина изображения по умолчанию</string>
 	<string name="image_alignment">Выравнивание</string>
 	<string name="refresh">Обновить</string>
@@ -896,70 +961,4 @@
 	<string name="preview">Предварительный просмотр</string>
 	<string name="reply">Ответ</string>
 	<string name="category_refresh_error">Ошибка обновления категорий</string>
-	<string-array name="alignment_array">
-		<item>Нет</item>
-		<item>Слева</item>
-		<item>По центру</item>
-		<item>Справа</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Комментарии на моём сайте</item>
-		<item>Оценки моих комментариев</item>
-		<item>Оценки моих записей</item>
-		<item>Подписки на сайт</item>
-		<item>Достижения сайта</item>
-		<item>Упоминания имени пользователя</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Ответы на мои комментарии</item>
-		<item>Оценки моих комментариев</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Предложения</item>
-		<item>Опросы</item>
-		<item>Сообщество</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Советы для эффективной работы с WordPress.com.</item>
-		<item>Возможности участия в исследованиях и опросах WordPress.com.</item>
-		<item>Информация о курсах и событиях на WordPress.com (онлайн и офлайн).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Опубликованные</item>
-		<item>Черновики</item>
-		<item>Запланированные</item>
-		<item>Удалённые</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Заметка</item>
-		<item>Аудио</item>
-		<item>Чат</item>
-		<item>Галерея</item>
-		<item>Изображение</item>
-		<item>Ссылка</item>
-		<item>Цитата</item>
-		<item>Стандартный</item>
-		<item>Статус</item>
-		<item>Видео</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Ваш сайт доступен всем и может индексироваться поисковыми системами.</item>
-		<item>Ваш сайт доступен всем посетителям, но для него выбран параметр «Попросить поисковые системы не индексировать сайт».</item>
-		<item>Ваш сайт доступен только вам и выбранным вами пользователям.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>Включить обязательный этап одобрения для всех комментариев.</item>
-		<item>Автоматически одобрять комментарии пользователей, у которых есть ранее одобренные комментарии.</item>
-		<item>Автоматически одобрять все комментарии.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>Нет комментариев</item>
-		<item>Комментарии известных пользователей</item>
-		<item>Все пользователи</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Бесплатно</item>
-		<item>Все</item>
-		<item>Премиум</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-sk/strings.xml
+++ b/WordPress/src/main/res/values-sk/strings.xml
@@ -362,13 +362,11 @@
 	<string name="contact_us">Kontaktujte nás</string>
 	<string name="add_location">Pridať lokalitu</string>
 	<string name="current_location">Aktuálna pozícia</string>
-	<string name="your_signature">Váš podpis</string>
 	<string name="search_current_location">Vyhľadať aktuálnu lokalitu</string>
 	<string name="search_location">Hľadať</string>
 	<string name="edit_location">Upraviť</string>
 	<string name="preference_send_usage_stats_summary">Automaticky odosielať štatistiky užívania pre zlepšenie WordPress pre Android</string>
 	<string name="preference_send_usage_stats">Poslať štatistiky</string>
-	<string name="preference_privacy">Súkromie</string>
 	<string name="schedule_verb">Rozvrh</string>
 	<string name="update_verb">Aktualizovať</string>
 	<string name="reader_toast_err_unfollow_blog">Nie je možné sledovať tento blog</string>
@@ -397,7 +395,6 @@
 	<string name="blog_name_reserved_but_may_be_available">Stránka je momentálne rezervovaná, no možno sa o pár dní uvoľní</string>
 	<string name="gallery_error">Súbor nebolo možné načítať</string>
 	<string name="blog_name_cant_be_used">Nemôžete použiť túto adresu stránky</string>
-	<string name="auto_sharing_preference_reset">Resetovať nastavenie automatického zdieľania</string>
 	<string name="username_reserved_but_may_be_available">Toto používateľské meno je momentálne rezervované, no o niekoľko dní môže byť voľné</string>
 	<string name="username_or_password_incorrect">Používateľské meno alebo heslo nie je správne</string>
 	<string name="blog_name_contains_invalid_characters">Adresa stránky nemôže obsahovať znak “_”</string>
@@ -406,7 +403,6 @@
 	<string name="nux_cannot_log_in">Prihlásenie nie je možné</string>
 	<string name="error_delete_post">Počas mazania %s nastala chyba</string>
 	<string name="blog_name_reserved">Táto adresa je obsadená</string>
-	<string name="invalid_url_message">Overte si, či vložená URL adresa je správna</string>
 	<string name="out_of_memory">Nedostatok voľného miesta v pamäti</string>
 	<string name="blog_not_found">Počas prístupu k blogu sa vyskytla chyba</string>
 	<string name="error_refresh_notifications">Notifikácie nebolo možné znova načítať</string>
@@ -450,7 +446,6 @@
 	<string name="username_must_include_letters">Používatelské meno musí obsahovať min. 1 písmeno (a-z)</string>
 	<string name="email_invalid">Vložte platnú emailovú adresu</string>
 	<string name="stats_empty_comments">Bez komentárov</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Vybraný blog už nie je viditeľný</string>
 	<string name="stats_bar_graph_empty">Štatistiky nie sú dostupné</string>
 	<string name="sdcard_message">Pre nahratie súboru je potrebné vložiť SD kartu</string>
 	<string name="no_account">Účet WordPress nenájdený, vytvorte nový účet</string>
@@ -570,17 +565,14 @@
 	<string name="creating_your_account">Váš účet sa vytvára</string>
 	<string name="error_refresh_media">Počas načítania knižnice súborov sa vyskytla chyba, zopakujte to neskôr.</string>
 	<string name="reader_empty_posts_in_tag_updating">Načítavajú sa príspevky</string>
-	<string name="reset_auto_share_preference">Obnoviť nastavenia automatického zdieľania</string>
 	<string name="reader_likes_you_and_multi">Vy a niekoľkí ďalší (%,d) ste to lajkli</string>
 	<string name="reader_likes_multi">počet ľudí, ktorým sa to páči: %,d</string>
 	<string name="download">Sťahujú sa súbory</string>
-	<string name="always_use_these_settings_to_share">Vždy použiť tieto nastavenia</string>
 	<string name="comment_spammed">Komentáre označené ako spam</string>
 	<string name="reader_toast_err_get_comment">Nedá sa nahrať tento komentár</string>
 	<string name="reader_label_reply">Odpovedať</string>
 	<string name="video">Video</string>
 	<string name="cant_share_no_visible_blog">Nemôžete zdieľať na WordPress bez viditeľného blogu</string>
-	<string name="share_preference_title">Zdieľať na WordPress</string>
 	<string name="account_two_step_auth_enabled">Tento účet má povolenú dvojkrokové overovanie. Pre vytvorenie hesla pre aplikácie si otvorte bezpečnostné nastavenia na WordPress.com.</string>
 	<string name="reader_likes_you_and_one">Lajkli ste to vy a niekto ďalší</string>
 	<string name="reader_toast_err_get_post">Nie je možné načítať príspevok</string>
@@ -631,12 +623,10 @@
 	<string name="media_gallery_type_squares">Štvorce</string>
 	<string name="media_gallery_type_tiled">Dlaždice</string>
 	<string name="media_gallery_type_slideshow">Prezent8cia</string>
-	<string name="media_no_video_message">K nahratiu videa aktualizujte VideoPress!</string>
 	<string name="media_gallery_image_order_reverse">Opačné poradie</string>
 	<string name="stats_view_visitors_and_views">Návštevníci a zobrazenia</string>
 	<string name="stats_view_clicks">Kliknutia</string>
 	<string name="media_gallery_type_circles">Kruhy</string>
-	<string name="media_no_video_title">VideoPress nedostupný</string>
 	<string name="post_excerpt">Zhrnutie</string>
 	<string name="media_add_popup_capture_video">Natočiť video</string>
 	<string name="media_gallery_type">Typ</string>
@@ -694,10 +684,8 @@
 	<string name="note_reply_successful">Odpoveď zverejnená</string>
 	<string name="follows">Sledovania</string>
 	<string name="loading">Načítava sa...</string>
-	<string name="post_signature">Pridať podpis</string>
 	<string name="httpuser">HTTP používateľské meno</string>
 	<string name="httppassword">HTTP heslo</string>
-	<string name="add_tagline">Pridať podpis do nových príspevkov</string>
 	<string name="error_media_upload">Pri nahrávaní multimédií sa vyskytla chyba</string>
 	<string name="content_description_add_media">Pridať súbor</string>
 	<string name="post_content">Obsah (kliknutím pridajte text a súbor)</string>
@@ -722,11 +710,9 @@
 	<string name="scaled_image">Šírka zmenšeného obrázku</string>
 	<string name="scheduled">Načasované</string>
 	<string name="link_enter_url">URL adresa</string>
-	<string name="posted_from">Odoslané z WordPress pre Android</string>
 	<string name="version">Verzia</string>
 	<string name="app_title">WordPress pre Android</string>
 	<string name="tos">Zmluvné podmienky</string>
-	<string name="about">O aplikácii</string>
 	<string name="image_alignment">Zarovnanie</string>
 	<string name="refresh">Obnoviť</string>
 	<string name="untitled">Bez názvu</string>
@@ -770,55 +756,4 @@
 	<string name="no">Nie</string>
 	<string name="error">Chyba</string>
 	<string name="category_refresh_error">Chyba aktualizací kategorií</string>
-	<string-array name="alignment_array">
-		<item>Žiadny</item>
-		<item>Vľavo</item>
-		<item>Do stredu</item>
-		<item>Vpravo</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Komentáre na mojej webovej stránke</item>
-		<item>Počet lajkov na moje komentáre</item>
-		<item>Počet lajkov na moje príspevky</item>
-		<item>Odbery webovej stránky</item>
-		<item>Výsledky webovej stránky</item>
-		<item>Zmienky používateľa</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Odpovede na moje komentáre</item>
-		<item>Počet lajkov na mojich komentároch</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Návrhy</item>
-		<item>Výskum</item>
-		<item>Komunita</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Tipy ako získať čo najviac z WordPress.com.</item>
-		<item>Príležitosti zúčastniť sa výskumu a prieskumov WordPress.com.</item>
-		<item>Informácie o kurzoch a udalostiach WordPress.com (online a osobne).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Zverejnené</item>
-		<item>Koncepty</item>
-		<item>Naplánované</item>
-		<item>Odstránené</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Poznámka na okraj</item>
-		<item>Audio</item>
-		<item>Chat</item>
-		<item>Galéria</item>
-		<item>Obrázok</item>
-		<item>Odkaz</item>
-		<item>Citát</item>
-		<item>Štandard</item>
-		<item>Stav</item>
-		<item>Video</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Zadarmo</item>
-		<item>Všetky</item>
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-sq/strings.xml
+++ b/WordPress/src/main/res/values-sq/strings.xml
@@ -1,6 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">S’u ruajtën dot rregullimet e llogarisë tuaj</string>
+	<string name="post_format_status">Gjendje</string>
+	<string name="post_format_video">Video</string>
+	<string name="align_none">Asnjë</string>
+	<string name="align_left">Majtas</string>
+	<string name="align_center">Në qendër</string>
+	<string name="align_right">Djathtas</string>
+	<string name="theme_free">Falas</string>
+	<string name="theme_all">Krejt</string>
+	<string name="theme_premium">Me pagesë</string>
+	<string name="post_format_chat">Fjalosje</string>
+	<string name="post_format_gallery">Galeri</string>
+	<string name="post_format_image">Figurë</string>
+	<string name="post_format_link">Lidhje</string>
+	<string name="post_format_quote">Citim</string>
+	<string name="post_format_standard">Standard</string>
+	<string name="notif_events">Të dhëna mbi kurse dhe veprimtari WordPress.com (në Internet &amp; në rrugë klasike).</string>
+	<string name="post_format_aside">Anësore</string>
+	<string name="post_format_audio">Audio</string>
+	<string name="notif_surveys">Mundësi për të marrë pjesë në kërkime &amp; pyetësorë nga WordPress.com.</string>
+	<string name="notif_tips">Këshilla për përfitimin e maksimumit nga WordPress.com.</string>
+	<string name="notif_community">Bashkësi</string>
+	<string name="replies_to_my_comments">Përgjigje ndaj komenteve të mia</string>
+	<string name="notif_suggestions">Këshilla</string>
+	<string name="notif_research">Punë kërkimore</string>
+	<string name="site_achievements">Arritje sajti</string>
+	<string name="username_mentions">Përmendje të emrit të përdoruesit</string>
+	<string name="likes_on_my_posts">Pëlqime të postimeve të mia</string>
+	<string name="site_follows">Ndjekje të sajtit</string>
+	<string name="likes_on_my_comments">Pëlqime të komenteve të mia</string>
+	<string name="comments_on_my_site">Komente te sajti im</string>
+	<string name="site_settings_list_editor_summary_other">%d objekte</string>
+	<string name="site_settings_list_editor_summary_one">1 objekt</string>
+	<string name="approve_auto_if_previously_approved">Komente përdoruesish të njohur</string>
+	<string name="approve_auto">Krejt përdoruesit</string>
+	<string name="approve_manual">Pa komente</string>
+	<string name="site_settings_paging_summary_other">%d komente për faqe</string>
+	<string name="site_settings_paging_summary_one">1 koment për faqe</string>
+	<string name="site_settings_multiple_links_summary_other">Kërko miratim për më tepër se %d lidhje</string>
+	<string name="site_settings_multiple_links_summary_one">Kërko miratim për më tepër se 1 lidhje</string>
+	<string name="site_settings_multiple_links_summary_zero">Kërko miratim për më tepër se 0 lidhje</string>
+	<string name="detail_approve_auto">Mirato vetvetiu komentet e gjithkujt.</string>
+	<string name="detail_approve_auto_if_previously_approved">Miratoje vetvetiu, nëse përdoruesi ka një koment të mëparshëm të miratuar.</string>
+	<string name="detail_approve_manual">Kërkoni miratim dorazi për komentet e kujtdo.</string>
+	<string name="filter_trashed_posts">Të shpënë te hedhurinat</string>
+	<string name="days_quantity_one">1 ditë</string>
+	<string name="days_quantity_other">%d ditë</string>
+	<string name="filter_published_posts">Të botuara</string>
+	<string name="filter_draft_posts">Skica</string>
+	<string name="filter_scheduled_posts">E planifikuar për</string>
+	<string name="pending_email_change_snackbar">Që të ripohoni adresën tuaj të re, klikoni lidhjen e verifikimit te email-i i dërguar për %1$s</string>
+	<string name="primary_site">Sajti parësor</string>
+	<string name="web_address">Adresë Web</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">Për disa media ngarkimi dështoi. Ju lutemi, riprovoni ose fshijini.</string>
+	<string name="editor_toast_uploading_please_wait">Po ngarkoni media. Ju lutemi, pritni deri sa kjo të plotësohet.</string>
+	<string name="error_refresh_comments_showing_older">Komentet s’u freskuan dot këtë herë - po shfaqen komente më të vjetër</string>
+	<string name="editor_post_settings_set_featured_image">Vëre Si Figurë të Zgjedhur</string>
+	<string name="editor_post_settings_featured_image">Figurë e Zgjedhur</string>
+	<string name="new_editor_promo_desc">WordPress-i për Android tani përfshin një përpunues pamor të ri\n    Provojeni duke krijuar një postim të ri.</string>
+	<string name="new_editor_promo_title">Përpunues i ri fringo.</string>
+	<string name="new_editor_promo_button_label">Bukur, faleminderit!</string>
+	<string name="visual_editor_enabled">Përpunuesi Pamor u aktivizua</string>
+	<string name="editor_content_placeholder">Ndajeni shembullin tuaj me ta…</string>
+	<string name="editor_page_title_placeholder">Titull Faqeje</string>
+	<string name="editor_post_title_placeholder">Titull Postimi</string>
+	<string name="email_address">Adresë email</string>
+	<string name="preference_show_visual_editor">Shfaq përpunuesin pamor</string>
+	<string name="dlg_sure_to_delete_comments">Të fshihen përgjithmonë këto komente?</string>
+	<string name="preference_editor">Përpunues</string>
+	<string name="dlg_sure_to_delete_comment">Të fshihet përgjithmonë ky koment?</string>
+	<string name="mnu_comment_delete_permanently">Fshije</string>
+	<string name="comment_deleted_permanently">Koment u fshi</string>
+	<string name="mnu_comment_untrash">Riktheje</string>
+	<string name="comments_empty_list_filtered">Pa komente %s</string>
+	<string name="could_not_load_page">S’u ngarkua dot faqja</string>
+	<string name="comment_status_all">Krejt</string>
+	<string name="interface_language">Gjuhë Ndërfaqeje</string>
+	<string name="off">Off</string>
+	<string name="about_the_app">Rreth aplikacionit</string>
+	<string name="error_post_account_settings">S’u ruajtën dot rregullimet e llogarisë tuaj</string>
 	<string name="error_post_my_profile">S’u ruajt dot profili juaj</string>
 	<string name="error_fetch_account_settings">S’u morën dot rregullimet e llogarisë tuaj</string>
 	<string name="error_fetch_my_profile">S’u mor dot profili juaj</string>
@@ -15,6 +94,9 @@
 	<string name="add_category">Shtoni kategori</string>
 	<string name="disabled">E çaktivizuar</string>
 	<string name="site_settings_image_original_size">Madhësia Origjinale</string>
+	<string name="privacy_private">Sajti juaj është i dukshëm vetëm për ju dhe për përdorues që miratoni</string>
+	<string name="privacy_public_not_indexed">Sajti juaj është i dukshëm për këdo, por kërkon që motorët e kërkimeve të mos e indeksojnë</string>
+	<string name="privacy_public">Sajti juaj është i dukshëm për këdo dhe mund të indeksohet nga motorë kërkimesh</string>
 	<string name="about_me_hint">Pak fjalë rreth jush…</string>
 	<string name="public_display_name_hint">Nëse nuk caktohet një i tillë, si emër ekrani do të përdoret emri juaj i përdoruesit</string>
 	<string name="about_me">Rreth meje</string>
@@ -487,11 +569,9 @@
 	<string name="hs__username_blank_error">Jepni një emër të vlefshëm</string>
 	<string name="add_location">Shtoni vend</string>
 	<string name="current_location">Vendi i tanishëm</string>
-	<string name="your_signature">Nënshkrim juaj:</string>
 	<string name="search_location">Kërko</string>
 	<string name="edit_location">Përpunoni</string>
 	<string name="search_current_location">Lokalizoje</string>
-	<string name="preference_privacy">Privatësi</string>
 	<string name="preference_send_usage_stats">Dërgo statistika</string>
 	<string name="preference_send_usage_stats_summary">Dërgo vetvetiu statistika përdorimi për të na ndihmuar ta përmirësojmë WordPress-in për Android</string>
 	<string name="update_verb">Përditësoje</string>
@@ -535,11 +615,9 @@
 	<string name="cat_name_required">Emri i kategorisë është i domosdoshëm</string>
 	<string name="category_automatically_renamed">Emri i kategorisë %1$s s’është i vlefshëm. I riemërtua si %2$s.</string>
 	<string name="no_account">S’u gjet llogari WordPress, shtoni një llogari dhe riprovoni</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Blogu i përzgjedhur më parë s’është më i dukshëm</string>
 	<string name="sdcard_message">Për të ngarkuar media, lypset një kartë SD e montuar</string>
 	<string name="stats_empty_comments">Ende pa komente</string>
 	<string name="stats_bar_graph_empty">S’ka statistika gati</string>
-	<string name="invalid_url_message">Kontrolloni nëse URL-ja e blogut të dhënë është e vlefshme</string>
 	<string name="reply_failed">Përgjigja dështoi</string>
 	<string name="notifications_empty_list">S’ka njoftime</string>
 	<string name="error_refresh_posts">Postimet s’u rifreskuan dot tani</string>
@@ -576,13 +654,13 @@
 	<string name="blog_name_reserved_but_may_be_available">Hëpërhë ky sajt është ruajtur për dikë, por mund të jetë i lirë pas pak ditësh</string>
 	<string name="username_or_password_incorrect">Emri i përdoruesit apo fjalëkalimi që dhatë është i pasaktë</string>
 	<string name="nux_cannot_log_in">S’bëjmë dot hyrjen për ju</string>
-	<string name="auto_sharing_preference_reset">Rregullimet për vetëndarje u ricaktuan</string>
 	<string name="username_not_allowed">Emër përdoruesi që s’lejohet</string>
 	<string name="email_not_allowed">Ajo adresë email s’lejohet</string>
 	<string name="blog_name_not_allowed">Ajo adresë sajti s’lejohet</string>
 	<string name="blog_name_cant_be_used">S’mund të përdorni atë adresë sajti</string>
 	<string name="email_exists">Ajo adresë email është tashmë në përdorim</string>
 	<string name="error_delete_post">Ndodhi një gabim teksa fshihej %s</string>
+	<string name="invalid_url_message">Kontrolloni nëse URL-ja e dhënë është e vlefshme</string>
 	<string name="select_categories">Përzgjidhni kategori</string>
 	<string name="account_details">Hollësi llogarie</string>
 	<string name="edit_post">Përpunojeni postimin</string>
@@ -686,6 +764,7 @@
 	<string name="file_error_create">S’u krijua dot kartelë e përkohshme për ngarkim medie. Sigurohuni që në pajisjen tuaj ka hapësirë të lirë të mjaftueshme.</string>
 	<string name="email_reserved">Kjo adresë email është tashmë e përdorur. Kontrolloni email-et e marrë për një email aktivizimi. Nëse s’e aktivizoni, mund të riprovoni pas pak ditësh.</string>
 	<string name="error_blog_hidden">Ky blog është i fshehur dhe s’u ngarkua dot. Aktivizojeni sërish te rregullimet dhe riprovoni.</string>
+	<string name="invalid_site_url_message">Kontrolloni nëse URL-ja e sajtit të dhënë është e vlefshme</string>
 	<string name="deleting_page">Po fshihet faqe</string>
 	<string name="deleting_post">Po fshihet postim</string>
 	<string name="share_url_post">Ndajeni postimin me të tjerët</string>
@@ -701,9 +780,6 @@
 	<string name="video">Video</string>
 	<string name="comment_spammed">Komenti u shënua si i padëshiruar</string>
 	<string name="cant_share_no_visible_blog">S’mund të ndani me të tjerët në WordPress pa një blog të dukshëm</string>
-	<string name="share_preference_title">Ndajeni me të tjerët në WordPress</string>
-	<string name="always_use_these_settings_to_share">Përdor përherë këto rregullime</string>
-	<string name="reset_auto_share_preference">Rikthe në fillimet rregullimet për vetëndarje</string>
 	<string name="reader_likes_you_and_multi">Këtë e pëlqeni ju dhe %,d të tjerë</string>
 	<string name="download">Po shkarkohet media</string>
 	<string name="select_time">Përzgjidhni kohë</string>
@@ -808,9 +884,7 @@
 	<string name="passcode_turn_off">Aktivizo kyçje PIN-i</string>
 	<string name="passcode_turn_on">Çaktivizo kyçje PIN-i</string>
 	<string name="media_gallery_image_order_reverse">Përmbyse</string>
-	<string name="media_no_video_title">VideoPress-i jo gati</string>
 	<string name="passcode_set">PIN u caktua</string>
-	<string name="media_no_video_message">Merrni VideoPress-in që të ngarkoni video!</string>
 	<string name="upload">Ngarkoje</string>
 	<string name="sign_in">Hyni</string>
 	<string name="notifications">Njoftime</string>
@@ -819,8 +893,6 @@
 	<string name="more_notifications">dhe%d të tjera.</string>
 	<string name="note_reply_successful">Përgjigja u botua</string>
 	<string name="loading">Po ngarkohet…</string>
-	<string name="post_signature">Nënshkrim postimi</string>
-	<string name="add_tagline">Shtojuni postimeve të reja një nënshkrim</string>
 	<string name="httpuser">Emër përdoruesi HTTP</string>
 	<string name="httppassword">Fjalëkalim HTTP</string>
 	<string name="error_media_upload">Ndodhi një gabim gjatë ngarkimit të medias</string>
@@ -847,11 +919,9 @@
 	<string name="scaled_image">Gjerësi figure të ripërmasuar</string>
 	<string name="scheduled">E planifikuar</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Postuar me WordPress për Android</string>
 	<string name="version">Version</string>
 	<string name="tos">Kushte Shërbimi</string>
 	<string name="app_title">WordPress për Android</string>
-	<string name="about">Rreth</string>
 	<string name="max_thumbnail_px_width">Gjerësi Parazgjedhje Figure</string>
 	<string name="image_alignment">Drejtim</string>
 	<string name="refresh">Rifresko</string>
@@ -873,6 +943,7 @@
 	<string name="title">Titull</string>
 	<string name="tags_separate_with_commas">Etiketa (etiketat ndajini me presje)</string>
 	<string name="categories">Kategori</string>
+	<string name="dlg_deleting_comments">Po fshihen komente</string>
 	<string name="notification_blink">Xixëllo dritëzë njoftimesh</string>
 	<string name="notification_sound">Luaj tingull njoftimesh</string>
 	<string name="notification_vibrate">Dridhu</string>
@@ -896,70 +967,4 @@
 	<string name="yes">Po</string>
 	<string name="no">Jo</string>
 	<string name="notification_settings">Rregullime Njoftimesh</string>
-	<string-array name="alignment_array">
-		<item>Asnjë</item>
-		<item>Majtas</item>
-		<item>Qendër</item>
-		<item>Djathtas</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Komente te sajti im</item>
-		<item>Pëlqime të komenteve të mia</item>
-		<item>Pëlqime të postimeve të mia</item>
-		<item>Ndjekje të sajtit</item>
-		<item>Arritje sajti</item>
-		<item>Përmendje të emrit të përdoruesit</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Përgjigje ndaj komenteve të mia</item>
-		<item>Pëlqime të komenteve të mia</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Këshillime</item>
-		<item>Punë kërkimore</item>
-		<item>Bashkësia</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Ndihmëza për të shfrytëzuar WordPress.com-in në maksimum.</item>
-		<item>Mundësi për pjesëmarrje në kërkime &amp; pyetësorë te WordPress.com .</item>
-		<item>Të dhëna mbi kurse dhe veprimtari WordPress.com (në Internet &amp; në rrugë klasike).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Të botuar</item>
-		<item>Skica</item>
-		<item>Të planifikuar</item>
-		<item>Të hedhur te hedhurinat</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Mënjanë</item>
-		<item>Audio</item>
-		<item>Fjalosje</item>
-		<item>Galeri</item>
-		<item>Pamje</item>
-		<item>Lidhje</item>
-		<item>Përmendje</item>
-		<item>Standard</item>
-		<item>Gjendje</item>
-		<item>Video</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Sajti juaj është i dukshëm për këdo dhe mund të indeksohet nga motorë kërkimesh</item>
-		<item>Sajti juaj është i dukshëm për këdo, por kërkon që motorët e kërkimeve të mos e indeksojnë</item>
-		<item>Sajti juaj është i dukshëm vetëm për ju dhe për përdorues që miratoni</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>Kërkoni miratim dorazi për komentet e kujtdo.</item>
-		<item>Miratoje vetvetiu, nëse përdoruesi ka një koment të mëparshëm të miratuar.</item>
-		<item>Mirato vetvetiu komentet e gjithkujt.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>Pa komente</item>
-		<item>Komente përdoruesish të njohur</item>
-		<item>Krejt përdoruesit</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Falas</item>
-		<item>Krejt</item>
-		<item>Me Pagesë</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-sr/strings.xml
+++ b/WordPress/src/main/res/values-sr/strings.xml
@@ -289,13 +289,11 @@
 	<string name="contact_us">Контактирајте нас</string>
 	<string name="add_location">Додајте локацију</string>
 	<string name="current_location">Тренутна локација</string>
-	<string name="your_signature">Ваш потпис:</string>
 	<string name="search_current_location">Лоцирај</string>
 	<string name="edit_location">Уреди</string>
 	<string name="search_location">Претрага</string>
 	<string name="preference_send_usage_stats_summary">Аутоматски пошаљи статистике ради унапређења Вордпреса за Андроид</string>
 	<string name="preference_send_usage_stats">Пошаљи статистике</string>
-	<string name="preference_privacy">Приватност</string>
 	<string name="update_verb">Ажурирај</string>
 	<string name="schedule_verb">Заказати</string>
 	<string name="reader_empty_recommended_blogs">Нема препоручених блогова</string>
@@ -320,7 +318,6 @@
 	<string name="help">Помоћ</string>
 	<string name="ssl_certificate_ask_trust">Уколико се уобичајено на ово веб место повезујете без проблема, ова грешка може да значи да неко други покушава да се представи као ваше веб место и у том случају не би требало да наставите. Желите ли ипак да верујете овој потврди?</string>
 	<string name="mnu_comment_unspam">Није непожељен коментар</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Претходно изабрани блог није више видљив</string>
 	<string name="error_refresh_posts">Чланци тренутно не могу бити освежени</string>
 	<string name="username_only_lowercase_letters_and_numbers">Корисничко име може да садржи само мала слова енглеске латинице (a-z) и бројеве</string>
 	<string name="sdcard_message">Уграђена SD картица је неопходна за отпремање медија</string>
@@ -373,11 +370,9 @@
 	<string name="out_of_memory">Уређај нема доступне меморије</string>
 	<string name="notifications_empty_list">Нема обавештења</string>
 	<string name="reply_failed">Одговарање неуспешно</string>
-	<string name="invalid_url_message">Проверите да ли је унети URL исправан</string>
 	<string name="stats_bar_graph_empty">Нема статистика</string>
 	<string name="stats_empty_comments">Нема коментара</string>
 	<string name="no_site_error">Није могуће повезати се на Вордпрес веб место</string>
-	<string name="auto_sharing_preference_reset">Подешавања за аутоматско дељење су ресетована</string>
 	<string name="no_account">Није пронађен Вордпрес налог. Додајте налог и покушајте поново</string>
 	<string name="category_automatically_renamed">Име категорије %1$s није исправно. Преименована је у %2$s.</string>
 	<string name="cat_name_required">Име категорије је неопходно</string>
@@ -497,10 +492,7 @@
 	<string name="reader_empty_posts_in_tag_updating">Добављам чланке...</string>
 	<string name="reader_likes_you_and_multi">Вама и %,d других се ово свиђа</string>
 	<string name="reader_likes_multi">%,d људи се ово свиђа</string>
-	<string name="always_use_these_settings_to_share">Увек користи ова подешавања</string>
-	<string name="reset_auto_share_preference">Врати подразумевана подешавања аутоматског дељења</string>
 	<string name="cant_share_no_visible_blog">Не можете делити на Вордпрес без видљивог блога</string>
-	<string name="share_preference_title">Дељење на Вордпрес</string>
 	<string name="download">Преузимање медија</string>
 	<string name="video">Видео снимак</string>
 	<string name="reader_label_reply">Одговор</string>
@@ -554,7 +546,6 @@
 	<string name="media_add_popup_capture_photo">Фотографиши</string>
 	<string name="media_gallery_type_slideshow">Приказ слајдова</string>
 	<string name="media_gallery_type">Врста</string>
-	<string name="media_no_video_message">Купите Видеопрес надоградњу да бисте отпремили видео снимак!</string>
 	<string name="post_excerpt">Исечак</string>
 	<string name="themes_features_label">Особине</string>
 	<string name="media_add_popup_capture_video">Сними видео снимак</string>
@@ -602,7 +593,6 @@
 	<string name="media_edit_caption_text">Натпис</string>
 	<string name="media_edit_description_text">Опис</string>
 	<string name="media_edit_title_text">Наслов</string>
-	<string name="media_no_video_title">Видеопрес није доступан</string>
 	<string name="media_gallery_type_circles">Кругови</string>
 	<string name="media_gallery_type_squares">Квадрати</string>
 	<string name="media_gallery_image_order_reverse">Обрнутим редоследом</string>
@@ -618,8 +608,6 @@
 	<string name="new_notifications">%d нових обавештења</string>
 	<string name="note_reply_successful">Успешно одговорено</string>
 	<string name="loading">Учитавање...</string>
-	<string name="add_tagline">Додај потпис у нове чланке</string>
-	<string name="post_signature">Потпис у чланку</string>
 	<string name="httppassword">HTTP лозинка</string>
 	<string name="httpuser">HTTP корисничко име</string>
 	<string name="error_media_upload">Дошло је до грешке током отпремања медија</string>
@@ -646,11 +634,9 @@
 	<string name="upload_scaled_image">Отпреми и повежи са сразмерном сликом</string>
 	<string name="scheduled">Заказано</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Објављено са Вордпреса за Андроид</string>
 	<string name="tos">Услови сервиса</string>
 	<string name="version">Издање</string>
 	<string name="app_title">Вордпрес за Андроид</string>
-	<string name="about">О</string>
 	<string name="image_alignment">Поравнање</string>
 	<string name="refresh">Освежи</string>
 	<string name="untitled">Без имена</string>
@@ -694,50 +680,4 @@
 	<string name="error">Грешка</string>
 	<string name="cancel">Откажи</string>
 	<string name="notification_settings">Подешавања обавештења</string>
-	<string-array name="alignment_array">
-		<item>Нема</item>
-		<item>Лево</item>
-		<item>На средини</item>
-		<item>Десно</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Коментари на мом веб месту</item>
-		<item>Свиђања на мојим коментарима</item>
-		<item>Свиђања на мојим чланцима</item>
-		<item>Праћења веб места</item>
-		<item>Достигнућа веб места</item>
-		<item>Спомињања корисничког имена</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Одговори на моје коментаре</item>
-		<item>Свиђања на мојим коментарима</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Предлози</item>
-		<item>Истраживање</item>
-		<item>Заједница</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Савети за добављање што више од WordPress.com.</item>
-		<item>Прилика за учествовање у WordPress.com истраживањима и анкетама.</item>
-		<item>Подаци о WordPress.com курсевима и догађајима (на мрежи и уживо).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Објављено</item>
-		<item>Нацрти</item>
-		<item>Заказано</item>
-		<item>На отпаду</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Са стране</item>
-		<item>Звучни запис</item>
-		<item>Ћаскање</item>
-		<item>Галерија</item>
-		<item>Слика</item>
-		<item>Веза</item>
-		<item>Цитат</item>
-		<item>Уобичајен</item>
-		<item>Стање</item>
-		<item>Видео снимак</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -1,6 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">Kunde inte spara dina kontoinställningar</string>
+	<string name="post_format_status">Status</string>
+	<string name="post_format_video">Videoklipp</string>
+	<string name="align_none">Ingen</string>
+	<string name="align_left">Vänster</string>
+	<string name="align_center">Mitten</string>
+	<string name="align_right">Höger</string>
+	<string name="theme_free">Free</string>
+	<string name="theme_all">Alla</string>
+	<string name="theme_premium">Premium</string>
+	<string name="post_format_chat">Chatt</string>
+	<string name="post_format_gallery">Galleri</string>
+	<string name="post_format_image">Bild</string>
+	<string name="post_format_link">Länk</string>
+	<string name="post_format_quote">Citat</string>
+	<string name="post_format_standard">Standard</string>
+	<string name="notif_events">Information om kurser och evenemang på WordPress.com (online och fysiska möten).</string>
+	<string name="post_format_aside">Notering</string>
+	<string name="post_format_audio">Ljud</string>
+	<string name="notif_surveys">Möjligheter att delta i WordPress.coms studier och undersökningar.</string>
+	<string name="notif_tips">Tips för att få ut så mycket som möjligt av WordPress.com.</string>
+	<string name="notif_community">Community</string>
+	<string name="replies_to_my_comments">Svar på mina kommentarer</string>
+	<string name="notif_suggestions">Förslag</string>
+	<string name="notif_research">Forskning</string>
+	<string name="site_achievements">Webbplats-troféer</string>
+	<string name="username_mentions">Omnämnande av användarnamn</string>
+	<string name="likes_on_my_posts">Gilla-markeringar för mina inlägg</string>
+	<string name="site_follows">Webbplatsföljare</string>
+	<string name="likes_on_my_comments">Gillar mina kommentarer</string>
+	<string name="comments_on_my_site">Kommentarer på min webbplats</string>
+	<string name="site_settings_list_editor_summary_other">%d poster</string>
+	<string name="site_settings_list_editor_summary_one">1 post</string>
+	<string name="approve_auto_if_previously_approved">Kända användares kommentarer</string>
+	<string name="approve_auto">Alla användare</string>
+	<string name="approve_manual">Inga kommentarer</string>
+	<string name="site_settings_paging_summary_other">%d kommentarer per sida</string>
+	<string name="site_settings_paging_summary_one">1 kommentar per sida</string>
+	<string name="site_settings_multiple_links_summary_other">Kräv godkännande för fler än %d länkar</string>
+	<string name="site_settings_multiple_links_summary_one">Kräv godkännande för fler än 1 länk</string>
+	<string name="site_settings_multiple_links_summary_zero">Kräv godkännande för fler än 0 länkar</string>
+	<string name="detail_approve_auto">Godkänn allas kommentarer automatiskt.</string>
+	<string name="detail_approve_auto_if_previously_approved">Godkänn automatiskt om användaren har en tidigare godkänd kommentar</string>
+	<string name="detail_approve_manual">Kräv manuellt godkännande för alla kommentarer.</string>
+	<string name="filter_trashed_posts">Borttagen</string>
+	<string name="days_quantity_one">1 dag</string>
+	<string name="days_quantity_other">%d dagar</string>
+	<string name="filter_published_posts">Publicerad</string>
+	<string name="filter_draft_posts">Utkast</string>
+	<string name="filter_scheduled_posts">Schemalagd</string>
+	<string name="pending_email_change_snackbar">Klicka på verifieringslänken i e-postmeddelandet som skickades till %1$s för att bekräfta din nya adress</string>
+	<string name="primary_site">Primär webbplats</string>
+	<string name="web_address">Webbadress</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">Uppladdning av vissa mediefiler har misslyckats. Försök igen eller ta bort dem.</string>
+	<string name="editor_toast_uploading_please_wait">Mediefiler laddas upp för tillfället. Vänta tills de är färdiguppladdade.</string>
+	<string name="error_refresh_comments_showing_older">Kommentarer kan inte uppdateras just nu – visar äldre kommentarer</string>
+	<string name="editor_post_settings_set_featured_image">Ange utvald bild</string>
+	<string name="editor_post_settings_featured_image">Utvald bild</string>
+	<string name="new_editor_promo_desc">I WordPress-appen för Android ingår nu en ny, fantastisk, visuell\n redigerare. Prova gärna genom att skapa ett nytt inlägg.</string>
+	<string name="new_editor_promo_title">Helt ny redigerare</string>
+	<string name="new_editor_promo_button_label">Tack!</string>
+	<string name="visual_editor_enabled">Visuell redigerare aktiverad</string>
+	<string name="editor_content_placeholder">Berätta din historia här...</string>
+	<string name="editor_page_title_placeholder">Sidans rubrik</string>
+	<string name="editor_post_title_placeholder">Inläggets rubrik</string>
+	<string name="email_address">E-postadress</string>
+	<string name="preference_show_visual_editor">Visa visuell redigerare</string>
+	<string name="dlg_sure_to_delete_comments">Radera dessa kommentarer premanent?</string>
+	<string name="preference_editor">Redigerare</string>
+	<string name="dlg_sure_to_delete_comment">Radera denna kommentar premanent?</string>
+	<string name="mnu_comment_delete_permanently">Ta bort</string>
+	<string name="comment_deleted_permanently">Kommentar raderad</string>
+	<string name="mnu_comment_untrash">Återställ</string>
+	<string name="comments_empty_list_filtered">Inga %s kommentarer</string>
+	<string name="could_not_load_page">Kunde inte ladda sida</string>
+	<string name="comment_status_all">Alla</string>
+	<string name="interface_language">Gränssnittspråk</string>
+	<string name="off">Av</string>
+	<string name="about_the_app">Om appen</string>
 	<string name="error_post_my_profile">Kunde inte spara din profil</string>
 	<string name="error_fetch_account_settings">Kunde inte hämta dina kontoinställningar</string>
 	<string name="error_fetch_my_profile">Kunde inte hämta din profil</string>
@@ -487,11 +565,9 @@
 	<string name="hs__invalid_email_error">Ange en giltig e-postadress</string>
 	<string name="add_location">Lägg till plats</string>
 	<string name="current_location">Nuvarande plats</string>
-	<string name="your_signature">Din signatur:</string>
 	<string name="search_location">Sök</string>
 	<string name="edit_location">Redigera</string>
 	<string name="search_current_location">Hitta</string>
-	<string name="preference_privacy">Integritet</string>
 	<string name="preference_send_usage_stats">Skicka statistik</string>
 	<string name="preference_send_usage_stats_summary">Skicka automatiskt användarstatistik för att hjälpa oss förbättra WordPress för Android</string>
 	<string name="update_verb">Uppdatera</string>
@@ -524,7 +600,6 @@
 	<string name="no_account">Inget WordPress-konto hittat, skapa ett konto och försök igen</string>
 	<string name="stats_empty_comments">Inga kommentarer ännu</string>
 	<string name="stats_bar_graph_empty">Ingen statistik tillgänglig</string>
-	<string name="invalid_url_message">Kontrollera att blogg URL:en är gilltig</string>
 	<string name="error_generic">Ett fel uppstod</string>
 	<string name="error_downloading_image">Fel vid nedladdning av bild</string>
 	<string name="error_load_comment">Kunde inte ladda kommentaren</string>
@@ -572,13 +647,11 @@
 	<string name="error_refresh_posts">Inläggen kunde inte uppdateras just nu</string>
 	<string name="error_refresh_stats">Statistiken kunde inte uppdateras just nu</string>
 	<string name="error_refresh_notifications">Notifieringar kunde inte uppdateras just nu</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Tidigare vald blogg är inte längre synlig</string>
 	<string name="could_not_remove_account">Det gick inte att ta bort webbplatsen</string>
 	<string name="gallery_error">Medieobjektet kunde inte hämtas</string>
 	<string name="blog_not_found">Ett fel uppstod vid anslutning till bloggen</string>
 	<string name="theme_set_failed">Kunde inte ställa in tema</string>
 	<string name="theme_auth_error_message">Se till att du har behörighet att ställa in teman</string>
-	<string name="auto_sharing_preference_reset">Inställningar för automatisk delning återställda</string>
 	<string name="sdcard_message">Ett SD-kort är nödvändigt för att ladda upp media</string>
 	<string name="username_only_lowercase_letters_and_numbers">Användarnamn får bara innehålla små bokstäver (a-z) och siffror</string>
 	<string name="blog_name_only_lowercase_letters_and_numbers">Webbplatsadressen kan bara innehålla små bokstäver (a-z) och siffror</string>
@@ -686,6 +759,7 @@
 	<string name="email_reserved">E-postadressen har redan använts. Kolla efter ett aktiveringsmail i din inbox. Om du inte aktiverar kan du försöka igen om några dagar.</string>
 	<string name="email_cant_be_used_to_signup">Du kan inte använda den e-postadressen för att registrera dig. Vi har problem med att de blockerar viss av våra e-post. Använd en annan e-postleverantör.</string>
 	<string name="notifications_empty_all">Inga notiser … ännu.</string>
+	<string name="invalid_site_url_message">Kontrollera att webbplatsens URL är giltig</string>
 	<string name="deleting_page">Tar bort sida</string>
 	<string name="deleting_post">Tar bort inlägg</string>
 	<string name="share_url_post">Dela inlägg</string>
@@ -699,13 +773,10 @@
 	<string name="video">Video</string>
 	<string name="download">Laddar ner media</string>
 	<string name="comment_spammed">Kommentar markerad som skräppost</string>
-	<string name="share_preference_title">Dela till WordPress</string>
-	<string name="always_use_these_settings_to_share">Använd alltid dessa inställningar</string>
 	<string name="reader_likes_you_and_multi">Du och %,d andra gillar detta</string>
 	<string name="reader_likes_multi">%,d gillar detta</string>
 	<string name="reader_toast_err_get_comment">Kunde inte hämta denna kommentar</string>
 	<string name="cant_share_no_visible_blog">Du kan inte dela på WordPress utan att ha en synlig blogg</string>
-	<string name="reset_auto_share_preference">Återställ inställningar för automatisk delning</string>
 	<string name="select_time">Välj tid</string>
 	<string name="pick_photo">Välj bild</string>
 	<string name="pick_video">Välj video</string>
@@ -765,8 +836,6 @@
 	<string name="media_gallery_type_tiled">Mosaik</string>
 	<string name="media_gallery_type_circles">Cirklar</string>
 	<string name="media_gallery_type_slideshow">Bildspel</string>
-	<string name="media_no_video_title">VideoPress otillgängligt</string>
-	<string name="media_no_video_message">Skaffa VideoPress-uppgraderingen för att ladda upp video!</string>
 	<string name="media_edit_title_text">Rubrik</string>
 	<string name="media_edit_caption_text">Bildtext</string>
 	<string name="media_edit_description_text">Beskrivning</string>
@@ -819,8 +888,6 @@
 	<string name="new_notifications">%d nya notifieringar</string>
 	<string name="follows">Följer</string>
 	<string name="loading">Laddar...</string>
-	<string name="post_signature">Inläggssignatur</string>
-	<string name="add_tagline">Lägg till en signatur till nya inlägg</string>
 	<string name="httpuser">HTTP-användarnamn</string>
 	<string name="httppassword">HTTP-lösenord</string>
 	<string name="error_media_upload">Ett fel uppstod vid uppladdning av media</string>
@@ -847,11 +914,9 @@
 	<string name="upload_scaled_image">Ladda upp och länka till skalad bild</string>
 	<string name="scheduled">Tidsinställt</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">Postat med WordPress för Android</string>
 	<string name="version">Version</string>
 	<string name="tos">Allmänna villkor</string>
 	<string name="app_title">WordPress for Android</string>
-	<string name="about">Om</string>
 	<string name="max_thumbnail_px_width">Förvald bildbredd</string>
 	<string name="image_alignment">Justering</string>
 	<string name="refresh">Uppdatera</string>
@@ -896,70 +961,4 @@
 	<string name="preview">Förhandsgranska</string>
 	<string name="on">om</string>
 	<string name="notification_settings">Notisinställningar</string>
-	<string-array name="alignment_array">
-		<item>Ingen</item>
-		<item>Vänster</item>
-		<item>Centrera</item>
-		<item>Höger</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Kommentarer på min webbplats</item>
-		<item>Gilla-markeringar för mina kommentarer</item>
-		<item>Gilla-markeringar för mina inlägg</item>
-		<item>Webbplatsföljare</item>
-		<item>Webbplats-troféer</item>
-		<item>Omnämnande av användarnamn</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Svar på mina kommentarer</item>
-		<item>Gillar mina kommentarer</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Förslag</item>
-		<item>Forskning</item>
-		<item>Community</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>Tips för att få ut så mycket som möjligt av WordPress.com.</item>
-		<item>Möjligheter att delta i WordPress.coms studier och undersökningar.</item>
-		<item>Information om kurser och evenemang på WordPress.com (online och fysiska möten).</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Publicerad</item>
-		<item>Utkast</item>
-		<item>Tidsinställd</item>
-		<item>Borttagen</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Notering</item>
-		<item>Ljud</item>
-		<item>Chat</item>
-		<item>Galleri</item>
-		<item>Bild</item>
-		<item>Länk</item>
-		<item>Citat</item>
-		<item>Standard</item>
-		<item>Status</item>
-		<item>Video</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Din webbplats är synlig för alla och kan indexeras av sökmotorer</item>
-		<item>Din webbplats är synlig för alla, men begär att sökmotorerna inte ska indexera den</item>
-		<item>Din webbplats är bara synlig för dig själv och användare som du godkänner</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>Kräv manuellt godkännande för alla kommentarer.</item>
-		<item>Godkänn automatiskt om användaren har en tidigare godkänd kommentar.</item>
-		<item>Godkänn allas kommentarer automatiskt.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>Inga kommentarer</item>
-		<item>Kända användares kommentarer</item>
-		<item>Alla användare</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Gratis</item>
-		<item>Alla</item>
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-th/strings.xml
+++ b/WordPress/src/main/res/values-th/strings.xml
@@ -439,11 +439,9 @@
 	<string name="hs__invalid_email_error">ใส่ที่อยู่อีเมลที่ใช้งานได้</string>
 	<string name="add_location">เพิ่มสถานที่</string>
 	<string name="current_location">สถานที่ปัจจุบัน</string>
-	<string name="your_signature">ลายเซ็นของคุณ:</string>
 	<string name="search_location">ค้นหา</string>
 	<string name="edit_location">แก้ไข</string>
 	<string name="search_current_location">ค้นหาสถานที่</string>
-	<string name="preference_privacy">ส่วนตัว</string>
 	<string name="preference_send_usage_stats">ส่งสถิติ</string>
 	<string name="preference_send_usage_stats_summary">ส่งข้อมูลการใช้งานอัตโนมัติเพื่อช่วยเราในการปรับปรุงเวิร์ดเพรสสำหรับแอนดรอยด์</string>
 	<string name="update_verb">อัปเดต</string>
@@ -508,7 +506,6 @@
 	<string name="comments_empty_list">ไม่มีความเห็น</string>
 	<string name="stats_empty_comments">ยังไม่มีความเห็น</string>
 	<string name="stats_bar_graph_empty">สถิติยังไม่พร้อมให้ดู</string>
-	<string name="invalid_url_message">ตรวจสอบ URL บล็อกที่ใส่มาว่าใช้งานได้หรือไม่</string>
 	<string name="reply_failed">การตอบกลับล้มเหลว</string>
 	<string name="notifications_empty_list">ไม่มีการเตือน</string>
 	<string name="gallery_error">ไม่สามารถรับไฟล์สื่อ</string>
@@ -524,8 +521,6 @@
 	<string name="error_downloading_image">การดาวน์โหลดรูปภาพผิดพลาด</string>
 	<string name="no_network_message">ไม่มีเครือข่ายที่ใช้งานได้ตอนนี้</string>
 	<string name="theme_fetch_failed">ล้มเหลวในการดึง themes</string>
-	<string name="auto_sharing_preference_reset">ล้างค่าการตั้งค่าการแบ่งปันอัตโนมัติ</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">บล็อกที่เลือกล่าสุดไม่สามารถมองเห็นได้อีกแล้ว</string>
 	<string name="sdcard_message">ต้องมี SD card เพื่อใช้ในการอัปโหลดไฟล์สื่อ</string>
 	<string name="error_refresh_posts">ไม่สามารถโหลดใหม่เรื่องในตอนนี้</string>
 	<string name="error_refresh_pages">ไม่สามารถโหลดใหม่หน้าในตอนนี้</string>
@@ -648,10 +643,7 @@
 	<string name="error_refresh_media">บางสิ่งผิดปกติในระหว่างโหลดใหม่คลังไฟล์สื่อ  โปรดลองใหม่ภายหลัง</string>
 	<string name="reader_empty_posts_in_tag_updating">กำลังดึงข้อมูลเรื่อง...</string>
 	<string name="comment_spammed">ความเห็นนี้ถูกบันทึกเป็นสแปม</string>
-	<string name="share_preference_title">แบ่งปันไปยังเวิร์ดเพรส</string>
 	<string name="cant_share_no_visible_blog">คุณสามารถแบ่งปันไปยังเวิร์ดเพรสได้ถ้าไม่มีบล็อกที่มองเห็นได้</string>
-	<string name="reset_auto_share_preference">ล้างค่าการตั้งค่าการแบ่งปันอัตโนมัติ</string>
-	<string name="always_use_these_settings_to_share">ใช้การตั้งค่าเหล่านี้เสมอ</string>
 	<string name="reader_likes_multi">%,d คนชอบสิ่งนี้</string>
 	<string name="reader_likes_you_and_multi">คุณและ %,d คนชอบสิ่งนี้</string>
 	<string name="reader_toast_err_get_comment">ไม่สามารถดึงข้อมูลความเห็นนี้</string>
@@ -743,8 +735,6 @@
 	<string name="media_gallery_type_tiled">เรียงแบบกระเบื้อง</string>
 	<string name="media_gallery_type_circles">เรียงแบบวงกลม</string>
 	<string name="media_gallery_type_slideshow">สไลด์โชว์</string>
-	<string name="media_no_video_title">VideoPress ยังใช้งานไม่ได้</string>
-	<string name="media_no_video_message">อัปเกรด VideoPress เพื่ออัปโหลดวีดีโอ</string>
 	<string name="media_add_popup_capture_photo">จับภาพรูปภาพ</string>
 	<string name="media_add_popup_capture_video">จับภาพวีดีโอ</string>
 	<string name="media_gallery_image_order_random">สุ่ม</string>
@@ -771,8 +761,6 @@
 	<string name="more_notifications">และ %d เพิ่มเติม</string>
 	<string name="follows">ติดตาม</string>
 	<string name="loading">กำลังโหลดข้อมูล...</string>
-	<string name="post_signature">ลายเซ็นเรื่อง</string>
-	<string name="add_tagline">ใส่ลายเซ็นลงไปเรื่องใหม่</string>
 	<string name="httpuser">ชื่อผู้ใช้ HTTP</string>
 	<string name="httppassword">รหัสผ่าน HTTP</string>
 	<string name="error_media_upload">มีความผิดพลาดเกิดขึ้นขณะทำการอัปโหลดไฟล์สื่อ</string>
@@ -799,11 +787,9 @@
 	<string name="scaled_image">ปรับขนาดความกว้างรูปภาพแล้ว</string>
 	<string name="scheduled">กำหนดตารางเวลาแล้ว</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">โพสท์จากเวิร์ดเพรสสำหรับแอนดรอยด์</string>
 	<string name="version">รุ่น</string>
 	<string name="tos">เงื่อนไขบริการ</string>
 	<string name="app_title">เวิร์ดเพรสสำหรับแอนดรอยด์</string>
-	<string name="about">เกี่ยวกับ</string>
 	<string name="max_thumbnail_px_width">ความกว้างรูปค่าเริ่มต้น</string>
 	<string name="image_alignment">จัดหน้า</string>
 	<string name="refresh">รีเฟรช</string>
@@ -848,62 +834,4 @@
 	<string name="category_refresh_error">โหลดหมวดหมู่อีกครั้งผิดพลาด</string>
 	<string name="preview">ดูก่อน</string>
 	<string name="notification_settings">การตั้งค่าการเตือน</string>
-	<string-array name="alignment_array">
-		<item>ไม่มีการจัดเรียง</item>
-		<item>จัดชิดซ้าย</item>
-		<item>ตรงกลาง</item>
-		<item>จัดชิดขวา</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>ความเห็นบนเว็บของฉัน</item>
-		<item>ไลค์บนความเห็นของฉัน</item>
-		<item>ไลค์บนเรื่องของฉัน</item>
-		<item>การติดตามเว็บ</item>
-		<item>ผลสำเร็จของเว็บ</item>
-		<item>การอ้างถึงชื่อผู้ใช้</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>ข้อความตอบกลับไปที่ความเห็นของฉัน</item>
-		<item>ไลค์บนความเห็นของฉัน</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>คำแนะนำ</item>
-		<item>การวิจัย</item>
-		<item>ชุมชน</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>ข้อแนะนำสำหรับการใช้งานที่ได้ประโยชน์สูงสุดจาก WordPress.com</item>
-		<item>โอกาสในการมีส่วนร่วมในการวิจัยและสำรวจของ WordPress.com</item>
-		<item>รายละเอียดเกี่ยวกับหลักสูตรและเหตุการณ์บน WordPress.com (ออนไลน์ &amp; เจอตัวจริง)</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>เผยแพร่แล้ว</item>
-		<item>ฉบับร่าง</item>
-		<item>ตั้งตารางเวลาแล้ว</item>
-		<item>เป็นขยะแล้ว</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>ชนิดเรื่องสั้นไม่มีหัวข้อ</item>
-		<item>ชนิดเรื่องไฟล์เสียง</item>
-		<item>ชนิดเรื่องบทสนทนา</item>
-		<item>ชนิดเรื่องคลังรูป</item>
-		<item>ชนิดเรื่องรูปภาพ</item>
-		<item>ชนิดเรื่องลิงก์</item>
-		<item>ชนิดเรื่องคำคม</item>
-		<item>ชนิดเรื่องมาตรฐาน</item>
-		<item>ชนิดเรื่องสถานะ</item>
-		<item>ชนิดเรื่องวีดีโอ</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>ต้องการการอนุมัติด้วยมือทุกครั้งสำหรับความเห็นของทุกคน</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>ไม่มีความเห็น</item>
-		<item>ผู้ใช้ทั้งหมด</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>ฟรี</item>
-		<item>ทั้งหมด</item>
-		<item>พรีเมี่ยม</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -1,6 +1,85 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">Hesap ayarlarınız kaydedilemedi</string>
+	<string name="post_format_status">Durum</string>
+	<string name="post_format_video">Video</string>
+	<string name="align_none">Hiçbiri</string>
+	<string name="align_left">Sol</string>
+	<string name="align_center">Orta</string>
+	<string name="align_right">Sağ</string>
+	<string name="theme_free">Ücretsiz</string>
+	<string name="theme_all">Tümü</string>
+	<string name="theme_premium">Premium</string>
+	<string name="post_format_chat">Sohbet</string>
+	<string name="post_format_gallery">Galeri</string>
+	<string name="post_format_image">Görsel</string>
+	<string name="post_format_link">Bağlantı</string>
+	<string name="post_format_quote">Alıntı</string>
+	<string name="post_format_standard">Standart</string>
+	<string name="notif_events">WordPress.com kursları ve etkinlikleri hakkında bilgi (çevrimiçi ve bire bir).</string>
+	<string name="post_format_aside">Yan sütun</string>
+	<string name="post_format_audio">Ses</string>
+	<string name="notif_surveys">WordPress.com araştırma ve anketlerine katkıda bulunma olanakları.</string>
+	<string name="notif_tips">WordPress.com\'dan en fazlasını almak için ipuçları.</string>
+	<string name="notif_community">Topluluk</string>
+	<string name="replies_to_my_comments">Yorumlarıma cevaplar</string>
+	<string name="notif_suggestions">Öneriler</string>
+	<string name="notif_research">Araştırma</string>
+	<string name="site_achievements">Site başarıları</string>
+	<string name="username_mentions">Kullanıcı adı bahsedenleri</string>
+	<string name="likes_on_my_posts">Yazılarımdaki beğenmeler</string>
+	<string name="site_follows">Site takipleri</string>
+	<string name="likes_on_my_comments">Yorumlarımdaki beğenmeler</string>
+	<string name="comments_on_my_site">Sitemdeki yorumlar</string>
+	<string name="site_settings_list_editor_summary_other">%d öğe</string>
+	<string name="site_settings_list_editor_summary_one">1 öğe</string>
+	<string name="approve_auto_if_previously_approved">Bilinen kullanıcıların yorumları</string>
+	<string name="approve_auto">Tüm kullanıcılar</string>
+	<string name="approve_manual">Yorum yapılmamış</string>
+	<string name="site_settings_paging_summary_other">Sayfa başına %d yorum</string>
+	<string name="site_settings_paging_summary_one">Sayfa başına 1 yorum</string>
+	<string name="site_settings_multiple_links_summary_other">%d bağlantıdan fazlası onay gerektirir</string>
+	<string name="site_settings_multiple_links_summary_one">1 bağlantıdan fazlası onay gerektirir</string>
+	<string name="site_settings_multiple_links_summary_zero">0 bağlantıdan fazlası onay gerektirir</string>
+	<string name="detail_approve_auto">Herkesin yorumlarını otomatik olarak onayla.</string>
+	<string name="detail_approve_auto_if_previously_approved">Kullanıcının daha önceden onaylanmış bir yorumu varsa otomatik olarak onayla</string>
+	<string name="detail_approve_manual">Herkesin yorumları için el ile onaylama ister.</string>
+	<string name="filter_trashed_posts">Çöpe taşındı</string>
+	<string name="days_quantity_one">1 gün</string>
+	<string name="days_quantity_other">%d gün</string>
+	<string name="filter_published_posts">Yayımlandı</string>
+	<string name="filter_draft_posts">Taslaklar</string>
+	<string name="filter_scheduled_posts">Takvime Eklendi</string>
+	<string name="pending_email_change_snackbar">Yeni adresinizin onaylanması için %1$s adresine gönderilen e-postadaki doğrulama bağlantısına tıklayın.</string>
+	<string name="primary_site">Birincil site</string>
+	<string name="web_address">Web Adresi</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">Bazı görsel yüklemeler başarısız oldu. Lütfen yeniden deneyin ya da silin.</string>
+	<string name="editor_toast_uploading_please_wait">Şu anda medya yüklüyorsunuz. Lütfen bu işlem tamamlanıncaya kadar bekleyin.</string>
+	<string name="error_refresh_comments_showing_older">Yorumlar şu anda yenilenemiyor, eski yorumlar gösteriliyor</string>
+	<string name="editor_post_settings_set_featured_image">Öne çıkarılan görsel ayarla</string>
+	<string name="editor_post_settings_featured_image">Öne Çıkan Görüntü</string>
+	<string name="new_editor_promo_desc">Android için WordPress uygulaması artık yeni ve güzel bir görsel düzenleyici\n içeriyor. Yeni bir gönderi oluşturarak deneyin.</string>
+	<string name="new_editor_promo_title">Yepyeni bir düzenleyici</string>
+	<string name="new_editor_promo_button_label">Harika, teşekkürler!</string>
+	<string name="visual_editor_enabled">Görsel Düzenleyici etkinleştirildi</string>
+	<string name="editor_content_placeholder">Hikayenizi burada paylaşın...</string>
+	<string name="editor_page_title_placeholder">Sayfa Başlığı</string>
+	<string name="editor_post_title_placeholder">Yazı Başlığı</string>
+	<string name="email_address">E-posta adresi</string>
+	<string name="preference_show_visual_editor">Görsel düzenleyiciyi göster</string>
+	<string name="dlg_sure_to_delete_comments">Bu yorumlar kalıcı olarak silinsin mi?</string>
+	<string name="preference_editor">Düzenleyici</string>
+	<string name="dlg_sure_to_delete_comment">Bu yorum kalıcı olarak silinsin mi?</string>
+	<string name="mnu_comment_delete_permanently">Sil</string>
+	<string name="comment_deleted_permanently">Yorum silindi</string>
+	<string name="mnu_comment_untrash">Geri yükle</string>
+	<string name="comments_empty_list_filtered">%s yorum yok</string>
+	<string name="could_not_load_page">Sayfa yüklenemiyor</string>
+	<string name="comment_status_all">Tümü</string>
+	<string name="interface_language">Arayüz Dili</string>
+	<string name="off">Kapalı</string>
+	<string name="about_the_app">Uygulama hakkında</string>
+	<string name="error_post_account_settings">Hesap ayarlarınız kaydedilemedi</string>
 	<string name="error_post_my_profile">Profiliniz kaydedilemedi</string>
 	<string name="error_fetch_account_settings">Hesap ayarlarınız alınamadı</string>
 	<string name="error_fetch_my_profile">Profiliniz alınamadı</string>
@@ -15,6 +94,9 @@
 	<string name="search">Ara</string>
 	<string name="disabled">Devre dışı</string>
 	<string name="site_settings_image_original_size">Orijinal Boyut</string>
+	<string name="privacy_private">Siteniz sadece siz ve onay verdiğiniz kullanıcılar tarafından görüntülenebilir</string>
+	<string name="privacy_public_not_indexed">Siteniz herkes tarafından görüntülenebilir, ancak arama motorlarından kendisini indekslememelerini ister</string>
+	<string name="privacy_public">Siteniz herkes tarafından görülebilir ve arama motorları tarafından indekslenebilir</string>
 	<string name="about_me_hint">Hakkınızda birkaç kelime…</string>
 	<string name="public_display_name_hint">Ayarlanmazsa, görünen ad varsayılan olarak kullanıcı adınız şeklinde belirlenir</string>
 	<string name="about_me">Hakkımda</string>
@@ -487,11 +569,9 @@
 	<string name="hs__invalid_email_error">Geçerli bir e-posta adresi girin</string>
 	<string name="add_location">Konum Ekle</string>
 	<string name="current_location">Şimdiki Konumunuz</string>
-	<string name="your_signature">İmzanız:</string>
 	<string name="search_location">Arama</string>
 	<string name="edit_location">Düzenle</string>
 	<string name="search_current_location">Yerleştir</string>
-	<string name="preference_privacy">Gizlilik</string>
 	<string name="preference_send_usage_stats">Kullanım istatistiklerini gönder</string>
 	<string name="preference_send_usage_stats_summary">Android için WordPress\'i geliştirmemize yardımcı olmak için bize otomatik olarak kullanım istatistiklerini gönderin. </string>
 	<string name="update_verb">Güncelle</string>
@@ -527,12 +607,9 @@
 	<string name="adding_cat_failed">Kategori ekleme başarısız</string>
 	<string name="adding_cat_success">Kategori başarı ile eklendi</string>
 	<string name="no_account">WordPress hesabı bulunamadı, bir hesap ekleyip tekrar deneyin</string>
-	<string name="auto_sharing_preference_reset">Otomatik-Paylaşım ayarlarını sıfırlama</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">Önceki seçilmiş blog görünmüyor</string>
 	<string name="sdcard_message">Medya yüklemek için takılı SD kart gereklidir</string>
 	<string name="stats_empty_comments">Henüz yorum yok</string>
 	<string name="stats_bar_graph_empty">Erişilebilir istatistikler yok</string>
-	<string name="invalid_url_message">Girdiğiniz blog URL\'sinin geçerli olduğunu kontrol edin</string>
 	<string name="reply_failed">Cevaplama başarısız</string>
 	<string name="notifications_empty_list">Bildirim yok</string>
 	<string name="error_delete_post">%s silinirken hata ile karşılaşıldı</string>
@@ -583,6 +660,7 @@
 	<string name="blog_name_contains_invalid_characters">Site adresi "_" karakteri içeremez</string>
 	<string name="blog_name_reserved">Bu site rezerve edilmiş</string>
 	<string name="blog_name_reserved_but_may_be_available">Bu site zaten rezerve edilmiş fakat birkaç gün içerisine erişilebilinir</string>
+	<string name="invalid_url_message">Girdiğiniz adresin geçerli olduğunu kontrol edin</string>
 	<string name="select_categories">Kategorileri seçin</string>
 	<string name="account_details">Hesap detayları</string>
 	<string name="add_comment">Yorum ekle</string>
@@ -686,6 +764,7 @@
 	<string name="post_not_published">Yazı durumu yayımlanmadı</string>
 	<string name="page_not_published">Sayfa durumu yayımlanmadı</string>
 	<string name="notifications_empty_all">Bildirim yok...henüz.</string>
+	<string name="invalid_site_url_message">Girdiğiniz site URL\'sinin geçerli olduğunu kontrol edin</string>
 	<string name="share_url_page">Sayfayı paylaş</string>
 	<string name="share_link">Bağlantıyı paylaş</string>
 	<string name="deleting_page">Sayfa siliniyor</string>
@@ -699,12 +778,9 @@
 	<string name="reader_label_reply">Yanıtla</string>
 	<string name="video">Video</string>
 	<string name="download">Medya indiriliyor</string>
-	<string name="share_preference_title">WordPress ile paylaş</string>
-	<string name="reset_auto_share_preference">Otomatik paylaşma ayarlarını sıfırla</string>
 	<string name="reader_likes_multi">%,d kişi bunu beğendi</string>
 	<string name="reader_likes_you_and_multi">Siz ve %,d kişi bunu beğendi</string>
 	<string name="cant_share_no_visible_blog">Görünürbir bloğunuz olmadan WordPress ile paylaşamazsınız</string>
-	<string name="always_use_these_settings_to_share">Herzaman bu ayarları kullan</string>
 	<string name="comment_spammed">Yorum istenmeyen olarak işaretlendi</string>
 	<string name="select_time">Zaman seçin</string>
 	<string name="select_date">Tarih seçin</string>
@@ -768,7 +844,6 @@
 	<string name="unattached">Bağlantısız</string>
 	<string name="media_gallery_image_order_random">Rastgele</string>
 	<string name="media_gallery_image_order_reverse">Tersten</string>
-	<string name="media_no_video_title">VideoPress kullanılabilir değil</string>
 	<string name="post_excerpt">Özet</string>
 	<string name="share_action">Paylaş</string>
 	<string name="stats">İstatistikler</string>
@@ -800,7 +875,6 @@
 	<string name="custom_date">Özel tarih</string>
 	<string name="media_gallery_type_squares">Kare</string>
 	<string name="media_gallery_type_circles">Çember</string>
-	<string name="media_no_video_message">Video gönderimi için VideoPress yükseltmesini edin!</string>
 	<string name="theme_activate_button">Aktifleştir</string>
 	<string name="theme_activating_button">Aktifleştiriliyor</string>
 	<string name="theme_auth_error_title">Temalar alınamadı</string>
@@ -819,8 +893,6 @@
 	<string name="note_reply_successful">Yanıt yayımlandı</string>
 	<string name="follows">Takipçiler</string>
 	<string name="loading">Yükleniyor...</string>
-	<string name="post_signature">Yazı imzası</string>
-	<string name="add_tagline">Yeni yazılara imza ekle</string>
 	<string name="httpuser">HTTP Kullanici Adi</string>
 	<string name="httppassword">HTTP Sifre</string>
 	<string name="error_media_upload">Ortam yüklenirken bir hata oluştu</string>
@@ -847,11 +919,9 @@
 	<string name="upload_scaled_image">Boyutlandırılmış görseli yükle ve bağlantı ver</string>
 	<string name="scheduled">Zamanlandı</string>
 	<string name="link_enter_url">Adres</string>
-	<string name="posted_from">Android için WordPress ile gönderilmiştir</string>
 	<string name="version">Sürüm</string>
 	<string name="app_title">Android için WordPress</string>
 	<string name="tos">Hizmet Şartları</string>
-	<string name="about">Hakkında</string>
 	<string name="max_thumbnail_px_width">Varsayılan Görsel Genişliği</string>
 	<string name="image_alignment">Konumlandırma</string>
 	<string name="refresh">Yenile</string>
@@ -873,6 +943,7 @@
 	<string name="categories">Kategoriler</string>
 	<string name="tags_separate_with_commas">Etiketler (etiketleri virgül ile ayırın)</string>
 	<string name="title">Başlık</string>
+	<string name="dlg_deleting_comments">Yorumlar siliniyor</string>
 	<string name="notification_sound">Bilgilendirme sesi çal</string>
 	<string name="notification_vibrate">Titre</string>
 	<string name="notification_blink">Bilgilendirme ışığını parlat</string>
@@ -896,70 +967,4 @@
 	<string name="no">Hayır</string>
 	<string name="category_refresh_error">Kategori tazeleme hatası</string>
 	<string name="notification_settings">Bildirim Ayarları</string>
-	<string-array name="alignment_array">
-		<item>Hiç biri</item>
-		<item>Sol</item>
-		<item>Orta</item>
-		<item>Sağ</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>Sitemdeki yorumlar</item>
-		<item>Yorumlarımdaki beğenmeler</item>
-		<item>Yazılarımdaki beğenmeler</item>
-		<item>Site takipleri</item>
-		<item>Site başarıları</item>
-		<item>Kullanıcı adı bahsedenleri</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>Yorumlarıma cevaplar</item>
-		<item>Yorumlarımdaki beğenmeler</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>Öneriler</item>
-		<item>Araştırma</item>
-		<item>Topluluk</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>WordPress.com\'dan en iyi biçimde yararlanmak için ipuçları.</item>
-		<item>WordPress.com araştırma ve anketlerine katılma olanağı.</item>
-		<item>WordPress.com kursları ve etkinlikleri (çevrimiçi ve yüz yüze) hakkında bilgi.</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>Yayımlandı</item>
-		<item>Taslaklar</item>
-		<item>Zamanlandı</item>
-		<item>Çöpe taşındı</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Yan sütun</item>
-		<item>Ses</item>
-		<item>Sohbet</item>
-		<item>Galeri</item>
-		<item>Görsel</item>
-		<item>Bağlantı</item>
-		<item>Alıntı</item>
-		<item>Standard</item>
-		<item>Durum</item>
-		<item>Video</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>Siteniz herkes tarafından görülebilir ve arama motorları tarafından endekslenebilir</item>
-		<item>Siteniz herkes tarafından görülebilir, ancak arama motorlarından kendisini endekslememelerini ister</item>
-		<item>Siteniz sadece siz ve onay verdiğiniz kullanıcılar tarafından görülebilir</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>Herkesin yorumları için el ile onaylama ister.</item>
-		<item>Kullanıcının daha önceden onaylanmış bir yorumu varsa otomatik olarak onayla.</item>
-		<item>Herkesin yorumlarını otomatik olarak onayla.</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>Hiçbir yorum</item>
-		<item>Bilinen kullanıcıların yorumları</item>
-		<item>Tüm kullanıcılar</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>Ücretsiz</item>
-		<item>Tümü</item>
-		<item>Premium</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-uz/strings.xml
+++ b/WordPress/src/main/res/values-uz/strings.xml
@@ -15,9 +15,6 @@
 	<string name="download">Media saqlanmoqda</string>
 	<string name="comment_spammed">Mulohaza spam sifatida belgilandi</string>
 	<string name="cant_share_no_visible_blog">Ochiq blogsiz WordPress bilan bo‘lisha olmaysiz</string>
-	<string name="share_preference_title">WordPress bilan bo‘lishish</string>
-	<string name="reset_auto_share_preference">Avto-bo‘lishish moslamalarini qayta tiklash</string>
-	<string name="always_use_these_settings_to_share">Har doim ushbu moslamalardan foydalanish</string>
 	<string name="select_time">Vaqt tanlang</string>
 	<string name="reader_likes_you_and_one">Siz va yana bir kishi buni yoqtiradi</string>
 	<string name="select_date">Sana tanlang</string>
@@ -62,8 +59,6 @@
 	<string name="media_gallery_type">Tur</string>
 	<string name="media_gallery_type_squares">Kvadrat</string>
 	<string name="media_gallery_type_tiled">Bir qator</string>
-	<string name="media_no_video_title">VideoPress mavjud emas</string>
-	<string name="media_no_video_message">Video yuklash uchun VideoPress ni apgreyd qil</string>
 	<string name="media_edit_title_text">Sarlavha</string>
 	<string name="media_edit_caption_text">Titr</string>
 	<string name="media_edit_description_text">Izoh</string>
@@ -120,8 +115,6 @@
 	<string name="sign_in">Kirish</string>
 	<string name="loading">Yuklanmoqda...</string>
 	<string name="httppassword">HTTP parol</string>
-	<string name="post_signature">Imzo</string>
-	<string name="add_tagline">Yangi postlarga imzo qo\'shish</string>
 	<string name="httpuser">HTTP foydalanuvchi nomi</string>
 	<string name="error_media_upload">Media yuklash jarayonida xatolik yuz berdi.</string>
 	<string name="publish_date">Chop etish</string>
@@ -147,11 +140,9 @@
 	<string name="scaled_image">Yangi hajm uchun en qiymati</string>
 	<string name="scheduled">Jadvalga kiritildi</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">WordPress Android orqali chop etildi</string>
 	<string name="version">Versiya</string>
 	<string name="tos">Xizmat shartlari</string>
 	<string name="app_title">WordPress for Android</string>
-	<string name="about">Haqida</string>
 	<string name="image_alignment">Tekislash</string>
 	<string name="refresh">Yangila</string>
 	<string name="untitled">Nomsiz</string>
@@ -192,22 +183,4 @@
 	<string name="error">Xato</string>
 	<string name="save">Saqla</string>
 	<string name="on">da</string>
-	<string-array name="alignment_array">
-		<item>Hech bir</item>
-		<item>Chap</item>
-		<item>O‘rta</item>
-		<item>O‘ng</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>Yonma-yon</item>
-		<item>Audio</item>
-		<item>Chat</item>
-		<item>Galereya</item>
-		<item>Rasm</item>
-		<item>Havola</item>
-		<item>Iqtibos</item>
-		<item>Standard</item>
-		<item>Status</item>
-		<item>Video</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-zh-rCN/strings.xml
+++ b/WordPress/src/main/res/values-zh-rCN/strings.xml
@@ -1,6 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">不能保存您的账户设置</string>
+	<string name="post_format_status">状态</string>
+	<string name="post_format_video">视频</string>
+	<string name="align_none">无</string>
+	<string name="align_left">左</string>
+	<string name="align_center">中</string>
+	<string name="align_right">右</string>
+	<string name="theme_free">免费</string>
+	<string name="theme_all">全部</string>
+	<string name="theme_premium">付费</string>
+	<string name="post_format_chat">聊天</string>
+	<string name="post_format_gallery">图库</string>
+	<string name="post_format_image">图像</string>
+	<string name="post_format_link">链接</string>
+	<string name="post_format_quote">引用</string>
+	<string name="post_format_standard">标准</string>
+	<string name="notif_events">有关 WordPress.com 课程和活动（在线和现场）的信息。</string>
+	<string name="post_format_aside">旁白</string>
+	<string name="post_format_audio">音频</string>
+	<string name="notif_surveys">参加 WordPress.com 研究和调查的机会。</string>
+	<string name="notif_tips">有关畅享 WordPress.com 的提示。</string>
+	<string name="notif_community">社区</string>
+	<string name="replies_to_my_comments">我的评论收到的回复</string>
+	<string name="notif_suggestions">建议</string>
+	<string name="notif_research">研究</string>
+	<string name="site_achievements">站点成就</string>
+	<string name="username_mentions">用户名提到的次数</string>
+	<string name="likes_on_my_posts">我的文章收到的赞</string>
+	<string name="site_follows">站点关注人数</string>
+	<string name="likes_on_my_comments">我的评论收到的赞</string>
+	<string name="comments_on_my_site">我的站点上的评论</string>
+	<string name="site_settings_list_editor_summary_other">%d 个条目</string>
+	<string name="site_settings_list_editor_summary_one">1 个条目</string>
+	<string name="approve_auto_if_previously_approved">已知用户的评论</string>
+	<string name="approve_auto">所有用户</string>
+	<string name="approve_manual">没有评论</string>
+	<string name="site_settings_paging_summary_other">每页 %d 条评论</string>
+	<string name="site_settings_paging_summary_one">每页 1 条评论</string>
+	<string name="site_settings_multiple_links_summary_other">超过 %d 个链接需要审核</string>
+	<string name="site_settings_multiple_links_summary_one">超过 1 个链接需要审核</string>
+	<string name="site_settings_multiple_links_summary_zero">超过 0 个链接需要审核</string>
+	<string name="detail_approve_auto">自动批准每个人的评论。</string>
+	<string name="detail_approve_auto_if_previously_approved">如果用户已有获得批准的评论，则自动批准该用户的其他评论</string>
+	<string name="detail_approve_manual">每个人的评论都需要进行人工审核。</string>
+	<string name="filter_trashed_posts">已放入回收站</string>
+	<string name="days_quantity_one">1 天</string>
+	<string name="days_quantity_other">%d 天</string>
+	<string name="filter_published_posts">已发布</string>
+	<string name="filter_draft_posts">草稿</string>
+	<string name="filter_scheduled_posts">预发布</string>
+	<string name="pending_email_change_snackbar">单击发送给 %1$s 的电子邮件中的验证链接以确认您的新地址</string>
+	<string name="primary_site">主站点</string>
+	<string name="web_address">网页地址</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">部分媒体上传失败。请重新上传或删除它们。</string>
+	<string name="editor_toast_uploading_please_wait">您目前正在上传媒体。请等待，直到此任务完成。</string>
+	<string name="error_refresh_comments_showing_older">目前无法刷新评论 – 显示的是旧评论</string>
+	<string name="editor_post_settings_set_featured_image">设置推荐图像</string>
+	<string name="editor_post_settings_featured_image">推荐图像</string>
+	<string name="new_editor_promo_desc">适用于 Android 的 WordPress 应用程序现在包含美观的全新可视化\n编辑器。请创建一篇新文章试试看。</string>
+	<string name="new_editor_promo_title">全新的编辑器</string>
+	<string name="new_editor_promo_button_label">太棒了，谢谢！</string>
+	<string name="visual_editor_enabled">已启用可视化编辑器</string>
+	<string name="editor_content_placeholder">在此处分享您的故事…</string>
+	<string name="editor_page_title_placeholder">页面标题</string>
+	<string name="editor_post_title_placeholder">文章标题</string>
+	<string name="email_address">电子邮件地址</string>
+	<string name="preference_show_visual_editor">显示可视化编辑器</string>
+	<string name="dlg_sure_to_delete_comments">是否永久删除这些评论？</string>
+	<string name="preference_editor">编辑器</string>
+	<string name="dlg_sure_to_delete_comment">是否永久删除该评论？</string>
+	<string name="mnu_comment_delete_permanently">删除</string>
+	<string name="comment_deleted_permanently">已删除评论</string>
+	<string name="mnu_comment_untrash">恢复</string>
+	<string name="comments_empty_list_filtered">没有%s评论</string>
+	<string name="could_not_load_page">无法加载页面</string>
+	<string name="comment_status_all">全部</string>
+	<string name="interface_language">界面语言</string>
+	<string name="off">关闭</string>
+	<string name="about_the_app">关于该应用程序</string>
 	<string name="error_post_my_profile">无法保存您的个人资料</string>
 	<string name="error_fetch_account_settings">无法检索您的帐户设置</string>
 	<string name="error_fetch_my_profile">无法检索您的个人资料</string>
@@ -487,11 +565,9 @@
 	<string name="hs__invalid_email_error">请输入有效电子邮件地址</string>
 	<string name="add_location">添加位置</string>
 	<string name="current_location">当前位置</string>
-	<string name="your_signature">您的签名：</string>
 	<string name="search_location">搜索</string>
 	<string name="edit_location">编辑</string>
 	<string name="search_current_location">定位</string>
-	<string name="preference_privacy">隐私</string>
 	<string name="preference_send_usage_stats">发送统计数据</string>
 	<string name="preference_send_usage_stats_summary">自动发送使用统计数据以帮助我们改进 Android 版 WordPress</string>
 	<string name="update_verb">更新</string>
@@ -534,10 +610,7 @@
 	<string name="cat_name_required">“分类名称”必填</string>
 	<string name="category_automatically_renamed">"分类名称 %1$s 不可用. 它已经被重命名为 %2$s."</string>
 	<string name="no_account">未找到 WordPress 账号，请添加一个账号后再试</string>
-	<string name="auto_sharing_preference_reset">重置自动分享设置</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">已选定的博客不可用</string>
 	<string name="sdcard_message">上传媒体需要已装载的 SD 卡</string>
-	<string name="invalid_url_message">请检查所输博客 URL 是否有效</string>
 	<string name="reply_failed">回复失败</string>
 	<string name="notifications_empty_list">没有通知</string>
 	<string name="error_delete_post">在删除 %s 时发生了一个错误</string>
@@ -686,6 +759,7 @@
 	<string name="blog_removed_successfully">已成功删除站点</string>
 	<string name="remove_account">删除站点</string>
 	<string name="notifications_empty_all">尚无通知…。</string>
+	<string name="invalid_site_url_message">请检查输入的站点 URL 是否有效</string>
 	<string name="deleting_page">正在删除页面</string>
 	<string name="deleting_post">正在删除日志</string>
 	<string name="share_url_post">分享日志</string>
@@ -702,9 +776,6 @@
 	<string name="video">视频</string>
 	<string name="download">下载媒体文件</string>
 	<string name="cant_share_no_visible_blog">没有一个博客，你不能分享到WordPress</string>
-	<string name="share_preference_title">分享到WordPress</string>
-	<string name="reset_auto_share_preference">重置自动分享设置</string>
-	<string name="always_use_these_settings_to_share">默认使用这些设置</string>
 	<string name="comment_spammed">评论被标记为垃圾评论</string>
 	<string name="select_time">选择时间</string>
 	<string name="reader_likes_you_and_one">你和另一个人喜欢</string>
@@ -798,8 +869,6 @@
 	<string name="media_gallery_type_tiled">磁贴</string>
 	<string name="media_gallery_type_circles">环状</string>
 	<string name="media_gallery_type_slideshow">幻灯片</string>
-	<string name="media_no_video_title">VideoPress不可用</string>
-	<string name="media_no_video_message">得到videopress升级来上传视频！</string>
 	<string name="stats_entry_referrers">推荐人</string>
 	<string name="stats_totals_views">浏览次数</string>
 	<string name="stats_totals_clicks">点击数</string>
@@ -819,8 +888,6 @@
 	<string name="notifications">通知</string>
 	<string name="follows">关注</string>
 	<string name="loading">正在加载…</string>
-	<string name="post_signature">文章签名</string>
-	<string name="add_tagline">为新发表的博文添加签名</string>
 	<string name="httpuser">HTTP 用户名</string>
 	<string name="httppassword">HTTP 密码</string>
 	<string name="error_media_upload">上传媒体时出错</string>
@@ -847,11 +914,9 @@
 	<string name="scaled_image">图像缩放宽度</string>
 	<string name="scheduled">定时</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">发自 WordPress for Android</string>
 	<string name="version">版本</string>
 	<string name="tos">服务条款</string>
 	<string name="app_title">WordPress for Android</string>
-	<string name="about">关于</string>
 	<string name="max_thumbnail_px_width">默认图片宽度</string>
 	<string name="image_alignment">对齐</string>
 	<string name="refresh">刷新</string>
@@ -896,70 +961,4 @@
 	<string name="no">否</string>
 	<string name="preview">预览</string>
 	<string name="notification_settings">通知设置</string>
-	<string-array name="alignment_array">
-		<item>不对齐</item>
-		<item>居左</item>
-		<item>居中</item>
-		<item>居右</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>我的站点上的评论</item>
-		<item>我的评论收到的赞</item>
-		<item>我的文章收到的赞</item>
-		<item>站点关注人数</item>
-		<item>站点成就</item>
-		<item>用户名提到的次数</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>我的评论收到的回复</item>
-		<item>我的评论收到的赞</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>建议</item>
-		<item>研究</item>
-		<item>社区</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>有关畅享 WordPress.com 的提示。</item>
-		<item>参加 WordPress.com 研究和调查的机会。</item>
-		<item>有关 WordPress.com 课程和活动（在线和现场）的信息。</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>已发布</item>
-		<item>草稿</item>
-		<item>预发布</item>
-		<item>已放入回收站</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>笔记</item>
-		<item>音频</item>
-		<item>聊天</item>
-		<item>图库</item>
-		<item>图像</item>
-		<item>链接</item>
-		<item>引用</item>
-		<item>标准</item>
-		<item>状态</item>
-		<item>视频</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>您的站点对所有人可见，并且可以被搜索引擎编入索引</item>
-		<item>您的站点对所有人可见，但要求搜索引擎不将其编入索引</item>
-		<item>您的站点仅对您以及您审核通过的用户可见</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>每个人的评论都需要进行人工审核。</item>
-		<item>如果用户已有审核通过的评论，则系统将自动审核该用户的其他评论。</item>
-		<item>自动审核每个人的评论。</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>没有评论</item>
-		<item>已知用户的评论</item>
-		<item>所有用户</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>免费</item>
-		<item>全部</item>
-		<item>付费</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -1,6 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">無法儲存你的帳號設定</string>
+	<string name="post_format_status">狀態</string>
+	<string name="post_format_video">影片</string>
+	<string name="align_none">無</string>
+	<string name="align_left">靠左</string>
+	<string name="align_center">置中</string>
+	<string name="align_right">靠右</string>
+	<string name="theme_free">免費</string>
+	<string name="theme_all">全部</string>
+	<string name="theme_premium">進階版</string>
+	<string name="post_format_chat">聊天</string>
+	<string name="post_format_gallery">圖庫</string>
+	<string name="post_format_image">圖片</string>
+	<string name="post_format_link">連結</string>
+	<string name="post_format_quote">引文</string>
+	<string name="post_format_standard">標準版</string>
+	<string name="notif_events">WordPress.com 課程與活動相關資訊 (線上和專人洽詢)。</string>
+	<string name="post_format_aside">旁白</string>
+	<string name="post_format_audio">音訊</string>
+	<string name="notif_surveys">參與 WordPress.com 研究與調查的機會。</string>
+	<string name="notif_tips">讓 WordPress.com 發揮最大功效的秘訣。</string>
+	<string name="notif_community">社群</string>
+	<string name="replies_to_my_comments">留言的回覆</string>
+	<string name="notif_suggestions">建議</string>
+	<string name="notif_research">研究</string>
+	<string name="site_achievements">網站成就</string>
+	<string name="username_mentions">使用者名稱標記</string>
+	<string name="likes_on_my_posts">文章按讚數</string>
+	<string name="site_follows">網站關注數</string>
+	<string name="likes_on_my_comments">留言按讚數</string>
+	<string name="comments_on_my_site">網站留言</string>
+	<string name="site_settings_list_editor_summary_other">%d 個項目</string>
+	<string name="site_settings_list_editor_summary_one">1 個項目</string>
+	<string name="approve_auto_if_previously_approved">已知使用者的留言</string>
+	<string name="approve_auto">所有使用者</string>
+	<string name="approve_manual">無留言</string>
+	<string name="site_settings_paging_summary_other">每頁 %d 則留言</string>
+	<string name="site_settings_paging_summary_one">每頁 1 則留言</string>
+	<string name="site_settings_multiple_links_summary_other">需要審核超過 %d 個連結</string>
+	<string name="site_settings_multiple_links_summary_one">需要審核超過 1 個連結</string>
+	<string name="site_settings_multiple_links_summary_zero">需要審核超過 0 個連結</string>
+	<string name="detail_approve_auto">自動核准所有人的留言。</string>
+	<string name="detail_approve_auto_if_previously_approved">如果使用者有已審核的留言，則自動核准</string>
+	<string name="detail_approve_manual">需要人工審核所有人的留言。</string>
+	<string name="filter_trashed_posts">已移至垃圾桶</string>
+	<string name="days_quantity_one">1 天</string>
+	<string name="days_quantity_other">%d 天</string>
+	<string name="filter_published_posts">已發表</string>
+	<string name="filter_draft_posts">草稿</string>
+	<string name="filter_scheduled_posts">已排程</string>
+	<string name="pending_email_change_snackbar">按一下電子郵件 (收件者：%1$s) 中的驗證連結以確認您的新地址</string>
+	<string name="primary_site">主要網站</string>
+	<string name="web_address">網站位址</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">部分媒體上傳失敗。請重新上傳或刪除這些媒體。</string>
+	<string name="editor_toast_uploading_please_wait">你目前正在上傳媒體。請等待此作業完成。</string>
+	<string name="error_refresh_comments_showing_older">目前無法重新整理留言 – 顯示較舊的留言</string>
+	<string name="editor_post_settings_set_featured_image">設定特色圖片</string>
+	<string name="editor_post_settings_featured_image">特色圖片</string>
+	<string name="new_editor_promo_desc">Android 版 WordPress 應用程式現已包含美觀的全新視覺化\n編輯器。建立新的文章，即可試用編輯器。</string>
+	<string name="new_editor_promo_title">全新編輯器</string>
+	<string name="new_editor_promo_button_label">太棒了，謝謝！</string>
+	<string name="visual_editor_enabled">視覺化編輯器已啟用</string>
+	<string name="editor_content_placeholder">在此分享你的故事...</string>
+	<string name="editor_page_title_placeholder">頁面標題</string>
+	<string name="editor_post_title_placeholder">文章標題</string>
+	<string name="email_address">電子郵件地址</string>
+	<string name="preference_show_visual_editor">顯示視覺化編輯器</string>
+	<string name="dlg_sure_to_delete_comments">永久刪除這些留言？</string>
+	<string name="preference_editor">編輯者</string>
+	<string name="dlg_sure_to_delete_comment">永久刪除此回應？</string>
+	<string name="mnu_comment_delete_permanently">刪除</string>
+	<string name="comment_deleted_permanently">留言已刪除</string>
+	<string name="mnu_comment_untrash">還原</string>
+	<string name="comments_empty_list_filtered">無%s留言</string>
+	<string name="could_not_load_page">無法載入頁面</string>
+	<string name="comment_status_all">全部</string>
+	<string name="interface_language">介面語言</string>
+	<string name="off">關閉</string>
+	<string name="about_the_app">關於此應用程式</string>
 	<string name="error_post_my_profile">無法儲存你的個人檔案</string>
 	<string name="error_fetch_account_settings">無法擷取你的帳號設定</string>
 	<string name="error_fetch_my_profile">無法擷取你的個人檔案</string>
@@ -487,11 +565,9 @@
 	<string name="hs__invalid_email_error">輸入有效的電子郵件地址</string>
 	<string name="add_location">新增位置</string>
 	<string name="current_location">目前的位置</string>
-	<string name="your_signature">你的簽名：</string>
 	<string name="search_location">搜尋</string>
 	<string name="edit_location">編輯</string>
 	<string name="search_current_location">尋找</string>
-	<string name="preference_privacy">隱私</string>
 	<string name="preference_send_usage_stats">傳送統計資料</string>
 	<string name="preference_send_usage_stats_summary">自動傳送使用統計資料，協助我們改善 Android 版 WordPress</string>
 	<string name="update_verb">更新</string>
@@ -535,12 +611,9 @@
 	<string name="cat_name_required">類別名稱欄位為必填</string>
 	<string name="category_automatically_renamed">類別名稱 %1$s 無效。已將它重新命名為 %2$s。</string>
 	<string name="no_account">未找到 WordPress 帳號，請新增帳號然後重試一次</string>
-	<string name="auto_sharing_preference_reset">自動分享設定已重設</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">之前選取的網誌已不再顯示</string>
 	<string name="sdcard_message">需要掛接 SD 卡以上傳媒體</string>
 	<string name="stats_empty_comments">尚無回應</string>
 	<string name="stats_bar_graph_empty">沒有可用的統計</string>
-	<string name="invalid_url_message">檢查輸入的網誌網址是否有效</string>
 	<string name="reply_failed">回覆失敗</string>
 	<string name="notifications_empty_list">沒有通知</string>
 	<string name="error_delete_post">刪除 %s 時發生錯誤</string>
@@ -686,6 +759,7 @@
 	<string name="blog_name_invalid">無效的網站位址</string>
 	<string name="blog_title_invalid">無效的網站標題</string>
 	<string name="notifications_empty_all">尚未有任何通知。</string>
+	<string name="invalid_site_url_message">檢查輸入的網站 URL 是否有效</string>
 	<string name="deleting_page">正在刪除頁面</string>
 	<string name="deleting_post">正在刪除文章</string>
 	<string name="share_url_post">分享文章</string>
@@ -702,9 +776,6 @@
 	<string name="video">影片</string>
 	<string name="download">正在下載媒體</string>
 	<string name="cant_share_no_visible_blog">你無法在沒有可見網誌的情形下分享至 WordPress</string>
-	<string name="share_preference_title">分享至 WordPress</string>
-	<string name="reset_auto_share_preference">重設自動分享設定</string>
-	<string name="always_use_these_settings_to_share">一律使用這些設定</string>
 	<string name="comment_spammed">已將留言標記為垃圾</string>
 	<string name="select_time">選取時間</string>
 	<string name="reader_likes_you_and_one">你和其他 1 人都說這個讚</string>
@@ -760,7 +831,6 @@
 	<string name="media_add_popup_capture_video">錄影</string>
 	<string name="media_gallery_type_slideshow">幻燈片</string>
 	<string name="media_gallery_image_order_random">隨機</string>
-	<string name="media_no_video_title">VideoPress 不能用</string>
 	<string name="media_edit_description_text">說明</string>
 	<string name="media_edit_title_hint">在這裡輸入標題</string>
 	<string name="theme_set_success">成功設定佈景主題</string>
@@ -779,7 +849,6 @@
 	<string name="media_edit_failure">更新失敗</string>
 	<string name="themes_details_label">細節</string>
 	<string name="stats_view_tags_and_categories">標籤與分類</string>
-	<string name="media_no_video_message">取得 VideoPress 升級以上傳影片！</string>
 	<string name="themes_features_label">功能</string>
 	<string name="theme_activate_button">啟用</string>
 	<string name="theme_activating_button">啟用中</string>
@@ -819,8 +888,6 @@
 	<string name="more_notifications">還有 %d 個。</string>
 	<string name="follows">關注者</string>
 	<string name="loading">載入中...</string>
-	<string name="post_signature">文章簽名</string>
-	<string name="add_tagline">為新文章新增一個簽名</string>
 	<string name="httppassword">HTTP 密碼</string>
 	<string name="httpuser">HTTP 使用者帳號</string>
 	<string name="error_media_upload">上傳媒體時發生錯誤</string>
@@ -847,11 +914,9 @@
 	<string name="scaled_image">圖片縮放寬度</string>
 	<string name="scheduled">定時</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">發自 WordPress for Android</string>
 	<string name="version">版本</string>
 	<string name="tos">服務條款</string>
 	<string name="app_title">WordPress for Android</string>
-	<string name="about">關於</string>
 	<string name="max_thumbnail_px_width">預設圖片寬度</string>
 	<string name="image_alignment">對齊</string>
 	<string name="refresh">更新</string>
@@ -896,70 +961,4 @@
 	<string name="no">否</string>
 	<string name="preview">預覽</string>
 	<string name="notification_settings">通知設定</string>
-	<string-array name="alignment_array">
-		<item>無</item>
-		<item>靠左</item>
-		<item>置中</item>
-		<item>靠右</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>網站留言</item>
-		<item>按讚的留言</item>
-		<item>按讚的文章</item>
-		<item>網站關注</item>
-		<item>網站成就</item>
-		<item>使用者名稱標記</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>留言的回覆</item>
-		<item>按讚的留言</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>建議</item>
-		<item>研究</item>
-		<item>社群</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>讓 WordPress.com 發揮最大功效的秘訣。</item>
-		<item>參與 WordPress.com 研究與調查的機會。</item>
-		<item>WordPress.com 課程與活動相關資訊 (線上和專人洽詢)。</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>已發表</item>
-		<item>草稿</item>
-		<item>已排程</item>
-		<item>已移至垃圾桶</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>註記</item>
-		<item>音訊</item>
-		<item>聊天</item>
-		<item>藝廊</item>
-		<item>圖像</item>
-		<item>連結</item>
-		<item>引用</item>
-		<item>標準</item>
-		<item>狀態</item>
-		<item>影片</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>所有人都能看見你的網站，且搜尋引擎可能會將網站加入索引</item>
-		<item>所有人都能看見你的網站，但網站會要求搜尋引擎不要加入索引</item>
-		<item>只有你和經核准的使用者可看見你的網站</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>需要人工審核所有人的留言。</item>
-		<item>如果使用者有已審核的留言，則自動核准。</item>
-		<item>自動核准所有人的留言。</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>無留言</item>
-		<item>已知使用者的留言</item>
-		<item>所有使用者</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>免費</item>
-		<item>所有</item>
-		<item>進階</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -1,6 +1,84 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-	<string name="error_post_my_account_settings">無法儲存你的帳號設定</string>
+	<string name="post_format_status">狀態</string>
+	<string name="post_format_video">影片</string>
+	<string name="align_none">無</string>
+	<string name="align_left">靠左</string>
+	<string name="align_center">置中</string>
+	<string name="align_right">靠右</string>
+	<string name="theme_free">免費</string>
+	<string name="theme_all">全部</string>
+	<string name="theme_premium">進階版</string>
+	<string name="post_format_chat">聊天</string>
+	<string name="post_format_gallery">圖庫</string>
+	<string name="post_format_image">圖片</string>
+	<string name="post_format_link">連結</string>
+	<string name="post_format_quote">引文</string>
+	<string name="post_format_standard">標準版</string>
+	<string name="notif_events">WordPress.com 課程與活動相關資訊 (線上和專人洽詢)。</string>
+	<string name="post_format_aside">旁白</string>
+	<string name="post_format_audio">音訊</string>
+	<string name="notif_surveys">參與 WordPress.com 研究與調查的機會。</string>
+	<string name="notif_tips">讓 WordPress.com 發揮最大功效的秘訣。</string>
+	<string name="notif_community">社群</string>
+	<string name="replies_to_my_comments">留言的回覆</string>
+	<string name="notif_suggestions">建議</string>
+	<string name="notif_research">研究</string>
+	<string name="site_achievements">網站成就</string>
+	<string name="username_mentions">使用者名稱標記</string>
+	<string name="likes_on_my_posts">文章按讚數</string>
+	<string name="site_follows">網站關注數</string>
+	<string name="likes_on_my_comments">留言按讚數</string>
+	<string name="comments_on_my_site">網站留言</string>
+	<string name="site_settings_list_editor_summary_other">%d 個項目</string>
+	<string name="site_settings_list_editor_summary_one">1 個項目</string>
+	<string name="approve_auto_if_previously_approved">已知使用者的留言</string>
+	<string name="approve_auto">所有使用者</string>
+	<string name="approve_manual">無留言</string>
+	<string name="site_settings_paging_summary_other">每頁 %d 則留言</string>
+	<string name="site_settings_paging_summary_one">每頁 1 則留言</string>
+	<string name="site_settings_multiple_links_summary_other">需要審核超過 %d 個連結</string>
+	<string name="site_settings_multiple_links_summary_one">需要審核超過 1 個連結</string>
+	<string name="site_settings_multiple_links_summary_zero">需要審核超過 0 個連結</string>
+	<string name="detail_approve_auto">自動核准所有人的留言。</string>
+	<string name="detail_approve_auto_if_previously_approved">如果使用者有已審核的留言，則自動核准</string>
+	<string name="detail_approve_manual">需要人工審核所有人的留言。</string>
+	<string name="filter_trashed_posts">已移至垃圾桶</string>
+	<string name="days_quantity_one">1 天</string>
+	<string name="days_quantity_other">%d 天</string>
+	<string name="filter_published_posts">已發表</string>
+	<string name="filter_draft_posts">草稿</string>
+	<string name="filter_scheduled_posts">已排程</string>
+	<string name="pending_email_change_snackbar">按一下電子郵件 (收件者：%1$s) 中的驗證連結以確認您的新地址</string>
+	<string name="primary_site">主要網站</string>
+	<string name="web_address">網站位址</string>
+	<string name="account_settings">@string/me_btn_settings</string>
+	<string name="editor_toast_failed_uploads">部分媒體上傳失敗。請重新上傳或刪除這些媒體。</string>
+	<string name="editor_toast_uploading_please_wait">你目前正在上傳媒體。請等待此作業完成。</string>
+	<string name="error_refresh_comments_showing_older">目前無法重新整理留言 – 顯示較舊的留言</string>
+	<string name="editor_post_settings_set_featured_image">設定特色圖片</string>
+	<string name="editor_post_settings_featured_image">特色圖片</string>
+	<string name="new_editor_promo_desc">Android 版 WordPress 應用程式現已包含美觀的全新視覺化\n編輯器。建立新的文章，即可試用編輯器。</string>
+	<string name="new_editor_promo_title">全新編輯器</string>
+	<string name="new_editor_promo_button_label">太棒了，謝謝！</string>
+	<string name="visual_editor_enabled">視覺化編輯器已啟用</string>
+	<string name="editor_content_placeholder">在此分享你的故事...</string>
+	<string name="editor_page_title_placeholder">頁面標題</string>
+	<string name="editor_post_title_placeholder">文章標題</string>
+	<string name="email_address">電子郵件地址</string>
+	<string name="preference_show_visual_editor">顯示視覺化編輯器</string>
+	<string name="dlg_sure_to_delete_comments">永久刪除這些留言？</string>
+	<string name="preference_editor">編輯者</string>
+	<string name="dlg_sure_to_delete_comment">永久刪除此回應？</string>
+	<string name="mnu_comment_delete_permanently">刪除</string>
+	<string name="comment_deleted_permanently">留言已刪除</string>
+	<string name="mnu_comment_untrash">還原</string>
+	<string name="comments_empty_list_filtered">無%s留言</string>
+	<string name="could_not_load_page">無法載入頁面</string>
+	<string name="comment_status_all">全部</string>
+	<string name="interface_language">介面語言</string>
+	<string name="off">關閉</string>
+	<string name="about_the_app">關於此應用程式</string>
 	<string name="error_post_my_profile">無法儲存你的個人檔案</string>
 	<string name="error_fetch_account_settings">無法擷取你的帳號設定</string>
 	<string name="error_fetch_my_profile">無法擷取你的個人檔案</string>
@@ -487,11 +565,9 @@
 	<string name="hs__invalid_email_error">輸入有效的電子郵件地址</string>
 	<string name="add_location">新增位置</string>
 	<string name="current_location">目前的位置</string>
-	<string name="your_signature">你的簽名：</string>
 	<string name="search_location">搜尋</string>
 	<string name="edit_location">編輯</string>
 	<string name="search_current_location">尋找</string>
-	<string name="preference_privacy">隱私</string>
 	<string name="preference_send_usage_stats">傳送統計資料</string>
 	<string name="preference_send_usage_stats_summary">自動傳送使用統計資料，協助我們改善 Android 版 WordPress</string>
 	<string name="update_verb">更新</string>
@@ -535,12 +611,9 @@
 	<string name="cat_name_required">類別名稱欄位為必填</string>
 	<string name="category_automatically_renamed">類別名稱 %1$s 無效。已將它重新命名為 %2$s。</string>
 	<string name="no_account">未找到 WordPress 帳號，請新增帳號然後重試一次</string>
-	<string name="auto_sharing_preference_reset">自動分享設定已重設</string>
-	<string name="auto_sharing_preference_reset_caused_by_error">之前選取的網誌已不再顯示</string>
 	<string name="sdcard_message">需要掛接 SD 卡以上傳媒體</string>
 	<string name="stats_empty_comments">尚無回應</string>
 	<string name="stats_bar_graph_empty">沒有可用的統計</string>
-	<string name="invalid_url_message">檢查輸入的網誌網址是否有效</string>
 	<string name="reply_failed">回覆失敗</string>
 	<string name="notifications_empty_list">沒有通知</string>
 	<string name="error_delete_post">刪除 %s 時發生錯誤</string>
@@ -686,6 +759,7 @@
 	<string name="blog_name_invalid">無效的網站位址</string>
 	<string name="blog_title_invalid">無效的網站標題</string>
 	<string name="notifications_empty_all">尚未有任何通知。</string>
+	<string name="invalid_site_url_message">檢查輸入的網站 URL 是否有效</string>
 	<string name="deleting_page">正在刪除頁面</string>
 	<string name="deleting_post">正在刪除文章</string>
 	<string name="share_url_post">分享文章</string>
@@ -702,9 +776,6 @@
 	<string name="video">影片</string>
 	<string name="download">正在下載媒體</string>
 	<string name="cant_share_no_visible_blog">你無法在沒有可見網誌的情形下分享至 WordPress</string>
-	<string name="share_preference_title">分享至 WordPress</string>
-	<string name="reset_auto_share_preference">重設自動分享設定</string>
-	<string name="always_use_these_settings_to_share">一律使用這些設定</string>
 	<string name="comment_spammed">已將留言標記為垃圾</string>
 	<string name="select_time">選取時間</string>
 	<string name="reader_likes_you_and_one">你和其他 1 人都說這個讚</string>
@@ -760,7 +831,6 @@
 	<string name="media_add_popup_capture_video">錄影</string>
 	<string name="media_gallery_type_slideshow">幻燈片</string>
 	<string name="media_gallery_image_order_random">隨機</string>
-	<string name="media_no_video_title">VideoPress 不能用</string>
 	<string name="media_edit_description_text">說明</string>
 	<string name="media_edit_title_hint">在這裡輸入標題</string>
 	<string name="theme_set_success">成功設定佈景主題</string>
@@ -779,7 +849,6 @@
 	<string name="media_edit_failure">更新失敗</string>
 	<string name="themes_details_label">細節</string>
 	<string name="stats_view_tags_and_categories">標籤與分類</string>
-	<string name="media_no_video_message">取得 VideoPress 升級以上傳影片！</string>
 	<string name="themes_features_label">功能</string>
 	<string name="theme_activate_button">啟用</string>
 	<string name="theme_activating_button">啟用中</string>
@@ -819,8 +888,6 @@
 	<string name="more_notifications">還有 %d 個。</string>
 	<string name="follows">關注者</string>
 	<string name="loading">載入中...</string>
-	<string name="post_signature">文章簽名</string>
-	<string name="add_tagline">為新文章新增一個簽名</string>
 	<string name="httppassword">HTTP 密碼</string>
 	<string name="httpuser">HTTP 使用者帳號</string>
 	<string name="error_media_upload">上傳媒體時發生錯誤</string>
@@ -847,11 +914,9 @@
 	<string name="scaled_image">圖片縮放寬度</string>
 	<string name="scheduled">定時</string>
 	<string name="link_enter_url">URL</string>
-	<string name="posted_from">發自 WordPress for Android</string>
 	<string name="version">版本</string>
 	<string name="tos">服務條款</string>
 	<string name="app_title">WordPress for Android</string>
-	<string name="about">關於</string>
 	<string name="max_thumbnail_px_width">預設圖片寬度</string>
 	<string name="image_alignment">對齊</string>
 	<string name="refresh">更新</string>
@@ -896,70 +961,4 @@
 	<string name="no">否</string>
 	<string name="preview">預覽</string>
 	<string name="notification_settings">通知設定</string>
-	<string-array name="alignment_array">
-		<item>無</item>
-		<item>靠左</item>
-		<item>置中</item>
-		<item>靠右</item>
-	</string-array>
-	<string-array name="notifications_blog_settings">
-		<item>網站留言</item>
-		<item>按讚的留言</item>
-		<item>按讚的文章</item>
-		<item>網站關注</item>
-		<item>網站成就</item>
-		<item>使用者名稱標記</item>
-	</string-array>
-	<string-array name="notifications_other_settings">
-		<item>留言的回覆</item>
-		<item>按讚的留言</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings">
-		<item>建議</item>
-		<item>研究</item>
-		<item>社群</item>
-	</string-array>
-	<string-array name="notifications_wpcom_settings_summaries">
-		<item>讓 WordPress.com 發揮最大功效的秘訣。</item>
-		<item>參與 WordPress.com 研究與調查的機會。</item>
-		<item>WordPress.com 課程與活動相關資訊 (線上和專人洽詢)。</item>
-	</string-array>
-	<string-array name="post_filters_array">
-		<item>已發表</item>
-		<item>草稿</item>
-		<item>已排程</item>
-		<item>已移至垃圾桶</item>
-	</string-array>
-	<string-array name="post_formats_array">
-		<item>註記</item>
-		<item>音訊</item>
-		<item>聊天</item>
-		<item>藝廊</item>
-		<item>圖像</item>
-		<item>連結</item>
-		<item>引用</item>
-		<item>標準</item>
-		<item>狀態</item>
-		<item>影片</item>
-	</string-array>
-	<string-array name="privacy_details">
-		<item>所有人都能看見你的網站，且搜尋引擎可能會將網站加入索引</item>
-		<item>所有人都能看見你的網站，但網站會要求搜尋引擎不要加入索引</item>
-		<item>只有你和經核准的使用者可看見你的網站</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_details">
-		<item>需要人工審核所有人的留言。</item>
-		<item>如果使用者有已審核的留言，則自動核准。</item>
-		<item>自動核准所有人的留言。</item>
-	</string-array>
-	<string-array name="site_settings_auto_approve_entries">
-		<item>無留言</item>
-		<item>已知使用者的留言</item>
-		<item>所有使用者</item>
-	</string-array>
-	<string-array name="themes_filter_array">
-		<item>免費</item>
-		<item>所有</item>
-		<item>進階</item>
-	</string-array>
 </resources>

--- a/WordPress/src/main/res/values/available_languages.xml
+++ b/WordPress/src/main/res/values/available_languages.xml
@@ -3,7 +3,7 @@
 <string-array name="available_languages" translatable="false">
 
 <item>
-en_us
+en-US
 </item>
 
 <item>
@@ -23,7 +23,7 @@ es
 </item>
 
 <item>
-es_cl
+es-CL
 </item>
 
 <item>
@@ -87,19 +87,19 @@ uz
 </item>
 
 <item>
-zh_cn
+zh-CN
 </item>
 
 <item>
-zh_tw
+zh-TW
 </item>
 
 <item>
-zh_hk
+zh-HK
 </item>
 
 <item>
-en_gb
+en-GB
 </item>
 
 <item>
@@ -115,7 +115,7 @@ he
 </item>
 
 <item>
-pt_br
+pt-BR
 </item>
 
 <item>
@@ -131,7 +131,7 @@ mk
 </item>
 
 <item>
-en_au
+en-AU
 </item>
 
 <item>

--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta6'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta7'
     }
 }
 

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta6'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta7'
     }
 }
 

--- a/libs/editor/example/build.gradle
+++ b/libs/editor/example/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta6'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta7'
     }
 }
 

--- a/libs/networking/WordPressNetworking/build.gradle
+++ b/libs/networking/WordPressNetworking/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta6'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta7'
     }
 }
 

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta6'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta7'
     }
 }
 


### PR DESCRIPTION
Remove videopress check in the media browser and Update translations for 5.2 
Fix #3850
