### PR TITLE
Issue #4081: Add information about Windows symlink for visual editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ test the project:
 
 You can use [Android Studio][3] by importing the project as a Gradle project.
 
+### Additional Build Instructions for Windows ###
+
+The [visual editor][10] uses a linux-style symlink for its [assets folder][11],
+which has to be converted to a Windows symlink.
+
+From git bash, inside the project root:
+
+    $ rm libs/editor/WordPressEditor/src/main/assets
+    $ git ls-files --deleted -z | git update-index --assume-unchanged -z --stdin
+
+Then, from a Windows command prompt:
+
+    mklink /D [PROJECT_ROOT]\libs\editor\WordPressEditor\src\main\assets %PROJECT_ROOT%\libs\editor\libs\editor-common\assets
+
+Finally, update `[PROJECT_ROOT]\.git\info\exclude` to ignore the symlink locally:
+
+    # editor assets symlink
+    libs/editor/WordPressEditor/src/main/assets
+
 ## Directory structure ##
 
     |-- libs                    # dependencies used to build debug variants
@@ -122,3 +141,5 @@ be covered by a different license compatible with the GPLv2.
 [7]: https://developer.wordpress.com/docs/api/
 [8]: https://facebook.github.io/buck
 [9]: https://facebook.github.io/watchman/docs/install.html
+[10]: https://github.com/wordpress-mobile/WordPress-Editor-Android
+[11]: https://github.com/wordpress-mobile/WordPress-Android/blob/develop/libs/editor/WordPressEditor/src/main/assets

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/Utils.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/Utils.java
@@ -36,7 +36,7 @@ public class Utils {
             InputStream in = assetManager.open(filename);
             return getStringFromInputStream(in);
         } catch (IOException e) {
-            AppLog.e(AppLog.T.EDITOR, e.getMessage());
+            AppLog.e(AppLog.T.EDITOR, "Unable to load editor HTML (is the assets symlink working?): " + e.getMessage());
             return null;
         }
     }


### PR DESCRIPTION
Fixes #4081. When building the editor on windows (or WPAndroid with the visual editor enabled), a linux symlink needs to be converted to a Windows symlink, as per the editor's [build instructions](https://github.com/wordpress-mobile/WordPress-Editor-Android#build-instructions).

If the symlink isn't correctly configured, the app runs but the editor doesn't load, and the only error log is very cryptic:

```
E/WordPress-EDITOR: android-editor.html
```

I added a better message in the event that the editor HTML fails to load, along with a hint that it might be symlink-related. I also added Windows-specific instructions to the WPAndroid README similar to the ones in the editor's own repo.

To test:
Attempt a clean clone and build on Windows, following new build instructions.


Needs review: @kwonye 
