### PR TITLE
Fix reader images resize

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -374,7 +374,7 @@ class ReaderPostRenderer {
         .append("  a { text-decoration: none; color: ").append(mResourceVars.linkColorStr).append("; }")
 
         // make sure images aren't wider than the display, strictly enforced for images without size
-        .append("  img { max-width: 100%; }")
+        .append("  img { max-width: 100%; width: auto; height: auto; }")
         .append("  img.size-none { max-width: 100% !important; height: auto !important; }")
 
         // center large/medium images, provide a small bottom margin, and add a background color

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -75,14 +75,15 @@ class ReaderPostRenderer {
         new Thread() {
             @Override
             public void run() {
-                if (!mResourceVars.isWideDisplay) {
+                final boolean renderAsTiledGallery = shouldRenderAsTiledGallery();
+
+                if (!renderAsTiledGallery) {
                     resizeImages();
                 }
 
                 resizeIframes();
 
-                final String htmlContent = formatPostContentForWebView(mRenderBuilder
-                        .toString(), mResourceVars.isWideDisplay);
+                final String htmlContent = formatPostContentForWebView(mRenderBuilder.toString(), renderAsTiledGallery);
                 mRenderBuilder = null;
                 handler.post(new Runnable() {
                     @Override
@@ -92,6 +93,14 @@ class ReaderPostRenderer {
                 });
             }
         }.start();
+    }
+
+    public boolean shouldRenderAsTiledGallery() {
+        // determine whether a tiled-gallery exists in the content
+        final boolean hasTiledGallery = Pattern.compile("tiled-gallery[\\s\"']").matcher(mRenderBuilder.toString())
+                .find();
+
+        return hasTiledGallery && mResourceVars.isWideDisplay;
     }
 
     /*
@@ -310,12 +319,7 @@ class ReaderPostRenderer {
     /*
      * returns the full content, including CSS, that will be shown in the WebView for this post
      */
-    private String formatPostContentForWebView(final String content, boolean isWideDisplay) {
-        // determine whether a tiled-gallery exists in the content
-        final boolean hasTiledGallery = Pattern.compile("tiled-gallery[\\s\"']").matcher(content).find();
-
-        final boolean renderAsTiledGallery = hasTiledGallery && isWideDisplay;
-
+    private String formatPostContentForWebView(final String content, boolean renderAsTiledGallery) {
         // unique CSS class assigned to the gallery elements for easy selection
         final String galleryOnlyClass = "gallery-only-class" + new Random().nextInt(1000);
 


### PR DESCRIPTION
Fixes #4344 

To test:

* On a 9" tablet
* In Reader, open a post with rather big images. Example: https://rachel-test-domain.com/2016/07/05/images/
* Images should be displayed without any apparent distortion in their size or view ratios

