### PR TITLE
Change CheckBoxPreference to SwitchPreference in App Settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -5,13 +5,13 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Bundle;
-import android.preference.CheckBoxPreference;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
+import android.preference.SwitchPreference;
 import android.text.TextUtils;
 import android.util.Pair;
 import android.view.MenuItem;
@@ -105,14 +105,14 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
                 preferenceScreen.removePreference(editor);
             }
         } else {
-            final CheckBoxPreference visualEditorCheckBox = (CheckBoxPreference) findPreference(getActivity()
+            final SwitchPreference visualEditorSwitch = (SwitchPreference) findPreference(getActivity()
                     .getString(R.string.pref_key_visual_editor_enabled));
-            visualEditorCheckBox.setChecked(AppPrefs.isVisualEditorEnabled());
-            visualEditorCheckBox.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            visualEditorSwitch.setChecked(AppPrefs.isVisualEditorEnabled());
+            visualEditorSwitch.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 @Override
                 public boolean onPreferenceChange(final Preference preference, final Object newValue) {
-                    visualEditorCheckBox.setChecked(!visualEditorCheckBox.isChecked());
-                    AppPrefs.setVisualEditorEnabled(visualEditorCheckBox.isChecked());
+                    visualEditorSwitch.setChecked(!visualEditorSwitch.isChecked());
+                    AppPrefs.setVisualEditorEnabled(visualEditorSwitch.isChecked());
                     return false;
                 }
             });

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -8,7 +8,7 @@
         android:layout="@layout/preference_layout"
         android:title="@string/interface_language" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="true"
         android:key="@string/pref_key_send_usage"
         android:layout="@layout/preference_layout"
@@ -20,7 +20,7 @@
         android:layout="@layout/preference_category"
         android:title="@string/preference_editor">
 
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="true"
             android:key="@string/pref_key_visual_editor_enabled"
             android:layout="@layout/preference_layout"


### PR DESCRIPTION
#### Fix
Change `CheckBoxPreference` to `SwitchPreference` in App Settings to make all settings screens consistent.

#### Test
1. Go to Me tab.
2. Tap App Settings option.
3. See switch for Stats and Visual Editor preferences.

#### Review
@maxme or @daniloercoli or @nbradbury