### PR TITLE
Adding isAdded() check to prevent null-pointer exception

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
@@ -54,7 +54,7 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
 
     private void restoreState(Bundle savedInstanceState) {
         if (savedInstanceState != null) {
-            if (savedInstanceState.containsKey(BUNDLE_LAST_SEARCH)) {
+            if (savedInstanceState.containsKey(BUNDLE_LAST_SEARCH) && isAdded()) {
                 mLastSearch = savedInstanceState.getString(BUNDLE_LAST_SEARCH);
                 configureSearchView();
             }


### PR DESCRIPTION
Fixes #3983 

To test:

Unfortunately can't repro. The only reason the actionView should not be available is because the fragment is not visible yet. The `isAdded()` check should prevent the NPE.


Needs review: @tonyr59h 

