### PR TITLE
Enable the Visual Editor in 5.4 betas

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -212,6 +212,16 @@ public class WordPress extends Application {
 
         // If users uses a custom locale set it on start of application
         WPActivityUtils.applyLocale(getContext());
+
+        // TODO: remove this after the visual editor is enabled in a release version (5.4 if everything goes well)
+        enableVisualEditorForBetaUsers();
+    }
+
+    private void enableVisualEditorForBetaUsers() {
+        if (BuildConfig.VERSION_NAME.contains("5.4-rc")) {
+            AppPrefs.setVisualEditorAvailable(true);
+            AppPrefs.setVisualEditorEnabled(true);
+        }
     }
 
     private void initAnalytics(final long elapsedTimeOnCreate) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -326,10 +326,8 @@ public class AppPrefs {
     }
 
     public static boolean isVisualEditorAvailable() {
-        // TODO: When we allow users to test the visual editor, we should change this function by:
-        // return BuildConfig.VISUAL_EDITOR_AVAILABLE
-        //        || getBoolean(UndeletablePrefKey.VISUAL_EDITOR_AVAILABLE, false);
-        return BuildConfig.VISUAL_EDITOR_AVAILABLE;
+        return BuildConfig.VISUAL_EDITOR_AVAILABLE
+                || getBoolean(UndeletablePrefKey.VISUAL_EDITOR_AVAILABLE, false);
     }
 
     public static boolean isVisualEditorEnabled() {


### PR DESCRIPTION
If we find a blocking issue with the visual editor during the beta and can't fix it before 5.4 release we could eventually revert 7b72f6a and release final 5.4 with the new editor disabled.

With this patch merged:

* Users who signup via the app have the visual editor enabled
* Users who enable the editor via the "secret" urls will have the visual editor available / enabled - https://bia.is/wpbeta/2016/02/02/wordpress-scheme/
* Users who run the 5.4-rc-N versions will have the visual editor enabled. 

Everyone else will have the legacy editor and for them, the option to enable the visual editor won't show up in the settings.

Note: I prefered to write e239bf9 instead of adding beta build variant because it's easy to make mistake with a new variant (forget a feature flag for instance) while e239bf9 changeset is pretty harmless (and we'll revert it as soon as the visual editor ships in a release version).