### PR TITLE
made changes so SuggestionService will be bound/unbound correctly

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -321,6 +321,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 }
             }
         });
+
         ActivityId.trackLastActivity(ActivityId.POST_EDITOR);
     }
 
@@ -376,13 +377,13 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
     @Override
     protected void onDestroy() {
-        super.onDestroy();
-
         AnalyticsTracker.track(AnalyticsTracker.Stat.EDITOR_CLOSED);
 
         if (mSuggestionServiceConnectionManager != null) {
             mSuggestionServiceConnectionManager.unbindFromService();
         }
+
+        super.onDestroy();
     }
 
     @Override
@@ -422,10 +423,12 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 }
             }
 
-            mSuggestionServiceConnectionManager = new SuggestionServiceConnectionManager(this, remoteBlogId);
-            mTagSuggestionAdapter = SuggestionUtils.setupTagSuggestions(remoteBlogId, this, mSuggestionServiceConnectionManager);
-            if (mTagSuggestionAdapter != null) {
-                mTags.setAdapter(mTagSuggestionAdapter);
+            if (mSuggestionServiceConnectionManager == null) {
+                mSuggestionServiceConnectionManager = new SuggestionServiceConnectionManager(this, remoteBlogId);
+                mTagSuggestionAdapter = SuggestionUtils.setupTagSuggestions(remoteBlogId, this, mSuggestionServiceConnectionManager);
+                if (mTagSuggestionAdapter != null) {
+                    mTags.setAdapter(mTagSuggestionAdapter);
+                }
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/util/SuggestionServiceConnectionManager.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/util/SuggestionServiceConnectionManager.java
@@ -13,7 +13,7 @@ public class SuggestionServiceConnectionManager implements ServiceConnection {
     private final Context mContext;
     private final int mRemoteBlogId;
     private boolean mAttemptingToBind = false;
-    private boolean mBound = false;
+    private boolean mBindCalled = false;
 
     public SuggestionServiceConnectionManager(Context context, int remoteBlogId) {
         mContext = context;
@@ -23,6 +23,7 @@ public class SuggestionServiceConnectionManager implements ServiceConnection {
     public void bindToService() {
         if (!mAttemptingToBind) {
             mAttemptingToBind = true;
+            mBindCalled = true;
             Intent intent = new Intent(mContext, SuggestionService.class);
             mContext.bindService(intent, this, Context.BIND_AUTO_CREATE);
         }
@@ -30,9 +31,9 @@ public class SuggestionServiceConnectionManager implements ServiceConnection {
 
     public void unbindFromService() {
         mAttemptingToBind = false;
-        if (mBound) {
+        if (mBindCalled) {
             mContext.unbindService(this);
-            mBound = false;
+            mBindCalled = false;
         }
     }
 
@@ -45,11 +46,10 @@ public class SuggestionServiceConnectionManager implements ServiceConnection {
         suggestionService.updateTags(mRemoteBlogId);
 
         mAttemptingToBind = false;
-        mBound = true;
     }
 
     @Override
     public void onServiceDisconnected(ComponentName componentName) {
-        mBound = false;
+        // noop
     }
 }


### PR DESCRIPTION
Fixes #4013

Ok so, I’ve been reading about this [here](http://developer.android.com/intl/es/guide/components/bound-services.html) and [here](http://developer.android.com/intl/es/guide/components/bound-services.html#Additional_Notes) 

and after doing several tests and taking this in particular:

```The binding is asynchronous. bindService() returns immediately and does not return the IBinder to the client.```

I found this:

1) unbinding for EditPostActivity was being called after `super.onDestroy()`, so I changed that (it was OK everywhere else I looked for the call to `unbindService`)

2) also, if you went into this activity and then pressed back rapidly enough (doesn’t even need to be super quick, just enter and then press the back button when the activity is finished rendering), the service would be still processing the bind request, so there was a local `mBound` flag that was still not set to true, so `unbindService`  was not being actually called, thus being the culprit for the leak.

I eliminated the `mBound` flag altogether as it doesn’t serve a purpose other than preventing the service from being unbound if it wasn’t bounded yet, which is not something we should prevent as it’s totally legal to call `unbindService` once you called `bindService`, no matter what, being `bindService` an async method that returns immediately.

Now, that solved the issue at hand, but brought a new issue with itself, which is the service was not being registered when going into the Comments section and tapped on a comment to see it in CommentDetailFragment.

```
java.lang.IllegalArgumentException: Service not registered: org.wordpress.android.ui.suggestion.util.SuggestionServiceConnectionManager@c163ebd
                                                                           at android.app.LoadedApk.forgetServiceDispatcher(LoadedApk.java:1029)
                                                                           at android.app.ContextImpl.unbindService(ContextImpl.java:1816)
                                                                           at android.content.ContextWrapper.unbindService(ContextWrapper.java:551)
                                                                           at org.wordpress.android.ui.suggestion.util.SuggestionServiceConnectionManager.unbindFromService(SuggestionServiceConnectionManager.java:32)
                                                                           at org.wordpress.android.ui.comments.CommentDetailFragment.onDestroy(CommentDetailFragment.java:206)
                                                                           at android.app.Fragment.performDestroy(Fragment.java:2266)

```


I realised this was because `bindService` for suggestions for sites (and also tag suggestions) is only called if we have no suggestions (i.e. the suggestions table is empty at the time we land on the Activity that makes use of the service). 

```
        List<Suggestion> suggestions = SuggestionTable.getSuggestionsForSite(remoteBlogId);
        // if the tags are not stored yet, we want to trigger an update for it
        if (tags.isEmpty()) {
            serviceConnectionManager.bindToService();
        }
```

Makes sense! So what we really need to be tracking here is whether we have called `bindService` at least once in order to be able to call `unbindService`.

This is then the main change you’ll see in this PR.

3) also, I saw some tags initialisers in `onCreateOptionsMenu` in EditPostActivity.java, and I think someone must have done that because the controls they needed were part of a fragment, and the fragment was created when `onCreateOptionsMenu` was called (and not yet created when the activity's `onCreate` method is called, of course)… Why initialising it in the Activity then? 
Moreover, `onCreateOptionsMenu` was being called twice sometimes - added a patch in this PR so the tagging service is setup/bound to once in the activity for now.

I’m addressing this last point on another PR (EDIT: check PR #4023).

Tested on all 3 cases where the SuggestionService is used: ReaderCommentListActivity, EditPostActivity, and CommentDetailFragment.

