### PR TITLE
Feature/3591 menu items precalculate type

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/MenuItemModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/MenuItemModel.java
@@ -20,7 +20,8 @@ import java.util.Map;
  */
 
 public class MenuItemModel implements Serializable {
-    public static final String SELECTED_POST_KEY = "selected-post";
+    public static final String POST_TYPE_NAME = "post_type";
+    public static final String TAG_TYPE_NAME = "post_tag";
 
     //
     // Primary key attributes (cannot be null)
@@ -111,11 +112,11 @@ public class MenuItemModel implements Serializable {
 
         if (type != null ) {
 
-            if (type.compareToIgnoreCase("post_tag") == 0) {
+            if (type.compareToIgnoreCase(TAG_TYPE_NAME) == 0) {
                 calculatedType = MenuItemEditorFactory.ITEM_TYPE.TAG.name();
                 return MenuItemEditorFactory.ITEM_TYPE.TAG;
             }
-            else if (type.compareToIgnoreCase("post_type") == 0) {
+            else if (type.compareToIgnoreCase(POST_TYPE_NAME) == 0) {
                 calculatedType = MenuItemEditorFactory.ITEM_TYPE.POST.name();
                 return MenuItemEditorFactory.ITEM_TYPE.POST;
             }

--- a/WordPress/src/main/java/org/wordpress/android/models/Tag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Tag.java
@@ -3,7 +3,6 @@ package org.wordpress.android.models;
 import android.text.TextUtils;
 
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.util.JSONUtils;
 import org.wordpress.android.util.StringUtils;
@@ -43,7 +42,7 @@ public class Tag {
             return null;
         }
 
-        ArrayList<Tag> suggestions = new ArrayList<Tag>(jsonArray.length());
+        ArrayList<Tag> suggestions = new ArrayList<>(jsonArray.length());
 
         for (int i = 0; i < jsonArray.length(); i++) {
             Tag suggestion = Tag.fromJSON(jsonArray.optJSONObject(i), siteID);
@@ -56,9 +55,4 @@ public class Tag {
     public String getTag() {
         return StringUtils.notNullStr(tag);
     }
-
-    public long getId() {
-        return id;
-    }
-
 }

--- a/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusDataModeler.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/menus/MenusDataModeler.java
@@ -374,6 +374,7 @@ public class MenusDataModeler {
         if (hierarchyList != null) {
             for (MenuItemModel item : hierarchyList) {
                 item.flattenedLevel = currentLevel;
+                item.calculateCustomType();
                 flattenedList.add(item);
                 if (item.hasChildren()) {
                     List<MenuItemModel> tmpList = flattenMenuItemModelList(item.children, currentLevel+1);

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/EditMenuItemDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/EditMenuItemDialog.java
@@ -157,8 +157,9 @@ public class EditMenuItemDialog extends DialogFragment implements Toolbar.OnMenu
 
     public void setType(String type) {
         mWorkingItem.type = type;
+        mWorkingItem.calculateCustomType();
         mToolbar.setTitle(mWorkingItem.name);
-        setPickerAndChildViewSelection(type.toUpperCase());
+        setPickerAndChildViewSelection(mWorkingItem.calculatedType.toUpperCase());
         mCurrentEditor = (BaseMenuItemEditor) mEditorFlipper.getCurrentView();
         if (mCurrentEditor != null) {
             mCurrentEditor.setMenuItem(mWorkingItem);
@@ -211,7 +212,7 @@ public class EditMenuItemDialog extends DialogFragment implements Toolbar.OnMenu
         mTypePicker.setAdapter(adapter);
 
         fillViewFlipper();
-        setPickerAndChildViewSelection(mWorkingItem.type.toUpperCase());
+        setPickerAndChildViewSelection(mWorkingItem.calculatedType.toUpperCase());
         mTypePicker.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
@@ -223,7 +224,13 @@ public class EditMenuItemDialog extends DialogFragment implements Toolbar.OnMenu
         });
     }
 
-    private void setPickerAndChildViewSelection(String type){
+    private void setPickerAndChildViewSelection(String type) {
+        Integer itemIdx = mItemPositions.get(type);
+        mTypePicker.setSelection(itemIdx);
+        mEditorFlipper.setDisplayedChild(itemIdx);
+    }
+
+    private void setPickerAndChildViewSelectionOLD(String type){
         Integer itemIdx = mItemPositions.get(type);
 
         //special case for tag

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/EditMenuItemDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/EditMenuItemDialog.java
@@ -230,39 +230,4 @@ public class EditMenuItemDialog extends DialogFragment implements Toolbar.OnMenu
         mEditorFlipper.setDisplayedChild(itemIdx);
     }
 
-    private void setPickerAndChildViewSelectionOLD(String type){
-        Integer itemIdx = mItemPositions.get(type);
-
-        //special case for tag
-        if (type.compareToIgnoreCase("post_tag") == 0) {
-            itemIdx = mItemPositions.get(ITEM_TYPE.TAG.name());
-        }
-        else if (type.compareToIgnoreCase("post_type") == 0) {
-            itemIdx = mItemPositions.get(ITEM_TYPE.POST.name());
-        }
-
-        if (itemIdx == null) {
-
-            if (ITEM_TYPE.typeForString(type).equals(ITEM_TYPE.CUSTOM)) {
-                //check special cases:
-                //- custom and the url is EQUAL to the blog's home address: show the HOME PAGE icon
-                String homeUrl = WordPress.getCurrentBlog().getHomeURL() + "/";
-                if (!TextUtils.isEmpty(mWorkingItem.url) && !TextUtils.isEmpty(homeUrl) && mWorkingItem.url.equalsIgnoreCase(homeUrl)) {
-                    mTypePicker.setSelection(mItemPositions.get(ITEM_TYPE.PAGE.name().toUpperCase()));
-                    mEditorFlipper.setDisplayedChild(mItemPositions.get(ITEM_TYPE.PAGE.name().toUpperCase()));
-                }
-                else
-                    //check special cases:
-                    //- custom and url different from home: show LINK ICON
-                    if (!TextUtils.isEmpty(mWorkingItem.url) && !TextUtils.isEmpty(homeUrl) && !mWorkingItem.url.equalsIgnoreCase(homeUrl)) {
-                        mTypePicker.setSelection(mItemPositions.get(ITEM_TYPE.LINK.name().toUpperCase()));
-                        mEditorFlipper.setDisplayedChild(mItemPositions.get(ITEM_TYPE.LINK.name().toUpperCase()));
-                    }
-
-            }
-        } else {
-            mTypePicker.setSelection(itemIdx);
-            mEditorFlipper.setDisplayedChild(itemIdx);
-        }
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -451,7 +451,7 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
         newItem.flattenedLevel = originalItem.flattenedLevel;
         newItem.type = MenuItemEditorFactory.ITEM_TYPE.POST.name().toLowerCase(); //default type: POST
         newItem.calculateCustomType();
-        newItem.typeFamily = "post_type";
+        newItem.typeFamily = MenuItemModel.POST_TYPE_NAME;
         newItem.typeLabel = MenuItemEditorFactory.ITEM_TYPE.POST.name();
         switch (where) {
             case TO_CHILDREN:

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -9,7 +9,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
@@ -451,6 +450,7 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
         newItem.name = getString(R.string.menus_item_new_item);
         newItem.flattenedLevel = originalItem.flattenedLevel;
         newItem.type = MenuItemEditorFactory.ITEM_TYPE.POST.name().toLowerCase(); //default type: POST
+        newItem.calculateCustomType();
         newItem.typeFamily = "post_type";
         newItem.typeLabel = MenuItemEditorFactory.ITEM_TYPE.POST.name();
         switch (where) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/MenuItemEditorFactory.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/MenuItemEditorFactory.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.text.TextUtils;
 
 import org.wordpress.android.R;
+import org.wordpress.android.models.MenuItemModel;
 
 /**
  * Provides appropriate {@link BaseMenuItemEditor} subclasses.
@@ -30,7 +31,7 @@ public class MenuItemEditorFactory {
 
             //special case for tag
             // This is a weird behavior of the API and is not documented.
-            if (typeName.compareToIgnoreCase("post_tag") == 0) {
+            if (typeName.compareToIgnoreCase(MenuItemModel.TAG_TYPE_NAME) == 0) {
                 return TAG;
             }
             else if (typeName.compareToIgnoreCase("post_type") == 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PageItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PageItemEditor.java
@@ -251,7 +251,7 @@ public class PageItemEditor extends BaseMenuItemEditor implements SearchView.OnQ
                 menuItem.contentId = Long.valueOf(post.getRemotePostId());
 
                 menuItem.type = MenuItemEditorFactory.ITEM_TYPE.PAGE.name().toLowerCase(); //default type: PAGE
-                menuItem.typeFamily = "post_type";
+                menuItem.typeFamily = MenuItemModel.POST_TYPE_NAME;
                 menuItem.typeLabel = MenuItemEditorFactory.ITEM_TYPE.PAGE.name();
             } else {
                 // this is the HOME item

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PostItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PostItemEditor.java
@@ -207,7 +207,7 @@ public class PostItemEditor extends BaseMenuItemEditor implements SearchView.OnQ
     private void fillData(@NonNull MenuItemModel menuItem) {
         //check selected item in array and set selected
         menuItem.type = MenuItemEditorFactory.ITEM_TYPE.POST.name().toLowerCase(); //default type: POST
-        menuItem.typeFamily = "post_type";
+        menuItem.typeFamily = MenuItemModel.POST_TYPE_NAME;
         menuItem.typeLabel = MenuItemEditorFactory.ITEM_TYPE.POST.name();
 
         PostsListPost post = mFilteredPosts.get(mPostListView.getCheckedItemPosition());

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/TagItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/TagItemEditor.java
@@ -98,7 +98,7 @@ public class TagItemEditor extends BaseMenuItemEditor implements SearchView.OnQu
     private void setSelection(long contentId) {
         for (int i=0; i < mFilteredTags.size(); i++) {
             Tag tagModel = mFilteredTags.get(i);
-            long tagId = tagModel.getId();
+            long tagId = tagModel.id;
             if (tagId == contentId){
                 mTagListView.setSelection(i);
                 break;
@@ -216,8 +216,8 @@ public class TagItemEditor extends BaseMenuItemEditor implements SearchView.OnQu
         menuItem.typeLabel = "Tag";
 
         Tag tag = mFilteredTags.get(mTagListView.getCheckedItemPosition());
-        if (tag != null && tag.getId() > 0) {
-            menuItem.contentId = tag.getId();
+        if (tag != null && tag.id > 0) {
+            menuItem.contentId = tag.id;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/TagItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/TagItemEditor.java
@@ -211,7 +211,7 @@ public class TagItemEditor extends BaseMenuItemEditor implements SearchView.OnQu
 
     private void fillData(@NonNull MenuItemModel menuItem) {
         //check selected item in array and set selected
-        menuItem.type = "post_tag";
+        menuItem.type = MenuItemModel.TAG_TYPE_NAME;
         menuItem.typeFamily = "taxonomy";
         menuItem.typeLabel = "Tag";
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuItemAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuItemAdapter.java
@@ -111,7 +111,7 @@ public class MenuItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                     public void onClick(View v) {
                         menuItem.editingMode = false;
                         mInAddingMode = false;
-                        //mAddingModeStarterPosition plus one as at this very moment we have the 3 adder control buttons in out list
+                        //mAddingModeStarterPosition plus one as at this very moment we have the 3 adder control buttons in our list
                         triggerAddControlRemoveAnimation(mAddingModeStarterPosition + 1, true);
                         mListener.onAddClick(mAddingModeStarterPosition, getWhereToAddMenuItem(mAddingModeStarterPosition+1, adderPosition));
                         Handler hdlr = new Handler();
@@ -148,12 +148,16 @@ public class MenuItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                         mListener.onItemClick(menuItem, itemPosition);
                     }
                 });
-                ITEM_TYPE itemType = ITEM_TYPE.typeForString(menuItem.type);
+                ITEM_TYPE itemType = ITEM_TYPE.typeForString(menuItem.calculatedType != null ? menuItem.calculatedType : menuItem.type);
                 if (itemType != ITEM_TYPE.NULL) {
                     int itemRes = MenuItemEditorFactory.getIconDrawableRes(itemType);
                     if (itemRes != -1) {
                         holder.imgMenuItemType.setImageResource(itemRes);
+                    } else {
+                        holder.imgMenuItemType.setImageResource(0);
                     }
+                } else {
+                    holder.imgMenuItemType.setImageResource(0);
                 }
 
                 if (mInAddingMode) {
@@ -161,8 +165,7 @@ public class MenuItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                     holder.containerButtons.setVisibility(View.GONE);
                     if (menuItem.editingMode) {
                         holder.containerCancel.setVisibility(View.VISIBLE);
-                    }
-                    else {
+                    } else {
                         holder.containerCancel.setVisibility(View.GONE);
                     }
 


### PR DESCRIPTION
Fixes #3591 (partially)

This brings a type precalculation on menu items when flattening the structure, so they don't need to be evaluated every time items are shown in the RecyclerView

Needs review: @tonyr59h 
