### PR TITLE
Current user capabilities

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -260,7 +260,7 @@ public class WordPressDB {
         boolean isNewInstall = (currentVersion == 0);
 
         if (!isNewInstall && currentVersion != DATABASE_VERSION) {
-            AppLog.d(T.DB, "updgrading database from version " + currentVersion + " to " + DATABASE_VERSION);
+            AppLog.d(T.DB, "upgrading database from version " + currentVersion + " to " + DATABASE_VERSION);
         }
 
         switch (currentVersion) {

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -85,7 +85,7 @@ public class WordPressDB {
     public static final String COLUMN_NAME_VIDEO_PRESS_SHORTCODE = "videoPressShortcode";
     public static final String COLUMN_NAME_UPLOAD_STATE          = "uploadState";
 
-    private static final int DATABASE_VERSION = 45;
+    private static final int DATABASE_VERSION = 46;
 
     private static final String CREATE_TABLE_BLOGS = "create table if not exists accounts (id integer primary key autoincrement, "
             + "url text, blogName text, username text, password text, imagePlacement text, centerThumbnail boolean, fullSizeImage boolean, maxImageWidth text, maxImageWidthId integer);";
@@ -225,6 +225,9 @@ public class WordPressDB {
 
     // add plan_product_name_short to blog
     private static final String ADD_BLOGS_PLAN_PRODUCT_NAME_SHORT = "alter table accounts add plan_product_name_short text default '';";
+
+    // add capabilities to blog
+    private static final String ADD_BLOGS_CAPABILITIES = "alter table accounts add capabilities text default '';";
 
     // used for migration
     private static final String DEPRECATED_WPCOM_USERNAME_PREFERENCE = "wp_pref_wpcom_username";
@@ -413,6 +416,9 @@ public class WordPressDB {
             case 44:
                 PeopleTable.createTables(db);
                 currentVersion++;
+            case 45:
+                db.execSQL(ADD_BLOGS_CAPABILITIES);
+                currentVersion++;
         }
         db.setVersion(DATABASE_VERSION);
     }
@@ -523,6 +529,7 @@ public class WordPressDB {
         }
         values.put("isAdmin", blog.isAdmin());
         values.put("isHidden", blog.isHidden());
+        values.put("capabilities", blog.getCapabilities());
         return db.insert(BLOGS_TABLE, null, values) > -1;
     }
 
@@ -723,6 +730,7 @@ public class WordPressDB {
         values.put("isHidden", blog.isHidden());
         values.put("plan_product_id", blog.getPlanID());
         values.put("plan_product_name_short", blog.getPlanShortName());
+        values.put("capabilities", blog.getCapabilities());
         if (blog.getWpVersion() != null) {
             values.put("wpVersion", blog.getWpVersion());
         } else {
@@ -815,7 +823,7 @@ public class WordPressDB {
                              "blogId", "dotcomFlag", "dotcom_username", "dotcom_password", "api_key",
                              "api_blogid", "wpVersion", "postFormats", "isScaledImage",
                              "scaledImgWidth", "homeURL", "blog_options", "isAdmin", "isHidden",
-                             "plan_product_id", "plan_product_name_short"};
+                             "plan_product_id", "plan_product_name_short", "capabilities"};
         Cursor c = db.query(BLOGS_TABLE, fields, "id=?", new String[]{Integer.toString(localId)}, null, null, null);
 
         Blog blog = null;
@@ -873,6 +881,7 @@ public class WordPressDB {
                 blog.setHidden(c.getInt(c.getColumnIndex("isHidden")) > 0);
                 blog.setPlanID(c.getLong(c.getColumnIndex("plan_product_id")));
                 blog.setPlanShortName(c.getString(c.getColumnIndex("plan_product_name_short")));
+                blog.setCapabilities(c.getString(c.getColumnIndex("capabilities")));
             }
         }
         c.close();

--- a/WordPress/src/main/java/org/wordpress/android/models/Blog.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Blog.java
@@ -513,6 +513,7 @@ public class Blog {
     }
 
     public boolean checkCapability(Capability capability) {
+        // If a capability is missing it means the user don't have it.
         if (capabilities == null || capabilities.isEmpty() || capability == null) {
             return false;
         }

--- a/WordPress/src/main/java/org/wordpress/android/models/Blog.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Blog.java
@@ -39,6 +39,7 @@ public class Blog {
     private String httppassword = "";
     private String postFormats;
     private String blogOptions = "{}";
+    private String capabilities;
     private boolean isAdmin;
     private boolean isHidden;
     private long planID;
@@ -47,7 +48,7 @@ public class Blog {
     public Blog() {
     }
 
-    public Blog(int localTableBlogId, String url, String homeURL, String blogName, String username, String password, String imagePlacement, boolean featuredImageCapable, boolean fullSizeImage, boolean scaledImage, int scaledImageWidth, String maxImageWidth, int maxImageWidthId, int remoteBlogId, String dotcom_username, String dotcom_password, String api_key, String api_blogid, boolean dotcomFlag, String wpVersion, String httpuser, String httppassword, String postFormats, String blogOptions, boolean isAdmin, boolean isHidden) {
+    public Blog(int localTableBlogId, String url, String homeURL, String blogName, String username, String password, String imagePlacement, boolean featuredImageCapable, boolean fullSizeImage, boolean scaledImage, int scaledImageWidth, String maxImageWidth, int maxImageWidthId, int remoteBlogId, String dotcom_username, String dotcom_password, String api_key, String api_blogid, boolean dotcomFlag, String wpVersion, String httpuser, String httppassword, String postFormats, String blogOptions, String capabilities, boolean isAdmin, boolean isHidden) {
         this.localTableBlogId = localTableBlogId;
         this.url = url;
         this.homeURL = homeURL;
@@ -72,6 +73,7 @@ public class Blog {
         this.httppassword = httppassword;
         this.postFormats = postFormats;
         this.blogOptions = blogOptions;
+        this.capabilities = capabilities;
         this.isAdmin = isAdmin;
         this.isHidden = isHidden;
     }
@@ -497,7 +499,16 @@ public class Blog {
     public String getPlanShortName() {
         return StringUtils.notNullStr(planShortName);
     }
+
     public void setPlanShortName(String name) {
         this.planShortName = StringUtils.notNullStr(name);
+    }
+
+    public String getCapabilities() {
+        return capabilities;
+    }
+
+    public void setCapabilities(String capabilities) {
+        this.capabilities = capabilities;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/Blog.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Blog.java
@@ -519,7 +519,7 @@ public class Blog {
         }
         try {
             JSONObject jsonObject = new JSONObject(capabilities);
-            return jsonObject.optBoolean(capability.toString());
+            return jsonObject.optBoolean(capability.getLabel());
         } catch (JSONException e) {
             AppLog.e(T.PEOPLE, "Capabilities is not a valid json: " + capabilities);
             return false;

--- a/WordPress/src/main/java/org/wordpress/android/models/Blog.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Blog.java
@@ -512,7 +512,7 @@ public class Blog {
         this.capabilities = capabilities;
     }
 
-    public boolean checkCapability(Capability capability) {
+    public boolean hasCapability(Capability capability) {
         // If a capability is missing it means the user don't have it.
         if (capabilities == null || capabilities.isEmpty() || capability == null) {
             return false;

--- a/WordPress/src/main/java/org/wordpress/android/models/Blog.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Blog.java
@@ -511,4 +511,17 @@ public class Blog {
     public void setCapabilities(String capabilities) {
         this.capabilities = capabilities;
     }
+
+    public boolean checkCapability(String capability) {
+        if (capabilities == null || capabilities.isEmpty() || capability == null || capability.isEmpty()) {
+            return false;
+        }
+        try {
+            JSONObject jsonObject = new JSONObject(capabilities);
+            return jsonObject.optBoolean(capability);
+        } catch (JSONException e) {
+            AppLog.e(T.PEOPLE, "Capabilities is not a valid json: " + capabilities);
+            return false;
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/Blog.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Blog.java
@@ -512,13 +512,13 @@ public class Blog {
         this.capabilities = capabilities;
     }
 
-    public boolean checkCapability(String capability) {
-        if (capabilities == null || capabilities.isEmpty() || capability == null || capability.isEmpty()) {
+    public boolean checkCapability(Capability capability) {
+        if (capabilities == null || capabilities.isEmpty() || capability == null) {
             return false;
         }
         try {
             JSONObject jsonObject = new JSONObject(capabilities);
-            return jsonObject.optBoolean(capability);
+            return jsonObject.optBoolean(capability.toString());
         } catch (JSONException e) {
             AppLog.e(T.PEOPLE, "Capabilities is not a valid json: " + capabilities);
             return false;

--- a/WordPress/src/main/java/org/wordpress/android/models/Capability.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Capability.java
@@ -1,0 +1,17 @@
+package org.wordpress.android.models;
+
+/**
+ * Used to decide what can the current user do in a particular blog
+ * A list of capabilities can be found in: https://codex.wordpress.org/Roles_and_Capabilities#Capabilities
+ */
+public enum Capability {
+    EDIT_USERS("edit_users"), // Check if user can change another user's role
+    LIST_USERS("list_users"), // Check if user can visit People page
+    PROMOTE_USERS("promote_users"); // Check if user can invite another user
+
+    private final String label;
+
+    Capability(String label) {
+        this.label = label;
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/models/Capability.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Capability.java
@@ -15,8 +15,7 @@ public enum Capability {
         this.label = label;
     }
 
-    @Override
-    public String toString() {
+    public String getLabel() {
         return label;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/Capability.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Capability.java
@@ -14,4 +14,9 @@ public enum Capability {
     Capability(String label) {
         this.label = label;
     }
+
+    @Override
+    public String toString() {
+        return label;
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
@@ -74,9 +74,10 @@ public class BlogUtils {
                 planID = MapUtils.getMapLong(blogMap, "planID");
             }
             String planShortName = MapUtils.getMapStr(blogMap, "plan_product_name_short");
+            String capabilities =  MapUtils.getMapStr(blogMap, "capabilities");
 
             retValue |= addOrUpdateBlog(blogName, xmlrpc, homeUrl, blogId, username, password, httpUsername,
-                    httpPassword, isAdmin, isVisible, planID, planShortName);
+                    httpPassword, isAdmin, isVisible, planID, planShortName, capabilities);
         }
         return retValue;
     }
@@ -106,7 +107,7 @@ public class BlogUtils {
     public static boolean addOrUpdateBlog(String blogName, String xmlRpcUrl, String homeUrl, String blogId,
                                            String username, String password, String httpUsername, String httpPassword,
                                            boolean isAdmin, boolean isVisible,
-                                           long planID, String planShortName) {
+                                           long planID, String planShortName, String capabilities) {
         Blog blog;
         if (!WordPress.wpDB.isBlogInDatabase(Integer.parseInt(blogId), xmlRpcUrl)) {
             // The blog isn't in the app, so let's create it
@@ -129,6 +130,7 @@ public class BlogUtils {
             blog.setHidden(!isVisible);
             blog.setPlanID(planID);
             blog.setPlanShortName(planShortName);
+            blog.setCapabilities(capabilities);
             WordPress.wpDB.saveBlog(blog);
             return true;
         } else {
@@ -148,6 +150,10 @@ public class BlogUtils {
                 }
                 if (!blog.getPlanShortName().equals(planShortName)) {
                     blog.setPlanShortName(planShortName);
+                    blogUpdated = true;
+                }
+                if (!blog.getCapabilities().equals(capabilities)) {
+                    blog.setCapabilities(capabilities);
                     blogUpdated = true;
                 }
                 if (blogUpdated) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
@@ -152,7 +152,7 @@ public class BlogUtils {
                     blog.setPlanShortName(planShortName);
                     blogUpdated = true;
                 }
-                if (!blog.getCapabilities().equals(capabilities)) {
+                if (blog.getCapabilities() == null || !blog.getCapabilities().equals(capabilities)) {
                     blog.setCapabilities(capabilities);
                     blogUpdated = true;
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewBlogFragment.java
@@ -199,7 +199,7 @@ public class NewBlogFragment extends AbstractFragment implements TextWatcher {
                     String blogId = details.getString("blogid");
                     String username = AccountHelper.getDefaultAccount().getUserName();
                     BlogUtils.addOrUpdateBlog(blogName, xmlRpcUrl, homeUrl, blogId, username, null, null, null,
-                            true, true, PlansConstants.DEFAULT_PLAN_ID_FOR_NEW_BLOG, null);
+                            true, true, PlansConstants.DEFAULT_PLAN_ID_FOR_NEW_BLOG, null, null);
                     ToastUtils.showToast(getActivity(), R.string.new_blog_wpcom_created);
                 } catch (JSONException e) {
                     AppLog.e(T.NUX, "Invalid JSON response from site/new", e);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/FetchBlogListWPCom.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/FetchBlogListWPCom.java
@@ -44,6 +44,9 @@ public class FetchBlogListWPCom extends FetchBlogListAbstract {
                     site.put("isAdmin", jsonSite.get("user_can_manage"));
                     site.put("isVisible", jsonSite.get("visible"));
 
+                    // store capabilities as a text blob
+                    site.put("capabilities", jsonSite.get("capabilities").toString());
+
                     JSONObject plan = jsonSite.getJSONObject("plan");
                     site.put("planID", plan.get("product_id"));
                     site.put("plan_product_name_short", plan.get("product_name_short"));

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/FetchBlogListWPCom.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/FetchBlogListWPCom.java
@@ -45,7 +45,7 @@ public class FetchBlogListWPCom extends FetchBlogListAbstract {
                     site.put("isVisible", jsonSite.get("visible"));
 
                     // store capabilities as a text blob
-                    site.put("capabilities", jsonSite.get("capabilities").toString());
+                    site.put("capabilities", jsonSite.getString("capabilities"));
 
                     JSONObject plan = jsonSite.getJSONObject("plan");
                     site.put("planID", plan.get("product_id"));

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -393,8 +393,8 @@ public class MySiteFragment extends Fragment
         }
 
         // toggle people row visibility
-        boolean canVisitPeople = blog.hasCapability(Capability.LIST_USERS);
-        mPeopleView.setVisibility(canVisitPeople ? View.VISIBLE : View.GONE);
+        boolean canListPeople = blog.hasCapability(Capability.LIST_USERS);
+        mPeopleView.setVisibility(canListPeople ? View.VISIBLE : View.GONE);
     }
 
     private void toggleAdminVisibility() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -23,6 +23,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Account;
 import org.wordpress.android.models.AccountHelper;
 import org.wordpress.android.models.Blog;
+import org.wordpress.android.models.Capability;
 import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
@@ -61,6 +62,7 @@ public class MySiteFragment extends Fragment
     private WPTextView mBlogSubtitleTextView;
     private LinearLayout mLookAndFeelHeader;
     private RelativeLayout mThemesContainer;
+    private RelativeLayout mPeopleView;
     private RelativeLayout mPlanContainer;
     private View mConfigurationHeader;
     private View mSettingsView;
@@ -142,6 +144,7 @@ public class MySiteFragment extends Fragment
         mBlogSubtitleTextView = (WPTextView) rootView.findViewById(R.id.my_site_subtitle_label);
         mLookAndFeelHeader = (LinearLayout) rootView.findViewById(R.id.my_site_look_and_feel_header);
         mThemesContainer = (RelativeLayout) rootView.findViewById(R.id.row_themes);
+        mPeopleView = (RelativeLayout) rootView.findViewById(R.id.row_people);
         mPlanContainer = (RelativeLayout) rootView.findViewById(R.id.row_plan);
         mConfigurationHeader = rootView.findViewById(R.id.row_configuration);
         mSettingsView = rootView.findViewById(R.id.row_settings);
@@ -224,7 +227,7 @@ public class MySiteFragment extends Fragment
             }
         });
 
-        rootView.findViewById(R.id.row_people).setOnClickListener(new View.OnClickListener() {
+        mPeopleView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 ActivityLauncher.viewCurrentBlogPeople(getActivity());
@@ -388,6 +391,10 @@ public class MySiteFragment extends Fragment
         } else {
             mPlanContainer.setVisibility(View.GONE);
         }
+
+        // toggle people row visibility
+        boolean canVisitPeople = blog.checkCapability(Capability.LIST_USERS);
+        mPeopleView.setVisibility(canVisitPeople ? View.VISIBLE : View.GONE);
     }
 
     private void toggleAdminVisibility() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -360,9 +360,14 @@ public class MySiteFragment extends Fragment
         mThemesContainer.setVisibility(themesVisibility);
 
         // show settings for all self-hosted to expose Delete Site
-        int settingsVisibility = blog.isAdmin() || !blog.isDotcomFlag() ? View.VISIBLE : View.GONE;
+        boolean isAdminOrSelfHosted =  blog.isAdmin() || !blog.isDotcomFlag();
+        boolean canListPeople = blog.hasCapability(Capability.LIST_USERS);
+        mSettingsView.setVisibility(isAdminOrSelfHosted ? View.VISIBLE : View.GONE);
+        mPeopleView.setVisibility(canListPeople ? View.VISIBLE : View.GONE);
+
+        // if either people or settings is visible, configuration header should be visible
+        int settingsVisibility = (isAdminOrSelfHosted || canListPeople) ? View.VISIBLE : View.GONE;
         mConfigurationHeader.setVisibility(settingsVisibility);
-        mSettingsView.setVisibility(settingsVisibility);
 
         mBlavatarImageView.setImageUrl(GravatarUtils.blavatarFromUrl(blog.getUrl(), mBlavatarSz), WPNetworkImageView.ImageType.BLAVATAR);
 
@@ -391,10 +396,6 @@ public class MySiteFragment extends Fragment
         } else {
             mPlanContainer.setVisibility(View.GONE);
         }
-
-        // toggle people row visibility
-        boolean canListPeople = blog.hasCapability(Capability.LIST_USERS);
-        mPeopleView.setVisibility(canListPeople ? View.VISIBLE : View.GONE);
     }
 
     private void toggleAdminVisibility() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -393,7 +393,7 @@ public class MySiteFragment extends Fragment
         }
 
         // toggle people row visibility
-        boolean canVisitPeople = blog.checkCapability(Capability.LIST_USERS);
+        boolean canVisitPeople = blog.hasCapability(Capability.LIST_USERS);
         mPeopleView.setVisibility(canVisitPeople ? View.VISIBLE : View.GONE);
     }
 


### PR DESCRIPTION
Related #3901. This PR adds a `capabilities` field to the `Blog` model which is saved as a json string from the network request. That property is also used to check `list_users` capability to decide whether to show the People page to the current user for a specific site or not. This is the very first PR that uses the capabilities, there will be others soon which will use at least `edit_users` & `promote_users` capabilities.

**To test:**
* Go into my site page for a .com blog where you have the `list_users` capability (any site where you're an admin will do) and make sure the People row is visible
* Go into another .com site where you don't have the `list_users` capability and make sure the People row is NOT visible. P.S: I've added my 2nd account as an Author to a test site to test this out.
* Go into a self-hosted site and make sure the People row is NOT visible.

**/cc** @maxme: Whenever I add something to `Blog` I feel like I missed something, because it's scattered around. Do you mind taking a quick look at the PR to make sure that's not the case? Thanks!
**/cc** @astralbodies 

Needs review: @hypest 