### PR TITLE
Disable contextual action bar for ReaderWebView on Reader Post Detail…

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -151,6 +151,15 @@ public class ReaderPostDetailFragment extends Fragment
         mReaderWebView.setCustomViewListener(this);
         mReaderWebView.setUrlClickListener(this);
         mReaderWebView.setPageFinishedListener(this);
+        mReaderWebView.setHapticFeedbackEnabled(false);
+        mReaderWebView.setOnLongClickListener(
+            new View.OnLongClickListener() {
+                @Override
+                public boolean onLongClick(View view) {
+                    return true;
+                }
+            }
+        );
 
         // hide footer and scrollView until the post is loaded
         mLayoutFooter.setVisibility(View.INVISIBLE);


### PR DESCRIPTION
... screen

#### Fix
Disable contextual action bar for `ReaderWebView` on Reader Post Detail screen since `View in Browser` and `Share` actions already exist as described in https://github.com/wordpress-mobile/WordPress-Android/issues/4065.

#### Test
1. Go to Reader tab.
2. Tap any post.
3. Select any text in the post by long-pressing.

#### Review
@maxme or @daniloercoli or @nbradbury