### PR TITLE
issue/4322-npe-comment-detail-reply

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -239,9 +239,10 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         mSubmitReplyBtn = mLayoutReply.findViewById(R.id.btn_submit_reply);
 
         View replyBox = mLayoutReply.findViewById(R.id.reply_box);
-        if (mComment.getStatusEnum() == CommentStatus.SPAM ||
-                mComment.getStatusEnum() == CommentStatus.TRASH ||
-                mComment.getStatusEnum() == CommentStatus.DELETE) {
+        if (mComment != null &&
+                (mComment.getStatusEnum() == CommentStatus.SPAM ||
+                        mComment.getStatusEnum() == CommentStatus.TRASH ||
+                        mComment.getStatusEnum() == CommentStatus.DELETE)) {
             replyBox.setVisibility(View.GONE);
         } else {
             replyBox.setVisibility(View.VISIBLE);


### PR DESCRIPTION
Fixes #4322 - added null check. Prior to this fix, opening a comment from a notification would result in a NPE.