### PR TITLE
Visual editor migration

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -216,16 +216,6 @@ public class WordPress extends Application {
 
         // If users uses a custom locale set it on start of application
         WPActivityUtils.applyLocale(getContext());
-
-        // TODO: remove this after the visual editor is enabled in a release version (5.4 if everything goes well)
-        enableVisualEditorForBetaUsers();
-    }
-
-    private void enableVisualEditorForBetaUsers() {
-        if (BuildConfig.VERSION_NAME.contains("5.4-rc")) {
-            AppPrefs.setVisualEditorAvailable(true);
-            AppPrefs.setVisualEditorEnabled(true);
-        }
     }
 
     private void initAnalytics(final long elapsedTimeOnCreate) {

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -85,7 +85,7 @@ public class WordPressDB {
     public static final String COLUMN_NAME_VIDEO_PRESS_SHORTCODE = "videoPressShortcode";
     public static final String COLUMN_NAME_UPLOAD_STATE          = "uploadState";
 
-    private static final int DATABASE_VERSION = 46;
+    private static final int DATABASE_VERSION = 47;
 
     private static final String CREATE_TABLE_BLOGS = "create table if not exists accounts (id integer primary key autoincrement, "
             + "url text, blogName text, username text, password text, imagePlacement text, centerThumbnail boolean, fullSizeImage boolean, maxImageWidth text, maxImageWidthId integer);";
@@ -418,6 +418,10 @@ public class WordPressDB {
                 currentVersion++;
             case 45:
                 db.execSQL(ADD_BLOGS_CAPABILITIES);
+                currentVersion++;
+            case 46:
+                AppPrefs.setVisualEditorAvailable(true);
+                AppPrefs.setVisualEditorEnabled(true);
                 currentVersion++;
         }
         db.setVersion(DATABASE_VERSION);


### PR DESCRIPTION
Note: there is no changes in the DB, but since we have all other migrations done there I added the visual editor migration there.

1. old users upgrading from any versions to this version should have the new editor available and enabled
1. new users should have the new editor available and enabled
1. users who previously disabled the new editor should have it enabled

#3 is about our future announcement "hey check out the new editor" and I guess these users are rare.