### PR TITLE
Stats - Finish Stats Activity when closing the "No Jetpack" prompt by using back button

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -621,6 +621,7 @@ public class StatsActivity extends AppCompatActivity
         if (currentBlog == null) {
             AppLog.e(T.STATS, "The blog with local_blog_id " + mLocalBlogID + " cannot be loaded from the DB.");
             Toast.makeText(this, R.string.stats_no_blog, Toast.LENGTH_LONG).show();
+            finish();
             return;
         }
         if (currentBlog.isAdmin()) {
@@ -652,9 +653,17 @@ public class StatsActivity extends AppCompatActivity
                     .setTitle(getString(R.string.jetpack_not_found));
             builder.setPositiveButton(R.string.yes, null);
         }
-        builder.create().show();
-    }
 
+        AlertDialog dialog = builder.create();
+        dialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
+            @Override
+            public void onCancel(DialogInterface dialog) {
+                // User pressed the back key Hide Stats.
+                finish();
+            }
+        });
+        dialog.show();
+    }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {


### PR DESCRIPTION
Fixes #3942

To test:
Try to open Stats on a self hosted site with no Jetpack installed, and tap the back button when the "No Jetpack" dialog is shown on the screen.

Needs review: @aerych 