### PR TITLE
Remove clipping for scrollable views with padding

### DIFF
--- a/WordPress/src/main/res/layout/comment_edit_activity.xml
+++ b/WordPress/src/main/res/layout/comment_edit_activity.xml
@@ -3,6 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fillViewport="true"
+    android:clipToPadding="false"
     android:paddingBottom="@dimen/margin_large"
     android:paddingLeft="@dimen/margin_extra_large"
     android:paddingRight="@dimen/margin_extra_large"

--- a/WordPress/src/main/res/layout/people_invite_fragment.xml
+++ b/WordPress/src/main/res/layout/people_invite_fragment.xml
@@ -9,6 +9,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white"
+    android:clipToPadding="false"
     android:paddingLeft="16dp"
     android:paddingRight="16dp"
     android:clickable="true">

--- a/WordPress/src/main/res/layout/people_list_fragment.xml
+++ b/WordPress/src/main/res/layout/people_list_fragment.xml
@@ -10,7 +10,8 @@
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="@dimen/margin_medium"
+        android:clipToPadding="false"
+        android:paddingTop="@dimen/margin_medium"
         android:scrollbars="vertical"/>
 
     <ProgressBar

--- a/WordPress/src/main/res/layout/post_list_fragment.xml
+++ b/WordPress/src/main/res/layout/post_list_fragment.xml
@@ -52,6 +52,7 @@
                 android:id="@+id/recycler_view"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:clipToPadding="false"
                 android:paddingTop="@dimen/margin_medium"
                 android:scrollbars="vertical" />
 
@@ -83,4 +84,3 @@
         tools:visibility="visible" />
 
 </RelativeLayout>
-

--- a/WordPress/src/main/res/layout/post_preview_fragment.xml
+++ b/WordPress/src/main/res/layout/post_preview_fragment.xml
@@ -8,7 +8,6 @@
         android:id="@+id/webView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="@dimen/margin_medium"
         android:scrollbarStyle="outsideInset" />
 
 </FrameLayout>


### PR DESCRIPTION
### Fix
Remove clipping by setting `android:clipToPadding="false"` to scrollable views with padding.  This eliminates the "magic barriers" when a list is scrolled into padding or the over scroll glow is shown against the padding rather than the visual edge which is counterintuitive.  See the screenshots below.

![remove_clipping](https://cloud.githubusercontent.com/assets/3827611/16537764/50b70d04-3fc9-11e6-9974-576bdf384ccf.png)

### Test
<ol><b>People List (Third Set of Screenshots)</b>
<li>Go to Sites tab.</li>
<li>Tap People option.</li>
<li>Fling list down.</li>
</ol>
<ol><b>Post List (Fourth Set of Screenshots)</b>
<li>Go to Sites tab.</li>
<li>Tap Blog Posts option.</li>
<li>Scroll list up.</li>
</ol>