### PR TITLE
implemented enable/disable SEND option while an operation is in progress

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -4,6 +4,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.ui.people.utils.PeopleUtils;
 import org.wordpress.android.ui.people.utils.PeopleUtils.ValidateUsernameCallback.ValidationResult;
 import org.wordpress.android.util.EditTextUtils;
+import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 
@@ -57,6 +58,7 @@ public class PeopleInviteFragment extends Fragment implements
     private Map<String, View> mUsernameErrorViews = new Hashtable<>();
     private String mRole;
     private String mCustomMessage = "";
+    private boolean mInviteOperationInProgress = false;
 
     public static PeopleInviteFragment newInstance(String dotComBlogId) {
         PeopleInviteFragment peopleInviteFragment = new PeopleInviteFragment();
@@ -72,6 +74,12 @@ public class PeopleInviteFragment extends Fragment implements
     public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
         inflater.inflate(R.menu.people_invite, menu);
         super.onCreateOptionsMenu(menu, inflater);
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        menu.getItem(0).setEnabled(!mInviteOperationInProgress); // here pass the index of save menu item
+        super.onPrepareOptionsMenu(menu);
     }
 
     /**
@@ -423,6 +431,10 @@ public class PeopleInviteFragment extends Fragment implements
             return;
         }
 
+        if (!NetworkUtils.checkConnection(getActivity())) {
+            return;
+        }
+
         if (mUsernameButtons.size() == 0) {
             ToastUtils.showToast(getActivity(), R.string.invite_error_no_usernames);
             return;
@@ -441,6 +453,10 @@ public class PeopleInviteFragment extends Fragment implements
                     R.string.invite_error_invalid_usernames_multiple, invalidCount));
             return;
         }
+
+        //set the  "SEND" option disabled
+        mInviteOperationInProgress = true;
+        getActivity().invalidateOptionsMenu();
 
         String dotComBlogId = getArguments().getString(ARG_BLOGID);
         PeopleUtils.sendInvitations(new ArrayList<>(mUsernameButtons.keySet()), mRole, mCustomMessage, dotComBlogId,
@@ -469,6 +485,10 @@ public class PeopleInviteFragment extends Fragment implements
                         } else {
                             ToastUtils.showToast(getActivity(), R.string.invite_sent, ToastUtils.Duration.LONG);
                         }
+
+                        //set the  "SEND" option enabled again
+                        mInviteOperationInProgress = false;
+                        getActivity().invalidateOptionsMenu();
                     }
 
                     @Override
@@ -478,6 +498,11 @@ public class PeopleInviteFragment extends Fragment implements
                         }
 
                         ToastUtils.showToast(getActivity(), R.string.invite_error_sending);
+
+                        //set the  "SEND" option enabled again
+                        mInviteOperationInProgress = false;
+                        getActivity().invalidateOptionsMenu();
+
                     }
                 });
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -317,6 +317,12 @@ public class PeopleInviteFragment extends Fragment implements
         }
 
         if (usernamesToCheck.size() > 0) {
+
+            if (!NetworkUtils.checkConnection(getActivity())) {
+                enableSendButton(true);
+                return;
+            }
+
             String dotComBlogId = getArguments().getString(ARG_BLOGID);
             PeopleUtils.validateUsernames(usernamesToCheck, dotComBlogId, new PeopleUtils.ValidateUsernameCallback() {
                 @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -79,7 +79,7 @@ public class PeopleInviteFragment extends Fragment implements
 
     @Override
     public void onPrepareOptionsMenu(Menu menu) {
-        menu.getItem(0).setEnabled(!mInviteOperationInProgress); // here pass the index of save menu item
+        menu.getItem(0).setEnabled(!mInviteOperationInProgress); // here pass the index of send menu item
         super.onPrepareOptionsMenu(menu);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -43,6 +43,7 @@ public class PeopleInviteFragment extends Fragment implements
     private static final String KEY_USERNAME_RESULTS = "KEY_USERNAME_RESULTS";
     private static final String KEY_ROLE = "KEY_ROLE";
     private static final String KEY_CUSTOM_MESSAGE = "KEY_CUSTOM_MESSAGE";
+    private static final String KEY_INVITE_IN_PROGRESS = "KEY_INVITE_IN_PROGRESS";
 
     private static final String FLAG_SUCCESS = "SUCCESS";
 
@@ -101,6 +102,7 @@ public class PeopleInviteFragment extends Fragment implements
         outState.putSerializable(KEY_USERNAME_RESULTS, mUsernameResults);
         outState.putString(KEY_ROLE, mRole);
         outState.putString(KEY_CUSTOM_MESSAGE, mCustomMessage);
+        outState.putBoolean(KEY_INVITE_IN_PROGRESS, mInviteOperationInProgress);
 
         super.onSaveInstanceState(outState);
     }
@@ -126,6 +128,8 @@ public class PeopleInviteFragment extends Fragment implements
             populateUsernameButtons(usernames);
 
             role = savedInstanceState.getString(KEY_ROLE);
+
+            mInviteOperationInProgress = savedInstanceState.getBoolean(KEY_INVITE_IN_PROGRESS);
         }
 
         if (role == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -108,13 +108,6 @@ public class PeopleInviteFragment extends Fragment implements
     }
 
     @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        // retain this fragment across configuration changes
-        setRetainInstance(true);
-    }
-
-    @Override
     public View onCreateView(final LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         setHasOptionsMenu(true);
         return inflater.inflate(R.layout.people_invite_fragment, container, false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -424,30 +424,41 @@ public class PeopleInviteFragment extends Fragment implements
             return;
         }
 
+        enableSendButton(false);
+
         if (mUsernameEditText.getText().toString().length() > 0) {
             addUsername(mUsernameEditText, new ValidationEndListener() {
                 @Override
                 public void onValidationEnd() {
-                    checkAndSend();
+                    if (!checkAndSend()){
+                        //re-enable SEND button if validation failed
+                        enableSendButton(true);
+                    }
                 }
             });
         } else {
-            checkAndSend();
+            if (!checkAndSend()){
+                //re-enable SEND button if validation failed
+                enableSendButton(true);
+            }
         }
     }
 
-    private void checkAndSend() {
+    /*
+    * returns true if send is attempted, false if validation failed
+    * */
+    private boolean checkAndSend() {
         if (!isAdded()) {
-            return;
+            return false;
         }
 
         if (!NetworkUtils.checkConnection(getActivity())) {
-            return;
+            return false;
         }
 
         if (mUsernameButtons.size() == 0) {
             ToastUtils.showToast(getActivity(), R.string.invite_error_no_usernames);
-            return;
+            return false;
         }
 
         int invalidCount = 0;
@@ -461,12 +472,11 @@ public class PeopleInviteFragment extends Fragment implements
             ToastUtils.showToast(getActivity(), StringUtils.getQuantityString(getActivity(), 0,
                     R.string.invite_error_invalid_usernames_one,
                     R.string.invite_error_invalid_usernames_multiple, invalidCount));
-            return;
+            return false;
         }
 
         //set the  "SEND" option disabled
-        mInviteOperationInProgress = true;
-        getActivity().invalidateOptionsMenu();
+        enableSendButton(false);
 
         String dotComBlogId = getArguments().getString(ARG_BLOGID);
         PeopleUtils.sendInvitations(new ArrayList<>(mUsernameButtons.keySet()), mRole, mCustomMessage, dotComBlogId,
@@ -497,8 +507,7 @@ public class PeopleInviteFragment extends Fragment implements
                         }
 
                         //set the  "SEND" option enabled again
-                        mInviteOperationInProgress = false;
-                        getActivity().invalidateOptionsMenu();
+                        enableSendButton(true);
                     }
 
                     @Override
@@ -510,10 +519,16 @@ public class PeopleInviteFragment extends Fragment implements
                         ToastUtils.showToast(getActivity(), R.string.invite_error_sending);
 
                         //set the  "SEND" option enabled again
-                        mInviteOperationInProgress = false;
-                        getActivity().invalidateOptionsMenu();
+                        enableSendButton(true);
 
                     }
                 });
+
+        return true;
+    }
+
+    private void enableSendButton(boolean enable){
+        mInviteOperationInProgress = !enable;
+        getActivity().invalidateOptionsMenu();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -318,11 +318,6 @@ public class PeopleInviteFragment extends Fragment implements
 
         if (usernamesToCheck.size() > 0) {
 
-            if (!NetworkUtils.checkConnection(getActivity())) {
-                enableSendButton(true);
-                return;
-            }
-
             String dotComBlogId = getArguments().getString(ARG_BLOGID);
             PeopleUtils.validateUsernames(usernamesToCheck, dotComBlogId, new PeopleUtils.ValidateUsernameCallback() {
                 @Override
@@ -420,6 +415,11 @@ public class PeopleInviteFragment extends Fragment implements
     @Override
     public void send() {
         if (!isAdded()) {
+            return;
+        }
+
+        if (!NetworkUtils.checkConnection(getActivity())) {
+            enableSendButton(true);
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -528,6 +528,8 @@ public class PeopleInviteFragment extends Fragment implements
 
     private void enableSendButton(boolean enable){
         mInviteOperationInProgress = !enable;
-        getActivity().invalidateOptionsMenu();
+        if (getActivity() != null) {
+            getActivity().invalidateOptionsMenu();
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -108,9 +108,15 @@ public class PeopleInviteFragment extends Fragment implements
     }
 
     @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        // retain this fragment across configuration changes
+        setRetainInstance(true);
+    }
+
+    @Override
     public View onCreateView(final LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         setHasOptionsMenu(true);
-
         return inflater.inflate(R.layout.people_invite_fragment, container, false);
     }
 


### PR DESCRIPTION
Fixes #4332

To test: 
- Go into the user Invites screen by visiting MySite > People and tapping the "+" button on the actionbar
- Start typing a username and before hitting "enter"
- Put the device to offline mode
- Tap the "SEND" action

The SEND button is disabled right after you tap on it and validations are passed, and is re-enabled once the operation is finished (either successfully or unsuccessfully).

This comes particularly handy in the case of not having good network coverage (not necessarily when no network at all, but rather an intermittent connection or delayed response from the server), as it may take several seconds for the action to complete, or even fail by timeout.

Needs review: @hypest 

