### PR TITLE
Stats - Fix view broken in portrait on tablets

### DIFF
--- a/WordPress/src/main/res/layout-sw720dp/stats_activity.xml
+++ b/WordPress/src/main/res/layout-sw720dp/stats_activity.xml
@@ -45,13 +45,13 @@
             <org.wordpress.android.ui.stats.NestedScrollViewExt
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:paddingLeft="@dimen/content_margin"
+                android:paddingRight="@dimen/content_margin"
                 android:id="@+id/scroll_view_stats"
                 android:fillViewport="true">
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:layout_marginLeft="@dimen/content_margin"
-                    android:layout_marginRight="@dimen/content_margin"
                     android:orientation="vertical">
 
                     <!-- Insights -->


### PR DESCRIPTION
Fixes #3920 by moving the margin settings up in the UI hierarchy.

To test:
Open Stats in Portrait on Nexus 10, then move to landscape and back to portrait.


