### PR TITLE
[Stats] Bring Geochart legend back working

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
@@ -116,17 +116,18 @@ public class StatsGeoviewsFragment extends StatsAbstractListFragment {
                 // See: https://developers.google.com/chart/interactive/docs/gallery/geochart
                 String htmlPage = "<html>" +
                         "<head>" +
+                        "<script type=\"text/javascript\" src=\"https://www.gstatic.com/charts/loader.js\"></script>" +
                         "<script type=\"text/javascript\" src=\"https://www.google.com/jsapi\"></script>" +
                         "<script type=\"text/javascript\">" +
-                            "google.load(\"visualization\", \"1\", {packages:[\"geochart\"]});" +
-                            "google.setOnLoadCallback(drawRegionsMap);" +
+                            "google.charts.load('current', {'packages':['geochart']});" +
+                            "google.charts.setOnLoadCallback(drawRegionsMap);" +
                             "function drawRegionsMap() {" +
                                 "var data = google.visualization.arrayToDataTable(" +
                                 "[" +
                                 "['Country', '" + label + "']," +
                                         dataToLoad +
                                 "]);" +
-                                "var options = {keepAspectRatio: true, region: 'world', colorAxis: { colors: [ '#FFF088', '#F34605' ] }, enableRegionInteractivity: true};" +
+                                "var options = {keepAspectRatio: true, region: 'world', legend: 'none', colorAxis: { colors: [ '#FFF088', '#F34605' ] }, enableRegionInteractivity: true};" +
                                 "var chart = new google.visualization.GeoChart(document.getElementById('regions_div'));" +
                                 "chart.draw(data, options);" +
                             "}" +

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
@@ -119,7 +119,7 @@ public class StatsGeoviewsFragment extends StatsAbstractListFragment {
                         "<script type=\"text/javascript\" src=\"https://www.gstatic.com/charts/loader.js\"></script>" +
                         "<script type=\"text/javascript\" src=\"https://www.google.com/jsapi\"></script>" +
                         "<script type=\"text/javascript\">" +
-                            "google.charts.load('current', {'packages':['geochart']});" +
+                            "google.charts.load('42', {'packages':['geochart']});" +
                             "google.charts.setOnLoadCallback(drawRegionsMap);" +
                             "function drawRegionsMap() {" +
                                 "var data = google.visualization.arrayToDataTable(" +
@@ -127,7 +127,7 @@ public class StatsGeoviewsFragment extends StatsAbstractListFragment {
                                 "['Country', '" + label + "']," +
                                         dataToLoad +
                                 "]);" +
-                                "var options = {keepAspectRatio: true, region: 'world', legend: 'none', colorAxis: { colors: [ '#FFF088', '#F34605' ] }, enableRegionInteractivity: true};" +
+                                "var options = {keepAspectRatio: true, region: 'world', colorAxis: { colors: [ '#FFF088', '#F34605' ] }, enableRegionInteractivity: true};" +
                                 "var chart = new google.visualization.GeoChart(document.getElementById('regions_div'));" +
                                 "chart.draw(data, options);" +
                             "}" +

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
@@ -114,6 +114,7 @@ public class StatsGeoviewsFragment extends StatsAbstractListFragment {
                 String label = getResources().getString(getTotalsLabelResId());
 
                 // See: https://developers.google.com/chart/interactive/docs/gallery/geochart
+                // Loading the v42 of the Google Charts API, since the latest stable version has a problem with the legend. https://github.com/wordpress-mobile/WordPress-Android/issues/4131
                 String htmlPage = "<html>" +
                         "<head>" +
                         "<script type=\"text/javascript\" src=\"https://www.gstatic.com/charts/loader.js\"></script>" +

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
@@ -115,6 +115,7 @@ public class StatsGeoviewsFragment extends StatsAbstractListFragment {
 
                 // See: https://developers.google.com/chart/interactive/docs/gallery/geochart
                 // Loading the v42 of the Google Charts API, since the latest stable version has a problem with the legend. https://github.com/wordpress-mobile/WordPress-Android/issues/4131
+                // https://developers.google.com/chart/interactive/docs/release_notes#release-candidate-details
                 String htmlPage = "<html>" +
                         "<head>" +
                         "<script type=\"text/javascript\" src=\"https://www.gstatic.com/charts/loader.js\"></script>" +


### PR DESCRIPTION
Fixes #4131 by loading the old version of Google Charts API (v42 - corresponding to the April 30 2015 release).
The latest 2 stable versions of it have a problem with the legend that under some circumstances started being black when rendered in our webview. Tried to fix the issue in some other ways, but even the examples provided with the API may present black legend when rendered in our webview in a fragment. The issue ins't there if we only load 1 value in the geochart. Thanks @aerych for showing me up this.
Releases note https://developers.google.com/chart/interactive/docs/release_notes#release-candidate-details

To test:  Load Stats and switch to a period timeframe. Check that the legend is correctly rendered on the screen.
