### PR TITLE
Remove posts from unfollowed blogs from reader

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -184,8 +184,8 @@ public class ReaderPostTable {
         numDeleted += db.delete("tbl_posts", "pseudo_id NOT IN (SELECT DISTINCT pseudo_id FROM tbl_post_tags)", null);
 
         // delete all the posts from the blogs we stopped following
-        numDeleted +=  db.delete("tbl_posts", "blog_id NOT IN (SELECT DISTINCT blog_id FROM tbl_blog_info WHERE " +
-                "tbl_blog_info.is_following != 0)", null);
+        numDeleted += db.delete("tbl_posts",
+                "blog_id NOT IN (SELECT DISTINCT blog_id FROM tbl_blog_info WHERE tbl_blog_info.is_following != 0)", null);
 
         return numDeleted;
     }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -401,8 +401,8 @@ public class ReaderPostTable {
     /*
     * delete all the posts from the blogs we no longer follow
     */
-    public static void deletePostsFromUnfollowedBlogs() {
-        ReaderDatabase.getWritableDb().delete("tbl_posts",
+    public static int deletePostsFromUnfollowedBlogs() {
+       return ReaderDatabase.getWritableDb().delete("tbl_posts",
                 "blog_id NOT IN (SELECT DISTINCT blog_id FROM tbl_blog_info WHERE tbl_blog_info.is_following != 0)", null);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -402,6 +402,14 @@ public class ReaderPostTable {
         return numDeleted;
     }
 
+    /*
+    * delete all the posts from the blogs we no longer follow
+    */
+    public static void deletePostsFromUnfollowedBlogs() {
+        ReaderDatabase.getWritableDb().delete("tbl_posts",
+                "blog_id NOT IN (SELECT DISTINCT blog_id FROM tbl_blog_info WHERE tbl_blog_info.is_following != 0)", null);
+    }
+
     public static int deletePostsInBlog(long blogId) {
         String[] args = {Long.toString(blogId)};
         return ReaderDatabase.getWritableDb().delete("tbl_posts", "blog_id = ?", args);

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -183,6 +183,10 @@ public class ReaderPostTable {
         // delete posts in tbl_posts that no longer exist in tbl_post_tags
         numDeleted += db.delete("tbl_posts", "pseudo_id NOT IN (SELECT DISTINCT pseudo_id FROM tbl_post_tags)", null);
 
+        // delete all the posts from the blogs we stopped following
+        numDeleted +=  db.delete("tbl_posts", "blog_id NOT IN (SELECT DISTINCT blog_id FROM tbl_blog_info WHERE " +
+                "tbl_blog_info.is_following != 0)", null);
+
         return numDeleted;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -183,10 +183,6 @@ public class ReaderPostTable {
         // delete posts in tbl_posts that no longer exist in tbl_post_tags
         numDeleted += db.delete("tbl_posts", "pseudo_id NOT IN (SELECT DISTINCT pseudo_id FROM tbl_post_tags)", null);
 
-        // delete all the posts from the blogs we stopped following
-        numDeleted += db.delete("tbl_posts",
-                "blog_id NOT IN (SELECT DISTINCT blog_id FROM tbl_blog_info WHERE tbl_blog_info.is_following != 0)", null);
-
         return numDeleted;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -270,6 +270,7 @@ public class ReaderUpdateService extends Service {
 
                 if (!localBlogs.isSameList(serverBlogs)) {
                     ReaderBlogTable.setFollowedBlogs(serverBlogs);
+                    ReaderPostTable.deletePostsFromUnfollowedBlogs();
                     AppLog.d(AppLog.T.READER, "reader blogs service > followed blogs changed");
                     EventBus.getDefault().post(new ReaderEvents.FollowedBlogsChanged());
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -269,16 +269,16 @@ public class ReaderUpdateService extends Service {
                 ReaderBlogList serverBlogs = ReaderBlogList.fromJson(jsonObject);
                 ReaderBlogList localBlogs = ReaderBlogTable.getFollowedBlogs();
 
-                boolean blogsHaveChanged = !localBlogs.isSameList(serverBlogs);
+                boolean followedBlogsChanged = !localBlogs.isSameList(serverBlogs);
 
-                if (blogsHaveChanged) {
+                if (followedBlogsChanged) {
                     ReaderBlogTable.setFollowedBlogs(serverBlogs);
                     AppLog.d(AppLog.T.READER, "reader blogs service > followed blogs changed");
                 }
 
                 int numberOfDeletedPosts = ReaderPostTable.deletePostsFromUnfollowedBlogs();
 
-                if (blogsHaveChanged || numberOfDeletedPosts > 0) {
+                if (followedBlogsChanged || numberOfDeletedPosts > 0) {
                     EventBus.getDefault().post(new ReaderEvents.FollowedBlogsChanged());
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -261,6 +261,7 @@ public class ReaderUpdateService extends Service {
         // request using ?meta=site,feed to get extra info
         WordPress.getRestClientUtilsV1_1().get("read/following/mine?meta=site%2Cfeed", listener, errorListener);
     }
+
     private void handleFollowedBlogsResponse(final JSONObject jsonObject) {
         new Thread() {
             @Override
@@ -268,10 +269,16 @@ public class ReaderUpdateService extends Service {
                 ReaderBlogList serverBlogs = ReaderBlogList.fromJson(jsonObject);
                 ReaderBlogList localBlogs = ReaderBlogTable.getFollowedBlogs();
 
-                if (!localBlogs.isSameList(serverBlogs)) {
+                boolean blogsHaveChanged = !localBlogs.isSameList(serverBlogs);
+
+                if (blogsHaveChanged) {
                     ReaderBlogTable.setFollowedBlogs(serverBlogs);
-                    ReaderPostTable.deletePostsFromUnfollowedBlogs();
                     AppLog.d(AppLog.T.READER, "reader blogs service > followed blogs changed");
+                }
+
+                int numberOfDeletedPosts = ReaderPostTable.deletePostsFromUnfollowedBlogs();
+
+                if (blogsHaveChanged || numberOfDeletedPosts > 0) {
                     EventBus.getDefault().post(new ReaderEvents.FollowedBlogsChanged());
                 }
 


### PR DESCRIPTION
Fixes #2647 

Currently, when you stop following a blog from outside of an Android app, the posts from that blog will remain in the reader, unless you stop following/block the blog from within the app. If you wont do this those posts will be deleted one by one when the limit of posts in DB will be reached.

This PR addresses this, by adding a query that deletes all the posts from unfollowed blogs to the end of  the purge call executed at the application start.

To test: Unfollow blog, close the app (completely), reopen app - posts from unfollowed blogs should be gone.

Needs review: @nbradbury 