### PR TITLE
Issue/reader cleanup rome

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -14,7 +14,6 @@ import android.view.View;
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.models.AccountHelper;
-import org.wordpress.android.models.ReaderComment;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.ui.ActivityLauncher;
@@ -160,17 +159,6 @@ public class ReaderActivityLauncher {
         intent.putExtra(ReaderConstants.ARG_BLOG_ID, blogId);
         intent.putExtra(ReaderConstants.ARG_POST_ID, postId);
         ActivityLauncher.slideInFromRight(context, intent);
-    }
-
-    /*
-     * show users who liked the passed comment
-     */
-    public static void showReaderLikingUsers(Context context, ReaderComment comment) {
-        Intent intent = new Intent(context, ReaderUserListActivity.class);
-        intent.putExtra(ReaderConstants.ARG_BLOG_ID, comment.blogId);
-        intent.putExtra(ReaderConstants.ARG_POST_ID, comment.postId);
-        intent.putExtra(ReaderConstants.ARG_COMMENT_ID, comment.commentId);
-        context.startActivity(intent);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
@@ -60,11 +60,12 @@ public class ReaderBlogFragment extends Fragment
     }
 
     private void checkEmptyView() {
-        if (!isAdded()) {
-            return;
-        }
-        boolean isEmpty = hasBlogAdapter() && getBlogAdapter().isEmpty();
+        if (!isAdded()) return;
+
         TextView emptyView = (TextView) getView().findViewById(R.id.text_empty);
+        if (emptyView == null) return;
+
+        boolean isEmpty = hasBlogAdapter() && getBlogAdapter().isEmpty();
         if (isEmpty) {
             switch (getBlogType()) {
                 case RECOMMENDED:

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderBlogFragment.java
@@ -59,7 +59,7 @@ public class ReaderBlogFragment extends Fragment
         return view;
     }
 
-    void checkEmptyView() {
+    private void checkEmptyView() {
         if (!isAdded()) {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -280,7 +280,7 @@ public class ReaderCommentListActivity extends AppCompatActivity {
 
             // Enable post title click if we came from notifications with a commentId
             if (mCommentId > 0) {
-                mCommentAdapter.setHeaderClickEnabled(true);
+                mCommentAdapter.enableHeaderClicks();
             }
 
             // adapter calls this when data has been loaded & displayed

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -46,6 +46,7 @@ import org.wordpress.android.widgets.RecyclerItemDecoration;
 import org.wordpress.android.widgets.SuggestionAutoCompleteText;
 
 import java.util.List;
+import java.util.Locale;
 
 import de.greenrobot.event.EventBus;
 
@@ -117,8 +118,10 @@ public class ReaderCommentListActivity extends AppCompatActivity {
 
         mCommentBox = (ViewGroup) findViewById(R.id.layout_comment_box);
         mEditComment = (SuggestionAutoCompleteText) mCommentBox.findViewById(R.id.edit_comment);
-        mEditComment.getAutoSaveTextHelper().setUniqueId(String.format("%s%d%d", AccountHelper
-                .getCurrentUsernameForBlog(null), mPostId, mBlogId));
+        mEditComment.getAutoSaveTextHelper().setUniqueId(
+                String.format(Locale.getDefault(),
+                        "%s%d%d",
+                        AccountHelper.getCurrentUsernameForBlog(null), mPostId, mBlogId));
         mSubmitReplyBtn = mCommentBox.findViewById(R.id.btn_submit_reply);
 
         if (!loadPost()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -80,13 +80,15 @@ public class ReaderCommentListActivity extends AppCompatActivity {
         setContentView(R.layout.reader_activity_comment_list);
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-        setSupportActionBar(toolbar);
-        toolbar.setNavigationOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                onBackPressed();
-            }
-        });
+        if (toolbar != null) {
+            setSupportActionBar(toolbar);
+            toolbar.setNavigationOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    onBackPressed();
+                }
+            });
+        }
 
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
@@ -218,19 +220,24 @@ public class ReaderCommentListActivity extends AppCompatActivity {
         super.onSaveInstanceState(outState);
     }
 
+    private void showCommentsClosedMessage(boolean show) {
+        TextView txtCommentsClosed = (TextView) findViewById(R.id.text_comments_closed);
+        if (txtCommentsClosed != null) {
+            txtCommentsClosed.setVisibility(show ? View.VISIBLE : View.GONE);
+        }
+    }
     private boolean loadPost() {
         mPost = ReaderPostTable.getPost(mBlogId, mPostId, true);
         if (mPost == null) {
             return false;
         }
 
-        TextView txtCommentsClosed = (TextView) findViewById(R.id.text_comments_closed);
         if (ReaderUtils.isLoggedOutReader()) {
             mCommentBox.setVisibility(View.GONE);
-            txtCommentsClosed.setVisibility(View.GONE);
+            showCommentsClosedMessage(false);
         } else if (mPost.isCommentsOpen) {
             mCommentBox.setVisibility(View.VISIBLE);
-            txtCommentsClosed.setVisibility(View.GONE);
+            showCommentsClosedMessage(false);
 
             mEditComment.setOnEditorActionListener(new TextView.OnEditorActionListener() {
                 @Override
@@ -251,7 +258,7 @@ public class ReaderCommentListActivity extends AppCompatActivity {
         } else {
             mCommentBox.setVisibility(View.GONE);
             mEditComment.setEnabled(false);
-            txtCommentsClosed.setVisibility(View.VISIBLE);
+            showCommentsClosedMessage(true);
         }
 
         return true;
@@ -327,12 +334,16 @@ public class ReaderCommentListActivity extends AppCompatActivity {
 
     private void showProgress() {
         ProgressBar progress = (ProgressBar) findViewById(R.id.progress_loading);
-        progress.setVisibility(View.VISIBLE);
+        if (progress != null) {
+            progress.setVisibility(View.VISIBLE);
+        }
     }
 
     private void hideProgress() {
         ProgressBar progress = (ProgressBar) findViewById(R.id.progress_loading);
-        progress.setVisibility(View.GONE);
+        if (progress != null) {
+            progress.setVisibility(View.GONE);
+        }
     }
 
     @SuppressWarnings("unused")
@@ -377,6 +388,8 @@ public class ReaderCommentListActivity extends AppCompatActivity {
 
     private void checkEmptyView() {
         TextView txtEmpty = (TextView) findViewById(R.id.text_empty);
+        if (txtEmpty == null) return;
+
         boolean isEmpty = hasCommentAdapter()
                 && getCommentAdapter().isEmpty()
                 && !mIsSubmittingComment;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
@@ -9,6 +9,11 @@ import org.wordpress.android.util.StringUtils;
  * Reader-related EventBus event classes
  */
 public class ReaderEvents {
+
+    private ReaderEvents() {
+        throw new AssertionError();
+    }
+
     public static class FollowedTagsChanged {}
     public static class RecommendedTagsChanged{}
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
@@ -6,6 +6,10 @@ import org.wordpress.android.models.ReaderPost;
 
 public class ReaderInterfaces {
 
+    private ReaderInterfaces() {
+        throw new AssertionError();
+    }
+
     public interface OnPostSelectedListener {
         void onPostSelected(ReaderPost post);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderInterfaces.java
@@ -6,33 +6,33 @@ import org.wordpress.android.models.ReaderPost;
 
 public class ReaderInterfaces {
 
-    public static interface OnPostSelectedListener {
-        public void onPostSelected(ReaderPost post);
+    public interface OnPostSelectedListener {
+        void onPostSelected(ReaderPost post);
     }
 
-    public static interface OnTagSelectedListener {
-        public void onTagSelected(String tagName);
+    public interface OnTagSelectedListener {
+        void onTagSelected(String tagName);
     }
 
     /*
      * called from post detail fragment so toolbar can animate in/out when scrolling
      */
-    public static interface AutoHideToolbarListener {
-        public void onShowHideToolbar(boolean show);
+    public interface AutoHideToolbarListener {
+        void onShowHideToolbar(boolean show);
     }
 
     /*
      * called when user taps the dropdown arrow next to a post to show the popup menu
      */
-    public static interface OnPostPopupListener {
-        public void onShowPostPopup(View view, ReaderPost post);
+    public interface OnPostPopupListener {
+        void onShowPostPopup(View view, ReaderPost post);
     }
 
     /*
      * used by adapters to notify when data has been loaded
      */
     public interface DataLoadedListener {
-        public void onDataLoaded(boolean isEmpty);
+        void onDataLoaded(boolean isEmpty);
     }
 
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerActivity.java
@@ -58,7 +58,7 @@ public class ReaderPhotoViewerActivity extends AppCompatActivity
         }
 
         mViewPager.setPageTransformer(false, new ReaderViewPagerTransformer(TransformType.FLOW));
-        mViewPager.setOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener() {
+        mViewPager.addOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener() {
             @Override
             public void onPageSelected(int position) {
                 updateTitle(position);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPhotoViewerFragment.java
@@ -61,6 +61,7 @@ public class ReaderPhotoViewerFragment extends Fragment {
         return view;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void onAttach(Activity activity) {
         super.onAttach(activity);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -275,7 +275,8 @@ public class ReaderPostDetailFragment extends Fragment
         likeCount.setSelected(isAskingToLike);
         ReaderAnim.animateLikeButton(likeCount.getImageView(), isAskingToLike);
 
-        if (!ReaderPostActions.performLikeAction(mPost, isAskingToLike)) {
+        boolean success = ReaderPostActions.performLikeAction(mPost, isAskingToLike);
+        if (!success) {
             likeCount.setSelected(!isAskingToLike);
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -126,6 +126,7 @@ public class ReaderPostDetailFragment extends Fragment
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void onAttach(Activity activity) {
         super.onAttach(activity);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -568,15 +568,6 @@ public class ReaderPostDetailFragment extends Fragment
      */
     private boolean mIsPostTaskRunning = false;
     private class ShowPostTask extends AsyncTask<Void, Void, Boolean> {
-        TextView txtTitle;
-        TextView txtAuthor;
-        TextView txtBlogName;
-        TextView txtDateLine;
-        TextView txtTag;
-        ReaderFollowButton followButton;
-        ViewGroup layoutHeader;
-        WPNetworkImageView imgAvatar;
-
         @Override
         protected void onPreExecute() {
             mIsPostTaskRunning = true;
@@ -589,11 +580,6 @@ public class ReaderPostDetailFragment extends Fragment
 
         @Override
         protected Boolean doInBackground(Void... params) {
-            final View container = getView();
-            if (container == null) {
-                return false;
-            }
-
             mPost = ReaderPostTable.getPost(mBlogId, mPostId, false);
             if (mPost == null) {
                 return false;
@@ -614,19 +600,6 @@ public class ReaderPostDetailFragment extends Fragment
                     }
                 }
             }
-
-            mReaderWebView.setIsPrivatePost(mPost.isPrivate);
-            mReaderWebView.setBlogSchemeIsHttps(UrlUtils.isHttps(mPost.getBlogUrl()));
-
-            txtTitle = (TextView) container.findViewById(R.id.text_title);
-            txtBlogName = (TextView) container.findViewById(R.id.text_blog_name);
-            txtAuthor = (TextView) container.findViewById(R.id.text_author);
-            txtDateLine = (TextView) container.findViewById(R.id.text_dateline);
-            txtTag = (TextView) container.findViewById(R.id.text_tag);
-
-            layoutHeader = (ViewGroup) container.findViewById(R.id.layout_post_detail_header);
-            followButton = (ReaderFollowButton) layoutHeader.findViewById(R.id.follow_button);
-            imgAvatar = (WPNetworkImageView) container.findViewById(R.id.image_avatar);
 
             return true;
         }
@@ -653,6 +626,19 @@ public class ReaderPostDetailFragment extends Fragment
                 }
                 return;
             }
+
+            mReaderWebView.setIsPrivatePost(mPost.isPrivate);
+            mReaderWebView.setBlogSchemeIsHttps(UrlUtils.isHttps(mPost.getBlogUrl()));
+
+            TextView txtTitle = (TextView) getView().findViewById(R.id.text_title);
+            TextView txtBlogName = (TextView) getView().findViewById(R.id.text_blog_name);
+            TextView txtAuthor = (TextView) getView().findViewById(R.id.text_author);
+            TextView txtDateLine = (TextView) getView().findViewById(R.id.text_dateline);
+            TextView txtTag = (TextView) getView().findViewById(R.id.text_tag);
+
+            ViewGroup layoutHeader = (ViewGroup) getView().findViewById(R.id.layout_post_detail_header);
+            ReaderFollowButton followButton = (ReaderFollowButton) layoutHeader.findViewById(R.id.follow_button);
+            WPNetworkImageView imgAvatar = (WPNetworkImageView) getView().findViewById(R.id.image_avatar);
 
             if (!canShowFooter()) {
                 mLayoutFooter.setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -65,13 +65,13 @@ public class ReaderPostListActivity extends AppCompatActivity {
     protected void onResumeFragments() {
         super.onResumeFragments();
         //this particular Activity doesn't show filtering, so we'll disable the FilteredRecyclerView toolbar here
-        disableFilteredRecylerViewToolbar();
+        disableFilteredRecyclerViewToolbar();
     }
 
     /*
     * This method hides the FilteredRecyclerView toolbar with spinner so to disable content filtering, for reusability
     * */
-    private void disableFilteredRecylerViewToolbar(){
+    private void disableFilteredRecyclerViewToolbar(){
         // make it invisible - setting height to zero here because setting visibility to View.GONE wouldn't take the
         // occupied space, as otherwise expected
         AppBarLayout appBarLayout = (AppBarLayout) findViewById(R.id.app_bar_layout);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -51,6 +51,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.ResourceUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.widgets.RecyclerItemDecoration;
@@ -468,8 +469,8 @@ public class ReaderPostListFragment extends Fragment
             ReaderUtils.setBackgroundToRoundRipple(settingsControl);
         }
         // the following will change the look and feel of the toolbar to match the current design
-        mRecyclerView.setToolbarBackgroundColor(getResources().getColor(R.color.blue_medium));
-        mRecyclerView.setToolbarSpinnerTextColor(getResources().getColor(R.color.white));
+        mRecyclerView.setToolbarBackgroundColor(ResourceUtils.getColorResource(context, R.color.blue_medium));
+        mRecyclerView.setToolbarSpinnerTextColor(ResourceUtils.getColorResource(context, R.color.white));
         mRecyclerView.setToolbarSpinnerDrawable(R.drawable.arrow);
         mRecyclerView.setToolbarLeftAndRightPadding(
                 getResources().getDimensionPixelSize(R.dimen.margin_medium) + spacingHorizontal,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1096,15 +1096,10 @@ public class ReaderPostListFragment extends Fragment
         }
 
         ReaderPostListType type = getPostListType();
-        Map<String, Object> analyticsProperties = new HashMap<>();
 
         switch (type) {
             case TAG_FOLLOWED:
             case TAG_PREVIEW:
-                String key = (type == ReaderPostListType.TAG_PREVIEW ?
-                        AnalyticsTracker.READER_DETAIL_TYPE_TAG_PREVIEW :
-                        AnalyticsTracker.READER_DETAIL_TYPE_NORMAL);
-                analyticsProperties.put(AnalyticsTracker.READER_DETAIL_TYPE_KEY, key);
                 ReaderActivityLauncher.showReaderPostPagerForTag(
                         getActivity(),
                         getCurrentTag(),
@@ -1113,8 +1108,6 @@ public class ReaderPostListFragment extends Fragment
                         post.postId);
                 break;
             case BLOG_PREVIEW:
-                analyticsProperties.put(AnalyticsTracker.READER_DETAIL_TYPE_KEY,
-                        AnalyticsTracker.READER_DETAIL_TYPE_BLOG_PREVIEW);
                 ReaderActivityLauncher.showReaderPostPagerForBlog(
                         getActivity(),
                         post.blogId,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1277,6 +1277,7 @@ public class ReaderPostListFragment extends Fragment
                 mTags.clear();
                 mTags.addAll(tagList);
                 if (mFilterCriteriaLoaderListener != null)
+                    //noinspection unchecked
                     mFilterCriteriaLoaderListener.onFilterCriteriasLoaded((List)mTags);
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -165,6 +165,7 @@ public class ReaderPostPagerActivity extends AppCompatActivity
         return super.onOptionsItemSelected(item);
     }
 
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     private boolean hasPagerAdapter() {
         return (mViewPager != null && mViewPager.getAdapter() != null);
     }
@@ -188,15 +189,29 @@ public class ReaderPostPagerActivity extends AppCompatActivity
             outState.putSerializable(ReaderConstants.ARG_POST_LIST_TYPE, getPostListType());
         }
 
-        if (hasPagerAdapter()) {
-            ReaderBlogIdPostId id = getPagerAdapter().getCurrentBlogIdPostId();
-            if (id != null) {
-                outState.putLong(ReaderConstants.ARG_BLOG_ID, id.getBlogId());
-                outState.putLong(ReaderConstants.ARG_POST_ID, id.getPostId());
-            }
+        ReaderBlogIdPostId id = getAdapterCurrentBlogIdPostId();
+        if (id != null) {
+            outState.putLong(ReaderConstants.ARG_BLOG_ID, id.getBlogId());
+            outState.putLong(ReaderConstants.ARG_POST_ID, id.getPostId());
         }
 
         super.onSaveInstanceState(outState);
+    }
+
+    private ReaderBlogIdPostId getAdapterCurrentBlogIdPostId() {
+        PostPagerAdapter adapter = getPagerAdapter();
+        if (adapter == null) {
+            return null;
+        }
+        return adapter.getCurrentBlogIdPostId();
+    }
+
+    private ReaderBlogIdPostId getAdapterBlogIdPostIdAtPosition(int position) {
+        PostPagerAdapter adapter = getPagerAdapter();
+        if (adapter == null) {
+            return null;
+        }
+        return adapter.getBlogIdPostIdAtPosition(position);
     }
 
     @Override
@@ -217,7 +232,7 @@ public class ReaderPostPagerActivity extends AppCompatActivity
     private void trackPostAtPositionIfNeeded(int position) {
         if (!hasPagerAdapter() || mTrackedPositions.contains(position)) return;
 
-        ReaderBlogIdPostId idPair = getPagerAdapter().getBlogIdPostIdAtPosition(position);
+        ReaderBlogIdPostId idPair = getAdapterBlogIdPostIdAtPosition(position);
         if (idPair == null) return;
 
         AppLog.d(AppLog.T.READER, "reader pager > tracking post at position " + position);
@@ -296,11 +311,11 @@ public class ReaderPostPagerActivity extends AppCompatActivity
     }
 
     private Fragment getActivePagerFragment() {
-        if (hasPagerAdapter()) {
-            return getPagerAdapter().getActiveFragment();
-        } else {
+        PostPagerAdapter adapter = getPagerAdapter();
+        if (adapter == null) {
             return null;
         }
+        return adapter.getActiveFragment();
     }
 
     private ReaderPostDetailFragment getActiveDetailFragment() {
@@ -313,11 +328,11 @@ public class ReaderPostPagerActivity extends AppCompatActivity
     }
 
     private Fragment getPagerFragmentAtPosition(int position) {
-        if (hasPagerAdapter()) {
-            return getPagerAdapter().getFragmentAtPosition(position);
-        } else {
+        PostPagerAdapter adapter = getPagerAdapter();
+        if (adapter == null) {
             return null;
         }
+        return adapter.getFragmentAtPosition(position);
     }
 
     private ReaderPostDetailFragment getDetailFragmentAtPosition(int position) {
@@ -365,9 +380,10 @@ public class ReaderPostPagerActivity extends AppCompatActivity
 
     @SuppressWarnings("unused")
     public void onEventMainThread(ReaderEvents.UpdatePostsEnded event) {
-        if (isFinishing() || !hasPagerAdapter()) {
-            return;
-        }
+        if (isFinishing()) return;
+
+        PostPagerAdapter adapter = getPagerAdapter();
+        if (adapter == null) return;
 
         mIsRequestingMorePosts = false;
         mProgress.setVisibility(View.GONE);
@@ -375,13 +391,13 @@ public class ReaderPostPagerActivity extends AppCompatActivity
         if (event.getResult() == ReaderActions.UpdateResult.HAS_NEW) {
             AppLog.d(AppLog.T.READER, "reader pager > older posts received");
             // remember which post to keep active
-            ReaderBlogIdPostId id = getPagerAdapter().getCurrentBlogIdPostId();
+            ReaderBlogIdPostId id = adapter.getCurrentBlogIdPostId();
             long blogId = (id != null ? id.getBlogId() : 0);
             long postId = (id != null ? id.getPostId() : 0);
             loadPosts(blogId, postId);
         } else {
             AppLog.d(AppLog.T.READER, "reader pager > all posts loaded");
-            getPagerAdapter().mAllPostsLoaded = true;
+            adapter.mAllPostsLoaded = true;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -105,7 +105,7 @@ public class ReaderPostPagerActivity extends AppCompatActivity
             mPostListType = ReaderPostListType.TAG_FOLLOWED;
         }
 
-        mViewPager.setOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener() {
+        mViewPager.addOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener() {
             @Override
             public void onPageSelected(int position) {
                 super.onPageSelected(position);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -180,16 +180,14 @@ class ReaderPostRenderer {
     private String makeImageTag(final String imageUrl, int width, int height, final String imageClass) {
         String newImageUrl = ReaderUtils.getResizedImageUrl(imageUrl, width, height, mPost.isPrivate);
         if (height > 0) {
-            return new StringBuilder("<img class='").append(imageClass).append("'")
-                    .append(" src='").append(newImageUrl).append("'")
-                    .append(" width='").append(pxToDp(width)).append("'")
-                    .append(" height='").append(pxToDp(height)).append("' />")
-                    .toString();
+            return "<img class='" + imageClass + "'" +
+                    " src='" + newImageUrl + "'" +
+                    " width='" + pxToDp(width) + "'" +
+                    " height='" + pxToDp(height) + "' />";
         } else {
-            return new StringBuilder("<img class='").append(imageClass).append("'")
-                    .append( "src='").append(newImageUrl).append("'")
-                    .append(" width='").append(pxToDp(width)).append("' />")
-                    .toString();
+            return "<img class='" + imageClass + "'" +
+                    "src='" + newImageUrl + "'" +
+                    " width='" + pxToDp(width) + "' />";
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -92,7 +92,7 @@ class ReaderPostRenderer {
     void resizeImages() {
         ReaderHtmlUtils.HtmlScannerListener imageListener = new ReaderHtmlUtils.HtmlScannerListener() {
             @Override
-            public void onTagFound(String imageTag, String imageUrl, int start, int end) {
+            public void onTagFound(String imageTag, String imageUrl) {
                 if (!imageUrl.contains("wpcom-smileys")) {
                     replaceImageTag(imageTag, imageUrl);
                 }
@@ -112,7 +112,7 @@ class ReaderPostRenderer {
     void resizeIframes() {
         ReaderHtmlUtils.HtmlScannerListener iframeListener = new ReaderHtmlUtils.HtmlScannerListener() {
             @Override
-            public void onTagFound(String tag, String src, int start, int end) {
+            public void onTagFound(String tag, String src) {
                 replaceIframeTag(tag, src);
             }
             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -89,7 +89,7 @@ class ReaderPostRenderer {
     /*
      * scan the content for images and make sure they're correctly sized for the device
      */
-    void resizeImages() {
+    private void resizeImages() {
         ReaderHtmlUtils.HtmlScannerListener imageListener = new ReaderHtmlUtils.HtmlScannerListener() {
             @Override
             public void onTagFound(String imageTag, String imageUrl) {
@@ -109,7 +109,7 @@ class ReaderPostRenderer {
     /*
      * scan the content for iframes and make sure they're correctly sized for the device
      */
-    void resizeIframes() {
+    private void resizeIframes() {
         ReaderHtmlUtils.HtmlScannerListener iframeListener = new ReaderHtmlUtils.HtmlScannerListener() {
             @Override
             public void onTagFound(String tag, String src) {
@@ -292,11 +292,10 @@ class ReaderPostRenderer {
             newHeight = mResourceVars.videoHeightPx;
         }
 
-        String newTag = new StringBuilder("<iframe src='").append(src).append("'")
-                .append(" frameborder='0' allowfullscreen='true' allowtransparency='true'")
-                .append(" width='").append(pxToDp(newWidth)).append("'")
-                .append(" height='").append(pxToDp(newHeight)).append("' />")
-                .toString();
+        String newTag = "<iframe src='" + src + "'" +
+                " frameborder='0' allowfullscreen='true' allowtransparency='true'" +
+                " width='" + pxToDp(newWidth) + "'" +
+                " height='" + pxToDp(newHeight) + "' />";
 
         int start = mRenderBuilder.indexOf(tag);
         if (start == -1) {
@@ -311,6 +310,7 @@ class ReaderPostRenderer {
      * returns the full content, including CSS, that will be shown in the WebView for this post
      */
     private String formatPostContentForWebView(final String content) {
+        @SuppressWarnings("StringBufferReplaceableByString")
         StringBuilder sbHtml = new StringBuilder("<!DOCTYPE html><html><head><meta charset='UTF-8' />");
 
         // title isn't necessary, but it's invalid html5 without one

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -188,6 +188,7 @@ class ReaderPostRenderer {
         int newHeight;
         if (width > 0 && height > 0) {
             if (height > width) {
+                //noinspection SuspiciousNameCombination
                 newHeight = mResourceVars.fullSizeImageWidthPx;
                 float ratio = ((float) width / (float) height);
                 newWidth = (int) (newHeight * ratio);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -97,10 +97,6 @@ class ReaderPostRenderer {
                     replaceImageTag(imageTag, imageUrl);
                 }
             }
-            @Override
-            public void onScanCompleted() {
-                // nop
-            }
         };
         ReaderImageScanner scanner = new ReaderImageScanner(mRenderBuilder.toString(), mPost.isPrivate);
         scanner.beginScan(imageListener);
@@ -114,10 +110,6 @@ class ReaderPostRenderer {
             @Override
             public void onTagFound(String tag, String src) {
                 replaceIframeTag(tag, src);
-            }
-            @Override
-            public void onScanCompleted() {
-                // nop
             }
         };
         ReaderIframeScanner scanner = new ReaderIframeScanner(mRenderBuilder.toString());

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -43,6 +43,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.ResourceUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.widgets.WPViewPager;
@@ -89,8 +90,8 @@ public class ReaderSubsActivity extends AppCompatActivity
 
         TabLayout tabLayout = (TabLayout) findViewById(R.id.tab_layout);
         tabLayout.setTabMode(TabLayout.MODE_SCROLLABLE);
-        int normalColor = ReaderUtils.getColorResource(this, R.color.blue_light);
-        int selectedColor = ReaderUtils.getColorResource(this, R.color.white);
+        int normalColor = ResourceUtils.getColorResource(this, R.color.blue_light);
+        int selectedColor = ResourceUtils.getColorResource(this, R.color.white);
         tabLayout.setTabTextColors(normalColor, selectedColor);
         tabLayout.setTabMode(TabLayout.MODE_SCROLLABLE);
         tabLayout.setupWithViewPager(mViewPager);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -420,7 +420,7 @@ public class ReaderSubsActivity extends AppCompatActivity
         // note that this uses the endpoint to follow as a feed since typed URLs are more
         // likely to point to a feed than a wp blog (and the endpoint should internally
         // follow it as a blog if it is one)
-        ReaderBlogActions.followFeedByUrl(normUrl, true, followListener);
+        ReaderBlogActions.followFeedByUrl(normUrl, followListener);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -89,8 +89,8 @@ public class ReaderSubsActivity extends AppCompatActivity
 
         TabLayout tabLayout = (TabLayout) findViewById(R.id.tab_layout);
         tabLayout.setTabMode(TabLayout.MODE_SCROLLABLE);
-        int normalColor = getResources().getColor(R.color.blue_light);
-        int selectedColor = getResources().getColor(R.color.white);
+        int normalColor = ReaderUtils.getColorResource(this, R.color.blue_light);
+        int selectedColor = ReaderUtils.getColorResource(this, R.color.white);
         tabLayout.setTabTextColors(normalColor, selectedColor);
         tabLayout.setTabMode(TabLayout.MODE_SCROLLABLE);
         tabLayout.setupWithViewPager(mViewPager);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -97,13 +97,16 @@ public class ReaderSubsActivity extends AppCompatActivity
         tabLayout.setupWithViewPager(mViewPager);
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-        setSupportActionBar(toolbar);
-        toolbar.setNavigationOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                onBackPressed();
-            }
-        });
+        if (toolbar != null) {
+            setSupportActionBar(toolbar);
+            toolbar.setNavigationOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    onBackPressed();
+                }
+            });
+        }
+
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             // Shadow removed on Activities with a tab toolbar

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTagFragment.java
@@ -35,14 +35,15 @@ public class ReaderTagFragment extends Fragment implements ReaderTagAdapter.TagD
     }
 
     private void checkEmptyView() {
-        if (!isAdded()) {
-            return;
-        }
-        boolean isEmpty = hasTagAdapter() && getTagAdapter().isEmpty();
+        if (!isAdded()) return;
+
         TextView emptyView = (TextView) getView().findViewById(R.id.text_empty);
-        emptyView.setVisibility(isEmpty ? View.VISIBLE : View.GONE);
-        if (isEmpty) {
-            emptyView.setText(R.string.reader_empty_followed_tags);
+        if (emptyView != null) {
+            boolean isEmpty = hasTagAdapter() && getTagAdapter().isEmpty();
+            emptyView.setVisibility(isEmpty ? View.VISIBLE : View.GONE);
+            if (isEmpty) {
+                emptyView.setText(R.string.reader_empty_followed_tags);
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTypes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderTypes.java
@@ -5,17 +5,13 @@ public class ReaderTypes {
 
     public static final ReaderPostListType DEFAULT_POST_LIST_TYPE = ReaderPostListType.TAG_FOLLOWED;
 
-    public static enum ReaderPostListType {
+    public enum ReaderPostListType {
         TAG_FOLLOWED,   // list posts in a followed tag
         TAG_PREVIEW,    // list posts in a specific tag
         BLOG_PREVIEW;   // list posts in a specific blog/feed
 
         public boolean isTagType() {
             return this.equals(TAG_FOLLOWED) || this.equals(TAG_PREVIEW);
-        }
-
-        public boolean isPreviewType() {
-            return this.equals(TAG_PREVIEW) || this.equals(BLOG_PREVIEW);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderUserListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderUserListActivity.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.reader;
 
 import android.os.Bundle;
+import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.Toolbar;
@@ -13,9 +14,9 @@ import org.wordpress.android.datasets.ReaderUserTable;
 import org.wordpress.android.models.ReaderUserList;
 import org.wordpress.android.ui.reader.adapters.ReaderUserAdapter;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
-import org.wordpress.android.widgets.RecyclerItemDecoration;
 import org.wordpress.android.ui.reader.views.ReaderRecyclerView;
 import org.wordpress.android.util.DisplayUtils;
+import org.wordpress.android.widgets.RecyclerItemDecoration;
 
 /*
  * displays a list of users who like a specific reader post
@@ -34,15 +35,21 @@ public class ReaderUserListActivity extends AppCompatActivity {
         setTitle(null);
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-        setSupportActionBar(toolbar);
-        toolbar.setNavigationOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                onBackPressed();
-            }
-        });
-        getSupportActionBar().setDisplayShowTitleEnabled(true);
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        if (toolbar != null) {
+            setSupportActionBar(toolbar);
+            toolbar.setNavigationOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    onBackPressed();
+                }
+            });
+        }
+
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            getSupportActionBar().setDisplayShowTitleEnabled(true);
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
 
         if (savedInstanceState != null) {
             mRestorePosition = savedInstanceState.getInt(ReaderConstants.KEY_RESTORE_POSITION);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderViewPagerTransformer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderViewPagerTransformer.java
@@ -12,7 +12,7 @@ import android.view.View;
  * http://developer.android.com/training/animation/screen-slide.html#pagetransformer
  */
 class ReaderViewPagerTransformer implements ViewPager.PageTransformer {
-    static enum TransformType {
+    enum TransformType {
         FLOW,
         DEPTH,
         ZOOM,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -252,17 +252,14 @@ public class ReaderBlogActions {
             return false;
         }
 
-        final boolean isSubscribed;
+        boolean isSubscribed;
         if (json.has("subscribed")) {
             // read/follows/
             isSubscribed = json.optBoolean("subscribed", false);
-        } else if (json.has("is_following")) {
-            // site/$site/follows/
-            isSubscribed = json.optBoolean("is_following", false);
         } else {
-            isSubscribed = false;
+            // site/$site/follows/
+            isSubscribed = json.has("is_following") && json.optBoolean("is_following", false);
         }
-
         return (isSubscribed == isAskingToFollow);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -117,8 +117,7 @@ public class ReaderBlogActions {
     }
 
     public static boolean followFeedByUrl(final String feedUrl,
-                                           final boolean isAskingToFollow,
-                                           final ActionListener actionListener) {
+                                          final ActionListener actionListener) {
         if (TextUtils.isEmpty(feedUrl)) {
             if (actionListener != null) {
                 actionListener.onActionResult(false);
@@ -128,7 +127,7 @@ public class ReaderBlogActions {
 
         ReaderBlog blogInfo = ReaderBlogTable.getFeedInfo(ReaderBlogTable.getFeedIdFromUrl(feedUrl));
         if (blogInfo != null) {
-            return internalFollowFeed(blogInfo.feedId, blogInfo.getFeedUrl(), isAskingToFollow, actionListener);
+            return internalFollowFeed(blogInfo.feedId, blogInfo.getFeedUrl(), true, actionListener);
         }
 
         updateFeedInfo(0, feedUrl, new UpdateBlogInfoListener() {
@@ -138,7 +137,7 @@ public class ReaderBlogActions {
                     internalFollowFeed(
                             blogInfo.feedId,
                             blogInfo.getFeedUrl(),
-                            isAskingToFollow,
+                            true,
                             actionListener);
                 } else if (actionListener != null) {
                     actionListener.onActionResult(false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -116,18 +116,19 @@ public class ReaderBlogActions {
         return true;
     }
 
-    public static boolean followFeedByUrl(final String feedUrl,
-                                          final ActionListener actionListener) {
+    public static void followFeedByUrl(final String feedUrl,
+                                       final ActionListener actionListener) {
         if (TextUtils.isEmpty(feedUrl)) {
             if (actionListener != null) {
                 actionListener.onActionResult(false);
             }
-            return false;
+            return;
         }
 
         ReaderBlog blogInfo = ReaderBlogTable.getFeedInfo(ReaderBlogTable.getFeedIdFromUrl(feedUrl));
         if (blogInfo != null) {
-            return internalFollowFeed(blogInfo.feedId, blogInfo.getFeedUrl(), true, actionListener);
+            internalFollowFeed(blogInfo.feedId, blogInfo.getFeedUrl(), true, actionListener);
+            return;
         }
 
         updateFeedInfo(0, feedUrl, new UpdateBlogInfoListener() {
@@ -144,8 +145,6 @@ public class ReaderBlogActions {
                 }
             }
         });
-
-        return true;
     }
 
     private static boolean internalFollowFeed(

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -8,7 +8,6 @@ import com.android.volley.VolleyError;
 import com.android.volley.toolbox.StringRequest;
 import com.wordpress.rest.RestRequest;
 
-import org.apache.http.HttpStatus;
 import org.json.JSONObject;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -24,6 +23,8 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.VolleyUtils;
+
+import java.net.HttpURLConnection;
 
 public class ReaderBlogActions {
 
@@ -291,7 +292,7 @@ public class ReaderBlogActions {
             public void onErrorResponse(VolleyError volleyError) {
                 // authentication error may indicate that API access has been disabled for this blog
                 int statusCode = VolleyUtils.statusCodeFromVolleyError(volleyError);
-                boolean isAuthErr = (statusCode == HttpStatus.SC_FORBIDDEN);
+                boolean isAuthErr = (statusCode == HttpURLConnection.HTTP_FORBIDDEN);
                 // if we failed to get the blog info using the id and this isn't an authentication
                 // error, try again using just the domain
                 if (!isAuthErr && hasBlogId && hasBlogUrl) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -139,7 +139,7 @@ public class ReaderPostActions {
             public void run() {
                 ReaderPost serverPost = ReaderPost.fromJson(jsonObject);
 
-                // TODO: this temporary fix was added 25-Apr-2016 as a workound for the fact that
+                // TODO: this temporary fix was added 25-Apr-2016 as a workaround for the fact that
                 // the read/sites/{blogId}/posts/{postId} endpoint doesn't contain the feedId or
                 // feedItemId of the post. because of this, we need to copy them from the local post
                 // before calling isSamePost (since the difference in those IDs causes it to return false)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
@@ -34,7 +34,7 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     public enum ReaderBlogType {RECOMMENDED, FOLLOWED}
 
     public interface BlogClickListener {
-        public void onBlogClicked(Object blog);
+        void onBlogClicked(Object blog);
     }
 
     private final ReaderBlogType mBlogType;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderBlogAdapter.java
@@ -109,7 +109,7 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     @Override
-    public void onBindViewHolder(RecyclerView.ViewHolder holder, final int position) {
+    public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
         if (holder instanceof BlogViewHolder) {
             final BlogViewHolder blogHolder = (BlogViewHolder) holder;
             switch (getBlogType()) {
@@ -143,12 +143,13 @@ public class ReaderBlogAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 blogHolder.itemView.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
+                        int clickedPosition = blogHolder.getAdapterPosition();
                         switch (getBlogType()) {
                             case RECOMMENDED:
-                                mClickListener.onBlogClicked(mRecommendedBlogs.get(position));
+                                mClickListener.onBlogClicked(mRecommendedBlogs.get(clickedPosition));
                                 break;
                             case FOLLOWED:
-                                mClickListener.onBlogClicked(mFollowedBlogs.get(position));
+                                mClickListener.onBlogClicked(mFollowedBlogs.get(clickedPosition));
                                 break;
                         }
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -34,6 +34,7 @@ import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.ResourceUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
@@ -133,9 +134,9 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         int mediumMargin = context.getResources().getDimensionPixelSize(R.dimen.margin_medium);
         mContentWidth = displayWidth - (cardMargin * 2) - (contentPadding * 2) - (mediumMargin * 2);
 
-        mColorAuthor = ReaderUtils.getColorResource(context, R.color.blue_medium);
-        mColorNotAuthor = ReaderUtils.getColorResource(context, R.color.grey_dark);
-        mColorHighlight = ReaderUtils.getColorResource(context, R.color.grey_lighten_30);
+        mColorAuthor = ResourceUtils.getColorResource(context, R.color.blue_medium);
+        mColorNotAuthor = ResourceUtils.getColorResource(context, R.color.grey_dark);
+        mColorHighlight = ResourceUtils.getColorResource(context, R.color.grey_lighten_30);
 
         setHasStableIds(true);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.reader.adapters;
 import android.content.Context;
 import android.graphics.Color;
 import android.os.AsyncTask;
-import android.support.annotation.ColorRes;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -134,16 +133,11 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         int mediumMargin = context.getResources().getDimensionPixelSize(R.dimen.margin_medium);
         mContentWidth = displayWidth - (cardMargin * 2) - (contentPadding * 2) - (mediumMargin * 2);
 
-        mColorAuthor = getColorResource(context, R.color.blue_medium);
-        mColorNotAuthor = getColorResource(context, R.color.grey_dark);
-        mColorHighlight = getColorResource(context, R.color.grey_lighten_30);
+        mColorAuthor = ReaderUtils.getColorResource(context, R.color.blue_medium);
+        mColorNotAuthor = ReaderUtils.getColorResource(context, R.color.grey_dark);
+        mColorHighlight = ReaderUtils.getColorResource(context, R.color.grey_lighten_30);
 
         setHasStableIds(true);
-    }
-
-    @SuppressWarnings("deprecation")
-    private int getColorResource(Context context, @ColorRes int colorResId) {
-        return context.getResources().getColor(colorResId);
     }
 
     public void setReplyListener(RequestReplyListener replyListener) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.reader.adapters;
 import android.content.Context;
 import android.graphics.Color;
 import android.os.AsyncTask;
+import android.support.annotation.ColorRes;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -133,11 +134,16 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         int mediumMargin = context.getResources().getDimensionPixelSize(R.dimen.margin_medium);
         mContentWidth = displayWidth - (cardMargin * 2) - (contentPadding * 2) - (mediumMargin * 2);
 
-        mColorAuthor = context.getResources().getColor(R.color.blue_medium);
-        mColorNotAuthor = context.getResources().getColor(R.color.grey_dark);
-        mColorHighlight = context.getResources().getColor(R.color.grey_lighten_30);
+        mColorAuthor = getColorResource(context, R.color.blue_medium);
+        mColorNotAuthor = getColorResource(context, R.color.grey_dark);
+        mColorHighlight = getColorResource(context, R.color.grey_lighten_30);
 
         setHasStableIds(true);
+    }
+
+    @SuppressWarnings("deprecation")
+    private int getColorResource(Context context, @ColorRes int colorResId) {
+        return context.getResources().getColor(colorResId);
     }
 
     public void setReplyListener(RequestReplyListener replyListener) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -206,9 +206,12 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
             return;
         }
 
-        CommentHolder commentHolder = (CommentHolder) holder;
         final ReaderComment comment = getItem(position);
+        if (comment == null) {
+            return;
+        }
 
+        CommentHolder commentHolder = (CommentHolder) holder;
         commentHolder.txtAuthor.setText(comment.getAuthorName());
 
         java.util.Date dtPublished = DateTimeUtils.iso8601ToJavaDate(comment.getPublished());

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -50,7 +50,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
     private boolean mShowProgressForHighlightedComment = false;
     private final boolean mIsPrivatePost;
     private final boolean mIsLoggedOutReader;
-    private boolean mHeaderClickEnabled;
+    private boolean mIsHeaderClickEnabled;
 
     private final int mColorAuthor;
     private final int mColorNotAuthor;
@@ -152,8 +152,8 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         mDataRequestedListener = dataRequestedListener;
     }
 
-    public void setHeaderClickEnabled(boolean headerClickEnabled) {
-        mHeaderClickEnabled = headerClickEnabled;
+    public void enableHeaderClicks() {
+        mIsHeaderClickEnabled = true;
     }
 
     @Override
@@ -195,7 +195,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         if (holder instanceof PostHeaderHolder) {
             PostHeaderHolder headerHolder = (PostHeaderHolder) holder;
             headerHolder.mHeaderView.setPost(mPost);
-            if (mHeaderClickEnabled) {
+            if (mIsHeaderClickEnabled) {
                 headerHolder.mHeaderView.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -578,7 +578,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
     }
 
-    public void clear() {
+    private void clear() {
         mPosts.clear();
         notifyDataSetChanged();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -52,7 +52,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private final int mPhotonHeight;
     private final int mAvatarSzMedium;
     private final int mAvatarSzSmall;
-    private final int mAvatarSzExtraSmall;
     private final int mMarginLarge;
 
     private final String mWordCountFmtStr;
@@ -499,7 +498,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         mPostListType = postListType;
         mAvatarSzMedium = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_medium);
         mAvatarSzSmall = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_small);
-        mAvatarSzExtraSmall = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_extra_small);
         mMarginLarge = context.getResources().getDimensionPixelSize(R.dimen.margin_large);
         mIsLoggedOutReader = ReaderUtils.isLoggedOutReader();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -84,7 +84,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private static final int VIEW_TYPE_TAG_INFO    = 3;
     private static final int VIEW_TYPE_GAP_MARKER  = 4;
 
-    private static final long ITEM_ID_CUSTOM_VIEW = -1L;
+    private static final long ITEM_ID_CUSTOM_VIEW  = -1L;
+    private static final long ITEM_ID_INVALID_VIEW = -2L;
 
     /*
      * cross-post
@@ -204,7 +205,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             return VIEW_TYPE_TAG_INFO;
         } else if (position == mGapMarkerPosition) {
             return VIEW_TYPE_GAP_MARKER;
-        } else if (getItem(position).isXpost()) {
+        } else if (isXpostAtPosition(position)) {
             return VIEW_TYPE_XPOST;
         } else {
             return VIEW_TYPE_POST;
@@ -255,6 +256,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     private void renderXPost(int position, ReaderXPostViewHolder holder) {
         final ReaderPost post = getItem(position);
+        if (post == null) return;
 
         if (post.hasPostAvatar()) {
             holder.imgAvatar.setImageUrl(
@@ -287,6 +289,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     private void renderPost(final int position, ReaderPostViewHolder holder) {
         final ReaderPost post = getItem(position);
+        if (post == null) return;
+
         ReaderTypes.ReaderPostListType postListType = getPostListType();
 
         holder.txtTitle.setText(post.getTitle());
@@ -633,6 +637,11 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         return mPosts.get(arrayPos);
     }
 
+    private boolean isXpostAtPosition(int position) {
+        ReaderPost post = getItem(position);
+        return post != null && post.isXpost();
+    }
+
     @Override
     public int getItemCount() {
         if (hasCustomFirstItem()) {
@@ -648,7 +657,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     @Override
     public long getItemId(int position) {
         if (getItemViewType(position) == VIEW_TYPE_POST) {
-            return getItem(position).getStableId();
+            ReaderPost post = getItem(position);
+            return post != null ? post.getStableId() : ITEM_ID_INVALID_VIEW;
         } else {
             return ITEM_ID_CUSTOM_VIEW;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -730,7 +730,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         boolean isAskingToLike = !isCurrentlyLiked;
         ReaderAnim.animateLikeButton(holder.likeCount.getImageView(), isAskingToLike);
 
-        if (!ReaderPostActions.performLikeAction(post, isAskingToLike)) {
+        boolean success = ReaderPostActions.performLikeAction(post, isAskingToLike);
+        if (!success) {
             ToastUtils.showToast(context, R.string.reader_toast_err_generic);
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderUserAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderUserAdapter.java
@@ -39,7 +39,7 @@ public class ReaderUserAdapter  extends RecyclerView.Adapter<ReaderUserAdapter.U
         return mUsers.size();
     }
 
-    boolean isEmpty() {
+    private boolean isEmpty() {
         return (getItemCount() == 0);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/models/ReaderBlogIdPostIdList.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/models/ReaderBlogIdPostIdList.java
@@ -17,6 +17,7 @@ public class ReaderBlogIdPostIdList extends ArrayList<ReaderBlogIdPostId>
      * rather than its actual class - use this to convert the serialized list back
      * into a ReaderBlogIdPostIdList
      */
+    @SuppressWarnings("unused")
     public ReaderBlogIdPostIdList(Serializable serializedList) {
         super();
         if (serializedList != null && serializedList instanceof ArrayList) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/models/ReaderBlogIdPostIdList.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/models/ReaderBlogIdPostIdList.java
@@ -20,6 +20,7 @@ public class ReaderBlogIdPostIdList extends ArrayList<ReaderBlogIdPostId>
     public ReaderBlogIdPostIdList(Serializable serializedList) {
         super();
         if (serializedList != null && serializedList instanceof ArrayList) {
+            //noinspection unchecked
             ArrayList<ReaderBlogIdPostId> list = (ArrayList<ReaderBlogIdPostId>) serializedList;
             for (ReaderBlogIdPostId idPair: list) {
                 this.add(idPair);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/models/ReaderImageList.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/models/ReaderImageList.java
@@ -47,7 +47,8 @@ public class ReaderImageList extends ArrayList<String> {
         }
     }
 
-    public void addImageUrl(int index, String imageUrl) {
+    public void addImageUrl(@SuppressWarnings("SameParameterValue") int index,
+                            String imageUrl) {
         if (imageUrl != null && imageUrl.startsWith("http")) {
             this.add(index, fixImageUrl(imageUrl));
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -76,6 +76,7 @@ public class ReaderUpdateService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         if (intent != null && intent.hasExtra(ARG_UPDATE_TASKS)) {
+            @SuppressWarnings("unchecked")
             EnumSet<UpdateTask> tasks = (EnumSet<UpdateTask>) intent.getSerializableExtra(ARG_UPDATE_TASKS);
             performTasks(tasks);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -76,7 +76,7 @@ public class ReaderUpdateService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         if (intent != null && intent.hasExtra(ARG_UPDATE_TASKS)) {
-            @SuppressWarnings("unchecked")
+            //noinspection unchecked
             EnumSet<UpdateTask> tasks = (EnumSet<UpdateTask>) intent.getSerializableExtra(ARG_UPDATE_TASKS);
             performTasks(tasks);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
@@ -11,7 +11,6 @@ public class ReaderHtmlUtils {
 
     public interface HtmlScannerListener {
         void onTagFound(String tag, String src);
-        void onScanCompleted();
     }
 
     // regex for matching width attributes in tags

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
@@ -80,7 +80,8 @@ public class ReaderHtmlUtils {
      * if the url is invalid, or the param doesn't exist, or the param value could not be
      * converted to an int
      */
-    public static int getIntQueryParam(final String url, final String param) {
+    public static int getIntQueryParam(final String url,
+                                       @SuppressWarnings("SameParameterValue") final String param) {
         if (url == null
                 || param == null
                 || !url.startsWith("http")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
@@ -10,7 +10,7 @@ import java.util.regex.Pattern;
 public class ReaderHtmlUtils {
 
     public interface HtmlScannerListener {
-        void onTagFound(String tag, String src, int start, int end);
+        void onTagFound(String tag, String src);
         void onScanCompleted();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
@@ -9,9 +9,9 @@ import java.util.regex.Pattern;
 
 public class ReaderHtmlUtils {
 
-    public static interface HtmlScannerListener {
-        public void onTagFound(String tag, String src, int start, int end);
-        public void onScanCompleted();
+    public interface HtmlScannerListener {
+        void onTagFound(String tag, String src, int start, int end);
+        void onScanCompleted();
     }
 
     // regex for matching width attributes in tags

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderIframeScanner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderIframeScanner.java
@@ -27,7 +27,7 @@ public class ReaderIframeScanner {
             String tag = mContent.substring(matcher.start(), matcher.end());
             String src = ReaderHtmlUtils.getSrcAttrValue(tag);
             if (!TextUtils.isEmpty(src)) {
-                listener.onTagFound(tag, src, matcher.start(), matcher.end());
+                listener.onTagFound(tag, src);
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderIframeScanner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderIframeScanner.java
@@ -30,7 +30,5 @@ public class ReaderIframeScanner {
                 listener.onTagFound(tag, src);
             }
         }
-
-        listener.onScanCompleted();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
@@ -40,7 +40,7 @@ public class ReaderImageScanner {
             String imageTag = mContent.substring(imgMatcher.start(), imgMatcher.end());
             String imageUrl = ReaderHtmlUtils.getSrcAttrValue(imageTag);
             if (!TextUtils.isEmpty(imageUrl)) {
-                listener.onTagFound(imageTag, imageUrl, imgMatcher.start(), imgMatcher.end());
+                listener.onTagFound(imageTag, imageUrl);
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
@@ -31,7 +31,6 @@ public class ReaderImageScanner {
         }
 
         if (!mContentContainsImages) {
-            listener.onScanCompleted();
             return;
         }
 
@@ -43,8 +42,6 @@ public class ReaderImageScanner {
                 listener.onTagFound(imageTag, imageUrl);
             }
         }
-
-        listener.onScanCompleted();
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderLinkMovementMethod.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderLinkMovementMethod.java
@@ -43,6 +43,7 @@ public class ReaderLinkMovementMethod extends LinkMovementMethod {
     /*
      * override MovementMethod.getInstance() to ensure our getInstance(false) is used
      */
+    @SuppressWarnings("unused")
     public static ReaderLinkMovementMethod getInstance() {
         return getInstance(false);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -2,8 +2,12 @@ package org.wordpress.android.ui.reader.utils;
 
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
+import android.support.annotation.ColorRes;
+import android.support.annotation.DrawableRes;
+import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import android.view.View;
 
@@ -215,6 +219,22 @@ public class ReaderUtils {
      */
     public static ReaderTag getDefaultTag() {
         return getTagFromTagName(ReaderTag.TAG_TITLE_DEFAULT, ReaderTagType.DEFAULT);
+    }
+
+    /*
+     * returns a color resource - avoids having deprecation warnings everywhere getColor() is used
+     */
+    @SuppressWarnings("deprecation")
+    public static int getColorResource(@NonNull Context context, @ColorRes int colorResId) {
+        return context.getResources().getColor(colorResId);
+    }
+
+    /*
+     * returns a color resource - avoids having deprecation warnings everywhere getDrawable() is used
+     */
+    @SuppressWarnings("deprecation")
+    public static Drawable getDrawableResource(@NonNull Context context, @DrawableRes int drawableResId) {
+        return context.getResources().getDrawable(drawableResId);
     }
 
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -2,12 +2,8 @@ package org.wordpress.android.ui.reader.utils;
 
 import android.annotation.TargetApi;
 import android.content.Context;
-import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
-import android.support.annotation.ColorRes;
-import android.support.annotation.DrawableRes;
-import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import android.view.View;
 
@@ -219,22 +215,6 @@ public class ReaderUtils {
      */
     public static ReaderTag getDefaultTag() {
         return getTagFromTagName(ReaderTag.TAG_TITLE_DEFAULT, ReaderTagType.DEFAULT);
-    }
-
-    /*
-     * returns a color resource - avoids having deprecation warnings everywhere getColor() is used
-     */
-    @SuppressWarnings("deprecation")
-    public static int getColorResource(@NonNull Context context, @ColorRes int colorResId) {
-        return context.getResources().getColor(colorResId);
-    }
-
-    /*
-     * returns a color resource - avoids having deprecation warnings everywhere getDrawable() is used
-     */
-    @SuppressWarnings("deprecation")
-    public static Drawable getDrawableResource(@NonNull Context context, @DrawableRes int drawableResId) {
-        return context.getResources().getDrawable(drawableResId);
     }
 
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderVideoUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderVideoUtils.java
@@ -38,17 +38,6 @@ public class ReaderVideoUtils {
 		return (!TextUtils.isEmpty(getYouTubeVideoId(link)));
 	}
 
-    /*
-     * accepts a YouTube link in any format (such as the /embed/ format) and turns it into a
-     * standard YouTube video link
-     */
-    public static String fixYouTubeVideoLink(final String videoUrl) {
-        String videoId = getYouTubeVideoId(videoUrl);
-        if (TextUtils.isEmpty(videoId))
-            return videoUrl;
-        return "http://www.youtube.com/watch?v=" + videoId;
-    }
-
 	/*
 	 * extract the video id from the passed YouTube url
      */

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderVideoUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderVideoUtils.java
@@ -168,7 +168,7 @@ public class ReaderVideoUtils {
         WordPress.requestQueue.add(request);
     }
 
-    public static interface VideoThumbnailListener {
-        public void onResponse(boolean successful, String thumbnailUrl);
+    public interface VideoThumbnailListener {
+        void onResponse(boolean successful, String thumbnailUrl);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderGapMarkerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderGapMarkerView.java
@@ -3,7 +3,6 @@ package org.wordpress.android.ui.reader.views;
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.View;
-import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
@@ -20,7 +19,6 @@ import org.wordpress.android.util.NetworkUtils;
  */
 public class ReaderGapMarkerView extends RelativeLayout {
     private TextView mText;
-    private ImageView mImage;
     private ProgressBar mProgress;
     private ReaderTag mCurrentTag;
 
@@ -42,7 +40,6 @@ public class ReaderGapMarkerView extends RelativeLayout {
     private void initView(Context context) {
         View view = inflate(context, R.layout.reader_gap_marker_view, this);
         mText = (TextView) view.findViewById(R.id.text_gap_marker);
-        mImage = (ImageView) view.findViewById(R.id.image_gap_marker);
         mProgress = (ProgressBar) view.findViewById(R.id.progress_gap_marker);
 
         mText.setOnClickListener(new OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderIconCountView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderIconCountView.java
@@ -2,8 +2,6 @@ package org.wordpress.android.ui.reader.views;
 
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.graphics.drawable.Drawable;
-import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -55,10 +53,10 @@ public class ReaderIconCountView extends LinearLayout {
                 mIconType = a.getInteger(R.styleable.ReaderIconCountView_readerIcon, ICON_LIKE);
                 switch (mIconType) {
                     case ICON_LIKE :
-                        mImageView.setImageDrawable(getDrawableResource(context, R.drawable.reader_button_like));
+                        mImageView.setImageDrawable(ReaderUtils.getDrawableResource(context, R.drawable.reader_button_like));
                         break;
                     case ICON_COMMENT :
-                        mImageView.setImageDrawable(getDrawableResource(context, R.drawable.reader_button_comment));
+                        mImageView.setImageDrawable(ReaderUtils.getDrawableResource(context, R.drawable.reader_button_comment));
                         break;
                 }
 
@@ -68,11 +66,6 @@ public class ReaderIconCountView extends LinearLayout {
         }
 
         ReaderUtils.setBackgroundToRoundRipple(mImageView);
-    }
-
-    @SuppressWarnings("deprecation")
-    private Drawable getDrawableResource(Context context, @DrawableRes int drawableResId) {
-        return context.getResources().getDrawable(drawableResId);
     }
 
     public ImageView getImageView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderIconCountView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderIconCountView.java
@@ -10,6 +10,7 @@ import android.widget.TextView;
 import org.wordpress.android.R;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.FormatUtils;
+import org.wordpress.android.util.ResourceUtils;
 
 /*
  * used when showing comment + comment count, like + like count
@@ -53,10 +54,10 @@ public class ReaderIconCountView extends LinearLayout {
                 mIconType = a.getInteger(R.styleable.ReaderIconCountView_readerIcon, ICON_LIKE);
                 switch (mIconType) {
                     case ICON_LIKE :
-                        mImageView.setImageDrawable(ReaderUtils.getDrawableResource(context, R.drawable.reader_button_like));
+                        mImageView.setImageDrawable(ResourceUtils.getDrawableResource(context, R.drawable.reader_button_like));
                         break;
                     case ICON_COMMENT :
-                        mImageView.setImageDrawable(ReaderUtils.getDrawableResource(context, R.drawable.reader_button_comment));
+                        mImageView.setImageDrawable(ResourceUtils.getDrawableResource(context, R.drawable.reader_button_comment));
                         break;
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderIconCountView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderIconCountView.java
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.reader.views;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -53,10 +55,10 @@ public class ReaderIconCountView extends LinearLayout {
                 mIconType = a.getInteger(R.styleable.ReaderIconCountView_readerIcon, ICON_LIKE);
                 switch (mIconType) {
                     case ICON_LIKE :
-                        mImageView.setImageDrawable(context.getResources().getDrawable(R.drawable.reader_button_like));
+                        mImageView.setImageDrawable(getDrawableResource(context, R.drawable.reader_button_like));
                         break;
                     case ICON_COMMENT :
-                        mImageView.setImageDrawable(context.getResources().getDrawable(R.drawable.reader_button_comment));
+                        mImageView.setImageDrawable(getDrawableResource(context, R.drawable.reader_button_comment));
                         break;
                 }
 
@@ -66,6 +68,11 @@ public class ReaderIconCountView extends LinearLayout {
         }
 
         ReaderUtils.setBackgroundToRoundRipple(mImageView);
+    }
+
+    @SuppressWarnings("deprecation")
+    private Drawable getDrawableResource(Context context, @DrawableRes int drawableResId) {
+        return context.getResources().getDrawable(drawableResId);
     }
 
     public ImageView getImageView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPhotoView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPhotoView.java
@@ -90,6 +90,7 @@ public class ReaderPhotoView extends RelativeLayout {
              && container.getRequestUrl().equals(url));
     }
 
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     private boolean hasLayout() {
         // if the view's bounds aren't known yet, and this is not a wrap-content/wrap-content
         // view, hold off on loading the image.

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPhotoView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPhotoView.java
@@ -31,7 +31,7 @@ import uk.co.senab.photoview.PhotoViewAttacher;
  */
 public class ReaderPhotoView extends RelativeLayout {
 
-    public static interface PhotoViewListener {
+    public interface PhotoViewListener {
         void onTapPhotoView();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderRecyclerView.java
@@ -27,16 +27,4 @@ public class ReaderRecyclerView extends RecyclerView {
             setLayoutManager(new LinearLayoutManager(context));
         }
     }
-
-    // http://stackoverflow.com/a/25227797/1673548
-    public boolean canScrollUp() {
-        return super.canScrollVertically(-1) || (getChildAt(0) != null && getChildAt(0).getTop() < 0);
-    }
-
-    /*
-     * returns the vertical scroll position
-     */
-    public int getVerticalScrollOffset() {
-        return super.computeVerticalScrollOffset();
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -206,13 +206,10 @@ public class ReaderWebView extends WebView {
             // loaded (is visible) - have seen some posts containing iframes
             // automatically try to open urls (without being clicked)
             // before the page has loaded
-            if (view.getVisibility() == View.VISIBLE
+            return view.getVisibility() == View.VISIBLE
                     && mReaderWebView.hasUrlClickListener()
-                    && isValidClickedUrl(url)) {
-                return mReaderWebView.getUrlClickListener().onUrlClick(url);
-            } else {
-                return false;
-            }
+                    && isValidClickedUrl(url)
+                    && mReaderWebView.getUrlClickListener().onUrlClick(url);
         }
 
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -212,6 +212,7 @@ public class ReaderWebView extends WebView {
                     && mReaderWebView.getUrlClickListener().onUrlClick(url);
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         public WebResourceResponse shouldInterceptRequest(WebView view, String url) {
             URL imageUrl  = null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -33,6 +33,7 @@ import java.net.URL;
 public class ReaderWebView extends WebView {
 
     public interface ReaderWebViewUrlClickListener {
+        @SuppressWarnings("SameReturnValue")
         boolean onUrlClick(String url);
         boolean onImageUrlClick(String imageUrl, View view, int x, int y);
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/ResourceUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/ResourceUtils.java
@@ -1,0 +1,25 @@
+package org.wordpress.android.util;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.ColorRes;
+import android.support.annotation.DrawableRes;
+import android.support.annotation.NonNull;
+
+public class ResourceUtils {
+    /*
+     * returns a color resource - avoids having deprecation warnings everywhere getColor() is used
+     */
+    @SuppressWarnings("deprecation")
+    public static int getColorResource(@NonNull Context context, @ColorRes int colorResId) {
+        return context.getResources().getColor(colorResId);
+    }
+
+    /*
+     * returns a drawable resource - avoids having deprecation warnings everywhere getDrawable() is used
+     */
+    @SuppressWarnings("deprecation")
+    public static Drawable getDrawableResource(@NonNull Context context, @DrawableRes int drawableResId) {
+        return context.getResources().getDrawable(drawableResId);
+    }
+}


### PR DESCRIPTION
Our squad's primary Rome meetup project is to improve the apps by removing outdated code, fixing warnings, and generally cleaning up the messy bits.

This PR addresses the Reader, specifically fixing many of the warnings produced by Android Studio's `Analyze > Inspect Code` feature when run on the `wordpress/android/ui/reader` directory. A separate PR to address warnings in the layout resources will come separately, if needed.

Before and after pics below - note that there are still a number of warnings, but the majority of them are NPE warnings on `getView()` requests that we know will work.

**Before**
<img width="666" alt="before" src="https://cloud.githubusercontent.com/assets/3903757/15681303/ecb2022e-2758-11e6-89e1-0c64f7d8678c.png">

**After**
<img width="664" alt="after" src="https://cloud.githubusercontent.com/assets/3903757/15681316/f83b2828-2758-11e6-88c6-41a6f658b773.png">
