### PR TITLE
Post edit: moved SuggestionServiceConnectionManager to fragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -81,9 +81,6 @@ import org.wordpress.android.ui.media.services.MediaUploadService;
 import org.wordpress.android.ui.posts.services.PostUploadService;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
-import org.wordpress.android.ui.suggestion.adapters.TagSuggestionAdapter;
-import org.wordpress.android.ui.suggestion.util.SuggestionServiceConnectionManager;
-import org.wordpress.android.ui.suggestion.util.SuggestionUtils;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -180,14 +177,10 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
     private Post mPost;
     private Post mOriginalPost;
-    private TagSuggestionAdapter mTagSuggestionAdapter;
-    private SuggestionServiceConnectionManager mSuggestionServiceConnectionManager;
-    private int remoteBlogId;
 
     private EditorFragmentAbstract mEditorFragment;
     private EditPostSettingsFragment mEditPostSettingsFragment;
     private EditPostPreviewFragment mEditPostPreviewFragment;
-    private SuggestionAutoCompleteText mTags;
 
     private EditorMediaUploadListener mEditorMediaUploadListener;
 
@@ -379,10 +372,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         super.onDestroy();
 
         AnalyticsTracker.track(AnalyticsTracker.Stat.EDITOR_CLOSED);
-
-        if (mSuggestionServiceConnectionManager != null) {
-            mSuggestionServiceConnectionManager.unbindFromService();
-        }
     }
 
     @Override
@@ -406,27 +395,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             inflater.inflate(R.menu.edit_post, menu);
         } else {
             inflater.inflate(R.menu.edit_post_legacy, menu);
-        }
-
-        mTags = (SuggestionAutoCompleteText) findViewById(R.id.tags);
-        if (mTags != null) {
-            mTags.setTokenizer(new SuggestionAutoCompleteText.CommaTokenizer());
-
-            remoteBlogId = -1;
-            String blogID = WordPress.getCurrentRemoteBlogId();
-            if (blogID != null) {
-                try {
-                    remoteBlogId = Integer.parseInt(blogID);
-                } catch (NumberFormatException e) {
-                    AppLog.e(T.EDITOR, "The remote blog ID can't be parsed as Integer: " + remoteBlogId);
-                }
-            }
-
-            mSuggestionServiceConnectionManager = new SuggestionServiceConnectionManager(this, remoteBlogId);
-            mTagSuggestionAdapter = SuggestionUtils.setupTagSuggestions(remoteBlogId, this, mSuggestionServiceConnectionManager);
-            if (mTagSuggestionAdapter != null) {
-                mTags.setAdapter(mTagSuggestionAdapter);
-            }
         }
 
         return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -92,16 +92,15 @@ public class EditPostSettingsFragment extends Fragment
     private Post mPost;
 
     private Spinner mStatusSpinner, mPostFormatSpinner;
-    private EditText mPasswordEditText, mTagsEditText, mExcerptEditText;
+    private EditText mPasswordEditText, mExcerptEditText;
     private TextView mPubDateText;
     private ViewGroup mSectionCategories;
     private ViewGroup mRootView;
     private TextView mFeaturedImageLabel;
     private NetworkImageView mFeaturedImageView;
     private Button mFeaturedImageButton;
-    private SuggestionAutoCompleteText mTags;
+    private SuggestionAutoCompleteText mTagsEditText;
 
-    private TagSuggestionAdapter mTagSuggestionAdapter;
     private SuggestionServiceConnectionManager mSuggestionServiceConnectionManager;
 
     private int mFeaturedImageId;
@@ -170,7 +169,6 @@ public class EditPostSettingsFragment extends Fragment
 
             }
         });
-        mTagsEditText = (EditText) mRootView.findViewById(R.id.tags);
         mSectionCategories = ((ViewGroup) mRootView.findViewById(R.id.sectionCategories));
 
         mFeaturedImageLabel = (TextView) mRootView.findViewById(R.id.featuredImageLabel);
@@ -256,9 +254,9 @@ public class EditPostSettingsFragment extends Fragment
                     }
             );
 
-            mTags = (SuggestionAutoCompleteText) mRootView.findViewById(R.id.tags);
-            if (mTags != null) {
-                mTags.setTokenizer(new SuggestionAutoCompleteText.CommaTokenizer());
+            mTagsEditText = (SuggestionAutoCompleteText) mRootView.findViewById(R.id.tags);
+            if (mTagsEditText != null) {
+                mTagsEditText.setTokenizer(new SuggestionAutoCompleteText.CommaTokenizer());
 
                 setupSuggestionServiceAndAdapter();
             }
@@ -300,9 +298,9 @@ public class EditPostSettingsFragment extends Fragment
         remoteBlogId = StringUtils.stringToInt(blogID, -1);
 
         mSuggestionServiceConnectionManager = new SuggestionServiceConnectionManager(getActivity(), remoteBlogId);
-        mTagSuggestionAdapter = SuggestionUtils.setupTagSuggestions(remoteBlogId, getActivity(), mSuggestionServiceConnectionManager);
-        if (mTagSuggestionAdapter != null) {
-            mTags.setAdapter(mTagSuggestionAdapter);
+        TagSuggestionAdapter tagSuggestionAdapter = SuggestionUtils.setupTagSuggestions(remoteBlogId, getActivity(), mSuggestionServiceConnectionManager);
+        if (tagSuggestionAdapter != null) {
+            mTagsEditText.setAdapter(tagSuggestionAdapter);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -43,6 +43,7 @@ import android.widget.Toast;
 import com.android.volley.toolbox.NetworkImageView;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import com.helpshift.util.StringUtil;
 
 import org.apache.commons.lang.StringEscapeUtils;
 import org.json.JSONArray;
@@ -66,6 +67,7 @@ import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.GeocoderUtils;
 import org.wordpress.android.util.JSONUtils;
 import org.wordpress.android.util.PermissionUtils;
+import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.LocationHelper;
 import org.wordpress.android.widgets.SuggestionAutoCompleteText;
@@ -101,7 +103,6 @@ public class EditPostSettingsFragment extends Fragment
 
     private TagSuggestionAdapter mTagSuggestionAdapter;
     private SuggestionServiceConnectionManager mSuggestionServiceConnectionManager;
-    private int remoteBlogId;
 
     private int mFeaturedImageId;
 
@@ -259,16 +260,6 @@ public class EditPostSettingsFragment extends Fragment
             if (mTags != null) {
                 mTags.setTokenizer(new SuggestionAutoCompleteText.CommaTokenizer());
 
-                remoteBlogId = -1;
-                String blogID = WordPress.getCurrentRemoteBlogId();
-                if (blogID != null) {
-                    try {
-                        remoteBlogId = Integer.parseInt(blogID);
-                    } catch (NumberFormatException e) {
-                        AppLog.e(T.EDITOR, "The remote blog ID can't be parsed as Integer: " + remoteBlogId);
-                    }
-                }
-
                 setupSuggestionServiceAndAdapter();
             }
         }
@@ -303,6 +294,10 @@ public class EditPostSettingsFragment extends Fragment
 
     private void setupSuggestionServiceAndAdapter() {
         if (!isAdded()) return;
+
+        int remoteBlogId = -1;
+        String blogID = WordPress.getCurrentRemoteBlogId();
+        remoteBlogId = StringUtils.stringToInt(blogID, -1);
 
         mSuggestionServiceConnectionManager = new SuggestionServiceConnectionManager(getActivity(), remoteBlogId);
         mTagSuggestionAdapter = SuggestionUtils.setupTagSuggestions(remoteBlogId, getActivity(), mSuggestionServiceConnectionManager);


### PR DESCRIPTION
(cont'd from this PR https://github.com/wordpress-mobile/WordPress-Android/pull/4021, which fixes #4013 )

Detail:
There were some tags initialisers in `onCreateOptionsMenu` in EditPostActivity.java. This PR moves that code out of the Activity and makes it be part of the EditPostSettingsFragment where it belongs.

To test:
1) go to blog posts
2) edit/create a blog post for a site that has no tags yet (or erase the app's data before starting to test)
3) go to Post settings screen (see option at the bottom of the Edit screen)

Things to observe:
a) It should not break (force close), and tags for your post should be saved. 
b) It should bind/unbind the service once per fragment creation for EditPostSettingsFragment only (to be checked by placing breakpoints [here](https://github.com/wordpress-mobile/WordPress-Android/compare/issue/4013-serviceconnection-leak-part-2?expand=1#diff-2a05761a1946e0ddb314645e44ab3eb6R132) and [here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/suggestion/util/SuggestionUtils.java#L57)

