### PR TITLE
Change generic preference to switch for passcode

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsActivity.java
@@ -3,11 +3,13 @@ package org.wordpress.android.ui.prefs;
 import android.app.FragmentManager;
 import android.os.Bundle;
 import android.preference.Preference;
+import android.preference.SwitchPreference;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
 import org.wordpress.android.ui.ActivityLauncher;
+import org.wordpress.passcodelock.AppLockManager;
 import org.wordpress.passcodelock.PasscodePreferenceFragment;
 
 public class AppSettingsActivity extends AppCompatActivity {
@@ -56,6 +58,8 @@ public class AppSettingsActivity extends AppCompatActivity {
 
         if (togglePref != null && changePref != null) {
             mPasscodePreferenceFragment.setPreferences(togglePref, changePref);
+            ((SwitchPreference) togglePref).setChecked(
+                    AppLockManager.getInstance().getAppLock().isPasswordLocked());
         }
     }
 

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -34,7 +34,7 @@
         android:persistent="false"
         android:title="@string/passcode_preference_title">
 
-        <Preference
+        <SwitchPreference
             android:key="@string/pref_key_passcode_toggle"
             android:layout="@layout/preference_layout"
             android:persistent="false"


### PR DESCRIPTION
#### Fix
Change the generic preference to a switch for the passcode (i.e. PIN lock) as shown in the screenshots below.

![passcode_preference](https://cloud.githubusercontent.com/assets/3827611/15937852/d157b358-2e2d-11e6-8450-fa66cee1ddb3.png)

Using a switch to show state when enabling/disabling dependent preferences is common among popular apps.  See a few examples below.

![switch_samples](https://cloud.githubusercontent.com/assets/3827611/15937981/5233ac66-2e2e-11e6-9310-e496c6d37f42.png)

#### Test
1. Go to Me tab.
2. Tap App Settings option.
3. Notice "Turn PIN lock on" preference.