### PR TITLE
Issue/reader remove old blogs i follow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -19,7 +19,7 @@ import java.io.OutputStream;
  */
 public class ReaderDatabase extends SQLiteOpenHelper {
     protected static final String DB_NAME = "wpreader.db";
-    private static final int DB_VERSION = 111;
+    private static final int DB_VERSION = 112;
 
     /*
      * version history
@@ -63,6 +63,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      *  109 - added "feed_item_id" to tbl_posts
      *  110 - added xpost_post_id and xpost_blog_id to tbl_posts
      *  111 - added author_first_name to tbl_posts
+     *  112 - no structural change, just reset db
      */
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -545,7 +545,7 @@ public class ReaderPostTable {
             }
 
 
-            // if blog/feed is no longer followed, remove its posts tagged with "Blogs I Follow" in
+            // if blog/feed is no longer followed, remove its posts tagged with "Followed Sites" in
             // tbl_post_tags
             if (!isFollowed) {
                 if (blogId != 0) {
@@ -683,7 +683,7 @@ public class ReaderPostTable {
 
         if (tag.tagType == ReaderTagType.DEFAULT) {
             // skip posts that are no longer liked if this is "Posts I Like", skip posts that are no
-            // longer followed if this is "Blogs I Follow"
+            // longer followed if this is "Followed Sites"
             if (tag.isPostsILike()) {
                 sql += " AND tbl_posts.is_liked != 0";
             } else if (tag.isFollowedSites()) {

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -17,12 +17,7 @@ public class ReaderTag implements Serializable, FilterCriteria {
     private static final String TAG_NAME_LIKED = "Posts I Like";
     private static final String TAG_NAME_DISCOVER = "Discover";
     private static final String TAG_NAME_DEFAULT = TAG_NAME_DISCOVER;
-
-    // as of 15-Sept-2015 this is still "Blogs I Follow" but it will soon be renamed
-    // to "Followed Sites"
-    // TODO: remove TAG_NAME_FOLLOWED_SITES_OLD once backend has been updated
     public static final String TAG_NAME_FOLLOWED_SITES = "Followed Sites";
-    public static final String TAG_NAME_FOLLOWED_SITES_OLD = "Blogs I Follow";
 
     public ReaderTag(String tagName, String endpoint, ReaderTagType tagType) {
         if (TextUtils.isEmpty(tagName)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -202,11 +202,6 @@ public class ReaderUpdateService extends Service {
             if (jsonTopic != null) {
                 String tagName = JSONUtils.getStringDecoded(jsonTopic, "title");
                 String endpoint = JSONUtils.getString(jsonTopic, "URL");
-                // rename "Blogs I Follow" to "Followed Sites"
-                if (topicType == ReaderTagType.DEFAULT
-                        && tagName.equals(ReaderTag.TAG_NAME_FOLLOWED_SITES_OLD)) {
-                    tagName = ReaderTag.TAG_NAME_FOLLOWED_SITES;
-                }
                 topics.add(new ReaderTag(tagName, endpoint, topicType));
             }
         }


### PR DESCRIPTION
This PR drops the remnants of "Blogs I Follow" which was renamed to "Followed Sites" in #3188. Now that the backend has been changed to use "Followed Sites" (see https://wpcom.trac.automattic.com/changeset/133804 ) we no longer need to rename "Blogs I Follow" to "Followed Sites" when new posts are retrieved.

Note that the reader database is reset as a precaution (probably unnecessary), just to make sure there aren't any posts tagged "Blogs I Follow" instead of "Followed Sites."

Aside: this *may* help with  #3908, but still looking into that issue.