### PR TITLE
Use Thread.start() to start a new thread

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SelfHostedSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SelfHostedSiteSettings.java
@@ -133,8 +133,7 @@ class SelfHostedSiteSettings extends SiteSettingsInterface {
      */
     @Override
     protected void fetchRemoteData() {
-
-        Thread thread = new Thread(new Runnable() {
+        new Thread() {
             @Override
             public void run() {
                 Object[] params = {mBlog.getRemoteBlogId(), mBlog.getUsername(), mBlog.getPassword()};
@@ -143,8 +142,7 @@ class SelfHostedSiteSettings extends SiteSettingsInterface {
                 instantiateInterface().callAsync(mOptionsCallback, Method.GET_OPTIONS, params);
                 instantiateInterface().callAsync(mCategoriesCallback, Method.GET_CATEGORIES, params);
             }
-        });
-        thread.run();
+        }.start();
     }
 
     /**


### PR DESCRIPTION
Fixes #

To test:



Needs review: @

To start a new thread, you have to use Thread.start() instead of
Thread.run(). Also there is no need for a intermediary Runnable object
here.