### PR TITLE
issue/3939-reader-primary-tag-encoding

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -235,8 +235,8 @@ public class ReaderPost {
     private static void assignAuthorFromJson(ReaderPost post, JSONObject jsonAuthor) {
         if (jsonAuthor == null) return;
 
-        post.authorName = JSONUtils.getString(jsonAuthor, "name");
-        post.authorFirstName = JSONUtils.getString(jsonAuthor, "first_name");
+        post.authorName = JSONUtils.getStringDecoded(jsonAuthor, "name");
+        post.authorFirstName = JSONUtils.getStringDecoded(jsonAuthor, "first_name");
         post.postAvatar = JSONUtils.getString(jsonAuthor, "avatar_URL");
         post.authorId = jsonAuthor.optLong("ID");
 

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -273,7 +273,7 @@ public class ReaderPost {
             int postCount = jsonThisTag.optInt("post_count");
             if (postCount > popularCount) {
                 nextMostPopularTag = mostPopularTag;
-                mostPopularTag = JSONUtils.getString(jsonThisTag, "name");
+                mostPopularTag = JSONUtils.getStringDecoded(jsonThisTag, "name");
                 popularCount = postCount;
             }
         }


### PR DESCRIPTION
Fixes #3939 - reader primary/secondary tags are now decoded, which resolves the problem shown below.

![e0ac2d02-0015-11e6-9a73-d4bcfa0a5cd2](https://cloud.githubusercontent.com/assets/3903757/14456095/2bc487ca-0071-11e6-9b59-012061bf92fb.png)


