### PR TITLE
Fixes #3934: make play store services optional

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -24,7 +24,7 @@ import com.android.volley.toolbox.ImageLoader;
 import com.android.volley.toolbox.Volley;
 import com.crashlytics.android.Crashlytics;
 import com.google.android.gms.common.ConnectionResult;
-import com.google.android.gms.common.GooglePlayServicesUtil;
+import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.gcm.GoogleCloudMessaging;
 import com.google.android.gms.iid.InstanceID;
 import com.google.gson.Gson;
@@ -248,7 +248,7 @@ public class WordPress extends Application {
     public void deferredInit(Activity activity) {
         AppLog.i(T.UTILS, "Deferred Initialisation");
 
-        if (checkPlayServices(activity)) {
+        if (isGooglePlayServicesAvailable(activity)) {
             // Register for Cloud messaging
             startService(new Intent(this, GCMRegistrationIntentService.class));
         }
@@ -377,21 +377,22 @@ public class WordPress extends Application {
         AppLog.w(T.UTILS, "Strict mode enabled");
     }
 
-    public boolean checkPlayServices(Activity activity) {
-        int connectionResult = GooglePlayServicesUtil.isGooglePlayServicesAvailable(activity);
+    public boolean isGooglePlayServicesAvailable(Activity activity) {
+        GoogleApiAvailability googleApiAvailability = GoogleApiAvailability.getInstance().
+        int connectionResult = googleApiAvailability.isGooglePlayServicesAvailable(activity);
         switch (connectionResult) {
             // Success: return true
             case ConnectionResult.SUCCESS:
                 return true;
             // Play Services unavailable, show an error dialog is the Play Services Lib needs an update
             case ConnectionResult.SERVICE_VERSION_UPDATE_REQUIRED:
-                GooglePlayServicesUtil.getErrorDialog(connectionResult, activity, 0);
+                googleApiAvailability.getErrorDialog(activity, connectionResult, 0);
             default:
             case ConnectionResult.SERVICE_MISSING:
             case ConnectionResult.SERVICE_DISABLED:
             case ConnectionResult.SERVICE_INVALID:
                 AppLog.w(T.NOTIFS, "Google Play Services unavailable, connection result: "
-                        + GooglePlayServicesUtil.getErrorString(connectionResult));
+                        + googleApiAvailability.getErrorString(connectionResult));
         }
         return false;
     }

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -3,6 +3,7 @@ package org.wordpress.android;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Application;
+import android.app.Dialog;
 import android.content.ComponentCallbacks2;
 import android.content.Context;
 import android.content.Intent;
@@ -378,7 +379,7 @@ public class WordPress extends Application {
     }
 
     public boolean isGooglePlayServicesAvailable(Activity activity) {
-        GoogleApiAvailability googleApiAvailability = GoogleApiAvailability.getInstance().
+        GoogleApiAvailability googleApiAvailability = GoogleApiAvailability.getInstance();
         int connectionResult = googleApiAvailability.isGooglePlayServicesAvailable(activity);
         switch (connectionResult) {
             // Success: return true
@@ -386,7 +387,10 @@ public class WordPress extends Application {
                 return true;
             // Play Services unavailable, show an error dialog is the Play Services Lib needs an update
             case ConnectionResult.SERVICE_VERSION_UPDATE_REQUIRED:
-                googleApiAvailability.getErrorDialog(activity, connectionResult, 0);
+                Dialog dialog = googleApiAvailability.getErrorDialog(activity, connectionResult, 0);
+                if (dialog != null) {
+                    dialog.show();
+                }
             default:
             case ConnectionResult.SERVICE_MISSING:
             case ConnectionResult.SERVICE_DISABLED:

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -34,6 +34,7 @@ import com.google.android.gms.auth.api.credentials.Credential;
 import com.google.android.gms.auth.api.credentials.CredentialRequest;
 import com.google.android.gms.auth.api.credentials.CredentialRequestResult;
 import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.api.CommonStatusCodes;
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.common.api.GoogleApiClient.ConnectionCallbacks;
@@ -273,6 +274,11 @@ public class SignInFragment extends AbstractFragment implements TextWatcher, Con
         moveBottomButtons();
     }
 
+    private boolean isGooglePlayServicesAvailable() {
+        return isAdded() && (GoogleApiAvailability.getInstance()
+                .isGooglePlayServicesAvailable(getActivity()) == ConnectionResult.SUCCESS);
+    }
+
     private void initInfoButtons(View rootView) {
         OnClickListener infoButtonListener = new OnClickListener() {
             @Override
@@ -292,6 +298,9 @@ public class SignInFragment extends AbstractFragment implements TextWatcher, Con
     }
 
     private void initSmartLockForPasswords() {
+        if (!isGooglePlayServicesAvailable()) {
+            return;
+        }
         mCredentialsClient = new GoogleApiClient.Builder(getActivity())
                 .addConnectionCallbacks(this)
                 .enableAutoManage((SignInActivity) getActivity(), this)
@@ -300,6 +309,9 @@ public class SignInFragment extends AbstractFragment implements TextWatcher, Con
     }
 
     public void smartLockAutoFill() {
+        if (!isGooglePlayServicesAvailable() || mCredentialsClient == null) {
+            return;
+        }
         CredentialRequest credentialRequest = new CredentialRequest.Builder()
                 .setSupportsPasswordLogin(true)
                 .build();
@@ -639,6 +651,9 @@ public class SignInFragment extends AbstractFragment implements TextWatcher, Con
     }
 
     private void saveCrendentialsInSmartLock() {
+        if (!isGooglePlayServicesAvailable() || mCredentialsClient == null) {
+            return;
+        }
         Credential credential = new Credential.Builder(mUsername).setPassword(mPassword).build();
         Auth.CredentialsApi.save(mCredentialsClient, credential).setResultCallback(
                 new ResultCallback<Status>() {
@@ -657,6 +672,9 @@ public class SignInFragment extends AbstractFragment implements TextWatcher, Con
     }
 
     private void deleteCredentialsInSmartLock() {
+        if (!isGooglePlayServicesAvailable() || mCredentialsClient == null) {
+            return;
+        }
         Credential credential = new Credential.Builder(mUsername).setPassword(mPassword).build();
         Auth.CredentialsApi.delete(mCredentialsClient, credential).setResultCallback(
                 new ResultCallback<Status>() {


### PR DESCRIPTION
Fixes #3934: make play store services optional

Note: I'm not showing the error dialog again in the SignInFragment for a required updated, if the user dismisses it first during app start services won't be used (we don't want to force him to update right now).

cc @nbradbury 