### PR TITLE
Optimize Optimizely startup

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
@@ -4,15 +4,11 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 
-import com.optimizely.Optimizely;
-
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.util.ProfilingUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.WPOptimizelyEventListener;
 
 public class WPLaunchActivity extends Activity {
 
@@ -34,16 +30,9 @@ public class WPLaunchActivity extends Activity {
             return;
         }
 
-        configureOptimizely();
-
         Intent intent = new Intent(this, WPMainActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
         startActivity(intent);
         finish();
-    }
-
-    private void configureOptimizely() {
-        Optimizely.addOptimizelyEventListener(new WPOptimizelyEventListener());
-        Optimizely.startOptimizelyWithAPIToken(BuildConfig.OPTIMIZELY_TOKEN, getApplication());
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -15,9 +15,11 @@ import android.text.TextUtils;
 import android.view.View;
 import android.widget.TextView;
 
+import com.optimizely.Optimizely;
 import com.simperium.client.Bucket;
 import com.simperium.client.BucketObjectMissingException;
 
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.GCMMessageService;
 import org.wordpress.android.GCMRegistrationIntentService;
 import org.wordpress.android.R;
@@ -55,6 +57,7 @@ import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ProfilingUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.WPOptimizelyEventListener;
 import org.wordpress.android.widgets.WPViewPager;
 
 import de.greenrobot.event.EventBus;
@@ -177,6 +180,7 @@ public class WPMainActivity extends Activity implements Bucket.Listener<Note> {
 
         if (savedInstanceState == null) {
             if (AccountHelper.isSignedIn()) {
+                startOptimizely(true);
                 // open note detail if activity called from a push, otherwise return to the tab
                 // that was showing last time
                 boolean openedFromPush = (getIntent() != null && getIntent().getBooleanExtra(ARG_OPENED_FROM_PUSH,
@@ -192,8 +196,18 @@ public class WPMainActivity extends Activity implements Bucket.Listener<Note> {
                     checkMagicLinkSignIn();
                 }
             } else {
+                startOptimizely(false);
                 ActivityLauncher.showSignInForResult(this);
             }
+        }
+    }
+
+    private void startOptimizely(boolean isAsync) {
+        Optimizely.addOptimizelyEventListener(new WPOptimizelyEventListener());
+        if (isAsync) {
+            Optimizely.startOptimizelyAsync(BuildConfig.OPTIMIZELY_TOKEN, getApplication(), null);
+        } else {
+            Optimizely.startOptimizelyWithAPIToken(BuildConfig.OPTIMIZELY_TOKEN, getApplication());
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -203,10 +203,10 @@ public class WPMainActivity extends Activity implements Bucket.Listener<Note> {
     }
 
     private void startOptimizely(boolean isAsync) {
-        Optimizely.addOptimizelyEventListener(new WPOptimizelyEventListener());
         if (isAsync) {
-            Optimizely.startOptimizelyAsync(BuildConfig.OPTIMIZELY_TOKEN, getApplication(), null);
+            Optimizely.startOptimizelyAsync(BuildConfig.OPTIMIZELY_TOKEN, getApplication(), new WPOptimizelyEventListener());
         } else {
+            Optimizely.addOptimizelyEventListener(new WPOptimizelyEventListener());
             Optimizely.startOptimizelyWithAPIToken(BuildConfig.OPTIMIZELY_TOKEN, getApplication());
         }
     }


### PR DESCRIPTION
Fixes #4106 

From my testing (printing out elapsed `System.getCurrentTime()` before and after), it has reduced the average method call time from 6000 ms to 2200 ms.

To test:

Start up the app cleanly (removed from the back stack) both when signed in and signed out. Notice how much faster it is when you are already signed in.

Needs review: @maxme 
