### PR TITLE
Remove redundant onPause from ReaderWebView when hiding view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderWebView.java
@@ -357,8 +357,6 @@ public class ReaderWebView extends WebView {
 
             mCustomView = null;
             mCustomViewCallback = null;
-
-            mReaderWebView.onPause();
         }
 
         boolean isCustomViewShowing() {


### PR DESCRIPTION
### Fix
When exiting a fullscreen video using the back button or video fullscreen toggle, the post becomes blank/white as described in https://github.com/wordpress-mobile/WordPress-Android/issues/4355.  The fix removes a redundant `onPause` call to the `ReaderWebView` when returning from fullscreen mode since `onPause` is already called in `ReaderPostDetailFragment.pauseWebView()`.

### Test
<ol><b>Know a Post with Video</b>
<li>Go to Reader tab.</li>
<li>Select a post with video.</li>
<li>Start video in post.</li>
<li>Tap fullscreen toggle.</li>
<li>Exit fullscreen (tap toggle or press back).</li>
</ol>

<ol><b>Don't Know a Post with Video</b>
<li>Go to Reader tab.</li>
<li>Tap gear icon.</li>
<li>Go to Followed Tags tab.</li>
<li>Follow YouTube tag.</li>
<li>Tap back navigation.</li>
<li>Select YouTube from dropdown menu.</li>
<li>Select a post.</li>
<li>Start video in post.</li>
<li>Tap fullscreen toggle.</li>
<li>Exit fullscreen (tap toggle or press back).</li>
</ol>