### PR TITLE
Issue/4219 fix empty view at media browser

### DIFF
--- a/WordPress/src/main/res/layout/media_grid_fragment.xml
+++ b/WordPress/src/main/res/layout/media_grid_fragment.xml
@@ -32,15 +32,13 @@
             android:id="@+id/media_filter_result_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@id/media_filter_spinner_container"
             android:padding="8dp"
             android:visibility="gone"/>
 
         <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
             android:id="@+id/ptr_layout"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_below="@id/media_filter_result_text">
+            android:layout_height="match_parent">
 
             <GridView
                 android:id="@+id/media_gridview"
@@ -64,7 +62,6 @@
         android:id="@+id/empty_view"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
-        android:layout_below="@+id/media_filter_spinner_container"
         android:gravity="center"
         android:orientation="horizontal"
         android:visibility="gone">

--- a/WordPress/src/main/res/layout/media_grid_fragment.xml
+++ b/WordPress/src/main/res/layout/media_grid_fragment.xml
@@ -1,58 +1,64 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             xmlns:app="http://schemas.android.com/apk/res-auto"
+             xmlns:tools="http://schemas.android.com/tools"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent">
 
-    <FrameLayout
-        android:id="@+id/media_filter_spinner_container"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/grey_lighten_30"
-        android:clickable="true"
-        android:paddingLeft="8dp"
-        android:paddingRight="16dp">
-
-        <org.wordpress.android.ui.CustomSpinner
-            android:id="@+id/media_filter_spinner"
-            style="@style/DropDownNav.WordPress"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:clickable="false"
-            android:paddingLeft="0dp" />
-    </FrameLayout>
-
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/media_filter_result_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/media_filter_spinner_container"
-        android:padding="8dp"
-        android:visibility="gone" />
-
-    <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
-        android:id="@+id/ptr_layout"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/media_filter_result_text">
+        android:orientation="vertical">
 
-        <GridView
-            android:id="@+id/media_gridview"
+        <FrameLayout
+            android:id="@+id/media_filter_spinner_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="center"
-            android:horizontalSpacing="@dimen/margin_small"
-            android:numColumns="@integer/media_grid_num_columns"
-            android:paddingLeft="@dimen/margin_small"
-            android:paddingRight="@dimen/margin_small"
-            android:scrollbarStyle="outsideOverlay"
-            android:stretchMode="columnWidth"
-            android:verticalSpacing="@dimen/margin_small"
-            tools:listitem="@layout/media_grid_item"/>
+            android:background="@color/grey_lighten_30"
+            android:clickable="true"
+            android:paddingLeft="8dp"
+            android:paddingRight="16dp">
 
-    </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
+            <org.wordpress.android.ui.CustomSpinner
+                android:id="@+id/media_filter_spinner"
+                style="@style/DropDownNav.WordPress"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:clickable="false"
+                android:paddingLeft="0dp"/>
+        </FrameLayout>
+
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/media_filter_result_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/media_filter_spinner_container"
+            android:padding="8dp"
+            android:visibility="gone"/>
+
+        <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
+            android:id="@+id/ptr_layout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_below="@id/media_filter_result_text">
+
+            <GridView
+                android:id="@+id/media_gridview"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:horizontalSpacing="@dimen/margin_small"
+                android:numColumns="@integer/media_grid_num_columns"
+                android:paddingLeft="@dimen/margin_small"
+                android:paddingRight="@dimen/margin_small"
+                android:scrollbarStyle="outsideOverlay"
+                android:stretchMode="columnWidth"
+                android:verticalSpacing="@dimen/margin_small"
+                tools:listitem="@layout/media_grid_item"/>
+
+        </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
+    </LinearLayout>
+
 
     <LinearLayout
         android:id="@+id/empty_view"
@@ -72,7 +78,7 @@
             android:layout_marginLeft="@dimen/empty_list_title_side_margin"
             android:layout_marginRight="@dimen/empty_list_title_side_margin"
             android:text="@string/media_empty_list_custom_date"
-            app:fixWidowWords="true" />
+            app:fixWidowWords="true"/>
 
     </LinearLayout>
-</LinearLayout>
+</FrameLayout>


### PR DESCRIPTION
Fixes #4219 

Looks like that empty view in media browser got accidentally hidden [here](https://github.com/wordpress-mobile/WordPress-Android/commit/5895a7899e15a51e383d07b914eb5ce695802eaa), when optimizing layouts with RelativeLayout.

Parent view was changed to FrameLayout (looks like we want to avoid RelativeLayout), so empty view will be centered relative to it (before if was below spinner). 