### PR TITLE
Check for null comment before auto-approving

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -823,7 +823,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
                         mEditReply.getAutoSaveTextHelper().clearSavedText(mEditReply);
 
                         // approve the comment
-                        if (mComment.getStatusEnum() != CommentStatus.APPROVED) {
+                        if (mComment != null && mComment.getStatusEnum() != CommentStatus.APPROVED) {
                             moderateComment(CommentStatus.APPROVED);
                         }
                     } else {


### PR DESCRIPTION
Fixes #4306

It looks like it's a response to a comment that came from a notification, in which case a comment is set to `null` on purpose:
```
public void onPause() {
    super.onPause();
    // Reset comment if this is from a notification
    if (mNote != null) {
        mComment = null;
    }
}
```
