### PR TITLE
fix #4029: disable Auto Fill when adding a self hosted site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -224,7 +224,6 @@ public class SignInFragment extends AbstractFragment implements TextWatcher, Con
         initInfoButtons(rootView);
         moveBottomButtons();
         initSmartLockForPasswords();
-
         return rootView;
     }
 
@@ -310,7 +309,9 @@ public class SignInFragment extends AbstractFragment implements TextWatcher, Con
     }
 
     public void smartLockAutoFill() {
-        if (!isGooglePlayServicesAvailable() || mCredentialsClient == null) {
+        // We don't want to autofill username and password fields if self hosted has been selected (pre-selected or
+        // user selected).
+        if (!isGooglePlayServicesAvailable() || mCredentialsClient == null || mSelfHosted) {
             return;
         }
         CredentialRequest credentialRequest = new CredentialRequest.Builder()


### PR DESCRIPTION
It will fix #4029, and will also fix a minor UX issue when the user tap "Add self hosted" and auto fill is triggered  late after the activity init (can happen because Smart Lock pulls data from Google's servers).