### PR TITLE
Fix the crash caused by XML onClick handler

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AboutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AboutActivity.java
@@ -39,6 +39,9 @@ public class AboutActivity extends AppCompatActivity implements OnClickListener 
 
         WPTextView copyright = (WPTextView) findViewById(R.id.about_copyright);
         copyright.setText("©" + Calendar.getInstance().get(Calendar.YEAR) + " " + getString(R.string.automattic_inc));
+
+        WPTextView about = (WPTextView) findViewById(R.id.about_url);
+        about.setOnClickListener(this);
     }
 
     @Override

--- a/WordPress/src/main/res/layout/about_activity.xml
+++ b/WordPress/src/main/res/layout/about_activity.xml
@@ -78,7 +78,6 @@
                 android:id="@+id/about_url"
                 android:text="@string/automattic_url"
                 android:clickable="true"
-                android:onClick="onClick"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_medium"


### PR DESCRIPTION
Fixes #4182

To test:

Go to Me tab -> App Settings -> WordPress for Android -> click on automattic.com

