### PR TITLE
Declare URL association in the manifest

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -461,4 +461,6 @@
         </service>
     </application>
 
+    <!-- Smart Lock for Passwords -->
+    <meta-data android:name="asset_statements" android:resource="@string/asset_statements" />
 </manifest>

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -247,4 +247,9 @@
         <item>431</item>
         <item>11</item>
     </string-array>
+
+    <!-- Smart Lock for Passwords -->
+    <string name="asset_statements" translatable="false">
+        [{\"include\": \"https://wordpress.com/.well-known/assetlinks.json\"}]
+    </string>
 </resources>


### PR DESCRIPTION
Fixes #3968 - when this is merged we must publish a new alpha and then fill the Smart Lock for Passwords affiliation form.
