### PR TITLE
Smart lock back on tracks

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -311,8 +311,11 @@ public class SignInFragment extends AbstractFragment implements TextWatcher, Con
     }
 
     protected boolean isGooglePlayServicesAvailable() {
-        return isAdded() && GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(getActivity())
-                == ConnectionResult.SUCCESS;
+        if (getActivity() == null) {
+            return false;
+        }
+        int status = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(getActivity());
+        return status == ConnectionResult.SUCCESS;
     }
 
     private void initInfoButtons(View rootView) {


### PR DESCRIPTION
Smart lock wasn't working with the introduction of [this commit](https://github.com/wordpress-mobile/WordPress-Android/commit/52cde2e79bd0fa57526279cafb57edcf46401343).

This PR fixes the issue.