### PR TITLE
[Plans] Add Analytics to plans

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -82,7 +82,7 @@ public class ActivityLauncher {
         Intent intent = new Intent(context, PlansActivity.class);
         intent.putExtra(PlansActivity.ARG_LOCAL_TABLE_BLOG_ID, blogLocalTableId);
         slideInFromRight(context, intent);
-        AnalyticsUtils.trackWithCurrentBlogDetails(AnalyticsTracker.Stat.OPENED_PLANS);
+        AnalyticsUtils.trackWithBlogDetails(AnalyticsTracker.Stat.OPENED_PLANS, WordPress.getBlog(blogLocalTableId));
     }
 
     public static void viewCurrentBlogPosts(Context context) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -82,6 +82,7 @@ public class ActivityLauncher {
         Intent intent = new Intent(context, PlansActivity.class);
         intent.putExtra(PlansActivity.ARG_LOCAL_TABLE_BLOG_ID, blogLocalTableId);
         slideInFromRight(context, intent);
+        AnalyticsUtils.trackWithCurrentBlogDetails(AnalyticsTracker.Stat.OPENED_PLANS);
     }
 
     public static void viewCurrentBlogPosts(Context context) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
@@ -379,7 +379,7 @@ public class PlansActivity extends AppCompatActivity {
                                 AppLog.d(AppLog.T.PLANS, "Purchase Info details: " + info.toString());
                                 AppLog.d(AppLog.T.PLANS, "You have bought the " + info.getSku() + ". Excellent choice, adventurer!");
                             }
-                            analyticsProperties.put("product_id", plan.getProductID();
+                            analyticsProperties.put("product_id", plan.getProductID());
                             analyticsProperties.put("product_name", plan.getProductNameShort());
                             analyticsProperties.put("product_slug", plan.getProductSlug());
                             analyticsProperties.put("bill_period", plan.getBillPeriod());

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
@@ -355,7 +355,7 @@ public class PlansActivity extends AppCompatActivity {
     private void startPurchaseProcess(int position) {
         final Plan plan = getPageAdapter().getPlan(position);
         String sku = plan.getAndroidSKU();
-        Blog currentBlog = WordPress.getBlog(mLocalBlogID);
+        final Blog currentBlog = WordPress.getBlog(mLocalBlogID);
         JSONObject extraData = new JSONObject();
         try {
             extraData.put("blog_id", currentBlog.getDotComBlogId());
@@ -391,8 +391,9 @@ public class PlansActivity extends AppCompatActivity {
                                 analyticsProperties.put("reason", result.getResponse());
                             }
 
-                            AnalyticsUtils.trackWithCurrentBlogDetails(
+                            AnalyticsUtils.trackWithBlogDetails(
                                     result.isSuccess() ? AnalyticsTracker.Stat.PRODUCT_PURCHASED : AnalyticsTracker.Stat.PRODUCT_PAYMENT_ERROR,
+                                    currentBlog,
                                     analyticsProperties
                             );
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
@@ -407,7 +407,7 @@ public class PlansActivity extends AppCompatActivity {
                                  */
                                 AppPrefs.setInAppPurchaseRefreshRequired(true);
                                 PlansUtils.synchIAPsWordPressCom();
-                                boolean isBusinessPlan = PlansUtils.isBusinessPlan(plan.getProductID())
+                                boolean isBusinessPlan = PlansUtils.isBusinessPlan(plan.getProductID());
                                 Intent intent = new Intent(PlansActivity.this, PlanPostPurchaseActivity.class);
                                 intent.putExtra(PlanPostPurchaseActivity.ARG_IS_BUSINESS_PLAN, isBusinessPlan);
                                 startActivity(intent);

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
@@ -407,7 +407,7 @@ public class PlansActivity extends AppCompatActivity {
                                  */
                                 AppPrefs.setInAppPurchaseRefreshRequired(true);
                                 PlansUtils.synchIAPsWordPressCom();
-                                boolean isBusinessPlan = (mViewPager.getCurrentItem() == mViewPager.getAdapter().getCount() - 1);
+                                boolean isBusinessPlan = PlansUtils.isBusinessPlan(plan.getProductID())
                                 Intent intent = new Intent(PlansActivity.this, PlanPostPurchaseActivity.class);
                                 intent.putExtra(PlanPostPurchaseActivity.ARG_IS_BUSINESS_PLAN, isBusinessPlan);
                                 startActivity(intent);

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansUtils.java
@@ -102,6 +102,16 @@ public class PlansUtils {
     }
 
     /**
+     * Weather the plan ID is a business plan.
+     *
+     * @param planID - The plan ID
+     * @return boolean - true if the current blog is on a business plan.
+     */
+    public static boolean isBusinessPlan(long planID) {
+        return planID == PlansConstants.JETPACK_BUSINESS_PLAN_ID || planID == PlansConstants.BUSINESS_PLAN_ID;
+    }
+
+    /**
      * Weather the plan ID is a free plan.
      *
      * @param planID - The plan ID

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -103,6 +103,7 @@ public final class AnalyticsTracker {
         NOTIFICATION_FLAGGED_AS_SPAM,
         OPENED_POSTS,
         OPENED_PAGES,
+        OPENED_PLANS,
         OPENED_COMMENTS,
         OPENED_VIEW_SITE,
         OPENED_VIEW_ADMIN,
@@ -171,7 +172,9 @@ public final class AnalyticsTracker {
         SITE_SETTINGS_DELETE_SITE_REQUESTED,
         SITE_SETTINGS_DELETE_SITE_RESPONSE_OK,
         SITE_SETTINGS_DELETE_SITE_RESPONSE_ERROR,
-        ABTEST_START
+        ABTEST_START,
+        PRODUCT_PURCHASED,
+        PRODUCT_PAYMENT_ERROR
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
@@ -619,6 +619,10 @@ public class AnalyticsTrackerMixpanel extends Tracker {
                 instructions = AnalyticsTrackerMixpanelInstructionsForStat.
                         mixpanelInstructionsForEventName("Site Menu - Opened Pages");
                 break;
+            case OPENED_PLANS:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Site Menu - Opened Plans");
+                break;
             case OPENED_COMMENTS:
                 instructions = AnalyticsTrackerMixpanelInstructionsForStat.
                         mixpanelInstructionsForEventName("Site Menu - Opened Comments");
@@ -1015,6 +1019,12 @@ public class AnalyticsTrackerMixpanel extends Tracker {
                 break;
             case ABTEST_START:
                 instructions = AnalyticsTrackerMixpanelInstructionsForStat.mixpanelInstructionsForEventName("AB Test - Started");
+                break;
+            case PRODUCT_PURCHASED:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.mixpanelInstructionsForEventName("Plans - Product Purchased");
+                break;
+            case PRODUCT_PAYMENT_ERROR:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.mixpanelInstructionsForEventName("AB Test - Product Payment Error");
                 break;
             default:
                 instructions = null;

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -253,7 +253,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 predefinedEventProperties.put("menu_item", "pages");
                 break;
             case OPENED_PLANS:
-                eventName = "plans_view";
+                eventName = "site_menu_opened";
+                predefinedEventProperties.put("menu_item", "plans");
                 break;
             case OPENED_COMMENTS:
                 eventName = "site_menu_opened";

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -252,6 +252,9 @@ public class AnalyticsTrackerNosara extends Tracker {
                 eventName = "site_menu_opened";
                 predefinedEventProperties.put("menu_item", "pages");
                 break;
+            case OPENED_PLANS:
+                eventName = "plans_view";
+                break;
             case OPENED_COMMENTS:
                 eventName = "site_menu_opened";
                 predefinedEventProperties.put("menu_item", "comments");
@@ -536,6 +539,12 @@ public class AnalyticsTrackerNosara extends Tracker {
                 break;
             case ABTEST_START:
                 eventName = "abtest_start";
+                break;
+            case PRODUCT_PURCHASED:
+                eventName = "checkout_product_purchase";
+                break;
+            case PRODUCT_PAYMENT_ERROR:
+                eventName = "checkout_payment_error";
                 break;
             default:
                 eventName = null;


### PR DESCRIPTION
Added 3 new events to analytics:

- `checkout_product_purchase` - when the purchase is completed with success.
- `checkout_payment_error` - when the purchase fails on the Google Store.
- `plans_view` - when the user opens the Plans menu item.

Ive' tried to re-use the same event names we've in `calypso`.

Relevant tracks events found on the backed:
```
calypso_plans_view
calypso_plans_compare
calypso_checkout_form_submit
calypso_checkout_page_view
calypso_checkout_product_purchase
calypso_checkout_payment_error
calypso_purchases_click_contact_support
calypso_checkout_thank_you_view
** Others not relevant to us
```

cc @astralbodies 
cc @frosty @koke - Could you guys get a close look to this PR?
Properties tracked down here are some of those already tracked in the `calypso` version.