### PR TITLE
Fixes #3930: crash when adding invalid image

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1061,14 +1061,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         }
     }
 
-    private class HandleMediaSelectionTask extends AsyncTask<Intent, Void, Void> {
-        @Override
-        protected Void doInBackground(Intent... params) {
-            handleMediaSelectionResult(params[0]);
-            return null;
-        }
-    }
-
     private void fillContentEditorFields() {
         // Needed blog settings needed by the editor
         if (WordPress.getCurrentBlog() != null) {
@@ -1498,7 +1490,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         }
         WordPress.wpDB.saveMediaFile(mediaFile);
         mEditorFragment.appendMediaFile(mediaFile, mediaFile.getFilePath(), WordPress.imageLoader);
-
         return true;
     }
 
@@ -1511,8 +1502,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             switch (requestCode) {
                 case MediaPickerActivity.ACTIVITY_REQUEST_CODE_MEDIA_SELECTION:
                     if (resultCode == MediaPickerActivity.ACTIVITY_RESULT_CODE_MEDIA_SELECTED) {
-                        new HandleMediaSelectionTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
-                                data);
+                        handleMediaSelectionResult(data);
                     } else if (resultCode == MediaPickerActivity.ACTIVITY_RESULT_CODE_GALLERY_CREATED) {
                         handleGalleryResult(data);
                     }


### PR DESCRIPTION
Fixes #3930

Original issue (#2406) only happens with the legacy editor (`createWPEditImageSpanLocal` was the culprit, it's time consuming because it generates a thumbnail).

Profiling test (adding 20 pictures using multi select) when dropping the async task introduced in https://github.com/wordpress-mobile/WordPress-Android/pull/2515:
```D/WordPress-PROFILING(  518): handleMediaSelectionResult: end, 1838 ms```

Profiling test (adding 20 pictures using multi select) with this patch:
```D/WordPress-PROFILING(21119): handleMediaSelectionResult: end, 40 ms```
