### PR TITLE
Issue/3589 menu selection bar db loader

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/networking/MenusRestWPComTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/networking/MenusRestWPComTest.java
@@ -120,7 +120,7 @@ public class MenusRestWPComTest extends InstrumentationTestCase {
                             }
                             @Override public Context getContext() { return mTargetContext; }
                             @Override public void onMenuCreated(int requestId, MenuModel menu) { countDown(); }
-                            @Override public void onMenusReceived(int requestId, List<MenuModel> menus) { countDown(); }
+                            @Override public void onMenusReceived(int requestId, List<MenuModel> menus, List<MenuLocationModel> locations) { countDown(); }
                             @Override public void onMenuDeleted(int requestId, MenuModel menu, boolean deleted) { countDown(); }
                             @Override public void onErrorResponse(int requestId, MenusRestWPCom.REST_ERROR error) { countDown(); }
                         });
@@ -156,7 +156,7 @@ public class MenusRestWPComTest extends InstrumentationTestCase {
                             }
                             @Override public Context getContext() { return mTargetContext; }
                             @Override public void onMenuCreated(int requestId, MenuModel menu) { countDown(); }
-                            @Override public void onMenusReceived(int requestId, List<MenuModel> menus) { countDown(); }
+                            @Override public void onMenusReceived(int requestId, List<MenuModel> menus, List<MenuLocationModel> locations) { countDown(); }
                             @Override public void onMenuDeleted(int requestId, MenuModel menu, boolean deleted) { countDown(); }
                             @Override public void onErrorResponse(int requestId, MenusRestWPCom.REST_ERROR error) { countDown(); }
                         });
@@ -189,9 +189,8 @@ public class MenusRestWPComTest extends InstrumentationTestCase {
                             @Override public long getSiteId() {
                                 return Long.valueOf(WordPress.getCurrentRemoteBlogId());
                             }
-                            @Override public void onMenusReceived(int requestId, List<MenuModel> menus) {
+                            @Override public void onMenusReceived(int requestId, List<MenuModel> menus, List<MenuLocationModel> locations) {
                                 success[0] = requestId == mTestRequest && menus != null && menus.size() > 0;
-                                countDown();
                             }
                             @Override public Context getContext() { return mTargetContext; }
                             @Override public void onMenuCreated(int requestId, MenuModel menu) { countDown(); }
@@ -224,8 +223,8 @@ public class MenusRestWPComTest extends InstrumentationTestCase {
                             @Override public long getSiteId() {
                                 return Long.valueOf(WordPress.getCurrentRemoteBlogId());
                             }
-                            @Override public void onMenusReceived(int requestId, List<MenuModel> menu) {
-                                success[0] = requestId == mTestRequest && menu != null && menu.size() > 0 && menu.get(0).menuId == expectedId;
+                            @Override public void onMenusReceived(int requestId, List<MenuModel> menus, List<MenuLocationModel> locations) {
+                                success[0] = requestId == mTestRequest && menus != null && menus.size() > 0 && menus.get(0).menuId == expectedId;
                                 countDown();
                             }
                             @Override public Context getContext() { return mTargetContext; }
@@ -258,8 +257,8 @@ public class MenusRestWPComTest extends InstrumentationTestCase {
                             @Override public long getSiteId() {
                                 return Long.valueOf(WordPress.getCurrentRemoteBlogId());
                             }
-                            @Override public void onMenusReceived(int requestId, List<MenuModel> menu) {
-                                success[0] = requestId == mTestRequest && menu.isEmpty();
+                            @Override public void onMenusReceived(int requestId, List<MenuModel> menus, List<MenuLocationModel> locations) {
+                                success[0] = requestId == mTestRequest && menus.isEmpty();
                                 countDown();
                             }
                             @Override public Context getContext() { return mTargetContext; }
@@ -297,7 +296,7 @@ public class MenusRestWPComTest extends InstrumentationTestCase {
                                 countDown();
                             }
                             @Override public Context getContext() { return mTargetContext; }
-                            @Override public void onMenusReceived(int requestId, List<MenuModel> menu) { countDown(); }
+                            @Override public void onMenusReceived(int requestId, List<MenuModel> menus, List<MenuLocationModel> locations) { countDown(); }
                             @Override public void onMenuCreated(int requestId, MenuModel menu) { countDown(); }
                             @Override public void onMenuDeleted(int requestId, MenuModel menu, boolean deleted) { countDown(); }
                             @Override public void onMenuUpdated(int requestId, MenuModel menu) { countDown(); }
@@ -339,7 +338,7 @@ public class MenusRestWPComTest extends InstrumentationTestCase {
                             }
                             @Override public Context getContext() { return mTargetContext; }
                             @Override public void onMenuUpdated(int requestId, MenuModel menu) { countDown(); }
-                            @Override public void onMenusReceived(int requestId, List<MenuModel> menus) { countDown(); }
+                            @Override public void onMenusReceived(int requestId, List<MenuModel> menus, List<MenuLocationModel> locations) { countDown(); }
                             @Override public void onErrorResponse(int requestId, MenusRestWPCom.REST_ERROR error) { countDown(); }
                         });
                         Assert.assertTrue((mTestRequest = mTestRest.createMenu(goodMenu)) != -1);
@@ -375,7 +374,7 @@ public class MenusRestWPComTest extends InstrumentationTestCase {
                             @Override public Context getContext() { return mTargetContext; }
                             @Override public void onMenuUpdated(int requestId, MenuModel menu) { countDown(); }
                             @Override public void onMenuCreated(int requestId, MenuModel menu) { countDown(); }
-                            @Override public void onMenusReceived(int requestId, List<MenuModel> menus) { countDown(); }
+                            @Override public void onMenusReceived(int requestId, List<MenuModel> menus, List<MenuLocationModel> locations) { countDown(); }
                             @Override public void onErrorResponse(int requestId, MenusRestWPCom.REST_ERROR error) { countDown(); }
                         });
                         Assert.assertTrue((mTestRequest = mTestRest.deleteMenu(badMenu)) != -1);
@@ -431,7 +430,7 @@ public class MenusRestWPComTest extends InstrumentationTestCase {
     private final MenusListener EMPTY_DELEGATE = new MenusListener() {
         @Override public long getSiteId() { return -1; }
         @Override public Context getContext() { return null; }
-        @Override public void onMenusReceived(int requestId, List<MenuModel> menus) { countDown(); }
+        @Override public void onMenusReceived(int requestId, List<MenuModel> menus, List<MenuLocationModel> locations) { countDown(); }
         @Override public void onMenuCreated(int requestId, MenuModel menu) { countDown(); }
         @Override public void onMenuDeleted(int requestId, MenuModel menu, boolean deleted) { countDown(); }
         @Override public void onMenuUpdated(int requestId, MenuModel menu) { countDown(); }

--- a/WordPress/src/androidTest/java/org/wordpress/android/networking/MenusRestWPComTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/networking/MenusRestWPComTest.java
@@ -9,6 +9,7 @@ import junit.framework.Assert;
 
 import org.wordpress.android.TestUtils;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.models.MenuLocationModel;
 import org.wordpress.android.models.MenuModel;
 import org.wordpress.android.networking.menus.MenusRestWPCom;
 import org.wordpress.android.networking.menus.MenusRestWPCom.MenusListener;
@@ -69,7 +70,7 @@ public class MenusRestWPComTest extends InstrumentationTestCase {
                                 countDown();
                             }
                             @Override public Context getContext() { return mTargetContext; }
-                            @Override public void onMenusReceived(int requestId, List<MenuModel> menus) { countDown(); }
+                            @Override public void onMenusReceived(int requestId, List<MenuModel> menus, List<MenuLocationModel> locations) { countDown(); }
                             @Override public void onMenuDeleted(int requestId, MenuModel menu, boolean deleted) { countDown(); }
                             @Override public void onMenuUpdated(int requestId, MenuModel menu) { countDown(); }
                             @Override public void onErrorResponse(int requestId, MenusRestWPCom.REST_ERROR error) { countDown(); }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/MenuItemTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/MenuItemTable.java
@@ -87,7 +87,7 @@ public class MenuItemTable {
         if (itemId < 0) return null;
 
         String[] args = {String.valueOf(itemId)};
-        Cursor cursor = WordPress.wpDB.getDatabase().rawQuery("SELECT * FROM " + MENU_ITEMS_TABLE_NAME + UNIQUE_WHERE_SQL + ";", args);
+        Cursor cursor = WordPress.wpDB.getDatabase().rawQuery("SELECT * FROM " + MENU_ITEMS_TABLE_NAME + " WHERE " + UNIQUE_WHERE_SQL + ";", args);
         cursor.moveToFirst();
         MenuItemModel item = deserializeFromDatabase(cursor);
         cursor.close();
@@ -97,7 +97,7 @@ public class MenuItemTable {
     public static List<MenuItemModel> getMenuItemsForMenu(long menuId) {
         List<MenuItemModel> items = new ArrayList<>();
         String[] args = {String.valueOf(menuId)};
-        Cursor cursor = WordPress.wpDB.getDatabase().rawQuery("SELECT * FROM " + MENU_ITEMS_TABLE_NAME + UNIQUE_WHERE_SQL_MENU_ID + ";", args);
+        Cursor cursor = WordPress.wpDB.getDatabase().rawQuery("SELECT * FROM " + MENU_ITEMS_TABLE_NAME + " WHERE " + UNIQUE_WHERE_SQL_MENU_ID + ";", args);
         if (cursor.moveToFirst()) {
             do {
                 MenuItemModel item = deserializeFromDatabase(cursor);

--- a/WordPress/src/main/java/org/wordpress/android/datasets/MenuItemTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/MenuItemTable.java
@@ -55,9 +55,9 @@ public class MenuItemTable {
                     ");";
 
     /** Well-formed WHERE clause for identifying a row using PRIMARY KEY constraints */
-    public static final String UNIQUE_WHERE_SQL = " WHERE " + ID_COLUMN + "=?";
+    public static final String UNIQUE_WHERE_SQL = ID_COLUMN + "=?";
 
-    public static final String UNIQUE_WHERE_SQL_MENU_ID = " WHERE " + MENU_ID_COLUMN + "=?";
+    public static final String UNIQUE_WHERE_SQL_MENU_ID = MENU_ID_COLUMN + "=?";
 
     public static void saveMenuItem(MenuItemModel item) {
         if (item == null || item.itemId < 0) return;

--- a/WordPress/src/main/java/org/wordpress/android/datasets/MenuItemTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/MenuItemTable.java
@@ -55,7 +55,7 @@ public class MenuItemTable {
                     ");";
 
     /** Well-formed WHERE clause for identifying a row using PRIMARY KEY constraints */
-    public static final String UNIQUE_WHERE_SQL = "WHERE " + ID_COLUMN + "=?";
+    public static final String UNIQUE_WHERE_SQL = " WHERE " + ID_COLUMN + "=?";
 
     public static void saveMenuItem(MenuItemModel item) {
         if (item == null || item.itemId < 0) return;
@@ -79,7 +79,7 @@ public class MenuItemTable {
         if (itemId < 0) return null;
 
         String[] args = {String.valueOf(itemId)};
-        Cursor cursor = WordPress.wpDB.getDatabase().rawQuery(UNIQUE_WHERE_SQL, args);
+        Cursor cursor = WordPress.wpDB.getDatabase().rawQuery("SELECT * FROM " + MENU_ITEMS_TABLE_NAME + UNIQUE_WHERE_SQL + ";", args);
         cursor.moveToFirst();
         MenuItemModel item = deserializeFromDatabase(cursor);
         cursor.close();

--- a/WordPress/src/main/java/org/wordpress/android/datasets/MenuItemTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/MenuItemTable.java
@@ -57,12 +57,20 @@ public class MenuItemTable {
     /** Well-formed WHERE clause for identifying a row using PRIMARY KEY constraints */
     public static final String UNIQUE_WHERE_SQL = " WHERE " + ID_COLUMN + "=?";
 
+    public static final String UNIQUE_WHERE_SQL_MENU_ID = " WHERE " + MENU_ID_COLUMN + "=?";
+
     public static void saveMenuItem(MenuItemModel item) {
         if (item == null || item.itemId < 0) return;
 
         ContentValues row = serializeToDatabase(item);
         WordPress.wpDB.getDatabase().insertWithOnConflict(
                 MENU_ITEMS_TABLE_NAME, null, row, SQLiteDatabase.CONFLICT_REPLACE);
+    }
+
+    public static int deleteMenuItemForMenuId(long menuId) {
+        if (menuId < 0) return 0;
+        String[] args = {String.valueOf(menuId)};
+        return WordPress.wpDB.getDatabase().delete(MENU_ITEMS_TABLE_NAME, UNIQUE_WHERE_SQL_MENU_ID, args);
     }
 
     public static void deleteMenuItem(long itemId) {
@@ -86,9 +94,10 @@ public class MenuItemTable {
         return item;
     }
 
-    public static List<MenuItemModel> getAllMenuItems() {
+    public static List<MenuItemModel> getMenuItemsForMenu(long menuId) {
         List<MenuItemModel> items = new ArrayList<>();
-        Cursor cursor = WordPress.wpDB.getDatabase().rawQuery("SELECT * FROM " + MENU_ITEMS_TABLE_NAME + ";", null);
+        String[] args = {String.valueOf(menuId)};
+        Cursor cursor = WordPress.wpDB.getDatabase().rawQuery("SELECT * FROM " + MENU_ITEMS_TABLE_NAME + UNIQUE_WHERE_SQL_MENU_ID + ";", args);
         if (cursor.moveToFirst()) {
             do {
                 MenuItemModel item = deserializeFromDatabase(cursor);

--- a/WordPress/src/main/java/org/wordpress/android/datasets/MenuLocationTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/MenuLocationTable.java
@@ -7,6 +7,7 @@ import android.text.TextUtils;
 
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.MenuLocationModel;
+import org.wordpress.android.models.MenuModel;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -62,6 +63,23 @@ public class MenuLocationTable {
         ContentValues values = serializeToDatabase(location);
         return WordPress.wpDB.getDatabase().insertWithOnConflict(
                 MENU_LOCATIONS_TABLE_NAME, null, values, SQLiteDatabase.CONFLICT_REPLACE) != -1;
+    }
+
+    public static void saveMenuLocations(List<MenuLocationModel> locations) {
+        if (locations == null || locations.size() == 0) return;
+
+        SQLiteDatabase db = WordPress.wpDB.getDatabase();
+        db.beginTransaction();
+        try {
+            for (MenuLocationModel location: locations) {
+                ContentValues values = serializeToDatabase(location);
+                db.insertWithOnConflict(
+                        MENU_LOCATIONS_TABLE_NAME, null, values, SQLiteDatabase.CONFLICT_REPLACE);
+            }
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
+        }
     }
 
     public static void deleteMenuLocationForCurrentSite(String locationName) {

--- a/WordPress/src/main/java/org/wordpress/android/datasets/MenuTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/MenuTable.java
@@ -44,7 +44,7 @@ public class MenuTable {
                     ITEMS_COLUMN + " TEXT" +
                     ");";
 
-    public static final String UNIQUE_WHERE_SQL = " WHERE " + ID_COLUMN + "=?";
+    public static final String UNIQUE_WHERE_SQL = ID_COLUMN + "=?";
 
     /** Well-formed SELECT query for selecting rows for a given site ID */
     public static final String SELECT_SITE_MENUS_SQL =
@@ -161,7 +161,7 @@ public class MenuTable {
      */
     public static MenuModel getMenuFromId(long id) {
         String[] args = {String.valueOf(id)};
-        Cursor cursor = WordPress.wpDB.getDatabase().rawQuery(UNIQUE_WHERE_SQL, args);
+        Cursor cursor = WordPress.wpDB.getDatabase().rawQuery(" WHERE " + UNIQUE_WHERE_SQL, args);
         cursor.moveToFirst();
         MenuModel menu = deserializeFromDatabase(cursor);
         cursor.close();

--- a/WordPress/src/main/java/org/wordpress/android/datasets/MenuTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/MenuTable.java
@@ -44,14 +44,7 @@ public class MenuTable {
                     ITEMS_COLUMN + " TEXT" +
                     ");";
 
-    public static final String UNIQUE_WHERE_SQL = "WHERE " + ID_COLUMN + "=?";
-    public static final String COLUMN_NAMES =
-            SITE_ID_COLUMN + "," +
-            ID_COLUMN + "," +
-            NAME_COLUMN + "," +
-            DETAILS_COLUMN + "," +
-            LOCATIONS_COLUMN + "," +
-            ITEMS_COLUMN;
+    public static final String UNIQUE_WHERE_SQL = " WHERE " + ID_COLUMN + "=?";
 
     /** Well-formed SELECT query for selecting rows for a given site ID */
     public static final String SELECT_SITE_MENUS_SQL =
@@ -195,5 +188,30 @@ public class MenuTable {
 
         return menus;
     }
+
+    public static void deleteMenu(long menuId) {
+        if (menuId < 0) return;
+        String[] args = {String.valueOf(menuId)};
+
+        SQLiteDatabase db = WordPress.wpDB.getDatabase();
+
+        db.beginTransaction();
+        try {
+            //delete menu items for this menu first
+            MenuItemTable.deleteMenuItemForMenuId(menuId);
+            //now delete menu
+            db.delete(MENU_TABLE_NAME, UNIQUE_WHERE_SQL, args);
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
+        }
+
+    }
+
+    public static void deleteAllMenus() {
+        MenuItemTable.deleteAllMenuItems();
+        WordPress.wpDB.getDatabase().delete(MENU_TABLE_NAME, null, null);
+    }
+
 
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/MenuLocationModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/MenuLocationModel.java
@@ -48,6 +48,6 @@ public class MenuLocationModel implements NameInterface {
 
     @Override
     public String getName() {
-        return name;
+        return details;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/MenuLocationModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/MenuLocationModel.java
@@ -12,9 +12,12 @@ import org.wordpress.android.util.StringUtils;
  */
 
 public class MenuLocationModel implements NameInterface {
-
-
     public static final String LOCATION_DEFAULT = "default";
+    public static final String LOCATION_EMPTY   = "empty";
+
+    public static final long ADD_MENU_ID = -1;
+    public static final long DEFAULT_MENU_ID = -2;
+    public static final long NO_MENU_ID = -3;
 
     //
     // Primary key attributes (cannot be null)

--- a/WordPress/src/main/java/org/wordpress/android/models/MenuLocationModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/MenuLocationModel.java
@@ -15,10 +15,6 @@ public class MenuLocationModel implements NameInterface {
     public static final String LOCATION_DEFAULT = "default";
     public static final String LOCATION_EMPTY   = "empty";
 
-    public static final long ADD_MENU_ID = -1;
-    public static final long DEFAULT_MENU_ID = -2;
-    public static final long NO_MENU_ID = -3;
-
     //
     // Primary key attributes (cannot be null)
     //

--- a/WordPress/src/main/java/org/wordpress/android/models/MenuLocationModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/MenuLocationModel.java
@@ -12,6 +12,10 @@ import org.wordpress.android.util.StringUtils;
  */
 
 public class MenuLocationModel implements NameInterface {
+
+
+    public static final String LOCATION_DEFAULT = "default";
+
     //
     // Primary key attributes (cannot be null)
     //

--- a/WordPress/src/main/java/org/wordpress/android/models/MenuModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/MenuModel.java
@@ -18,6 +18,7 @@ public class MenuModel implements NameInterface {
     public String details;
     public List<MenuLocationModel> locations;
     public List<MenuItemModel> menuItems;
+    public boolean isDefault;
 
     @Override
     public boolean equals(Object other) {

--- a/WordPress/src/main/java/org/wordpress/android/models/MenuModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/MenuModel.java
@@ -13,6 +13,7 @@ import java.util.List;
  */
 
 public class MenuModel implements NameInterface {
+    public long siteId;
     public long menuId;
     public String name;
     public String details;

--- a/WordPress/src/main/java/org/wordpress/android/models/MenuModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/MenuModel.java
@@ -20,6 +20,10 @@ public class MenuModel implements NameInterface {
     public List<MenuLocationModel> locations;
     public List<MenuItemModel> menuItems;
 
+    public static final long ADD_MENU_ID = -1;
+    public static final long DEFAULT_MENU_ID = -2;
+    public static final long NO_MENU_ID = -3;
+
     @Override
     public boolean equals(Object other) {
         if (!(other instanceof MenuModel)) return false;
@@ -36,4 +40,34 @@ public class MenuModel implements NameInterface {
     public String getName() {
         return name;
     }
+
+    public boolean isDefaultMenu() {
+        if (menuId == DEFAULT_MENU_ID) {
+            return true;
+        }
+        return false;
+    }
+
+    public boolean isNoMenu() {
+        if (menuId == NO_MENU_ID) {
+            return true;
+        }
+        return false;
+    }
+
+    public boolean isSpecialMenu() {
+        return isNoMenu() || isDefaultMenu();
+    }
+
+    public void stripLocationFromMenu(MenuLocationModel location){
+        if (locations != null && location != null && location.name != null) {
+            for (MenuLocationModel loc : locations) {
+                if (loc.name != null && loc.name.equals(location.name)) {
+                    locations.remove(loc);
+                    break;
+                }
+            }
+        }
+    }
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusDataModeler.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusDataModeler.java
@@ -98,9 +98,11 @@ public class MenusDataModeler {
             List<MenuLocationModel> locationModels = new ArrayList<>();
             for (MenuLocationModel locationModel : locations){
                 for (String locationName : locationNames){
-                    if (locationModel.getName().equals(locationName)) {
-                        locationModels.add(locationModel);
-                        break;
+                    if (locationModel.name != null) {
+                        if (locationModel.name.equals(locationName)) {
+                            locationModels.add(locationModel);
+                            break;
+                        }
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusRestWPCom.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusRestWPCom.java
@@ -104,7 +104,7 @@ public class MenusRestWPCom {
     }
 
     public int updateMenu(final MenuModel menu) {
-        if (menu == null) return -1;
+        if (menu == null || isSpecialMenu(menu)) return -1;
         final int requestId = ++mRequestCounter;
         String path = formatPath(MENU_REST_PATH, String.valueOf(menu.menuId));
         JSONObject params = new JSONObject();
@@ -214,6 +214,10 @@ public class MenusRestWPCom {
             return String.format(base, String.valueOf(mListener.getSiteId()), menuId);
         }
         return String.format(base, String.valueOf(mListener.getSiteId()));
+    }
+
+    private boolean isSpecialMenu(@NonNull MenuModel menu) {
+        return menu.menuId == MenuLocationModel.NO_MENU_ID || menu.menuId == MenuLocationModel.DEFAULT_MENU_ID;
     }
 
     @NonNull

--- a/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusRestWPCom.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusRestWPCom.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.networking.menus;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
 import com.android.volley.VolleyError;
@@ -110,13 +111,7 @@ public class MenusRestWPCom {
         try {
             params.put(MENU_NAME_KEY, menu.name);
             params.put(MENU_DESCRIPTION_KEY, menu.details);
-            JSONArray locationsArray = new JSONArray();
-            if (menu.locations != null && menu.locations.size() > 0) {
-                for (MenuLocationModel locationModel : menu.locations) {
-                    if (locationModel != null) locationsArray.put(locationModel.name);
-                }
-            }
-            params.put(MENU_LOCATIONS_KEY, locationsArray);
+            params.put(MENU_LOCATIONS_KEY, serializeLocations(menu.locations));
         } catch (JSONException e) {
         }
         WordPress.getRestClientUtilsV1_1().post(path, params, null, new RestRequest.Listener() {
@@ -219,5 +214,16 @@ public class MenusRestWPCom {
             return String.format(base, String.valueOf(mListener.getSiteId()), menuId);
         }
         return String.format(base, String.valueOf(mListener.getSiteId()));
+    }
+
+    @NonNull
+    private JSONArray serializeLocations(List<MenuLocationModel> locations) {
+        JSONArray locationsArray = new JSONArray();
+        if (locations != null && locations.size() > 0) {
+            for (MenuLocationModel location : locations) {
+                if (location != null) locationsArray.put(location.name);
+            }
+        }
+        return locationsArray;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusRestWPCom.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusRestWPCom.java
@@ -105,7 +105,7 @@ public class MenusRestWPCom {
     }
 
     public int updateMenu(final MenuModel menu) {
-        if (menu == null || isSpecialMenu(menu)) return -1;
+        if (menu == null || menu.isSpecialMenu()) return -1;
         final int requestId = ++mRequestCounter;
         String path = formatPath(MENU_REST_PATH, String.valueOf(menu.menuId));
         JSONObject params = new JSONObject();
@@ -114,16 +114,18 @@ public class MenusRestWPCom {
             params.put(MENU_DESCRIPTION_KEY, menu.details);
             params.put(MENU_LOCATIONS_KEY, serializeLocations(menu.locations));
         } catch (JSONException e) {
-            Log.d(AppLog.T.MENUS, "failed to serialize menus update params, aborting REST call");
+            AppLog.d(AppLog.T.MENUS, "failed to serialize menus update params, aborting REST call");
             return -1;
         }
         WordPress.getRestClientUtilsV1_1().post(path, params, null, new RestRequest.Listener() {
-            @Override public void onResponse(JSONObject response) {
+            @Override
+            public void onResponse(JSONObject response) {
                 MenuModel result = menuFromJson(response.optJSONObject(MENU_KEY), menu.locations, mListener.getSiteId());
                 mListener.onMenuUpdated(requestId, result);
             }
         }, new RestRequest.ErrorListener() {
-            @Override public void onErrorResponse(VolleyError volleyError) {
+            @Override
+            public void onErrorResponse(VolleyError volleyError) {
                 int statusCode = statusCodeFromVolleyError(volleyError);
                 REST_ERROR error = REST_ERROR.UPDATE_ERROR;
                 if (statusCode == HTTP_FORBIDDEN) error = REST_ERROR.AUTHENTICATION_ERROR;
@@ -139,14 +141,16 @@ public class MenusRestWPCom {
         String path = formatPath(MENU_REST_PATH, String.valueOf(menuId));
         Map<String, String> params = new HashMap<>();
         WordPress.getRestClientUtilsV1_1().get(path, params, null, new RestRequest.Listener() {
-            @Override public void onResponse(JSONObject response) {
+            @Override
+            public void onResponse(JSONObject response) {
                 MenuModel result = menuFromJson(response.optJSONObject(MENU_KEY), null, mListener.getSiteId());
                 List<MenuModel> resultList = new ArrayList<>();
                 if (result != null) resultList.add(result);
                 mListener.onMenusReceived(requestId, resultList, null);
             }
         }, new RestRequest.ErrorListener() {
-            @Override public void onErrorResponse(VolleyError volleyError) {
+            @Override
+            public void onErrorResponse(VolleyError volleyError) {
                 int statusCode = statusCodeFromVolleyError(volleyError);
                 REST_ERROR error = REST_ERROR.FETCH_ERROR;
                 if (statusCode == HTTP_FORBIDDEN) error = REST_ERROR.AUTHENTICATION_ERROR;
@@ -162,7 +166,8 @@ public class MenusRestWPCom {
         String path = formatPath(MENUS_REST_PATH, null);
         Map<String, String> params = new HashMap<>();
         WordPress.getRestClientUtilsV1_1().get(path, params, null, new RestRequest.Listener() {
-            @Override public void onResponse(JSONObject response) {
+            @Override
+            public void onResponse(JSONObject response) {
                 /* first we get all locations */
                 JSONArray locationsJson = response.optJSONArray(ALL_MENUS_LOCATIONS_KEY);
                 List<MenuLocationModel> locations = menuLocationsFromJson(locationsJson, mListener.getSiteId());
@@ -181,7 +186,8 @@ public class MenusRestWPCom {
                 mListener.onMenusReceived(requestId, menus, locations);
             }
         }, new RestRequest.ErrorListener() {
-            @Override public void onErrorResponse(VolleyError volleyError) {
+            @Override
+            public void onErrorResponse(VolleyError volleyError) {
                 int statusCode = statusCodeFromVolleyError(volleyError);
                 REST_ERROR error = REST_ERROR.FETCH_ERROR;
                 if (statusCode == HTTP_FORBIDDEN) error = REST_ERROR.AUTHENTICATION_ERROR;
@@ -197,12 +203,14 @@ public class MenusRestWPCom {
         String path = formatPath(DELETE_MENU_REST_PATH, String.valueOf(menu.menuId));
         Map<String, String> params = new HashMap<>();
         WordPress.getRestClientUtilsV1_1().post(path, params, null, new RestRequest.Listener() {
-            @Override public void onResponse(JSONObject response) {
+            @Override
+            public void onResponse(JSONObject response) {
                 boolean deleted = response.optBoolean(DELETED_KEY, false);
                 mListener.onMenuDeleted(requestId, menu, deleted);
             }
         }, new RestRequest.ErrorListener() {
-            @Override public void onErrorResponse(VolleyError volleyError) {
+            @Override
+            public void onErrorResponse(VolleyError volleyError) {
                 int statusCode = statusCodeFromVolleyError(volleyError);
                 REST_ERROR error = REST_ERROR.DELETE_ERROR;
                 if (statusCode == HTTP_FORBIDDEN) error = REST_ERROR.AUTHENTICATION_ERROR;
@@ -217,10 +225,6 @@ public class MenusRestWPCom {
             return String.format(base, String.valueOf(mListener.getSiteId()), menuId);
         }
         return String.format(base, String.valueOf(mListener.getSiteId()));
-    }
-
-    private boolean isSpecialMenu(@NonNull MenuModel menu) {
-        return menu.menuId == MenuLocationModel.NO_MENU_ID || menu.menuId == MenuLocationModel.DEFAULT_MENU_ID;
     }
 
     @NonNull

--- a/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusRestWPCom.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusRestWPCom.java
@@ -13,10 +13,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.models.MenuLocationModel;
 import org.wordpress.android.models.MenuModel;
 import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.WPHtml;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -109,24 +106,18 @@ public class MenusRestWPCom {
         if (menu == null) return -1;
         final int requestId = ++mRequestCounter;
         String path = formatPath(MENU_REST_PATH, String.valueOf(menu.menuId));
-        Map<String, String> params = new HashMap<>();
-        params.put(MENU_NAME_KEY, menu.name);
+        JSONObject params = new JSONObject();
         try {
-
+            params.put(MENU_NAME_KEY, menu.name);
+            params.put(MENU_DESCRIPTION_KEY, menu.details);
+            JSONArray locationsArray = new JSONArray();
             if (menu.locations != null && menu.locations.size() > 0) {
-                String commaSeparatedLocations = "";
-                for (MenuLocationModel location : menu.locations) {
-                    commaSeparatedLocations = commaSeparatedLocations + URLEncoder.encode(location.name, ENCODING_UTF8) + ",";
+                for (MenuLocationModel locationModel : menu.locations) {
+                    if (locationModel != null) locationsArray.put(locationModel.name);
                 }
-
-                //strip off last comma
-                if (commaSeparatedLocations.endsWith(",")) {
-                    commaSeparatedLocations.substring(0, commaSeparatedLocations.length()-2);
-                }
-                params.put(MENU_LOCATIONS_KEY, commaSeparatedLocations);
             }
-        } catch (UnsupportedEncodingException e) {
-            AppLog.e(AppLog.T.UTILS, e);
+            params.put(MENU_LOCATIONS_KEY, locationsArray);
+        } catch (JSONException e) {
         }
         WordPress.getRestClientUtilsV1_1().post(path, params, null, new RestRequest.Listener() {
             @Override public void onResponse(JSONObject response) {

--- a/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusRestWPCom.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusRestWPCom.java
@@ -108,7 +108,7 @@ public class MenusRestWPCom {
         params.put(MENU_NAME_KEY, menu.name);
         WordPress.getRestClientUtilsV1_1().post(path, params, null, new RestRequest.Listener() {
             @Override public void onResponse(JSONObject response) {
-                MenuModel result = menuFromJson(response.optJSONObject(MENU_KEY), menu.locations);
+                MenuModel result = menuFromJson(response.optJSONObject(MENU_KEY), menu.locations, mListener.getSiteId());
                 mListener.onMenuUpdated(requestId, result);
             }
         }, new RestRequest.ErrorListener() {
@@ -129,7 +129,7 @@ public class MenusRestWPCom {
         Map<String, String> params = new HashMap<>();
         WordPress.getRestClientUtilsV1_1().get(path, params, null, new RestRequest.Listener() {
             @Override public void onResponse(JSONObject response) {
-                MenuModel result = menuFromJson(response.optJSONObject(MENU_KEY), null);
+                MenuModel result = menuFromJson(response.optJSONObject(MENU_KEY), null, mListener.getSiteId());
                 List<MenuModel> resultList = new ArrayList<>();
                 if (result != null) resultList.add(result);
                 mListener.onMenusReceived(requestId, resultList, null);
@@ -154,14 +154,14 @@ public class MenusRestWPCom {
             @Override public void onResponse(JSONObject response) {
                 /* first we get all locations */
                 JSONArray locationsJson = response.optJSONArray(ALL_MENUS_LOCATIONS_KEY);
-                List<MenuLocationModel> locations = menuLocationsFromJson(locationsJson);
+                List<MenuLocationModel> locations = menuLocationsFromJson(locationsJson, mListener.getSiteId());
 
                 /* now we get all menus */
                 JSONArray menusJson = response.optJSONArray(ALL_MENUS_MENUS_KEY);
                 List<MenuModel> menus = new ArrayList<>();
                 try {
                     for (int i = 0; i < menusJson.length(); ++i) {
-                        menus.add(menuFromJson(menusJson.getJSONObject(i), locations));
+                        menus.add(menuFromJson(menusJson.getJSONObject(i), locations, mListener.getSiteId()));
                     }
                 } catch (JSONException exception) {
                     AppLog.w(AppLog.T.API, "Error parsing All Menus REST response");

--- a/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusRestWPCom.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusRestWPCom.java
@@ -193,8 +193,8 @@ public class MenusRestWPCom {
         }, new RestRequest.ErrorListener() {
             @Override public void onErrorResponse(VolleyError volleyError) {
                 int statusCode = statusCodeFromVolleyError(volleyError);
-                REST_ERROR error = REST_ERROR.FETCH_ERROR;
-                if (statusCode == HTTP_FORBIDDEN) error = REST_ERROR.DELETE_ERROR;
+                REST_ERROR error = REST_ERROR.DELETE_ERROR;
+                if (statusCode == HTTP_FORBIDDEN) error = REST_ERROR.AUTHENTICATION_ERROR;
                 mListener.onErrorResponse(requestId, error);
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusRestWPCom.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusRestWPCom.java
@@ -3,6 +3,7 @@ package org.wordpress.android.networking.menus;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
@@ -113,6 +114,8 @@ public class MenusRestWPCom {
             params.put(MENU_DESCRIPTION_KEY, menu.details);
             params.put(MENU_LOCATIONS_KEY, serializeLocations(menu.locations));
         } catch (JSONException e) {
+            Log.d(AppLog.T.MENUS, "failed to serialize menus update params, aborting REST call");
+            return -1;
         }
         WordPress.getRestClientUtilsV1_1().post(path, params, null, new RestRequest.Listener() {
             @Override public void onResponse(JSONObject response) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusActivity.java
@@ -18,8 +18,6 @@ public class MenusActivity extends AppCompatActivity {
 
     private static final String MENUS_FRAGMENT_KEY = "menusFragment";
 
-    private MenusFragment mMenusFragment;
-
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusActivity.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.menus;
 
-import android.app.FragmentManager;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -8,6 +7,8 @@ import android.support.v7.app.AppCompatActivity;
 import org.wordpress.android.ui.ActivityLauncher;
 
 import android.content.Intent;
+import android.support.v7.widget.Toolbar;
+import android.view.MenuItem;
 
 import org.wordpress.android.R;
 import org.wordpress.android.ui.ActivityId;
@@ -25,21 +26,20 @@ public class MenusActivity extends AppCompatActivity {
 
         setContentView(R.layout.menu_activity);
 
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
-            actionBar.setHomeButtonEnabled(true);
+            actionBar.setTitle(R.string.menus);
+            actionBar.setDisplayShowTitleEnabled(true);
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
 
-        FragmentManager fragmentManager = getFragmentManager();
-        mMenusFragment = (MenusFragment) fragmentManager.findFragmentByTag(MENUS_FRAGMENT_KEY);
-
-        if (mMenusFragment == null) {
-            mMenusFragment = new MenusFragment();
-            mMenusFragment.setArguments(getIntent().getExtras());
-            fragmentManager.beginTransaction()
-                    .replace(android.R.id.content, mMenusFragment, MENUS_FRAGMENT_KEY)
-                    .commit();
+        if (savedInstanceState == null) {
+            MenusFragment menusFragment = new MenusFragment();
+            getFragmentManager().beginTransaction()
+                    .add(R.id.layout_fragment_container, menusFragment, MENUS_FRAGMENT_KEY)
+                    .commitAllowingStateLoss();
         }
     }
 
@@ -53,6 +53,15 @@ public class MenusActivity extends AppCompatActivity {
     public void finish() {
         super.finish();
         ActivityLauncher.slideOutToRight(this);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(final MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            onBackPressed();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -52,6 +52,7 @@ public class MenusFragment extends Fragment {
             }
             @Override public void onMenuCreated(int requestId, MenuModel menu) {
                 Toast.makeText(getActivity(), "menu: " + menu.name + " created", Toast.LENGTH_SHORT).show();
+                //TODO:  add this newly created menu to the spinner
                 mRequestBeingProcessed = false;
             }
             @Override public Context getContext() { return getActivity(); }
@@ -74,6 +75,8 @@ public class MenusFragment extends Fragment {
                         // update Menus spinner
                         mMenusSpinner.setItems((List)menus);
                         bSpinnersUpdated = true;
+
+                        //TODO save menus to local DB here
                     }
                 }
 
@@ -137,7 +140,7 @@ public class MenusFragment extends Fragment {
                 Snackbar snackbar = Snackbar.make(getView(), getString(R.string.menus_menu_deleted), Snackbar.LENGTH_LONG)
                         .setAction(R.string.undo, undoListener);
 
-                // wait for the undo snackbar to disappear before actually deleting the post
+                // wait for the undo snackbar to disappear before actually deleting the menu
                 snackbar.setCallback(new Snackbar.Callback() {
                     @Override
                     public void onDismissed(Snackbar snackbar, int event) {
@@ -183,7 +186,7 @@ public class MenusFragment extends Fragment {
 
     private void updateMenus() {
         if (mIsUpdatingMenus) {
-            AppLog.w(AppLog.T.COMMENTS, "update comments task already running");
+            AppLog.w(AppLog.T.MENUS, "update menus task already running");
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -85,7 +85,7 @@ public class MenusFragment extends Fragment {
                         // no op
                     } else {
                         //insert first Default Menu
-                        insertDefaultMenu(menus);
+                        prepareMenuList(menus);
 
                         // update Menus spinner
                         mMenusSpinner.setItems((List)menus);
@@ -242,9 +242,14 @@ public class MenusFragment extends Fragment {
         mMenusSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                MenuModel model = (MenuModel) mMenusSpinner.getItems().get(position);
-                //TODO: check when to tell this is a default menu or not
-                mAddEditRemoveControl.setMenu(model, false);
+                if (mMenusSpinner.getItems().size() == (position + 1)) {
+                    //clicked on "add new menu"
+                    mAddEditRemoveControl.setMenu(null, false);
+                } else {
+                    MenuModel model = (MenuModel) mMenusSpinner.getItems().get(position);
+                    //TODO: check when to tell this is a default menu or not
+                    mAddEditRemoveControl.setMenu(model, false);
+                }
             }
 
             @Override
@@ -350,11 +355,24 @@ public class MenusFragment extends Fragment {
         }
     }
 
+    private void prepareMenuList(List<MenuModel> menus) {
+        insertDefaultMenu(menus);
+        insertAddMenuOption(menus);
+    }
+
     private void insertDefaultMenu(List<MenuModel> menus) {
         if (menus != null) {
             MenuModel defaultMenu = new MenuModel();
             defaultMenu.name = getString(R.string.menus_default_menu_name);
             menus.add(0, defaultMenu);
+        }
+    }
+
+    private void insertAddMenuOption(List<MenuModel> menus) {
+        if (menus != null) {
+            MenuModel addMenuOption = new MenuModel();
+            addMenuOption.name = getString(R.string.menus_add_menu_name);
+            menus.add(addMenuOption);
         }
     }
 
@@ -396,7 +414,7 @@ public class MenusFragment extends Fragment {
             if (result) {
                 mMenuLocationsSpinner.setItems((List)tmpMenuLocations);
                 //insert first Default Menu
-                insertDefaultMenu(tmpMenus);
+                prepareMenuList(tmpMenus);
                 mMenusSpinner.setItems((List)tmpMenus);
             }
 
@@ -436,7 +454,7 @@ public class MenusFragment extends Fragment {
             if (result) {
                 mMenuLocationsSpinner.setItems((List)tmpMenuLocations);
                 //insert first Default Menu
-                insertDefaultMenu(tmpMenus);
+                prepareMenuList(tmpMenus);
                 mMenusSpinner.setItems((List)tmpMenus);
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -62,7 +62,7 @@ public class MenusFragment extends Fragment {
                     return;
                 }
 
-                Toast.makeText(getActivity(), "menu: " + menu.name + " created", Toast.LENGTH_SHORT).show();
+                Toast.makeText(getActivity(), getString(R.string.menus_menu_created), Toast.LENGTH_SHORT).show();
                 // add this newly created menu to the spinner
                 if (mMenusSpinner.getItems() != null) {
                     //remove "add menu option" item (which is the last one)
@@ -126,16 +126,17 @@ public class MenusFragment extends Fragment {
                     return;
                 }
 
-                if (deleted)
-                    Toast.makeText(getActivity(), "menu: " + menu.name + " deleted", Toast.LENGTH_SHORT).show();
-                else
-                    Toast.makeText(getActivity(), "menu: " + menu.name + " delete request NOT DELETED", Toast.LENGTH_SHORT).show();
-
-                //delete menu from Spinner here
-                if (mMenusSpinner.getItems() != null) {
-                    if (mMenusSpinner.getItems().remove(menu)) {
-                        mMenusSpinner.setItems(mMenusSpinner.getItems());
+                if (deleted) {
+                    Toast.makeText(getActivity(), getString(R.string.menus_menu_deleted), Toast.LENGTH_SHORT).show();
+                    //delete menu from Spinner here
+                    if (mMenusSpinner.getItems() != null) {
+                        if (mMenusSpinner.getItems().remove(menu)) {
+                            mMenusSpinner.setItems(mMenusSpinner.getItems());
+                        }
                     }
+                }
+                else {
+                    Toast.makeText(getActivity(), getString(R.string.could_not_delete_menu), Toast.LENGTH_SHORT).show();
                 }
 
                 mRequestBeingProcessed = false;
@@ -148,7 +149,7 @@ public class MenusFragment extends Fragment {
                     return;
                 }
 
-                Toast.makeText(getActivity(), "menu: " + menu.name + " updated", Toast.LENGTH_SHORT).show();
+                Toast.makeText(getActivity(), getString(R.string.menus_menu_updated), Toast.LENGTH_SHORT).show();
 
                 //update menu in Spinner here
                 if (mMenusSpinner.getItems() != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -386,8 +386,9 @@ public class MenusFragment extends Fragment {
                             MenuLocationModel.LOCATION_DEFAULT.equals(menuLocationSelected.defaultState)) {
                         insertDefaultMenu(menus);
                     } else {
-                        menus.remove(0);
+                        removeDefaultMenu(menus);
                     }
+
 
                     for (int i = 0; i < menus.size() && !bFound; i++) {
                         MenuModel menu = menus.get(i);
@@ -395,6 +396,7 @@ public class MenusFragment extends Fragment {
                             for (MenuLocationModel menuLocation : menu.locations) {
                                 if (menuLocationSelected.equals(menuLocation)) {
                                     //set this one and break;
+                                    mMenusSpinner.setItems((List)menus);
                                     mMenusSpinner.setSelection(i);
                                     bFound = true;
                                     break;
@@ -406,7 +408,11 @@ public class MenusFragment extends Fragment {
                     if (!bFound) {
                         //select the latest menu in the list, taking into account the latest position
                         // holds the "+ add new menu" option
-                        mMenusSpinner.setSelection(mMenusSpinner.getCount() - 2);
+                        mMenusSpinner.setItems((List)menus);
+                        if (menus.size() >= 2)
+                            mMenusSpinner.setSelection(menus.size()-2);
+                        else
+                            mMenusSpinner.setSelection(0);
                     }
                 }
             }
@@ -445,7 +451,6 @@ public class MenusFragment extends Fragment {
         //also fetch latest menus from the server
         mIsUpdatingMenus = true;
         mCurrentLoadRequestId = mRestWPCom.fetchAllMenus();
-
     }
 
 
@@ -517,16 +522,34 @@ public class MenusFragment extends Fragment {
         }
     }
 
+    private void removeDefaultMenu(List<MenuModel> menus){
+        if (menus != null) {
+            int defaultMenuPos = -1;
+            for (int i=0; i < menus.size(); i++) {
+                MenuModel menu = menus.get(i);
+                if (menu.isDefault) {
+                    defaultMenuPos = i;
+                    break;
+                }
+            }
+
+            if (defaultMenuPos >= 0) {
+                menus.remove(defaultMenuPos);
+            }
+        }
+    }
+
     private List<MenuModel> getUserMenusOnly(List<MenuModel> menus){
         ArrayList<MenuModel> tmpMenus = new ArrayList();
-        for (MenuModel menu : menus) {
-            if (menu.siteId > 0) {
-                tmpMenus.add(menu);
+        if (menus != null) {
+            for (MenuModel menu : menus) {
+                if (menu.siteId > 0) {
+                    tmpMenus.add(menu);
+                }
             }
         }
         return tmpMenus;
     }
-
 
     private void restoreMenuInSpinner(MenuModel menu) {
         //restore the menu item in the spinner list

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -632,7 +632,7 @@ public class MenusFragment extends Fragment {
             if (id == MenuModel.ADD_MENU_ID ||
                     id == MenuModel.DEFAULT_MENU_ID ||
                     id == MenuModel.NO_MENU_ID) {
-                toRemove.add(menus.get(0));
+                toRemove.add(menus.get(i));
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 public class MenusFragment extends Fragment {
 
-    private static final int BASE_DISPLAY_COUNT_MENU_LOCATIONS = -2;
+    private static final int BASE_DISPLAY_COUNT_MENUS = -2;
 
     private boolean mUndoPressed = false;
     private MenusRestWPCom mRestWPCom;
@@ -93,7 +93,7 @@ public class MenusFragment extends Fragment {
                         // no op
                     } else {
                         // update Menu Locations spinner
-                        mMenuLocationsSpinner.setItems((List)locations, BASE_DISPLAY_COUNT_MENU_LOCATIONS);
+                        mMenuLocationsSpinner.setItems((List)locations, 0);
                         bSpinnersUpdated = true;
                     }
                 }
@@ -122,7 +122,7 @@ public class MenusFragment extends Fragment {
 
                         addSpecialMenus(locations.get(0), menus);
                         // update Menus spinner
-                        mMenusSpinner.setItems((List)menus, 0);
+                        mMenusSpinner.setItems((List)menus, BASE_DISPLAY_COUNT_MENUS);
                         bSpinnersUpdated = true;
                     }
                 }
@@ -163,7 +163,7 @@ public class MenusFragment extends Fragment {
                     //delete menu from Spinner here
                     if (mMenusSpinner.getItems() != null) {
                         if (mMenusSpinner.getItems().remove(menu)) {
-                            mMenusSpinner.setItems(mMenusSpinner.getItems(), 0);
+                            mMenusSpinner.setItems(mMenusSpinner.getItems(), BASE_DISPLAY_COUNT_MENUS);
                         }
                     }
                 }
@@ -219,7 +219,7 @@ public class MenusFragment extends Fragment {
                         //within the Spinner control - note that if a menu has been updated, it is currently being shown and
                         //selected within the Spinner control view, so it needs to change to reflect the update as well.
                         if (selectedPos >= 0) {
-                            mMenusSpinner.setItems(mMenusSpinner.getItems(), 0);
+                            mMenusSpinner.setItems(mMenusSpinner.getItems(), BASE_DISPLAY_COUNT_MENUS);
                             mMenusSpinner.setSelection(selectedPos);
                         }
                     }
@@ -288,7 +288,7 @@ public class MenusFragment extends Fragment {
                 //delete menu from Spinner here
                 if (mMenusSpinner.getItems() != null) {
                     if (mMenusSpinner.getItems().remove(menu)) {
-                        mMenusSpinner.setItems(mMenusSpinner.getItems(), 0);
+                        mMenusSpinner.setItems(mMenusSpinner.getItems(), BASE_DISPLAY_COUNT_MENUS);
                         mMenusSpinner.setSelection(-1, true);
                     }
                 }
@@ -419,7 +419,7 @@ public class MenusFragment extends Fragment {
                     addSpecialMenus(menuLocationSelected, menus);
                     //we need to re-set (re-create) the spinner adapter in order to make the selection be re-drawn
                     //otherwise if items have changed but the selection remains the same, changes don' get rendered
-                    mMenusSpinner.setItems((List) menus, 0);
+                    mMenusSpinner.setItems((List) menus, BASE_DISPLAY_COUNT_MENUS);
 
                     for (int i = 0; i < menus.size() && !bFound; i++) {
                         MenuModel menu = menus.get(i);
@@ -540,7 +540,7 @@ public class MenusFragment extends Fragment {
             // add the special menus back
             addSpecialMenus((MenuLocationModel) mMenuLocationsSpinner.getSelectedItem(), menuItems);
             // update the spinner items
-            mMenusSpinner.setItems((List)menuItems, 0);
+            mMenusSpinner.setItems((List)menuItems, BASE_DISPLAY_COUNT_MENUS);
             //set this newly created menu
             mMenusSpinner.setSelection(mMenusSpinner.getItems().size() - 2);
         }
@@ -582,11 +582,11 @@ public class MenusFragment extends Fragment {
         @Override
         protected void onPostExecute(Boolean result) {
             if (result) {
-                mMenuLocationsSpinner.setItems((List)tmpMenuLocations, BASE_DISPLAY_COUNT_MENU_LOCATIONS);
+                mMenuLocationsSpinner.setItems((List)tmpMenuLocations, 0);
                 if (tmpMenuLocations != null && tmpMenuLocations.size() > 0) {
                     addSpecialMenus(tmpMenuLocations.get(0), tmpMenus);
                 }
-                mMenusSpinner.setItems((List)tmpMenus, 0);
+                mMenusSpinner.setItems((List)tmpMenus, BASE_DISPLAY_COUNT_MENUS);
             }
 
             if ( (!result || tmpMenuLocations == null || tmpMenuLocations.size() == 0)

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -273,7 +273,10 @@ public class MenusFragment extends Fragment {
                 if (!isAdded() || !NetworkUtils.checkConnection(getActivity()) ) {
                     return;
                 }
-                mCurrentCreateRequestId = mRestWPCom.createMenu(menu);
+                //set the menu's current configuration now
+                MenuModel menuToUpdate = setMenuLocation(menu);
+
+                mCurrentCreateRequestId = mRestWPCom.createMenu(menuToUpdate);
             }
 
             @Override
@@ -334,40 +337,7 @@ public class MenusFragment extends Fragment {
                 }
 
                 //set the menu's current configuration now
-                MenuModel menuToUpdate = menu;
-                if (menu != null) {
-
-                    //first check if this is one of the special menus
-                    if (!menu.isSpecialMenu()) {
-
-                        MenuLocationModel location = (MenuLocationModel) mMenuLocationsSpinner.getSelectedItem();
-                        if (location != null) {
-                            if (menu.locations == null) {
-                                menu.locations = new ArrayList<MenuLocationModel>();
-                            }
-
-                            if (menu.locations.size() > 0) {
-                                //now add location if not existing there yet
-                                for (MenuLocationModel existingLocs : menu.locations) {
-                                    if (!existingLocs.equals(location)) {
-                                        menu.locations.add(location);
-                                        break;
-                                    }
-                                }
-                            } else {
-                                //no menu locations yet, just add it
-                                menu.locations.add(location);
-                            }
-                        }
-                    } else {
-                        //if this is a special Menu, we need to retrieve the last "real" menu and erase the current location
-                        //from its locations list
-                        if (mCurrentMenuForLocation != null) {
-                            mCurrentMenuForLocation.stripLocationFromMenu((MenuLocationModel) mMenuLocationsSpinner.getSelectedItem());
-                            menuToUpdate = mCurrentMenuForLocation;
-                        }
-                    }
-                }
+                MenuModel menuToUpdate = setMenuLocation(menu);
 
                 mCurrentUpdateRequestId = mRestWPCom.updateMenu(menuToUpdate);
             }
@@ -647,6 +617,44 @@ public class MenusFragment extends Fragment {
         addMenu.menuId = MenuModel.ADD_MENU_ID;
         addMenu.name = getString(R.string.menus_add_menu_name);
         insertSpecialMenu(menus, menus.size(), addMenu);
+    }
+
+    private MenuModel setMenuLocation(MenuModel menu) {
+        if (menu != null) {
+            //first check if this is one of the special menus
+            if (!menu.isSpecialMenu()) {
+
+                MenuLocationModel location = (MenuLocationModel) mMenuLocationsSpinner.getSelectedItem();
+                if (location != null) {
+                    if (menu.locations == null) {
+                        menu.locations = new ArrayList<MenuLocationModel>();
+                    }
+
+                    if (menu.locations.size() > 0) {
+                        //now add location if not existing there yet
+                        for (MenuLocationModel existingLocs : menu.locations) {
+                            if (!existingLocs.equals(location)) {
+                                menu.locations.add(location);
+                                break;
+                            }
+                        }
+                    } else {
+                        //no menu locations yet, just add it
+                        menu.locations.add(location);
+                    }
+                }
+
+            } else {
+                //if this is a special Menu, we need to retrieve the last "real" menu and erase the current location
+                //from its locations list
+                if (mCurrentMenuForLocation != null) {
+                    mCurrentMenuForLocation.stripLocationFromMenu((MenuLocationModel) mMenuLocationsSpinner.getSelectedItem());
+                    return mCurrentMenuForLocation;
+                }
+            }
+        }
+
+        return menu;
     }
 
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -284,7 +284,7 @@ public class MenusFragment extends Fragment {
 
                 if (!isAdded() || !NetworkUtils.checkConnection(getActivity()) ) {
                     //restore the Add/Edit/Remove control
-                    mAddEditRemoveControl.setMenu(menu, false);
+                    mAddEditRemoveControl.setMenu(menu);
                     return false;
                 }
 
@@ -301,7 +301,7 @@ public class MenusFragment extends Fragment {
                     public void onClick(View v) {
                         mUndoPressed = true;
                         // user undid the trash action, so reset the control to whatever it had
-                        mAddEditRemoveControl.setMenu(menu, false);
+                        mAddEditRemoveControl.setMenu(menu);
                         //restore the menu item in the spinner list
                         restoreMenuInSpinner(menu);
                     }
@@ -354,11 +354,10 @@ public class MenusFragment extends Fragment {
                     // (as opposed to how the calypso web does this)
                     //but wait for the user to enter a name for the menu and click SAVE on the AddRemoveEdit view control
                     //that's why we set the menu within the control to null
-                    mAddEditRemoveControl.setMenu(null, false);
+                    mAddEditRemoveControl.setMenu(null);
                 } else {
                     MenuModel model = (MenuModel) mMenusSpinner.getItems().get(position);
-                    //TODO: check when to tell this is a default menu or not
-                    mAddEditRemoveControl.setMenu(model, (position == 0));
+                    mAddEditRemoveControl.setMenu(model);
                 }
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -28,6 +28,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.CollectionUtils;
 import org.wordpress.android.util.NetworkUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class MenusFragment extends Fragment {
@@ -82,7 +83,7 @@ public class MenusFragment extends Fragment {
                 mRequestBeingProcessed = false;
             }
             @Override public Context getContext() { return getActivity(); }
-            @Override public void onMenusReceived(int requestId, final List<MenuModel> menus, List<MenuLocationModel> locations) {
+            @Override public void onMenusReceived(int requestId, final List<MenuModel> menus, final List<MenuLocationModel> locations) {
                 boolean bSpinnersUpdated = false;
                 if (locations != null) {
                     if (CollectionUtils.areListsEqual(locations, mMenuLocationsSpinner.getItems())) {
@@ -98,12 +99,15 @@ public class MenusFragment extends Fragment {
                     if (CollectionUtils.areListsEqual(menus, mMenusSpinner.getItems())) {
                         // no op
                     } else {
-                        //TODO save menus to local DB here
+                        final List<MenuModel> userMenusOnly = getUserMenusOnly(menus);
+
+                        //save menus to local DB here
                         new AsyncTask<Void, Void, Boolean>() {
                             @Override
                             protected Boolean doInBackground(Void... params) {
-                                //MenuTable.saveMenu()
-
+                                //make a copy of the menu array and strip off the default and add menu "menus"
+                                MenuTable.saveMenus(userMenusOnly);
+                                MenuLocationTable.saveMenuLocations(locations);
                                 return null;
                             }
 
@@ -119,7 +123,6 @@ public class MenusFragment extends Fragment {
                         // update Menus spinner
                         mMenusSpinner.setItems((List)menus);
                         bSpinnersUpdated = true;
-
                     }
                 }
 
@@ -472,6 +475,16 @@ public class MenusFragment extends Fragment {
             addMenuOption.name = getString(R.string.menus_add_menu_name);
             menus.add(addMenuOption);
         }
+    }
+
+    private List<MenuModel> getUserMenusOnly(List<MenuModel> menus){
+        ArrayList<MenuModel> tmpMenus = new ArrayList();
+        for (MenuModel menu : menus) {
+            if (menu.siteId > 0) {
+                tmpMenus.add(menu);
+            }
+        }
+        return tmpMenus;
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -78,22 +78,9 @@ public class MenusFragment extends Fragment {
 
                     Toast.makeText(getActivity(), getString(R.string.menus_menu_created), Toast.LENGTH_SHORT).show();
                     // add this newly created menu to the spinner
-                    if (mMenusSpinner.getItems() != null) {
-                        List<MenuModel> menuItems = mMenusSpinner.getItems();
-                        // remove special menus in order to add new menu to end of list
-                        removeSpecialMenus(menuItems);
-                        //add the newly created menu
-                        menuItems.add(menu);
-                        // add the special menus back
-                        addSpecialMenus((MenuLocationModel) mMenuLocationsSpinner.getSelectedItem(), menuItems);
-                        // update the spinner items
-                        mMenusSpinner.setItems((List)menuItems);
-                        // enable the action UI elements
-                        mAddEditRemoveControl.setActive(true);
-
-                        //set this newly created menu
-                        mMenusSpinner.setSelection(mMenusSpinner.getItems().size() - 2);
-                    }
+                    addMenuToCurrentList(menu);
+                    // enable the action UI elements
+                    mAddEditRemoveControl.setActive(true);
                 }
             }
             @Override public Context getContext() { return getActivity(); }
@@ -264,7 +251,7 @@ public class MenusFragment extends Fragment {
                     Toast.makeText(getActivity(), getString(R.string.could_not_delete_menu), Toast.LENGTH_SHORT).show();
                     if (requestId == mCurrentDeleteRequestId && mMenuDeletedHolder != null) {
                         //restore the menu item in the spinner list
-                        restoreMenuInSpinner(mMenuDeletedHolder);
+                        addMenuToCurrentList(mMenuDeletedHolder);
                     }
                 }
             }
@@ -311,7 +298,7 @@ public class MenusFragment extends Fragment {
                         // user undid the trash action, so reset the control to whatever it had
                         mAddEditRemoveControl.setMenu(menu);
                         //restore the menu item in the spinner list
-                        restoreMenuInSpinner(menu);
+                        addMenuToCurrentList(menu);
                     }
                 };
 
@@ -539,17 +526,19 @@ public class MenusFragment extends Fragment {
         return tmpMenus;
     }
 
-    private void restoreMenuInSpinner(MenuModel menu) {
-        //restore the menu item in the spinner list
-        if (mMenusSpinner.getItems() != null) {
-            //remove "add menu option" item (which is the last one)
-            mMenusSpinner.getItems().remove(mMenusSpinner.getItems().size() - 1);
+    private void addMenuToCurrentList(MenuModel menu) {
+        if (!isAdded()) return;
+        List<MenuModel> menuItems = mMenusSpinner.getItems();
 
+        if (menuItems != null) {
+            // remove special menus in order to add new menu to end of list
+            removeSpecialMenus(menuItems);
             //add the newly created menu
-            mMenusSpinner.getItems().add(menu);
-
-            mMenusSpinner.setItems(mMenusSpinner.getItems());
-
+            menuItems.add(menu);
+            // add the special menus back
+            addSpecialMenus((MenuLocationModel) mMenuLocationsSpinner.getSelectedItem(), menuItems);
+            // update the spinner items
+            mMenusSpinner.setItems((List)menuItems);
             //set this newly created menu
             mMenusSpinner.setSelection(mMenusSpinner.getItems().size() - 2);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -55,30 +55,44 @@ public class MenusFragment extends Fragment {
             @Override public long getSiteId() {
                 return Long.valueOf(WordPress.getCurrentRemoteBlogId());
             }
-            @Override public void onMenuCreated(int requestId, MenuModel menu) {
-
-                //TODO save new menu to local DB here
-
+            @Override public void onMenuCreated(int requestId, final MenuModel menu) {
                 if (!isAdded()) {
                     return;
                 }
 
-                Toast.makeText(getActivity(), getString(R.string.menus_menu_created), Toast.LENGTH_SHORT).show();
-                // add this newly created menu to the spinner
-                if (mMenusSpinner.getItems() != null) {
-                    //remove "add menu option" item (which is the last one)
-                    mMenusSpinner.getItems().remove(mMenusSpinner.getItems().size() - 1);
+                if (menu != null) {
+                    //save new menu to local DB here
+                    new AsyncTask<Void, Void, Boolean>() {
+                        @Override
+                        protected Boolean doInBackground(Void... params) {
+                            MenuTable.saveMenu(menu);
+                            return null;
+                        }
 
-                    //add the newly created menu
-                    mMenusSpinner.getItems().add(menu);
+                        @Override
+                        protected void onPostExecute(Boolean result) {
+                        };
 
-                    //re-add the "add menu option" item
-                    insertAddMenuOption(mMenusSpinner.getItems());
-                    mMenusSpinner.setItems(mMenusSpinner.getItems());
+                    }.execute();
 
-                    //set this newly created menu
-                    mMenusSpinner.setSelection(mMenusSpinner.getItems().size() - 2);
 
+                    Toast.makeText(getActivity(), getString(R.string.menus_menu_created), Toast.LENGTH_SHORT).show();
+                    // add this newly created menu to the spinner
+                    if (mMenusSpinner.getItems() != null) {
+                        //remove "add menu option" item (which is the last one)
+                        mMenusSpinner.getItems().remove(mMenusSpinner.getItems().size() - 1);
+
+                        //add the newly created menu
+                        mMenusSpinner.getItems().add(menu);
+
+                        //re-add the "add menu option" item
+                        insertAddMenuOption(mMenusSpinner.getItems());
+                        mMenusSpinner.setItems(mMenusSpinner.getItems());
+
+                        //set this newly created menu
+                        mMenusSpinner.setSelection(mMenusSpinner.getItems().size() - 2);
+
+                    }
                 }
                 mRequestBeingProcessed = false;
             }
@@ -99,13 +113,13 @@ public class MenusFragment extends Fragment {
                     if (CollectionUtils.areListsEqual(menus, mMenusSpinner.getItems())) {
                         // no op
                     } else {
+                        //make a copy of the menu array and strip off the default and add menu "menus"
                         final List<MenuModel> userMenusOnly = getUserMenusOnly(menus);
 
                         //save menus to local DB here
                         new AsyncTask<Void, Void, Boolean>() {
                             @Override
                             protected Boolean doInBackground(Void... params) {
-                                //make a copy of the menu array and strip off the default and add menu "menus"
                                 MenuTable.saveMenus(userMenusOnly);
                                 MenuLocationTable.saveMenuLocations(locations);
                                 return null;
@@ -137,11 +151,25 @@ public class MenusFragment extends Fragment {
             }
 
             @Override public void onMenuDeleted(int requestId, MenuModel menu, boolean deleted) {
-                //TODO delete menus from local DB here
+                //delete menu from local DB here
+                final long menuId = menu.menuId;
+                new AsyncTask<Void, Void, Boolean>() {
+                    @Override
+                    protected Boolean doInBackground(Void... params) {
+                        MenuTable.deleteMenu(menuId);
+                        return null;
+                    }
+
+                    @Override
+                    protected void onPostExecute(Boolean result) {
+                    };
+
+                }.execute();
 
                 if (!isAdded()) {
                     return;
                 }
+
 
                 if (deleted) {
                     Toast.makeText(getActivity(), getString(R.string.menus_menu_deleted), Toast.LENGTH_SHORT).show();
@@ -158,9 +186,21 @@ public class MenusFragment extends Fragment {
 
                 mRequestBeingProcessed = false;
             }
-            @Override public void onMenuUpdated(int requestId, MenuModel menu) {
+            @Override public void onMenuUpdated(int requestId, final MenuModel menu) {
 
-                //TODO update menu in local DB here
+                //update menu in local DB here
+                new AsyncTask<Void, Void, Boolean>() {
+                    @Override
+                    protected Boolean doInBackground(Void... params) {
+                        MenuTable.saveMenu(menu);
+                        return null;
+                    }
+
+                    @Override
+                    protected void onPostExecute(Boolean result) {
+                    };
+
+                }.execute();
 
                 if (!isAdded()) {
                     return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -6,7 +6,6 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
-import android.view.Menu;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -75,25 +74,25 @@ public class MenusFragment extends Fragment {
                         @Override
                         protected void onPostExecute(Boolean result) {
                         };
-
                     }.execute();
-
 
                     Toast.makeText(getActivity(), getString(R.string.menus_menu_created), Toast.LENGTH_SHORT).show();
                     // add this newly created menu to the spinner
                     if (mMenusSpinner.getItems() != null) {
-                        //remove "add menu option" item (which is the last one)
-                        mMenusSpinner.getItems().remove(mMenusSpinner.getItems().size() - 1);
-
+                        List<MenuModel> menuItems = mMenusSpinner.getItems();
+                        // remove special menus in order to add new menu to end of list
+                        removeSpecialMenus(menuItems);
                         //add the newly created menu
-                        mMenusSpinner.getItems().add(menu);
-
-                        //re-add the "add menu option" item
-                        mMenusSpinner.setItems(mMenusSpinner.getItems());
+                        menuItems.add(menu);
+                        // add the special menus back
+                        addSpecialMenus((MenuLocationModel) mMenuLocationsSpinner.getSelectedItem(), menuItems);
+                        // update the spinner items
+                        mMenusSpinner.setItems((List)menuItems);
+                        // enable the action UI elements
+                        mAddEditRemoveControl.setActive(true);
 
                         //set this newly created menu
                         mMenusSpinner.setSelection(mMenusSpinner.getItems().size() - 2);
-
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -34,6 +34,8 @@ import java.util.List;
 
 public class MenusFragment extends Fragment {
 
+    private static final int BASE_DISPLAY_COUNT_MENU_LOCATIONS = -2;
+
     private boolean mUndoPressed = false;
     private MenusRestWPCom mRestWPCom;
     private MenuAddEditRemoveView mAddEditRemoveControl;
@@ -91,7 +93,7 @@ public class MenusFragment extends Fragment {
                         // no op
                     } else {
                         // update Menu Locations spinner
-                        mMenuLocationsSpinner.setItems((List)locations);
+                        mMenuLocationsSpinner.setItems((List)locations, BASE_DISPLAY_COUNT_MENU_LOCATIONS);
                         bSpinnersUpdated = true;
                     }
                 }
@@ -120,7 +122,7 @@ public class MenusFragment extends Fragment {
 
                         addSpecialMenus(locations.get(0), menus);
                         // update Menus spinner
-                        mMenusSpinner.setItems((List)menus);
+                        mMenusSpinner.setItems((List)menus, 0);
                         bSpinnersUpdated = true;
                     }
                 }
@@ -161,7 +163,7 @@ public class MenusFragment extends Fragment {
                     //delete menu from Spinner here
                     if (mMenusSpinner.getItems() != null) {
                         if (mMenusSpinner.getItems().remove(menu)) {
-                            mMenusSpinner.setItems(mMenusSpinner.getItems());
+                            mMenusSpinner.setItems(mMenusSpinner.getItems(), 0);
                         }
                     }
                 }
@@ -217,7 +219,7 @@ public class MenusFragment extends Fragment {
                         //within the Spinner control - note that if a menu has been updated, it is currently being shown and
                         //selected within the Spinner control view, so it needs to change to reflect the update as well.
                         if (selectedPos >= 0) {
-                            mMenusSpinner.setItems(mMenusSpinner.getItems());
+                            mMenusSpinner.setItems(mMenusSpinner.getItems(), 0);
                             mMenusSpinner.setSelection(selectedPos);
                         }
                     }
@@ -286,7 +288,7 @@ public class MenusFragment extends Fragment {
                 //delete menu from Spinner here
                 if (mMenusSpinner.getItems() != null) {
                     if (mMenusSpinner.getItems().remove(menu)) {
-                        mMenusSpinner.setItems(mMenusSpinner.getItems());
+                        mMenusSpinner.setItems(mMenusSpinner.getItems(), 0);
                         mMenusSpinner.setSelection(-1, true);
                     }
                 }
@@ -417,7 +419,7 @@ public class MenusFragment extends Fragment {
                     addSpecialMenus(menuLocationSelected, menus);
                     //we need to re-set (re-create) the spinner adapter in order to make the selection be re-drawn
                     //otherwise if items have changed but the selection remains the same, changes don' get rendered
-                    mMenusSpinner.setItems((List) menus);
+                    mMenusSpinner.setItems((List) menus, 0);
 
                     for (int i = 0; i < menus.size() && !bFound; i++) {
                         MenuModel menu = menus.get(i);
@@ -538,7 +540,7 @@ public class MenusFragment extends Fragment {
             // add the special menus back
             addSpecialMenus((MenuLocationModel) mMenuLocationsSpinner.getSelectedItem(), menuItems);
             // update the spinner items
-            mMenusSpinner.setItems((List)menuItems);
+            mMenusSpinner.setItems((List)menuItems, 0);
             //set this newly created menu
             mMenusSpinner.setSelection(mMenusSpinner.getItems().size() - 2);
         }
@@ -580,11 +582,11 @@ public class MenusFragment extends Fragment {
         @Override
         protected void onPostExecute(Boolean result) {
             if (result) {
-                mMenuLocationsSpinner.setItems((List)tmpMenuLocations);
+                mMenuLocationsSpinner.setItems((List)tmpMenuLocations, BASE_DISPLAY_COUNT_MENU_LOCATIONS);
                 if (tmpMenuLocations != null && tmpMenuLocations.size() > 0) {
                     addSpecialMenus(tmpMenuLocations.get(0), tmpMenus);
                 }
-                mMenusSpinner.setItems((List)tmpMenus);
+                mMenusSpinner.setItems((List)tmpMenus, 0);
             }
 
             if ( (!result || tmpMenuLocations == null || tmpMenuLocations.size() == 0)
@@ -646,4 +648,5 @@ public class MenusFragment extends Fragment {
         addMenu.name = getString(R.string.menus_add_menu_name);
         insertSpecialMenu(menus, menus.size(), addMenu);
     }
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -275,7 +275,6 @@ public class MenusFragment extends Fragment {
                 if (!isAdded() || !NetworkUtils.checkConnection(getActivity()) ) {
                     return;
                 }
-
                 mCurrentCreateRequestId = mRestWPCom.createMenu(menu);
             }
 
@@ -335,6 +334,30 @@ public class MenusFragment extends Fragment {
                 if (!isAdded() || !NetworkUtils.checkConnection(getActivity()) ) {
                     return;
                 }
+
+                //set the menu's current configuration now
+                if (menu != null) {
+                    MenuLocationModel location = (MenuLocationModel) mMenuLocationsSpinner.getSelectedItem();
+                    if (location != null) {
+                        if (menu.locations == null) {
+                            menu.locations = new ArrayList<MenuLocationModel>();
+                        }
+
+                        if (menu.locations.size() > 0) {
+                            //now add location if not existing there yet
+                            for (MenuLocationModel existingLocs : menu.locations) {
+                                if (!existingLocs.equals(location)) {
+                                    menu.locations.add(location);
+                                    break;
+                                }
+                            }
+                        } else {
+                            //no menu locations yet, just add it
+                            menu.locations.add(location);
+                        }
+                    }
+                }
+
                 mCurrentUpdateRequestId = mRestWPCom.updateMenu(menu);
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -292,10 +292,7 @@ public class MenusFragment extends Fragment {
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
                 if (mMenusSpinner.getItems().size() == (position + 1)) {
                     //clicked on "add new menu"
-//                    MenuModel newMenu = new MenuModel();
-//                    newMenu.name = getString(R.string.menus_new_menu_name) + " " + (mMenusSpinner.getItems().size()-1);
-//                    mCurrentCreateRequestId = mRestWPCom.createMenu(newMenu);
-//                    mAddEditRemoveControl.setMenu(newMenu, false);
+
                     //for new menus, given we might be off line, it' best to not try creating a default menu right away
                     // (as opposed to how the calypso web does this)
                     //but wait for the user to enter a name for the menu and click SAVE on the AddRemoveEdit view control

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -62,7 +62,12 @@ public class MenusFragment extends Fragment {
                 Toast.makeText(getActivity(), "menu: " + menu.name + " created", Toast.LENGTH_SHORT).show();
                 // add this newly created menu to the spinner
                 if (mMenusSpinner.getItems() != null) {
+                    //remove "add menu option" item (which is the last one)
+                    mMenusSpinner.getItems().remove(mMenusSpinner.getItems().size() - 1);
+                    //add the newly created menu
                     mMenusSpinner.getItems().add(menu);
+                    //re-add the "add menu option" item
+                    insertAddMenuOption(mMenusSpinner.getItems());
                     mMenusSpinner.setItems(mMenusSpinner.getItems());
                 }
                 mRequestBeingProcessed = false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -380,6 +380,9 @@ public class MenusFragment extends Fragment {
                             mMenuLocationsSpinner.getItems().get(position);
 
                     addSpecialMenus(menuLocationSelected, menus);
+                    //we need to re-set (re-create) the spinner adapter in order to make the selection be re-drawn
+                    //otherwise if items have changed but the selection remains the same, changes don' get rendered
+                    mMenusSpinner.setItems((List) menus);
 
                     for (int i = 0; i < menus.size() && !bFound; i++) {
                         MenuModel menu = menus.get(i);
@@ -387,7 +390,6 @@ public class MenusFragment extends Fragment {
                             for (MenuLocationModel menuLocation : menu.locations) {
                                 if (menuLocationSelected.equals(menuLocation)) {
                                     //set this one and break;
-                                    mMenusSpinner.setItems((List)menus);
                                     mMenusSpinner.setSelection(i);
                                     bFound = true;
                                     break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -83,6 +83,9 @@ public class MenusFragment extends Fragment {
                     addMenuToCurrentList(menu);
                     // enable the action UI elements
                     mAddEditRemoveControl.setActive(true);
+
+                    //now update the menu so the menu location will be saved server-side
+                    mCurrentUpdateRequestId = mRestWPCom.updateMenu(menu);
                 }
             }
             @Override public Context getContext() { return getActivity(); }

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -218,6 +218,14 @@ public class MenusFragment extends Fragment {
             @Override
             public void onMenuDelete(final MenuModel menu) {
 
+                //delete menu from Spinner here
+                if (mMenusSpinner.getItems() != null) {
+                    if (mMenusSpinner.getItems().remove(menu)) {
+                        mMenusSpinner.setItems(mMenusSpinner.getItems());
+                        mMenusSpinner.setSelection(-1, true);
+                    }
+                }
+
                 View.OnClickListener undoListener = new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
@@ -264,13 +272,6 @@ public class MenusFragment extends Fragment {
 
                 snackbar.show();
 
-                //delete menu from Spinner here
-                if (mMenusSpinner.getItems() != null) {
-                    if (mMenusSpinner.getItems().remove(menu)) {
-                        mMenusSpinner.setItems(mMenusSpinner.getItems());
-                        mMenusSpinner.setSelection(-1);
-                    }
-                }
             }
 
             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -101,6 +101,7 @@ public class MenusFragment extends Fragment {
             @Override
             public void onErrorResponse(int requestId, MenusRestWPCom.REST_ERROR error) {
                 Toast.makeText(getActivity(), "could not retrieve menus", Toast.LENGTH_SHORT).show();
+                //TODO show error message and go back to previous Activity
                 mRequestBeingProcessed = false;
             }
         });
@@ -168,9 +169,6 @@ public class MenusFragment extends Fragment {
         mMenusSpinner = (MenusSpinner) view.findViewById(R.id.selected_menu_spinner);
 //        menuLocationsSpinner.setItems(new String[]{"Primary Menu", "Social Links"});
 //        selectedMenuSpinner.setItems(new String[]{"Main Menu", "Social Menu", "Professional Menu", "Test Menu", "New Menu"});
-
-        updateMenus();
-
 
         //FIXME: start - delete all this test code!
         Button setMenuBtn = (Button) view.findViewById(R.id.menu_test_set_menu);
@@ -269,6 +267,12 @@ public class MenusFragment extends Fragment {
         super.onPause();
     }
 
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        updateMenus();
+    }
+
     private void updateMenus() {
         if (mIsUpdatingMenus) {
             AppLog.w(AppLog.T.COMMENTS, "update comments task already running");
@@ -328,6 +332,11 @@ public class MenusFragment extends Fragment {
             if (result) {
                 mMenuLocationsSpinner.setItems((List)tmpMenuLocations);
                 mMenusSpinner.setItems((List)tmpMenus);
+            }
+
+            if ( (!result || tmpMenuLocations == null || tmpMenuLocations.size() == 0)
+                    || tmpMenus == null || tmpMenus.size() == 0 ) {
+                //TODO show error message and go back to previous Activity
             }
 
             mIsLoadTaskRunning = false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusSpinner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusSpinner.java
@@ -36,9 +36,9 @@ public class MenusSpinner extends Spinner {
         array.recycle();
     }
 
-    public void setItems(List<NameInterface> items) {
+    public void setItems(List<NameInterface> items, int displayBaseCount) {
         if (items != null && items.size() > 0) {
-            mAdapter = new MenusSpinnerAdapter(items);
+            mAdapter = new MenusSpinnerAdapter(items, displayBaseCount);
             setAdapter(mAdapter);
         } else {
             setAdapter(null);
@@ -56,10 +56,12 @@ public class MenusSpinner extends Spinner {
         private static final int NORMAL_VIEW_TYPE = 1;
 
         private final List<NameInterface> mItems;
+        private int mDisplayBaseCount; //count starts from this value
 
-        public MenusSpinnerAdapter(List<NameInterface> items) {
+        public MenusSpinnerAdapter(List<NameInterface> items, int displayBaseCount) {
             super();
             mItems = items;
+            mDisplayBaseCount = displayBaseCount;
         }
 
         public boolean hasItems() {
@@ -128,7 +130,7 @@ public class MenusSpinner extends Spinner {
             }
 
             TextView titleView = (TextView) convertView.findViewById(R.id.menu_spinner_title);
-            titleView.setText(String.format(mTitle, getCount() - 2));
+            titleView.setText(String.format(mTitle, getCount() + mDisplayBaseCount));
 
             if (hasItems() && position < mItems.size()) {
                 TextView nameView = (TextView) convertView.findViewById(R.id.menu_spinner_name);

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusSpinner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusSpinner.java
@@ -124,7 +124,7 @@ public class MenusSpinner extends Spinner {
 
             if (mIconResource > 0) {
                 ImageView iconView = (ImageView) convertView.findViewById(R.id.menu_spinner_icon);
-                iconView.setBackgroundResource(mIconResource);
+                iconView.setImageResource(mIconResource);
             }
 
             TextView titleView = (TextView) convertView.findViewById(R.id.menu_spinner_title);

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusSpinner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusSpinner.java
@@ -19,6 +19,7 @@ import java.util.List;
 public class MenusSpinner extends Spinner {
     private String mTitle;
     private int mIconResource;
+    private MenusSpinnerAdapter mAdapter;
 
     public MenusSpinner(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -37,10 +38,17 @@ public class MenusSpinner extends Spinner {
 
     public void setItems(List<NameInterface> items) {
         if (items != null && items.size() > 0) {
-            setAdapter(new MenusSpinnerAdapter(items));
+            mAdapter = new MenusSpinnerAdapter(items);
+            setAdapter(mAdapter);
         } else {
             setAdapter(null);
         }
+    }
+
+    public List getItems(){
+        if (mAdapter != null)
+            return mAdapter.getItems();
+        return null;
     }
 
     private class MenusSpinnerAdapter implements SpinnerAdapter {
@@ -142,5 +150,10 @@ public class MenusSpinner extends Spinner {
         public boolean isEmpty() {
             return !hasItems();
         }
+
+        public List getItems(){
+            return mItems;
+        }
+
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusSpinner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusSpinner.java
@@ -128,7 +128,7 @@ public class MenusSpinner extends Spinner {
             }
 
             TextView titleView = (TextView) convertView.findViewById(R.id.menu_spinner_title);
-            titleView.setText(String.format(mTitle, getCount()));
+            titleView.setText(String.format(mTitle, getCount() - 2));
 
             if (hasItems() && position < mItems.size()) {
                 TextView nameView = (TextView) convertView.findViewById(R.id.menu_spinner_name);

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusSpinner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusSpinner.java
@@ -130,8 +130,10 @@ public class MenusSpinner extends Spinner {
             TextView titleView = (TextView) convertView.findViewById(R.id.menu_spinner_title);
             titleView.setText(String.format(mTitle, getCount()));
 
-            TextView nameView = (TextView) convertView.findViewById(R.id.menu_spinner_name);
-            nameView.setText(mItems.get(position).getName());
+            if (hasItems() && position < mItems.size()) {
+                TextView nameView = (TextView) convertView.findViewById(R.id.menu_spinner_name);
+                nameView.setText(mItems.get(position).getName());
+            }
 
             return convertView;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuAddEditRemoveView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuAddEditRemoveView.java
@@ -251,14 +251,14 @@ public class MenuAddEditRemoveView extends LinearLayout {
     }
 
     public boolean isCurrentMenuDefault() {
-        if (this.mCurrentMenu != null && this.mCurrentMenu.menuId == MenuLocationModel.DEFAULT_MENU_ID) {
+        if (this.mCurrentMenu != null && this.mCurrentMenu.isDefaultMenu()) {
             return true;
         }
         return false;
     }
 
     public boolean isCurrentMenuNoMenu() {
-        if (this.mCurrentMenu != null && this.mCurrentMenu.menuId == MenuLocationModel.NO_MENU_ID) {
+        if (this.mCurrentMenu != null && this.mCurrentMenu.isNoMenu()) {
             return true;
         }
         return false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuAddEditRemoveView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuAddEditRemoveView.java
@@ -34,7 +34,7 @@ public class MenuAddEditRemoveView extends LinearLayout {
 
     public interface MenuAddEditRemoveActionListener {
         void onMenuCreate(MenuModel menu);
-        void onMenuDelete(MenuModel menu, boolean isDefault);
+        void onMenuDelete(MenuModel menu);
         void onMenuUpdate(MenuModel menu);
     }
 
@@ -122,7 +122,7 @@ public class MenuAddEditRemoveView extends LinearLayout {
                 setActive(false);
                 if (mActionListener != null) {
                     if (mCurrentMenu != null) {
-                        mActionListener.onMenuDelete(mCurrentMenu, isCurrentMenuDefault());
+                        mActionListener.onMenuDelete(mCurrentMenu);
                         setMenu(null, false);
                     } else {
                         // in case this is a new menu (i.e. not really editing) we don't call the listener
@@ -147,7 +147,7 @@ public class MenuAddEditRemoveView extends LinearLayout {
                     mMenuInactiveTitleText.setText(menuTitle);
                     setActive(false);
                     if (mActionListener != null){
-                        if (mCurrentMenu == null){
+                        if (mCurrentMenu == null || mCurrentMenu.menuId == 0){
                             MenuModel menu = new MenuModel();
                             menu.name = menuTitle;
                             mActionListener.onMenuCreate(menu);

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuAddEditRemoveView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuAddEditRemoveView.java
@@ -34,7 +34,7 @@ public class MenuAddEditRemoveView extends LinearLayout {
 
     public interface MenuAddEditRemoveActionListener {
         void onMenuCreate(MenuModel menu);
-        void onMenuDelete(MenuModel menu);
+        boolean onMenuDelete(MenuModel menu); //return true if you want the MenuAddEditRemove control to reset itself afterwards
         void onMenuUpdate(MenuModel menu);
     }
 
@@ -122,8 +122,9 @@ public class MenuAddEditRemoveView extends LinearLayout {
                 setActive(false);
                 if (mActionListener != null) {
                     if (mCurrentMenu != null) {
-                        mActionListener.onMenuDelete(mCurrentMenu);
-                        setMenu(null, false);
+                        if (mActionListener.onMenuDelete(mCurrentMenu)) {
+                            setMenu(null, false);
+                        }
                     } else {
                         // in case this is a new menu (i.e. not really editing) we don't call the listener
                         // - we just clear the text and set inactive

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuAddEditRemoveView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuAddEditRemoveView.java
@@ -29,11 +29,12 @@ public class MenuAddEditRemoveView extends LinearLayout {
     private boolean mIsActive;
 
     private MenuModel mCurrentMenu;
+    private boolean mCurrentMenuIsDefault;
     private MenuAddEditRemoveActionListener mActionListener;
 
     public interface MenuAddEditRemoveActionListener {
         void onMenuCreate(MenuModel menu);
-        void onMenuDelete(MenuModel menu);
+        void onMenuDelete(MenuModel menu, boolean isDefault);
         void onMenuUpdate(MenuModel menu);
     }
 
@@ -121,7 +122,7 @@ public class MenuAddEditRemoveView extends LinearLayout {
                 setActive(false);
                 if (mActionListener != null) {
                     if (mCurrentMenu != null) {
-                        mActionListener.onMenuDelete(mCurrentMenu);
+                        mActionListener.onMenuDelete(mCurrentMenu, isCurrentMenuDefault());
                         setMenu(null, false);
                     } else {
                         // in case this is a new menu (i.e. not really editing) we don't call the listener
@@ -218,6 +219,7 @@ public class MenuAddEditRemoveView extends LinearLayout {
             mMenuSave.setEnabled(false);
         }
 
+        this.mCurrentMenuIsDefault = isDefault;
         if (isDefault){
             mMenuRemove.setVisibility(View.GONE);
         } else {
@@ -229,6 +231,10 @@ public class MenuAddEditRemoveView extends LinearLayout {
 
     public MenuModel getMenu() {
         return this.mCurrentMenu;
+    }
+
+    public boolean isCurrentMenuDefault() {
+        return this.mCurrentMenuIsDefault;
     }
 
     //set a listener to listen for SAVE and REMOVE buttons

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuAddEditRemoveView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuAddEditRemoveView.java
@@ -81,7 +81,10 @@ public class MenuAddEditRemoveView extends LinearLayout {
         mMenuInactiveStateView.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
-                setActive(true);
+                //do not allow editing for default menus
+                if (!isCurrentMenuDefault()) {
+                    setActive(true);
+                }
             }
         });
 
@@ -222,8 +225,10 @@ public class MenuAddEditRemoveView extends LinearLayout {
 
         this.mCurrentMenuIsDefault = isDefault;
         if (isDefault){
+            mMenuInactiveTitleText.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0);
             mMenuRemove.setVisibility(View.GONE);
         } else {
+            mMenuInactiveTitleText.setCompoundDrawablesWithIntrinsicBounds(0,0,R.drawable.icon_menus_edit,0);
             mMenuRemove.setVisibility(View.VISIBLE);
         }
 

--- a/WordPress/src/main/res/layout/menu_activity.xml
+++ b/WordPress/src/main/res/layout/menu_activity.xml
@@ -6,6 +6,10 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <include
+        layout="@layout/toolbar"
+        android:id="@+id/toolbar" />
+
     <FrameLayout
         android:id="@+id/layout_fragment_container"
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/menu_spinner.xml
+++ b/WordPress/src/main/res/layout/menu_spinner.xml
@@ -21,9 +21,12 @@
         android:tint="@color/grey" />
 
     <LinearLayout
+        android:id="@+id/menu_spinner_texts"
         android:orientation="vertical"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
+        android:layout_width="0dp"
+        android:layout_weight="1"
+        android:layout_height="wrap_content"
+        android:layout_toRightOf="@id/menu_spinner_icon">
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/menu_spinner_title"
@@ -45,5 +48,14 @@
             tools:text="this is the menu title"/>
 
     </LinearLayout>
+
+    <ImageView
+        android:id="@+id/menu_chevron"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:layout_gravity="center_vertical"
+        android:src="@drawable/gallery_arrow_dropdown_open"
+        android:layout_alignParentRight="true"
+        android:tint="@color/grey" />
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/menu_spinner.xml
+++ b/WordPress/src/main/res/layout/menu_spinner.xml
@@ -51,8 +51,8 @@
 
     <ImageView
         android:id="@+id/menu_chevron"
-        android:layout_width="36dp"
-        android:layout_height="36dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
         android:src="@drawable/gallery_arrow_dropdown_open"
         android:layout_alignParentRight="true"

--- a/WordPress/src/main/res/layout/menu_spinner.xml
+++ b/WordPress/src/main/res/layout/menu_spinner.xml
@@ -5,7 +5,11 @@
     android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/margin_medium">
+    android:paddingTop="@dimen/margin_medium"
+    android:paddingBottom="@dimen/margin_medium"
+    android:paddingRight="@dimen/margin_extra_large"
+    android:paddingLeft="@dimen/margin_extra_large"
+    >
 
     <ImageView
         android:id="@+id/menu_spinner_icon"

--- a/WordPress/src/main/res/layout/menu_spinner.xml
+++ b/WordPress/src/main/res/layout/menu_spinner.xml
@@ -5,7 +5,7 @@
     android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/margin_extra_large">
+    android:padding="@dimen/margin_medium">
 
     <ImageView
         android:id="@+id/menu_spinner_icon"
@@ -25,7 +25,7 @@
             android:id="@+id/menu_spinner_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="@dimen/text_sz_medium"
+            android:textSize="@dimen/text_sz_large"
             android:textColor="@color/grey_lighten_10"
             tools:text="2 menu areas in this theme"/>
 

--- a/WordPress/src/main/res/layout/menu_spinner.xml
+++ b/WordPress/src/main/res/layout/menu_spinner.xml
@@ -1,45 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="horizontal"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:padding="@dimen/margin_extra_large">
 
-    <RelativeLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+    <ImageView
+        android:id="@+id/menu_spinner_icon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
         android:layout_marginRight="@dimen/margin_extra_large"
-
-        android:layout_marginTop="@dimen/margin_extra_large"
-        android:layout_marginBottom="@dimen/margin_extra_large"
-        >
-        <ImageView
-            android:id="@+id/menu_spinner_icon"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:tint="@color/grey" />
-    </RelativeLayout>
+        android:layout_gravity="center_vertical"
+        android:src="@drawable/gridicon_menus"
+        android:tint="@color/grey" />
 
     <LinearLayout
         android:orientation="vertical"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content">
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/menu_spinner_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textSize="@dimen/text_sz_medium"
-            android:textColor="@color/grey_lighten_10" />
+            android:textColor="@color/grey_lighten_10"
+            tools:text="2 menu areas in this theme"/>
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/menu_spinner_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:singleLine="true"
             android:textSize="@dimen/text_sz_extra_large"
-            android:textColor="@color/grey_dark" />
+            android:textColor="@color/grey_dark"
+            tools:text="this is the menu title"/>
 
     </LinearLayout>
 

--- a/WordPress/src/main/res/layout/menu_spinner.xml
+++ b/WordPress/src/main/res/layout/menu_spinner.xml
@@ -9,8 +9,8 @@
 
     <ImageView
         android:id="@+id/menu_spinner_icon"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
         android:layout_marginRight="@dimen/margin_extra_large"
         android:layout_gravity="center_vertical"
         android:src="@drawable/gridicon_menus"

--- a/WordPress/src/main/res/layout/menu_spinner.xml
+++ b/WordPress/src/main/res/layout/menu_spinner.xml
@@ -7,12 +7,20 @@
     android:layout_height="match_parent"
     android:padding="@dimen/margin_extra_large">
 
-    <ImageView
-        android:id="@+id/menu_spinner_icon"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_marginRight="@dimen/margin_extra_large"
-        android:tint="@color/wp_blue_dark" />
+
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:layout_marginBottom="@dimen/margin_extra_large"
+        >
+        <ImageView
+            android:id="@+id/menu_spinner_icon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:tint="@color/grey" />
+    </RelativeLayout>
 
     <LinearLayout
         android:orientation="vertical"

--- a/WordPress/src/main/res/layout/menu_spinner_item.xml
+++ b/WordPress/src/main/res/layout/menu_spinner_item.xml
@@ -2,7 +2,6 @@
 
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -19,6 +18,6 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_alignParentRight="true"
-        android:tint="@color/grey_dark" />
+        android:tint="@color/grey" />
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/menus_fragment.xml
+++ b/WordPress/src/main/res/layout/menus_fragment.xml
@@ -1,115 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/grey_light"
     android:padding="@dimen/content_margin">
 
-    <org.wordpress.android.ui.menus.MenusSpinner
-        android:id="@+id/menu_locations_spinner"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/margin_small"
-        app:spinnerTitle="@string/location_menu_spinner_title"
-        app:spinnerIcon="@drawable/gridicon_layout" />
 
     <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/empty_view"
+        style="@style/WordPress.EmptyList.Title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:layout_marginBottom="@dimen/margin_small"
-        android:text="@string/uses" />
+        android:layout_centerInParent="true"
+        android:layout_marginBottom="@dimen/empty_list_title_bottom_margin"
+        android:layout_marginLeft="@dimen/empty_list_title_side_margin"
+        android:layout_marginRight="@dimen/empty_list_title_side_margin"
+        android:gravity="center"
+        android:text="@string/empty_list_default"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
-    <org.wordpress.android.ui.menus.MenusSpinner
-        android:id="@+id/selected_menu_spinner"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:spinnerTitle="@string/menus_spinner_title"
-        app:spinnerIcon="@drawable/gridicon_menus" />
-
-
-    <!--//FIXME: start - delete all this!-->
-
-    <org.wordpress.android.widgets.WPTextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/content_margin"
-        android:text="@string/menus_test_test"/>
-
-    <Button
-        android:id="@+id/menu_test_fetch_all"
-        android:layout_margin="@dimen/content_margin"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/menus_test_get_all_menus"
-        />
-
-    <TextView
-        android:id="@+id/test_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
 
     <LinearLayout
-        android:layout_width="wrap_content"
+        android:id="@+id/spinner_group"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/content_margin"
-        android:orientation="horizontal">
-        <Button
-            android:id="@+id/menu_test_fetch_good_menu"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/menus_test_get_last_menu"
-            />
+        android:orientation="vertical">
 
-        <Button
-            android:id="@+id/menu_test_fetch_bad_menu"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/menus_test_get_inexistent_menu"
-            />
 
-        <Button
-            android:id="@+id/menu_test_fetch_zero_menu"
+        <org.wordpress.android.ui.menus.MenusSpinner
+            android:id="@+id/menu_locations_spinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_small"
+            app:spinnerTitle="@string/location_menu_spinner_title"
+            app:spinnerIcon="@drawable/gridicon_layout" />
+
+        <org.wordpress.android.widgets.WPTextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/menus_test_get_id_zero"
-            />
+            android:layout_gravity="center"
+            android:layout_marginBottom="@dimen/margin_small"
+            android:text="@string/uses" />
+
+        <org.wordpress.android.ui.menus.MenusSpinner
+            android:id="@+id/selected_menu_spinner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:spinnerTitle="@string/menus_spinner_title"
+            app:spinnerIcon="@drawable/gridicon_menus" />
 
     </LinearLayout>
 
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/content_margin"
-        android:orientation="horizontal">
-        <Button
-            android:id="@+id/menu_test_set_menu"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/menus_test_set_menu"
-            />
-
-        <Button
-            android:id="@+id/menu_test_set_menu_default"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/menus_test_set_default"
-            />
-
-        <Button
-            android:id="@+id/menu_test_reset_control"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/menus_test_reset"
-            />
-    </LinearLayout>
-
-    <View style="@style/MenusDividerView" />
-   <!--//FIXME: end - delete all this!-->
 
     <org.wordpress.android.ui.menus.views.MenuAddEditRemoveView
         android:id="@+id/menu_add_edit_remove_view"

--- a/WordPress/src/main/res/layout/menus_fragment.xml
+++ b/WordPress/src/main/res/layout/menus_fragment.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/grey_light"
-    android:padding="@dimen/content_margin">
+    >
 
 
     <org.wordpress.android.widgets.WPTextView
@@ -30,14 +30,18 @@
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
+        <View style="@style/MenusDividerView" />
 
         <org.wordpress.android.ui.menus.MenusSpinner
             android:id="@+id/menu_locations_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_small"
+            android:background="@color/white"
             app:spinnerTitle="@string/location_menu_spinner_title"
-            app:spinnerIcon="@drawable/gridicon_layout" />
+            app:spinnerIcon="@drawable/gridicon_layout"
+            />
+
+        <View style="@style/MenusDividerView" />
 
         <org.wordpress.android.widgets.WPTextView
             android:layout_width="wrap_content"
@@ -46,18 +50,20 @@
             android:layout_marginBottom="@dimen/margin_small"
             android:text="@string/uses" />
 
+        <View style="@style/MenusDividerView" />
+
         <org.wordpress.android.ui.menus.MenusSpinner
             android:id="@+id/selected_menu_spinner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:background="@color/white"
             app:spinnerTitle="@string/menus_spinner_title"
             app:spinnerIcon="@drawable/gridicon_menus" />
 
+        <View style="@style/MenusDividerView" />
+
     </LinearLayout>
 
-    <View style="@style/MenusDividerView"
-        android:layout_marginTop="@dimen/content_margin"
-        android:layout_marginBottom="@dimen/content_margin"/>
 
     <org.wordpress.android.ui.menus.views.MenuAddEditRemoveView
         android:id="@+id/menu_add_edit_remove_view"

--- a/WordPress/src/main/res/layout/menus_fragment.xml
+++ b/WordPress/src/main/res/layout/menus_fragment.xml
@@ -48,6 +48,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:layout_marginBottom="@dimen/margin_small"
+            android:textAllCaps="true"
             android:text="@string/uses" />
 
         <View style="@style/MenusDividerView" />

--- a/WordPress/src/main/res/layout/menus_fragment.xml
+++ b/WordPress/src/main/res/layout/menus_fragment.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -56,6 +55,9 @@
 
     </LinearLayout>
 
+    <View style="@style/MenusDividerView"
+        android:layout_marginTop="@dimen/content_margin"
+        android:layout_marginBottom="@dimen/content_margin"/>
 
     <org.wordpress.android.ui.menus.views.MenuAddEditRemoveView
         android:id="@+id/menu_add_edit_remove_view"

--- a/WordPress/src/main/res/layout/menus_menu_add_edit_remove.xml
+++ b/WordPress/src/main/res/layout/menus_menu_add_edit_remove.xml
@@ -29,10 +29,11 @@
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/menu_title_tv"
                     style="@style/MenuNameInactiveText"
-                    android:layout_width="match_parent"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_vertical"
                     android:drawableRight="@drawable/icon_menus_edit"
+                    android:drawablePadding="@dimen/margin_small"
                     android:drawableTint="@color/grey_darken_20"
                     tools:text="Title" />
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1434,6 +1434,7 @@
     <string name="menus_spinner_title">%d menus available</string>
     <string name="menus_spinner_empty">No menus loaded for this site</string>
     <string name="menus_default_menu_name">Default Menu</string>
+    <string name="menus_add_menu_name">+ Add new menu</string>
     <string name="could_not_load_menus">Could not load menus for this site</string>
     <string name="could_not_refresh_menus">Could not refresh menus for this site - showing local pre-saved menus</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1428,7 +1428,6 @@
     <string name="plans_post_purchase_button_themes">Browse Themes</string>
 
     <!-- Calypso menus -->
-    <string name="menus_menu_deleted">Menu deleted</string>
     <string name="uses">uses</string>
     <string name="location_menu_spinner_title">%d menu areas in this theme</string>
     <string name="menus_spinner_title">%d menus available</string>
@@ -1439,7 +1438,11 @@
     <string name="could_not_refresh_menus">Could not refresh menus for this site - showing local pre-saved menus</string>
     <string name="could_not_create_menu">Could not create menu</string>
     <string name="could_not_update_menu">Could not update menu</string>
+    <string name="could_not_delete_menu">Could not delete menu</string>
     <string name="menus_new_menu_name">Menu</string>
+    <string name="menus_menu_created">Menu created</string>
+    <string name="menus_menu_deleted">Menu deleted</string>
+    <string name="menus_menu_updated">Menu updated</string>
 
     <string name="get_a_link_sent_to_your_email_to_sign_in_instantly">Get a link sent to your email to sign in instantly</string>
     <string name="logging_in">Logging in</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1433,6 +1433,7 @@
     <string name="menus_spinner_title">%d menus available</string>
     <string name="menus_spinner_empty">No menus loaded for this site</string>
     <string name="menus_default_menu_name">Default Menu</string>
+    <string name="menus_no_menu_name">No Menu</string>
     <string name="menus_add_menu_name">+ Add new menu</string>
     <string name="could_not_load_menus">Could not load menus for this site</string>
     <string name="could_not_refresh_menus">Could not refresh menus for this site - showing local pre-saved menus</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1437,6 +1437,9 @@
     <string name="menus_add_menu_name">+ Add new menu</string>
     <string name="could_not_load_menus">Could not load menus for this site</string>
     <string name="could_not_refresh_menus">Could not refresh menus for this site - showing local pre-saved menus</string>
+    <string name="could_not_create_menu">Could not create menu</string>
+    <string name="could_not_update_menu">Could not update menu</string>
+    <string name="menus_new_menu_name">Menu</string>
 
     <string name="get_a_link_sent_to_your_email_to_sign_in_instantly">Get a link sent to your email to sign in instantly</string>
     <string name="logging_in">Logging in</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1403,6 +1403,11 @@
     <string name="uses">uses</string>
     <string name="location_menu_spinner_title">%d menu areas in this theme</string>
     <string name="menus_spinner_title">%d menus available</string>
+    <string name="menus_spinner_empty">No menus loaded for this site</string>
+    <string name="could_not_load_menus">Could not load menus for this site</string>
+    <string name="could_not_refresh_menus">Could not refresh menus for this site - showing local pre-saved menus</string>
+
+
 
     <string name="web_address_dialog_hint">Shown publicly when you comment.</string>
     <string name="exporting_content_progress">Exporting content…</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1400,14 +1400,6 @@
     <string name="pending_email_change_snackbar">Click the verification link in the email sent to %1$s to confirm your new address</string>
     <string name="primary_site">Primary site</string>
     <string name="web_address">Web Address</string>
-    <string name="uses">uses</string>
-    <string name="location_menu_spinner_title">%d menu areas in this theme</string>
-    <string name="menus_spinner_title">%d menus available</string>
-    <string name="menus_spinner_empty">No menus loaded for this site</string>
-    <string name="could_not_load_menus">Could not load menus for this site</string>
-    <string name="could_not_refresh_menus">Could not refresh menus for this site - showing local pre-saved menus</string>
-
-
 
     <string name="web_address_dialog_hint">Shown publicly when you comment.</string>
     <string name="exporting_content_progress">Exporting content…</string>
@@ -1437,18 +1429,14 @@
 
     <!-- Calypso menus -->
     <string name="menus_menu_deleted">Menu deleted</string>
+    <string name="uses">uses</string>
+    <string name="location_menu_spinner_title">%d menu areas in this theme</string>
+    <string name="menus_spinner_title">%d menus available</string>
+    <string name="menus_spinner_empty">No menus loaded for this site</string>
+    <string name="menus_default_menu_name">Default Menu</string>
+    <string name="could_not_load_menus">Could not load menus for this site</string>
+    <string name="could_not_refresh_menus">Could not refresh menus for this site - showing local pre-saved menus</string>
 
-    <!-- FIXME delete these test strings -->
-    <string name="menus_test_test">Test</string>
-    <string name="menus_test_get_all_menus">Get all menus</string>
-    <string name="menus_test_get_last_menu">get last menu</string>
-    <string name="menus_test_get_inexistent_menu">get inexistent menu</string>
-    <string name="menus_test_get_id_zero">Get id=0 menu</string>
-    <string name="menus_test_set_menu">Set menu</string>
-    <string name="menus_test_set_default">Set default menu</string>
-    <string name="menus_test_reset">Reset</string>
-    <string name="menus_test_start_label">Add / Edit / Remove component starts below</string>
-    
     <string name="get_a_link_sent_to_your_email_to_sign_in_instantly">Get a link sent to your email to sign in instantly</string>
     <string name="logging_in">Logging in</string>
     <string name="magic_link_unavailable_error_message">Currently unavailable. Please enter your password</string>


### PR DESCRIPTION
Fixes #3589

This brings the Menu locations and Menus spinners to life. Now you can add/remove/edit menus and spinners will reflect so accordingly.

![add_edit_remove_menus3](https://cloud.githubusercontent.com/assets/6597771/15688981/3437576c-2753-11e6-8d04-40c4f58cb966.gif)

The way it works is, basically it loads the menus right away from the DB and renders the screen, and at the same time triggers a refresh call to the server. Once it comes back from the server, the DB is updated and the screen is updated as well.

Some things that need further discussion:
- check the default menu behaviour, is it coming in the API? As per my checks it is not, so I wonder whether there’s some magic ID number for the default menu if I wanted to edit the name or, in the very near future, the menu items. Is it possible to add/edit menu items on the Default Menu? How’s that handled?

- you’ll need to delete the database / clear app data / drop the Menus table programmatically once as I’ve added one missing column to it (SITE_ID_COLUMN)

Random notes:
+ added navigation bar to the activity
+ save info to db
+ tried to change look and feel of spinners to match the white background/blue border in the web
(tried and didn’t like it really, we’d better have @mattmiklic  take a look)

Further work:
- componentize the spinners as in the way MenuAddEditRemoveView works



Needs review: @tonyr59h 

**Added note**: please merge https://github.com/wordpress-mobile/WordPress-Android/pull/4146 **AFTER** reviewing and merging this one