### PR TITLE
Make sure "View Admin" is available in the menu

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/AccountTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/AccountTable.java
@@ -111,10 +111,10 @@ public class AccountTable {
                 account.setFirstName(c.getString(c.getColumnIndex("first_name")));
                 account.setLastName(c.getString(c.getColumnIndex("last_name")));
                 account.setAboutMe(c.getString(c.getColumnIndex("about_me")));
+                account.setDateCreated(DateTimeUtils.iso8601ToJavaDate(c.getString(c.getColumnIndex("date"))));
                 account.setNewEmail(c.getString(c.getColumnIndex("new_email")));
                 account.setPendingEmailChange(c.getInt(c.getColumnIndex("pending_email_change")) > 0);
                 account.setWebAddress(c.getString(c.getColumnIndex("web_address")));
-                account.setDateCreated(DateTimeUtils.iso8601ToJavaDate(c.getString(c.getColumnIndex("date"))));
             }
             return account;
         } finally {

--- a/WordPress/src/main/java/org/wordpress/android/datasets/AccountTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/AccountTable.java
@@ -92,7 +92,7 @@ public class AccountTable {
 
     private static Account getAccountByLocalId(long localId) {
         Account account = new Account();
-
+        
         String[] args = {Long.toString(localId)};
         Cursor c = getReadableDb().rawQuery("SELECT * FROM " + ACCOUNT_TABLE + " WHERE local_id=?", args);
 
@@ -114,6 +114,7 @@ public class AccountTable {
                 account.setNewEmail(c.getString(c.getColumnIndex("new_email")));
                 account.setPendingEmailChange(c.getInt(c.getColumnIndex("pending_email_change")) > 0);
                 account.setWebAddress(c.getString(c.getColumnIndex("web_address")));
+                account.setDateCreated(DateTimeUtils.iso8601ToJavaDate(c.getString(c.getColumnIndex("date"))));
             }
             return account;
         } finally {

--- a/WordPress/src/main/java/org/wordpress/android/datasets/AccountTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/AccountTable.java
@@ -92,7 +92,7 @@ public class AccountTable {
 
     private static Account getAccountByLocalId(long localId) {
         Account account = new Account();
-        
+
         String[] args = {Long.toString(localId)};
         Cursor c = getReadableDb().rawQuery("SELECT * FROM " + ACCOUNT_TABLE + " WHERE local_id=?", args);
 

--- a/WordPress/src/main/java/org/wordpress/android/models/AccountHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/AccountHelper.java
@@ -11,12 +11,18 @@ import org.wordpress.android.datasets.AccountTable;
  */
 public class AccountHelper {
     private static Account sAccount;
+    private final static Object mLock = new Object();
 
     public static Account getDefaultAccount() {
         if (sAccount == null) {
-            sAccount = AccountTable.getDefaultAccount();
-            if (sAccount == null) {
-                sAccount = new Account();
+            // Singleton pattern in concurrent env.
+            synchronized(mLock) {
+                if (sAccount == null) {
+                    sAccount = AccountTable.getDefaultAccount();
+                    if (sAccount == null) {
+                        sAccount = new Account();
+                    }
+                }
             }
         }
         return sAccount;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -343,7 +343,7 @@ public class MySiteFragment extends Fragment
         mScrollView.setVisibility(View.VISIBLE);
         mNoSiteView.setVisibility(View.GONE);
 
-        toggleAdminVisibility();
+        toggleAdminVisibility(blog);
 
         int themesVisibility = ThemeBrowserActivity.isAccessible() ? View.VISIBLE : View.GONE;
         mLookAndFeelHeader.setVisibility(themesVisibility);
@@ -383,17 +383,21 @@ public class MySiteFragment extends Fragment
         }
     }
 
-    private void toggleAdminVisibility() {
-        if (shouldHideWPAdmin()) {
+    private void toggleAdminVisibility(@Nullable final Blog blog) {
+        if (blog == null) {
+            return;
+        }
+        if (shouldHideWPAdmin(blog)) {
             mAdminView.setVisibility(View.GONE);
         } else {
             mAdminView.setVisibility(View.VISIBLE);
         }
     }
 
-    private boolean shouldHideWPAdmin() {
-        Blog blog = WordPress.getCurrentBlog();
-
+    private boolean shouldHideWPAdmin(@Nullable final Blog blog) {
+        if (blog == null) {
+            return false;
+        }
         if (!blog.isDotcomFlag()) {
             return false;
         } else {


### PR DESCRIPTION
Fixes #4004

To test:

- Sign in with an account that has admin privileges
- Go to the My Site tab
- Force stop the app (or swipe from backstack)
- Start the app

The "View Admin" must be there. (If your account was created before 2015-9-7).

The most important commits of this PR are https://github.com/wordpress-mobile/WordPress-Android/commit/76b9af0eb6ad897cec96f63d8210d633ecf29252 and https://github.com/wordpress-mobile/WordPress-Android/commit/7d7117d7007fc8e6f097045979a030a9477b5eef

The others are just optimization.
