### PR TITLE
issue/4034-reader-follow-default-tag

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -180,11 +180,12 @@ public class ReaderTag implements Serializable, FilterCriteria {
     }
 
     @Override
-    public boolean equals(Object tag){
-        if (tag == null) return false;
-
-        if (!ReaderTag.class.isAssignableFrom(tag.getClass())) return false;
-
-        return getLabel().equals(((ReaderTag) tag).getLabel());
+    public boolean equals(Object object){
+        if (object instanceof ReaderTag) {
+            ReaderTag tag = (ReaderTag) object;
+            return (tag.tagType == this.tagType && tag.getLabel().equals(this.getLabel()));
+        } else {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Fixes #4034

To test: In the web reader, follow a tag named "Posts I Like" then open the Android reader and select that tag. Prior to this fix it would incorrectly show posts from the default "Posts I Like" topic.

The problem was due to not taking the tag type (DEFAULT or FOLLOWING) into account in the `equals` implementation of the `ReaderTag` object.