### PR TITLE
added wrapping ScrollView to NotificationsSettingsDialogPreference view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CompoundButton;
 import android.widget.LinearLayout;
+import android.widget.ScrollView;
 import android.widget.Switch;
 import android.widget.TextView;
 
@@ -18,6 +19,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.models.NotificationsSettings;
 import org.wordpress.android.models.NotificationsSettings.Channel;
 import org.wordpress.android.models.NotificationsSettings.Type;
+import org.wordpress.android.ui.stats.ScrollViewExt;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.JSONUtils;
 
@@ -58,16 +60,23 @@ public class NotificationsSettingsDialogPreference extends DialogPreference {
 
     @Override
     protected View onCreateDialogView() {
-        LinearLayout view = new LinearLayout(getContext());
-        view.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT));
-        view.setOrientation(LinearLayout.VERTICAL);
+
+        ScrollView outterView = new ScrollView(getContext());
+        outterView.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT));
+
+        LinearLayout innerView = new LinearLayout(getContext());
+        innerView.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT));
+        innerView.setOrientation(LinearLayout.VERTICAL);
 
         View spacerView = new View(getContext());
         int spacerHeight = getContext().getResources().getDimensionPixelSize(R.dimen.margin_medium);
         spacerView.setLayoutParams(new ViewGroup.LayoutParams(ActionBar.LayoutParams.MATCH_PARENT, spacerHeight));
-        view.addView(spacerView);
+        innerView.addView(spacerView);
 
-        return configureLayoutForView(view);
+        outterView.addView(innerView);
+        configureLayoutForView(innerView);
+
+        return outterView;
     }
 
     private View configureLayoutForView(LinearLayout view) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsDialogPreference.java
@@ -61,8 +61,8 @@ public class NotificationsSettingsDialogPreference extends DialogPreference {
     @Override
     protected View onCreateDialogView() {
 
-        ScrollView outterView = new ScrollView(getContext());
-        outterView.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT));
+        ScrollView outerView = new ScrollView(getContext());
+        outerView.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT));
 
         LinearLayout innerView = new LinearLayout(getContext());
         innerView.setLayoutParams(new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT));
@@ -73,10 +73,10 @@ public class NotificationsSettingsDialogPreference extends DialogPreference {
         spacerView.setLayoutParams(new ViewGroup.LayoutParams(ActionBar.LayoutParams.MATCH_PARENT, spacerHeight));
         innerView.addView(spacerView);
 
-        outterView.addView(innerView);
+        outerView.addView(innerView);
         configureLayoutForView(innerView);
 
-        return outterView;
+        return outerView;
     }
 
     private View configureLayoutForView(LinearLayout view) {


### PR DESCRIPTION
Fixes #4389

Added a ScrollView to the dialog so it allows scrolling when the content doesn't fit the screen

![notif_settings](https://cloud.githubusercontent.com/assets/6597771/16874794/c196b094-4a71-11e6-91f9-4abc3c29cb7d.gif)


To test:
1. log in to Android WP app, and keep your phone in protrait mode
2. go to the profile tab
3. tap on "Notification Settings"
4. Pick any site and then choose either "Notifications tab" or "App notifications" 
4.1 (alternatively, instead of picking a site, tap on "Email from WordPress.com")
5. the dialog is shown
6. rotate your device
7. if the dialog's content doesn't fit, then it should allow scrolling now

Needs review: @roundhill

