### PR TITLE
Fixes removing follower & email follower

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
@@ -3,6 +3,7 @@ package org.wordpress.android.datasets;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.support.annotation.Nullable;
 
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Person;
@@ -169,8 +170,11 @@ public class PeopleTable {
         return SqlUtils.intForQuery(getReadableDb(), sql, args);
     }
 
-    public static void deleteUser(long personID, int localTableBlogId) {
-        deletePerson(TEAM_TABLE, personID, localTableBlogId);
+    public static void deletePerson(long personID, int localTableBlogId, Person.PersonType personType) {
+        String table = getTableForPersonType(personType);
+        if (table != null) {
+            deletePerson(table, personID, localTableBlogId);
+        }
     }
 
     private static void deletePerson(String table, long personID, int localTableBlogId) {
@@ -207,20 +211,13 @@ public class PeopleTable {
         return people;
     }
 
+    @Nullable
     public static Person getPerson(long personId, int localTableBlogId, Person.PersonType personType) {
-        String table = null;
-        switch (personType) {
-            case USER:
-                table = TEAM_TABLE;
-                break;
-            case FOLLOWER:
-                table = FOLLOWERS_TABLE;
-                break;
-            case EMAIL_FOLLOWER:
-                table = EMAIL_FOLLOWERS_TABLE;
-                break;
+        String table = getTableForPersonType(personType);
+        if (table != null) {
+            return getPerson(table, personId, localTableBlogId);
         }
-        return getPerson(table, personId, localTableBlogId);
+        return null;
     }
 
     public static Person getUser(long personId, int localTableBlogId) {
@@ -280,5 +277,18 @@ public class PeopleTable {
             return "";
         }
         return " ORDER BY lower(display_name), lower(user_name)";
+    }
+
+    @Nullable
+    private static String getTableForPersonType(Person.PersonType personType) {
+        switch (personType) {
+            case USER:
+                return TEAM_TABLE;
+            case FOLLOWER:
+                return FOLLOWERS_TABLE;
+            case EMAIL_FOLLOWER:
+                return EMAIL_FOLLOWERS_TABLE;
+        }
+        return null;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -448,7 +448,7 @@ public class PeopleManagementActivity extends AppCompatActivity
         final Person.PersonType personType = person.getPersonType();
         final String displayName = person.getDisplayName();
 
-        PeopleUtils.RemoveUserCallback callback = new PeopleUtils.RemoveUserCallback() {
+        PeopleUtils.RemovePersonCallback callback = new PeopleUtils.RemovePersonCallback() {
             @Override
             public void onSuccess(long personID, int localTableBlogId) {
                 if (personType == Person.PersonType.USER) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -455,11 +455,7 @@ public class PeopleManagementActivity extends AppCompatActivity
                     AnalyticsUtils.trackWithCurrentBlogDetails(AnalyticsTracker.Stat.PERSON_REMOVED);
                 }
 
-                // remove the person from db, navigate back to list fragment and refresh it
-                Person person = PeopleTable.getUser(personID, localTableBlogId);
-                if (person != null) {
-                    PeopleTable.deleteUser(personID, localTableBlogId);
-                }
+                PeopleTable.deletePerson(personID, localTableBlogId, personType);
 
                 String message = getString(R.string.person_removed, displayName);
                 ToastUtils.showToast(PeopleManagementActivity.this, message, ToastUtils.Duration.LONG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -455,6 +455,7 @@ public class PeopleManagementActivity extends AppCompatActivity
                     AnalyticsUtils.trackWithCurrentBlogDetails(AnalyticsTracker.Stat.PERSON_REMOVED);
                 }
 
+                // remove the person from db, navigate back to list fragment and refresh it
                 PeopleTable.deletePerson(personID, localTableBlogId, personType);
 
                 String message = getString(R.string.person_removed, displayName);

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
@@ -153,7 +153,7 @@ public class PeopleUtils {
     }
 
     public static void removeUser(String blogId, final long personID, final int localTableBlogId,
-                                  final RemoveUserCallback callback) {
+                                  final RemovePersonCallback callback) {
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
             public void onResponse(JSONObject jsonObject) {
@@ -184,7 +184,7 @@ public class PeopleUtils {
     }
 
     public static void removeFollower(String blogId, final long personID, final int localTableBlogId,
-                                      Person.PersonType personType, final RemoveUserCallback callback) {
+                                      Person.PersonType personType, final RemovePersonCallback callback) {
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
             public void onResponse(JSONObject jsonObject) {
@@ -250,7 +250,7 @@ public class PeopleUtils {
         void onSuccess(List<Person> peopleList, int pageFetched, boolean isEndOfList);
     }
 
-    public interface RemoveUserCallback extends Callback {
+    public interface RemovePersonCallback extends Callback {
         void onSuccess(long personID, int localTableBlogId);
     }
 


### PR DESCRIPTION
In the followers PR #4142 there was a major refactor for the DB layer and this was something that wasn't handled correctly there. Basically, we were always trying to remove a user after a successful remove person callback, but now we'll remove the correct person type (user, follower or email follower).

To test: Go into people page and try to remove a user, follower & email follower and verify that all of these types are correctly removed from the list.

Needs review: @mzorz 

/cc @astralbodies & @hypest 
