### PR TITLE
Fixes a couple spelling mistakes in invite strings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -424,7 +424,7 @@ public class PeopleInviteFragment extends Fragment implements
         }
 
         if (mUsernameButtons.size() == 0) {
-            ToastUtils.showToast(getActivity(), R.string.invite_error_no_usenames);
+            ToastUtils.showToast(getActivity(), R.string.invite_error_no_usernames);
             return;
         }
 
@@ -437,8 +437,8 @@ public class PeopleInviteFragment extends Fragment implements
 
         if (invalidCount > 0) {
             ToastUtils.showToast(getActivity(), StringUtils.getQuantityString(getActivity(), 0,
-                    R.string.invite_error_invalid_usenames_one,
-                    R.string.invite_error_invalid_usenames_multiple, invalidCount));
+                    R.string.invite_error_invalid_usernames_one,
+                    R.string.invite_error_invalid_usernames_multiple, invalidCount));
             return;
         }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1392,7 +1392,6 @@
     <string name="person_removed_general">User removed successfully</string>
     <string name="invite_people">Invite People</string>
     <string name="invite_names_title">Usernames or Emails</string>
-    <string name="invite_names_hint">Type an email address or username...</string>
     <string name="invite">Invite</string>
     <string name="button_invite" translatable="false">@string/invite</string>
     <string name="invite_username_not_found">No user was found for username \'%s\'</string>
@@ -1403,11 +1402,11 @@
     <string name="invite_message_remaining_one">1 character remaining</string>
     <string name="invite_message_remaining_other">%d characters remaining</string>
     <string name="invite_message_info">(Optional) You can enter a custom message of up to 500 characters that will be included in the invitation to the user(s).</string>
-    <string name="invite_error_no_usenames">Please add at least one username</string>
-    <string name="invite_error_invalid_usenames_one">Cannot send: A username or email is invalid</string>
-    <string name="invite_error_invalid_usenames_multiple">Cannot send: There are invalid usernames or emails</string>
-    <string name="invite_error_sending">An error occured while trying to send the invite!</string>
-    <string name="invite_error_some_failed">Invite sent but error(s) ocurred!</string>
+    <string name="invite_error_no_usernames">Please add at least one username</string>
+    <string name="invite_error_invalid_usernames_one">Cannot send: A username or email is invalid</string>
+    <string name="invite_error_invalid_usernames_multiple">Cannot send: There are invalid usernames or emails</string>
+    <string name="invite_error_sending">An error occurred while trying to send the invite!</string>
+    <string name="invite_error_some_failed">Invite sent but error(s) occurred!</string>
     <string name="invite_error_for_username">%1$s: %2$s</string>
     <string name="invite_sent">Invite sent successfully</string>
 


### PR DESCRIPTION
Also removes `invite_names_hint` string resource as it wasn't used anywhere in the code. @hypest maybe that string was intended to be used in the username text field in the invite screen. Let me know if that's the case and I'll re-add it and set it as the hint.