### PR TITLE
Properly detect when the app goes to the background

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -762,6 +762,20 @@ public class WordPress extends Application {
             }
         }
 
+        /**
+         * The two methods below (startActivityTransitionTimer and stopActivityTransitionTimer)
+         * are used to track when the app goes to background.
+         *
+         * Our implementation uses `onActivityPaused` and `onActivityResumed` of ApplicationLifecycleMonitor
+         * to start and stop the timer that detects when the app goes to background.
+         *
+         * So when the user is simply navigating between the activities, the onActivityPaused() calls `startActivityTransitionTimer`
+         * and starts the timer, but almost immediately the new activity being entered, the ApplicationLifecycleMonitor cancels the timer
+         * in its onActivityResumed method, that in order calls `stopActivityTransitionTimer`.
+         * And so mIsInBackground would be false.
+         *
+         * In the case the app is sent to background, the TimerTask is instead executed, and the code that handles all the background logic is run.
+         */
         private void startActivityTransitionTimer() {
             this.mActivityTransitionTimer = new Timer();
             this.mActivityTransitionTimerTask = new TimerTask() {


### PR DESCRIPTION
Fixes #4033 by adding a Timer and a TimerTask that handles all the `onBackground` code. [Details below].

As explained in the ticket the current implementation doesn't detect when the app goes to background in case of device running in "low memory" condition.

I've tried different solutions, but this one was the most reliable to me. 
The proposed solution use the methods `onActivityPaused` and `onActivityResumed` of `ApplicationLifecycleMonitor` to start and stop the timer that detects when the app goes to background. 

So in the case when the user is simply navigating between the activities, the `onActivityPaused()` starts the timer, but almost immediately the new activity being entered, the ApplicationLifecycleMonitor  cancels the timer in its `onActivityResumed` method. And so `mIsInBackground` would be false.
In the case the app is sent to background, the TimerTask is executed and the code that handles all the background logic is run.

Please, double check that everything is working fine with Dialogs and Prompts.
