### PR TITLE
issue/3990-reader-empty-tag-picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -273,9 +273,7 @@ public class ReaderPostListFragment extends Fragment
         super.onStart();
         EventBus.getDefault().register(this);
 
-        if (mRecyclerView != null) {
-            mRecyclerView.refreshFilterCriteriaOptions();
-        }
+        reloadTags();
 
         // purge database and update followed tags/blog if necessary - note that we don't purge unless
         // there's a connection to avoid removing posts the user would expect to see offline
@@ -312,6 +310,9 @@ public class ReaderPostListFragment extends Fragment
     @SuppressWarnings("unused")
     public void onEventMainThread(ReaderEvents.FollowedTagsChanged event) {
         if (getPostListType() == ReaderPostListType.TAG_FOLLOWED) {
+            // reload the tag filter since tags have changed
+            reloadTags();
+
             // update the current tag if the list fragment is empty - this will happen if
             // the tag table was previously empty (ie: first run)
             if (isPostAdapterEmpty()) {
@@ -830,6 +831,16 @@ public class ReaderPostListFragment extends Fragment
             getPostAdapter().reload();
         }
     }
+
+    /*
+     * reload the list of tags for the dropdown filter
+     */
+    private void reloadTags() {
+        if (isAdded() && mRecyclerView != null) {
+            mRecyclerView.refreshFilterCriteriaOptions();
+        }
+    }
+
 
     /*
      * get posts for the current blog from the server


### PR DESCRIPTION
Fixes #3990 

To test:
- Sign in to a self-hosted ~~wpcom~~ account. 
- Sign in to wpcom. 
- Switch to the reader tab.
- In the tag picker, select a tag you are following that is not one of the default/recommended tags shown to a signed out user. 
- Switch to the profile tab and sign out of wpcom. 
- Switch back to the reader. 

Prior to this fix, the tag picker would be empty in this situation.