### PR TITLE
User invite error string resource is untranslatable

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1408,7 +1408,7 @@
     <string name="invite_error_invalid_usenames_multiple">Cannot send: There are invalid usernames or emails</string>
     <string name="invite_error_sending">An error occured while trying to send the invite!</string>
     <string name="invite_error_some_failed">Invite sent but error(s) ocurred!</string>
-    <string name="invite_error_for_username">%1$s: %2$s</string>
+    <string name="invite_error_for_username" translatable="false">%1$s: %2$s</string>
     <string name="invite_sent">Invite sent successfully</string>
 
     <!--My profile-->


### PR DESCRIPTION
The error message for when a invite username is invalid is not translatable as it comes from the server so, mark it not-translatable in the string resource.

Needs review: @maxme 

