### PR TITLE
issue/reader-search-clear-fix

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionAdapter.java
@@ -20,6 +20,10 @@ public class ReaderSearchSuggestionAdapter extends CursorAdapter {
     private static final int MAX_SUGGESTIONS = 5;
     private static final int CLEAR_ALL_ROW_ID = -1;
 
+    private static final int NUM_VIEW_TYPES  = 2;
+    private static final int VIEW_TYPE_QUERY = 0;
+    private static final int VIEW_TYPE_CLEAR = 1;
+
     private String mCurrentFilter;
     private final Object[] mClearAllRow;
     private final int mClearAllBgColor;
@@ -76,6 +80,21 @@ public class ReaderSearchSuggestionAdapter extends CursorAdapter {
         } else {
             return null;
         }
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        // use a different view type for the "clear" row so it doesn't get recycled and used
+        // as a query row
+        if (getItemId(position) == CLEAR_ALL_ROW_ID) {
+            return VIEW_TYPE_CLEAR;
+        }
+        return VIEW_TYPE_QUERY;
+    }
+
+    @Override
+    public int getViewTypeCount() {
+        return NUM_VIEW_TYPES;
     }
 
     private class SuggestionViewHolder {


### PR DESCRIPTION
This fixes a bug in the reader search suggestion adapter that is unfortunately very hard to reproduce (I only saw it twice while attempting dozens of times to repro it).

It was possible that the view for the "clear" row would be recycled and re-used as a regular search query row. This resulted in the word "Clear" being displayed in the suggestion dropdown without the gray background color, and clicking on it would perform a search for "Clear" instead of clearing the suggestions.

The simple fix was to use a different view type for the "clear" row. After this fix was added, I was never able to repro the problem - the "clear" row always displayed & worked correctly.

**Before**
![before](https://cloud.githubusercontent.com/assets/3903757/15748857/a6e7323a-28e0-11e6-95c4-ad8f70a23aa9.png)

**After**
![after](https://cloud.githubusercontent.com/assets/3903757/15748494/66ecd8ac-28df-11e6-88a1-0bd8c2381ca6.png)


