### PR TITLE
Issue/3979 reader referrer

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -341,7 +341,6 @@ public class WPWebViewActivity extends WebViewActivity {
             return true;
         } else if (itemID == R.id.menu_browser) {
             ReaderActivityLauncher.openUrl(this, mWebView.getUrl(), ReaderActivityLauncher.OpenUrlType.EXTERNAL);
-            // AppLockManager.getInstance().setExtendedTimeout();
             return true;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -212,8 +212,8 @@ public class WPWebViewActivity extends WebViewActivity {
         }
 
         if (TextUtils.isEmpty(authURL) && TextUtils.isEmpty(username) && TextUtils.isEmpty(password)) {
-            // Only the URL to load is passed to this activity. Use a the normal loader
-            // not authenticated, and add our referrer header
+            // Only the URL to load is passed to this activity. Use the normal un-authenticated
+            // loader, optionally with our referrer header
             String referrerUrl = extras.getString(REFERRER_URL);
             if (!TextUtils.isEmpty(referrerUrl)) {
                 Map<String, String> headers = new HashMap<>();

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -3,7 +3,6 @@ package org.wordpress.android.ui;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.Menu;
@@ -21,6 +20,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.models.AccountHelper;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.models.Post;
+import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.UrlUtils;
@@ -28,7 +28,6 @@ import org.wordpress.android.util.WPMeShortlinks;
 import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.util.WPWebViewClient;
 import org.wordpress.android.util.helpers.WPWebChromeClient;
-import org.wordpress.passcodelock.AppLockManager;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
@@ -341,16 +340,8 @@ public class WPWebViewActivity extends WebViewActivity {
             startActivity(Intent.createChooser(share, getText(R.string.share_link)));
             return true;
         } else if (itemID == R.id.menu_browser) {
-            String url = mWebView.getUrl();
-            if (url != null) {
-                Uri uri = Uri.parse(url);
-                if (uri != null) {
-                    Intent i = new Intent(Intent.ACTION_VIEW);
-                    i.setData(uri);
-                    startActivity(i);
-                    AppLockManager.getInstance().setExtendedTimeout();
-                }
-            }
+            ReaderActivityLauncher.openUrl(this, mWebView.getUrl(), ReaderActivityLauncher.OpenUrlType.EXTERNAL);
+            // AppLockManager.getInstance().setExtendedTimeout();
             return true;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WebViewActivity.java
@@ -12,6 +12,8 @@ import android.webkit.WebView;
 
 import org.wordpress.android.R;
 
+import java.util.Map;
+
 /**
  * Basic activity for displaying a WebView.
  */
@@ -133,6 +135,10 @@ public abstract class WebViewActivity extends AppCompatActivity {
      */
     protected void loadUrl(String url) {
         mWebView.loadUrl(url);
+    }
+
+    public void loadUrl(String url, Map<String, String> additionalHttpHeaders) {
+        mWebView.loadUrl(url, additionalHttpHeaders);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPUrlUtils;
 
 import java.util.HashMap;
@@ -231,21 +232,37 @@ public class ReaderActivityLauncher {
         }
 
         if (openUrlType == OpenUrlType.INTERNAL) {
-            // That won't work on wpcom sites with custom urls
-            if (WPUrlUtils.isWordPressCom(url)) {
-                WPWebViewActivity.openUrlByUsingWPCOMCredentials(context, url,
-                        AccountHelper.getDefaultAccount().getUserName());
-            } else {
-                WPWebViewActivity.openURL(context, url);
-            }
+            openUrlInternal(context, url);
         } else {
-            try {
-                Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                context.startActivity(intent);
-            } catch (ActivityNotFoundException e) {
-                String readerToastErrorUrlIntent = context.getString(R.string.reader_toast_err_url_intent);
-                ToastUtils.showToast(context, String.format(readerToastErrorUrlIntent, url), ToastUtils.Duration.LONG);
-            }
+            openUrlExternal(context, url);
+        }
+    }
+
+    /*
+     * open the passed url in the app's internal WebView activity
+     */
+    private static void openUrlInternal(Context context, String url) {
+        // That won't work on wpcom sites with custom urls
+        if (WPUrlUtils.isWordPressCom(url)) {
+            WPWebViewActivity.openUrlByUsingWPCOMCredentials(context, url,
+                    AccountHelper.getDefaultAccount().getUserName());
+        } else {
+            WPWebViewActivity.openURL(context, url, ReaderConstants.HTTP_REFERER_URL);
+        }
+    }
+
+    /*
+     * open the passed url in the device's external browser
+     */
+    private static void openUrlExternal(Context context, String url) {
+        try {
+            // add the GA utm_source param to the URL
+            url = UrlUtils.appendUrlParameter(url, "utm_source", ReaderConstants.HTTP_REFERER_URL);
+            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+            context.startActivity(intent);
+        } catch (ActivityNotFoundException e) {
+            String readerToastErrorUrlIntent = context.getString(R.string.reader_toast_err_url_intent);
+            ToastUtils.showToast(context, String.format(readerToastErrorUrlIntent, url), ToastUtils.Duration.LONG);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -227,9 +227,7 @@ public class ReaderActivityLauncher {
         openUrl(context, url, OpenUrlType.INTERNAL);
     }
     public static void openUrl(Context context, String url, OpenUrlType openUrlType) {
-        if (TextUtils.isEmpty(url)) {
-            return;
-        }
+        if (TextUtils.isEmpty(url)) return;
 
         if (openUrlType == OpenUrlType.INTERNAL) {
             openUrlInternal(context, url);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
+import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.ActivityOptionsCompat;
 import android.text.TextUtils;
@@ -228,7 +229,7 @@ public class ReaderActivityLauncher {
         openUrl(context, url, OpenUrlType.INTERNAL);
     }
     public static void openUrl(Context context, String url, OpenUrlType openUrlType) {
-        if (TextUtils.isEmpty(url)) return;
+        if (context == null || TextUtils.isEmpty(url)) return;
 
         if (openUrlType == OpenUrlType.INTERNAL) {
             openUrlInternal(context, url);
@@ -240,7 +241,7 @@ public class ReaderActivityLauncher {
     /*
      * open the passed url in the app's internal WebView activity
      */
-    private static void openUrlInternal(Context context, String url) {
+    private static void openUrlInternal(Context context, @NonNull String url) {
         // That won't work on wpcom sites with custom urls
         if (WPUrlUtils.isWordPressCom(url)) {
             WPWebViewActivity.openUrlByUsingWPCOMCredentials(context, url,
@@ -253,7 +254,7 @@ public class ReaderActivityLauncher {
     /*
      * open the passed url in the device's external browser
      */
-    private static void openUrlExternal(Context context, String url) {
+    private static void openUrlExternal(Context context, @NonNull String url) {
         try {
             // add the GA utm_source param to the URL
             url = UrlUtils.appendUrlParameter(url, "utm_source", ReaderConstants.HTTP_REFERER_URL);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -24,6 +24,7 @@ import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPUrlUtils;
+import org.wordpress.passcodelock.AppLockManager;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -258,6 +259,7 @@ public class ReaderActivityLauncher {
             url = UrlUtils.appendUrlParameter(url, "utm_source", ReaderConstants.HTTP_REFERER_URL);
             Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
             context.startActivity(intent);
+            AppLockManager.getInstance().setExtendedTimeout();
         } catch (ActivityNotFoundException e) {
             String readerToastErrorUrlIntent = context.getString(R.string.reader_toast_err_url_intent);
             ToastUtils.showToast(context, String.format(readerToastErrorUrlIntent, url), ToastUtils.Duration.LONG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -1,14 +1,16 @@
 package org.wordpress.android.ui.reader;
 
 public class ReaderConstants {
-    public static final int  READER_MAX_POSTS_TO_REQUEST       = 20;     // max # posts to request when updating posts
-    public static final int  READER_MAX_POSTS_TO_DISPLAY       = 200;    // max # posts to display
-    public static final int  READER_MAX_COMMENTS_TO_REQUEST    = 20;     // max # top-level comments to request when updating comments
-    public static final int  READER_MAX_USERS_TO_DISPLAY       = 500;    // max # users to show in ReaderUserListActivity
-    public static final long READER_AUTO_UPDATE_DELAY_MINUTES  = 10;     // 10 minute delay between automatic updates
-    public static final int  READER_MAX_RECOMMENDED_TO_REQUEST = 20;     // max # of recommended blogs to request
+    public static final int  READER_MAX_POSTS_TO_REQUEST       = 20;       // max # posts to request when updating posts
+    public static final int  READER_MAX_POSTS_TO_DISPLAY       = 200;      // max # posts to display
+    public static final int  READER_MAX_COMMENTS_TO_REQUEST    = 20;       // max # top-level comments to request when updating comments
+    public static final int  READER_MAX_USERS_TO_DISPLAY       = 500;      // max # users to show in ReaderUserListActivity
+    public static final long READER_AUTO_UPDATE_DELAY_MINUTES  = 10;       // 10 minute delay between automatic updates
+    public static final int  READER_MAX_RECOMMENDED_TO_REQUEST = 20;       // max # of recommended blogs to request
 
-    public static final int MIN_FEATURED_IMAGE_WIDTH = 640;              // min width for an image to be suitable featured image
+    public static final int MIN_FEATURED_IMAGE_WIDTH = 640;                // min width for an image to be suitable featured image
+
+    public static final String HTTP_REFERER_URL = "https://wordpress.com"; // referrer url for reader posts opened in a browser
 
     // intent arguments / keys
     static final String ARG_TAG               = "tag";


### PR DESCRIPTION
Fixes #3979 - Adds referrer information to links opened via the reader:
* For links opened in the internal browser we add the referrer via a header.
* For links opened in the external browser, we add a `utm_source` query param to the URL
In both cases the referrer is set as `https://wordpress.com`.
