### PR TITLE
Save enable/disable as actual saving happens to the server

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/MenusFragment.java
@@ -233,12 +233,17 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
                             mMenusSpinner.setSelection(selectedPos);
                         }
                     }
+
+                    mAddEditRemoveControl.onSaveCompleted(true);
+
                 }
             }
 
             @Override
             public void onErrorResponse(int requestId, MenusRestWPCom.REST_ERROR error) {
                 if (!isAdded()) return;
+
+                mAddEditRemoveControl.onSaveCompleted(false);
 
                 if (error == MenusRestWPCom.REST_ERROR.FETCH_ERROR) {
                     if (mMenuLocationsSpinner.getCount() == 0 || mMenusSpinner.getCount() == 0) {
@@ -281,6 +286,8 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
             @Override
             public void onMenuCreate(MenuModel menu) {
                 if (!isAdded() || !NetworkUtils.checkConnection(getActivity()) ) return;
+
+                mAddEditRemoveControl.onSaveStarted(menu);
 
                 //set the menu's current configuration now
                 MenuModel menuToUpdate = setMenuLocation(menu);
@@ -347,6 +354,8 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
             @Override
             public void onMenuUpdate(MenuModel menu) {
                 if (!isAdded() || !NetworkUtils.checkConnection(getActivity())) return;
+
+                mAddEditRemoveControl.onSaveStarted(menu);
 
                 //set the menu's current configuration now
                 MenuModel menuToUpdate = setMenuLocation(menu);
@@ -763,7 +772,6 @@ public class MenusFragment extends Fragment implements MenuItemAdapter.MenuItemI
      * AsyncTask to load menus from SQLite
      */
     private boolean mIsLoadTaskRunning = false;
-
 
     private class LoadMenusTask extends AsyncTask<Void, Void, Boolean> {
         List<MenuModel> tmpMenus;

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuAddEditRemoveView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuAddEditRemoveView.java
@@ -20,7 +20,7 @@ import org.wordpress.android.widgets.WPTextView;
 /**
  * Menu add/remove control used in menus editing
  */
-public class MenuAddEditRemoveView extends LinearLayout {
+public class MenuAddEditRemoveView extends LinearLayout implements MenuSaveProgressListener {
     private LinearLayout mMenuInactiveStateView;
     private WPTextView mMenuInactiveTitleText;
     private WPEditText mMenuEditText;
@@ -272,6 +272,16 @@ public class MenuAddEditRemoveView extends LinearLayout {
         return mMenuEditText.getText().toString();
     }
 
+    @Override
+    public void onSaveCompleted(boolean successfully) {
+        mMenuSave.setEnabled(true);
+        mMenuSave.setText(R.string.save);
+    }
 
+    @Override
+    public void onSaveStarted(MenuModel menu) {
+        mMenuSave.setEnabled(false);
+        mMenuSave.setText(R.string.saving);
+    }
 
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuSaveProgressListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/menus/views/MenuSaveProgressListener.java
@@ -1,0 +1,8 @@
+package org.wordpress.android.ui.menus.views;
+
+import org.wordpress.android.models.MenuModel;
+
+public interface MenuSaveProgressListener {
+    void onSaveCompleted(boolean successfully); // use this method to signal MenuAddEditRemoveView that the saving operation has ended
+    void onSaveStarted(MenuModel menu); // use this method to signal MenuAddEditRemoveView that the saving operation has just started
+}

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1517,6 +1517,7 @@
     <string name="menu_item_type_portfolio">Portfolio</string>
     <string name="menu_item_type_comic">Comic</string>
 
+
     <!-- empty menu item adapter views -->
     <string name="menu_item_type_page_empty_list">No pages found</string>
     <string name="menu_item_type_post_empty_list">No posts found</string>


### PR DESCRIPTION
Fixes #3591 (partially)

This one adds a UX refinement: when clicking SAVE, we disable it and show  'saving...', and once it's done (either succesfully or unsuccessfully)  the button is returned to the enabled state

Needs review: @tonyr59h 

