### PR TITLE
Convert new username to lowercase & ignore non-alphanumeric characters

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.accounts;
 
 import android.content.Context;
+import android.text.Editable;
 
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Blog;
@@ -74,7 +75,7 @@ public class BlogUtils {
                 planID = MapUtils.getMapLong(blogMap, "planID");
             }
             String planShortName = MapUtils.getMapStr(blogMap, "plan_product_name_short");
-            String capabilities =  MapUtils.getMapStr(blogMap, "capabilities");
+            String capabilities = MapUtils.getMapStr(blogMap, "capabilities");
 
             retValue |= addOrUpdateBlog(blogName, xmlrpc, homeUrl, blogId, username, password, httpUsername,
                     httpPassword, isAdmin, isVisible, planID, planShortName, capabilities);
@@ -105,9 +106,9 @@ public class BlogUtils {
      * Return false if no change has been made.
      */
     public static boolean addOrUpdateBlog(String blogName, String xmlRpcUrl, String homeUrl, String blogId,
-                                           String username, String password, String httpUsername, String httpPassword,
-                                           boolean isAdmin, boolean isVisible,
-                                           long planID, String planShortName, String capabilities) {
+                                          String username, String password, String httpUsername, String httpPassword,
+                                          boolean isAdmin, boolean isVisible,
+                                          long planID, String planShortName, String capabilities) {
         Blog blog;
         if (!WordPress.wpDB.isBlogInDatabase(Integer.parseInt(blogId), xmlRpcUrl)) {
             // The blog isn't in the app, so let's create it
@@ -173,10 +174,18 @@ public class BlogUtils {
 
     /**
      * Get a Blog's local Id.
+     *
      * @param blog The Blog to get its local ID
      * @return Blog's local id or {@value BlogUtils#BLOG_ID_INVALID} if null
      */
     public static int getBlogLocalId(final Blog blog) {
         return (blog != null ? blog.getLocalTableBlogId() : BLOG_ID_INVALID);
+    }
+
+    public static void convertToLowercase(Editable s) {
+        String lowerCase = s.toString().toLowerCase();
+        if (!lowerCase.equals(s.toString())) {
+            s.replace(0, s.length(), lowerCase);
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewBlogFragment.java
@@ -18,8 +18,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
-import org.wordpress.android.ui.accounts.helpers.CreateUserAndBlog;
 import org.wordpress.android.models.AccountHelper;
+import org.wordpress.android.ui.accounts.helpers.CreateUserAndBlog;
 import org.wordpress.android.ui.plans.PlansConstants;
 import org.wordpress.android.util.AlertUtils;
 import org.wordpress.android.util.AppLog;
@@ -51,11 +51,7 @@ public class NewBlogFragment extends AbstractFragment implements TextWatcher {
 
     @Override
     public void onTextChanged(CharSequence s, int start, int before, int count) {
-        if (fieldsFilled()) {
-            mSignupButton.setEnabled(true);
-        } else {
-            mSignupButton.setEnabled(false);
-        }
+        checkIfFieldsFilled();
     }
 
     public void setSignoutOnCancelMode(boolean mode) {
@@ -237,15 +233,33 @@ public class NewBlogFragment extends AbstractFragment implements TextWatcher {
         mProgressBarSignIn = (RelativeLayout) rootView.findViewById(R.id.nux_sign_in_progress_bar);
 
         mSiteUrlTextField = (EditText) rootView.findViewById(R.id.site_url);
-        mSiteUrlTextField.addTextChangedListener(this);
         mSiteUrlTextField.setOnKeyListener(mSiteUrlKeyListener);
         mSiteUrlTextField.setOnEditorActionListener(mEditorAction);
+        mSiteUrlTextField.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                checkIfFieldsFilled();
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                String lowerCase = s.toString().toLowerCase();
+                if (!lowerCase.equals(s.toString())) {
+                    s.replace(0, s.length(), lowerCase);
+                }
+            }
+        });
 
         mSiteTitleTextField = (EditText) rootView.findViewById(R.id.site_title);
         mSiteTitleTextField.addTextChangedListener(this);
         mSiteTitleTextField.addTextChangedListener(mSiteTitleWatcher);
         mSiteTitleTextField.setOnFocusChangeListener(new View.OnFocusChangeListener() {
-            @Override public void onFocusChange(View v, boolean hasFocus) {
+            @Override
+            public void onFocusChange(View v, boolean hasFocus) {
                 if (hasFocus) {
                     mAutoCompleteUrl = EditTextUtils.getText(mSiteTitleTextField)
                             .equals(EditTextUtils.getText(mSiteUrlTextField))
@@ -254,6 +268,14 @@ public class NewBlogFragment extends AbstractFragment implements TextWatcher {
             }
         });
         return rootView;
+    }
+
+    private void checkIfFieldsFilled() {
+        if (fieldsFilled()) {
+            mSignupButton.setEnabled(true);
+        } else {
+            mSignupButton.setEnabled(false);
+        }
     }
 
     private final OnClickListener mSignupClickListener = new OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewBlogFragment.java
@@ -247,10 +247,7 @@ public class NewBlogFragment extends AbstractFragment implements TextWatcher {
 
             @Override
             public void afterTextChanged(Editable s) {
-                String lowerCase = s.toString().toLowerCase();
-                if (!lowerCase.equals(s.toString())) {
-                    s.replace(0, s.length(), lowerCase);
-                }
+                BlogUtils.convertToLowercase(s);
             }
         });
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -388,10 +388,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
 
             @Override
             public void afterTextChanged(Editable s) {
-                String lowerCase = s.toString().toLowerCase();
-                if (!lowerCase.equals(s.toString())) {
-                    s.replace(0, s.length(), lowerCase);
-                }
+                BlogUtils.convertToLowercase(s);
             }
         });
 
@@ -411,10 +408,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
 
             @Override
             public void afterTextChanged(Editable s) {
-                String lowerCase = s.toString().toLowerCase();
-                if (!lowerCase.equals(s.toString())) {
-                    s.replace(0, s.length(), lowerCase);
-                }
+                BlogUtils.convertToLowercase(s);
             }
         });
         mUsernameTextField.setOnFocusChangeListener(new View.OnFocusChangeListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -6,6 +6,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.Html;
+import android.text.InputFilter;
 import android.text.TextWatcher;
 import android.util.Patterns;
 import android.view.KeyEvent;
@@ -397,6 +398,10 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
 
             @Override
             public void afterTextChanged(Editable s) {
+                String lowerCase = s.toString().toLowerCase();
+                if (!lowerCase.equals(s.toString())) {
+                    s.replace(0, s.length(), lowerCase);
+                }
             }
         });
         mUsernameTextField.setOnFocusChangeListener(new View.OnFocusChangeListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -6,7 +6,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.Html;
-import android.text.InputFilter;
 import android.text.TextWatcher;
 import android.util.Patterns;
 import android.view.KeyEvent;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -64,11 +64,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
 
     @Override
     public void onTextChanged(CharSequence s, int start, int before, int count) {
-        if (fieldsFilled()) {
-            mSignupButton.setEnabled(true);
-        } else {
-            mSignupButton.setEnabled(false);
-        }
+        checkIfFieldsFilled();
     }
 
     private boolean fieldsFilled() {
@@ -314,7 +310,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
                     }
                 });
         AppLog.i(T.NUX, "User tries to create a new account, username: " + username + ", email: " + email
-                        + ", site name: " + siteName + ", site URL: " + siteUrl);
+                + ", site name: " + siteName + ", site URL: " + siteUrl);
         createUserAndBlog.startCreateUserAndBlogProcess();
     }
 
@@ -352,12 +348,12 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
         termsOfServiceTextView.setText(Html.fromHtml(String.format(getString(R.string.agree_terms_of_service), "<u>",
                 "</u>")));
         termsOfServiceTextView.setOnClickListener(new OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        Uri uri = Uri.parse(Constants.URL_TOS);
-                        startActivity(new Intent(Intent.ACTION_VIEW, uri));
-                    }
-                }
+                                                      @Override
+                                                      public void onClick(View v) {
+                                                          Uri uri = Uri.parse(Constants.URL_TOS);
+                                                          startActivity(new Intent(Intent.ACTION_VIEW, uri));
+                                                      }
+                                                  }
         );
 
         mSignupButton = (WPTextView) rootView.findViewById(R.id.signup_button);
@@ -377,9 +373,27 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
         mEmailTextField.addTextChangedListener(this);
         mPasswordTextField.addTextChangedListener(this);
         mUsernameTextField.addTextChangedListener(this);
-        mSiteUrlTextField.addTextChangedListener(this);
         mSiteUrlTextField.setOnKeyListener(mSiteUrlKeyListener);
         mSiteUrlTextField.setOnEditorActionListener(mEditorAction);
+
+        mSiteUrlTextField.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                checkIfFieldsFilled();
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                String lowerCase = s.toString().toLowerCase();
+                if (!lowerCase.equals(s.toString())) {
+                    s.replace(0, s.length(), lowerCase);
+                }
+            }
+        });
 
         mUsernameTextField.addTextChangedListener(new TextWatcher() {
             @Override
@@ -404,7 +418,8 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
             }
         });
         mUsernameTextField.setOnFocusChangeListener(new View.OnFocusChangeListener() {
-            @Override public void onFocusChange(View v, boolean hasFocus) {
+            @Override
+            public void onFocusChange(View v, boolean hasFocus) {
                 if (hasFocus) {
                     mAutoCompleteUrl = EditTextUtils.getText(mUsernameTextField)
                             .equals(EditTextUtils.getText(mSiteUrlTextField))
@@ -423,6 +438,14 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
         initPasswordVisibilityButton(rootView, mPasswordTextField);
         initInfoButton(rootView);
         return rootView;
+    }
+
+    private void checkIfFieldsFilled() {
+        if (fieldsFilled()) {
+            mSignupButton.setEnabled(true);
+        } else {
+            mSignupButton.setEnabled(false);
+        }
     }
 
     private final OnKeyListener mSiteUrlKeyListener = new OnKeyListener() {

--- a/WordPress/src/main/res/layout/create_blog_fragment.xml
+++ b/WordPress/src/main/res/layout/create_blog_fragment.xml
@@ -72,6 +72,7 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/add_account_blog_url"
                     android:inputType="textUri"
+                    android:digits="0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
                     android:clickable="true"
                     android:paddingLeft="0dp"
                     android:paddingTop="12dp"

--- a/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
+++ b/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
@@ -160,6 +160,7 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/add_account_blog_url"
                     android:inputType="textUri"
+                    android:digits="0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
                     android:clickable="true"
                     android:paddingLeft="0dp"
                     android:paddingTop="12dp"

--- a/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
+++ b/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
@@ -87,6 +87,7 @@
                     android:layout_height="wrap_content"
                     style="@style/WordPress.NUXEditText"
                     android:inputType="textUri"
+                    android:digits="0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
                     android:hint="@string/username"
                     android:maxLength="@integer/max_length_username"
                     app:persistenceEnabled="true"/>


### PR DESCRIPTION
Fixes #4152 

To test: After entering a username with capital letters included, the username is auto-corrected to all lowercase letters. Only letters and digits are allowed, all other characters are ignored.

Review: @nbradbury or @theck13 or @maxme or @daniloercoli