### PR TITLE
Themes: Ensure active theme is identified in search view.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -254,6 +254,9 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
                                         mThemeBrowserFragment.setCurrentThemeId(mCurrentTheme.getId());
                                     }
                                 }
+                                if (mThemeSearchFragment != null && mThemeSearchFragment.isVisible()) {
+                                    mThemeSearchFragment.setRefreshing(false);
+                                }
                             }
                         } catch (JSONException e) {
                             AppLog.e(T.THEMES, e);


### PR DESCRIPTION
Fixes #3951 

To test:
Start with a blog using the Twenty Sixteen theme. 
Open the themes feature.
Search for "twenty"
Notice that the Twenty Sixteen theme is shown as active. 
Activate the Twenty Fifteen theme 
Click "Done" when the confirmation pop up appears so you remain in the search view. 
Note the Twenty Fifteen theme is now shown as active, not the Twenty Sixteen theme.

Demo:
https://cloudup.com/co6zwfRmTJh

Needs review: @kwonye 

