### PR TITLE
Only check for network on delete action if this is not a local draft 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -428,6 +428,8 @@ public class PostsListFragment extends Fragment
      * send the passed post to the trash with undo
      */
     private void trashPost(final PostsListPost post) {
+        //only check if network is available in case this is not a local draft - local drafts have not yet
+        //been posted to the server so they can be trashed w/o further care
         if (!isAdded() || (!post.isLocalDraft() && !NetworkUtils.checkConnection(getActivity()))) {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -428,7 +428,7 @@ public class PostsListFragment extends Fragment
      * send the passed post to the trash with undo
      */
     private void trashPost(final PostsListPost post) {
-        if (!isAdded() || !NetworkUtils.checkConnection(getActivity())) {
+        if (!isAdded() || (!post.isLocalDraft() && !NetworkUtils.checkConnection(getActivity()))) {
             return;
         }
 


### PR DESCRIPTION
Fixes #3998

To test:
1) login to the app and open a site of yours
2) turn on airplane mode or make sure you have no connectivity
3) create a new post and go back to save it
4) in the blog post list, you should be able to click "trash" on the recently created local draft and it should disappear - snackbar is shown too and record is deleted from the db


Needs review: @nbradbury 

