### PR TITLE
Editor - Fix regex issue with failed images

### DIFF
--- a/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3409,7 +3409,7 @@ ZSSField.prototype.isEmpty = function() {
 ZSSField.prototype.getHTML = function() {
     var html = this.wrappedObject.html();
     if (ZSSEditor.defaultParagraphSeparator == 'div') {
-        html = html.replace(/(<div)/igm, '<p').replace(/<\/div>/igm, '</p>');
+        html = html.replace(/(<div(?=[>\s]))/igm, '<p').replace(/<\/div>/igm, '</p>');
     }
     html = wp.saveText(html);
     html = ZSSEditor.removeVisualFormatting( html );
@@ -3441,7 +3441,7 @@ ZSSField.prototype.setHTML = function(html) {
 
     if (ZSSEditor.defaultParagraphSeparator == 'div') {
         // Replace the paragraph tags we get from wpload with divs
-        mutatedHTML = mutatedHTML.replace(/(<p)/igm, '<div').replace(/<\/p>/igm, '</div>');
+        mutatedHTML = mutatedHTML.replace(/(<p(?=[>\s]))/igm, '<div').replace(/<\/p>/igm, '</div>');
     }
 
     this.wrappedObject.html(mutatedHTML);


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/346. An excessively liberal regex was matching the `<p` part of `<progress` when converting `p` to `div` and breaking progress elements.

To test:
Attempt to follow the steps outlined in https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/346, opening a post with a failed image. Retry and upload should work smoothly with no leftover container/progress tags.

Needs review: @maxme