### PR TITLE
Reader post content tweaks for tablets

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -345,19 +345,19 @@ class ReaderPostRenderer {
         .append("  body, p, div, a { word-wrap: break-word; }")
 
         // use a consistent top/bottom margin for paragraphs, with no top margin for the first one
-        .append("  p { margin-top: ").append(mResourceVars.marginSmallPx).append("px;")
-        .append("      margin-bottom: ").append(mResourceVars.marginSmallPx).append("px; }")
+        .append("  p { margin-top: ").append(mResourceVars.marginMediumPx).append("px;")
+        .append("      margin-bottom: ").append(mResourceVars.marginMediumPx).append("px; }")
         .append("  p:first-child { margin-top: 0px; }")
 
         // add background color and padding to pre blocks, and add overflow scrolling
         // so user can scroll the block if it's wider than the display
         .append("  pre { overflow-x: scroll;")
         .append("        background-color: ").append(mResourceVars.greyExtraLightStr).append("; ")
-        .append("        padding: ").append(mResourceVars.marginSmallPx).append("px; }")
+        .append("        padding: ").append(mResourceVars.marginMediumPx).append("px; }")
 
         // add a left border to blockquotes
-        .append("  blockquote { margin-left: ").append(mResourceVars.marginSmallPx).append("px; ")
-        .append("               padding-left: ").append(mResourceVars.marginSmallPx).append("px; ")
+        .append("  blockquote { margin-left: ").append(mResourceVars.marginMediumPx).append("px; ")
+        .append("               padding-left: ").append(mResourceVars.marginMediumPx).append("px; ")
         .append("               border-left: 3px solid ").append(mResourceVars.greyLightStr).append("; }")
 
         // show links in the same color they are elsewhere in the app
@@ -372,7 +372,7 @@ class ReaderPostRenderer {
         .append("  img.size-full, img.size-large, img.size-medium {")
         .append("     display: block; margin-left: auto; margin-right: auto;")
         .append("     background-color: ").append(mResourceVars.greyExtraLightStr).append(";")
-        .append("     margin-bottom: ").append(mResourceVars.marginSmallPx).append("px; }");
+        .append("     margin-bottom: ").append(mResourceVars.marginMediumPx).append("px; }");
 
         if (isWideDisplay) {
             sbHtml
@@ -464,12 +464,12 @@ class ReaderPostRenderer {
         .append("  .wp-caption img { margin-top: 0px; margin-bottom: 0px; }")
         .append("  .wp-caption .wp-caption-text {")
         .append("       font-size: smaller; line-height: 1.2em; margin: 0px;")
-        .append("       padding: ").append(mResourceVars.marginExtraSmallPx).append("px; ")
+        .append("       padding: ").append(mResourceVars.marginMediumPx).append("px; ")
         .append("       color: ").append(mResourceVars.greyMediumDarkStr).append("; }")
 
         // attribution for Discover posts
         .append("  div#discover { ")
-        .append("       margin-top: ").append(mResourceVars.marginSmallPx).append("px;")
+        .append("       margin-top: ").append(mResourceVars.marginMediumPx).append("px;")
         .append("       font-family: sans-serif;")
         .append(" }")
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -74,14 +74,14 @@ class ReaderPostRenderer {
         new Thread() {
             @Override
             public void run() {
-                if (!mResourceVars.canShowTiledGallery) {
+                if (!mResourceVars.isWideDisplay) {
                     resizeImages();
                 }
 
                 resizeIframes();
 
                 final String htmlContent = formatPostContentForWebView(mRenderBuilder
-                        .toString(), mResourceVars.canShowTiledGallery);
+                        .toString(), mResourceVars.isWideDisplay);
                 mRenderBuilder = null;
                 handler.post(new Runnable() {
                     @Override
@@ -309,7 +309,7 @@ class ReaderPostRenderer {
     /*
      * returns the full content, including CSS, that will be shown in the WebView for this post
      */
-    private String formatPostContentForWebView(final String content, boolean renderAsTiledGallery) {
+    private String formatPostContentForWebView(final String content, boolean isWideDisplay) {
         // unique CSS class assigned to the gallery elements for easy selection
         final String galleryOnlyClass = "gallery-only-class" + new Random().nextInt(1000);
 
@@ -331,14 +331,14 @@ class ReaderPostRenderer {
 
         // set line-height, font-size but not for gallery divs when rendering as tiled gallery as those will be
         // handled with the .tiled-gallery rules bellow.
-        .append("  p, div" + (renderAsTiledGallery ? ":not(." + galleryOnlyClass + ")" : "") +
+        .append("  p, div" + (isWideDisplay ? ":not(." + galleryOnlyClass + ")" : "") +
                 ", li { line-height: 1.6em; font-size: 0.95em; }")
 
         .append("  h1, h2 { line-height: 1.2em; }")
 
         // counteract pre-defined height/width styles, except for the tiled-gallery divs when rendering as tiled gallery
         // as those will be handled with the .tiled-gallery rules bellow.
-        .append("  p, div" + (renderAsTiledGallery ? ":not(." + galleryOnlyClass + ")" : "") +
+        .append("  p, div" + (isWideDisplay ? ":not(." + galleryOnlyClass + ")" : "") +
                 ", dl, table { width: auto !important; height: auto !important; }")
 
         // make sure long strings don't force the user to scroll horizontally
@@ -374,9 +374,23 @@ class ReaderPostRenderer {
         .append("     background-color: ").append(mResourceVars.greyExtraLightStr).append(";")
         .append("     margin-bottom: ").append(mResourceVars.marginSmallPx).append("px; }");
 
-        if (renderAsTiledGallery) {
+        if (isWideDisplay) {
             sbHtml
-            .append("  .tiled-gallery {")
+            .append(".alignleft {")
+            .append("    max-width: 100%;")
+            .append("    float: left;")
+            .append("    margin-top: 12px;")
+            .append("    margin-bottom: 12px;")
+            .append("    margin-right: 32px;}")
+            .append(".alignright {")
+            .append("    max-width: 100%;")
+            .append("    float: right;")
+            .append("    margin-top: 12px;")
+            .append("    margin-bottom: 12px;")
+            .append("    margin-left: 32px;}")
+
+            // tiled-gallery related styles
+            .append(".tiled-gallery {")
             .append("    clear:both;")
             .append("    overflow:hidden;}")
             .append(".tiled-gallery img {")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -332,7 +332,7 @@ class ReaderPostRenderer {
         // set line-height, font-size but not for gallery divs when rendering as tiled gallery as those will be
         // handled with the .tiled-gallery rules bellow.
         .append("  p, div" + (isWideDisplay ? ":not(." + galleryOnlyClass + ")" : "") +
-                ", li { line-height: 1.6em; font-size: 0.95em; }")
+                ", li { line-height: 1.6em; font-size: 100%; }")
 
         .append("  h1, h2 { line-height: 1.2em; }")
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -464,6 +464,7 @@ class ReaderPostRenderer {
         .append("  .wp-caption img { margin-top: 0px; margin-bottom: 0px; }")
         .append("  .wp-caption .wp-caption-text {")
         .append("       font-size: smaller; line-height: 1.2em; margin: 0px;")
+        .append("       text-align: center;")
         .append("       padding: ").append(mResourceVars.marginMediumPx).append("px; ")
         .append("       color: ").append(mResourceVars.greyMediumDarkStr).append("; }")
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -446,7 +446,7 @@ class ReaderPostRenderer {
         }
 
         // see http://codex.wordpress.org/CSS#WordPress_Generated_Classes
-        sbHtml.append("  .wp-caption { background-color: ").append(mResourceVars.greyExtraLightStr).append("; }")
+        sbHtml
         .append("  .wp-caption img { margin-top: 0px; margin-bottom: 0px; }")
         .append("  .wp-caption .wp-caption-text {")
         .append("       font-size: smaller; line-height: 1.2em; margin: 0px;")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderResourceVars.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderResourceVars.java
@@ -11,8 +11,7 @@ import org.wordpress.android.util.HtmlUtils;
  * class which holds all resource-based variables used when rendering post detail
  */
 class ReaderResourceVars {
-    final int marginSmallPx;
-    final int marginExtraSmallPx;
+    final int marginMediumPx;
 
     final boolean isWideDisplay;
 
@@ -38,8 +37,7 @@ class ReaderResourceVars {
         int detailMarginWidthPx = resources.getDimensionPixelOffset(R.dimen.reader_detail_margin);
 
         featuredImageHeightPx = resources.getDimensionPixelSize(R.dimen.reader_featured_image_height);
-        marginSmallPx = resources.getDimensionPixelSize(R.dimen.margin_small);
-        marginExtraSmallPx = resources.getDimensionPixelSize(R.dimen.margin_extra_small);
+        marginMediumPx = resources.getDimensionPixelSize(R.dimen.margin_medium);
 
         linkColorStr = HtmlUtils.colorResToHtmlColor(context, R.color.reader_hyperlink);
         greyMediumDarkStr = HtmlUtils.colorResToHtmlColor(context, R.color.grey_darken_30);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderResourceVars.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderResourceVars.java
@@ -14,7 +14,7 @@ class ReaderResourceVars {
     final int marginSmallPx;
     final int marginExtraSmallPx;
 
-    final boolean canShowTiledGallery;
+    final boolean isWideDisplay;
 
     final int fullSizeImageWidthPx;
     final int featuredImageHeightPx;
@@ -32,7 +32,7 @@ class ReaderResourceVars {
 
         int displayWidthPx = DisplayUtils.getDisplayPixelWidth(context);
 
-        canShowTiledGallery = DisplayUtils.pxToDp(context, displayWidthPx) > 640;
+        isWideDisplay = DisplayUtils.pxToDp(context, displayWidthPx) > 640;
 
         int marginLargePx = resources.getDimensionPixelSize(R.dimen.margin_large);
         int detailMarginWidthPx = resources.getDimensionPixelOffset(R.dimen.reader_detail_margin);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.reader.views;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.os.Build;
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -15,7 +14,6 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
-import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.AccountHelper;
 import org.wordpress.android.util.AppLog;
@@ -62,12 +60,10 @@ public class ReaderWebView extends WebView {
 
     private boolean mIsDestroyed;
 
-    private int mBoundedWidth;
-
     public ReaderWebView(Context context) {
         super(context);
 
-        init(context, null);
+        init();
     }
 
     @Override
@@ -83,22 +79,18 @@ public class ReaderWebView extends WebView {
     public ReaderWebView(Context context, AttributeSet attrs) {
         super(context, attrs);
 
-        init(context, attrs);
+        init();
     }
 
     public ReaderWebView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
 
-        init(context, attrs);
+        init();
     }
 
     @SuppressLint("NewApi")
-    private void init(Context context, AttributeSet attrs) {
+    private void init() {
         if (!isInEditMode()) {
-            TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.wpBoundedWidth);
-            mBoundedWidth = a.getDimensionPixelSize(R.styleable.wpBoundedWidth_bounded_width, 0);
-            a.recycle();
-
             mToken = AccountHelper.getDefaultAccount().getAccessToken();
 
             mReaderChromeClient = new ReaderWebChromeClient(this);
@@ -122,16 +114,6 @@ public class ReaderWebView extends WebView {
                 CookieManager.getInstance().setAcceptThirdPartyCookies(this, true);
             }
         }
-    }
-
-    @Override
-    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        if(mBoundedWidth > 0 && mBoundedWidth < MeasureSpec.getSize(widthMeasureSpec)) {
-            int measureMode = MeasureSpec.getMode(widthMeasureSpec);
-            widthMeasureSpec = MeasureSpec.makeMeasureSpec(mBoundedWidth, measureMode);
-        }
-
-        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
     }
 
     public void clearContent() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -85,8 +85,8 @@ public class ReaderWebView extends WebView {
     public ReaderWebView(Context context, AttributeSet attrs) {
         super(context, attrs);
 
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.BoundedWidth);
-        mBoundedWidth = a.getDimensionPixelSize(R.styleable.BoundedWidth_bounded_width, 0);
+        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.wpBoundedWidth);
+        mBoundedWidth = a.getDimensionPixelSize(R.styleable.wpBoundedWidth_bounded_width, 0);
         a.recycle();
 
         init();
@@ -95,8 +95,8 @@ public class ReaderWebView extends WebView {
     public ReaderWebView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
 
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.BoundedWidth);
-        mBoundedWidth = a.getDimensionPixelSize(R.styleable.BoundedWidth_bounded_width, 0);
+        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.wpBoundedWidth);
+        mBoundedWidth = a.getDimensionPixelSize(R.styleable.wpBoundedWidth_bounded_width, 0);
         a.recycle();
 
         init();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.reader.views;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.os.Build;
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -14,6 +15,7 @@ import android.webkit.WebResourceResponse;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
+import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.AccountHelper;
 import org.wordpress.android.util.AppLog;
@@ -60,9 +62,13 @@ public class ReaderWebView extends WebView {
 
     private boolean mIsDestroyed;
 
+    private final int mBoundedWidth;
 
     public ReaderWebView(Context context) {
         super(context);
+
+        mBoundedWidth = 0;
+
         init();
     }
 
@@ -78,11 +84,21 @@ public class ReaderWebView extends WebView {
 
     public ReaderWebView(Context context, AttributeSet attrs) {
         super(context, attrs);
+
+        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.BoundedWidth);
+        mBoundedWidth = a.getDimensionPixelSize(R.styleable.BoundedWidth_bounded_width, 0);
+        a.recycle();
+
         init();
     }
 
     public ReaderWebView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+
+        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.BoundedWidth);
+        mBoundedWidth = a.getDimensionPixelSize(R.styleable.BoundedWidth_bounded_width, 0);
+        a.recycle();
+
         init();
     }
 
@@ -112,6 +128,16 @@ public class ReaderWebView extends WebView {
                 CookieManager.getInstance().setAcceptThirdPartyCookies(this, true);
             }
         }
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        if(mBoundedWidth > 0 && mBoundedWidth < MeasureSpec.getSize(widthMeasureSpec)) {
+            int measureMode = MeasureSpec.getMode(widthMeasureSpec);
+            widthMeasureSpec = MeasureSpec.makeMeasureSpec(mBoundedWidth, measureMode);
+        }
+
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
     }
 
     public void clearContent() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -62,14 +62,12 @@ public class ReaderWebView extends WebView {
 
     private boolean mIsDestroyed;
 
-    private final int mBoundedWidth;
+    private int mBoundedWidth;
 
     public ReaderWebView(Context context) {
         super(context);
 
-        mBoundedWidth = 0;
-
-        init();
+        init(context, null);
     }
 
     @Override
@@ -85,26 +83,22 @@ public class ReaderWebView extends WebView {
     public ReaderWebView(Context context, AttributeSet attrs) {
         super(context, attrs);
 
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.wpBoundedWidth);
-        mBoundedWidth = a.getDimensionPixelSize(R.styleable.wpBoundedWidth_bounded_width, 0);
-        a.recycle();
-
-        init();
+        init(context, null);
     }
 
     public ReaderWebView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
 
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.wpBoundedWidth);
-        mBoundedWidth = a.getDimensionPixelSize(R.styleable.wpBoundedWidth_bounded_width, 0);
-        a.recycle();
-
-        init();
+        init(context, null);
     }
 
     @SuppressLint("NewApi")
-    private void init() {
+    private void init(Context context, AttributeSet attrs) {
         if (!isInEditMode()) {
+            TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.wpBoundedWidth);
+            mBoundedWidth = a.getDimensionPixelSize(R.styleable.wpBoundedWidth_bounded_width, 0);
+            a.recycle();
+
             mToken = AccountHelper.getDefaultAccount().getAccessToken();
 
             mReaderChromeClient = new ReaderWebChromeClient(this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -83,13 +83,13 @@ public class ReaderWebView extends WebView {
     public ReaderWebView(Context context, AttributeSet attrs) {
         super(context, attrs);
 
-        init(context, null);
+        init(context, attrs);
     }
 
     public ReaderWebView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
 
-        init(context, null);
+        init(context, attrs);
     }
 
     @SuppressLint("NewApi")

--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -25,7 +25,8 @@
 
                 <RelativeLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                    android:layout_height="wrap_content"
+                    android:paddingTop="@dimen/margin_large">
 
                     <include
                         layout="@layout/reader_include_post_detail_header"

--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -23,37 +23,36 @@
                 android:clipToPadding="false"
                 android:scrollbarStyle="insideOverlay">
 
-                <LinearLayout
+                <RelativeLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical">
+                    android:layout_height="wrap_content">
 
                     <include
                         layout="@layout/reader_include_post_detail_header"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:layout_alignLeft="@+id/layout_post_detail_content"
+                        android:layout_alignRight="@+id/layout_post_detail_content"
                         android:layout_marginBottom="@dimen/margin_large"
                         android:layout_marginTop="@dimen/margin_large" />
 
-                    <View
-                        android:id="@+id/divider_header"
-                        android:layout_width="match_parent"
-                        android:layout_height="1dp"
-                        android:layout_marginBottom="@dimen/margin_small"
-                        android:background="@color/reader_divider_grey" />
-
                     <include
                         layout="@layout/reader_include_post_detail_content"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
+                        android:layout_below="@+id/layout_post_detail_header"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_centerHorizontal="true"
+                        android:layout_marginLeft="@dimen/reader_detail_margin"
+                        android:layout_marginRight="@dimen/reader_detail_margin" />
 
                     <org.wordpress.android.widgets.WPTextView
                         android:id="@+id/text_related_posts_label"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:layout_below="@+id/layout_post_detail_content"
+                        android:layout_alignLeft="@+id/layout_post_detail_content"
+                        android:layout_alignRight="@+id/layout_post_detail_content"
                         android:layout_marginBottom="@dimen/reader_related_post_margin"
-                        android:layout_marginLeft="@dimen/reader_detail_margin"
-                        android:layout_marginRight="@dimen/reader_detail_margin"
                         android:layout_marginTop="@dimen/reader_related_post_margin"
                         android:text="@string/reader_label_related_posts"
                         android:textAllCaps="true"
@@ -67,8 +66,9 @@
                         android:id="@+id/container_related_posts"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_marginLeft="@dimen/reader_detail_margin"
-                        android:layout_marginRight="@dimen/reader_detail_margin"
+                        android:layout_below="@+id/text_related_posts_label"
+                        android:layout_alignLeft="@+id/layout_post_detail_content"
+                        android:layout_alignRight="@+id/layout_post_detail_content"
                         android:background="@drawable/reader_related_posts_background"
                         android:orientation="vertical"
                         android:paddingBottom="@dimen/reader_related_post_margin"
@@ -79,9 +79,10 @@
                     <View
                         android:id="@+id/footer_spacer"
                         android:layout_width="match_parent"
-                        android:layout_height="@dimen/toolbar_height" />
+                        android:layout_height="@dimen/toolbar_height"
+                        android:layout_below="@id/container_related_posts" />
 
-                </LinearLayout>
+                </RelativeLayout>
 
             </org.wordpress.android.widgets.WPScrollView>
 

--- a/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
@@ -32,10 +32,9 @@
 
     <org.wordpress.android.ui.reader.views.ReaderWebView
         android:id="@+id/reader_webview"
-        android:layout_width="match_parent"
+        android:layout_width="@dimen/reader_webview_width"
         android:layout_height="wrap_content"
         android:layout_below="@id/text_author"
-        app:bounded_width="@dimen/webview_max_width"
         android:layout_marginTop="@dimen/margin_large"
         android:scrollbars="none" />
 

--- a/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
@@ -3,26 +3,28 @@
 <!--
     included by ReaderPostDetailFragment
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/layout_post_detail_content"
+    android:layout_width="wrap_content"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingTop="@dimen/margin_large">
+    android:paddingTop="@dimen/margin_large" >
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/text_title"
         style="@style/ReaderTextView.Post.Title.Detail"
-        android:layout_marginLeft="@dimen/reader_detail_margin"
-        android:layout_marginRight="@dimen/reader_detail_margin"
+        android:layout_alignLeft="@+id/reader_webview"
+        android:layout_alignRight="@+id/reader_webview"
         tools:text="text_title" />
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/text_author"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="@dimen/reader_detail_margin"
-        android:layout_marginRight="@dimen/reader_detail_margin"
+        android:layout_below="@id/text_title"
+        android:layout_alignLeft="@+id/reader_webview"
+        android:layout_alignRight="@+id/reader_webview"
         android:layout_marginTop="@dimen/margin_medium"
         android:textColor="@color/grey"
         android:textSize="@dimen/text_sz_medium"
@@ -32,8 +34,8 @@
         android:id="@+id/reader_webview"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="@dimen/reader_detail_margin"
-        android:layout_marginRight="@dimen/reader_detail_margin"
+        android:layout_below="@id/text_author"
+        app:bounded_width="@dimen/webview_max_width"
         android:layout_marginTop="@dimen/margin_large"
         android:scrollbars="none" />
 
@@ -41,7 +43,10 @@
         android:id="@+id/layout_liking_users_divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
+        android:layout_below="@id/reader_webview"
         android:layout_marginTop="@dimen/margin_medium"
+        android:layout_alignLeft="@+id/reader_webview"
+        android:layout_alignRight="@+id/reader_webview"
         android:background="@color/reader_divider_grey"
         android:visibility="gone"
         tools:visibility="visible" />
@@ -51,12 +56,13 @@
         android:id="@+id/layout_liking_users_view"
         android:layout_width="match_parent"
         android:layout_height="@dimen/avatar_sz_small"
+        android:layout_below="@id/layout_liking_users_divider"
+        android:layout_alignLeft="@+id/reader_webview"
+        android:layout_alignRight="@+id/reader_webview"
         android:layout_marginBottom="@dimen/margin_medium"
         android:layout_marginTop="@dimen/margin_medium"
         android:background="?android:selectableItemBackground"
-        android:paddingLeft="@dimen/reader_detail_margin"
-        android:paddingRight="@dimen/reader_detail_margin"
         android:visibility="gone"
         tools:visibility="visible" />
 
-</LinearLayout>
+</RelativeLayout>

--- a/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
@@ -19,49 +19,57 @@
         android:layout_marginBottom="@dimen/margin_large"
         android:background="@color/reader_divider_grey" />
 
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/text_tag"
-        style="@style/ReaderTextView"
-        android:layout_width="match_parent"
+    <RelativeLayout
+        android:layout_width="@dimen/reader_webview_width"
         android:layout_height="wrap_content"
-        android:layout_centerVertical="true"
+        android:layout_centerHorizontal="true"
         android:layout_marginLeft="@dimen/reader_detail_margin"
-        android:layout_marginTop="@dimen/margin_medium"
-        android:layout_toLeftOf="@+id/layout_icons"
-        android:background="?android:selectableItemBackground"
-        android:ellipsize="end"
-        android:gravity="center_vertical"
-        android:maxLines="1"
-        android:textColor="@color/reader_hyperlink"
-        android:textSize="@dimen/text_sz_large"
-        tools:text="#text_tag" />
-
-    <LinearLayout
-        android:id="@+id/layout_icons"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentRight="true"
-        android:layout_centerVertical="true"
         android:layout_marginRight="@dimen/reader_detail_margin"
-        android:layout_marginTop="@dimen/margin_medium"
-        android:orientation="horizontal">
+        android:layout_marginTop="@dimen/margin_medium">
 
-        <org.wordpress.android.ui.reader.views.ReaderIconCountView
-            android:id="@+id/count_comments"
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/text_tag"
+            style="@style/ReaderTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_toLeftOf="@+id/layout_icons"
+            android:background="?android:selectableItemBackground"
+            android:ellipsize="end"
+            android:gravity="center_vertical"
+            android:maxLines="1"
+            android:textColor="@color/reader_hyperlink"
+            android:textSize="@dimen/text_sz_large"
+            tools:text="#text_tag" />
+
+        <LinearLayout
+            android:id="@+id/layout_icons"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:padding="@dimen/margin_medium"
-            wp:readerIcon="comment" />
+            android:layout_alignParentRight="true"
+            android:layout_centerVertical="true"
+            android:orientation="horizontal">
 
-        <org.wordpress.android.ui.reader.views.ReaderIconCountView
-            android:id="@+id/count_likes"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:padding="@dimen/margin_medium"
-            wp:readerIcon="like" />
+            <org.wordpress.android.ui.reader.views.ReaderIconCountView
+                android:id="@+id/count_comments"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:padding="@dimen/margin_medium"
+                wp:readerIcon="comment" />
 
-    </LinearLayout>
+            <org.wordpress.android.ui.reader.views.ReaderIconCountView
+                android:id="@+id/count_likes"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:paddingLeft="@dimen/margin_medium"
+                android:paddingRight="0dp"
+                android:paddingTop="@dimen/margin_medium"
+                android:paddingBottom="@dimen/margin_medium"
+                wp:readerIcon="like" />
+
+        </LinearLayout>
+    </RelativeLayout>
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
@@ -31,7 +31,7 @@
             android:id="@+id/text_tag"
             style="@style/ReaderTextView"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="@dimen/reader_detail_tag_height"
             android:layout_centerVertical="true"
             android:layout_toLeftOf="@+id/layout_icons"
             android:background="?android:selectableItemBackground"

--- a/WordPress/src/main/res/layout/reader_include_post_detail_header.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_header.xml
@@ -15,7 +15,6 @@
         android:id="@+id/image_avatar"
         style="@style/ReaderImageView.Avatar"
         android:layout_centerVertical="true"
-        android:layout_marginLeft="@dimen/reader_detail_margin"
         android:layout_marginRight="@dimen/margin_large"
         tools:src="@drawable/gravatar_placeholder" />
 
@@ -58,7 +57,6 @@
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
-        android:layout_marginLeft="@dimen/margin_medium"
-        android:layout_marginRight="@dimen/reader_detail_margin" />
+        android:layout_marginLeft="@dimen/margin_medium" />
 
 </RelativeLayout>

--- a/WordPress/src/main/res/values-w720dp/dimens.xml
+++ b/WordPress/src/main/res/values-w720dp/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="reader_webview_width">600dp</dimen>
+</resources>

--- a/WordPress/src/main/res/values-w720dp/dimens.xml
+++ b/WordPress/src/main/res/values-w720dp/dimens.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="reader_webview_width">600dp</dimen>
+    <dimen name="reader_webview_width">680dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -82,7 +82,7 @@
         </attr>
     </declare-styleable>
 
-    <declare-styleable name="BoundedWidth">
+    <declare-styleable name="wpBoundedWidth">
         <attr name="bounded_width" format="dimension" />
     </declare-styleable>
 

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -82,4 +82,8 @@
         </attr>
     </declare-styleable>
 
+    <declare-styleable name="BoundedWidth">
+        <attr name="bounded_width" format="dimension" />
+    </declare-styleable>
+
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -114,6 +114,8 @@
     <dimen name="reader_follow_icon">16dp</dimen>
     <dimen name="reader_more_icon">48dp</dimen>
 
+    <dimen name="reader_detail_tag_height">48dp</dimen>
+
     <dimen name="reader_featured_image_height_default">220dp</dimen>
     <dimen name="reader_featured_image_height_tablet">280dp</dimen>
     <dimen name="reader_featured_image_height_tablet_large">340dp</dimen>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -69,7 +69,8 @@
     <dimen name="margin_extra_large">16dp</dimen>
     <dimen name="margin_filter_spinner">64dp</dimen>
 
-    <dimen name="webview_max_width">600dp</dimen>
+    <item name="wp_match_parent" type="dimen">-1</item>
+    <dimen name="reader_webview_width">@dimen/wp_match_parent</dimen>
 
     <!-- left/right margin for reader cards -->
     <dimen name="reader_card_margin_normal">0dp</dimen>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -69,6 +69,8 @@
     <dimen name="margin_extra_large">16dp</dimen>
     <dimen name="margin_filter_spinner">64dp</dimen>
 
+    <dimen name="webview_max_width">600dp</dimen>
+
     <!-- left/right margin for reader cards -->
     <dimen name="reader_card_margin_normal">0dp</dimen>
     <dimen name="reader_card_margin_normal_landscape">48dp</dimen>


### PR DESCRIPTION
This PR introduces a few small tweaks to how the Reader displays the post content. All in all, the end result is visually closer to what the iPad app and Calypso are display.

Here's a rundown of the tweaks:

* Narrower content width when viewed on a tablet (limit width to 600dp)
* Remove line separator between the blog title (header) and the post title
* Increase the content font size a bit (CSS now set to `font-size: 100%`)
* Increase the margins between the image, its caption and the post body
* Center align the image caption with the image
* Allow for left/right aligned images with text flowing next to them
* Remove the grey background of the images container
* 

While all of the post content and info are following the "narrow" column layout, I intentionally left the bottom bar (which harbours the tag name and comments/likes counts) full-width as it serves as a toolbar.

Would be nice to have some feedback on this from a designer as well. @rickybanister, you think you can have a look?

To make reviewing a bit easier, I've prepared a couple of "before" and "after" screengrab videos (on a 9" tablet):

**Before**: https://cloudup.com/cPr4LJUagqh
**After**: https://cloudup.com/cOF1oI-lCfG


To test:

* Using a large-ish tablet (or a 7" one in landscape)
* Open a post with images in the Reader
* Notice the various visual tweaks being applied

/cc @oguzkocer , @sendhil 
