### PR TITLE
Autosave update and save synchronization to fix eventual content loss

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -312,7 +312,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                     setTitle(mPost.isPage() ? R.string.page_settings : R.string.post_settings);
                 } else if (position == PAGE_PREVIEW) {
                     setTitle(mPost.isPage() ? R.string.preview_page : R.string.preview_post);
-                    savePost();
+                    savePostAsync();
                     if (mEditPostPreviewFragment != null) {
                         mEditPostPreviewFragment.loadPost();
                     }
@@ -330,7 +330,9 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 public void run() {
                     updatePostObject(true);
                     savePostToDb();
-                    mHandler.postDelayed(mAutoSave, AUTOSAVE_INTERVAL_MILLIS);
+                    if (mHandler != null) {
+                        mHandler.postDelayed(mAutoSave, AUTOSAVE_INTERVAL_MILLIS);
+                    }
                 }
             }).start();
         }
@@ -385,7 +387,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         // Saves both post objects so we can restore them in onCreate()
-        savePost();
+        savePostAsync();
         outState.putSerializable(STATE_KEY_CURRENT_POST, mPost);
         outState.putSerializable(STATE_KEY_ORIGINAL_POST, mOriginalPost);
 
@@ -804,7 +806,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         }
     }
 
-    private void savePost() {
+    private void savePostAsync() {
         new Thread(new Runnable() {
             @Override
             public void run() {
@@ -848,7 +850,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
     private void saveAndFinish() {
         // Fetch post title and content from editor fields and update the Post object
-        savePost();
+        updatePostObject(false);
 
         if (mEditorFragment != null && mPost.hasEmptyContentFields()) {
             // new and empty post? delete it
@@ -872,7 +874,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 savePostToDb();
             } else {
                 // TODO: Remove when legacy editor is dropped
-                savePost();
+                savePostAsync();
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -144,11 +144,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     public static final int MEDIA_PERMISSION_REQUEST_CODE = 1;
     public static final int LOCATION_PERMISSION_REQUEST_CODE = 2;
 
-    private static final String PROP_LOCAL_PHOTOS = "number_of_local_photos_added";
-    private static final String PROP_LIBRARY_PHOTOS = "number_of_wp_library_photos_added";
-    private static final String PROP_LOCAL_VIDEOS = "number_of_local_videos_added";
-    private static final String PROP_LIBRARY_VIDEOS = "number_of_wp_library_videos_added";
-
     private static int PAGE_CONTENT = 0;
     private static int PAGE_SETTINGS = 1;
     private static int PAGE_PREVIEW = 2;


### PR DESCRIPTION
Fix a probable concurrency error (when autosave is being called and user publish at the same time). Also 
fixes https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/352 by moving `updatePostContent` (and therefore `getTitle()` and `getContent()`)  to a worker thread.

Also bumped AUTOSAVE_INTERVAL_MILLIS from 10 secs to 60 secs (on a huge text blob, update+save can take up to 5 seconds), and replaced the TimeTask by a simple Handler + postDelayed.