### PR TITLE
Issue/4119 reader sort order

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -70,7 +70,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      *  116 - added tag_display_name to tag tables
      *  117 - changed tbl_posts.timestamp from INTEGER to REAL
      *  118 - renamed tbl_search_history to tbl_search_suggestions
-     *  119 - renamed tbl_posts.timestamp to sort_order
+     *  119 - renamed tbl_posts.timestamp to sort_index
      */
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -19,7 +19,7 @@ import java.io.OutputStream;
  */
 public class ReaderDatabase extends SQLiteOpenHelper {
     protected static final String DB_NAME = "wpreader.db";
-    private static final int DB_VERSION = 118;
+    private static final int DB_VERSION = 119;
 
     /*
      * version history
@@ -70,6 +70,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      *  116 - added tag_display_name to tag tables
      *  117 - changed tbl_posts.timestamp from INTEGER to REAL
      *  118 - renamed tbl_search_history to tbl_search_suggestions
+     *  119 - renamed tbl_posts.timestamp to sort_order
      */
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -45,7 +45,7 @@ public class ReaderPostTable {
           + "featured_image,"       // 16
           + "featured_video,"       // 17
           + "post_avatar,"          // 18
-          + "timestamp,"            // 19
+          + "sort_order,"           // 19
           + "published,"            // 20
           + "num_replies,"          // 21
           + "num_likes,"            // 22
@@ -83,7 +83,7 @@ public class ReaderPostTable {
           + "tbl_posts.url,"                  // 15
           + "tbl_posts.short_url,"            // 16
           + "tbl_posts.post_avatar,"          // 17
-          + "tbl_posts.timestamp,"            // 18
+          + "tbl_posts.sort_order,"           // 18
           + "tbl_posts.published,"            // 19
           + "tbl_posts.num_replies,"          // 20
           + "tbl_posts.num_likes,"            // 21
@@ -122,7 +122,7 @@ public class ReaderPostTable {
                 + " featured_image      TEXT,"
                 + " featured_video      TEXT,"
                 + " post_avatar         TEXT,"
-                + " timestamp           REAL DEFAULT 0,"
+                + " sort_order          REAL DEFAULT 0,"
                 + " published           TEXT,"
                 + " num_replies         INTEGER DEFAULT 0,"
                 + " num_likes           INTEGER DEFAULT 0,"
@@ -142,7 +142,7 @@ public class ReaderPostTable {
                 + " xpost_blog_id       INTEGER DEFAULT 0,"
                 + " PRIMARY KEY (post_id, blog_id)"
                 + ")");
-        db.execSQL("CREATE INDEX idx_posts_timestamp ON tbl_posts(timestamp)");
+        db.execSQL("CREATE INDEX idx_posts_sort_order ON tbl_posts(sort_order)");
 
         db.execSQL("CREATE TABLE tbl_post_tags ("
                 + "   post_id           INTEGER DEFAULT 0,"
@@ -206,7 +206,7 @@ public class ReaderPostTable {
                 + "  WHERE tbl_posts.pseudo_id = tbl_post_tags.pseudo_id"
                 + "  AND tbl_post_tags.tag_name=?"
                 + "  AND tbl_post_tags.tag_type=?"
-                + "  ORDER BY tbl_posts.timestamp"
+                + "  ORDER BY tbl_posts.sort_order"
                 + "  LIMIT ?"
                 + ")";
         int numDeleted = db.delete("tbl_post_tags", where, args);
@@ -509,7 +509,7 @@ public class ReaderPostTable {
         }
 
         String[] args = {Long.toString(ids.getBlogId()), Long.toString(ids.getPostId())};
-        String sql = "SELECT timestamp FROM tbl_posts WHERE blog_id=? AND post_id=?";
+        String sql = "SELECT sort_order FROM tbl_posts WHERE blog_id=? AND post_id=?";
         return SqlUtils.longForQuery(ReaderDatabase.getReadableDb(), sql, args);
     }
 
@@ -524,7 +524,7 @@ public class ReaderPostTable {
 
         String[] args = {Long.toString(timestamp), tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
         String where = "pseudo_id IN (SELECT tbl_posts.pseudo_id FROM tbl_posts, tbl_post_tags"
-                + " WHERE tbl_posts.timestamp < ?"
+                + " WHERE tbl_posts.sort_order < ?"
                 + " AND tbl_posts.pseudo_id = tbl_post_tags.pseudo_id"
                 + " AND tbl_post_tags.tag_name=? AND tbl_post_tags.tag_type=?)";
         int numDeleted = ReaderDatabase.getWritableDb().delete("tbl_post_tags", where, args);
@@ -702,7 +702,7 @@ public class ReaderPostTable {
             }
         }
 
-        sql += " ORDER BY tbl_posts.timestamp DESC";
+        sql += " ORDER BY tbl_posts.sort_order DESC";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + Integer.toString(maxPosts);
@@ -719,7 +719,7 @@ public class ReaderPostTable {
 
     public static ReaderPostList getPostsInBlog(long blogId, int maxPosts, boolean excludeTextColumn) {
         String columns = (excludeTextColumn ? COLUMN_NAMES_NO_TEXT : "tbl_posts.*");
-        String sql = "SELECT " + columns + " FROM tbl_posts WHERE blog_id = ? ORDER BY tbl_posts.timestamp DESC";
+        String sql = "SELECT " + columns + " FROM tbl_posts WHERE blog_id = ? ORDER BY tbl_posts.sort_order DESC";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + Integer.toString(maxPosts);
@@ -735,7 +735,7 @@ public class ReaderPostTable {
 
     public static ReaderPostList getPostsInFeed(long feedId, int maxPosts, boolean excludeTextColumn) {
         String columns = (excludeTextColumn ? COLUMN_NAMES_NO_TEXT : "tbl_posts.*");
-        String sql = "SELECT " + columns + " FROM tbl_posts WHERE feed_id = ? ORDER BY tbl_posts.timestamp DESC";
+        String sql = "SELECT " + columns + " FROM tbl_posts WHERE feed_id = ? ORDER BY tbl_posts.sort_order DESC";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + Integer.toString(maxPosts);
@@ -772,7 +772,7 @@ public class ReaderPostTable {
             }
         }
 
-        sql += " ORDER BY tbl_posts.timestamp DESC";
+        sql += " ORDER BY tbl_posts.sort_order DESC";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + Integer.toString(maxPosts);
@@ -796,7 +796,7 @@ public class ReaderPostTable {
      * same as getPostsInBlog() but only returns the blogId/postId pairs
      */
     public static ReaderBlogIdPostIdList getBlogIdPostIdsInBlog(long blogId, int maxPosts) {
-        String sql = "SELECT post_id FROM tbl_posts WHERE blog_id = ? ORDER BY tbl_posts.timestamp DESC";
+        String sql = "SELECT post_id FROM tbl_posts WHERE blog_id = ? ORDER BY tbl_posts.sort_order DESC";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + Integer.toString(maxPosts);
@@ -850,7 +850,7 @@ public class ReaderPostTable {
         post.setShortUrl(c.getString(c.getColumnIndex("short_url")));
         post.setPostAvatar(c.getString(c.getColumnIndex("post_avatar")));
 
-        post.sortOrder = c.getDouble(c.getColumnIndex("timestamp"));
+        post.sortOrder = c.getDouble(c.getColumnIndex("sort_order"));
         post.setPublished(c.getString(c.getColumnIndex("published")));
 
         post.numReplies = c.getInt(c.getColumnIndex("num_replies"));

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -635,7 +635,7 @@ public class ReaderPostTable {
                 stmtPosts.bindString(16, post.getFeaturedImage());
                 stmtPosts.bindString(17, post.getFeaturedVideo());
                 stmtPosts.bindString(18, post.getPostAvatar());
-                stmtPosts.bindDouble(19, post.timestamp);
+                stmtPosts.bindDouble(19, post.sortOrder);
                 stmtPosts.bindString(20, post.getPublished());
                 stmtPosts.bindLong  (21, post.numReplies);
                 stmtPosts.bindLong  (22, post.numLikes);
@@ -850,7 +850,7 @@ public class ReaderPostTable {
         post.setShortUrl(c.getString(c.getColumnIndex("short_url")));
         post.setPostAvatar(c.getString(c.getColumnIndex("post_avatar")));
 
-        post.timestamp = c.getDouble(c.getColumnIndex("timestamp"));
+        post.sortOrder = c.getDouble(c.getColumnIndex("timestamp"));
         post.setPublished(c.getString(c.getColumnIndex("published")));
 
         post.numReplies = c.getInt(c.getColumnIndex("num_replies"));

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -45,7 +45,7 @@ public class ReaderPostTable {
           + "featured_image,"       // 16
           + "featured_video,"       // 17
           + "post_avatar,"          // 18
-          + "sort_order,"           // 19
+          + "sort_index,"           // 19 - this is a score for search results, otherwise it's a timestamp
           + "published,"            // 20
           + "num_replies,"          // 21
           + "num_likes,"            // 22
@@ -83,7 +83,7 @@ public class ReaderPostTable {
           + "tbl_posts.url,"                  // 15
           + "tbl_posts.short_url,"            // 16
           + "tbl_posts.post_avatar,"          // 17
-          + "tbl_posts.sort_order,"           // 18
+          + "tbl_posts.sort_index,"           // 18
           + "tbl_posts.published,"            // 19
           + "tbl_posts.num_replies,"          // 20
           + "tbl_posts.num_likes,"            // 21
@@ -122,7 +122,7 @@ public class ReaderPostTable {
                 + " featured_image      TEXT,"
                 + " featured_video      TEXT,"
                 + " post_avatar         TEXT,"
-                + " sort_order          REAL DEFAULT 0,"
+                + " sort_index          REAL DEFAULT 0,"
                 + " published           TEXT,"
                 + " num_replies         INTEGER DEFAULT 0,"
                 + " num_likes           INTEGER DEFAULT 0,"
@@ -142,7 +142,7 @@ public class ReaderPostTable {
                 + " xpost_blog_id       INTEGER DEFAULT 0,"
                 + " PRIMARY KEY (post_id, blog_id)"
                 + ")");
-        db.execSQL("CREATE INDEX idx_posts_sort_order ON tbl_posts(sort_order)");
+        db.execSQL("CREATE INDEX idx_posts_sort_index ON tbl_posts(sort_index)");
 
         db.execSQL("CREATE TABLE tbl_post_tags ("
                 + "   post_id           INTEGER DEFAULT 0,"
@@ -206,7 +206,7 @@ public class ReaderPostTable {
                 + "  WHERE tbl_posts.pseudo_id = tbl_post_tags.pseudo_id"
                 + "  AND tbl_post_tags.tag_name=?"
                 + "  AND tbl_post_tags.tag_type=?"
-                + "  ORDER BY tbl_posts.sort_order"
+                + "  ORDER BY tbl_posts.sort_index"
                 + "  LIMIT ?"
                 + ")";
         int numDeleted = db.delete("tbl_post_tags", where, args);
@@ -458,7 +458,7 @@ public class ReaderPostTable {
     /*
      * returns the blogId/postId of the post with the passed tag that has a gap marker, or null if none exists
      */
-    public static ReaderBlogIdPostId getGapMarkerForTag(final ReaderTag tag) {
+    public static ReaderBlogIdPostId getGapMarkerIdsForTag(final ReaderTag tag) {
         if (tag == null) {
             return null;
         }
@@ -493,7 +493,7 @@ public class ReaderPostTable {
     }
 
     public static String getGapMarkerPubDateForTag(ReaderTag tag) {
-        ReaderBlogIdPostId ids = getGapMarkerForTag(tag);
+        ReaderBlogIdPostId ids = getGapMarkerIdsForTag(tag);
         if (ids == null) {
             return null;
         }
@@ -502,29 +502,29 @@ public class ReaderPostTable {
         return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(), sql, args);
     }
 
-    private static long getGapMarkerTimestampForTag(ReaderTag tag) {
-        ReaderBlogIdPostId ids = getGapMarkerForTag(tag);
+    private static long getGapMarkerSortIndexForTag(ReaderTag tag) {
+        ReaderBlogIdPostId ids = getGapMarkerIdsForTag(tag);
         if (ids == null) {
             return 0;
         }
 
         String[] args = {Long.toString(ids.getBlogId()), Long.toString(ids.getPostId())};
-        String sql = "SELECT sort_order FROM tbl_posts WHERE blog_id=? AND post_id=?";
+        String sql = "SELECT sort_index FROM tbl_posts WHERE blog_id=? AND post_id=?";
         return SqlUtils.longForQuery(ReaderDatabase.getReadableDb(), sql, args);
     }
 
     /*
-     * delete posts with the passed tag that are older than one with the gap marker for
+     * delete posts with the passed tag that come before the one with the gap marker for
      * this tag - note this may leave some stray posts in tbl_posts, but these will
      * be cleaned up by the next purge
      */
-    public static void deletePostsOlderThanGapMarkerForTag(ReaderTag tag) {
-        long timestamp = getGapMarkerTimestampForTag(tag);
-        if (timestamp == 0) return;
+    public static void deletePostsBeforeGapMarkerForTag(ReaderTag tag) {
+        long sortIndex = getGapMarkerSortIndexForTag(tag);
+        if (sortIndex == 0) return;
 
-        String[] args = {Long.toString(timestamp), tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
+        String[] args = {Long.toString(sortIndex), tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
         String where = "pseudo_id IN (SELECT tbl_posts.pseudo_id FROM tbl_posts, tbl_post_tags"
-                + " WHERE tbl_posts.sort_order < ?"
+                + " WHERE tbl_posts.sort_index < ?"
                 + " AND tbl_posts.pseudo_id = tbl_post_tags.pseudo_id"
                 + " AND tbl_post_tags.tag_name=? AND tbl_post_tags.tag_type=?)";
         int numDeleted = ReaderDatabase.getWritableDb().delete("tbl_post_tags", where, args);
@@ -635,7 +635,7 @@ public class ReaderPostTable {
                 stmtPosts.bindString(16, post.getFeaturedImage());
                 stmtPosts.bindString(17, post.getFeaturedVideo());
                 stmtPosts.bindString(18, post.getPostAvatar());
-                stmtPosts.bindDouble(19, post.sortOrder);
+                stmtPosts.bindDouble(19, post.sortIndex);
                 stmtPosts.bindString(20, post.getPublished());
                 stmtPosts.bindLong  (21, post.numReplies);
                 stmtPosts.bindLong  (22, post.numLikes);
@@ -702,7 +702,7 @@ public class ReaderPostTable {
             }
         }
 
-        sql += " ORDER BY tbl_posts.sort_order DESC";
+        sql += " ORDER BY tbl_posts.sort_index DESC";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + Integer.toString(maxPosts);
@@ -719,7 +719,7 @@ public class ReaderPostTable {
 
     public static ReaderPostList getPostsInBlog(long blogId, int maxPosts, boolean excludeTextColumn) {
         String columns = (excludeTextColumn ? COLUMN_NAMES_NO_TEXT : "tbl_posts.*");
-        String sql = "SELECT " + columns + " FROM tbl_posts WHERE blog_id = ? ORDER BY tbl_posts.sort_order DESC";
+        String sql = "SELECT " + columns + " FROM tbl_posts WHERE blog_id = ? ORDER BY tbl_posts.sort_index DESC";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + Integer.toString(maxPosts);
@@ -735,7 +735,7 @@ public class ReaderPostTable {
 
     public static ReaderPostList getPostsInFeed(long feedId, int maxPosts, boolean excludeTextColumn) {
         String columns = (excludeTextColumn ? COLUMN_NAMES_NO_TEXT : "tbl_posts.*");
-        String sql = "SELECT " + columns + " FROM tbl_posts WHERE feed_id = ? ORDER BY tbl_posts.sort_order DESC";
+        String sql = "SELECT " + columns + " FROM tbl_posts WHERE feed_id = ? ORDER BY tbl_posts.sort_index DESC";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + Integer.toString(maxPosts);
@@ -772,7 +772,7 @@ public class ReaderPostTable {
             }
         }
 
-        sql += " ORDER BY tbl_posts.sort_order DESC";
+        sql += " ORDER BY tbl_posts.sort_index DESC";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + Integer.toString(maxPosts);
@@ -796,7 +796,7 @@ public class ReaderPostTable {
      * same as getPostsInBlog() but only returns the blogId/postId pairs
      */
     public static ReaderBlogIdPostIdList getBlogIdPostIdsInBlog(long blogId, int maxPosts) {
-        String sql = "SELECT post_id FROM tbl_posts WHERE blog_id = ? ORDER BY tbl_posts.sort_order DESC";
+        String sql = "SELECT post_id FROM tbl_posts WHERE blog_id = ? ORDER BY tbl_posts.sort_index DESC";
 
         if (maxPosts > 0) {
             sql += " LIMIT " + Integer.toString(maxPosts);
@@ -850,7 +850,7 @@ public class ReaderPostTable {
         post.setShortUrl(c.getString(c.getColumnIndex("short_url")));
         post.setPostAvatar(c.getString(c.getColumnIndex("post_avatar")));
 
-        post.sortOrder = c.getDouble(c.getColumnIndex("sort_order"));
+        post.sortIndex = c.getDouble(c.getColumnIndex("sort_index"));
         post.setPublished(c.getString(c.getColumnIndex("published")));
 
         post.numReplies = c.getInt(c.getColumnIndex("num_replies"));

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -39,7 +39,7 @@ public class ReaderPost {
     private String primaryTag;    // most popular tag on this post based on usage in blog
     private String secondaryTag;  // second most popular tag on this post based on usage in blog
 
-    public double sortOrder;
+    public double sortIndex;
     private String published;
 
     private String url;
@@ -116,15 +116,15 @@ public class ReaderPost {
         post.blogName = JSONUtils.getStringDecoded(json, "site_name");
         post.published = JSONUtils.getString(json, "date");
 
-        // sort order is "score" for search results, liked posts should be sorted by the date
-        // they were liked, otherwise sort by the published date
+        // sort index determines how posts are sorted - this is a "score" for search results,
+        // liked date for liked posts, and published date for all others
         if (json.has("score")) {
-            post.sortOrder = json.optDouble("score");
+            post.sortIndex = json.optDouble("score");
         } else if (json.has("date_liked")) {
             String likeDate = JSONUtils.getString(json, "date_liked");
-            post.sortOrder = DateTimeUtils.iso8601ToTimestamp(likeDate);
+            post.sortIndex = DateTimeUtils.iso8601ToTimestamp(likeDate);
         } else {
-            post.sortOrder = DateTimeUtils.iso8601ToTimestamp(post.published);
+            post.sortIndex = DateTimeUtils.iso8601ToTimestamp(post.published);
         }
 
         // if the post is untitled, make up a title from the excerpt

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -39,7 +39,7 @@ public class ReaderPost {
     private String primaryTag;    // most popular tag on this post based on usage in blog
     private String secondaryTag;  // second most popular tag on this post based on usage in blog
 
-    public double timestamp;        // used for sorting
+    public double sortOrder;
     private String published;
 
     private String url;
@@ -116,19 +116,15 @@ public class ReaderPost {
         post.blogName = JSONUtils.getStringDecoded(json, "site_name");
         post.published = JSONUtils.getString(json, "date");
 
-        // a post's timestamp determines its sort order
+        // sort order is "score" for search results, liked posts should be sorted by the date
+        // they were liked, otherwise sort by the published date
         if (json.has("score")) {
-            // search results include a "score" that should be used for sorting
-            post.timestamp = json.optDouble("score");
-        } else {
-            // liked posts should be sorted by the date they were liked, otherwise sort by the
-            // published date
+            post.sortOrder = json.optDouble("score");
+        } else if (json.has("date_liked")) {
             String likeDate = JSONUtils.getString(json, "date_liked");
-            if (!TextUtils.isEmpty(likeDate)) {
-                post.timestamp = DateTimeUtils.iso8601ToTimestamp(likeDate);
-            } else {
-                post.timestamp = DateTimeUtils.iso8601ToTimestamp(post.published);
-            }
+            post.sortOrder = DateTimeUtils.iso8601ToTimestamp(likeDate);
+        } else {
+            post.sortOrder = DateTimeUtils.iso8601ToTimestamp(post.published);
         }
 
         // if the post is untitled, make up a title from the excerpt

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -826,7 +826,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 return -1;
             }
 
-            ReaderBlogIdPostId gapMarkerIds = ReaderPostTable.getGapMarkerForTag(mCurrentTag);
+            ReaderBlogIdPostId gapMarkerIds = ReaderPostTable.getGapMarkerIdsForTag(mCurrentTag);
             if (gapMarkerIds == null) {
                 return -1;
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderPostService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderPostService.java
@@ -313,8 +313,8 @@ public class ReaderPostService extends Service {
                                 break;
                             case REQUEST_OLDER_THAN_GAP:
                                 // if service was started as a request to fill a gap, delete existing posts
-                                // older than the one with the gap marker, then remove the existing gap marker
-                                ReaderPostTable.deletePostsOlderThanGapMarkerForTag(tag);
+                                // before the one with the gap marker, then remove the existing gap marker
+                                ReaderPostTable.deletePostsBeforeGapMarkerForTag(tag);
                                 ReaderPostTable.removeGapMarkerForTag(tag);
                                 break;
                         }


### PR DESCRIPTION
Fixes #4119 - no logic or functionality changes here - this simply renames the `timestamp` field to `sortIndex` in the Reader post model and `sort_index` in the Reader post table to reflect the fact that it's no longer always a timestamp.

Needs review @mzorz 
