### PR TITLE
Add dark toolbar theme to Reader search view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderSearchSuggestionAdapter.java
@@ -28,12 +28,14 @@ public class ReaderSearchSuggestionAdapter extends CursorAdapter {
     private String mCurrentFilter;
     private final Object[] mClearAllRow;
     private final int mClearAllBgColor;
+    private final int mSuggestionBgColor;
 
     public ReaderSearchSuggestionAdapter(Context context) {
         super(context, null, false);
         String clearAllText = context.getString(R.string.label_clear_search_history);
         mClearAllRow = new Object[]{CLEAR_ALL_ROW_ID, clearAllText};
         mClearAllBgColor = ContextCompat.getColor(context, R.color.grey_lighten_30);
+        mSuggestionBgColor = ContextCompat.getColor(context, R.color.filtered_list_suggestions);
     }
 
     public void setFilter(String filter) {
@@ -134,6 +136,8 @@ public class ReaderSearchSuggestionAdapter extends CursorAdapter {
                 }
             });
             holder.imgDelete.setVisibility(View.GONE);
+        } else {
+            view.setBackgroundColor(mSuggestionBgColor);
         }
 
         return view;

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -111,6 +111,7 @@
     <!-- Reader  -->
     <color name="reader_divider_grey">@color/grey_lighten_30</color>
     <color name="reader_hyperlink">@color/blue_medium</color>
+    <color name="filtered_list_suggestions">#f8f8f8</color>
 
     <!-- Comment Status -->
     <color name="comment_status_unapproved">@color/orange_jazzy</color>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -31,7 +31,7 @@
     </style>
 
     <!-- http://android-developers.blogspot.com/2014/10/appcompat-v21-material-design-for-pre.html -->
-    <style name="WordPress.SearchViewStyle" parent="Widget.AppCompat.Light.SearchView" />
+    <style name="WordPress.SearchViewStyle" parent="Widget.AppCompat.SearchView.ActionBar" />
 
     <style name="WordPress.DropDownListView.Light" parent="WordPress">
         <item name="android:dropDownListViewStyle">@style/DropDownListView.Light.WordPress</item>
@@ -93,6 +93,11 @@
     <style name="FilteredRecyclerViewToolbar" parent="Widget.AppCompat.Toolbar">
         <item name="android:paddingLeft">@dimen/margin_filter_spinner</item>
         <item name="android:elevation">@dimen/filter_subbar_elevation</item>
+        <item name="android:theme">@style/FilteredRecyclerViewToolbar.Theme</item>
+    </style>
+
+    <style name="FilteredRecyclerViewToolbar.Theme" parent="ThemeOverlay.AppCompat.Dark.ActionBar">
+        <item name="android:listDivider">@null</item>
     </style>
 
     <style name="ProgressBar.WordPress" parent="android:Widget.Holo.ProgressBar.Horizontal">


### PR DESCRIPTION
### Fix
Add dark toolbar theme with white text and icons to Reader search view.  See the screenshots below.

![search_by_side](https://cloud.githubusercontent.com/assets/3827611/16642362/7162d82e-43c7-11e6-9483-d4608ae7fae1.png)

### Test
1. Go to Reader tab.
2. Tap Search action on toolbar.
3. Enter a word.
4. Tap Search button on keyboard.
5. Tap Close action on toolbar.
6. Enter same word as Step 3.