### PR TITLE
Use the new version of the Passcode Library (1.2.0)

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     // Provided by the WordPress-Android Repository
     compile 'org.wordpress:drag-sort-listview:0.6.1' // not found in maven central
     compile 'org.wordpress:slidinguppanel:1.0.0' // not found in maven central
-    compile 'org.wordpress:passcodelock:1.1.0'
+    compile 'org.wordpress:passcodelock:1.2.0'
     compile 'org.wordpress:emailchecker:0.3'
 
     // Simperium

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -198,7 +198,7 @@ public class WordPress extends Application {
 
         AppLockManager.getInstance().enableDefaultAppLockIfAvailable(this);
         if (AppLockManager.getInstance().isAppLockFeatureEnabled()) {
-            AppLockManager.getInstance().getCurrentAppLock().setDisabledActivities(
+            AppLockManager.getInstance().getAppLock().setExemptActivities(
                     new String[]{"org.wordpress.android.ui.ShareIntentReceiverActivity"});
         }
 
@@ -518,7 +518,7 @@ public class WordPress extends Application {
         AnalyticsTracker.clearAllData();
 
         // disable passcode lock
-        AbstractAppLock appLock = AppLockManager.getInstance().getCurrentAppLock();
+        AbstractAppLock appLock = AppLockManager.getInstance().getAppLock();
         if (appLock != null) {
             appLock.setPassword(null);
         }


### PR DESCRIPTION
Fix #4041 

Version 1.2.0 of PasscodeLock-Android need to be published on Maven central.
