### PR TITLE
Load current theme if unavailable

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
@@ -58,13 +58,13 @@ public class ThemeWebActivity extends WPWebViewActivity {
         String blogId = WordPress.getCurrentBlog().getDotComBlogId();
         String themeId = WordPress.wpDB.getCurrentThemeId(blogId);
         if (themeId.isEmpty()) {
-            requestCurrentTheme(activity, blogId);
+            requestAndOpenCurrentTheme(activity, blogId);
         } else {
             openTheme(activity, themeId, type, true);
         }
     }
 
-    private static void requestCurrentTheme(final Activity activity, final String blogId) {
+    private static void requestAndOpenCurrentTheme(final Activity activity, final String blogId) {
         WordPress.getRestClientUtilsV1_1().getCurrentTheme(blogId, new RestRequest.Listener() {
             @Override
             public void onResponse(JSONObject response) {


### PR DESCRIPTION
Fixes #3909 

@nbradbury this is the only place I could think of that would "guarantee" the theme being available. It's also a good place to put it because the user is already experience the loading of the webview, so it's a minimal addition of time.

To test: 
In the post-purchase flow, click "customize" and you will be shown the customizer for your current theme.


Needs review: @nbradbury 
