### PR TITLE
Add configuration changes to Notification Settings

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -123,6 +123,7 @@
             android:theme="@style/CalypsoTheme" />
         <activity
             android:name=".ui.prefs.notifications.NotificationsSettingsActivity"
+            android:configChanges="orientation|screenSize"
             android:theme="@style/CalypsoTheme" />
         <activity
             android:name=".networking.SSLCertsViewActivity"


### PR DESCRIPTION
#### Fix
Add orientation and screen size configuration changes to Notifications Settings activity as described in https://github.com/wordpress-mobile/WordPress-Android/issues/3948.

#### Test
1. Go to Me tab.
2. Tap Notification Settings option.
3. Tap blog from Your Sites section.
4. Rotate device.

or

1. Go to Me tab.
2. Tap Notification Settings option.
3. Tap blog from Your Sites section.
4. Tap Notifications tab or Email option.
5. Rotate device.

#### Review
@aerych