### PR TITLE
Visual Editor: migrate legacy draft local medias to visual editor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -15,6 +15,7 @@ import android.database.Cursor;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
@@ -119,6 +120,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import de.greenrobot.event.EventBus;
 
@@ -1110,6 +1113,49 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         }
     }
 
+    private String getUploadErrorHtml(String mediaId, String path) {
+        String replacement;
+        if (Build.VERSION.SDK_INT >= 19) {
+            replacement = String.format(Locale.US,
+                    "<span id=\"img_container_%s\" class=\"img_container failed\" data-failed=\"%s\"><progress " +
+                            "id=\"progress_%s\" value=\"0\" class=\"wp_media_indicator failed\" contenteditable=\"false\">" +
+                            "</progress><img data-wpid=\"%s\" src=\"%s\" alt=\"\" class=\"failed\"></span>",
+                    mediaId, getString(R.string.tap_to_try_again), mediaId, mediaId, path);
+        } else {
+            // Before API 19, the WebView didn't support progress tags. Use an upload overlay instead of a progress bar
+            replacement = String.format(Locale.US,
+                    "<span id=\"img_container_%s\" class=\"img_container compat failed\" contenteditable=\"false\" " +
+                            "data-failed=\"%s\"><span class=\"upload-overlay failed\" " +
+                            "contenteditable=\"false\">Uploading…</span><span class=\"upload-overlay-bg\"></span>" +
+                            "<img data-wpid=\"%s\" src=\"%s\" alt=\"\" class=\"failed\"></span>",
+                    mediaId, getString(R.string.tap_to_try_again), mediaId, path);
+        }
+        return replacement;
+    }
+
+    private String migrateLegacyDraft(String content) {
+        if (content.contains("<img src=\"null\" android-uri=\"file:")) {
+            // We must replace image tags specific to the legacy editor local drafts:
+            // <img src="null" android-uri="file:///..." />
+            // And trigger an upload action for the specific image / video
+            Pattern pattern = Pattern.compile("<img src=\"null\" android-uri=\"([^\"]*)\".*/>");
+            Matcher matcher = pattern.matcher(content);
+            StringBuffer stringBuffer = new StringBuffer();
+            while (matcher.find()) {
+                String path = matcher.group(1).replace("file://", "");
+                MediaFile mediaFile = queueFileForUpload(path, null, "failed");
+                if (mediaFile == null) {
+                    continue;
+                }
+                String replacement = getUploadErrorHtml(mediaFile.getMediaId(), mediaFile.getFilePath());
+                matcher.appendReplacement(stringBuffer, replacement);
+            }
+            matcher.appendTail(stringBuffer);
+            return stringBuffer.toString();
+        }
+        return content;
+    }
+
     private void fillContentEditorFields() {
         // Needed blog settings needed by the editor
         if (WordPress.getCurrentBlog() != null) {
@@ -1134,7 +1180,10 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                             post.getContent().replaceAll("\uFFFC", ""));
                 } else {
                     // TODO: Might be able to drop .replaceAll() when legacy editor is removed
-                    mEditorFragment.setContent(post.getContent().replaceAll("\uFFFC", ""));
+                    String content = post.getContent().replaceAll("\uFFFC", "");
+                    // Prepare eventual legacy editor local draft for the new editor
+                    content = migrateLegacyDraft(content);
+                    mEditorFragment.setContent(content);
                 }
             }
             if (!TextUtils.isEmpty(post.getTitle())) {
@@ -1957,6 +2006,10 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
      *  the new {@link org.wordpress.android.util.helpers.MediaFile} ID is added if non-null
      */
     private MediaFile queueFileForUpload(String path, ArrayList<String> mediaIdOut) {
+        return queueFileForUpload(path, mediaIdOut, "queued");
+    }
+
+    private MediaFile queueFileForUpload(String path, ArrayList<String> mediaIdOut, String startingState) {
         // Invalid file path
         if (TextUtils.isEmpty(path)) {
             Toast.makeText(this, R.string.editor_toast_invalid_path, Toast.LENGTH_SHORT).show();
@@ -1979,7 +2032,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         mediaFile.setBlogId(String.valueOf(blog.getLocalTableBlogId()));
         mediaFile.setFileName(fileName);
         mediaFile.setFilePath(path);
-        mediaFile.setUploadState("queued");
+        mediaFile.setUploadState(startingState);
         mediaFile.setDateCreatedGMT(currentTime);
         mediaFile.setMediaId(String.valueOf(currentTime));
         mediaFile.setVideo(MediaUtils.isVideo(path));


### PR DESCRIPTION
Fix wordpress-mobile/WordPress-Editor-Android#291
