### PR TITLE
Visual editor: fix edit image settings for non-link wrapped images

### DIFF
--- a/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1963,6 +1963,11 @@ ZSSEditor.applyImageSelectionFormatting = function( imageNode ) {
 }
 
 ZSSEditor.removeImageSelectionFormatting = function( imageNode ) {
+    if (!$('#zss_field_content')[0].contains(imageNode)) {
+        // The image node has already been removed from the document
+        return;
+    }
+
     var node = ZSSEditor.findImageCaptionNode( imageNode );
     if ( !node.parentNode || node.parentNode.className.indexOf( "edit-container" ) == -1 ) {
         return;

--- a/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -3313,7 +3313,12 @@ ZSSField.prototype.handleTapEvent = function(e) {
             ZSSEditor.currentEditingImage = targetNode;
             var containerNode = ZSSEditor.applyImageSelectionFormatting(targetNode);
 
-            ZSSEditor.setFocusAfterElement(containerNode);
+            // Move the cursor to the tapped image, to prevent scrolling to the bottom of the document when the
+            // keyboard comes up. On API 19 and below does not work properly, with the image sometimes getting removed
+            // from the post instead of the edit overlay being displayed
+            if (nativeState.androidApiLevel > 19) {
+                ZSSEditor.setFocusAfterElement(containerNode);
+            }
 
             return;
         }

--- a/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
+++ b/libs/editor/libs/editor-common/assets/ZSSRichTextEditor.js
@@ -1958,6 +1958,8 @@ ZSSEditor.applyImageSelectionFormatting = function( imageNode ) {
     selectionNode.appendChild( node );
 
     this.trackNodeForMutation($(selectionNode));
+
+    return selectionNode;
 }
 
 ZSSEditor.removeImageSelectionFormatting = function( imageNode ) {
@@ -3309,9 +3311,9 @@ ZSSField.prototype.handleTapEvent = function(e) {
 
             // Format and flag the image as selected.
             ZSSEditor.currentEditingImage = targetNode;
-            ZSSEditor.applyImageSelectionFormatting(targetNode);
+            var containerNode = ZSSEditor.applyImageSelectionFormatting(targetNode);
 
-            ZSSEditor.setFocusAfterElement(targetNode);
+            ZSSEditor.setFocusAfterElement(containerNode);
 
             return;
         }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/392 and https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/393.

This is an editor-only change, but the issue only appears in WPAndroid (images are always wrapped in links when added in the Editor example app).

Superficially, this was caused by [this line](https://github.com/wordpress-mobile/WordPress-Editor-Android/blob/e6015b23a0c54bb2618a7d1f9f45b061aa1645bd/libs/editor-common/assets/ZSSRichTextEditor.js#L3312), which places the cursor immediately after the image that was tapped, to prevent the editor scrolling to the bottom of the post when the keyboard comes up (https://github.com/wordpress-mobile/WordPress-Editor-Android/pull/384). In some cases the WebView doesn't like this and decides to remove the whole container node. There's no good reason why this should happen that I can see, but there you go. This fix is basically the result of a trial-and-error approach: giving focus to the container instead of the image seems to make everything work smoothly.

..Except on API 19 and below, where I'm still seeing image removal issues no matter what. I decided to just drop the scroll fix for those API levels for now, as the image removal bug is much worse.

The [error log issue](https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/393) was due to `ZSSEditor.removeImageSelectionFormatting()` getting called on an image that had already been removed from the document. This shouldn't happen anymore with this fix, but I've added an appropriate check in 82903c7 anyway.

Needs review: @maxme 

Note: This should be cherry picked into `hotfix/5.4.1`.
