### PR TITLE
Block upload and switch to HTML mode until insert image or video has finished

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -589,7 +589,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         MediaUploadService mediaUploadService = MediaUploadService.getInstance();
 
         // Disable format bar buttons while a media upload is in progress
-        if ((mediaUploadService != null && mediaUploadService.hasUploads()) || mEditorFragment.isUploadingMedia()) {
+        if ((mediaUploadService != null && mediaUploadService.hasUploads()) || mEditorFragment.isUploadingMedia() ||
+                mEditorFragment.isActionInProgress()) {
             ToastUtils.showToast(this, R.string.editor_toast_uploading_please_wait, Duration.SHORT);
             return false;
         }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -71,6 +71,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
     private static final float TOOLBAR_ALPHA_ENABLED = 1;
     private static final float TOOLBAR_ALPHA_DISABLED = 0.5f;
+    public static final int MAX_ACTION_TIME_MS = 2000;
 
     private String mTitle = "";
     private String mContentHtml = "";
@@ -105,6 +106,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     private CountDownLatch mGetSelectedTextCountDownLatch;
 
     private final Map<String, ToggleButton> mTagToggleButtonMap = new HashMap<>();
+
+    private long mActionStartedAt = -1;
 
     public static EditorFragment newInstance(String title, String content) {
         EditorFragment fragment = new EditorFragment();
@@ -442,10 +445,15 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
         mEditorFragmentListener.onTrackableEvent(TrackableEvent.HTML_BUTTON_TAPPED);
 
+        if (System.currentTimeMillis() - mActionStartedAt < MAX_ACTION_TIME_MS) {
+            toggleButton.setChecked(false);
+            ToastUtils.showToast(getActivity(), R.string.alert_html_mode_not_ready, ToastUtils.Duration.LONG);
+            return;
+        }
+
         // Don't switch to HTML mode if currently uploading media
         if (!mUploadingMedia.isEmpty()) {
             toggleButton.setChecked(false);
-
             ToastUtils.showToast(getActivity(), R.string.alert_html_toggle_uploading, ToastUtils.Duration.LONG);
             return;
         }
@@ -843,6 +851,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                         mWebView.execJavaScriptFromString("ZSSEditor.insertImage('" + safeMediaUrl + "', '" + mediaId +
                                 "');");
                     }
+                    mActionStartedAt = System.currentTimeMillis();
                 } else {
                     String id = mediaFile.getMediaId();
                     if (mediaFile.isVideo()) {
@@ -1470,5 +1479,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             content.insert(selectionEnd, endTag);
             mSourceViewContent.setSelection(selectionEnd + endTag.length());
         }
+    }
+
+    @Override
+    public void onActionFinished() {
+        mActionStartedAt = -1;
     }
 }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -452,7 +452,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         // Don't switch to HTML mode if currently uploading media
         if (!mUploadingMedia.isEmpty() || isActionInProgress()) {
             toggleButton.setChecked(false);
-            ToastUtils.showToast(getActivity(), R.string.alert_html_toggle_uploading, ToastUtils.Duration.LONG);
+            ToastUtils.showToast(getActivity(), R.string.alert_action_while_uploading, ToastUtils.Duration.LONG);
             return;
         }
 
@@ -583,6 +583,11 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         } else if (id == R.id.format_bar_button_media) {
             mEditorFragmentListener.onTrackableEvent(TrackableEvent.MEDIA_BUTTON_TAPPED);
             ((ToggleButton) v).setChecked(false);
+
+            if (isActionInProgress()) {
+                ToastUtils.showToast(getActivity(), R.string.alert_action_while_uploading, ToastUtils.Duration.LONG);
+                return;
+            }
 
             if (mSourceView.getVisibility() == View.VISIBLE) {
                 ToastUtils.showToast(getActivity(), R.string.alert_insert_image_html_mode, ToastUtils.Duration.LONG);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -438,6 +438,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         }
     }
 
+    public boolean isActionInProgress() {
+        return System.currentTimeMillis() - mActionStartedAt < MAX_ACTION_TIME_MS;
+    }
+
     private void toggleHtmlMode(final ToggleButton toggleButton) {
         if (!isAdded()) {
             return;
@@ -445,14 +449,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
         mEditorFragmentListener.onTrackableEvent(TrackableEvent.HTML_BUTTON_TAPPED);
 
-        if (System.currentTimeMillis() - mActionStartedAt < MAX_ACTION_TIME_MS) {
-            toggleButton.setChecked(false);
-            ToastUtils.showToast(getActivity(), R.string.alert_html_mode_not_ready, ToastUtils.Duration.LONG);
-            return;
-        }
-
         // Don't switch to HTML mode if currently uploading media
-        if (!mUploadingMedia.isEmpty()) {
+        if (!mUploadingMedia.isEmpty() || isActionInProgress()) {
             toggleButton.setChecked(false);
             ToastUtils.showToast(getActivity(), R.string.alert_html_toggle_uploading, ToastUtils.Duration.LONG);
             return;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -21,6 +21,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
     public abstract void appendGallery(MediaGallery mediaGallery);
     public abstract void setUrlForVideoPressId(String videoPressId, String url, String posterUrl);
     public abstract boolean isUploadingMedia();
+    public abstract boolean isActionInProgress();
     public abstract boolean hasFailedMediaUploads();
     public abstract void removeAllFailedMediaUploads();
     public abstract void setTitlePlaceholder(CharSequence text);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/JsCallbackReceiver.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/JsCallbackReceiver.java
@@ -40,6 +40,8 @@ public class JsCallbackReceiver {
 
     private static final String CALLBACK_RESPONSE_STRING = "callback-response-string";
 
+    private static final String CALLBACK_ACTION_FINISHED = "callback-action-finished";
+
     private final OnJsEditorStateChangedListener mListener;
 
     private Set<String> mPreviousStyleSet = new HashSet<>();
@@ -223,6 +225,9 @@ public class JsCallbackReceiver {
                     responseDataSet = Utils.splitDelimitedString(params, JS_CALLBACK_DELIMITER);
                 }
                 mListener.onGetHtmlResponse(Utils.buildMapFromKeyValuePairs(responseDataSet));
+                break;
+            case CALLBACK_ACTION_FINISHED:
+                mListener.onActionFinished();
                 break;
             default:
                 AppLog.d(AppLog.T.EDITOR, "Unhandled callback: " + callbackId + ":" + params);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
@@ -1164,11 +1164,14 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
 
     @Override
     public void setTitlePlaceholder(CharSequence text) {
-
     }
 
     @Override
     public void setContentPlaceholder(CharSequence text) {
+    }
 
+    @Override
+    public boolean isActionInProgress() {
+        return false;
     }
 }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/OnJsEditorStateChangedListener.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/OnJsEditorStateChangedListener.java
@@ -16,4 +16,5 @@ public interface OnJsEditorStateChangedListener {
     void onMediaReplaced(String mediaId);
     void onVideoPressInfoRequested(String videoId);
     void onGetHtmlResponse(Map<String, String> responseArgs);
+    void onActionFinished();
 }

--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
 
     <string name="alert_insert_image_html_mode">Can\'t insert media directly in HTML mode. Please switch back to visual mode.</string>
     <string name="alert_html_toggle_uploading">You are currently uploading media. Please wait until this completes.</string>
+    <string name="alert_html_mode_not_ready">HTML mode not ready, try again.</string>
 
     <string name="stop_upload_dialog_title">Stop uploading?</string>
     <string name="stop_upload_button">Stop Upload</string>

--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -16,7 +16,6 @@
 
     <string name="alert_insert_image_html_mode">Can\'t insert media directly in HTML mode. Please switch back to visual mode.</string>
     <string name="alert_html_toggle_uploading">You are currently uploading media. Please wait until this completes.</string>
-    <string name="alert_html_mode_not_ready">HTML mode not ready, try again.</string>
 
     <string name="stop_upload_dialog_title">Stop uploading?</string>
     <string name="stop_upload_button">Stop Upload</string>

--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
     <string name="uploading_gallery_placeholder">Uploading gallery…</string>
 
     <string name="alert_insert_image_html_mode">Can\'t insert media directly in HTML mode. Please switch back to visual mode.</string>
-    <string name="alert_html_toggle_uploading">You are currently uploading media. Please wait until this completes.</string>
+    <string name="alert_action_while_uploading">You are currently uploading media. Please wait until this completes.</string>
 
     <string name="stop_upload_dialog_title">Stop uploading?</string>
     <string name="stop_upload_button">Stop Upload</string>

--- a/libs/editor/WordPressEditor/src/test/java/org/wordpress/android/editor/EditorFragmentAbstractTest.java
+++ b/libs/editor/WordPressEditor/src/test/java/org/wordpress/android/editor/EditorFragmentAbstractTest.java
@@ -80,6 +80,11 @@ public class EditorFragmentAbstractTest {
         }
 
         @Override
+        public boolean isActionInProgress() {
+            return false;
+        }
+
+        @Override
         public boolean hasFailedMediaUploads() {
             return false;
         }

--- a/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1205,6 +1205,7 @@ ZSSEditor.insertImage = function(url, remoteId, alt) {
     this.insertHTMLWrappedInParagraphTags(html);
 
     this.sendEnabledStyles();
+    this.callback("callback-action-finished");
 };
 
 /**
@@ -1516,6 +1517,7 @@ ZSSEditor.insertVideo = function(videoURL, posterURL, videopressID) {
     this.insertHTMLWrappedInParagraphTags(html);
 
     this.sendEnabledStyles();
+    this.callback("callback-action-finished");
 };
 
 /**


### PR DESCRIPTION
Fixes #wordpress-mobile/WordPress-Editor-Android#294

I'm using time with `mActionStartedAt` instead of a simple boolean because I fear the app/activity/fragment or webview lifecycle could interfere and we could miss the `action-finished` callback.

cc @aforcier 