### PR TITLE
Reader: Drop `utm_source` param when opening external URLs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -23,7 +23,6 @@ import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.passcodelock.AppLockManager;
 
@@ -256,8 +255,6 @@ public class ReaderActivityLauncher {
      */
     private static void openUrlExternal(Context context, @NonNull String url) {
         try {
-            // add the GA utm_source param to the URL
-            url = UrlUtils.appendUrlParameter(url, "utm_source", ReaderConstants.HTTP_REFERER_URL);
             Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
             context.startActivity(intent);
             AppLockManager.getInstance().setExtendedTimeout();


### PR DESCRIPTION
Fixes #4092 - It turns out that the `utm_source` param is unnecessary (ignored) when opening external links from the reader, so this PR drops it.