### PR TITLE
Revert "Update to emailchecker2"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: android
 jdk: oraclejdk7
-sudo: required
+sudo: false
 
 notifications:
   # Slack notification on failure (secured token).
@@ -22,7 +22,6 @@ android:
 
 env:
   global:
-    - MALLOC_ARENA_MAX=2
     - GRADLE_OPTS="-XX:MaxPermSize=4g -Xmx4g"
     - ANDROID_SDKS=android-14
     - ANDROID_TARGET=android-14

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -2,7 +2,6 @@ buildscript {
     repositories {
         jcenter()
         maven { url 'https://maven.fabric.io/public' }
-
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.0.0-rc1'
@@ -24,7 +23,6 @@ android {
 
     dexOptions {
         jumboMode = true
-        javaMaxHeapSize = "4g"
     }
 
     compileSdkVersion 23
@@ -96,7 +94,6 @@ dependencies {
     compile 'com.automattic:rest:1.0.3'
     compile 'org.wordpress:graphview:3.4.0'
     compile 'org.wordpress:persistentedittext:1.0.1'
-    compile 'org.wordpress:emailchecker2:1.1.0'
 
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.0'
     androidTestCompile 'org.objenesis:objenesis:2.1'
@@ -108,6 +105,7 @@ dependencies {
     compile 'org.wordpress:drag-sort-listview:0.6.1' // not found in maven central
     compile 'org.wordpress:slidinguppanel:1.0.0' // not found in maven central
     compile 'org.wordpress:passcodelock:1.1.0'
+    compile 'org.wordpress:emailchecker:0.3'
 
     // Simperium
     compile 'com.simperium.android:simperium:0.6.8'

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -32,7 +32,7 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.UserEmailUtils;
 import org.wordpress.android.widgets.WPTextView;
-import org.wordpress.emailchecker2.EmailChecker;
+import org.wordpress.emailchecker.EmailChecker;
 import org.wordpress.persistentedittext.PersistentEditTextHelper;
 
 import java.util.regex.Matcher;
@@ -46,8 +46,13 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
     private WPTextView mSignupButton;
     private WPTextView mProgressTextSignIn;
     private RelativeLayout mProgressBarSignIn;
+    private EmailChecker mEmailChecker;
     private boolean mEmailAutoCorrected;
     private boolean mAutoCompleteUrl;
+
+    public NewUserFragment() {
+        mEmailChecker = new EmailChecker();
+    }
 
     @Override
     public void afterTextChanged(Editable s) {
@@ -318,7 +323,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
             return;
         }
         final String email = EditTextUtils.getText(mEmailTextField).trim();
-        String suggest = EmailChecker.suggestDomainCorrection(email);
+        String suggest = mEmailChecker.suggestDomainCorrection(email);
         if (suggest.compareTo(email) != 0) {
             mEmailAutoCorrected = true;
             mEmailTextField.setText(suggest);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -59,7 +59,7 @@ import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.widgets.WPTextView;
-import org.wordpress.emailchecker2.EmailChecker;
+import org.wordpress.emailchecker.EmailChecker;
 import org.xmlrpc.android.ApiHelper;
 
 import java.util.EnumSet;
@@ -103,6 +103,8 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     private ImageView mInfoButton;
     private ImageView mInfoButtonSecondary;
 
+    private final EmailChecker mEmailChecker;
+
     private boolean mSelfHosted;
     private boolean mEmailAutoCorrected;
     private boolean mShouldSendTwoStepSMS;
@@ -113,6 +115,10 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     private String mHttpUsername;
     private String mHttpPassword;
     private Blog mJetpackBlog;
+
+    public SignInFragment() {
+        mEmailChecker = new EmailChecker();
+    }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -312,7 +318,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             return;
         }
         // It looks like an email address, then try to correct it
-        String suggest = EmailChecker.suggestDomainCorrection(email);
+        String suggest = mEmailChecker.suggestDomainCorrection(email);
         if (suggest.compareTo(email) != 0) {
             mEmailAutoCorrected = true;
             mUsernameEditText.setText(suggest);


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-Android#3903

Use the old emailchecker library (and remove the kotlin runtime) while we have a better solution for https://github.com/wordpress-mobile/WordPress-Android/issues/3924
