### PR TITLE
Move scrollbar from middle to edge of view

### DIFF
--- a/WordPress/src/main/res/layout/comment_edit_activity.xml
+++ b/WordPress/src/main/res/layout/comment_edit_activity.xml
@@ -7,7 +7,8 @@
     android:paddingLeft="@dimen/margin_extra_large"
     android:paddingRight="@dimen/margin_extra_large"
     android:paddingTop="@dimen/margin_large"
-    android:background="@color/white">
+    android:background="@color/white"
+    android:scrollbarStyle="outsideInset" >
 
     <RelativeLayout
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/people_invite_fragment.xml
+++ b/WordPress/src/main/res/layout/people_invite_fragment.xml
@@ -11,7 +11,8 @@
     android:background="@color/white"
     android:paddingLeft="16dp"
     android:paddingRight="16dp"
-    android:clickable="true">
+    android:clickable="true"
+    android:scrollbarStyle="outsideInset" >
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
### Fix
Move scrollbar from middle to edge of a list view using `android:scrollbarStyle="outsideInset"`.  See screenshot below

![move_scrollbar](https://cloud.githubusercontent.com/assets/3827611/16538045/68f67a80-3fd3-11e6-825f-b8cac4c5b2fd.png)

### Test
<ol><b>People List (First Set of Screenshots)</b>
<li>Go to Sites tab.</li>
<li>Tap People option.</li>
<li>Tap text box to show keyboard.</li>
<li>Fling view down.</li>
</ol>
<ol><b>Edit Comment (Second Set of Screenshots)</b>
<li>Go to Sites tab.</li>
<li>Tap Comments option.</li>
<li>Tap comment.</li>
<li>Tap overflow menu and choose Edit Comment.</li>
<li>Enter multiple lines in comment content to show scrollbar.</li>
<li>Fling view down.</li>
</ol>