### PR TITLE
Escape quotes on translated strings when calling execJavaScriptFromString

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -972,9 +972,9 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
                 // Set title and content placeholder text
                 mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_title').setPlaceholderText('" +
-                        mTitlePlaceholder + "');");
+                        Utils.escapeQuotes(mTitlePlaceholder) + "');");
                 mWebView.execJavaScriptFromString("ZSSEditor.getField('zss_field_content').setPlaceholderText('" +
-                        mContentPlaceholder + "');");
+                        Utils.escapeQuotes(mContentPlaceholder) + "');");
 
                 // Load title and content into ZSSEditor
                 updateVisualEditorFields();
@@ -982,7 +982,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 // If there are images that are still in progress (because the editor exited before they completed),
                 // set them to failed, so the user can restart them (otherwise they will stay stuck in 'uploading' mode)
                 mWebView.execJavaScriptFromString("ZSSEditor.markAllUploadingMediaAsFailed('"
-                        + getString(R.string.tap_to_try_again) + "');");
+                        + Utils.escapeQuotes(getString(R.string.tap_to_try_again)) + "');");
 
                 // Update the list of failed media uploads
                 mWebView.execJavaScriptFromString("ZSSEditor.getFailedMedia();");


### PR DESCRIPTION
Fix an issue with empty title placeholder in French

Before:

![screencap-2016-04-07t14-58-52 02-00](https://cloud.githubusercontent.com/assets/40213/14353974/ba161424-fcdb-11e5-8a06-6b65f54c12ef.png)

After:


![screencap-2016-04-07t15-37-49 02-00](https://cloud.githubusercontent.com/assets/40213/14353967/b578c9e8-fcdb-11e5-94f7-caa9b10f6dc9.png)
