### PR TITLE
Change layout with switch for screen width 300dp

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsActivity.java
@@ -58,8 +58,11 @@ public class AppSettingsActivity extends AppCompatActivity {
 
         if (togglePref != null && changePref != null) {
             mPasscodePreferenceFragment.setPreferences(togglePref, changePref);
-            ((SwitchPreference) togglePref).setChecked(
-                    AppLockManager.getInstance().getAppLock().isPasswordLocked());
+
+            if (togglePref instanceof SwitchPreference) {
+                ((SwitchPreference) togglePref).setChecked(
+                        AppLockManager.getInstance().getAppLock().isPasswordLocked());
+            }
         }
     }
 

--- a/WordPress/src/main/res/xml-sw300dp/app_settings.xml
+++ b/WordPress/src/main/res/xml-sw300dp/app_settings.xml
@@ -34,7 +34,7 @@
         android:persistent="false"
         android:title="@string/passcode_preference_title">
 
-        <Preference
+        <SwitchPreference
             android:key="@string/pref_key_passcode_toggle"
             android:layout="@layout/preference_layout"
             android:persistent="false"


### PR DESCRIPTION
#### Fix
Change the generic preference to a switch for the passcode (i.e. PIN lock) _**for devices with screen width greater than or equal to 300dp**_ as shown in the screenshots below.

![screenshot](https://cloud.githubusercontent.com/assets/3827611/16026874/ce7cd8fc-318e-11e6-9f10-222fea10c5a6.png)

#### Test
1. Go to Me tab.
2. Tap App Settings option.
3. Notice "Turn PIN lock on" preference.

#### Review
@maxme