### PR TITLE
Fix #4115: validate self hosted url, add https *and* http variants if scheme is unknown

### DIFF
--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
@@ -150,7 +150,7 @@ public class XMLRPCUtils {
         return URLUtil.isValidUrl(newUrl) ? newUrl : url;
     }
 
-    public static String sanitizeSiteUrl(String siteUrl, boolean isHttps) throws XMLRPCUtilsException {
+    public static String sanitizeSiteUrl(String siteUrl, boolean addHttps) throws XMLRPCUtilsException {
         // remove padding whitespace
         String url = siteUrl.trim();
 
@@ -163,7 +163,7 @@ public class XMLRPCUtils {
         url = UrlUtils.convertUrlToPunycodeIfNeeded(url);
 
         // Add http to the beginning of the URL if needed
-        url = UrlUtils.addUrlSchemeIfNeeded(url, isHttps);
+        url = UrlUtils.addUrlSchemeIfNeeded(url, addHttps);
 
         // strip url from known usual trailing paths
         url = XMLRPCUtils.stripKnownPaths(url);
@@ -313,7 +313,7 @@ public class XMLRPCUtils {
         // add the url as provided by the user
         urlsToTry.add(siteUrl);
 
-        // add a sanitized version of the http url
+        // add a sanitized version of the http url (if the user didn't specify it)
         final String sanitizedHttpsURL = sanitizeSiteUrl(siteUrl, true);
         if (!urlsToTry.contains(sanitizedHttpsURL)) {
             urlsToTry.add(sanitizedHttpsURL);
@@ -325,7 +325,7 @@ public class XMLRPCUtils {
             urlsToTry.add(appendedXmlrpcUrl);
         }
 
-        // add a sanitized version of the https url
+        // add a sanitized version of the https url (if the user didn't specify it)
         final String sanitizedHttpURL = sanitizeSiteUrl(siteUrl, false);
         if (!urlsToTry.contains(sanitizedHttpURL)) {
             urlsToTry.add(sanitizedHttpURL);

--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
@@ -1,5 +1,10 @@
 package org.xmlrpc.android;
 
+import android.support.annotation.StringRes;
+import android.text.TextUtils;
+import android.util.Xml;
+import android.webkit.URLUtil;
+
 import com.android.volley.TimeoutError;
 
 import org.apache.http.conn.ConnectTimeoutException;
@@ -11,13 +16,7 @@ import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPUrlUtils;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
-
 import org.xmlrpc.android.XMLRPCUtils.XMLRPCUtilsException.Kind;
-
-import android.support.annotation.StringRes;
-import android.text.TextUtils;
-import android.util.Xml;
-import android.webkit.URLUtil;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -152,11 +151,6 @@ public class XMLRPCUtils {
     }
 
     public static String sanitizeSiteUrl(String siteUrl) throws XMLRPCUtilsException {
-        if (TextUtils.isEmpty(siteUrl)) {
-            throw new XMLRPCUtilsException(XMLRPCUtilsException.Kind.SITE_URL_CANNOT_BE_EMPTY, R.string
-                    .invalid_site_url_message, siteUrl, null);
-        }
-
         // remove padding whitespace
         String url = siteUrl.trim();
 

--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
@@ -305,7 +305,7 @@ public class XMLRPCUtils {
     // whole process.
     private static String discoverSelfHostedXmlrpcUrl(String siteUrl, String httpUsername, String httpPassword) throws
             XMLRPCUtilsException {
-        // Array of Strings that contains the URLs we want to try
+        // Ordered set of Strings that contains the URLs we want to try
         final Set<String> urlsToTry = new LinkedHashSet<>();
 
         // add the url as provided by the user

--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
@@ -23,8 +23,10 @@ import java.io.StringReader;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -268,21 +270,17 @@ public class XMLRPCUtils {
             throws XMLRPCUtilsException {
         final String sanitizedSiteUrl = XMLRPCUtils.sanitizeSiteUrl(siteUrl, true);
 
-        // Array of Strings that contains the URLs we want to try. No discovery ;)
-        final List<String> urlsToTry = new ArrayList<>();
+        // Ordered set of Strings that contains the URLs we want to try. No discovery ;)
+        final Set<String> urlsToTry = new LinkedHashSet<>();
 
         // start by adding the url with 'xmlrpc.php'. This will be the first url to try.
         urlsToTry.add(XMLRPCUtils.appendXMLRPCPath(sanitizedSiteUrl));
 
         // add the sanitized URL without the '/xmlrpc.php' suffix added to it
-        if (!urlsToTry.contains(sanitizedSiteUrl)) {
-            urlsToTry.add(sanitizedSiteUrl);
-        }
+        urlsToTry.add(sanitizedSiteUrl);
 
         // add the user provided URL as well
-        if (!urlsToTry.contains(siteUrl)) {
-            urlsToTry.add(siteUrl);
-        }
+        urlsToTry.add(siteUrl);
 
         AppLog.i(AppLog.T.NUX, "The app will call system.listMethods on the following URLs: " + urlsToTry);
         for (String url : urlsToTry) {
@@ -308,34 +306,16 @@ public class XMLRPCUtils {
     private static String discoverSelfHostedXmlrpcUrl(String siteUrl, String httpUsername, String httpPassword) throws
             XMLRPCUtilsException {
         // Array of Strings that contains the URLs we want to try
-        final List<String> urlsToTry = new ArrayList<>();
+        final Set<String> urlsToTry = new LinkedHashSet<>();
 
         // add the url as provided by the user
         urlsToTry.add(siteUrl);
 
-        // add a sanitized version of the http url (if the user didn't specify it)
-        final String sanitizedHttpsURL = sanitizeSiteUrl(siteUrl, true);
-        if (!urlsToTry.contains(sanitizedHttpsURL)) {
-            urlsToTry.add(sanitizedHttpsURL);
-        }
-
-        String appendedXmlrpcUrl = appendXMLRPCPath(sanitizedHttpsURL);
-        if (!urlsToTry.contains(appendedXmlrpcUrl)) {
-            appendedXmlrpcUrl += "?rsd";
-            urlsToTry.add(appendedXmlrpcUrl);
-        }
-
         // add a sanitized version of the https url (if the user didn't specify it)
-        final String sanitizedHttpURL = sanitizeSiteUrl(siteUrl, false);
-        if (!urlsToTry.contains(sanitizedHttpURL)) {
-            urlsToTry.add(sanitizedHttpURL);
-        }
+        urlsToTry.add(sanitizeSiteUrl(siteUrl, true));
 
-        appendedXmlrpcUrl = appendXMLRPCPath(sanitizedHttpURL);
-        if (!urlsToTry.contains(appendedXmlrpcUrl)) {
-            appendedXmlrpcUrl += "?rsd";
-            urlsToTry.add(appendedXmlrpcUrl);
-        }
+        // add a sanitized version of the http url (if the user didn't specify it)
+        urlsToTry.add(sanitizeSiteUrl(siteUrl, false));
 
         AppLog.i(AppLog.T.NUX, "The app will call the RSD discovery process on the following URLs: " + urlsToTry);
 

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
@@ -86,25 +86,25 @@ public class UrlUtils {
      * http client will work as expected.
      *
      * @param url url entered by the user or fetched from a server
-     * @param isHTTPS true will make the url starts with https://
-     * @return transformed url prefixed by its http:// or https:// scheme
+     * @param addHttps true and the url is not starting with http://, it will make the url starts with https://
+     * @return url prefixed by http:// or https://
      */
-    public static String addUrlSchemeIfNeeded(String url, boolean isHttps) {
+    public static String addUrlSchemeIfNeeded(String url, boolean addHttps) {
         if (url == null) {
             return null;
         }
 
         // Remove leading double slash (eg. //example.com), needed for some wporg instances configured to
         // switch between http or https
-        url = removeLeadingDoubleSlash(url, (isHttps ? "https" : "http") + "://");
+        url = removeLeadingDoubleSlash(url, (addHttps ? "https" : "http") + "://");
 
         // If the URL is a valid http or https URL, we're good to go
         if (URLUtil.isHttpUrl(url) || URLUtil.isHttpsUrl(url)) {
             return url;
         }
 
-        // Else, remove the old scheme and add prefix it by https:// or http://
-        return (isHttps ? "https" : "http") + "://" + removeScheme(url);
+        // Else, remove the old scheme and prefix it by https:// or http://
+        return (addHttps ? "https" : "http") + "://" + removeScheme(url);
     }
 
     /**

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
@@ -86,25 +86,25 @@ public class UrlUtils {
      * http client will work as expected.
      *
      * @param url url entered by the user or fetched from a server
-     * @param isHTTPS true will make the url starts with https;//
-     * @return transformed url prefixed by its http;// or https;// scheme
+     * @param isHTTPS true will make the url starts with https://
+     * @return transformed url prefixed by its http:// or https:// scheme
      */
-    public static String addUrlSchemeIfNeeded(String url, boolean isHTTPS) {
+    public static String addUrlSchemeIfNeeded(String url, boolean isHttps) {
         if (url == null) {
             return null;
         }
 
         // Remove leading double slash (eg. //example.com), needed for some wporg instances configured to
         // switch between http or https
-        url = removeLeadingDoubleSlash(url, (isHTTPS ? "https" : "http") + "://");
+        url = removeLeadingDoubleSlash(url, (isHttps ? "https" : "http") + "://");
 
-        if (!URLUtil.isValidUrl(url)) {
-            if (!(url.toLowerCase().startsWith("http://")) && !(url.toLowerCase().startsWith("https://"))) {
-                url = (isHTTPS ? "https" : "http") + "://" + url;
-            }
+        // If the URL is a valid http or https URL, we're good to go
+        if (URLUtil.isHttpUrl(url) || URLUtil.isHttpsUrl(url)) {
+            return url;
         }
 
-        return url;
+        // Else, remove the old scheme and add prefix it by https:// or http://
+        return (isHttps ? "https" : "http") + "://" + removeScheme(url);
     }
 
     /**


### PR DESCRIPTION
Fixes #4115 
Fixes #4114

Before the patch the following valid URL was not working:

* `bia.is`

And this invalid URL was crashing the app:

* `hppt://bia.is`

Note: Instead of autoremoving invalid scheme, we could throw and "invalid URL" exception and notify the user they made a typo (From the crash reports, it's always typo like `htt://`, `hppt://`, `htp://`, etc. so I think it's just better to fix it for the user).
