### PR TITLE
People management remove display name property

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
@@ -30,7 +30,6 @@ public class PeopleTable {
                 + "user_name               TEXT,"
                 + "first_name              TEXT,"
                 + "last_name               TEXT,"
-                + "display_name            TEXT,"
                 + "avatar_url              TEXT,"
                 + "role                    TEXT,"
                 + "PRIMARY KEY (person_id, local_blog_id)"
@@ -58,7 +57,6 @@ public class PeopleTable {
         values.put("user_name", person.getUsername());
         values.put("first_name", person.getFirstName());
         values.put("last_name", person.getLastName());
-        values.put("display_name", person.getDisplayName());
         values.put("avatar_url", person.getAvatarUrl());
         values.put("role", Role.toKey(person.getRole()));
         database.insertWithOnConflict(PEOPLE_TABLE, null, values, SQLiteDatabase.CONFLICT_REPLACE);
@@ -117,10 +115,9 @@ public class PeopleTable {
         String username = c.getString(c.getColumnIndex("user_name"));
         String firstName = c.getString(c.getColumnIndex("first_name"));
         String lastName = c.getString(c.getColumnIndex("last_name"));
-        String displayName = c.getString(c.getColumnIndex("display_name"));
         String avatarUrl = c.getString(c.getColumnIndex("avatar_url"));
         Role role = Role.fromKey(c.getString(c.getColumnIndex("role")));
 
-        return new Person(personId, localTableBlogId, username, firstName, lastName, displayName, avatarUrl, role);
+        return new Person(personId, localTableBlogId, username, firstName, lastName, avatarUrl, role);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/Person.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Person.java
@@ -13,7 +13,6 @@ public class Person {
     private String username;
     private String firstName;
     private String lastName;
-    private String displayName;
     private String avatarUrl;
     private Role role;
 
@@ -22,7 +21,6 @@ public class Person {
                   String username,
                   String firstName,
                   String lastName,
-                  String displayName,
                   String avatarUrl,
                   Role role) {
         this.personID = personID;
@@ -30,7 +28,6 @@ public class Person {
         this.username = username;
         this.firstName = firstName;
         this.lastName = lastName;
-        this.displayName = displayName;
         this.avatarUrl = avatarUrl;
         this.role = role;
     }
@@ -47,12 +44,11 @@ public class Person {
             String username = json.optString("login");
             String firstName = json.optString("first_name");
             String lastName = json.optString("last_name");
-            String displayName = json.optString("nice_name");
             String avatarUrl = json.optString("avatar_URL");
             // We don't support multiple roles, so the first role is picked just as it's in Calypso
             Role role = Role.fromKey(json.optJSONArray("roles").optString(0));
 
-            return new Person(personID, localTableBlogId, username, firstName, lastName, displayName, avatarUrl, role);
+            return new Person(personID, localTableBlogId, username, firstName, lastName, avatarUrl, role);
         } catch (JSONException e) {
             AppLog.e(AppLog.T.PEOPLE, "JSON exception occurred while parsing the user json: " + e);
         } catch (NumberFormatException e) {
@@ -95,11 +91,7 @@ public class Person {
     }
 
     public String getDisplayName() {
-        return displayName;
-    }
-
-    public void setDisplayName(String displayName) {
-        this.displayName = displayName;
+        return getFirstName() + " " + getLastName();
     }
 
     public Role getRole() {


### PR DESCRIPTION
Relevant #3901. This PR removes the `displayName` property from `Person` model because `site/users` endpoint doesn't return the display name. It instead returns the username in `nice_name` field. I don't think we want to show that. So, there is no point on storing this information in the DB. Instead, we can just combine first & last name to show in the UI.

I didn't add a separate migration to this, since it never made it to `develop` and no users has it. To keep things simpler, I changed the previous migration instead. If you have already made the migration, you might need a clean install (/cc @hypest).

/cc @astralbodies 

Needs review: @hypest 

