### PR TITLE
Feature/3591 menu items wip edit refresh list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/PostsListPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/PostsListPost.java
@@ -18,6 +18,7 @@ import java.util.Date;
 public class PostsListPost {
     private static final int MAX_EXCERPT_LEN = 150;
 
+    private final String remotePostId;
     private final long postId;
     private final long blogId;
     private long dateCreatedGmt;
@@ -36,6 +37,7 @@ public class PostsListPost {
     private transient String featuredImageUrl;
 
     public PostsListPost(Post post) {
+        remotePostId = post.getRemotePostId();
         postId = post.getLocalTablePostId();
         blogId = post.getLocalTableBlogId();
         featuredImageId = post.getFeaturedImageId();
@@ -63,6 +65,10 @@ public class PostsListPost {
 
     public long getBlogId() {
         return blogId;
+    }
+
+    public String getRemotePostId() {
+        return remotePostId;
     }
 
     public String getTitle() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/EditMenuItemDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/EditMenuItemDialog.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.menus;
 
 import android.app.DialogFragment;
-import android.content.DialogInterface;
 import android.app.Fragment;
 import android.content.Intent;
 import android.os.Bundle;

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -498,9 +498,11 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
             //re-draw menu items
             if (mCurrentMenuItemBeingEdited > -1) {
                 MenuItemModel modifiedItem = (MenuItemModel) data.getSerializableExtra(EditMenuItemDialog.EDITED_ITEM_KEY);
-                List<MenuItemModel> flattenedList = mItemsView.getAdapter().getCurrentMenuItems();
-                flattenedList.set(mCurrentMenuItemBeingEdited, modifiedItem);
-                mItemsView.getAdapter().notifyItemChanged(mCurrentMenuItemBeingEdited);
+                if (modifiedItem != null) {
+                    List<MenuItemModel> flattenedList = mItemsView.getAdapter().getCurrentMenuItems();
+                    flattenedList.set(mCurrentMenuItemBeingEdited, modifiedItem);
+                    mItemsView.getAdapter().notifyItemChanged(mCurrentMenuItemBeingEdited);
+                }
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -449,6 +449,8 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
         newItem.name = getString(R.string.menus_item_new_item);
         newItem.flattenedLevel = originalItem.flattenedLevel;
         newItem.type = MenuItemEditorFactory.ITEM_TYPE.POST.name().toLowerCase(); //default type: POST
+        newItem.typeFamily = "post_type";
+        newItem.typeLabel = MenuItemEditorFactory.ITEM_TYPE.POST.name();
         switch (where) {
             case TO_CHILDREN:
                 newItem.flattenedLevel++;

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/BaseMenuItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/BaseMenuItemEditor.java
@@ -2,19 +2,29 @@ package org.wordpress.android.ui.menus.items;
 
 import android.content.Context;
 import android.support.annotation.Nullable;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.widget.LinearLayout;
 
 import org.wordpress.android.models.MenuItemModel;
+import org.wordpress.android.widgets.WPEditText;
 
 /**
  */
 public abstract class BaseMenuItemEditor extends LinearLayout {
     public abstract int getLayoutRes();
+    public abstract int getNameEditTextRes();
     public abstract void onSave();
     public abstract void onDelete();
 
     protected MenuItemModel mWorkingItem;
+    protected MenuItemNameChangeListener mMenuItemNameChangeListener;
+    private WPEditText mItemNameEditText;
+
+    public interface MenuItemNameChangeListener {
+        void onNameChanged(String newName);
+    }
 
     public BaseMenuItemEditor(Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
@@ -23,13 +33,45 @@ public abstract class BaseMenuItemEditor extends LinearLayout {
 
     public void setMenuItem(MenuItemModel menuItem) {
         mWorkingItem = menuItem;
+        if (mItemNameEditText != null) {
+            mItemNameEditText.setText(mWorkingItem.name);
+        }
     }
 
     public MenuItemModel getMenuItem() {
         return mWorkingItem;
     }
 
+    public void setMenuItemNameChangeListener(MenuItemNameChangeListener listener){
+        mMenuItemNameChangeListener = listener;
+    }
+
     protected void init() {
         inflate(getContext(), getLayoutRes(), this);
+
+        int editTextResId = getNameEditTextRes();
+        mItemNameEditText = (WPEditText) findViewById(editTextResId);
+        if (mItemNameEditText != null) {
+            mItemNameEditText.addTextChangedListener(new TextWatcher() {
+                @Override
+                public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+                }
+
+                @Override
+                public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+
+                }
+
+                @Override
+                public void afterTextChanged(Editable editable) {
+                    mWorkingItem.name = editable.toString();
+                    if (mMenuItemNameChangeListener != null) {
+                        mMenuItemNameChangeListener.onNameChanged(mWorkingItem.name);
+                    }
+                }
+            });
+        }
+
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/CategoryItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/CategoryItemEditor.java
@@ -58,6 +58,11 @@ public class CategoryItemEditor extends BaseMenuItemEditor {
     }
 
     @Override
+    public int getNameEditTextRes() {
+        return R.id.menu_item_title_edit;
+    }
+
+    @Override
     public MenuItemModel getMenuItem() {
         MenuItemModel menuItem = super.getMenuItem();
         return menuItem;

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/CategoryItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/CategoryItemEditor.java
@@ -63,12 +63,6 @@ public class CategoryItemEditor extends BaseMenuItemEditor {
     }
 
     @Override
-    public MenuItemModel getMenuItem() {
-        MenuItemModel menuItem = super.getMenuItem();
-        return menuItem;
-    }
-
-    @Override
     public void onSave() {
         // TODO: save to DB
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/CustomItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/CustomItemEditor.java
@@ -29,11 +29,6 @@ public class CustomItemEditor extends BaseMenuItemEditor {
     }
 
     @Override
-    public MenuItemModel getMenuItem() {
-        return null;
-    }
-
-    @Override
     public void onSave() {
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/LinkItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/LinkItemEditor.java
@@ -45,6 +45,11 @@ public class LinkItemEditor extends BaseMenuItemEditor {
     }
 
     @Override
+    public int getNameEditTextRes() {
+        return R.id.menu_item_title_edit;
+    }
+
+    @Override
     public MenuItemModel getMenuItem() {
         MenuItemModel menuItem = new MenuItemModel();
         fillData(menuItem);

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/MiscItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/MiscItemEditor.java
@@ -24,6 +24,11 @@ public class MiscItemEditor extends BaseMenuItemEditor {
     }
 
     @Override
+    public int getNameEditTextRes() {
+        return R.id.menu_item_title_edit;
+    }
+
+    @Override
     public MenuItemModel getMenuItem() {
         return null;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PageItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PageItemEditor.java
@@ -11,7 +11,6 @@ import android.widget.SearchView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
-import org.wordpress.android.datasets.MenuItemTable;
 import org.wordpress.android.models.MenuItemModel;
 import org.wordpress.android.models.Post;
 import org.wordpress.android.models.PostsListPost;

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PageItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PageItemEditor.java
@@ -106,11 +106,24 @@ public class PageItemEditor extends BaseMenuItemEditor implements SearchView.OnQ
     }
 
     private void setSelection(long contentId) {
+        boolean selectionMarked = false;
         for (int i=0; i < mFilteredPages.size(); i++) {
             PostsListPost post = mFilteredPages.get(i);
             String remoteId = post.getRemotePostId();
             if (remoteId != null && (!TextUtils.isEmpty(remoteId)) && Long.valueOf(remoteId) == contentId){
                 mPageListView.setSelection(i);
+                selectionMarked = true;
+                break;
+            }
+        }
+
+        if (!selectionMarked) {
+            //check if home
+            MenuItemModel item = super.getMenuItem();
+            if (item != null) {
+                if (item.url.compareToIgnoreCase(WordPress.getCurrentBlog().getHomeURL() + "/") == 0) {
+                    mPageListView.setSelection(0);
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PageItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PageItemEditor.java
@@ -71,11 +71,13 @@ public class PageItemEditor extends BaseMenuItemEditor implements SearchView.OnQ
         mPageListView.setEmptyView(emptyTextView);
 
         mPageListView.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
-            @Override public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
                 mWorkingItem.name = mPageListView.getSelectedItem().toString();
             }
 
-            @Override public void onNothingSelected(AdapterView<?> parent) {
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
             }
         });
     }
@@ -83,6 +85,11 @@ public class PageItemEditor extends BaseMenuItemEditor implements SearchView.OnQ
     @Override
     public int getLayoutRes() {
         return R.layout.page_menu_item_edit_view;
+    }
+
+    @Override
+    public int getNameEditTextRes() {
+        return R.id.menu_item_title_edit;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PostItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PostItemEditor.java
@@ -54,6 +54,11 @@ public class PostItemEditor extends BaseMenuItemEditor implements SearchView.OnQ
     }
 
     @Override
+    public int getNameEditTextRes() {
+        return R.id.menu_item_title_edit;
+    }
+
+    @Override
     public MenuItemModel getMenuItem() {
         MenuItemModel menuItem = new MenuItemModel();
         return menuItem;

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PostItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PostItemEditor.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.menus.items;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.view.View;
@@ -60,7 +61,8 @@ public class PostItemEditor extends BaseMenuItemEditor implements SearchView.OnQ
 
     @Override
     public MenuItemModel getMenuItem() {
-        MenuItemModel menuItem = new MenuItemModel();
+        MenuItemModel menuItem = super.getMenuItem();
+        fillData(menuItem);
         return menuItem;
     }
 
@@ -119,4 +121,10 @@ public class PostItemEditor extends BaseMenuItemEditor implements SearchView.OnQ
         }
         refreshAdapter();
     }
+
+    private void fillData(@NonNull MenuItemModel menuItem) {
+        //TODO check selected item in array and set selected
+
+    }
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PostItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PostItemEditor.java
@@ -76,6 +76,7 @@ public class PostItemEditor extends BaseMenuItemEditor implements SearchView.OnQ
             String remoteId = post.getRemotePostId();
             if (remoteId != null && Long.valueOf(remoteId) == contentId){
                 mPostListView.setSelection(i);
+                break;
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/TagItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/TagItemEditor.java
@@ -56,12 +56,6 @@ public class TagItemEditor extends BaseMenuItemEditor implements SearchView.OnQu
     }
 
     @Override
-    public MenuItemModel getMenuItem() {
-        MenuItemModel menuItem = super.getMenuItem();
-        return menuItem;
-    }
-
-    @Override
     public void onSave() {
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/TagItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/TagItemEditor.java
@@ -51,6 +51,11 @@ public class TagItemEditor extends BaseMenuItemEditor implements SearchView.OnQu
     }
 
     @Override
+    public int getNameEditTextRes() {
+        return R.id.menu_item_title_edit;
+    }
+
+    @Override
     public MenuItemModel getMenuItem() {
         MenuItemModel menuItem = super.getMenuItem();
         return menuItem;

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/TestimonialItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/TestimonialItemEditor.java
@@ -29,12 +29,6 @@ public class TestimonialItemEditor extends BaseMenuItemEditor {
     }
 
     @Override
-    public MenuItemModel getMenuItem() {
-        MenuItemModel menuItem = new MenuItemModel();
-        return menuItem;
-    }
-
-    @Override
     public void onSave() {
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/TestimonialItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/TestimonialItemEditor.java
@@ -24,6 +24,11 @@ public class TestimonialItemEditor extends BaseMenuItemEditor {
     }
 
     @Override
+    public int getNameEditTextRes() {
+        return R.id.menu_item_title_edit;
+    }
+
+    @Override
     public MenuItemModel getMenuItem() {
         MenuItemModel menuItem = new MenuItemModel();
         return menuItem;

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuItemAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuItemAdapter.java
@@ -25,7 +25,7 @@ import de.greenrobot.event.EventBus;
 
 public class MenuItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     public interface MenuItemInteractions {
-        void onItemClick(MenuItemModel item);
+        void onItemClick(MenuItemModel item, int position);
         void onCancelClick();
         void onAddClick(int position, ItemAddPosition where);
     }
@@ -134,6 +134,7 @@ public class MenuItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
             default:
             {
                 final MenuItemModel menuItem = mFlattenedMenuItems.get(position);
+                final int itemPosition = position;
                 MenuItemHolder holder = (MenuItemHolder) viewHolder;
 
                 holder.txtTitle.setText(Html.fromHtml(menuItem.name));
@@ -144,7 +145,7 @@ public class MenuItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                 holder.containerView.setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        mListener.onItemClick(menuItem);
+                        mListener.onItemClick(menuItem, itemPosition);
                     }
                 });
                 ITEM_TYPE itemType = ITEM_TYPE.typeForString(menuItem.type);

--- a/WordPress/src/main/res/layout/category_menu_item_edit_view.xml
+++ b/WordPress/src/main/res/layout/category_menu_item_edit_view.xml
@@ -3,6 +3,7 @@
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
+    android:focusableInTouchMode="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/WordPress/src/main/res/layout/category_menu_item_edit_view.xml
+++ b/WordPress/src/main/res/layout/category_menu_item_edit_view.xml
@@ -27,6 +27,7 @@
         <!-- empty view -->
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/empty_list_view"
+            android:layout_margin="@dimen/content_margin"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"

--- a/WordPress/src/main/res/layout/category_menu_item_edit_view.xml
+++ b/WordPress/src/main/res/layout/category_menu_item_edit_view.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<merge
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -10,6 +10,13 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
+
+        <org.wordpress.android.widgets.WPEditText
+            android:id="@+id/menu_item_title_edit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            style="@style/MenuNameActiveText"
+            tools:text="Title" />
 
         <org.wordpress.android.widgets.RadioButtonListView
             android:id="@+id/category_list"

--- a/WordPress/src/main/res/layout/link_menu_item_edit_view.xml
+++ b/WordPress/src/main/res/layout/link_menu_item_edit_view.xml
@@ -1,10 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical">
+
+    <org.wordpress.android.widgets.WPEditText
+        android:id="@+id/menu_item_title_edit"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        style="@style/MenuNameActiveText"
+        tools:text="Title" />
 
     <org.wordpress.android.widgets.WPTextView
         android:layout_width="wrap_content"

--- a/WordPress/src/main/res/layout/link_menu_item_edit_view.xml
+++ b/WordPress/src/main/res/layout/link_menu_item_edit_view.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:tools="http://schemas.android.com/tools"
+    android:focusableInTouchMode="true"
     android:orientation="vertical">
 
     <org.wordpress.android.widgets.WPEditText

--- a/WordPress/src/main/res/layout/searchable_single_select_list.xml
+++ b/WordPress/src/main/res/layout/searchable_single_select_list.xml
@@ -28,6 +28,7 @@
 
     <!-- empty view -->
     <org.wordpress.android.widgets.WPTextView
+        android:layout_margin="@dimen/content_margin"
         android:id="@+id/empty_list_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/searchable_single_select_list.xml
+++ b/WordPress/src/main/res/layout/searchable_single_select_list.xml
@@ -1,10 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical">
+
+    <org.wordpress.android.widgets.WPEditText
+        android:id="@+id/menu_item_title_edit"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        style="@style/MenuNameActiveText"
+        tools:text="Title" />
 
     <SearchView
         android:id="@+id/single_select_search_view"

--- a/WordPress/src/main/res/layout/searchable_single_select_list.xml
+++ b/WordPress/src/main/res/layout/searchable_single_select_list.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:tools="http://schemas.android.com/tools"
+    android:focusableInTouchMode="true"
     android:orientation="vertical">
 
     <org.wordpress.android.widgets.WPEditText

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1523,6 +1523,8 @@
     <string name="menu_item_type_tag_empty_list">No tags found</string>
     <string name="menu_item_type_category_empty_list">No categories found</string>
 
+    <string name="menu_item_special_home">Home (site)</string>
+
 
     <string name="get_a_link_sent_to_your_email_to_sign_in_instantly">Get a link sent to your email to sign in instantly</string>
     <string name="logging_in">Logging in</string>


### PR DESCRIPTION
Fixes #3591 (partially - wip)

It now adds the ability to edit/change the menu item name and refreshes the list accordingly after you hit "save" in the menu item editor dialog

Needs review: @tonyr59h 
