### PR TITLE
issue/4330-reader-no-related-for-private

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -453,10 +453,10 @@ public class ReaderPostDetailFragment extends Fragment
     }
 
     /*
-     * request posts related to the current one - only available for wp.com
+     * request posts related to the current one - only available for wp.com public posts
      */
     private void requestRelatedPosts() {
-        if (hasPost() && mPost.isWP()) {
+        if (hasPost() && mPost.isWP() && !mPost.isPrivate) {
             ReaderPostActions.requestRelatedPosts(mPost);
         }
     }


### PR DESCRIPTION
Fixes #4330 - related posts are no longer shown below private posts in the reader.

