### PR TITLE
Issue/cleanup comments

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActionResult.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActionResult.java
@@ -6,7 +6,7 @@ public class CommentActionResult {
     public static final int COMMENT_ID_UNKNOWN = -2; // This is used primarily for replies, when the commentID isn't known.
 
     private long mCommentID = COMMENT_ID_UNKNOWN;
-    private String mMessage;
+    private final String mMessage;
 
     public CommentActionResult(long commentID, String message) {
         mCommentID = commentID;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActionResult.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActionResult.java
@@ -13,7 +13,6 @@ public class CommentActionResult {
         mMessage = message;
     }
 
-    public long getCommentID() { return mCommentID; }
     public String getMessage() { return mMessage; }
     public boolean isSuccess() { return mCommentID != COMMENT_ID_ON_ERRORS; }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
@@ -59,8 +59,8 @@ public class CommentActions {
      * used by comment fragments to alert container activity of a change to one or more
      * comments (moderated, deleted, added, etc.)
      */
-    public enum ChangedFrom {COMMENT_LIST, COMMENT_DETAIL}
-    public enum ChangeType {EDITED, STATUS, REPLIED, TRASHED, SPAMMED}
+    public enum ChangedFrom {COMMENT_DETAIL}
+    public enum ChangeType {EDITED, REPLIED}
     public interface OnCommentChangeListener {
         void onCommentChanged(ChangedFrom changedFrom, ChangeType changeType);
     }
@@ -73,63 +73,6 @@ public class CommentActions {
         void onModerateCommentForNote(Note note, CommentStatus newStatus);
     }
 
-
-    /*
-     * add a comment for the passed post
-     */
-    public static void addComment(final int accountId,
-                                  final String postID,
-                                  final String commentText,
-                                  final CommentActionListener actionListener) {
-        final Blog blog = WordPress.getBlog(accountId);
-        if (blog==null || TextUtils.isEmpty(commentText)) {
-            if (actionListener != null) {
-                actionListener.onActionResult(new CommentActionResult(CommentActionResult.COMMENT_ID_ON_ERRORS   , null));
-            }
-            return;
-        }
-
-        final Handler handler = new Handler();
-
-        new Thread() {
-            @Override
-            public void run() {
-                XMLRPCClientInterface client = XMLRPCFactory.instantiate(blog.getUri(), blog.getHttpuser(),
-                        blog.getHttppassword());
-
-                Map<String, Object> commentHash = new HashMap<String, Object>();
-                commentHash.put("content", commentText);
-                commentHash.put("author", "");
-                commentHash.put("author_url", "");
-                commentHash.put("author_email", "");
-
-                Object[] params = {
-                        blog.getRemoteBlogId(),
-                        blog.getUsername(),
-                        blog.getPassword(),
-                        postID,
-                        commentHash};
-
-                int newCommentID = CommentActionResult.COMMENT_ID_ON_ERRORS;
-                String message = null;
-                try {
-                   newCommentID = (Integer) client.call(Method.NEW_COMMENT, params);
-                } catch (IOException | XmlPullParserException | XMLRPCException e) {
-                    AppLog.e(T.COMMENTS, "Error while sending new comment", e);
-                    message = e.getMessage();
-                }
-                final CommentActionResult cr = new CommentActionResult(newCommentID, message);
-                if (actionListener != null) {
-                    handler.post(new Runnable() {
-                        @Override
-                        public void run() {
-                            actionListener.onActionResult(cr);
-                        }
-                    });
-                }
-            }
-        }.start();
-    }
 
     /**
      * reply to an individual comment

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
@@ -62,7 +62,7 @@ public class CommentActions {
     public enum ChangedFrom {COMMENT_DETAIL}
     public enum ChangeType {EDITED, REPLIED}
     public interface OnCommentChangeListener {
-        void onCommentChanged(ChangedFrom changedFrom, ChangeType changeType);
+        void onCommentChanged(ChangeType changeType);
     }
 
     public interface OnCommentActionListener {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
@@ -302,6 +302,7 @@ public class CommentActions {
         new Thread() {
             @Override
             public void run() {
+                @SuppressWarnings("UnusedAssignment")
                 XMLRPCClientInterface client = XMLRPCFactory.instantiate(blog.getUri(), blog.getHttpuser(),
                         blog.getHttppassword());
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
@@ -59,7 +59,6 @@ public class CommentActions {
      * used by comment fragments to alert container activity of a change to one or more
      * comments (moderated, deleted, added, etc.)
      */
-    public enum ChangedFrom {COMMENT_DETAIL}
     public enum ChangeType {EDITED, REPLIED}
     public interface OnCommentChangeListener {
         void onCommentChanged(ChangeType changeType);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
@@ -408,14 +408,8 @@ public class CommentActions {
                 Object result;
                 try {
                     result = client.call(Method.DELETE_COMMENT, params);
-                } catch (final XMLRPCException e) {
+                } catch (final XMLRPCException | XmlPullParserException | IOException e) {
                     AppLog.e(T.COMMENTS, "Error while deleting comment", e);
-                    result = null;
-                } catch (IOException e) {
-                    AppLog.e(T.COMMENTS, "Error while deleting comment", e);
-                    result = null;
-                } catch (XmlPullParserException e) {
-                    AppLog.e(T.COMMENTS,"Error while deleting comment", e);
                     result = null;
                 }
 
@@ -484,11 +478,7 @@ public class CommentActions {
                         boolean success = (result != null && Boolean.parseBoolean(result.toString()));
                         if (success)
                             deletedComments.add(comment);
-                    } catch (XMLRPCException e) {
-                        AppLog.e(T.COMMENTS, "Error while deleting comment", e);
-                    } catch (IOException e) {
-                        AppLog.e(T.COMMENTS, "Error while deleting comment", e);
-                    } catch (XmlPullParserException e) {
+                    } catch (XMLRPCException | XmlPullParserException | IOException e) {
                         AppLog.e(T.COMMENTS, "Error while deleting comment", e);
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
@@ -97,7 +97,7 @@ public class CommentActions {
                 XMLRPCClientInterface client = XMLRPCFactory.instantiate(blog.getUri(), blog.getHttpuser(),
                         blog.getHttppassword());
 
-                Map<String, Object> replyHash = new HashMap<String, Object>();
+                Map<String, Object> replyHash = new HashMap<>();
                 replyHash.put("comment_parent", Long.toString(comment.commentID));
                 replyHash.put("content", replyText);
                 replyHash.put("author", "");

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
@@ -301,9 +301,7 @@ public class CommentActions {
         new Thread() {
             @Override
             public void run() {
-                @SuppressWarnings("UnusedAssignment")
-                XMLRPCClientInterface client = XMLRPCFactory.instantiate(blog.getUri(), blog.getHttpuser(),
-                        blog.getHttppassword());
+                XMLRPCFactory.instantiate(blog.getUri(), blog.getHttpuser(), blog.getHttppassword());
 
                 final boolean success = ApiHelper.editComment(blog, comment, newStatus);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
@@ -301,8 +301,6 @@ public class CommentActions {
         new Thread() {
             @Override
             public void run() {
-                XMLRPCFactory.instantiate(blog.getUri(), blog.getHttpuser(), blog.getHttppassword());
-
                 final boolean success = ApiHelper.editComment(blog, comment, newStatus);
 
                 if (success) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.comments;
 
 import android.content.Context;
 import android.os.AsyncTask;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.RecyclerView;
 import android.text.Html;
 import android.text.Spanned;
@@ -20,7 +21,6 @@ import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DateTimeUtils;
-import org.wordpress.android.util.ResourceUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.WPHtml;
 import org.wordpress.android.widgets.WPNetworkImageView;
@@ -119,11 +119,11 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
         mLocalBlogId = localBlogId;
 
-        mStatusColorSpam = ResourceUtils.getColorResource(context, R.color.comment_status_spam);
-        mStatusColorUnapproved = ResourceUtils.getColorResource(context, R.color.comment_status_unapproved);
+        mStatusColorSpam = ContextCompat.getColor(context, R.color.comment_status_spam);
+        mStatusColorUnapproved = ContextCompat.getColor(context, R.color.comment_status_unapproved);
 
-        mUnselectedColor = ResourceUtils.getColorResource(context, R.color.white);
-        mSelectedColor = ResourceUtils.getColorResource(context, R.color.translucent_grey_lighten_20);
+        mUnselectedColor = ContextCompat.getColor(context, R.color.white);
+        mSelectedColor = ContextCompat.getColor(context, R.color.translucent_grey_lighten_20);
 
         mStatusTextSpam = context.getResources().getString(R.string.comment_status_spam);
         mStatusTextUnapproved = context.getResources().getString(R.string.comment_status_unapproved);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
@@ -400,7 +400,7 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     private boolean mIsLoadTaskRunning = false;
     private class LoadCommentsTask extends AsyncTask<Void, Void, Boolean> {
         CommentList tmpComments;
-        CommentStatus mStatusFilter;
+        final CommentStatus mStatusFilter;
 
         public LoadCommentsTask (CommentStatus statusFilter){
             mStatusFilter = statusFilter;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
@@ -249,7 +249,7 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
         return mComments.size();
     }
 
-    boolean isEmpty() {
+    private boolean isEmpty() {
         return getItemCount() == 0;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
@@ -1,10 +1,6 @@
 package org.wordpress.android.ui.comments;
 
 import android.content.Context;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import android.graphics.drawable.BitmapDrawable;
-import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.support.v7.widget.RecyclerView;
 import android.text.Html;
@@ -24,14 +20,11 @@ import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DateTimeUtils;
-import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.ResourceUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.WPHtml;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
-import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
@@ -157,7 +157,7 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
-        View view = mInflater.inflate(R.layout.comment_listitem, null);
+        View view = mInflater.inflate(R.layout.comment_listitem, parent, false);
         CommentHolder holder = new CommentHolder(view);
         view.setTag(holder);
         return holder;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentAdapter.java
@@ -25,6 +25,7 @@ import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.ImageUtils;
+import org.wordpress.android.util.ResourceUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.WPHtml;
 import org.wordpress.android.widgets.WPNetworkImageView;
@@ -125,11 +126,11 @@ class CommentAdapter  extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
         mLocalBlogId = localBlogId;
 
-        mStatusColorSpam = context.getResources().getColor(R.color.comment_status_spam);
-        mStatusColorUnapproved = context.getResources().getColor(R.color.comment_status_unapproved);
+        mStatusColorSpam = ResourceUtils.getColorResource(context, R.color.comment_status_spam);
+        mStatusColorUnapproved = ResourceUtils.getColorResource(context, R.color.comment_status_unapproved);
 
-        mUnselectedColor = context.getResources().getColor(R.color.white);
-        mSelectedColor = context.getResources().getColor(R.color.translucent_grey_lighten_20);
+        mUnselectedColor = ResourceUtils.getColorResource(context, R.color.white);
+        mSelectedColor = ResourceUtils.getColorResource(context, R.color.translucent_grey_lighten_20);
 
         mStatusTextSpam = context.getResources().getString(R.string.comment_status_spam);
         mStatusTextUnapproved = context.getResources().getString(R.string.comment_status_unapproved);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailActivity.java
@@ -17,10 +17,10 @@ import org.wordpress.android.util.ToastUtils;
 // simple wrapper activity for CommentDetailFragment
 public class CommentDetailActivity extends AppCompatActivity {
 
-    public static final String KEY_COMMENT_DETAIL_LOCAL_TABLE_BLOG_ID = "local_table_blog_id";
-    public static final String KEY_COMMENT_DETAIL_COMMENT_ID = "comment_detail_comment_id";
-    public static final String KEY_COMMENT_DETAIL_NOTE_ID = "comment_detail_note_id";
-    public static final String KEY_COMMENT_DETAIL_IS_REMOTE = "comment_detail_is_remote";
+    private static final String KEY_COMMENT_DETAIL_LOCAL_TABLE_BLOG_ID = "local_table_blog_id";
+    private static final String KEY_COMMENT_DETAIL_COMMENT_ID = "comment_detail_comment_id";
+    private static final String KEY_COMMENT_DETAIL_NOTE_ID = "comment_detail_note_id";
+    private static final String KEY_COMMENT_DETAIL_IS_REMOTE = "comment_detail_is_remote";
 
     private static final String TAG_COMMENT_DETAIL_FRAGMENT = "tag_comment_detail_fragment";
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -653,7 +653,8 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
                     + "</font>";
             txtTitle.setText(Html.fromHtml(html));
         } else {
-            txtTitle.setText(getString(R.string.on) + " " + postTitle.trim());
+            String text = getString(R.string.on) + " " + postTitle.trim();
+            txtTitle.setText(text);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -216,7 +216,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         mTxtStatus = (TextView) view.findViewById(R.id.text_status);
         mTxtContent = (TextView) view.findViewById(R.id.text_content);
 
-        mLayoutButtons = (ViewGroup) inflater.inflate(R.layout.comment_action_footer, null, false);
+        mLayoutButtons = (ViewGroup) inflater.inflate(R.layout.comment_action_footer, container, false);
         mBtnLikeComment = mLayoutButtons.findViewById(R.id.btn_like);
         mBtnLikeIcon = (ImageView)mLayoutButtons.findViewById(R.id.btn_like_icon);
         mBtnLikeTextView = (TextView)mLayoutButtons.findViewById(R.id.btn_like_text);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -975,10 +975,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
      * does user have permission to moderate/reply/spam this comment?
      */
     private boolean canModerate() {
-        if (mEnabledActions == null)
-            return false;
-        return (mEnabledActions.contains(EnabledActions.ACTION_APPROVE)
-             || mEnabledActions.contains(EnabledActions.ACTION_UNAPPROVE));
+        return mEnabledActions != null && (mEnabledActions.contains(EnabledActions.ACTION_APPROVE) || mEnabledActions.contains(EnabledActions.ACTION_UNAPPROVE));
     }
     private boolean canMarkAsSpam() {
         return (mEnabledActions != null && mEnabledActions.contains(EnabledActions.ACTION_SPAM));

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -67,6 +67,7 @@ import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.HtmlUtils;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.ResourceUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.VolleyUtils;
 import org.wordpress.android.util.WPLinkMovementMethod;
@@ -609,9 +610,9 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             };
             imgAvatar.setOnClickListener(authorListener);
             txtName.setOnClickListener(authorListener);
-            txtName.setTextColor(getResources().getColor(R.color.reader_hyperlink));
+            txtName.setTextColor(ResourceUtils.getColorResource(getActivity(), R.color.reader_hyperlink));
         } else {
-            txtName.setTextColor(getResources().getColor(R.color.grey_darken_30));
+            txtName.setTextColor(ResourceUtils.getColorResource(getActivity(), R.color.grey_darken_30));
         }
 
         showPostTitle(getRemoteBlogId(), mComment.postID);
@@ -878,20 +879,20 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         switch (mComment.getStatusEnum()) {
             case APPROVED:
                 statusTextResId = R.string.comment_status_approved;
-                statusColor = getActivity().getResources().getColor(R.color.notification_status_unapproved_dark);
+                statusColor = ResourceUtils.getColorResource(getActivity(), R.color.notification_status_unapproved_dark);
                 break;
             case UNAPPROVED:
                 statusTextResId = R.string.comment_status_unapproved;
-                statusColor = getActivity().getResources().getColor(R.color.notification_status_unapproved_dark);
+                statusColor = ResourceUtils.getColorResource(getActivity(), R.color.notification_status_unapproved_dark);
                 break;
             case SPAM:
                 statusTextResId = R.string.comment_status_spam;
-                statusColor = getActivity().getResources().getColor(R.color.comment_status_spam);
+                statusColor = ResourceUtils.getColorResource(getActivity(), R.color.comment_status_spam);
                 break;
             case TRASH:
             default:
                 statusTextResId = R.string.comment_status_trash;
-                statusColor = getActivity().getResources().getColor(R.color.comment_status_spam);
+                statusColor = ResourceUtils.getColorResource(getActivity(), R.color.comment_status_spam);
                 break;
         }
 
@@ -973,11 +974,11 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         if (status == CommentStatus.APPROVED) {
             mBtnModerateIcon.setImageResource(R.drawable.ic_action_approve_active);
             mBtnModerateTextView.setText(R.string.comment_status_approved);
-            mBtnModerateTextView.setTextColor(getActivity().getResources().getColor(R.color.notification_status_unapproved_dark));
+            mBtnModerateTextView.setTextColor(ResourceUtils.getColorResource(getActivity(), R.color.notification_status_unapproved_dark));
         } else {
             mBtnModerateIcon.setImageResource(R.drawable.ic_action_approve);
             mBtnModerateTextView.setText(R.string.mnu_comment_approve);
-            mBtnModerateTextView.setTextColor(getActivity().getResources().getColor(R.color.grey));
+            mBtnModerateTextView.setTextColor(ResourceUtils.getColorResource(getActivity(), R.color.grey));
         }
     }
 
@@ -1125,12 +1126,12 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     private void toggleLikeButton(boolean isLiked) {
         if (isLiked) {
             mBtnLikeTextView.setText(getResources().getString(R.string.mnu_comment_liked));
-            mBtnLikeTextView.setTextColor(getResources().getColor(R.color.orange_jazzy));
+            mBtnLikeTextView.setTextColor(ResourceUtils.getColorResource(getActivity(), R.color.orange_jazzy));
             mBtnLikeIcon.setImageDrawable(getResources().getDrawable(R.drawable.ic_action_like_active));
             mBtnLikeComment.setActivated(true);
         } else {
             mBtnLikeTextView.setText(getResources().getString(R.string.reader_label_like));
-            mBtnLikeTextView.setTextColor(getResources().getColor(R.color.grey));
+            mBtnLikeTextView.setTextColor(ResourceUtils.getColorResource(getActivity(), R.color.grey));
             mBtnLikeIcon.setImageDrawable(getResources().getDrawable(R.drawable.ic_action_like));
             mBtnLikeComment.setActivated(false);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -861,7 +861,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
      * sets the drawable for moderation buttons
      */
     private void setTextDrawable(final TextView view, int resId) {
-        view.setCompoundDrawablesWithIntrinsicBounds(null, getResources().getDrawable(resId), null, null);
+        view.setCompoundDrawablesWithIntrinsicBounds(null, ResourceUtils.getDrawableResource(getActivity(), resId), null, null);
     }
 
     /*
@@ -1127,12 +1127,12 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         if (isLiked) {
             mBtnLikeTextView.setText(getResources().getString(R.string.mnu_comment_liked));
             mBtnLikeTextView.setTextColor(ResourceUtils.getColorResource(getActivity(), R.color.orange_jazzy));
-            mBtnLikeIcon.setImageDrawable(getResources().getDrawable(R.drawable.ic_action_like_active));
+            mBtnLikeIcon.setImageDrawable(ResourceUtils.getDrawableResource(getActivity(), R.drawable.ic_action_like_active));
             mBtnLikeComment.setActivated(true);
         } else {
             mBtnLikeTextView.setText(getResources().getString(R.string.reader_label_like));
             mBtnLikeTextView.setTextColor(ResourceUtils.getColorResource(getActivity(), R.color.grey));
-            mBtnLikeIcon.setImageDrawable(getResources().getDrawable(R.drawable.ic_action_like));
+            mBtnLikeIcon.setImageDrawable(ResourceUtils.getDrawableResource(getActivity(), R.drawable.ic_action_like));
             mBtnLikeComment.setActivated(false);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -68,7 +68,6 @@ import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.HtmlUtils;
 import org.wordpress.android.util.NetworkUtils;
-import org.wordpress.android.util.ResourceUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.VolleyUtils;
 import org.wordpress.android.util.WPLinkMovementMethod;
@@ -851,7 +850,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
      * sets the drawable for moderation buttons
      */
     private void setTextDrawable(final TextView view, int resId) {
-        view.setCompoundDrawablesWithIntrinsicBounds(null, ResourceUtils.getDrawableResource(getActivity(), resId), null, null);
+        view.setCompoundDrawablesWithIntrinsicBounds(null, ContextCompat.getDrawable(getActivity(), resId), null, null);
     }
 
     /*
@@ -1114,12 +1113,12 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         if (isLiked) {
             mBtnLikeTextView.setText(getResources().getString(R.string.mnu_comment_liked));
             mBtnLikeTextView.setTextColor(ContextCompat.getColor(getActivity(), R.color.orange_jazzy));
-            mBtnLikeIcon.setImageDrawable(ResourceUtils.getDrawableResource(getActivity(), R.drawable.ic_action_like_active));
+            mBtnLikeIcon.setImageDrawable(ContextCompat.getDrawable(getActivity(), R.drawable.ic_action_like_active));
             mBtnLikeComment.setActivated(true);
         } else {
             mBtnLikeTextView.setText(getResources().getString(R.string.reader_label_like));
             mBtnLikeTextView.setTextColor(ContextCompat.getColor(getActivity(), R.color.grey));
-            mBtnLikeIcon.setImageDrawable(ResourceUtils.getDrawableResource(getActivity(), R.drawable.ic_action_like));
+            mBtnLikeIcon.setImageDrawable(ContextCompat.getDrawable(getActivity(), R.drawable.ic_action_like));
             mBtnLikeComment.setActivated(false);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -400,6 +400,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         }
     }
 
+    @SuppressWarnings("deprecation") // TODO: Remove when minSdkVersion >= 23
     public void onAttach(Activity activity) {
         super.onAttach(activity);
         if (activity instanceof OnCommentChangeListener)

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -709,7 +709,6 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
 
                             @Override
                             public void onFailure(int statusCode) {
-                                // noop
                             }
                         });
             }
@@ -747,7 +746,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     }
 
     /*
-     * approve, unapprove, spam, or trash the current comment
+     * approve, disapprove, spam, or trash the current comment
      */
     private void moderateComment(final CommentStatus newStatus) {
         if (!isAdded() || !hasComment())

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -75,6 +75,7 @@ import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 
 import de.greenrobot.event.EventBus;
 
@@ -230,7 +231,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
 
         mLayoutReply = (ViewGroup) view.findViewById(R.id.layout_comment_box);
         mEditReply = (SuggestionAutoCompleteText) mLayoutReply.findViewById(R.id.edit_comment);
-        mEditReply.getAutoSaveTextHelper().setUniqueId(String.format("%s%d%d",
+        mEditReply.getAutoSaveTextHelper().setUniqueId(String.format(Locale.getDefault(), "%s%d%d",
                 AccountHelper.getCurrentUsernameForBlog(WordPress.getCurrentBlog()),
                 getRemoteBlogId(), getCommentId()));
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -8,6 +8,7 @@ import android.app.FragmentTransaction;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 import android.text.Html;
 import android.text.TextUtils;
 import android.view.KeyEvent;
@@ -599,9 +600,9 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             };
             imgAvatar.setOnClickListener(authorListener);
             txtName.setOnClickListener(authorListener);
-            txtName.setTextColor(ResourceUtils.getColorResource(getActivity(), R.color.reader_hyperlink));
+            txtName.setTextColor(ContextCompat.getColor(getActivity(), R.color.reader_hyperlink));
         } else {
-            txtName.setTextColor(ResourceUtils.getColorResource(getActivity(), R.color.grey_darken_30));
+            txtName.setTextColor(ContextCompat.getColor(getActivity(), R.color.grey_darken_30));
         }
 
         showPostTitle(getRemoteBlogId(), mComment.postID);
@@ -868,20 +869,20 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         switch (mComment.getStatusEnum()) {
             case APPROVED:
                 statusTextResId = R.string.comment_status_approved;
-                statusColor = ResourceUtils.getColorResource(getActivity(), R.color.notification_status_unapproved_dark);
+                statusColor = ContextCompat.getColor(getActivity(), R.color.notification_status_unapproved_dark);
                 break;
             case UNAPPROVED:
                 statusTextResId = R.string.comment_status_unapproved;
-                statusColor = ResourceUtils.getColorResource(getActivity(), R.color.notification_status_unapproved_dark);
+                statusColor = ContextCompat.getColor(getActivity(), R.color.notification_status_unapproved_dark);
                 break;
             case SPAM:
                 statusTextResId = R.string.comment_status_spam;
-                statusColor = ResourceUtils.getColorResource(getActivity(), R.color.comment_status_spam);
+                statusColor = ContextCompat.getColor(getActivity(), R.color.comment_status_spam);
                 break;
             case TRASH:
             default:
                 statusTextResId = R.string.comment_status_trash;
-                statusColor = ResourceUtils.getColorResource(getActivity(), R.color.comment_status_spam);
+                statusColor = ContextCompat.getColor(getActivity(), R.color.comment_status_spam);
                 break;
         }
 
@@ -963,11 +964,11 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         if (status == CommentStatus.APPROVED) {
             mBtnModerateIcon.setImageResource(R.drawable.ic_action_approve_active);
             mBtnModerateTextView.setText(R.string.comment_status_approved);
-            mBtnModerateTextView.setTextColor(ResourceUtils.getColorResource(getActivity(), R.color.notification_status_unapproved_dark));
+            mBtnModerateTextView.setTextColor(ContextCompat.getColor(getActivity(), R.color.notification_status_unapproved_dark));
         } else {
             mBtnModerateIcon.setImageResource(R.drawable.ic_action_approve);
             mBtnModerateTextView.setText(R.string.mnu_comment_approve);
-            mBtnModerateTextView.setTextColor(ResourceUtils.getColorResource(getActivity(), R.color.grey));
+            mBtnModerateTextView.setTextColor(ContextCompat.getColor(getActivity(), R.color.grey));
         }
     }
 
@@ -1112,12 +1113,12 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     private void toggleLikeButton(boolean isLiked) {
         if (isLiked) {
             mBtnLikeTextView.setText(getResources().getString(R.string.mnu_comment_liked));
-            mBtnLikeTextView.setTextColor(ResourceUtils.getColorResource(getActivity(), R.color.orange_jazzy));
+            mBtnLikeTextView.setTextColor(ContextCompat.getColor(getActivity(), R.color.orange_jazzy));
             mBtnLikeIcon.setImageDrawable(ResourceUtils.getDrawableResource(getActivity(), R.drawable.ic_action_like_active));
             mBtnLikeComment.setActivated(true);
         } else {
             mBtnLikeTextView.setText(getResources().getString(R.string.reader_label_like));
-            mBtnLikeTextView.setTextColor(ResourceUtils.getColorResource(getActivity(), R.color.grey));
+            mBtnLikeTextView.setTextColor(ContextCompat.getColor(getActivity(), R.color.grey));
             mBtnLikeIcon.setImageDrawable(ResourceUtils.getDrawableResource(getActivity(), R.drawable.ic_action_like));
             mBtnLikeComment.setActivated(false);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -493,10 +493,6 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         return mRemoteBlogId;
     }
 
-    public void setRestoredReplyText(String restoredReplyText) {
-        mRestoredReplyText = restoredReplyText;
-    }
-
     /*
      * reload the current comment from the local database
      */
@@ -505,14 +501,6 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             return;
         Comment updatedComment = CommentTable.getComment(mLocalBlogId, getCommentId());
         setComment(mLocalBlogId, updatedComment);
-    }
-
-    /*
-     * resets to no comment
-     */
-    void clear() {
-        setNote(null);
-        setComment(0, null);
     }
 
     /*
@@ -1136,12 +1124,6 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             mBtnLikeIcon.setImageDrawable(ResourceUtils.getDrawableResource(getActivity(), R.drawable.ic_action_like));
             mBtnLikeComment.setActivated(false);
         }
-    }
-
-    public String getReplyText() {
-        if (mEditReply == null) return null;
-
-        return mEditReply.getText().toString();
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -346,7 +346,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         }
     }
 
-    void setComment(int localBlogId, long commentId) {
+    private void setComment(int localBlogId, long commentId) {
         setComment(localBlogId, CommentTable.getComment(localBlogId, commentId));
     }
 
@@ -369,7 +369,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         mShouldFocusReplyField = shouldFocusReplyField;
     }
 
-    void setShouldRequestCommentFromNote(boolean shouldRequestComment) {
+    private void setShouldRequestCommentFromNote(boolean shouldRequestComment) {
         mShouldRequestCommentFromNote = shouldRequestComment;
     }
 
@@ -481,7 +481,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         return (mComment != null);
     }
 
-    long getCommentId() {
+    private long getCommentId() {
         return (mComment != null ? mComment.commentID : 0);
     }
 
@@ -500,7 +500,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     /*
      * reload the current comment from the local database
      */
-    void reloadComment() {
+    private void reloadComment() {
         if (!hasComment())
             return;
         Comment updatedComment = CommentTable.getComment(mLocalBlogId, getCommentId());

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -166,7 +166,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
      */
     public static CommentDetailFragment newInstanceForRemoteNoteComment(final String noteId) {
         CommentDetailFragment fragment = newInstance(noteId);
-        fragment.setShouldRequestCommentFromNote();
+        fragment.enableShouldRequestCommentFromNote();
         return fragment;
     }
 
@@ -364,11 +364,11 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             showComment();
     }
 
-    private void setShouldFocusReplyField() {
+    private void disableShouldFocusReplyField() {
         mShouldFocusReplyField = false;
     }
 
-    private void setShouldRequestCommentFromNote() {
+    private void enableShouldRequestCommentFromNote() {
         mShouldRequestCommentFromNote = true;
     }
 
@@ -610,7 +610,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             AniUtils.animateBottomBar(mLayoutReply, true);
             if (mEditReply != null && mShouldFocusReplyField) {
                 mEditReply.requestFocus();
-                setShouldFocusReplyField();
+                disableShouldFocusReplyField();
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -45,7 +45,6 @@ import org.wordpress.android.models.Note.EnabledActions;
 import org.wordpress.android.models.Suggestion;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.comments.CommentActions.ChangeType;
-import org.wordpress.android.ui.comments.CommentActions.ChangedFrom;
 import org.wordpress.android.ui.comments.CommentActions.OnCommentActionListener;
 import org.wordpress.android.ui.comments.CommentActions.OnCommentChangeListener;
 import org.wordpress.android.ui.comments.CommentActions.OnNoteCommentActionListener;
@@ -167,7 +166,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
      */
     public static CommentDetailFragment newInstanceForRemoteNoteComment(final String noteId) {
         CommentDetailFragment fragment = newInstance(noteId);
-        fragment.setShouldRequestCommentFromNote(true);
+        fragment.setShouldRequestCommentFromNote();
         return fragment;
     }
 
@@ -365,12 +364,12 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             showComment();
     }
 
-    private void setShouldFocusReplyField(boolean shouldFocusReplyField) {
-        mShouldFocusReplyField = shouldFocusReplyField;
+    private void setShouldFocusReplyField() {
+        mShouldFocusReplyField = false;
     }
 
-    private void setShouldRequestCommentFromNote(boolean shouldRequestComment) {
-        mShouldRequestCommentFromNote = shouldRequestComment;
+    private void setShouldRequestCommentFromNote() {
+        mShouldRequestCommentFromNote = true;
     }
 
     @Override
@@ -453,7 +452,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             }
             // tell the host to reload the comment list
             if (mOnCommentChangeListener != null)
-                mOnCommentChangeListener.onCommentChanged(ChangedFrom.COMMENT_DETAIL, ChangeType.EDITED);
+                mOnCommentChangeListener.onCommentChanged(ChangeType.EDITED);
         }
     }
 
@@ -611,7 +610,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             AniUtils.animateBottomBar(mLayoutReply, true);
             if (mEditReply != null && mShouldFocusReplyField) {
                 mEditReply.requestFocus();
-                setShouldFocusReplyField(false);
+                setShouldFocusReplyField();
             }
         }
 
@@ -811,7 +810,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             public void onActionResult(CommentActionResult result) {
                 mIsSubmittingReply = false;
                 if (result.isSuccess() && mOnCommentChangeListener != null)
-                    mOnCommentChangeListener.onCommentChanged(ChangedFrom.COMMENT_DETAIL, ChangeType.REPLIED);
+                    mOnCommentChangeListener.onCommentChanged(ChangeType.REPLIED);
                 if (isAdded()) {
                     mEditReply.setEnabled(true);
                     mSubmitReplyBtn.setVisibility(View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDialogs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDialogs.java
@@ -9,7 +9,7 @@ import org.wordpress.android.R;
 /**
  * Dialogs related to comment moderation displayed from CommentsActivity and NotificationsActivity
  */
-public class CommentDialogs {
+class CommentDialogs {
     public static final int ID_COMMENT_DLG_APPROVING = 100;
     public static final int ID_COMMENT_DLG_UNAPPROVING = 101;
     public static final int ID_COMMENT_DLG_SPAMMING = 102;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDialogs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDialogs.java
@@ -11,7 +11,7 @@ import org.wordpress.android.R;
  */
 class CommentDialogs {
     public static final int ID_COMMENT_DLG_APPROVING = 100;
-    public static final int ID_COMMENT_DLG_UNAPPROVING = 101;
+    public static final int ID_COMMENT_DLG_DISAPPROVING = 101;
     public static final int ID_COMMENT_DLG_SPAMMING = 102;
     public static final int ID_COMMENT_DLG_TRASHING = 103;
     public static final int ID_COMMENT_DLG_DELETING = 104;
@@ -26,7 +26,7 @@ class CommentDialogs {
             case ID_COMMENT_DLG_APPROVING :
                 resId = R.string.dlg_approving_comments;
                 break;
-            case ID_COMMENT_DLG_UNAPPROVING:
+            case ID_COMMENT_DLG_DISAPPROVING:
                 resId = R.string.dlg_unapproving_comments;
                 break;
             case ID_COMMENT_DLG_TRASHING:

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentUtils.java
@@ -76,7 +76,7 @@ public class CommentUtils {
         if (textView == null || textOffsetX < 0) return;
 
         SpannableString text = new SpannableString(textView.getText());
-        text.setSpan(new TextWrappingLeadingMarginSpan(1, textOffsetX), 0, text.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
+        text.setSpan(new TextWrappingLeadingMarginSpan(textOffsetX), 0, text.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
         textView.setText(text);
     }
 
@@ -84,9 +84,9 @@ public class CommentUtils {
         private final int margin;
         private final int lines;
 
-        public TextWrappingLeadingMarginSpan(int lines, int margin) {
+        public TextWrappingLeadingMarginSpan(int margin) {
             this.margin = margin;
-            this.lines = lines;
+            this.lines = 1;
         }
 
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentUtils.java
@@ -14,6 +14,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.util.EmoticonsUtils;
 import org.wordpress.android.util.HtmlUtils;
+import org.wordpress.android.util.ResourceUtils;
 import org.wordpress.android.util.helpers.WPImageGetter;
 
 public class CommentUtils {
@@ -47,9 +48,10 @@ public class CommentUtils {
         // now convert to HTML with an image getter that enforces a max image size
         final Spanned html;
         if (maxImageSize > 0 && content.contains("<img")) {
-            Drawable loading = textView.getContext().getResources().getDrawable(
-                org.wordpress.android.editor.R.drawable.legacy_dashicon_format_image_big_grey);
-            Drawable failed = textView.getContext().getResources().getDrawable(R.drawable.noticon_warning_big_grey);
+            Drawable loading = ResourceUtils.getDrawableResource(textView.getContext(),
+                    R.drawable.legacy_dashicon_format_image_big_grey);
+            Drawable failed = ResourceUtils.getDrawableResource(textView.getContext(),
+                    R.drawable.noticon_warning_big_grey);
             html = HtmlUtils.fromHtml(content, new WPImageGetter(textView, maxImageSize, WordPress.imageLoader, loading,
                     failed));
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentUtils.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.comments;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.drawable.Drawable;
+import android.support.v4.content.ContextCompat;
 import android.text.Layout;
 import android.text.SpannableString;
 import android.text.Spanned;
@@ -14,7 +15,6 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.util.EmoticonsUtils;
 import org.wordpress.android.util.HtmlUtils;
-import org.wordpress.android.util.ResourceUtils;
 import org.wordpress.android.util.helpers.WPImageGetter;
 
 public class CommentUtils {
@@ -48,9 +48,9 @@ public class CommentUtils {
         // now convert to HTML with an image getter that enforces a max image size
         final Spanned html;
         if (maxImageSize > 0 && content.contains("<img")) {
-            Drawable loading = ResourceUtils.getDrawableResource(textView.getContext(),
+            Drawable loading = ContextCompat.getDrawable(textView.getContext(),
                     R.drawable.legacy_dashicon_format_image_big_grey);
-            Drawable failed = ResourceUtils.getDrawableResource(textView.getContext(),
+            Drawable failed = ContextCompat.getDrawable(textView.getContext(),
                     R.drawable.noticon_warning_big_grey);
             html = HtmlUtils.fromHtml(content, new WPImageGetter(textView, maxImageSize, WordPress.imageLoader, loading,
                     failed));

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentUtils.java
@@ -81,8 +81,8 @@ public class CommentUtils {
     }
 
     private static class TextWrappingLeadingMarginSpan implements LeadingMarginSpan.LeadingMarginSpan2 {
-        private int margin;
-        private int lines;
+        private final int margin;
+        private final int lines;
 
         public TextWrappingLeadingMarginSpan(int lines, int margin) {
             this.margin = margin;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentUtils.java
@@ -59,17 +59,16 @@ public class CommentUtils {
         }
 
         // remove extra \n\n added by Html.convert()
-        CharSequence source = html;
         int start = 0;
-        int end = source.length();
-        while (start < end && Character.isWhitespace(source.charAt(start))) {
+        int end = html.length();
+        while (start < end && Character.isWhitespace(html.charAt(start))) {
             start++;
         }
-        while (end > start && Character.isWhitespace(source.charAt(end - 1))) {
+        while (end > start && Character.isWhitespace(html.charAt(end - 1))) {
             end--;
         }
 
-        textView.setText(source.subSequence(start, end));
+        textView.setText(html.subSequence(start, end));
     }
 
     // Assumes all lines after first line will not be indented

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -22,7 +22,6 @@ import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.models.Note;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.ActivityLauncher;
-import org.wordpress.android.ui.EmptyViewMessageType;
 import org.wordpress.android.ui.comments.CommentsListFragment.OnCommentSelectedListener;
 import org.wordpress.android.ui.notifications.NotificationFragment;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -244,7 +243,7 @@ public class CommentsActivity extends AppCompatActivity
 
         if (newStatus == CommentStatus.APPROVED || newStatus == CommentStatus.UNAPPROVED) {
             getListFragment().setCommentIsModerating(comment.commentID, true);
-            getListFragment().updateEmptyView(EmptyViewMessageType.NO_CONTENT);
+            getListFragment().updateEmptyView();
             CommentActions.moderateComment(accountId, comment, newStatus,
                     new CommentActions.CommentActionListener() {
                 @Override
@@ -258,7 +257,7 @@ public class CommentsActivity extends AppCompatActivity
                     if (result.isSuccess()) {
                         reloadCommentList();
                     } else {
-                        getListFragment().updateEmptyView(EmptyViewMessageType.NO_CONTENT);
+                        getListFragment().updateEmptyView();
                         ToastUtils.showToast(CommentsActivity.this,
                                 R.string.error_moderate_comment,
                                 ToastUtils.Duration.LONG
@@ -270,7 +269,7 @@ public class CommentsActivity extends AppCompatActivity
             mTrashedComments.add(comment);
             getListFragment().removeComment(comment);
             getListFragment().setCommentIsModerating(comment.commentID, true);
-            getListFragment().updateEmptyView(EmptyViewMessageType.NO_CONTENT);
+            getListFragment().updateEmptyView();
 
             String message = (newStatus == CommentStatus.TRASH ? getString(R.string.comment_trashed) : newStatus == CommentStatus.SPAM ? getString(R.string.comment_spammed) : getString(R.string.comment_deleted_permanently)  );
             View.OnClickListener undoListener = new View.OnClickListener() {
@@ -312,7 +311,7 @@ public class CommentsActivity extends AppCompatActivity
                                         ToastUtils.Duration.LONG
                                 );
                             } else {
-                                getListFragment().updateEmptyView(EmptyViewMessageType.NO_CONTENT);
+                                getListFragment().updateEmptyView();
                             }
                         }
                     });
@@ -324,7 +323,7 @@ public class CommentsActivity extends AppCompatActivity
     }
 
     @Override
-    public void onCommentChanged(CommentActions.ChangedFrom changedFrom, CommentActions.ChangeType changeType) {
+    public void onCommentChanged(CommentActions.ChangeType changeType) {
         if (changedFrom == CommentActions.ChangedFrom.COMMENT_DETAIL) {
             switch (changeType) {
                 case EDITED:

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -38,7 +38,7 @@ public class CommentsActivity extends AppCompatActivity
     private static final String KEY_SELECTED_COMMENT_ID = "selected_comment_id";
     static final String KEY_AUTO_REFRESHED = "has_auto_refreshed";
     static final String KEY_EMPTY_VIEW_MESSAGE = "empty_view_message";
-    static final String SAVED_COMMENTS_STATUS_TYPE = "saved_comments_status_type";
+    private static final String SAVED_COMMENTS_STATUS_TYPE = "saved_comments_status_type";
     private long mSelectedCommentId;
     private final CommentList mTrashedComments = new CommentList();
 
@@ -198,7 +198,7 @@ public class CommentsActivity extends AppCompatActivity
     /*
      * tell the comment list to get recent comments from server
      */
-    void updateCommentList() {
+    private void updateCommentList() {
         CommentsListFragment listFragment = getListFragment();
         if (listFragment != null) {
             //listFragment.setRefreshing(true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -324,15 +324,13 @@ public class CommentsActivity extends AppCompatActivity
 
     @Override
     public void onCommentChanged(CommentActions.ChangeType changeType) {
-        if (changedFrom == CommentActions.ChangedFrom.COMMENT_DETAIL) {
-            switch (changeType) {
-                case EDITED:
-                    reloadCommentList();
-                    break;
-                case REPLIED:
-                    updateCommentList();
-                    break;
-            }
+        switch (changeType) {
+            case EDITED:
+                reloadCommentList();
+                break;
+            case REPLIED:
+                updateCommentList();
+                break;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -450,12 +450,12 @@ public class CommentsListFragment extends Fragment {
         getAdapter().loadComments(mCommentStatusFilter);
     }
 
-    void updateEmptyView(EmptyViewMessageType emptyViewMessageType){
+    void updateEmptyView(){
         //this is called from CommentsActivity in the case the last moment for a given type has been changed from that
         //status, leaving the list empty, so we need to update the empty view. The method inside FilteredRecyclerView
         //does the handling itself, so we only check for null here.
         if (mFilteredCommentsView != null){
-            mFilteredCommentsView.updateEmptyView(emptyViewMessageType);
+            mFilteredCommentsView.updateEmptyView(EmptyViewMessageType.NO_CONTENT);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -203,14 +203,13 @@ public class CommentsListFragment extends Fragment {
             @Override
             public List<FilterCriteria> onLoadFilterCriteriaOptions(boolean refresh) {
                 @SuppressWarnings("unchecked")
-                ArrayList<FilterCriteria> criterias = new ArrayList();
-                Collections.addAll(criterias, commentStatuses);
-                return criterias;
+                ArrayList<FilterCriteria> criteria = new ArrayList();
+                Collections.addAll(criteria, commentStatuses);
+                return criteria;
             }
 
             @Override
             public void onLoadFilterCriteriaOptionsAsync(FilteredRecyclerView.FilterCriteriaAsyncLoaderListener listener, boolean refresh) {
-                //noop
             }
 
             @Override
@@ -276,7 +275,6 @@ public class CommentsListFragment extends Fragment {
 
             @Override
             public void onShowCustomEmptyView(EmptyViewMessageType emptyViewMsgType) {
-                //noop
             }
         });
 
@@ -303,8 +301,8 @@ public class CommentsListFragment extends Fragment {
         }
     }
 
-    public void setCommentStatusFilter(CommentStatus statusfilter) {
-        mCommentStatusFilter = statusfilter;
+    public void setCommentStatusFilter(CommentStatus statusFilter) {
+        mCommentStatusFilter = statusFilter;
     }
 
     private void dismissDialog(int id) {
@@ -336,7 +334,7 @@ public class CommentsListFragment extends Fragment {
                 dlgId = CommentDialogs.ID_COMMENT_DLG_APPROVING;
                 break;
             case UNAPPROVED:
-                dlgId = CommentDialogs.ID_COMMENT_DLG_UNAPPROVING;
+                dlgId = CommentDialogs.ID_COMMENT_DLG_DISAPPROVING;
                 break;
             case SPAM:
                 dlgId = CommentDialogs.ID_COMMENT_DLG_SPAMMING;
@@ -377,8 +375,8 @@ public class CommentsListFragment extends Fragment {
             AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(
                     getActivity());
             dialogBuilder.setTitle(getResources().getText(R.string.delete));
-            int resid = getAdapter().getSelectedCommentCount() > 1 ? R.string.dlg_sure_to_delete_comments : R.string.dlg_sure_to_delete_comment;
-            dialogBuilder.setMessage(getResources().getText(resid));
+            int resId = getAdapter().getSelectedCommentCount() > 1 ? R.string.dlg_sure_to_delete_comments : R.string.dlg_sure_to_delete_comment;
+            dialogBuilder.setMessage(getResources().getText(resId));
             dialogBuilder.setPositiveButton(getResources().getText(R.string.yes),
                     new DialogInterface.OnClickListener() {
                         public void onClick(DialogInterface dialog, int whichButton) {
@@ -511,9 +509,9 @@ public class CommentsListFragment extends Fragment {
         final boolean mIsLoadingMore;
         final CommentStatus mStatusFilter;
 
-        private UpdateCommentsTask(boolean loadMore, CommentStatus statusfilter) {
+        private UpdateCommentsTask(boolean loadMore, CommentStatus statusFilter) {
             mIsLoadingMore = loadMore;
-            mStatusFilter = statusfilter;
+            mStatusFilter = statusFilter;
         }
 
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -201,6 +201,7 @@ public class CommentsListFragment extends Fragment {
         mFilteredCommentsView.setFilterListener(new FilteredRecyclerView.FilterListener() {
             @Override
             public List<FilterCriteria> onLoadFilterCriteriaOptions(boolean refresh) {
+                @SuppressWarnings("unchecked")
                 ArrayList<FilterCriteria> criterias = new ArrayList();
                 for (CommentStatus criteria : commentStatuses) {
                     criterias.add(criteria);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -567,7 +567,7 @@ public class CommentsListFragment extends Fragment {
                                 blog.getPassword(),
                                 hPost };
             try {
-                CommentList comments = ApiHelper.refreshComments(blog, params, new ApiHelper.DatabasePersistCallback() {
+                return ApiHelper.refreshComments(blog, params, new ApiHelper.DatabasePersistCallback() {
                     @Override
                     public void onDataReadyToSave(List list) {
                         int localBlogId = blog.getLocalTableBlogId();
@@ -575,7 +575,6 @@ public class CommentsListFragment extends Fragment {
                         CommentTable.saveComments(localBlogId, (CommentList)list);
                     }
                 });
-                return comments;
             } catch (XMLRPCFault xmlrpcFault) {
                 mErrorType = ErrorType.UNKNOWN_ERROR;
                 if (xmlrpcFault.getFaultCode() == 401) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.FilteredRecyclerView;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.ResourceUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.xmlrpc.android.ApiHelper;
 import org.xmlrpc.android.ApiHelper.ErrorType;
@@ -280,8 +281,8 @@ public class CommentsListFragment extends Fragment {
         });
 
         // the following will change the look and feel of the toolbar to match the current design
-        mFilteredCommentsView.setToolbarBackgroundColor(getResources().getColor(R.color.blue_medium));
-        mFilteredCommentsView.setToolbarSpinnerTextColor(getResources().getColor(R.color.white));
+        mFilteredCommentsView.setToolbarBackgroundColor(ResourceUtils.getColorResource(getActivity(), R.color.blue_medium));
+        mFilteredCommentsView.setToolbarSpinnerTextColor(ResourceUtils.getColorResource(getActivity(), R.color.white));
         mFilteredCommentsView.setToolbarSpinnerDrawable(R.drawable.arrow);
         mFilteredCommentsView.setToolbarLeftAndRightPadding(
                 getResources().getDimensionPixelSize(R.dimen.margin_filter_spinner),

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -35,6 +35,7 @@ import org.xmlrpc.android.ApiHelper.ErrorType;
 import org.xmlrpc.android.XMLRPCFault;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -203,9 +204,7 @@ public class CommentsListFragment extends Fragment {
             public List<FilterCriteria> onLoadFilterCriteriaOptions(boolean refresh) {
                 @SuppressWarnings("unchecked")
                 ArrayList<FilterCriteria> criterias = new ArrayList();
-                for (CommentStatus criteria : commentStatuses) {
-                    criterias.add(criteria);
-                }
+                Collections.addAll(criterias, commentStatuses);
                 return criterias;
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -6,6 +6,7 @@ import android.content.DialogInterface;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.view.ActionMode;
 import android.view.LayoutInflater;
@@ -28,7 +29,6 @@ import org.wordpress.android.ui.FilteredRecyclerView;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.NetworkUtils;
-import org.wordpress.android.util.ResourceUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.xmlrpc.android.ApiHelper;
 import org.xmlrpc.android.ApiHelper.ErrorType;
@@ -282,8 +282,8 @@ public class CommentsListFragment extends Fragment {
         });
 
         // the following will change the look and feel of the toolbar to match the current design
-        mFilteredCommentsView.setToolbarBackgroundColor(ResourceUtils.getColorResource(getActivity(), R.color.blue_medium));
-        mFilteredCommentsView.setToolbarSpinnerTextColor(ResourceUtils.getColorResource(getActivity(), R.color.white));
+        mFilteredCommentsView.setToolbarBackgroundColor(ContextCompat.getColor(getActivity(), R.color.blue_medium));
+        mFilteredCommentsView.setToolbarSpinnerTextColor(ContextCompat.getColor(getActivity(), R.color.white));
         mFilteredCommentsView.setToolbarSpinnerDrawable(R.drawable.arrow);
         mFilteredCommentsView.setToolbarLeftAndRightPadding(
                 getResources().getDimensionPixelSize(R.dimen.margin_filter_spinner),

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
@@ -299,7 +299,7 @@ public class EditCommentActivity extends AppCompatActivity {
             final String authorUrl = getEditTextStr(R.id.author_url);
             final String content = getEditTextStr(R.id.edit_comment_content);
 
-            final Map<String, String> postHash = new HashMap<String, String>();
+            final Map<String, String> postHash = new HashMap<>();
 
             // using CommentStatus.toString() rather than getStatus() ensures that the XML-RPC
             // status value is used - important since comment may have been loaded via the


### PR DESCRIPTION
#### Fix
Various instances of outdated, unused, unchecked, and/or redundant code from warnings produced by the `Analyze > Inspect Code` feature in Android Studio on the `wordpress/android/ui/comments` directory.

#### Before
![before](https://cloud.githubusercontent.com/assets/3827611/15748798/7bfc4614-28e0-11e6-9aeb-9956d1a7a114.png)

#### After
![after](https://cloud.githubusercontent.com/assets/3827611/15748813/828cdebc-28e0-11e6-9d29-5b2fb13f3ca9.png)