### PR TITLE
Themes: Preserve whitespace in thanks prompt text.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -387,7 +387,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
 
         String thanksMessage = String.format(getString(R.string.theme_prompt), newTheme.getName());
         if (!newTheme.getAuthor().isEmpty()) {
-            thanksMessage = thanksMessage + String.format(getString(R.string.theme_by_author_prompt_append), newTheme.getAuthor());
+            thanksMessage = thanksMessage + " " + String.format(getString(R.string.theme_by_author_prompt_append), newTheme.getAuthor());
         }
 
         dialogBuilder.setMessage(thanksMessage);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1345,7 +1345,7 @@
     <string name="theme_done">DONE</string>
     <string name="theme_manage_site">MANAGE SITE</string>
     <string name="theme_prompt">Thanks for choosing %1$s</string>
-    <string name="theme_by_author_prompt_append"> by %1$s</string>
+    <string name="theme_by_author_prompt_append">" by %1$s"</string>
     <string name="theme_activation_error">Something went wrong. Could not activate theme</string>
     <string name="selected_theme">Selected Theme</string>
     <string name="could_not_load_theme">Could not load theme</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1345,7 +1345,7 @@
     <string name="theme_done">DONE</string>
     <string name="theme_manage_site">MANAGE SITE</string>
     <string name="theme_prompt">Thanks for choosing %1$s</string>
-    <string name="theme_by_author_prompt_append">" by %1$s"</string>
+    <string name="theme_by_author_prompt_append"> by %1$s</string>
     <string name="theme_activation_error">Something went wrong. Could not activate theme</string>
     <string name="selected_theme">Selected Theme</string>
     <string name="could_not_load_theme">Could not load theme</string>


### PR DESCRIPTION
Fixes #3950 

To test:
Use the Themes feature.
Search for "Twenty"
Activate the TwentySixteen theme from the search results. 
Notice that the thanks prompt has a space between the Theme name and "by".

For the fix I referenced this [stack overflow](https://stackoverflow.com/questions/1587056/android-string-concatenate-how-to-keep-the-spaces-at-the-end-and-or-beginnin) issue.  Quoting the string seemed more friendly to our polyglots vs a unicode character but I'm not sure.  Thoughts? 
Needs review: @maxme 

