### PR TITLE
Move related posts request to always trigger when page finishes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -943,8 +943,8 @@ public class ReaderPostDetailFragment extends Fragment
                     if (!mHasAlreadyUpdatedPost) {
                         mHasAlreadyUpdatedPost = true;
                         updatePost();
-                        requestRelatedPosts();
                     }
+                    requestRelatedPosts();
                 }
             }, 300);
         } else {


### PR DESCRIPTION
### Fix
Move request call for related posts (i.e. Related Reading section) to _always_ trigger when the page finishes loading including device rotations as described in https://github.com/wordpress-mobile/WordPress-Android/issues/4345.

### Test
1. Go to Reader tab.
2. Select Discover filter from dropdown menu.
3. Select Pet Blogger post.
4. Scroll to bottom of post.
5. Notice Related Reading section.
6. Rotate device orientation.
7. Notice Related Reading section.

