### PR TITLE
Issue/3994 reader list position

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -139,14 +139,13 @@ public class ReaderPostActions {
             public void run() {
                 ReaderPost serverPost = ReaderPost.fromJson(jsonObject);
 
-                // TODO: remove this temporary fix for backend issue - these fields aren't set
-                // correctly by the endpoint to request a single post, so we need to copy them
-                // from the local post before calling isSamePost (since the difference in those
-                // fields will cause isSamePost to always return false)
+                // TODO: this temporary fix was added 25-Apr-2016 as a workound for the fact that
+                // the read/sites/{blogId}/posts/{postId} endpoint doesn't contain the feedId or
+                // feedItemId of the post. because of this, we need to copy them from the local post
+                // before calling isSamePost (since the difference in those IDs causes it to return false)
                 if (serverPost.feedId == 0 && localPost.feedId != 0) {
                     serverPost.feedId = localPost.feedId;
                     serverPost.feedItemId = localPost.feedItemId;
-                    serverPost.isFollowedByCurrentUser = localPost.isFollowedByCurrentUser;
                 }
 
                 boolean hasChanges = !serverPost.isSamePost(localPost);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -141,7 +141,8 @@ public class ReaderPostActions {
 
                 // TODO: remove this temporary fix for backend issue - these fields aren't set
                 // correctly by the endpoint to request a single post, so we need to copy them
-                // from the local post
+                // from the local post before calling isSamePost (since the difference in those
+                // fields will cause isSamePost to always return false)
                 if (serverPost.feedId == 0 && localPost.feedId != 0) {
                     serverPost.feedId = localPost.feedId;
                     serverPost.feedItemId = localPost.feedItemId;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -138,6 +138,16 @@ public class ReaderPostActions {
             @Override
             public void run() {
                 ReaderPost serverPost = ReaderPost.fromJson(jsonObject);
+
+                // TODO: remove this temporary fix for backend issue - these fields aren't set
+                // correctly by the endpoint to request a single post, so we need to copy them
+                // from the local post
+                if (serverPost.feedId == 0 && localPost.feedId != 0) {
+                    serverPost.feedId = localPost.feedId;
+                    serverPost.feedItemId = localPost.feedItemId;
+                    serverPost.isFollowedByCurrentUser = localPost.isFollowedByCurrentUser;
+                }
+
                 boolean hasChanges = !serverPost.isSamePost(localPost);
 
                 if (hasChanges) {


### PR DESCRIPTION
Fixes #3994

The real issue discussed in #3994 was caused by a backend bug that has since been resolved, but while researching that problem I found another one. 

Each reader post has a `feed_ID` and `feed_item_ID` which relates to the feed it came from. The endpoint which returns a list of posts includes these values, but it turns out the endpoint which returns a single post does NOT contain them. This causes these IDs to be zeroed out when the user goes to the reader detail view and the post is updated.

Because those IDs are different (they're now zero), the app thinks the post has changed, causing it to refresh the detail view and then refresh the list view when the user returns to it.

I discussed this issue with the reader squad, and there are technical limitations that make it difficult for that endpoint to return the missing IDs. So for now we workaround the problem with this PR, which ensures that those IDs aren't zeroed out when a post is updated.
