### PR TITLE
Issue/auth token rewritten

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/networking/WPDelayedHurlStack.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/WPDelayedHurlStack.java
@@ -88,6 +88,19 @@ public class WPDelayedHurlStack implements HttpStack {
         sslContextInitializer.start();
     }
 
+
+    private static boolean hasAuthorizationHeader(Request request) {
+        try {
+            if (request.getHeaders() != null && request.getHeaders().containsKey("Authorization")) {
+                return true;
+            }
+        } catch (AuthFailureError e) {
+            // nope
+        }
+
+        return false;
+    }
+
     @Override
     public HttpResponse performRequest(Request<?> request, Map<String, String> additionalHeaders)
             throws IOException, AuthFailureError {
@@ -99,9 +112,15 @@ public class WPDelayedHurlStack implements HttpStack {
                 additionalHeaders.put("Authorization", auth);
             }
 
+            /**
+             *  Add the Authorization header to access private WP.com files.
+             *
+             *  Note: Additional headers have precedence over request headers, so add Authorization only it it's not already
+             *  available in the request.
+             *
+             */
             if (WPUrlUtils.safeToAddWordPressComAuthToken(request.getUrl()) && mCtx != null
-                    && AccountHelper.isSignedInWordPressDotCom()) {
-                // Add the auth header to access private WP.com files
+                    && AccountHelper.isSignedInWordPressDotCom() && !hasAuthorizationHeader(request)) {
                 additionalHeaders.put("Authorization", "Bearer " + AccountHelper.getDefaultAccount().getAccessToken());
             }
         }
@@ -110,8 +129,8 @@ public class WPDelayedHurlStack implements HttpStack {
 
         String url = request.getUrl();
 
-        // Ensure that an HTTPS request is made for images in private sites
-        if (additionalHeaders.containsKey("Authorization")) {
+        // Ensure that an HTTPS request is made to wpcom when Authorization is set.
+        if (additionalHeaders.containsKey("Authorization") || hasAuthorizationHeader(request)) {
             url = UrlUtils.makeHttps(url);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/WPRestClient.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPRestClient.java
@@ -407,7 +407,7 @@ public class WPRestClient {
         }
 
         public void sendWithAccessToken(String token){
-            mRequest.setAccessToken(token.toString());
+            mRequest.setAccessToken(token);
             mRestClient.send(mRequest);
         }
 

--- a/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/AuthenticatorRequest.java
+++ b/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/AuthenticatorRequest.java
@@ -77,7 +77,7 @@ public class AuthenticatorRequest {
     }
 
     public void sendWithAccessToken(String token){
-        mRequest.setAccessToken(token.toString());
+        mRequest.setAccessToken(token);
         mRestClient.send(mRequest);
     }
 


### PR DESCRIPTION
Fixes an issue where the `Authorization` HTTP Header were rewritten by our HTTP Stack implementation (with the main .com token) without checking that there was a valid `Authorization` already set in the HTTP request.

Note that `additional headers` have the precedence over the request headers, so one can force an override, but in this case we were adding it programmatically, to access image files on wpcom.

Also, make sure to use HTTPS when `Authorization` it's available.

To test:
Add a Jetpack blog not linked with the main wpcom account, and the access Stats. 
Stats should show you the credentials prompt, and after that you should be able to access Stats without problem.


Needs review: @maxme 

cc @aerych If you're testing the other PR about Stats and wondering why you can't access them on your Jetpack installation.
