### PR TITLE
Add dexInProcess to the dexOptions - faster builds

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -26,7 +26,8 @@ android {
 
     dexOptions {
         jumboMode = true
-        javaMaxHeapSize = "4g"
+        javaMaxHeapSize = "6g"
+        dexInProcess = true
     }
 
     compileSdkVersion 24


### PR DESCRIPTION
Full `assembleDebug` build comparison:

* with `dexInProcess`: Total time: 1 mins 17.274 secs
* without: Total time: 1 mins 44.647 secs

