### PR TITLE
Remove refreshAccountDetails() from onCreateView()

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -180,7 +180,6 @@ public class MeFragment extends Fragment {
         mNotificationsDividerView = rootView.findViewById(R.id.me_notifications_divider);
 
         addDropShadowToAvatar();
-        refreshAccountDetails();
 
         mAvatarContainer.setOnClickListener(new View.OnClickListener() {
             @Override


### PR DESCRIPTION
#### Fix
Remove redundant `refreshAccountDetails()` call from `onCreateView()` since it is also called in `onResume()` as described in https://github.com/wordpress-mobile/WordPress-Android/issues/4068.

#### Test
1. Go to Me.
2. Rotate device.
3. Tap My Profile.
4. Tap back arrow.
5. Rotate device.

#### Review
@nbradbury
