### PR TITLE
No email client causes crash when trying to sign in with magic links

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -309,8 +309,11 @@ public class SignInFragment extends AbstractFragment implements TextWatcher, Con
     }
 
     protected boolean isGooglePlayServicesAvailable() {
-        return isAdded() && GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(getActivity())
-                == ConnectionResult.SUCCESS;
+        if (getActivity() == null) {
+            return false;
+        }
+        int status = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(getActivity());
+        return status == ConnectionResult.SUCCESS;
     }
 
     private void initInfoButtons(View rootView) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkSentFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkSentFragment.java
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.accounts.login;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
@@ -13,6 +15,8 @@ import android.widget.TextView;
 import org.wordpress.android.R;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.util.HelpshiftHelper;
+
+import java.util.List;
 
 public class MagicLinkSentFragment extends Fragment {
     public interface OnMagicLinkSentInteraction {
@@ -49,12 +53,16 @@ public class MagicLinkSentFragment extends Fragment {
         });
 
         TextView openEmailView = (TextView) view.findViewById(R.id.open_email_button);
-        openEmailView.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                openEmailClient();
-            }
-        });
+        if (isEmailClientAvailable()) {
+            openEmailView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    openEmailClient();
+                }
+            });
+        } else {
+            openEmailView.setVisibility(View.GONE);
+        }
 
         initInfoButtons(view);
 
@@ -78,5 +86,18 @@ public class MagicLinkSentFragment extends Fragment {
         Intent intent = new Intent(Intent.ACTION_MAIN);
         intent.addCategory(Intent.CATEGORY_APP_EMAIL);
         getActivity().startActivity(intent);
+    }
+
+    private boolean isEmailClientAvailable() {
+        if (getActivity() == null) {
+            return false;
+        }
+
+        Intent intent = new Intent(Intent.ACTION_MAIN);
+        intent.addCategory(Intent.CATEGORY_APP_EMAIL);
+        PackageManager packageManager = getActivity().getPackageManager();
+        List<ResolveInfo> emailApps = packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+
+        return !emailApps.isEmpty();
     }
 }


### PR DESCRIPTION
Fixes #4185 

To test:

1. Get to `MagicLinkSentFragment` when you have no default email client and there will be no "Open email" button
2. Get to `MagicLinkSentFragment` when you have a default email client and there will be an "Open email" button