### PR TITLE
Fetch purchased themes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -104,6 +104,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
         ActivityId.trackLastActivity(ActivityId.THEMES);
 
         fetchThemesIfNoneAvailable();
+        fetchPurchasedThemes();
     }
 
     @Override
@@ -297,6 +298,23 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
         if (NetworkUtils.isNetworkAvailable(this) && WordPress.getCurrentBlog() != null
                 && WordPress.wpDB.getThemeCount(getBlogId()) == 0) {
             fetchThemes();
+            mThemeBrowserFragment.setRefreshing(true);
+        }
+    }
+
+    private void fetchPurchasedThemes() {
+        if (NetworkUtils.isNetworkAvailable(this) && WordPress.getCurrentBlog() != null) {
+            WordPress.getRestClientUtilsV1_2().getPurchasedThemes(getBlogId(), new Listener() {
+                @Override
+                public void onResponse(JSONObject response) {
+                    new FetchThemesTask().execute(response);
+                }
+            }, new ErrorListener() {
+                @Override
+                public void onErrorResponse(VolleyError error) {
+                    AppLog.d(T.THEMES, error.getMessage());
+                }
+            });
             mThemeBrowserFragment.setRefreshing(true);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -304,7 +304,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
 
     private void fetchPurchasedThemes() {
         if (NetworkUtils.isNetworkAvailable(this) && WordPress.getCurrentBlog() != null) {
-            WordPress.getRestClientUtilsV1_2().getPurchasedThemes(getBlogId(), new Listener() {
+            WordPress.getRestClientUtilsV1_1().getPurchasedThemes(getBlogId(), new Listener() {
                 @Override
                 public void onResponse(JSONObject response) {
                     new FetchThemesTask().execute(response);

--- a/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
+++ b/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
@@ -221,6 +221,11 @@ public class RestClientUtils {
         getThemes("free", siteId, limit, offset, listener, errorListener);
     }
 
+    public void getPurchasedThemes(String siteId, Listener listener, ErrorListener errorListener) {
+        String path = String.format("sites/%s/themes/purchased", siteId);
+        get(path, listener, errorListener);
+    }
+
     /**
      * Get all a site's themes
      */


### PR DESCRIPTION
Fixes #3459 

To test: 

1. On a site that has purchased premium themes, load the Theme browser for the first time.
2. Verify that the premium themes in your account show up in the list.

Needs review: @aerych 
