### PR TITLE
Change CheckBoxPreference to SwitchPreference in App Settings for screen width 300dp

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.preference.CheckBoxPreference;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceCategory;
@@ -105,17 +106,30 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
                 preferenceScreen.removePreference(editor);
             }
         } else {
-            final SwitchPreference visualEditorSwitch = (SwitchPreference) findPreference(getActivity()
+            final Preference visualEditorPreference = findPreference(getActivity()
                     .getString(R.string.pref_key_visual_editor_enabled));
-            visualEditorSwitch.setChecked(AppPrefs.isVisualEditorEnabled());
-            visualEditorSwitch.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-                @Override
-                public boolean onPreferenceChange(final Preference preference, final Object newValue) {
-                    visualEditorSwitch.setChecked(!visualEditorSwitch.isChecked());
-                    AppPrefs.setVisualEditorEnabled(visualEditorSwitch.isChecked());
-                    return false;
-                }
-            });
+
+            if (visualEditorPreference instanceof CheckBoxPreference) {
+                ((CheckBoxPreference) visualEditorPreference).setChecked(AppPrefs.isVisualEditorEnabled());
+                visualEditorPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                    @Override
+                    public boolean onPreferenceChange(final Preference preference, final Object newValue) {
+                        ((CheckBoxPreference) visualEditorPreference).setChecked(!((CheckBoxPreference) visualEditorPreference).isChecked());
+                        AppPrefs.setVisualEditorEnabled(((CheckBoxPreference) visualEditorPreference).isChecked());
+                        return false;
+                    }
+                });
+            } else if (visualEditorPreference instanceof SwitchPreference) {
+                ((SwitchPreference) visualEditorPreference).setChecked(AppPrefs.isVisualEditorEnabled());
+                visualEditorPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                    @Override
+                    public boolean onPreferenceChange(final Preference preference, final Object newValue) {
+                        ((SwitchPreference) visualEditorPreference).setChecked(!((SwitchPreference) visualEditorPreference).isChecked());
+                        AppPrefs.setVisualEditorEnabled(((SwitchPreference) visualEditorPreference).isChecked());
+                        return false;
+                    }
+                });
+            }
         }
     }
 

--- a/WordPress/src/main/res/xml-sw300dp/app_settings.xml
+++ b/WordPress/src/main/res/xml-sw300dp/app_settings.xml
@@ -8,7 +8,7 @@
         android:layout="@layout/preference_layout"
         android:title="@string/interface_language" />
 
-    <CheckBoxPreference
+    <SwitchPreference
         android:defaultValue="true"
         android:key="@string/pref_key_send_usage"
         android:layout="@layout/preference_layout"
@@ -20,7 +20,7 @@
         android:layout="@layout/preference_category"
         android:title="@string/preference_editor">
 
-        <CheckBoxPreference
+        <SwitchPreference
             android:defaultValue="true"
             android:key="@string/pref_key_visual_editor_enabled"
             android:layout="@layout/preference_layout"


### PR DESCRIPTION
#### Fix
Change `CheckBoxPreference` to `SwitchPreference` in App Settings to make all settings screens consistent _**for devices with screen width greater than or equal to 300dp**_.

#### Test
1. Go to Me tab.
2. Tap App Settings option.
3. See switch for Stats and Visual Editor preferences.

#### Review
@maxme