### PR TITLE
Issue/4173 fix theme browser npe

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -301,7 +301,11 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
         if (NetworkUtils.isNetworkAvailable(this) && WordPress.getCurrentBlog() != null
                 && WordPress.wpDB.getThemeCount(getBlogId()) == 0) {
             fetchThemes();
-            mThemeBrowserFragment.setRefreshing(true);
+
+            //do not interact with theme browser fragment if we are in search mode
+            if (!mIsInSearchMode) {
+                mThemeBrowserFragment.setRefreshing(true);
+            }
         }
     }
 
@@ -318,7 +322,11 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
                     AppLog.d(T.THEMES, error.getMessage());
                 }
             });
-            mThemeBrowserFragment.setRefreshing(true);
+
+            //do not interact with theme browser fragment if we are in search mode
+            if (!mIsInSearchMode) {
+                mThemeBrowserFragment.setRefreshing(true);
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
@@ -9,7 +9,6 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.ViewGroup;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -36,29 +35,14 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
-    }
-
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        View view = super.onCreateView(inflater, container, savedInstanceState);
-
-        restoreState(savedInstanceState);
-
-        return view;
+        if (savedInstanceState != null) {
+            mLastSearch = savedInstanceState.getString(BUNDLE_LAST_SEARCH);
+        }
     }
 
     @Override
     public void onResume() {
         super.onResume();
-    }
-
-    private void restoreState(Bundle savedInstanceState) {
-        if (savedInstanceState != null) {
-            if (savedInstanceState.containsKey(BUNDLE_LAST_SEARCH) && isAdded()) {
-                mLastSearch = savedInstanceState.getString(BUNDLE_LAST_SEARCH);
-                configureSearchView();
-            }
-        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #4173  and #3983 

Both issues are kinda related. To reproduce them, check "Don't keep activities", got to theme Browser, click on search Bar, press Home, and go back to app.


#4173 happens when we come back to theme search, after app have been destroyed, and trying to interact with theme browser fragment, which is not there yet. Simple check to determine if we are in search mode or not fixes this.

#3983 happens when we come back to theme search, after app have been destroyed, and trying to interact with MenuItem from onCreateView, even though MenuItem is initialised in onPrepareOptionsMenu, which is called after onCreateView. Minor refactoring fixes this issue.

Needs review: @maxme
