### PR TITLE
No email client causes crash when trying to sign in with magic links

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -46,6 +46,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.HelpshiftHelper;
 import org.wordpress.android.util.HelpshiftHelper.Tag;
 import org.wordpress.android.util.UrlUtils;
+import org.wordpress.android.util.WPActivityUtils;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -243,7 +244,7 @@ public class ActivityLauncher {
     }
 
     public static void showSignInForResult(Activity activity) {
-        if (isMagicLinkEnabledVariable.get()) {
+        if (isMagicLinkEnabledVariable.get() && WPActivityUtils.isEmailClientAvailable(activity)) {
             Intent intent = new Intent(activity, MagicLinkSignInActivity.class);
             activity.startActivityForResult(intent, RequestCodes.ADD_ACCOUNT);
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkSentFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkSentFragment.java
@@ -49,17 +49,13 @@ public class MagicLinkSentFragment extends Fragment {
         });
 
         TextView openEmailView = (TextView) view.findViewById(R.id.open_email_button);
-        if (isEmailClientAvailable()) {
-            openEmailView.setOnClickListener(new View.OnClickListener() {
+        openEmailView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     openEmailClient();
                 }
             });
-        } else {
-            openEmailView.setVisibility(View.GONE);
-        }
-
+        
         initInfoButtons(view);
 
         return view;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkSentFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkSentFragment.java
@@ -50,11 +50,11 @@ public class MagicLinkSentFragment extends Fragment {
 
         TextView openEmailView = (TextView) view.findViewById(R.id.open_email_button);
         openEmailView.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    openEmailClient();
-                }
-            });
+            @Override
+            public void onClick(View v) {
+                openEmailClient();
+            }
+        });
         
         initInfoButtons(view);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkSentFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkSentFragment.java
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.accounts.login;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
@@ -13,6 +15,8 @@ import android.widget.TextView;
 import org.wordpress.android.R;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.util.HelpshiftHelper;
+
+import java.util.List;
 
 public class MagicLinkSentFragment extends Fragment {
     public interface OnMagicLinkSentInteraction {
@@ -49,12 +53,16 @@ public class MagicLinkSentFragment extends Fragment {
         });
 
         TextView openEmailView = (TextView) view.findViewById(R.id.open_email_button);
-        openEmailView.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                openEmailClient();
-            }
-        });
+        if (isEmailClientAvailable()) {
+            openEmailView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    openEmailClient();
+                }
+            });
+        } else {
+            openEmailView.setVisibility(View.GONE);
+        }
 
         initInfoButtons(view);
 
@@ -78,5 +86,18 @@ public class MagicLinkSentFragment extends Fragment {
         Intent intent = new Intent(Intent.ACTION_MAIN);
         intent.addCategory(Intent.CATEGORY_APP_EMAIL);
         getActivity().startActivity(intent);
+    }
+
+    private boolean isEmailClientAvailable() {
+        if (getActivity() == null) {
+            return false;
+        }
+
+        Intent intent = new Intent(Intent.ACTION_MAIN);
+        intent.addCategory(Intent.CATEGORY_APP_EMAIL);
+        PackageManager packageManager = getActivity().getPackageManager();
+        List<ResolveInfo> emailApps = packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+
+        return !emailApps.isEmpty();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkSentFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkSentFragment.java
@@ -2,8 +2,6 @@ package org.wordpress.android.ui.accounts.login;
 
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
-import android.content.pm.ResolveInfo;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
@@ -15,8 +13,6 @@ import android.widget.TextView;
 import org.wordpress.android.R;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.util.HelpshiftHelper;
-
-import java.util.List;
 
 public class MagicLinkSentFragment extends Fragment {
     public interface OnMagicLinkSentInteraction {
@@ -86,18 +82,5 @@ public class MagicLinkSentFragment extends Fragment {
         Intent intent = new Intent(Intent.ACTION_MAIN);
         intent.addCategory(Intent.CATEGORY_APP_EMAIL);
         getActivity().startActivity(intent);
-    }
-
-    private boolean isEmailClientAvailable() {
-        if (getActivity() == null) {
-            return false;
-        }
-
-        Intent intent = new Intent(Intent.ACTION_MAIN);
-        intent.addCategory(Intent.CATEGORY_APP_EMAIL);
-        PackageManager packageManager = getActivity().getPackageManager();
-        List<ResolveInfo> emailApps = packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
-
-        return !emailApps.isEmpty();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -3,7 +3,10 @@ package org.wordpress.android.util;
 import android.app.Dialog;
 import android.app.Fragment;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
@@ -23,6 +26,7 @@ import android.widget.TextView;
 import org.wordpress.android.R;
 import org.wordpress.android.ui.prefs.AppSettingsFragment;
 
+import java.util.List;
 import java.util.Locale;
 
 public class WPActivityUtils {
@@ -121,5 +125,18 @@ public class WPActivityUtils {
             }
         }
         return context;
+    }
+
+    public static boolean isEmailClientAvailable(Context context) {
+        if (context == null) {
+            return false;
+        }
+
+        Intent intent = new Intent(Intent.ACTION_MAIN);
+        intent.addCategory(Intent.CATEGORY_APP_EMAIL);
+        PackageManager packageManager = context.getPackageManager();
+        List<ResolveInfo> emailApps = packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+
+        return !emailApps.isEmpty();
     }
 }


### PR DESCRIPTION
Fixes #4185 

To test:

1. Get to `MagicLinkSentFragment` when you have no default email client and there will be no "Open email" button
2. Get to `MagicLinkSentFragment` when you have a default email client and there will be an "Open email" button