### PR TITLE
Follow system font size in Reader post detail

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -95,6 +95,10 @@ public class ReaderWebView extends WebView {
             this.setWebChromeClient(mReaderChromeClient);
             this.setWebViewClient(new ReaderWebViewClient(this));
             this.getSettings().setUserAgentString(WordPress.getUserAgent());
+            this.getSettings().setDefaultFontSize(
+                    (int) (this.getSettings().getDefaultFontSize() * getResources().getConfiguration().fontScale));
+            this.getSettings().setDefaultFixedFontSize(
+                    (int) (this.getSettings().getDefaultFixedFontSize() * getResources().getConfiguration().fontScale));
             // Lollipop disables third-party cookies by default, but we need them in order
             // to support authenticated images
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -95,10 +95,15 @@ public class ReaderWebView extends WebView {
             this.setWebChromeClient(mReaderChromeClient);
             this.setWebViewClient(new ReaderWebViewClient(this));
             this.getSettings().setUserAgentString(WordPress.getUserAgent());
-            this.getSettings().setDefaultFontSize(
-                    (int) (this.getSettings().getDefaultFontSize() * getResources().getConfiguration().fontScale));
-            this.getSettings().setDefaultFixedFontSize(
-                    (int) (this.getSettings().getDefaultFixedFontSize() * getResources().getConfiguration().fontScale));
+
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+                final float fontScale = getResources().getConfiguration().fontScale;
+
+                this.getSettings().setDefaultFontSize((int) (this.getSettings().getDefaultFontSize() * fontScale));
+                this.getSettings().setDefaultFixedFontSize(
+                        (int) (this.getSettings().getDefaultFixedFontSize() * fontScale));
+            }
+
             // Lollipop disables third-party cookies by default, but we need them in order
             // to support authenticated images
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -96,8 +96,10 @@ public class ReaderWebView extends WebView {
             this.setWebViewClient(new ReaderWebViewClient(this));
             this.getSettings().setUserAgentString(WordPress.getUserAgent());
 
-            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
-                final float fontScale = getResources().getConfiguration().fontScale;
+            // Adjust content font size on APIs 19 and below as those do not do it automatically.
+            //  If fontScale is close to 1, just let it be 1.
+            final float fontScale = getResources().getConfiguration().fontScale;
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT && ((int) (fontScale * 10000)) != 10000) {
 
                 this.getSettings().setDefaultFontSize((int) (this.getSettings().getDefaultFontSize() * fontScale));
                 this.getSettings().setDefaultFixedFontSize(


### PR DESCRIPTION
Fixes #4284 

To test:

* Open a post in the Reader
* Notice the font size for future comparison
* Switch to the Android System Settings and change the Font Size to something different than the current setting
* Switch back to the app
* Notice the font size change accordingly


Needs review: @nbradbury , wanna have a look? Thanks!

