### PR TITLE
Add UploadPostTask to the SERIAL_EXECUTOR AsyncTask queue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -147,7 +147,7 @@ public class PostUploadService extends Service {
                 if (mPostsList.size() > 0) {
                     mCurrentUploadingPost = mPostsList.remove(0);
                     mCurrentTask = new UploadPostTask();
-                    mCurrentTask.execute(mCurrentUploadingPost);
+                    mCurrentTask.executeOnExecutor(AsyncTask.SERIAL_EXECUTOR, mCurrentUploadingPost);
                 } else {
                     stopSelf();
                 }


### PR DESCRIPTION
The root cause of #3966 is probably concurrent calls to `NotificationManager` methods.

I'm not sure why this crash happen only on 6.0+ Android ROMs (and particularly on Samsung), also before this patch, we should not have multiple `UploadPostTask` running in the same time since they're added to a queue and executed only when one has finished.

By making sure we add `UploadPostTask` to a serial executor, we should fix #3966.

