### PR TITLE
IllegalArgumentException crash in SiteSettingsFragment  

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -740,6 +740,16 @@ public class SiteSettingsFragment extends PreferenceFragment
                 AnalyticsTracker.Stat.SITE_SETTINGS_EXPORT_SITE_ACCESSED);
     }
 
+    private void dismissProgressDialog(ProgressDialog progressDialog) {
+        if (progressDialog != null && progressDialog.isShowing()) {
+            try {
+                progressDialog.dismiss();
+            } catch (IllegalArgumentException e) {
+                // dialog doesn't exist
+            }
+        }
+    }
+
     private void requestPurchasesForDeletionCheck() {
         final Blog currentBlog = WordPress.getCurrentBlog();
         final ProgressDialog progressDialog = ProgressDialog.show(getActivity(), "", getString(R.string.checking_purchases), true, false);
@@ -748,7 +758,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         WordPress.getRestClientUtils().getSitePurchases(currentBlog.getDotComBlogId(), new RestRequest.Listener() {
             @Override
             public void onResponse(JSONObject response) {
-                progressDialog.dismiss();
+                dismissProgressDialog(progressDialog);
                 if (isAdded()) {
                     showPurchasesOrDeleteSiteDialog(response, currentBlog);
                 }
@@ -756,7 +766,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         }, new RestRequest.ErrorListener() {
             @Override
             public void onErrorResponse(VolleyError error) {
-                progressDialog.dismiss();
+                dismissProgressDialog(progressDialog);
                 if (isAdded()) {
                     ToastUtils.showToast(getActivity(), getString(R.string.purchases_request_error));
                     AppLog.e(AppLog.T.API, "Error occurred while requesting purchases for deletion check: " + error.toString());
@@ -1241,7 +1251,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                             if (isAdded()) {
                                 AnalyticsUtils.trackWithCurrentBlogDetails(
                                         AnalyticsTracker.Stat.SITE_SETTINGS_EXPORT_SITE_RESPONSE_OK);
-                                progressDialog.dismiss();
+                                dismissProgressDialog(progressDialog);
                                 Snackbar.make(getView(), R.string.export_email_sent, Snackbar.LENGTH_LONG).show();
                             }
                         }
@@ -1253,7 +1263,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                                 errorProperty.put(ANALYTICS_ERROR_PROPERTY_KEY, error.getMessage());
                                 AnalyticsUtils.trackWithCurrentBlogDetails(
                                         AnalyticsTracker.Stat.SITE_SETTINGS_EXPORT_SITE_RESPONSE_ERROR, errorProperty);
-                                progressDialog.dismiss();
+                                dismissProgressDialog(progressDialog);
                             }
                         }
                     });
@@ -1281,7 +1291,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                             errorProperty.put(ANALYTICS_ERROR_PROPERTY_KEY, error.getMessage());
                             AnalyticsUtils.trackWithCurrentBlogDetails(
                                     AnalyticsTracker.Stat.SITE_SETTINGS_DELETE_SITE_RESPONSE_ERROR, errorProperty);
-                            progressDialog.dismiss();
+                            dismissProgressDialog(progressDialog);
                             handleDeleteSiteError();
                         }
                     });


### PR DESCRIPTION
Fixes #4124

To test:
- Go to site settings and Tap delete site.
- (Better to use a proxy and throttle the REST request).
- Tap home button and move the app in background.
- Wait....

Also fixes another issue where the app crashes if sent in BG while retrieving purchases of a site. The callback in this other case was trying to push a new dialog fragment into the stack, but the parent/target fragment was already paused.

@maxme 
