### PR TITLE
Use a long for featured image IDs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/Post.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Post.java
@@ -18,7 +18,7 @@ public class Post implements Serializable {
 
     public static String QUICK_MEDIA_TYPE_PHOTO = "QuickPhoto";
 
-    private static int FEATURED_IMAGE_INIT_VALUE = -2;
+    private static long FEATURED_IMAGE_INIT_VALUE = -2;
 
     private long localTablePostId;
     private int localTableBlogId;

--- a/WordPress/src/main/java/org/wordpress/android/models/Post.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Post.java
@@ -54,8 +54,8 @@ public class Post implements Serializable {
     private String quickPostType;
     private PostLocation mPostLocation;
 
-    private int lastKnownRemoteFeaturedImageId;
-    private int featuredImageId = FEATURED_IMAGE_INIT_VALUE;
+    private long lastKnownRemoteFeaturedImageId;
+    private long featuredImageId = FEATURED_IMAGE_INIT_VALUE;
 
     public Post() {
     }
@@ -483,7 +483,7 @@ public class Post implements Serializable {
         return TextUtils.isEmpty(this.getTitle()) && TextUtils.isEmpty(this.getContent());
     }
 
-    public int getFeaturedImageId() {
+    public long getFeaturedImageId() {
         if (featuredImageId == FEATURED_IMAGE_INIT_VALUE) {
             return 0;
         }
@@ -491,7 +491,7 @@ public class Post implements Serializable {
         return featuredImageId;
     }
 
-    public void setFeaturedImageId(int id) {
+    public void setFeaturedImageId(long id) {
         if (featuredImageId == FEATURED_IMAGE_INIT_VALUE) {
             lastKnownRemoteFeaturedImageId = id;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2098,7 +2098,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     }
 
     @Override
-    public void onFeaturedImageChanged(int mediaId) {
+    public void onFeaturedImageChanged(long mediaId) {
         mPost.setFeaturedImageId(mediaId);
         mEditPostSettingsFragment.updateFeaturedImage(mediaId);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -43,7 +43,6 @@ import android.widget.Toast;
 import com.android.volley.toolbox.NetworkImageView;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import com.helpshift.util.StringUtil;
 
 import org.apache.commons.lang.StringEscapeUtils;
 import org.json.JSONArray;
@@ -103,7 +102,7 @@ public class EditPostSettingsFragment extends Fragment
 
     private SuggestionServiceConnectionManager mSuggestionServiceConnectionManager;
 
-    private int mFeaturedImageId;
+    private long mFeaturedImageId;
 
     private ArrayList<String> mCategories;
 
@@ -376,11 +375,11 @@ public class EditPostSettingsFragment extends Fragment
         }
     }
 
-    public int getFeaturedImageId() {
+    public long getFeaturedImageId() {
         return mFeaturedImageId;
     }
 
-    public void updateFeaturedImage(int id) {
+    public void updateFeaturedImage(long id) {
         if (mFeaturedImageId != id) {
             mFeaturedImageId = id;
             if (mFeaturedImageId > 0) {
@@ -453,7 +452,7 @@ public class EditPostSettingsFragment extends Fragment
                             return;
                         }
 
-                        updateFeaturedImage(Integer.parseInt(ids.get(0)));
+                        updateFeaturedImage(Long.parseLong(ids.get(0)));
                     }
             }
         }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -50,7 +50,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
 
     protected EditorFragmentListener mEditorFragmentListener;
     protected boolean mFeaturedImageSupported;
-    protected int mFeaturedImageId;
+    protected long mFeaturedImageId;
     protected String mBlogSettingMaxImageWidth;
     protected ImageLoader mImageLoader;
     protected boolean mDebugModeEnabled;
@@ -101,7 +101,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
         mBlogSettingMaxImageWidth = blogSettingMaxImageWidth;
     }
 
-    public void setFeaturedImageId(int featuredImageId) {
+    public void setFeaturedImageId(long featuredImageId) {
         mFeaturedImageId = featuredImageId;
     }
 
@@ -142,7 +142,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
         void onAddMediaClicked();
         void onMediaRetryClicked(String mediaId);
         void onMediaUploadCancelClicked(String mediaId, boolean delete);
-        void onFeaturedImageChanged(int mediaId);
+        void onFeaturedImageChanged(long mediaId);
         void onVideoPressInfoRequested(String videoId);
         String onAuthHeaderRequested(String url);
         // TODO: remove saveMediaFile, it's currently needed for the legacy editor


### PR DESCRIPTION
Looking at the featured image id parameter in the XMRLPC API documentation (named "wp_post_thumbnail" there), it should be a string. But we're using long in the app for other media ids in other places like [here](https://github.com/wordpress-mobile/WordPress-Android/blob/9db16023dc62dd4c4f0e1701be775494be9cadd8/WordPress/src/main/java/org/wordpress/android/WordPressDB.java#L1658-L1661).

According to the crash reports it's always caused by a long (no fancy string IDs). The objective is to fix this crash, not refactor the app to use the correct type. I opened an issue [here in wpstores](https://github.com/wordpress-mobile/WordPress-Stores-Android/issues/36), so when we work on the app refactor, we'll make sure to pick the correct type.

If you need to test, I can send you credentials to a WP instance with long media ids.