### PR TITLE
Feature/3591 menu items show cancel dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/MenuModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/MenuModel.java
@@ -3,6 +3,7 @@ package org.wordpress.android.models;
 import org.wordpress.android.util.CollectionUtils;
 import org.wordpress.android.util.StringUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -23,6 +24,24 @@ public class MenuModel implements NameInterface {
     public static final long ADD_MENU_ID = -1;
     public static final long DEFAULT_MENU_ID = -2;
     public static final long NO_MENU_ID = -3;
+
+    public MenuModel () {
+    }
+
+    public MenuModel (MenuModel orig) {
+        siteId = orig.siteId;
+        menuId = orig.menuId;
+        name = orig.name;
+        details = orig.details;
+        if (orig.locations != null) {
+            locations = new ArrayList<>();
+            locations.addAll(orig.locations);
+        }
+        if (orig.menuItems != null) {
+            menuItems = new ArrayList<>();
+            menuItems.addAll(orig.menuItems);
+        }
+    }
 
     @Override
     public boolean equals(Object other) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/EditMenuItemDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/EditMenuItemDialog.java
@@ -38,6 +38,7 @@ public class EditMenuItemDialog extends DialogFragment implements Toolbar.OnMenu
     public static final int EDIT_REQUEST_CODE = 10001;
 
     public static final int SAVE_RESULT_CODE = 1;
+    public static final int NOT_SAVED_CODE = 2;
 
     public static final String EDITED_ITEM_KEY = "edited-item";
 
@@ -115,8 +116,12 @@ public class EditMenuItemDialog extends DialogFragment implements Toolbar.OnMenu
                     if (mCurrentEditor.isDirty()) {
                         showAlertDialog();
                     } else {
+                        sendResultToTarget(NOT_SAVED_CODE, null);
                         super.onBackPressed();
                     }
+                } else {
+                    sendResultToTarget(NOT_SAVED_CODE, null);
+                    super.onBackPressed();
                 }
             }
         };
@@ -165,8 +170,11 @@ public class EditMenuItemDialog extends DialogFragment implements Toolbar.OnMenu
     private void sendResultToTarget(int resultCode, MenuItemModel item) {
         Fragment fragment = getTargetFragment();
         if (fragment == null) return;
+
         Intent data = new Intent();
-        data.putExtra(EDITED_ITEM_KEY, item);
+        if (item != null) {
+            data.putExtra(EDITED_ITEM_KEY, item);
+        }
         fragment.onActivityResult(getTargetRequestCode(), resultCode, data);
     }
 
@@ -218,9 +226,11 @@ public class EditMenuItemDialog extends DialogFragment implements Toolbar.OnMenu
                     if (mCurrentEditor.isDirty()) {
                         showAlertDialog();
                     } else {
+                        sendResultToTarget(NOT_SAVED_CODE, null);
                         dismiss();
                     }
                 } else {
+                    sendResultToTarget(NOT_SAVED_CODE, null);
                     dismiss();
                 }
             }
@@ -270,6 +280,7 @@ public class EditMenuItemDialog extends DialogFragment implements Toolbar.OnMenu
                 new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int whichButton) {
                         //go back
+                        sendResultToTarget(NOT_SAVED_CODE, null);
                         EditMenuItemDialog.this.dismiss();
                     }
                 });

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.menus;
 
+import android.app.Fragment;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -64,11 +65,21 @@ public class MenusActivity extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        if (getFragmentManager().getBackStackEntryCount() > 0) {
-            getFragmentManager().popBackStack();
+        Fragment fragment =  getFragmentManager()
+                .findFragmentByTag(MENUS_FRAGMENT_KEY);
+        if (fragment != null && fragment.isVisible()) {
+            ((MenusFragment) fragment).dismissFragment();
         } else {
-            super.onBackPressed();
+            if (getFragmentManager().getBackStackEntryCount() > 0) {
+                getFragmentManager().popBackStack();
+            } else {
+                super.onBackPressed();
+            }
         }
+    }
+
+    public void forceBackPressed() {
+        super.onBackPressed();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -483,21 +483,38 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
 
         // add back arrow listener
         mToolbar.setNavigationOnClickListener(new View.OnClickListener() {
-            @Override public void onClick(View v) {
-                if (mOriginalFlattenedMenuItems != null) {
-                    if (!mOriginalFlattenedMenuItems.equals(mItemsView.getAdapter().getCurrentMenuItems())) {
-                        showAlertDialog(
-                                new DialogInterface.OnClickListener() {
-                                    public void onClick(DialogInterface dialog, int whichButton) {
-                                        getActivity().onBackPressed();
-                                    }
-                                });
-                        return;
-                    }
-                }
-                getActivity().onBackPressed();
+            @Override
+            public void onClick(View v) {
+                dismissFragment();
             }
         });
+    }
+
+    public void dismissFragment(){
+        if (mOriginalFlattenedMenuItems != null) {
+            if (!mOriginalFlattenedMenuItems.equals(mItemsView.getAdapter().getCurrentMenuItems())) {
+                showAlertDialog(
+                        new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int whichButton) {
+                                forceBackPressed();
+                            }
+                        });
+                return;
+            }
+        }
+        forceBackPressed();
+    }
+
+    public void forceBackPressed(){
+        if (getFragmentManager().getBackStackEntryCount() > 0) {
+            getFragmentManager().popBackStack();
+        } else {
+            if (getActivity() instanceof MenusActivity) {
+                ((MenusActivity)getActivity()).forceBackPressed();
+            } else {
+                getActivity().onBackPressed();
+            }
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -559,8 +559,9 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
                     position++;
                     mItemsView.getAdapter().notifyItemInserted(items.size() - 1);
                 } else {
+                    position++;
                     items.add(position, newItem);
-                    mItemsView.getAdapter().notifyItemInserted(position+1);
+                    mItemsView.getAdapter().notifyItemInserted(position);
                 }
                 break;
             case ABOVE :

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -63,6 +63,8 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
     private MenuModel mCurrentMenuForLocation;
     private MenuItemsView mItemsView;
     private int mCurrentMenuItemBeingEdited = -1;
+    private EditMenuItemDialog mDialog;
+
 
     @Override
     public void onCreate(Bundle bundle) {
@@ -503,8 +505,6 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
         }
         return typeList;
     }
-
-    private EditMenuItemDialog mDialog;
 
     private void showEditorDialog(MenuItemModel item) {
         FragmentManager fm = getFragmentManager();

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/BaseMenuItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/BaseMenuItemEditor.java
@@ -22,6 +22,7 @@ public abstract class BaseMenuItemEditor extends LinearLayout {
     protected MenuItemNameChangeListener mMenuItemNameChangeListener;
     protected WPEditText mItemNameEditText;
     protected boolean mItemNameDirty = false;
+    protected boolean mOtherDataDirty = false;
 
     public interface MenuItemNameChangeListener {
         void onNameChanged(String newName);
@@ -46,6 +47,10 @@ public abstract class BaseMenuItemEditor extends LinearLayout {
 
     public void setMenuItemNameChangeListener(MenuItemNameChangeListener listener){
         mMenuItemNameChangeListener = listener;
+    }
+
+    public boolean isDirty() {
+        return mItemNameDirty || mOtherDataDirty;
     }
 
     protected void init() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/CategoryItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/CategoryItemEditor.java
@@ -64,6 +64,7 @@ public class CategoryItemEditor extends BaseMenuItemEditor {
         mCategoryListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
+                mOtherDataDirty = true;
                 if (!mItemNameDirty) {
                     if (mItemNameEditText != null) {
                         mItemNameEditText.setText(mCategories.get(i).name);
@@ -93,6 +94,7 @@ public class CategoryItemEditor extends BaseMenuItemEditor {
     }
 
     private void setSelection(long contentId) {
+        mOtherDataDirty = false;
         for (int i=0; i < mCategories.size(); i++) {
             CategoryModel categ = mCategories.get(i);
             int id = categ.id;

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PageItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PageItemEditor.java
@@ -76,6 +76,7 @@ public class PageItemEditor extends BaseMenuItemEditor implements SearchView.OnQ
         mPageListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
+                mOtherDataDirty = true;
                 if (!mItemNameDirty) {
                     if (mItemNameEditText != null) {
                         mItemNameEditText.setText(mFilteredPages.get(i).getTitle());
@@ -105,6 +106,7 @@ public class PageItemEditor extends BaseMenuItemEditor implements SearchView.OnQ
     }
 
     private void setSelection(long contentId) {
+        mOtherDataDirty = false;
         boolean selectionMarked = false;
         for (int i=0; i < mFilteredPages.size(); i++) {
             PostsListPost post = mFilteredPages.get(i);

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PostItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PostItemEditor.java
@@ -71,6 +71,9 @@ public class PostItemEditor extends BaseMenuItemEditor implements SearchView.OnQ
         emptyTextView.setText(getContext().getString(R.string.menu_item_type_post_empty_list));
         mPostListView.setEmptyView(emptyTextView);
 
+        if (mPostListView.getCount() > 0)
+            mPostListView.setSelection(0);
+
         mPostListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
@@ -212,9 +215,15 @@ public class PostItemEditor extends BaseMenuItemEditor implements SearchView.OnQ
         menuItem.typeFamily = "post_type";
         menuItem.typeLabel = MenuItemEditorFactory.ITEM_TYPE.POST.name();
 
-        PostsListPost post = mFilteredPosts.get(mPostListView.getCheckedItemPosition());
-        if (post != null && post.getRemotePostId() != null) {
-            menuItem.contentId = Long.valueOf(post.getRemotePostId());
+        if (mPostListView.getCount() > 0) {
+            int selPos = mPostListView.getCheckedItemPosition();
+            if (selPos == -1 ) {
+                selPos = 0;
+            }
+            PostsListPost post = mFilteredPosts.get(selPos);
+            if (post != null && post.getRemotePostId() != null) {
+                menuItem.contentId = Long.valueOf(post.getRemotePostId());
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PostItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/PostItemEditor.java
@@ -74,6 +74,7 @@ public class PostItemEditor extends BaseMenuItemEditor implements SearchView.OnQ
         mPostListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
+                mOtherDataDirty = true;
                 if (!mItemNameDirty) {
                     if (mItemNameEditText != null) {
                         mItemNameEditText.setText(mFilteredPosts.get(i).getTitle());
@@ -103,6 +104,7 @@ public class PostItemEditor extends BaseMenuItemEditor implements SearchView.OnQ
     }
 
     private void setSelection(long contentId) {
+        mOtherDataDirty = false;
         for (int i=0; i < mFilteredPosts.size(); i++) {
             PostsListPost post = mFilteredPosts.get(i);
             String remoteId = post.getRemotePostId();

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/items/TagItemEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/items/TagItemEditor.java
@@ -67,6 +67,7 @@ public class TagItemEditor extends BaseMenuItemEditor implements SearchView.OnQu
         mTagListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
+                mOtherDataDirty = true;
                 if (!mItemNameDirty) {
                     if (mItemNameEditText != null) {
                         mItemNameEditText.setText(mFilteredTagTitles.get(i));
@@ -96,6 +97,7 @@ public class TagItemEditor extends BaseMenuItemEditor implements SearchView.OnQu
     }
 
     private void setSelection(long contentId) {
+        mOtherDataDirty = false;
         for (int i=0; i < mFilteredTags.size(); i++) {
             Tag tagModel = mFilteredTags.get(i);
             long tagId = tagModel.getId();

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuAddEditRemoveView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuAddEditRemoveView.java
@@ -268,5 +268,10 @@ public class MenuAddEditRemoveView extends LinearLayout {
         this.mActionListener = listener;
     }
 
+    public String getCurrentMenuNameInEditText() {
+        return mMenuEditText.getText().toString();
+    }
+
+
 
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuItemAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuItemAdapter.java
@@ -114,7 +114,8 @@ public class MenuItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
                         mInAddingMode = false;
                         if (mFlattenedMenuItems.size() == 1) {
                             mFlattenedMenuItems.remove(0);
-                            mListener.onAddClick(0, ItemAddPosition.BELOW);
+                            notifyItemRemoved(0);
+                            mListener.onAddClick(0, ItemAddPosition.ABOVE);
                         } else {
                             //mAddingModeStarterPosition plus one as at this very moment we have the 3 adder control buttons in our list
                             triggerAddControlRemoveAnimation(mAddingModeStarterPosition + 1, true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuItemsView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuItemsView.java
@@ -168,7 +168,6 @@ public class MenuItemsView extends RelativeLayout {
         return mItemAdapter.getCurrentMenuItems();
     }
 
-
     private boolean hasAdapter() {
         return (mItemAdapter != null);
     }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1524,8 +1524,9 @@
     <string name="menu_item_type_post_empty_list">No posts found</string>
     <string name="menu_item_type_tag_empty_list">No tags found</string>
     <string name="menu_item_type_category_empty_list">No categories found</string>
-
     <string name="menu_item_special_home">Home (site)</string>
+    <string name="menu_item_changes_not_saved">Your local changes haven\'t been saved. Are you sure you want to go back and discard changes?</string>
+    <string name="menu_item_changes_not_saved_title">Your changes</string>
 
 
     <string name="get_a_link_sent_to_your_email_to_sign_in_instantly">Get a link sent to your email to sign in instantly</string>


### PR DESCRIPTION
Fixes #3591 (partially)

This is an enhancement: this PR adds the check for the menu items having been modified and if you want to switch to edit another menu or go back without saving changes (either in the menu screen or within the menu item editing screen)  a dialog appears prompting you to confirm you want to discard the local changes.

<img width="611" alt="screen shot 2016-06-28 at 2 26 26 pm" src="https://cloud.githubusercontent.com/assets/6597771/16425733/5568329a-3d3c-11e6-9b44-122c06fd5563.png">

Needs review: @tonyr59h 


