### PR TITLE
issue/4380-reader-site-preview-crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -181,7 +181,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 int extraPadding = itemView.getContext().getResources().getDimensionPixelSize(R.dimen.margin_medium);
                 txtTitle.setPadding(
                         txtTitle.getPaddingLeft(),
-                        txtTitle.getTotalPaddingTop() + extraPadding,
+                        txtTitle.getPaddingTop() + extraPadding,
                         txtTitle.getPaddingRight(),
                         txtTitle.getPaddingBottom());
                 // show the dateline that appears below the title (hidden in layout)


### PR DESCRIPTION
Fixes #4380 

To test: Run the app in an API 19 emulator and tap the header above a post in the reader list view. Prior to this fix, the app would crash (due to a silly typo on my part).
