### PR TITLE
Also set the in-memory current Blog to visible

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -489,6 +489,7 @@ public class WordPress extends Application {
 
         if (currentBlog != null && currentBlog.isHidden()) {
             wpDB.setDotComBlogsVisibility(id, true);
+            currentBlog.setHidden(false);
         }
     }
 


### PR DESCRIPTION
Fixes #3554 

To test:
* Log out of WordPress.com
* Log in again

and assuming a non-hidden site is currently selected:

* Switch to a hidden site via the Search feature of the Site Picker
* Tap the red "New Post" floating button
* Notice the screen title. It should be the name of the newly selected (hidden) site


Needs review: @kwonye 

