### PR TITLE
Fixes #4192: helpshift deep linking + signin deep linking

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -490,7 +490,18 @@
                     android:scheme="wordpress" >
                 </data>
             </intent-filter>
+        </activity>
 
+        <activity
+            android:name=".ui.HelpshiftDeepLinkReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:host="helpshift"
+                    android:scheme="wordpress" />
+            </intent-filter>
         </activity>
 
         <!-- Smart Lock for Passwords -->

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -85,7 +85,17 @@
             android:name=".ui.accounts.SignInActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:theme="@style/SignInTheme"
-            android:windowSoftInputMode="adjustResize" />
+            android:windowSoftInputMode="adjustResize">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:host="signin"
+                    android:scheme="wordpress" />
+            </intent-filter>
+        </activity>
+
         <activity
             android:name=".ui.accounts.NewAccountActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"

--- a/WordPress/src/main/java/org/wordpress/android/ui/HelpshiftDeepLinkReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/HelpshiftDeepLinkReceiver.java
@@ -1,0 +1,29 @@
+package org.wordpress.android.ui;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+
+import com.helpshift.support.Support;
+
+public class HelpshiftDeepLinkReceiver extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        String action = getIntent().getAction();
+        Uri data = getIntent().getData();
+
+        if (Intent.ACTION_VIEW.equals(action) && data != null) {
+            String faqid = data.getQueryParameter("faqid");
+            String sectionid = data.getQueryParameter("sectionid");
+            if (faqid != null) {
+                Support.showSingleFAQ(this, faqid);
+            } else if (sectionid != null) {
+                Support.showFAQSection(this, sectionid);
+            }
+        }
+        finish();
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInActivity.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.accounts;
 
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
@@ -29,12 +30,25 @@ public class SignInActivity extends AppCompatActivity {
     public static final String EXTRA_JETPACK_SITE_AUTH = "EXTRA_JETPACK_SITE_AUTH";
     public static final String EXTRA_JETPACK_MESSAGE_AUTH = "EXTRA_JETPACK_MESSAGE_AUTH";
     public static final String EXTRA_IS_AUTH_ERROR = "EXTRA_IS_AUTH_ERROR";
+    public static final String EXTRA_PREFILL_URL = "EXTRA_PREFILL_URL";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         requestWindowFeature(Window.FEATURE_NO_TITLE);
         setContentView(R.layout.welcome_activity);
+
+        String action = getIntent().getAction();
+        Uri data = getIntent().getData();
+
+        if (Intent.ACTION_VIEW.equals(action) && data != null) {
+            if (data.getBooleanQueryParameter("selfhosted", false)) {
+                getIntent().putExtra(SignInActivity.EXTRA_START_FRAGMENT, SignInActivity.ADD_SELF_HOSTED_BLOG);
+                if (data.getQueryParameter("url") != null) {
+                    getIntent().putExtra(EXTRA_PREFILL_URL, data.getQueryParameter("url"));
+                }
+            }
+        }
 
         if (savedInstanceState == null) {
             addSignInFragment();
@@ -58,6 +72,7 @@ public class SignInActivity extends AppCompatActivity {
 
     protected void actionMode(Bundle extras) {
         int actionMode = SIGN_IN_REQUEST;
+        String prefillUrl = "";
         if (extras != null) {
             actionMode = extras.getInt(EXTRA_START_FRAGMENT, -1);
             if (extras.containsKey(EXTRA_JETPACK_SITE_AUTH)) {
@@ -69,10 +84,11 @@ public class SignInActivity extends AppCompatActivity {
             } else if (extras.containsKey(EXTRA_IS_AUTH_ERROR)) {
                 getSignInFragment().showAuthErrorMessage();
             }
+            prefillUrl = extras.getString(EXTRA_PREFILL_URL, "");
         }
         switch (actionMode) {
             case ADD_SELF_HOSTED_BLOG:
-                getSignInFragment().forceSelfHostedMode();
+                getSignInFragment().forceSelfHostedMode(prefillUrl);
                 break;
             default:
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -260,10 +260,11 @@ public class SignInFragment extends AbstractFragment implements TextWatcher, Con
      * Hide toggle button "add self hosted / sign in with WordPress.com" and show self hosted URL
      * edit box
      */
-    public void forceSelfHostedMode() {
+    public void forceSelfHostedMode(String prefillUrl) {
         mUrlButtonLayout.setVisibility(View.VISIBLE);
         mAddSelfHostedButton.setVisibility(View.GONE);
         mCreateAccountButton.setVisibility(View.GONE);
+        mUrlEditText.setText(prefillUrl);
         mSelfHosted = true;
     }
 


### PR DESCRIPTION
Fixes #4192 

To test:

Try to tap on `wordpress://` URLs from [here](https://bia.is/wpbeta/2016/06/10/deep-link-test/). Try when you're already signed in and when you're not.
