### PR TITLE
Issue/4244 comment list from comment notification

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -36,6 +36,7 @@ import org.wordpress.android.ui.notifications.blocks.NoteBlockClickableSpan;
 import org.wordpress.android.ui.notifications.blocks.UserNoteBlock;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.notifications.utils.SimperiumUtils;
+import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.actions.ReaderPostActions;
 import org.wordpress.android.ui.reader.services.ReaderCommentService;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
@@ -220,12 +221,17 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
                 }
             } else if (mNote.isFollowType()) {
                 detailActivity.showBlogPreviewActivity(mNote.getSiteId());
-            } else if (mNote.isCommentType() && mNote.getCommentId() > 0) {
-                detailActivity.showReaderCommentsList(mNote.getSiteId(), mNote.getPostId(), mNote.getCommentId());
             } else {
                 // otherwise, load the post in the Reader
                 detailActivity.showPostActivity(mNote.getSiteId(), mNote.getPostId());
             }
+        }
+
+        @Override
+        public void showReaderPostComments() {
+            if (!isAdded() || mNote == null || mNote.getCommentId() == 0) return;
+
+            ReaderActivityLauncher.showReaderComments(getActivity(), mNote.getSiteId(), mNote.getPostId(), mNote.getCommentId());
         }
 
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -220,6 +220,8 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
                 }
             } else if (mNote.isFollowType()) {
                 detailActivity.showBlogPreviewActivity(mNote.getSiteId());
+            } else if (mNote.isCommentType() && mNote.getCommentId() > 0) {
+                detailActivity.showReaderCommentsList(mNote.getSiteId(), mNote.getPostId(), mNote.getCommentId());
             } else {
                 // otherwise, load the post in the Reader
                 detailActivity.showPostActivity(mNote.getSiteId(), mNote.getPostId());

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
@@ -91,6 +91,15 @@ public class CommentUserNoteBlock extends UserNoteBlock {
                         false)
         );
 
+        noteBlockHolder.commentTextView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (getOnNoteBlockTextClickListener() != null) {
+                    getOnNoteBlockTextClickListener().showDetailForNoteIds();
+                }
+            }
+        });
+
         // Change display based on comment status and type:
         // 1. Comment replies are indented and have a 'pipe' background
         // 2. Unapproved comments have different background and text color

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
@@ -91,11 +91,12 @@ public class CommentUserNoteBlock extends UserNoteBlock {
                         false)
         );
 
+        // show all comments on this post when user clicks the comment text
         noteBlockHolder.commentTextView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 if (getOnNoteBlockTextClickListener() != null) {
-                    getOnNoteBlockTextClickListener().showDetailForNoteIds();
+                    getOnNoteBlockTextClickListener().showReaderPostComments();
                 }
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
@@ -91,16 +91,6 @@ public class CommentUserNoteBlock extends UserNoteBlock {
                         false)
         );
 
-        // show all comments on this post when user clicks the comment text
-        noteBlockHolder.commentTextView.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (getOnNoteBlockTextClickListener() != null) {
-                    getOnNoteBlockTextClickListener().showReaderPostComments();
-                }
-            }
-        });
-
         // Change display based on comment status and type:
         // 1. Comment replies are indented and have a 'pipe' background
         // 2. Unapproved comments have different background and text color
@@ -195,6 +185,16 @@ public class CommentUserNoteBlock extends UserNoteBlock {
                 public void onClick(View v) {
                     if (getOnNoteBlockTextClickListener() != null) {
                         getOnNoteBlockTextClickListener().showSitePreview(getMetaSiteId(), getMetaSiteUrl());
+                    }
+                }
+            });
+
+            // show all comments on this post when user clicks the comment text
+            commentTextView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (getOnNoteBlockTextClickListener() != null) {
+                        getOnNoteBlockTextClickListener().showReaderPostComments();
                     }
                 }
             });

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/NoteBlock.java
@@ -45,9 +45,10 @@ public class NoteBlock {
     private int mBackgroundColor;
 
     public interface OnNoteBlockTextClickListener {
-        public void onNoteBlockTextClicked(NoteBlockClickableSpan clickedSpan);
-        public void showDetailForNoteIds();
-        public void showSitePreview(long siteId, String siteUrl);
+        void onNoteBlockTextClicked(NoteBlockClickableSpan clickedSpan);
+        void showDetailForNoteIds();
+        void showReaderPostComments();
+        void showSitePreview(long siteId, String siteUrl);
     }
 
     public NoteBlock(JSONObject noteObject, OnNoteBlockTextClickListener onNoteBlockTextClickListener) {

--- a/WordPress/src/main/res/layout/note_block_comment_user.xml
+++ b/WordPress/src/main/res/layout/note_block_comment_user.xml
@@ -91,6 +91,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_medium"
+        android:background="?android:selectableItemBackground"
         android:paddingBottom="@dimen/margin_medium"
         android:textColor="@color/grey_dark"
         android:textSize="@dimen/text_sz_large"


### PR DESCRIPTION
Fixes #4244 - note that the issue relates to scrolling the tapped comment into view, but this functionality was already built into the reader. What was missing was the ability to tap on the comment to show all comments on the same post. This PR adds that ability.

Needs review: @roundhill 
