### PR TITLE
Feature/3591 menu items wip

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -64,6 +64,7 @@ public class MySiteFragment extends Fragment
     private LinearLayout mLookAndFeelHeader;
     private RelativeLayout mThemesContainer;
     private RelativeLayout mPeopleView;
+    private RelativeLayout mMenusView;
     private RelativeLayout mPlanContainer;
     private View mConfigurationHeader;
     private View mSettingsView;
@@ -146,6 +147,7 @@ public class MySiteFragment extends Fragment
         mLookAndFeelHeader = (LinearLayout) rootView.findViewById(R.id.my_site_look_and_feel_header);
         mThemesContainer = (RelativeLayout) rootView.findViewById(R.id.row_themes);
         mPeopleView = (RelativeLayout) rootView.findViewById(R.id.row_people);
+        mMenusView = (RelativeLayout) rootView.findViewById(R.id.row_menus);
         mPlanContainer = (RelativeLayout) rootView.findViewById(R.id.row_plan);
         mConfigurationHeader = rootView.findViewById(R.id.row_configuration);
         mSettingsView = rootView.findViewById(R.id.row_settings);
@@ -242,7 +244,7 @@ public class MySiteFragment extends Fragment
             }
         });
 
-        rootView.findViewById(R.id.row_menus).setOnClickListener(new View.OnClickListener() {
+        mMenusView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 ActivityLauncher.viewCurrentBlogMenus(getActivity());
@@ -371,6 +373,7 @@ public class MySiteFragment extends Fragment
         boolean isAdminOrSelfHosted =  blog.isAdmin() || !blog.isDotcomFlag();
         boolean canListPeople = blog.hasCapability(Capability.LIST_USERS);
         mSettingsView.setVisibility(isAdminOrSelfHosted ? View.VISIBLE : View.GONE);
+        mMenusView.setVisibility(isAdminOrSelfHosted ? View.VISIBLE : View.GONE);
         mPeopleView.setVisibility(canListPeople ? View.VISIBLE : View.GONE);
 
         // if either people or settings is visible, configuration header should be visible

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -27,6 +27,7 @@ import org.wordpress.android.models.MenuModel;
 import org.wordpress.android.networking.menus.MenusDataModeler;
 import org.wordpress.android.networking.menus.MenusRestWPCom;
 import org.wordpress.android.ui.EmptyViewMessageType;
+import org.wordpress.android.ui.menus.items.MenuItemEditorFactory;
 import org.wordpress.android.ui.menus.views.MenuAddEditRemoveView;
 import org.wordpress.android.ui.menus.views.MenuItemAdapter;
 import org.wordpress.android.ui.menus.views.MenuItemsView;
@@ -446,6 +447,7 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
         MenuItemModel newItem = new MenuItemModel();
         newItem.name = getString(R.string.menus_item_new_item);
         newItem.flattenedLevel = originalItem.flattenedLevel;
+        newItem.type = MenuItemEditorFactory.ITEM_TYPE.POST.name().toLowerCase(); //default type: POST
         switch (where) {
             case TO_CHILDREN:
                 newItem.flattenedLevel++;
@@ -465,13 +467,13 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
                 break;
         }
 
-//        if (newItem != null) {
-//            FragmentManager fm = getFragmentManager();
-//            EditMenuItemDialog dialog = EditMenuItemDialog.newInstance(newItem);
-//            dialog.show(fm, EditMenuItemDialog.class.getSimpleName());
-//        } else {
-//            //TODO show some error toast
-//        }
+        if (newItem != null) {
+            FragmentManager fm = getFragmentManager();
+            EditMenuItemDialog dialog = EditMenuItemDialog.newInstance(newItem);
+            dialog.show(fm, EditMenuItemDialog.class.getSimpleName());
+        } else {
+            //TODO show some error toast
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -467,13 +467,9 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
                 break;
         }
 
-        if (newItem != null) {
-            FragmentManager fm = getFragmentManager();
-            EditMenuItemDialog dialog = EditMenuItemDialog.newInstance(newItem);
-            dialog.show(fm, EditMenuItemDialog.class.getSimpleName());
-        } else {
-            //TODO show some error toast
-        }
+        FragmentManager fm = getFragmentManager();
+        EditMenuItemDialog dialog = EditMenuItemDialog.newInstance(newItem);
+        dialog.show(fm, EditMenuItemDialog.class.getSimpleName());
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -5,6 +5,7 @@ import android.app.FragmentManager;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -444,7 +445,7 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
 
         List<MenuItemModel> items = mItemsView.getCurrentMenuItems();
         MenuItemModel originalItem = items.get(position);
-        MenuItemModel newItem = new MenuItemModel();
+        final MenuItemModel newItem = new MenuItemModel();
         newItem.name = getString(R.string.menus_item_new_item);
         newItem.flattenedLevel = originalItem.flattenedLevel;
         newItem.type = MenuItemEditorFactory.ITEM_TYPE.POST.name().toLowerCase(); //default type: POST
@@ -467,9 +468,17 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
                 break;
         }
 
-        FragmentManager fm = getFragmentManager();
-        EditMenuItemDialog dialog = EditMenuItemDialog.newInstance(newItem);
-        dialog.show(fm, EditMenuItemDialog.class.getSimpleName());
+        //enclosed Dialog show in a delayed handler to allow animations to be appreciated
+        Handler hdlr = new Handler();
+        hdlr.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                FragmentManager fm = getFragmentManager();
+                EditMenuItemDialog dialog = EditMenuItemDialog.newInstance(newItem);
+                dialog.show(fm, EditMenuItemDialog.class.getSimpleName());
+            }
+        }, 350);
+
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -457,7 +457,7 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
                     items.add(newItem);
                     mItemsView.getAdapter().notifyItemInserted(items.size() - 1);
                 } else {
-                    items.add(position, newItem);
+                    items.add(position+1, newItem);
                     mItemsView.getAdapter().notifyItemInserted(position+1);
                 }
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -434,10 +434,44 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
 
     @Override
     public void onCancelClick() {
+        // no op
     }
 
     @Override
-    public void onAddClick() {
+    public void onAddClick(int position, MenuItemAdapter.ItemAddPosition where) {
+        //the user wants to add a new item <where: above/below/tochildren> relative to <position>
+
+        List<MenuItemModel> items = mItemsView.getCurrentMenuItems();
+        MenuItemModel originalItem = items.get(position);
+        MenuItemModel newItem = new MenuItemModel();
+        newItem.name = getString(R.string.menus_item_new_item);
+        newItem.flattenedLevel = originalItem.flattenedLevel;
+        switch (where) {
+            case TO_CHILDREN:
+                newItem.flattenedLevel++;
+            case BELOW :
+                if (position == items.size() - 1) {
+                    items.add(newItem);
+                    mItemsView.getAdapter().notifyItemInserted(items.size() - 1);
+                } else {
+                    items.add(position, newItem);
+                    mItemsView.getAdapter().notifyItemInserted(position+1);
+                }
+                break;
+            case ABOVE :
+            default:
+                items.add(position, newItem);
+                mItemsView.getAdapter().notifyItemInserted(position);
+                break;
+        }
+
+//        if (newItem != null) {
+//            FragmentManager fm = getFragmentManager();
+//            EditMenuItemDialog dialog = EditMenuItemDialog.newInstance(newItem);
+//            dialog.show(fm, EditMenuItemDialog.class.getSimpleName());
+//        } else {
+//            //TODO show some error toast
+//        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/CategoryItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/CategoryItemEditor.java
@@ -10,6 +10,7 @@ import org.wordpress.android.datasets.SiteSettingsTable;
 import org.wordpress.android.models.CategoryModel;
 import org.wordpress.android.models.MenuItemModel;
 import org.wordpress.android.widgets.RadioButtonListView;
+import org.wordpress.android.widgets.WPTextView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,6 +46,10 @@ public class CategoryItemEditor extends BaseMenuItemEditor {
         super.onViewAdded(child);
 
         mCategoryListView = (RadioButtonListView) child.findViewById(R.id.category_list);
+
+        WPTextView emptyTextView = (WPTextView) child.findViewById(R.id.empty_list_view);
+        emptyTextView.setText(getContext().getString(R.string.menu_item_type_category_empty_list));
+        mCategoryListView.setEmptyView(emptyTextView);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/MenuItemEditorFactory.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/MenuItemEditorFactory.java
@@ -31,6 +31,19 @@ public class MenuItemEditorFactory {
             else if (typeName.equalsIgnoreCase(CUSTOM.name())) return CUSTOM;
             else return NULL;
         }
+
+        public static ITEM_TYPE typeForIndex(int index){
+            if (NULL.ordinal() == index) return NULL;
+            if (POST.ordinal() == index) return POST;
+            if (PAGE.ordinal() == index) return PAGE;
+            if (CATEGORY.ordinal() == index) return CATEGORY;
+            if (TAG.ordinal() == index) return TAG;
+            if (LINK.ordinal() == index) return LINK;
+            if (TESTIMONIAL.ordinal() == index) return TESTIMONIAL;
+            if (CUSTOM.ordinal() == index) return CUSTOM;
+
+            return NULL;
+        }
     }
 
     public static int getIconDrawableRes(ITEM_TYPE type) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PageItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PageItemEditor.java
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.posts.services.PostEvents;
 import org.wordpress.android.ui.posts.services.PostUpdateService;
 import org.wordpress.android.widgets.RadioButtonListView;
 import org.wordpress.android.widgets.RadioButtonListView.RadioButtonListAdapter;
+import org.wordpress.android.widgets.WPTextView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -64,6 +65,11 @@ public class PageItemEditor extends BaseMenuItemEditor implements SearchView.OnQ
 
         ((SearchView) child.findViewById(R.id.single_select_search_view)).setOnQueryTextListener(this);
         mPageListView = (RadioButtonListView) child.findViewById(R.id.single_select_list_view);
+
+        WPTextView emptyTextView = (WPTextView) child.findViewById(R.id.empty_list_view);
+        emptyTextView.setText(getContext().getString(R.string.menu_item_type_page_empty_list));
+        mPageListView.setEmptyView(emptyTextView);
+
         mPageListView.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
                 mWorkingItem.name = mPageListView.getSelectedItem().toString();

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PostItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PostItemEditor.java
@@ -12,6 +12,7 @@ import org.wordpress.android.models.MenuItemModel;
 import org.wordpress.android.models.PostsListPost;
 import org.wordpress.android.models.PostsListPostList;
 import org.wordpress.android.widgets.RadioButtonListView;
+import org.wordpress.android.widgets.WPTextView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +42,10 @@ public class PostItemEditor extends BaseMenuItemEditor implements SearchView.OnQ
 
         ((SearchView) child.findViewById(R.id.single_select_search_view)).setOnQueryTextListener(this);
         mPostListView = (RadioButtonListView) child.findViewById(R.id.single_select_list_view);
+
+        WPTextView emptyTextView = (WPTextView) child.findViewById(R.id.empty_list_view);
+        emptyTextView.setText(getContext().getString(R.string.menu_item_type_post_empty_list));
+        mPostListView.setEmptyView(emptyTextView);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/TagItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/TagItemEditor.java
@@ -9,6 +9,7 @@ import android.widget.SearchView;
 import org.wordpress.android.R;
 import org.wordpress.android.models.MenuItemModel;
 import org.wordpress.android.widgets.RadioButtonListView;
+import org.wordpress.android.widgets.WPTextView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +38,10 @@ public class TagItemEditor extends BaseMenuItemEditor implements SearchView.OnQu
 
         ((SearchView) child.findViewById(R.id.single_select_search_view)).setOnQueryTextListener(this);
         mTagListView = (RadioButtonListView) child.findViewById(R.id.single_select_list_view);
+
+        WPTextView emptyTextView = (WPTextView) child.findViewById(R.id.empty_list_view);
+        emptyTextView.setText(getContext().getString(R.string.menu_item_type_tag_empty_list));
+        mTagListView.setEmptyView(emptyTextView);
         loadTags();
     }
 

--- a/WordPress/src/main/res/layout/category_menu_item_edit_view.xml
+++ b/WordPress/src/main/res/layout/category_menu_item_edit_view.xml
@@ -6,9 +6,27 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <org.wordpress.android.widgets.RadioButtonListView
-        android:id="@+id/category_list"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-</merge>
+        <org.wordpress.android.widgets.RadioButtonListView
+            android:id="@+id/category_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <!-- empty view -->
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/empty_list_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:text="@string/menu_item_type_category_empty_list">
+        </org.wordpress.android.widgets.WPTextView>
+    </LinearLayout>
+</merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">

--- a/WordPress/src/main/res/layout/category_menu_item_edit_view.xml
+++ b/WordPress/src/main/res/layout/category_menu_item_edit_view.xml
@@ -25,8 +25,4 @@
             android:text="@string/menu_item_type_category_empty_list">
         </org.wordpress.android.widgets.WPTextView>
     </LinearLayout>
-</merge
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+</merge>

--- a/WordPress/src/main/res/layout/searchable_single_select_list.xml
+++ b/WordPress/src/main/res/layout/searchable_single_select_list.xml
@@ -18,4 +18,13 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
+    <!-- empty view -->
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/empty_list_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:text="@string/menu_item_type_post_empty_list">
+    </org.wordpress.android.widgets.WPTextView>
+
 </LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1518,6 +1518,13 @@
         <item>@string/menu_item_type_testimonial</item>
     </string-array>
 
+    <string name="menu_item_type_page_empty_list">No pages found</string>
+    <string name="menu_item_type_post_empty_list">No posts found</string>
+    <string name="menu_item_type_tag_empty_list">No tags found</string>
+    <string name="menu_item_type_category_empty_list">No categories found</string>
+    <string name="menu_item_type_testimonial_empty_list">No testimonials found</string>
+
+
     <string name="get_a_link_sent_to_your_email_to_sign_in_instantly">Get a link sent to your email to sign in instantly</string>
     <string name="logging_in">Logging in</string>
     <string name="magic_link_unavailable_error_message">Currently unavailable. Please enter your password</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1499,6 +1499,7 @@
     <string name="menus_add_item_above">Add menu item above</string>
     <string name="menus_add_item_below">Add menu item below</string>
     <string name="menus_add_item_to_children">Add menu item to children</string>
+    <string name="menus_item_new_item">New item</string>
     <string name="link_item_editor_url_input_header">Link address (URL)</string>
     <string name="link_item_editor_open_new_window_option">Open link in new window/tab</string>
 
@@ -1518,6 +1519,7 @@
         <item>@string/menu_item_type_testimonial</item>
     </string-array>
 
+    <!-- empty menu item adapter views -->
     <string name="menu_item_type_page_empty_list">No pages found</string>
     <string name="menu_item_type_post_empty_list">No posts found</string>
     <string name="menu_item_type_tag_empty_list">No tags found</string>


### PR DESCRIPTION
Fixes #3591 

To test: Go to a site you're an admin of, and you'll see the Menus option. Check the Menus option and organise your menu items by adding, removing (swipe left/right) or changing the ordering with drag/drop.

![menu_items](https://cloud.githubusercontent.com/assets/6597771/16320313/870da6ae-396d-11e6-921c-5ce0e52b7363.gif)

TODO: 
- Still need to hide the Delete/Save options in the menu item view, and need to check the "dirty" flag to make the SAVE mandatory for changes in the menu items to be sent to the server.
- ~~Still need to allow the title to be edited/changed~~ done in #4273 

Needs review: @tonyr59h 
