### PR TITLE
Editor - Correctly import legacy image captions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1106,7 +1106,19 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 matcher.appendReplacement(stringBuffer, replacement);
             }
             matcher.appendTail(stringBuffer);
-            return stringBuffer.toString();
+            content = stringBuffer.toString();
+        }
+        if (content.contains("[caption")) {
+            // Convert old legacy post caption formatting to new format, to avoid being stripped by the visual editor
+            Pattern pattern = Pattern.compile("(\\[caption[^]]*caption=\"([^\"]*)\"[^]]*].+?)(\\[\\/caption])");
+            Matcher matcher = pattern.matcher(content);
+            StringBuffer stringBuffer = new StringBuffer();
+            while (matcher.find()) {
+                String replacement = matcher.group(1) + matcher.group(2) + matcher.group(3);
+                matcher.appendReplacement(stringBuffer, replacement);
+            }
+            matcher.appendTail(stringBuffer);
+            content = stringBuffer.toString();
         }
         return content;
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPHtml.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPHtml.java
@@ -463,8 +463,8 @@ public class WPHtml {
 
             if (!caption.equals("")) {
                 content = String.format(Locale.US,
-                        "[caption id=\"\" align=\"%s\" width=\"%d\" caption=\"%s\"]%s[/caption]",
-                        alignment, width, TextUtils.htmlEncode(caption), content);
+                        "[caption id=\"\" align=\"%s\" width=\"%d\"]%s%s[/caption]",
+                        alignment, width, content, TextUtils.htmlEncode(caption));
             }
         }
 

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/MediaFile.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/MediaFile.java
@@ -330,8 +330,8 @@ public class MediaFile {
                 fullSizeUrl, mediaTitle, alignmentCSS, resizedPictureURL);
 
         if (!TextUtils.isEmpty(getCaption())) {
-            content = String.format("[caption id=\"\" align=\"%s\" width=\"%d\" caption=\"%s\"]%s[/caption]",
-                    alignment, getWidth(), TextUtils.htmlEncode(getCaption()), content);
+            content = String.format("[caption id=\"\" align=\"%s\" width=\"%d\"]%s%s[/caption]",
+                    alignment, getWidth(), content, TextUtils.htmlEncode(getCaption()));
         }
 
         return content;


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/433.

The legacy editor stores captions differently from the web editor and the visual editor:

Legacy:
```HTML
[caption align="alignnone" caption="Caption text"]<image>[/caption]
```

Calypso/visual editor:
```HTML
[caption align="alignnone"]<image>Caption text[/caption]
```

I updated the legacy editor to save new image captions in the Calypso/visual way. I also added a migration step for legacy posts predating this PR, to convert their image captions to the new format.

Needs review: @maxme 