### PR TITLE
Fix for self hosted login form not falling back to http

### DIFF
--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
@@ -268,16 +268,19 @@ public class XMLRPCUtils {
 
     private static String verifyXmlrpcUrl(final String siteUrl, final String httpUsername, final String httpPassword)
             throws XMLRPCUtilsException {
-        final String sanitizedSiteUrl = XMLRPCUtils.sanitizeSiteUrl(siteUrl, true);
+        final String sanitizedSiteUrlHttps = XMLRPCUtils.sanitizeSiteUrl(siteUrl, true);
+        final String sanitizedSiteUrlHttp = XMLRPCUtils.sanitizeSiteUrl(siteUrl, false);
 
         // Ordered set of Strings that contains the URLs we want to try. No discovery ;)
         final Set<String> urlsToTry = new LinkedHashSet<>();
 
-        // start by adding the url with 'xmlrpc.php'. This will be the first url to try.
-        urlsToTry.add(XMLRPCUtils.appendXMLRPCPath(sanitizedSiteUrl));
+        // start by adding the URLs with 'xmlrpc.php'. This will be the first URLs to try.
+        urlsToTry.add(XMLRPCUtils.appendXMLRPCPath(sanitizedSiteUrlHttps));
+        urlsToTry.add(XMLRPCUtils.appendXMLRPCPath(sanitizedSiteUrlHttp));
 
-        // add the sanitized URL without the '/xmlrpc.php' suffix added to it
-        urlsToTry.add(sanitizedSiteUrl);
+        // add the sanitized URLs without the '/xmlrpc.php' suffix added to it
+        urlsToTry.add(sanitizedSiteUrlHttps);
+        urlsToTry.add(sanitizedSiteUrlHttp);
 
         // add the user provided URL as well
         urlsToTry.add(siteUrl);

--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
@@ -298,6 +298,11 @@ public class XMLRPCUtils {
                     return url;
                 }
             } catch (XMLRPCUtilsException e) {
+                if (e.kind == XMLRPCUtilsException.Kind.ERRONEOUS_SSL_CERTIFICATE ||
+                    e.kind == XMLRPCUtilsException.Kind.HTTP_AUTH_REQUIRED ||
+                    e.kind == XMLRPCUtilsException.Kind.MISSING_XMLRPC_METHOD) {
+                    throw e;
+                }
                 // swallow the error since we are just verifying various URLs
                 continue;
             } catch (RuntimeException re) {

--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
@@ -272,20 +272,15 @@ public class XMLRPCUtils {
         final Set<String> urlsToTry = new LinkedHashSet<>();
 
         final String sanitizedSiteUrlHttps = XMLRPCUtils.sanitizeSiteUrl(siteUrl, true);
+        final String sanitizedSiteUrlHttp = XMLRPCUtils.sanitizeSiteUrl(siteUrl, false);
 
         // start by adding the https URL with 'xmlrpc.php'. This will be the first URL to try.
+        urlsToTry.add(XMLRPCUtils.appendXMLRPCPath(sanitizedSiteUrlHttp));
         urlsToTry.add(XMLRPCUtils.appendXMLRPCPath(sanitizedSiteUrlHttps));
 
         // add the sanitized https URL without the '/xmlrpc.php' suffix added to it
-        urlsToTry.add(sanitizedSiteUrlHttps);
-
-        final String sanitizedSiteUrlHttp = XMLRPCUtils.sanitizeSiteUrl(siteUrl, false);
-
-        // add the http URL with 'xmlrpc.php'
-        urlsToTry.add(XMLRPCUtils.appendXMLRPCPath(sanitizedSiteUrlHttp));
-
-        // add the sanitized http URL without the '/xmlrpc.php' suffix added to it
         urlsToTry.add(sanitizedSiteUrlHttp);
+        urlsToTry.add(sanitizedSiteUrlHttps);
 
         // add the user provided URL as well
         urlsToTry.add(siteUrl);

--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
@@ -276,7 +276,7 @@ public class XMLRPCUtils {
         // start by adding the https URL with 'xmlrpc.php'. This will be the first URL to try.
         urlsToTry.add(XMLRPCUtils.appendXMLRPCPath(sanitizedSiteUrlHttps));
 
-        // add the sanitized http URL without the '/xmlrpc.php' suffix added to it
+        // add the sanitized https URL without the '/xmlrpc.php' suffix added to it
         urlsToTry.add(sanitizedSiteUrlHttps);
 
         final String sanitizedSiteUrlHttp = XMLRPCUtils.sanitizeSiteUrl(siteUrl, false);

--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
@@ -268,18 +268,23 @@ public class XMLRPCUtils {
 
     private static String verifyXmlrpcUrl(final String siteUrl, final String httpUsername, final String httpPassword)
             throws XMLRPCUtilsException {
-        final String sanitizedSiteUrlHttps = XMLRPCUtils.sanitizeSiteUrl(siteUrl, true);
-        final String sanitizedSiteUrlHttp = XMLRPCUtils.sanitizeSiteUrl(siteUrl, false);
-
         // Ordered set of Strings that contains the URLs we want to try. No discovery ;)
         final Set<String> urlsToTry = new LinkedHashSet<>();
 
-        // start by adding the URLs with 'xmlrpc.php'. This will be the first URLs to try.
+        final String sanitizedSiteUrlHttps = XMLRPCUtils.sanitizeSiteUrl(siteUrl, true);
+
+        // start by adding the https URL with 'xmlrpc.php'. This will be the first URL to try.
         urlsToTry.add(XMLRPCUtils.appendXMLRPCPath(sanitizedSiteUrlHttps));
+
+        // add the sanitized http URL without the '/xmlrpc.php' suffix added to it
+        urlsToTry.add(sanitizedSiteUrlHttps);
+
+        final String sanitizedSiteUrlHttp = XMLRPCUtils.sanitizeSiteUrl(siteUrl, false);
+
+        // add the http URL with 'xmlrpc.php'
         urlsToTry.add(XMLRPCUtils.appendXMLRPCPath(sanitizedSiteUrlHttp));
 
-        // add the sanitized URLs without the '/xmlrpc.php' suffix added to it
-        urlsToTry.add(sanitizedSiteUrlHttps);
+        // add the sanitized http URL without the '/xmlrpc.php' suffix added to it
         urlsToTry.add(sanitizedSiteUrlHttp);
 
         // add the user provided URL as well

--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCUtils.java
@@ -289,6 +289,9 @@ public class XMLRPCUtils {
                     // Endpoint found and works fine.
                     return url;
                 }
+            } catch (XMLRPCUtilsException e) {
+                // swallow the error since we are just verifying various URLs
+                continue;
             } catch (RuntimeException re) {
                 // depending how corrupt the user entered URL is, it can generate several kind of runtime exceptions,
                 // ignore them


### PR DESCRIPTION
Fixes #4196 

To test:
* Try to login into a *non-SSL enabled* self-hosted site by inputing its URL without any scheme (`http` or `https`)
* Provided the username and password are correct, the app should be able to login


Needs review: @maxme 
