### PR TITLE
Make sure the post content is loaded only after it's been saved to the DB

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -315,9 +315,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 } else if (position == PAGE_PREVIEW) {
                     setTitle(mPost.isPage() ? R.string.preview_page : R.string.preview_post);
                     savePostAsync();
-                    if (mEditPostPreviewFragment != null) {
-                        mEditPostPreviewFragment.loadPost();
-                    }
                 }
             }
         });
@@ -814,6 +811,9 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             public void run() {
                 updatePostObject(false);
                 savePostToDb();
+                if (mEditPostPreviewFragment != null) {
+                    mEditPostPreviewFragment.loadPost();
+                }
             }
         }).start();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -318,7 +318,14 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                         @Override
                         public void onPostSave() {
                             if (mEditPostPreviewFragment != null) {
-                                mEditPostPreviewFragment.loadPost();
+                                runOnUiThread(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        if (mEditPostPreviewFragment != null) {
+                                            mEditPostPreviewFragment.loadPost();
+                                        }
+                                    }
+                                });
                             }
                         }
                     });


### PR DESCRIPTION
Fixes #4012

To test: just start creating a new post and add a title, then click on the preview icon ("eye"). It should show the post contents (i.e., title if you only entered a title).

Needs review: @nbradbury 
