### PR TITLE
Issue/3940 reader tag titles

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -193,8 +193,6 @@ public class WordPress extends Application {
 
         RestClientUtils.setUserAgent(getUserAgent());
 
-        ReaderDatabase.reset(); // TODO: REMOVE THIS
-
         // Volley networking setup
         setupVolleyQueue();
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -193,6 +193,8 @@ public class WordPress extends Application {
 
         RestClientUtils.setUserAgent(getUserAgent());
 
+        ReaderDatabase.reset(); // TODO: REMOVE THIS
+
         // Volley networking setup
         setupVolleyQueue();
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -19,7 +19,7 @@ import java.io.OutputStream;
  */
 public class ReaderDatabase extends SQLiteOpenHelper {
     protected static final String DB_NAME = "wpreader.db";
-    private static final int DB_VERSION = 112;
+    private static final int DB_VERSION = 113;
 
     /*
      * version history
@@ -64,6 +64,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      *  110 - added xpost_post_id and xpost_blog_id to tbl_posts
      *  111 - added author_first_name to tbl_posts
      *  112 - no structural change, just reset db
+     *  113 - added tag_title to tbl_tags
      */
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -19,7 +19,7 @@ import java.io.OutputStream;
  */
 public class ReaderDatabase extends SQLiteOpenHelper {
     protected static final String DB_NAME = "wpreader.db";
-    private static final int DB_VERSION = 113;
+    private static final int DB_VERSION = 114;
 
     /*
      * version history
@@ -64,7 +64,8 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      *  110 - added xpost_post_id and xpost_blog_id to tbl_posts
      *  111 - added author_first_name to tbl_posts
      *  112 - no structural change, just reset db
-     *  113 - added tag_title to tbl_tags
+     *  113 - added tag_title to tag tables
+     *  114 - renamed tag_name to tag_slug in tag tables
      */
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -197,7 +197,7 @@ public class ReaderPostTable {
         }
 
         int numToPurge = numPosts - MAX_POSTS_PER_TAG;
-        String[] args = {tag.getTagName(), Integer.toString(tag.tagType.toInt()), Integer.toString(numToPurge)};
+        String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt()), Integer.toString(numToPurge)};
         String where = "pseudo_id IN ("
                 + "  SELECT tbl_posts.pseudo_id FROM tbl_posts, tbl_post_tags"
                 + "  WHERE tbl_posts.pseudo_id = tbl_post_tags.pseudo_id"
@@ -233,7 +233,7 @@ public class ReaderPostTable {
         if (tag == null) {
             return 0;
         }
-        String[] args = {tag.getTagName(), Integer.toString(tag.tagType.toInt())};
+        String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
         return SqlUtils.intForQuery(ReaderDatabase.getReadableDb(),
                     "SELECT count(*) FROM tbl_post_tags WHERE tag_name=? AND tag_type=?",
                     args);
@@ -385,7 +385,7 @@ public class ReaderPostTable {
         }
 
         // first delete posts from tbl_post_tags, and if any were deleted next delete posts in tbl_posts that no longer exist in tbl_post_tags
-        String[] args = {tag.getTagName(), Integer.toString(tag.tagType.toInt())};
+        String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
         int numDeleted = ReaderDatabase.getWritableDb().delete("tbl_post_tags",
                 "tag_name=? AND tag_type=?",
                 args);
@@ -415,7 +415,7 @@ public class ReaderPostTable {
                    + " WHERE tbl_posts.post_id = tbl_post_tags.post_id AND tbl_posts.blog_id = tbl_post_tags.blog_id"
                    + " AND tbl_post_tags.tag_name=? AND tbl_post_tags.tag_type=?"
                    + " ORDER BY published LIMIT 1";
-        String[] args = {tag.getTagName(), Integer.toString(tag.tagType.toInt())};
+        String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
         return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(), sql, args);
     }
 
@@ -439,7 +439,7 @@ public class ReaderPostTable {
     public static void removeGapMarkerForTag(final ReaderTag tag) {
         if (tag == null) return;
 
-        String[] args = {tag.getTagName(), Integer.toString(tag.tagType.toInt())};
+        String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
         String sql = "UPDATE tbl_post_tags SET has_gap_marker=0 WHERE has_gap_marker!=0 AND tag_name=? AND tag_type=?";
         ReaderDatabase.getWritableDb().execSQL(sql, args);
     }
@@ -452,7 +452,7 @@ public class ReaderPostTable {
             return null;
         }
 
-        String[] args = {tag.getTagName(), Integer.toString(tag.tagType.toInt())};
+        String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
         String sql = "SELECT blog_id, post_id FROM tbl_post_tags WHERE has_gap_marker!=0 AND tag_name=? AND tag_type=?";
         Cursor cursor = ReaderDatabase.getReadableDb().rawQuery(sql, args);
         try {
@@ -474,7 +474,7 @@ public class ReaderPostTable {
         String[] args = {
                 Long.toString(blogId),
                 Long.toString(postId),
-                tag.getTagName(),
+                tag.getTagSlug(),
                 Integer.toString(tag.tagType.toInt())
         };
         String sql = "UPDATE tbl_post_tags SET has_gap_marker=1 WHERE blog_id=? AND post_id=? AND tag_name=? AND tag_type=?";
@@ -511,7 +511,7 @@ public class ReaderPostTable {
         long timestamp = getGapMarkerTimestampForTag(tag);
         if (timestamp == 0) return;
 
-        String[] args = {Long.toString(timestamp), tag.getTagName(), Integer.toString(tag.tagType.toInt())};
+        String[] args = {Long.toString(timestamp), tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
         String where = "pseudo_id IN (SELECT tbl_posts.pseudo_id FROM tbl_posts, tbl_post_tags"
                 + " WHERE tbl_posts.timestamp < ?"
                 + " AND tbl_posts.pseudo_id = tbl_post_tags.pseudo_id"
@@ -550,10 +550,10 @@ public class ReaderPostTable {
             if (!isFollowed) {
                 if (blogId != 0) {
                     db.delete("tbl_post_tags", "blog_id=? AND tag_name=?",
-                            new String[]{Long.toString(blogId), ReaderTag.TAG_NAME_FOLLOWED_SITES});
+                            new String[]{Long.toString(blogId), ReaderTag.TAG_TITLE_FOLLOWED_SITES});
                 } else {
                     db.delete("tbl_post_tags", "feed_id=? AND tag_name=?",
-                            new String[]{Long.toString(feedId), ReaderTag.TAG_NAME_FOLLOWED_SITES});
+                            new String[]{Long.toString(feedId), ReaderTag.TAG_TITLE_FOLLOWED_SITES});
                 }
             }
 
@@ -647,7 +647,7 @@ public class ReaderPostTable {
 
             // now add to tbl_post_tags if a tag was passed
             if (tag != null) {
-                String tagName = tag.getTagName();
+                String tagName = tag.getTagSlug();
                 int tagType = tag.tagType.toInt();
                 for (ReaderPost post: posts) {
                     stmtTags.bindLong  (1, post.postId);
@@ -697,7 +697,7 @@ public class ReaderPostTable {
             sql += " LIMIT " + Integer.toString(maxPosts);
         }
 
-        String[] args = {tag.getTagName(), Integer.toString(tag.tagType.toInt())};
+        String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
         Cursor cursor = ReaderDatabase.getReadableDb().rawQuery(sql, args);
         try {
             return getPostListFromCursor(cursor);
@@ -767,7 +767,7 @@ public class ReaderPostTable {
             sql += " LIMIT " + Integer.toString(maxPosts);
         }
 
-        String[] args = {tag.getTagName(), Integer.toString(tag.tagType.toInt())};
+        String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
         Cursor cursor = ReaderDatabase.getReadableDb().rawQuery(sql, args);
         try {
             if (cursor != null && cursor.moveToFirst()) {

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderTagTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderTagTable.java
@@ -98,7 +98,7 @@ public class ReaderTagTable {
             );
 
             for (ReaderTag tag: tagList) {
-                stmt.bindString(1, tag.getTagName());
+                stmt.bindString(1, tag.getTagSlug());
                 stmt.bindString(2, tag.getTagTitle());
                 stmt.bindLong  (3, tag.tagType.toInt());
                 stmt.bindString(4, tag.getEndpoint());
@@ -117,7 +117,7 @@ public class ReaderTagTable {
         if (tag == null) {
             return false;
         }
-        String[] args = {tag.getTagName(), Integer.toString(tag.tagType.toInt())};
+        String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
         return SqlUtils.boolForQuery(ReaderDatabase.getReadableDb(),
                 "SELECT 1 FROM tbl_tags WHERE tag_name=?1 AND tag_type=?2",
                 args);
@@ -179,7 +179,7 @@ public class ReaderTagTable {
         if (tag == null) {
             return null;
         }
-        String[] args = {tag.getTagName(), Integer.toString(tag.tagType.toInt())};
+        String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
         return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(),
                "SELECT endpoint FROM tbl_tags WHERE tag_name=? AND tag_type=?",
                args);
@@ -228,7 +228,7 @@ public class ReaderTagTable {
         if (tag == null) {
             return;
         }
-        String[] args = {tag.getTagName(), Integer.toString(tag.tagType.toInt())};
+        String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
         ReaderDatabase.getWritableDb().delete("tbl_tags", "tag_name=? AND tag_type=?", args);
     }
 
@@ -237,7 +237,7 @@ public class ReaderTagTable {
         if (tag == null) {
             return "";
         }
-        String[] args = {tag.getTagName(), Integer.toString(tag.tagType.toInt())};
+        String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
         return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(),
                 "SELECT date_updated FROM tbl_tags WHERE tag_name=? AND tag_type=?",
                 args);
@@ -253,7 +253,7 @@ public class ReaderTagTable {
         SQLiteStatement stmt = ReaderDatabase.getWritableDb().compileStatement(sql);
         try {
             stmt.bindString(1, date);
-            stmt.bindString(2, tag.getTagName());
+            stmt.bindString(2, tag.getTagSlug());
             stmt.bindLong  (3, tag.tagType.toInt());
             stmt.execute();
         } finally {
@@ -331,7 +331,7 @@ public class ReaderTagTable {
 
                 // then insert the passed ones
                 for (ReaderTag tag: tagList) {
-                    stmt.bindString(1, tag.getTagName());
+                    stmt.bindString(1, tag.getTagSlug());
                     stmt.bindString(2, tag.getTagTitle());
                     stmt.bindLong  (3, tag.tagType.toInt());
                     stmt.bindString(4, tag.getEndpoint());

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderTagTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderTagTable.java
@@ -141,10 +141,6 @@ public class ReaderTagTable {
         return tagExistsOfType(tagSlug, ReaderTagType.FOLLOWED);
     }
 
-    public static boolean isDefaultTagName(String tagSlug) {
-        return tagExistsOfType(tagSlug, ReaderTagType.DEFAULT);
-    }
-
     private static ReaderTag getTagFromCursor(Cursor c) {
         if (c == null) {
             throw new IllegalArgumentException("null tag cursor");

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderTagTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderTagTable.java
@@ -94,13 +94,14 @@ public class ReaderTagTable {
         SQLiteStatement stmt = null;
         try {
             stmt = ReaderDatabase.getWritableDb().compileStatement(
-                    "INSERT OR REPLACE INTO tbl_tags (tag_name, tag_type, endpoint) VALUES (?1,?2,?3)"
+                    "INSERT OR REPLACE INTO tbl_tags (tag_name, tag_title, tag_type, endpoint) VALUES (?1,?2,?3,?4)"
             );
 
             for (ReaderTag tag: tagList) {
                 stmt.bindString(1, tag.getTagName());
-                stmt.bindLong  (2, tag.tagType.toInt());
-                stmt.bindString(3, tag.getEndpoint());
+                stmt.bindString(2, tag.getTagTitle());
+                stmt.bindLong  (3, tag.tagType.toInt());
+                stmt.bindString(4, tag.getEndpoint());
                 stmt.execute();
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderTagTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderTagTable.java
@@ -26,6 +26,7 @@ public class ReaderTagTable {
     protected static void createTables(SQLiteDatabase db) {
         db.execSQL("CREATE TABLE tbl_tags ("
                  + "	tag_name     TEXT COLLATE NOCASE,"
+                 + "	tag_title    TEXT COLLATE NOCASE,"
                  + "    tag_type     INTEGER DEFAULT 0,"
                  + "    endpoint     TEXT,"
                 + " 	date_updated TEXT,"
@@ -34,6 +35,7 @@ public class ReaderTagTable {
 
         db.execSQL("CREATE TABLE tbl_tags_recommended ("
                  + "	tag_name	TEXT COLLATE NOCASE,"
+                 + "	tag_title   TEXT COLLATE NOCASE,"
                  + "    tag_type    INTEGER DEFAULT 0,"
                  + "    endpoint    TEXT,"
                  + "    PRIMARY KEY (tag_name, tag_type)"
@@ -148,10 +150,11 @@ public class ReaderTagTable {
         }
 
         String tagName = c.getString(c.getColumnIndex("tag_name"));
+        String tagTitle = c.getString(c.getColumnIndex("tag_title"));
         String endpoint = c.getString(c.getColumnIndex("endpoint"));
         ReaderTagType tagType = ReaderTagType.fromInt(c.getInt(c.getColumnIndex("tag_type")));
 
-        return new ReaderTag(tagName, endpoint, tagType);
+        return new ReaderTag(tagName, tagTitle, endpoint, tagType);
     }
 
     public static ReaderTag getTag(String tagName, ReaderTagType tagType) {
@@ -318,7 +321,7 @@ public class ReaderTagTable {
 
         SQLiteDatabase db = ReaderDatabase.getWritableDb();
         SQLiteStatement stmt = db.compileStatement
-                ("INSERT INTO tbl_tags_recommended (tag_name, tag_type, endpoint) VALUES (?1,?2,?3)");
+                ("INSERT INTO tbl_tags_recommended (tag_name, tag_title, tag_type, endpoint) VALUES (?1,?2,?3,?4)");
         db.beginTransaction();
         try {
             try {
@@ -328,8 +331,9 @@ public class ReaderTagTable {
                 // then insert the passed ones
                 for (ReaderTag tag: tagList) {
                     stmt.bindString(1, tag.getTagName());
-                    stmt.bindLong  (2, tag.tagType.toInt());
-                    stmt.bindString(3, tag.getEndpoint());
+                    stmt.bindString(2, tag.getTagTitle());
+                    stmt.bindLong  (3, tag.tagType.toInt());
+                    stmt.bindString(4, tag.getEndpoint());
                     stmt.execute();
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -273,7 +273,7 @@ public class ReaderPost {
             int postCount = jsonThisTag.optInt("post_count");
             if (postCount > popularCount) {
                 nextMostPopularTag = mostPopularTag;
-                mostPopularTag = JSONUtils.getStringDecoded(jsonThisTag, "name");
+                mostPopularTag = JSONUtils.getStringDecoded(jsonThisTag, "display_name");
                 popularCount = postCount;
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -273,7 +273,7 @@ public class ReaderPost {
             int postCount = jsonThisTag.optInt("post_count");
             if (postCount > popularCount) {
                 nextMostPopularTag = mostPopularTag;
-                mostPopularTag = JSONUtils.getStringDecoded(jsonThisTag, "display_name");
+                mostPopularTag = JSONUtils.getStringDecoded(jsonThisTag, "slug");
                 popularCount = postCount;
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -424,7 +424,7 @@ public class ReaderPost {
     }
     public void setPrimaryTag(String tagName) {
         // this is a bit of a hack to avoid setting the primary tag to one of the defaults
-        if (!ReaderTag.isDefaultTagName(tagName)) {
+        if (!ReaderTag.isDefaultTagTitle(tagName)) {
             this.primaryTag = StringUtils.notNullStr(tagName);
         }
     }
@@ -436,7 +436,7 @@ public class ReaderPost {
         return StringUtils.notNullStr(secondaryTag);
     }
     public void setSecondaryTag(String tagName) {
-        if (!ReaderTag.isDefaultTagName(tagName)) {
+        if (!ReaderTag.isDefaultTagTitle(tagName)) {
             this.secondaryTag = StringUtils.notNullStr(tagName);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 
 public class ReaderTag implements Serializable, FilterCriteria {
     private String tagName;
+    private String tagTitle;
     private String endpoint;
     public final ReaderTagType tagType;
 
@@ -19,12 +20,16 @@ public class ReaderTag implements Serializable, FilterCriteria {
     private static final String TAG_NAME_DEFAULT = TAG_NAME_DISCOVER;
     public static final String TAG_NAME_FOLLOWED_SITES = "Followed Sites";
 
-    public ReaderTag(String tagName, String endpoint, ReaderTagType tagType) {
+    public ReaderTag(String tagName,
+                     String tagTitle,
+                     String endpoint,
+                     ReaderTagType tagType) {
         if (TextUtils.isEmpty(tagName)) {
             this.setTagName(getTagNameFromEndpoint(endpoint));
         } else {
             this.setTagName(tagName);
         }
+        this.setTagTitle(tagTitle);
         this.setEndpoint(endpoint);
         this.tagType = tagType;
     }
@@ -43,6 +48,13 @@ public class ReaderTag implements Serializable, FilterCriteria {
     }
     void setEndpoint(String endpoint) {
         this.endpoint = StringUtils.notNullStr(endpoint);
+    }
+
+    public String getTagTitle() {
+        return StringUtils.notNullStr(tagTitle);
+    }
+    void setTagTitle(String title) {
+        this.tagTitle = StringUtils.notNullStr(title);
     }
 
     public String getTagName() {

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -2,7 +2,6 @@ package org.wordpress.android.models;
 
 import android.text.TextUtils;
 
-import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.StringUtils;
 
 import java.io.Serializable;
@@ -59,7 +58,7 @@ public class ReaderTag implements Serializable, FilterCriteria {
      * when displaying a tag name, we want to use the title when available since it's often
      * more user-friendly
      */
-    public String getTagNameForDisplay() {
+    public String getTagDisplayName() {
         if (!TextUtils.isEmpty(tagTitle)) {
             return tagTitle;
         }
@@ -144,16 +143,12 @@ public class ReaderTag implements Serializable, FilterCriteria {
                 || title.equalsIgnoreCase(TAG_TITLE_LIKED));
     }
 
-    private String getSanitizedTagSlug() {
-        return ReaderUtils.sanitizeWithDashes(this.tagSlug);
-    }
-
     public static boolean isSameTag(ReaderTag tag1, ReaderTag tag2) {
         if (tag1 == null || tag2 == null) {
             return false;
         }
         return tag1.tagType == tag2.tagType
-            && tag1.getSanitizedTagSlug().equalsIgnoreCase(tag2.getSanitizedTagSlug());
+            && tag1.getTagSlug().equalsIgnoreCase(tag2.getTagSlug());
     }
 
     public boolean isPostsILike() {
@@ -181,7 +176,7 @@ public class ReaderTag implements Serializable, FilterCriteria {
      */
     @Override
     public String getLabel() {
-        return getTagNameForDisplay();
+        return getTagDisplayName();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -9,16 +9,16 @@ import java.io.Serializable;
 import java.util.regex.Pattern;
 
 public class ReaderTag implements Serializable, FilterCriteria {
-    private String tagName;
-    private String tagTitle;
-    private String endpoint;
+    private String tagName;     // tag for API calls, ex: "news-current-events"
+    private String tagTitle;    // tag for display, ex: "News & Current Events"
+    private String endpoint;    // endpoint for updating posts with this tag
     public final ReaderTagType tagType;
 
     // these are the default tag names, which aren't localized in the /read/menu/ response
     private static final String TAG_NAME_LIKED = "Posts I Like";
     private static final String TAG_NAME_DISCOVER = "Discover";
     private static final String TAG_NAME_DEFAULT = TAG_NAME_DISCOVER;
-    public static final String TAG_NAME_FOLLOWED_SITES = "Followed Sites";
+    public  static final String TAG_NAME_FOLLOWED_SITES = "Followed Sites";
 
     public ReaderTag(String tagName,
                      String tagTitle,
@@ -177,9 +177,15 @@ public class ReaderTag implements Serializable, FilterCriteria {
         return endpoint.toLowerCase().contains("/read/list/");
     }
 
+    /*
+     * the label is the text displayed in the dropdown filter - use the title when available
+     */
     @Override
     public String getLabel() {
-        return getCapitalizedTagName();
+        if (TextUtils.isEmpty(tagTitle)) {
+            return getCapitalizedTagName();
+        }
+        return tagTitle;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -17,7 +17,7 @@ public class ReaderTag implements Serializable, FilterCriteria {
     // these are the default tag names, which aren't localized in the /read/menu/ response
     private static final String TAG_NAME_LIKED = "Posts I Like";
     private static final String TAG_NAME_DISCOVER = "Discover";
-    private static final String TAG_NAME_DEFAULT = TAG_NAME_DISCOVER;
+    public  static final String TAG_NAME_DEFAULT = TAG_NAME_DISCOVER;
     public  static final String TAG_NAME_FOLLOWED_SITES = "Followed Sites";
 
     public ReaderTag(String tagName,
@@ -32,15 +32,6 @@ public class ReaderTag implements Serializable, FilterCriteria {
         this.setTagTitle(tagTitle);
         this.setEndpoint(endpoint);
         this.tagType = tagType;
-    }
-
-    public ReaderTag(String tagName, ReaderTagType tagType) {
-        this.setTagName(tagName);
-        this.tagType = tagType;
-    }
-
-    public static ReaderTag getDefaultTag() {
-        return new ReaderTag(TAG_NAME_DEFAULT, ReaderTagType.DEFAULT);
     }
 
     public String getEndpoint() {

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -63,8 +63,16 @@ public class ReaderTag implements Serializable, FilterCriteria {
     void setTagName(String name) {
         this.tagName = StringUtils.notNullStr(name);
     }
-    public String getCapitalizedTagName() {
-        if (tagName == null || tagName.length() == 0) {
+
+    /*
+     * when displaying a tag name, we want to use the title when available since it's often
+     * more user-friendly
+     */
+    public String getTagNameForDisplay() {
+        if (!TextUtils.isEmpty(tagTitle)) {
+            return tagTitle;
+        }
+        if (TextUtils.isEmpty(tagName)) {
             return "";
         }
         // If already uppercase, assume correctly formatted
@@ -178,14 +186,11 @@ public class ReaderTag implements Serializable, FilterCriteria {
     }
 
     /*
-     * the label is the text displayed in the dropdown filter - use the title when available
+     * the label is the text displayed in the dropdown filter
      */
     @Override
     public String getLabel() {
-        if (TextUtils.isEmpty(tagTitle)) {
-            return getCapitalizedTagName();
-        }
-        return tagTitle;
+        return getTagNameForDisplay();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -9,25 +9,25 @@ import java.io.Serializable;
 import java.util.regex.Pattern;
 
 public class ReaderTag implements Serializable, FilterCriteria {
-    private String tagName;     // tag for API calls, ex: "news-current-events"
+    private String tagSlug;     // tag for API calls, ex: "news-current-events"
     private String tagTitle;    // tag for display, ex: "News & Current Events"
     private String endpoint;    // endpoint for updating posts with this tag
     public final ReaderTagType tagType;
 
-    // these are the default tag names, which aren't localized in the /read/menu/ response
-    private static final String TAG_NAME_LIKED = "Posts I Like";
-    private static final String TAG_NAME_DISCOVER = "Discover";
-    public  static final String TAG_NAME_DEFAULT = TAG_NAME_DISCOVER;
-    public  static final String TAG_NAME_FOLLOWED_SITES = "Followed Sites";
+    // these are the default tags, which aren't localized in the /read/menu/ response
+    private static final String TAG_TITLE_LIKED = "Posts I Like";
+    private static final String TAG_TITLE_DISCOVER = "Discover";
+    public  static final String TAG_TITLE_DEFAULT = TAG_TITLE_DISCOVER;
+    public  static final String TAG_TITLE_FOLLOWED_SITES = "Followed Sites";
 
-    public ReaderTag(String tagName,
+    public ReaderTag(String tagSlug,
                      String tagTitle,
                      String endpoint,
                      ReaderTagType tagType) {
-        if (TextUtils.isEmpty(tagName)) {
-            this.setTagName(getTagNameFromEndpoint(endpoint));
+        if (TextUtils.isEmpty(tagSlug)) {
+            this.setTagSlug(getTagSlugFromEndpoint(endpoint));
         } else {
-            this.setTagName(tagName);
+            this.setTagSlug(tagSlug);
         }
         this.setTagTitle(tagTitle);
         this.setEndpoint(endpoint);
@@ -48,11 +48,11 @@ public class ReaderTag implements Serializable, FilterCriteria {
         this.tagTitle = StringUtils.notNullStr(title);
     }
 
-    public String getTagName() {
-        return StringUtils.notNullStr(tagName);
+    public String getTagSlug() {
+        return StringUtils.notNullStr(tagSlug);
     }
-    void setTagName(String name) {
-        this.tagName = StringUtils.notNullStr(name);
+    void setTagSlug(String slug) {
+        this.tagSlug = StringUtils.notNullStr(slug);
     }
 
     /*
@@ -63,21 +63,21 @@ public class ReaderTag implements Serializable, FilterCriteria {
         if (!TextUtils.isEmpty(tagTitle)) {
             return tagTitle;
         }
-        if (TextUtils.isEmpty(tagName)) {
+        if (TextUtils.isEmpty(tagSlug)) {
             return "";
         }
         // If already uppercase, assume correctly formatted
-        if (Character.isUpperCase(tagName.charAt(0))) {
-            return tagName;
+        if (Character.isUpperCase(tagSlug.charAt(0))) {
+            return tagSlug;
         }
         // Accounts for iPhone, ePaper, etc.
-        if (tagName.length() > 1 &&
-                Character.isLowerCase(tagName.charAt(0)) &&
-                Character.isUpperCase(tagName.charAt(1))) {
-            return tagName;
+        if (tagSlug.length() > 1 &&
+                Character.isLowerCase(tagSlug.charAt(0)) &&
+                Character.isUpperCase(tagSlug.charAt(1))) {
+            return tagSlug;
         }
         // Capitalize anything else.
-        return StringUtils.capitalize(tagName);
+        return StringUtils.capitalize(tagSlug);
     }
 
     /*
@@ -86,15 +86,15 @@ public class ReaderTag implements Serializable, FilterCriteria {
      * in the log could be considered a privacy issue
      */
     public String getTagNameForLog() {
-        String tagName = getTagName();
+        String tagSlug = getTagSlug();
         if (tagType == ReaderTagType.DEFAULT) {
-            return tagName;
-        } else if (tagName.length() >= 6) {
-            return tagName.substring(0, 3) + "...";
-        } else if (tagName.length() >= 4) {
-            return tagName.substring(0, 2) + "...";
-        } else if (tagName.length() >= 2) {
-            return tagName.substring(0, 1) + "...";
+            return tagSlug;
+        } else if (tagSlug.length() >= 6) {
+            return tagSlug.substring(0, 3) + "...";
+        } else if (tagSlug.length() >= 4) {
+            return tagSlug.substring(0, 2) + "...";
+        } else if (tagSlug.length() >= 2) {
+            return tagSlug.substring(0, 1) + "...";
         } else {
             return "...";
         }
@@ -110,9 +110,9 @@ public class ReaderTag implements Serializable, FilterCriteria {
     }
 
     /*
-     * extracts the tag name from a valid read/tags/[tagName]/posts endpoint
+     * extracts the tag slug from a valid read/tags/[tagSlug]/posts endpoint
      */
-    private static String getTagNameFromEndpoint(final String endpoint) {
+    private static String getTagSlugFromEndpoint(final String endpoint) {
         if (TextUtils.isEmpty(endpoint))
             return "";
 
@@ -133,19 +133,19 @@ public class ReaderTag implements Serializable, FilterCriteria {
     }
 
     /*
-     * is the passed tag name one of the default tags?
+     * is the passed string one of the default tags?
      */
-    public static boolean isDefaultTagName(String tagName) {
-        if (TextUtils.isEmpty(tagName)) {
+    public static boolean isDefaultTagTitle(String title) {
+        if (TextUtils.isEmpty(title)) {
             return false;
         }
-        return (tagName.equalsIgnoreCase(TAG_NAME_FOLLOWED_SITES)
-                || tagName.equalsIgnoreCase(TAG_NAME_DISCOVER)
-                || tagName.equalsIgnoreCase(TAG_NAME_LIKED));
+        return (title.equalsIgnoreCase(TAG_TITLE_FOLLOWED_SITES)
+                || title.equalsIgnoreCase(TAG_TITLE_DISCOVER)
+                || title.equalsIgnoreCase(TAG_TITLE_LIKED));
     }
 
-    private String getSanitizedTagName() {
-        return ReaderUtils.sanitizeWithDashes(this.tagName);
+    private String getSanitizedTagSlug() {
+        return ReaderUtils.sanitizeWithDashes(this.tagSlug);
     }
 
     public static boolean isSameTag(ReaderTag tag1, ReaderTag tag2) {
@@ -153,7 +153,7 @@ public class ReaderTag implements Serializable, FilterCriteria {
             return false;
         }
         return tag1.tagType == tag2.tagType
-            && tag1.getSanitizedTagName().equalsIgnoreCase(tag2.getSanitizedTagName());
+            && tag1.getSanitizedTagSlug().equalsIgnoreCase(tag2.getSanitizedTagSlug());
     }
 
     public boolean isPostsILike() {
@@ -164,7 +164,7 @@ public class ReaderTag implements Serializable, FilterCriteria {
     }
 
     public boolean isDiscover() {
-        return tagType == ReaderTagType.DEFAULT && getTagName().equals(TAG_NAME_DISCOVER);
+        return tagType == ReaderTagType.DEFAULT && getTagSlug().equals(TAG_TITLE_DISCOVER);
     }
 
     public boolean isTagTopic() {

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTagList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTagList.java
@@ -10,7 +10,7 @@ public class ReaderTagList extends ArrayList<ReaderTag> {
         }
 
         for (int i = 0; i < size(); i++) {
-            if (tagName.equals(this.get(i).getTagName())) {
+            if (tagName.equals(this.get(i).getTagSlug())) {
                 return i;
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -168,8 +168,8 @@ public class AppPrefs {
     }
 
     public static void setReaderTag(ReaderTag tag) {
-        if (tag != null && !TextUtils.isEmpty(tag.getTagName())) {
-            setString(DeletablePrefKey.READER_TAG_NAME, tag.getTagName());
+        if (tag != null && !TextUtils.isEmpty(tag.getTagSlug())) {
+            setString(DeletablePrefKey.READER_TAG_NAME, tag.getTagSlug());
             setInt(DeletablePrefKey.READER_TAG_TYPE, tag.tagType.toInt());
         } else {
             prefs().edit()

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -12,6 +12,7 @@ import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.ActivityId;
+import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.ui.stats.StatsTimeframe;
 
 public class AppPrefs {
@@ -163,7 +164,7 @@ public class AppPrefs {
             return null;
         }
         int tagType = getInt(DeletablePrefKey.READER_TAG_TYPE);
-        return new ReaderTag(tagName, ReaderTagType.fromInt(tagType));
+        return ReaderUtils.getTagFromTagName(tagName, ReaderTagType.fromInt(tagType));
     }
 
     public static void setReaderTag(ReaderTag tag) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -123,7 +123,7 @@ public class ReaderActivityLauncher {
             return;
         }
         Map<String, String> properties = new HashMap<>();
-        properties.put("tag", tag.getTagName());
+        properties.put("tag", tag.getTagSlug());
         AnalyticsTracker.track(AnalyticsTracker.Stat.READER_TAG_PREVIEWED, properties);
         Intent intent = new Intent(context, ReaderPostListActivity.class);
         intent.putExtra(ReaderConstants.ARG_TAG, tag);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -732,7 +732,7 @@ public class ReaderPostDetailFragment extends Fragment
                 txtTag.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        ReaderTag tag = new ReaderTag(tagToDisplay, ReaderTagType.FOLLOWED);
+                        ReaderTag tag = ReaderUtils.getTagFromTagName(tagToDisplay, ReaderTagType.FOLLOWED);
                         ReaderActivityLauncher.showReaderTagPreview(v.getContext(), tag);
                     }
                 });

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -123,7 +123,7 @@ public class ReaderPostListFragment extends Fragment
     public static ReaderPostListFragment newInstance() {
         ReaderTag tag = AppPrefs.getReaderTag();
         if (tag == null) {
-            tag = ReaderTag.getDefaultTag();
+            tag = ReaderUtils.getDefaultTag();
         }
         return newInstanceForTag(tag, ReaderPostListType.TAG_FOLLOWED);
     }
@@ -254,12 +254,12 @@ public class ReaderPostListFragment extends Fragment
             // user just added a tag so switch to it.
             String tagName = ((ReaderEvents.TagAdded) event).getTagName();
             EventBus.getDefault().removeStickyEvent(event);
-            ReaderTag newTag = new ReaderTag(tagName, ReaderTagType.FOLLOWED);
+            ReaderTag newTag = ReaderUtils.getTagFromTagName(tagName, ReaderTagType.FOLLOWED);
             setCurrentTag(newTag);
         } else if (!ReaderTagTable.tagExists(getCurrentTag())) {
             // current tag no longer exists, revert to default
             AppLog.d(T.READER, "reader post list > current tag no longer valid");
-            setCurrentTag(ReaderTag.getDefaultTag());
+            setCurrentTag(ReaderUtils.getDefaultTag());
         } else {
             // otherwise, refresh posts to make sure any changes are reflected and auto-update
             // posts in the current tag if it's time
@@ -432,7 +432,7 @@ public class ReaderPostListFragment extends Fragment
                     return getCurrentTag();
                 } else {
                     AppLog.w(T.READER, "reader post list > no current tag in onRecallSelection");
-                    return ReaderTag.getDefaultTag();
+                    return ReaderUtils.getDefaultTag();
                 }
             }
 
@@ -798,7 +798,7 @@ public class ReaderPostListFragment extends Fragment
             tagName = mTagPreviewHistory.pop();
         }
 
-        ReaderTag newTag = new ReaderTag(tagName, ReaderTagType.FOLLOWED);
+        ReaderTag newTag = ReaderUtils.getTagFromTagName(tagName, ReaderTagType.FOLLOWED);
         setCurrentTag(newTag);
 
         return true;
@@ -1119,7 +1119,7 @@ public class ReaderPostListFragment extends Fragment
     public void onTagSelected(String tagName) {
         if (!isAdded()) return;
 
-        ReaderTag tag = new ReaderTag(tagName, ReaderTagType.FOLLOWED);
+        ReaderTag tag = ReaderUtils.getTagFromTagName(tagName, ReaderTagType.FOLLOWED);
         if (getPostListType().equals(ReaderPostListType.TAG_PREVIEW)) {
             // user is already previewing a tag, so change current tag in existing preview
             setCurrentTag(tag);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -742,7 +742,7 @@ public class ReaderPostListFragment extends Fragment
     }
 
     private String getCurrentTagName() {
-        return (mCurrentTag != null ? mCurrentTag.getTagName() : "");
+        return (mCurrentTag != null ? mCurrentTag.getTagSlug() : "");
     }
 
     private boolean hasCurrentTag() {
@@ -769,7 +769,7 @@ public class ReaderPostListFragment extends Fragment
                 AppPrefs.setReaderTag(tag);
                 break;
             case TAG_PREVIEW:
-                mTagPreviewHistory.push(tag.getTagName());
+                mTagPreviewHistory.push(tag.getTagSlug());
                 break;
         }
 
@@ -1154,7 +1154,7 @@ public class ReaderPostListFragment extends Fragment
         if (stat == null) return;
 
         Map<String, String> properties = new HashMap<>();
-        properties.put("tag", tag.getTagName());
+        properties.put("tag", tag.getTagSlug());
 
         AnalyticsTracker.track(stat, properties);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -344,7 +344,7 @@ public class ReaderSubsActivity extends AppCompatActivity
             // make sure addition is reflected on followed tags
             getPageAdapter().refreshFollowedTagFragment();
             String labelAddedTag = getString(R.string.reader_label_added_tag);
-            showInfoToast(String.format(labelAddedTag, tag.getCapitalizedTagName()));
+            showInfoToast(String.format(labelAddedTag, tag.getTagNameForDisplay()));
         }
     }
 
@@ -457,7 +457,7 @@ public class ReaderSubsActivity extends AppCompatActivity
             mLastAddedTagName = null;
         }
         String labelRemovedTag = getString(R.string.reader_label_removed_tag);
-        showInfoToast(String.format(labelRemovedTag, tag.getCapitalizedTagName()));
+        showInfoToast(String.format(labelRemovedTag, tag.getTagNameForDisplay()));
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -347,7 +347,7 @@ public class ReaderSubsActivity extends AppCompatActivity
 
         if (ReaderTagActions.performTagAction(tag, TagAction.ADD, actionListener)) {
             AnalyticsTracker.track(AnalyticsTracker.Stat.READER_TAG_FOLLOWED);
-            mLastAddedTagName = tag.getTagName();
+            mLastAddedTagName = tag.getTagSlug();
             // make sure addition is reflected on followed tags
             getPageAdapter().refreshFollowedTagFragment();
             String labelAddedTag = getString(R.string.reader_label_added_tag);
@@ -460,7 +460,7 @@ public class ReaderSubsActivity extends AppCompatActivity
     @Override
     public void onTagDeleted(ReaderTag tag) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.READER_TAG_UNFOLLOWED);
-        if (mLastAddedTagName != null && mLastAddedTagName.equalsIgnoreCase(tag.getTagName())) {
+        if (mLastAddedTagName != null && mLastAddedTagName.equalsIgnoreCase(tag.getTagSlug())) {
             mLastAddedTagName = null;
         }
         String labelRemovedTag = getString(R.string.reader_label_removed_tag);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -39,6 +39,7 @@ import org.wordpress.android.ui.reader.adapters.ReaderBlogAdapter.ReaderBlogType
 import org.wordpress.android.ui.reader.adapters.ReaderTagAdapter;
 import org.wordpress.android.ui.reader.services.ReaderUpdateService;
 import org.wordpress.android.ui.reader.services.ReaderUpdateService.UpdateTask;
+import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.EditTextUtils;
@@ -336,7 +337,7 @@ public class ReaderSubsActivity extends AppCompatActivity
             }
         };
 
-        ReaderTag tag = new ReaderTag(tagName, ReaderTagType.FOLLOWED);
+        ReaderTag tag = ReaderUtils.getTagFromTagName(tagName, ReaderTagType.FOLLOWED);
 
         if (ReaderTagActions.performTagAction(tag, TagAction.ADD, actionListener)) {
             AnalyticsTracker.track(AnalyticsTracker.Stat.READER_TAG_FOLLOWED);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -189,15 +189,18 @@ public class ReaderSubsActivity extends AppCompatActivity
     }
 
     private void performUpdate() {
+        performUpdate(EnumSet.of(
+                UpdateTask.TAGS,
+                UpdateTask.FOLLOWED_BLOGS,
+                UpdateTask.RECOMMENDED_BLOGS));
+    }
+
+    private void performUpdate(EnumSet<UpdateTask> tasks) {
         if (!NetworkUtils.isNetworkAvailable(this)) {
             return;
         }
 
-        ReaderUpdateService.startService(this,
-                EnumSet.of(UpdateTask.TAGS,
-                           UpdateTask.FOLLOWED_BLOGS,
-                           UpdateTask.RECOMMENDED_BLOGS));
-
+        ReaderUpdateService.startService(this, tasks);
         mHasPerformedUpdate = true;
     }
 
@@ -329,7 +332,10 @@ public class ReaderSubsActivity extends AppCompatActivity
         ReaderActions.ActionListener actionListener = new ReaderActions.ActionListener() {
             @Override
             public void onActionResult(boolean succeeded) {
-                if (!succeeded && !isFinishing()) {
+                if (succeeded) {
+                    // update tags when one is added
+                    performUpdate(EnumSet.of(UpdateTask.TAGS));
+                } else if (!succeeded && !isFinishing()) {
                     getPageAdapter().refreshFollowedTagFragment();
                     ToastUtils.showToast(ReaderSubsActivity.this, R.string.reader_toast_err_add_tag);
                     mLastAddedTagName = null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -351,7 +351,7 @@ public class ReaderSubsActivity extends AppCompatActivity
             // make sure addition is reflected on followed tags
             getPageAdapter().refreshFollowedTagFragment();
             String labelAddedTag = getString(R.string.reader_label_added_tag);
-            showInfoToast(String.format(labelAddedTag, tag.getTagNameForDisplay()));
+            showInfoToast(String.format(labelAddedTag, tag.getTagDisplayName()));
         }
     }
 
@@ -464,7 +464,7 @@ public class ReaderSubsActivity extends AppCompatActivity
             mLastAddedTagName = null;
         }
         String labelRemovedTag = getString(R.string.reader_label_removed_tag);
-        showInfoToast(String.format(labelRemovedTag, tag.getTagNameForDisplay()));
+        showInfoToast(String.format(labelRemovedTag, tag.getTagDisplayName()));
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
@@ -43,7 +43,7 @@ public class ReaderTagActions {
         }
 
         final String path;
-        final String tagNameForApi = ReaderUtils.sanitizeWithDashes(tag.getTagName());
+        final String tagNameForApi = ReaderUtils.sanitizeWithDashes(tag.getTagSlug());
 
         switch (action) {
             case DELETE:
@@ -53,7 +53,7 @@ public class ReaderTagActions {
 
             case ADD :
                 String endpoint = "/read/tags/" + tagNameForApi + "/posts";
-                ReaderTag newTopic = new ReaderTag(tag.getTagName(), tag.getTagTitle(), endpoint, ReaderTagType.FOLLOWED);
+                ReaderTag newTopic = new ReaderTag(tag.getTagSlug(), tag.getTagTitle(), endpoint, ReaderTagType.FOLLOWED);
                 ReaderTagTable.addOrUpdateTag(newTopic);
                 path = "read/tags/" + tagNameForApi + "/mine/new";
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderTagActions.java
@@ -53,7 +53,7 @@ public class ReaderTagActions {
 
             case ADD :
                 String endpoint = "/read/tags/" + tagNameForApi + "/posts";
-                ReaderTag newTopic = new ReaderTag(tag.getTagName(), endpoint, ReaderTagType.FOLLOWED);
+                ReaderTag newTopic = new ReaderTag(tag.getTagName(), tag.getTagTitle(), endpoint, ReaderTagType.FOLLOWED);
                 ReaderTagTable.addOrUpdateTag(newTopic);
                 path = "read/tags/" + tagNameForApi + "/mine/new";
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -365,7 +365,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
 
         // show the best tag for this post
-        final String tagToDisplay = (mCurrentTag != null ? post.getTagForDisplay(mCurrentTag.getTagName()) : null);
+        final String tagToDisplay = (mCurrentTag != null ? post.getTagForDisplay(mCurrentTag.getTagSlug()) : null);
         if (!TextUtils.isEmpty(tagToDisplay)) {
             holder.txtTag.setText(ReaderUtils.makeHashTag(tagToDisplay));
             holder.txtTag.setVisibility(View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
@@ -90,7 +90,7 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
     @Override
     public void onBindViewHolder(TagViewHolder holder, int position) {
         final ReaderTag tag = mTags.get(position);
-        holder.txtTagName.setText(tag.getTagNameForDisplay());
+        holder.txtTagName.setText(tag.getTagDisplayName());
         holder.btnRemove.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.reader.adapters;
 
 import android.content.Context;
 import android.os.AsyncTask;
+import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -13,7 +14,6 @@ import org.wordpress.android.R;
 import org.wordpress.android.datasets.ReaderTagTable;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.ReaderTagList;
-import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.reader.ReaderInterfaces;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderTagActions;
@@ -94,13 +94,13 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
         holder.btnRemove.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                performDeleteTag(tag.getTagName());
+                performDeleteTag(tag);
 
             }
         });
     }
 
-    private void performDeleteTag(String tagName) {
+    private void performDeleteTag(@NonNull ReaderTag tag) {
         if (!NetworkUtils.checkConnection(getContext())) {
             return;
         }
@@ -115,11 +115,10 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
             }
         };
 
-        ReaderTag tag = new ReaderTag(tagName, ReaderTagType.FOLLOWED);
         boolean success = ReaderTagActions.performTagAction(tag, TagAction.DELETE, actionListener);
 
         if (success) {
-            int index = mTags.indexOfTagName(tagName);
+            int index = mTags.indexOfTagName(tag.getTagName());
             if (index > -1) {
                 mTags.remove(index);
                 notifyItemRemoved(index);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
@@ -90,7 +90,7 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
     @Override
     public void onBindViewHolder(TagViewHolder holder, int position) {
         final ReaderTag tag = mTags.get(position);
-        holder.txtTagName.setText(tag.getCapitalizedTagName());
+        holder.txtTagName.setText(tag.getTagNameForDisplay());
         holder.btnRemove.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderTagAdapter.java
@@ -78,7 +78,7 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
 
     @Override
     public long getItemId(int position) {
-        return mTags.get(position).getTagName().hashCode();
+        return mTags.get(position).getTagSlug().hashCode();
     }
 
     @Override
@@ -118,7 +118,7 @@ public class ReaderTagAdapter extends RecyclerView.Adapter<ReaderTagAdapter.TagV
         boolean success = ReaderTagActions.performTagAction(tag, TagAction.DELETE, actionListener);
 
         if (success) {
-            int index = mTags.indexOfTagName(tag.getTagName());
+            int index = mTags.indexOfTagName(tag.getTagSlug());
             if (index > -1) {
                 mTags.remove(index);
                 notifyItemRemoved(index);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderPostService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderPostService.java
@@ -362,7 +362,7 @@ public class ReaderPostService extends Service {
             return null;
         }
 
-        return String.format("read/tags/%s/posts", ReaderUtils.sanitizeWithDashes(tag.getTagName()));
+        return String.format("read/tags/%s/posts", ReaderUtils.sanitizeWithDashes(tag.getTagSlug()));
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -201,14 +201,14 @@ public class ReaderUpdateService extends Service {
             JSONObject jsonTopic = jsonTopics.optJSONObject(internalName);
             if (jsonTopic != null) {
                 String tagTitle = JSONUtils.getStringDecoded(jsonTopic, "title");
-                String tagName;
-                if (jsonTopic.has("display_name")) {
-                    tagName = JSONUtils.getStringDecoded(jsonTopic, "display_name");
+                String tagSlug;
+                if (jsonTopic.has("slug")) {
+                    tagSlug = JSONUtils.getStringDecoded(jsonTopic, "slug");
                 } else {
-                    tagName = tagTitle;
+                    tagSlug = tagTitle;
                 }
                 String endpoint = JSONUtils.getString(jsonTopic, "URL");
-                topics.add(new ReaderTag(tagName, tagTitle, endpoint, topicType));
+                topics.add(new ReaderTag(tagSlug, tagTitle, endpoint, topicType));
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -200,7 +200,8 @@ public class ReaderUpdateService extends Service {
             String internalName = it.next();
             JSONObject jsonTopic = jsonTopics.optJSONObject(internalName);
             if (jsonTopic != null) {
-                String tagName = JSONUtils.getStringDecoded(jsonTopic, "title");
+                String tagName = JSONUtils.getStringDecoded(jsonTopic, "display_name");
+                String title = JSONUtils.getStringDecoded(jsonTopic, "title"); // TODO: store title
                 String endpoint = JSONUtils.getString(jsonTopic, "URL");
                 topics.add(new ReaderTag(tagName, endpoint, topicType));
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -200,8 +200,13 @@ public class ReaderUpdateService extends Service {
             String internalName = it.next();
             JSONObject jsonTopic = jsonTopics.optJSONObject(internalName);
             if (jsonTopic != null) {
-                String tagName = JSONUtils.getStringDecoded(jsonTopic, "display_name");
                 String tagTitle = JSONUtils.getStringDecoded(jsonTopic, "title");
+                String tagName;
+                if (jsonTopic.has("display_name")) {
+                    tagName = JSONUtils.getStringDecoded(jsonTopic, "display_name");
+                } else {
+                    tagName = tagTitle;
+                }
                 String endpoint = JSONUtils.getString(jsonTopic, "URL");
                 topics.add(new ReaderTag(tagName, tagTitle, endpoint, topicType));
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -201,9 +201,9 @@ public class ReaderUpdateService extends Service {
             JSONObject jsonTopic = jsonTopics.optJSONObject(internalName);
             if (jsonTopic != null) {
                 String tagName = JSONUtils.getStringDecoded(jsonTopic, "display_name");
-                String title = JSONUtils.getStringDecoded(jsonTopic, "title"); // TODO: store title
+                String tagTitle = JSONUtils.getStringDecoded(jsonTopic, "title");
                 String endpoint = JSONUtils.getString(jsonTopic, "URL");
-                topics.add(new ReaderTag(tagName, endpoint, topicType));
+                topics.add(new ReaderTag(tagName, tagTitle, endpoint, topicType));
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -204,7 +204,7 @@ public class ReaderUtils {
      * the user hasn't already chosen one
      */
     public static ReaderTag getDefaultTag() {
-        return getTagFromTagName(ReaderTag.TAG_NAME_DEFAULT, ReaderTagType.DEFAULT);
+        return getTagFromTagName(ReaderTag.TAG_TITLE_DEFAULT, ReaderTagType.DEFAULT);
     }
 
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -10,7 +10,10 @@ import android.view.View;
 import org.wordpress.android.R;
 import org.wordpress.android.datasets.ReaderCommentTable;
 import org.wordpress.android.datasets.ReaderPostTable;
+import org.wordpress.android.datasets.ReaderTagTable;
 import org.wordpress.android.models.AccountHelper;
+import org.wordpress.android.models.ReaderTag;
+import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.util.StringUtils;
@@ -183,4 +186,26 @@ public class ReaderUtils {
             view.setBackgroundResource(R.drawable.ripple_oval);
         }
     }
+
+    /*
+     * returns a tag object from the passed tag name - first checks for it in the tag db
+     * (so we can also get its title & endpoint), returns a new tag if that fails
+     */
+    public static ReaderTag getTagFromTagName(String tagName, ReaderTagType tagType) {
+        ReaderTag tag = ReaderTagTable.getTag(tagName, tagType);
+        if (tag != null) {
+            return tag;
+        }
+        return new ReaderTag(tagName, null, null, tagType);
+    }
+
+    /*
+     * returns the default tag, which is the one selected by default in the reader when
+     * the user hasn't already chosen one
+     */
+    public static ReaderTag getDefaultTag() {
+        return getTagFromTagName(ReaderTag.TAG_NAME_DEFAULT, ReaderTagType.DEFAULT);
+    }
+
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagInfoView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderTagInfoView.java
@@ -49,13 +49,13 @@ public class ReaderTagInfoView extends LinearLayout {
         mCurrentTag = tag;
 
         TextView txtTagName = (TextView) findViewById(R.id.text_tag);
-        txtTagName.setText(ReaderUtils.makeHashTag(tag.getTagName()));
+        txtTagName.setText(ReaderUtils.makeHashTag(tag.getTagSlug()));
 
         if (ReaderUtils.isLoggedOutReader()) {
             mFollowButton.setVisibility(View.GONE);
         } else {
             mFollowButton.setVisibility(View.VISIBLE);
-            mFollowButton.setIsFollowed(ReaderTagTable.isFollowedTagName(tag.getTagName()));
+            mFollowButton.setIsFollowed(ReaderTagTable.isFollowedTagName(tag.getTagSlug()));
             mFollowButton.setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
@@ -70,7 +70,7 @@ public class ReaderTagInfoView extends LinearLayout {
             return;
         }
 
-        final boolean isAskingToFollow = !ReaderTagTable.isFollowedTagName(mCurrentTag.getTagName());
+        final boolean isAskingToFollow = !ReaderTagTable.isFollowedTagName(mCurrentTag.getTagSlug());
         ReaderTagActions.TagAction action = isAskingToFollow ? ReaderTagActions.TagAction.ADD : ReaderTagActions.TagAction.DELETE;
 
         ReaderActions.ActionListener listener = new ReaderActions.ActionListener() {


### PR DESCRIPTION
Fixes #3940 

The problem Eric uncovered was actually quite deep and touched a lot of areas of the reader. 

In a nutshell, the app wasn't differentiating between a tag's "title" (the title to display for the tag) and the tag's "name" (the name to use when updating the tag via the endpoint).

For example, the tag titled "News & Current Events" is named "news-current-events," but the Android app didn't store both the name & title, causing numerous problems in addition to the one mentioned in the original issue.

@aerych Any chance you'd be able to review this one, or at least verify that the code is working correctly?