### PR TITLE
Stats: Insights - Correctly set the Title label in the "Latest Post Summary" module for empty title post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsInsightsLatestPostSummaryFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsInsightsLatestPostSummaryFragment.java
@@ -4,6 +4,7 @@ import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.text.Spannable;
 import android.text.SpannableString;
+import android.text.TextUtils;
 import android.text.style.ForegroundColorSpan;
 import android.view.View;
 import android.view.ViewGroup;
@@ -132,6 +133,10 @@ public class StatsInsightsLatestPostSummaryFragment extends StatsAbstractInsight
         ).toLowerCase();
 
         String postTitle = StringEscapeUtils.unescapeHtml(mInsightsLatestPostModel.getPostTitle());
+        if (TextUtils.isEmpty(postTitle)) {
+            postTitle = getString(R.string.stats_insights_latest_post_no_title);
+        }
+
         final String trendLabelFormatted = String.format(
                 trendLabel, sinceLabel, postTitle);
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -770,6 +770,7 @@
     <string name="stats_insights">Insights</string>
     <string name="stats_insights_all_time">All-time posts, views, and visitors</string>
     <string name="stats_insights_today">Today\'s Stats</string>
+    <string name="stats_insights_latest_post_no_title">(no title)</string>
     <string name="stats_insights_latest_post_summary">Latest Post Summary</string>
     <string name="stats_insights_latest_post_trend">It\'s been %1$s since %2$s was published. Here\'s how the post has performed so far…</string>
     <string name="stats_insights_popular">Most popular day and hour</string>


### PR DESCRIPTION
Fixes #3922 

To test: Create a new post with empty title on a testing blog, and check the "Latest Post Summary" Stats. 
It must appear with `(no title)` label.

cc @astralbodies - Would you mind check that iOS handles this case correctly?