### PR TITLE
Disable replying to spam and trashed comments

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -238,6 +238,15 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
 
         mSubmitReplyBtn = mLayoutReply.findViewById(R.id.btn_submit_reply);
 
+        View replyBox = mLayoutReply.findViewById(R.id.reply_box);
+        if (mComment.getStatusEnum() == CommentStatus.SPAM ||
+                mComment.getStatusEnum() == CommentStatus.TRASH ||
+                mComment.getStatusEnum() == CommentStatus.DELETE) {
+            replyBox.setVisibility(View.GONE);
+        } else {
+            replyBox.setVisibility(View.VISIBLE);
+        }
+
         // hide comment like button until we know it can be enabled in showCommentForNote()
         mBtnLikeComment.setVisibility(View.GONE);
 

--- a/WordPress/src/main/res/layout/reader_include_comment_box.xml
+++ b/WordPress/src/main/res/layout/reader_include_comment_box.xml
@@ -20,6 +20,7 @@
         android:background="@color/grey_lighten_20" />
 
     <LinearLayout
+        android:id="@+id/reply_box"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal">


### PR DESCRIPTION
Fixes #4286

Just like in wp-admin, replying to trashed & spam comments should be disabled.
