### PR TITLE
Fixes #4303: vector drawable usaeg in site settings on API <= 19

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPStartOverPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPStartOverPreference.java
@@ -31,8 +31,6 @@ public class WPStartOverPreference extends WPPreference {
     public WPStartOverPreference(Context context, AttributeSet attrs) {
         super(context, attrs);
 
-        mButtonTextColor = ContextCompat.getColor(context, R.color.black);
-
         TypedArray array = context.obtainStyledAttributes(attrs, R.styleable.WPStartOverPreference);
 
         for (int i = 0; i < array.getIndexCount(); ++i) {
@@ -40,7 +38,7 @@ public class WPStartOverPreference extends WPPreference {
             if (index == R.styleable.WPStartOverPreference_buttonText) {
                 mButtonText = array.getString(index);
             } else if (index == R.styleable.WPStartOverPreference_buttonTextColor) {
-                mButtonTextColor = array.getColor(index, ContextCompat.getColor(context, R.color.grey_dark));
+                mButtonTextColor = array.getColor(index, ContextCompat.getColor(context, R.color.black));
             } else if (index == R.styleable.WPStartOverPreference_buttonTextAllCaps) {
                 mButtonTextAllCaps = array.getBoolean(index, false);
             } else if (index == R.styleable.WPStartOverPreference_preficon) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPStartOverPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/WPStartOverPreference.java
@@ -2,11 +2,14 @@ package org.wordpress.android.ui.prefs;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
+import android.support.graphics.drawable.VectorDrawableCompat;
 import android.support.v4.content.ContextCompat;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.Button;
+import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
@@ -23,6 +26,7 @@ public class WPStartOverPreference extends WPPreference {
     private String mButtonText;
     private int mButtonTextColor;
     private boolean mButtonTextAllCaps;
+    private Drawable mPrefIcon;
 
     public WPStartOverPreference(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -39,6 +43,8 @@ public class WPStartOverPreference extends WPPreference {
                 mButtonTextColor = array.getColor(index, ContextCompat.getColor(context, R.color.grey_dark));
             } else if (index == R.styleable.WPStartOverPreference_buttonTextAllCaps) {
                 mButtonTextAllCaps = array.getBoolean(index, false);
+            } else if (index == R.styleable.WPStartOverPreference_preficon) {
+                mPrefIcon = VectorDrawableCompat.create(context.getResources(), array.getResourceId(index, 0), null);
             }
         }
 
@@ -48,6 +54,11 @@ public class WPStartOverPreference extends WPPreference {
     @Override
     protected void onBindView(@NonNull View view) {
         super.onBindView(view);
+
+        if (view.findViewById(R.id.pref_icon) != null) {
+            ImageView imageView = (ImageView) view.findViewById(R.id.pref_icon);
+            imageView.setImageDrawable(mPrefIcon);
+        }
 
         if (view.findViewById(R.id.button) != null) {
             final WPStartOverPreference wpStartOverPreference = this;

--- a/WordPress/src/main/res/layout/start_over_preference.xml
+++ b/WordPress/src/main/res/layout/start_over_preference.xml
@@ -18,7 +18,7 @@
         android:orientation="horizontal">
 
         <ImageView
-            android:id="@+android:id/icon"
+            android:id="@+id/pref_icon"
             android:layout_width="@dimen/start_over_icon_size"
             android:layout_height="@dimen/start_over_icon_size"
             android:layout_marginRight="@dimen/start_over_icon_margin_right"

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -19,6 +19,7 @@
     </declare-styleable>
 
     <declare-styleable name="WPStartOverPreference">
+        <attr name="preficon" format="reference" />
         <attr name="buttonText" format="string" />
         <attr name="buttonTextColor" format="reference|color" />
         <attr name="buttonTextAllCaps" format="boolean" />

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -293,11 +293,11 @@
             <org.wordpress.android.ui.prefs.WPStartOverPreference
                 android:id="@+id/pref_start_over"
                 android:key="@string/pref_key_site_start_over"
-                android:icon="@drawable/gridicons_history"
                 android:title="@string/let_us_help"
                 android:summary="@string/start_over_text"
                 android:widgetLayout="@layout/start_over_preference_button"
                 android:layout="@layout/start_over_preference"
+                app:preficon="@drawable/gridicons_history"
                 app:longClickHint="@string/site_settings_start_over_hint"
                 app:buttonText="@string/contact_support"
                 app:buttonTextAllCaps="true" />

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -300,6 +300,7 @@
                 app:preficon="@drawable/gridicons_history"
                 app:longClickHint="@string/site_settings_start_over_hint"
                 app:buttonText="@string/contact_support"
+                app:buttonTextColor="@color/grey_dark"
                 app:buttonTextAllCaps="true" />
 
         </PreferenceScreen>


### PR DESCRIPTION
Fixes #4303: vector drawable usaeg in site settings on api <= 19

uses `VectorDrawableCompat.create()` to workaround a crash on API <= 19