### PR TITLE
Checking for non-null comment before trashing

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -284,6 +284,8 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         mBtnTrashComment.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                if (!hasComment()) return;
+
                 if (mComment.willTrashingPermanentlyDelete()) {
                     AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(
                             getActivity());


### PR DESCRIPTION
Fixes #3982 

I was unable to get a null comment to trash, but this PR adds the same null-check as the Spam button so NPE's will be avoided.

Needs review: @roundhill 