### PR TITLE
Fix :not CSS rule syntax in post detail webview

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -74,14 +74,14 @@ class ReaderPostRenderer {
         new Thread() {
             @Override
             public void run() {
-                if (!mResourceVars.canShowTiledGallery) {
+                if (!mResourceVars.isWideDisplay) {
                     resizeImages();
                 }
 
                 resizeIframes();
 
                 final String htmlContent = formatPostContentForWebView(mRenderBuilder
-                        .toString(), mResourceVars.canShowTiledGallery);
+                        .toString(), mResourceVars.isWideDisplay);
                 mRenderBuilder = null;
                 handler.post(new Runnable() {
                     @Override
@@ -309,7 +309,7 @@ class ReaderPostRenderer {
     /*
      * returns the full content, including CSS, that will be shown in the WebView for this post
      */
-    private String formatPostContentForWebView(final String content, boolean renderAsTiledGallery) {
+    private String formatPostContentForWebView(final String content, boolean isWideDisplay) {
         // unique CSS class assigned to the gallery elements for easy selection
         final String galleryOnlyClass = "gallery-only-class" + new Random().nextInt(1000);
 
@@ -331,14 +331,14 @@ class ReaderPostRenderer {
 
         // set line-height, font-size but not for gallery divs when rendering as tiled gallery as those will be
         // handled with the .tiled-gallery rules bellow.
-        .append("  p, div" + (renderAsTiledGallery ? ":not(." + galleryOnlyClass + ")" : "") +
+        .append("  p, div" + (isWideDisplay ? ":not(." + galleryOnlyClass + ")" : "") +
                 ", li { line-height: 1.6em; font-size: 0.95em; }")
 
         .append("  h1, h2 { line-height: 1.2em; }")
 
         // counteract pre-defined height/width styles, except for the tiled-gallery divs when rendering as tiled gallery
         // as those will be handled with the .tiled-gallery rules bellow.
-        .append("  p, div" + (renderAsTiledGallery ? ":not(." + galleryOnlyClass + ")" : "") +
+        .append("  p, div" + (isWideDisplay ? ":not(." + galleryOnlyClass + ")" : "") +
                 ", dl, table { width: auto !important; height: auto !important; }")
 
         // make sure long strings don't force the user to scroll horizontally
@@ -374,7 +374,7 @@ class ReaderPostRenderer {
         .append("     background-color: ").append(mResourceVars.greyExtraLightStr).append(";")
         .append("     margin-bottom: ").append(mResourceVars.marginSmallPx).append("px; }");
 
-        if (renderAsTiledGallery) {
+        if (isWideDisplay) {
             sbHtml
             .append("  .tiled-gallery {")
             .append("    clear:both;")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -24,6 +24,7 @@ import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
+import java.util.regex.Pattern;
 
 /**
  * generates and displays the HTML for post detail content - main purpose is to assign the
@@ -310,6 +311,11 @@ class ReaderPostRenderer {
      * returns the full content, including CSS, that will be shown in the WebView for this post
      */
     private String formatPostContentForWebView(final String content, boolean isWideDisplay) {
+        // determine whether a tiled-gallery exists in the content
+        final boolean hasTiledGallery = Pattern.compile("tiled-gallery[\\s\"']").matcher(content).find();
+
+        final boolean renderAsTiledGallery = hasTiledGallery && isWideDisplay;
+
         // unique CSS class assigned to the gallery elements for easy selection
         final String galleryOnlyClass = "gallery-only-class" + new Random().nextInt(1000);
 
@@ -331,14 +337,14 @@ class ReaderPostRenderer {
 
         // set line-height, font-size but not for gallery divs when rendering as tiled gallery as those will be
         // handled with the .tiled-gallery rules bellow.
-        .append("  p, div" + (isWideDisplay ? ":not(." + galleryOnlyClass + ")" : "") +
+        .append("  p, div" + (renderAsTiledGallery ? ":not(." + galleryOnlyClass + ")" : "") +
                 ", li { line-height: 1.6em; font-size: 0.95em; }")
 
         .append("  h1, h2 { line-height: 1.2em; }")
 
         // counteract pre-defined height/width styles, except for the tiled-gallery divs when rendering as tiled gallery
         // as those will be handled with the .tiled-gallery rules bellow.
-        .append("  p, div" + (isWideDisplay ? ":not(." + galleryOnlyClass + ")" : "") +
+        .append("  p, div" + (renderAsTiledGallery ? ":not(." + galleryOnlyClass + ")" : "") +
                 ", dl, table { width: auto !important; height: auto !important; }")
 
         // make sure long strings don't force the user to scroll horizontally
@@ -374,7 +380,7 @@ class ReaderPostRenderer {
         .append("     background-color: ").append(mResourceVars.greyExtraLightStr).append(";")
         .append("     margin-bottom: ").append(mResourceVars.marginSmallPx).append("px; }");
 
-        if (isWideDisplay) {
+        if (renderAsTiledGallery) {
             sbHtml
             .append("  .tiled-gallery {")
             .append("    clear:both;")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderResourceVars.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderResourceVars.java
@@ -14,7 +14,7 @@ class ReaderResourceVars {
     final int marginSmallPx;
     final int marginExtraSmallPx;
 
-    final boolean canShowTiledGallery;
+    final boolean isWideDisplay;
 
     final int fullSizeImageWidthPx;
     final int featuredImageHeightPx;
@@ -32,7 +32,7 @@ class ReaderResourceVars {
 
         int displayWidthPx = DisplayUtils.getDisplayPixelWidth(context);
 
-        canShowTiledGallery = DisplayUtils.pxToDp(context, displayWidthPx) > 640;
+        isWideDisplay = DisplayUtils.pxToDp(context, displayWidthPx) > 640;
 
         int marginLargePx = resources.getDimensionPixelSize(R.dimen.margin_large);
         int detailMarginWidthPx = resources.getDimensionPixelOffset(R.dimen.reader_detail_margin);


### PR DESCRIPTION
Fixes #4302

Unfortunately, the :not selector does not support cascading and it's unsuitable for excluding all tiled-gallery classes. Instead, this fix attaches a new class to the gallery elements and use that to uniquely exclude them.

To test:
* Open a tiled-gallery post in the Reader
* Notice that post body text is now styled correctly (line-height and font-size)


Needs review: @nbradbury 
