### PR TITLE
Fixes #4044 release checks checksum update

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -147,7 +147,7 @@ task generateCrashlyticsConfig(group: "generate", description: "Generate Crashly
         inputFile.withInputStream { stream ->
             properties.load(stream)
         }
-        def crashlyticsApiKey = properties.getProperty('crashlytics.apikey', '0')
+        def crashlyticsApiKey = properties.getProperty('wp.crashlytics.apikey', '0')
         def writer = new FileWriter(outputFile)
         writer.write("""// auto-generated file from ${rootDir}/gradle.properties do not modify
 apiKey=${crashlyticsApiKey}""")

--- a/tools/release-checks.sh
+++ b/tools/release-checks.sh
@@ -92,7 +92,7 @@ function printVersion() {
 function checkGradleProperties() {
 	/bin/echo -n "Check WordPress/gradle.properties..."
 	checksum=`cat WordPress/gradle.properties|grep "^wp."|tr "[A-Z]" "[a-z]"|sed "s/ //g"|sort|sha1sum |cut -d- -f1| sed "s/ //g"`
-	known_checksum="2a9fd98ebd7244da4fa3476cc3acddc37f8d529c"
+	known_checksum="4058cdf3d784e4b79f63514d4780e92c28b5ab78"
 	if [ x$checksum != x$known_checksum ]; then
 		pFail
 		exit 5


### PR DESCRIPTION
Fixes #4044

Also move `crashlytics.apikey` to that group of checked keys.