### PR TITLE
Display AMP version of posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -105,6 +105,11 @@ public class WPWebViewActivity extends WebViewActivity {
         outState.putString(NON_AMP_URL, mNonAmpUrl);
     }
 
+    private static boolean isAmpCapableServer(String addressToLoad) {
+        // add more AMP-capable servers here
+        return WPUrlUtils.isWordPressCom(addressToLoad);
+    }
+
     public static void openUrlByUsingWPCOMCredentials(Context context, String url, String user) {
         openWPCOMURL(context, url, user);
     }
@@ -137,7 +142,7 @@ public class WPWebViewActivity extends WebViewActivity {
         if (post != null) {
             intent.putExtra(WPWebViewActivity.SHARABLE_URL, WPMeShortlinks.getPostShortlink(blog, post));
 
-            if (!post.isPage()) {
+            if (!post.isPage() && isAmpCapableServer(url)) {
                 intent.putExtra(WPWebViewActivity.USE_AMP_IF_ENABLED, true);
             }
         }

--- a/WordPress/src/main/res/menu/webview.xml
+++ b/WordPress/src/main/res/menu/webview.xml
@@ -17,4 +17,8 @@
         android:icon="@drawable/ic_refresh_white_24dp"
         android:title="@string/refresh"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/menu_no_amp"
+        android:title="@string/view_in_browser_no_amp"
+        app:showAsAction="never" />
 </menu>

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -19,6 +19,8 @@
     <string name="pref_key_oss_licenses" translatable="false">wp_pref_open_source_licenses</string>
     <string name="pref_key_editor" translatable="false">wp_pref_editor</string>
     <string name="pref_key_visual_editor_enabled" translatable="false">wp_pref_visual_editor_enabled</string>
+    <string name="pref_key_posts_list" translatable="false">wp_pref_posts_list</string>
+    <string name="pref_key_amp_enabled" translatable="false">wp_pref_amp_enabled</string>
     <string name="pref_notification_blogs" translatable="false">wp_pref_notification_blogs</string>
     <string name="pref_notification_other_category" translatable="false">wp_pref_notification_other_category</string>
     <string name="pref_notification_other_blogs" translatable="false">wp_pref_notification_other_blogs</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -365,6 +365,7 @@
     <string name="post_not_published">Post status isn\'t published</string>
     <string name="page_not_published">Page status isn\'t published</string>
     <string name="view_in_browser">View in browser</string>
+    <string name="view_in_browser_no_amp">Open non AMP version</string>
     <string name="preview">Preview</string>
     <string name="update_verb">Update</string>
     <string name="sending_content">Uploading %s content</string>
@@ -617,6 +618,9 @@
     <string name="preference_send_usage_stats_summary">Automatically send usage statistics to help us improve WordPress for Android</string>
     <string name="preference_editor">Editor</string>
     <string name="preference_show_visual_editor">Show visual editor</string>
+    <string name="preference_posts_list">Posts List</string>
+    <string name="preference_use_amp">AMP</string>
+    <string name="preference_user_amp_summary">Use Accelerated Mobile Pages when possible</string>
 
     <!-- stats -->
     <string name="stats">Stats</string>

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -49,6 +49,20 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        android:key="@string/pref_key_posts_list"
+        android:layout="@layout/preference_category"
+        android:title="@string/preference_posts_list">
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_key_amp_enabled"
+            android:layout="@layout/preference_layout"
+            android:title="@string/preference_use_amp"
+            android:summary="@string/preference_user_amp_summary" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:key="@string/pref_key_about_section"
         android:layout="@layout/preference_category"
         android:title="@string/about_the_app">

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -40,6 +40,7 @@ public final class AnalyticsTracker {
         READER_TAG_LOADED,
         READER_TAG_PREVIEWED,
         READER_TAG_UNFOLLOWED,
+        AMP_POST_OPEN,
         STATS_ACCESSED,
         STATS_INSIGHTS_ACCESSED,
         STATS_PERIOD_DAYS_ACCESSED,


### PR DESCRIPTION
Fixes #4175 

This PR introduces the usage of AMP (Accelerated Mobile Pages) for viewing posts in the Posts List.

Using AMP is by default disabled and governed by a switch in the App Settings which the user can control.

For now, AMP can only be used for WordPress.com posts.

To test:
* Enable "AMP" in App Settings
* Got to the site's post list and tap "View" to open the post in the in-app browser
* Notice the simplified post content, missing (among other things) the comments section at the bottom
* Tap the "globe" icon in the ActionBar to open the post in the system browser
* Notice that the post is still simplified in system's browser as well. Also notice how fast the post is generally opened.
* Tap back to return to the app and this time tap the "Open non AMP version" menu action to open the post in the system browser again
* Notice the post having the "non-AMP" layout and content


Here's a screen video of the feature in action: https://cloudup.com/idL3qPQz6yc

Needs review: I'm thinking: @nbradbury