### PR TITLE
Reader: bump page view when user likes a post in the stream

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -254,7 +254,9 @@ public class ReaderPostActions {
     }
 
     public static void bumpPageViewForPost(long blogId, long postId) {
-        ReaderPost post = ReaderPostTable.getPost(blogId, postId, true);
+        bumpPageViewForPost(ReaderPostTable.getPost(blogId, postId, true));
+    }
+    public static void bumpPageViewForPost(ReaderPost post) {
         if (post == null) {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -729,6 +729,9 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         if (isAskingToLike) {
             AnalyticsUtils.trackWithBlogDetails(AnalyticsTracker.Stat.READER_ARTICLE_LIKED, mCurrentBlogId != 0 ? mCurrentBlogId : null);
+            // Consider a like to be enough to push a page view - solves a long-standing question
+            // from folks who ask 'why do I have more likes than page views?'.
+            ReaderPostActions.bumpPageViewForPost(post);
         } else {
             AnalyticsUtils.trackWithBlogDetails(AnalyticsTracker.Stat.READER_ARTICLE_LIKED, mCurrentBlogId != 0 ? mCurrentBlogId : null);
         }


### PR DESCRIPTION
When a post is liked in the reader list view, we now bump the page view for that post. From the [related wp-calypso issue](https://github.com/Automattic/wp-calypso/pull/4482):

> Solves a long-standing question from folks who ask 'why do I have more likes than page views?'. Consider a like to be enough to push a page view.