### PR TITLE
Remove bottom controls from Gravatar crop screen

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     compile 'org.wordpress:graphview:3.4.0'
     compile 'org.wordpress:persistentedittext:1.0.1'
 
-    compile 'com.yalantis:ucrop:1.2.4'
+    compile 'com.yalantis:ucrop:1.5.0'
     compile 'com.github.xizzhu:simple-tool-tip:0.5.0'
 
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.0'

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -509,6 +509,7 @@ public class MeFragment extends Fragment {
         options.setStatusBarColor(ContextCompat.getColor(context, R.color.status_bar_tint));
         options.setToolbarColor(ContextCompat.getColor(context, R.color.color_primary));
         options.setAllowedGestures(UCropActivity.ALL, UCropActivity.ALL, UCropActivity.ALL);
+        options.setHideBottomControls(true);
 
         UCrop.of(uri, Uri.fromFile(new File(context.getCacheDir(), "cropped_for_gravatar.jpg")))
                 .withAspectRatio(1, 1)


### PR DESCRIPTION
Removes the manual controls at the bottom of the Gravatar update crop screen. Those controls made the screen more complicated than needed.

To test:
* Open app, go to /me screen, tap the Gravatar to change it, select or shoot a photo
* At the "Edit Photo" screen, the bottom controls should be missing


Needs review: @nbradbury 

