### PR TITLE
Issue/214 preserve media search query

### DIFF
--- a/WordPress/src/main/res/menu/media.xml
+++ b/WordPress/src/main/res/menu/media.xml
@@ -6,7 +6,7 @@
         android:id="@+id/menu_search"
         app:actionViewClass="android.support.v7.widget.SearchView"
         android:icon="@drawable/ic_search_white_24dp"
-        app:showAsAction="ifRoom"
+        app:showAsAction="ifRoom|collapseActionView"
         android:title="@string/search" />
 
     <item


### PR DESCRIPTION
Fixes #214 

The fix works around quirks of SearchView that tries to reset search query whenever possible. We just preserve query while SearchView collapses/expands.

In addition to #214 this PR fixes the issue of loosing search query/state when activity is destroyed by OS in background.

To test: At Media activity open search bar, enter search query, open media item, navigate back - search bar and results should be visible.


Needs review: @aforcier or @maxme 
