### PR TITLE
Update follow and following text color

### DIFF
--- a/WordPress/src/main/res/color/reader_follow_button_text.xml
+++ b/WordPress/src/main/res/color/reader_follow_button_text.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/grey_disabled" android:state_enabled="false" />
     <item android:color="@color/reader_following" android:state_selected="true" />
-    <item android:color="@color/blue_light" android:state_pressed="true" />
     <item android:color="@color/reader_follow" />
 </selector>


### PR DESCRIPTION
### Fix
Update text color for Follow and Following buttons as described in https://github.com/wordpress-mobile/WordPress-Android/issues/4398.

### Test
<ol><b>Follow</b>
<li>Go to Reader tab.</li>
<li>Tap Search action.</li>
<li>Enter random word.</li>
<li>Tap unfollowed site.</li>
<li>Notice Follow text color.</li>
</ol>

<ol><b>Following</b>
<li>Go to Reader tab.</li>
<li>Choose Followed Sites from the dropdown list.</li>
<li>Tap first post in list.</li>
<li>Notice Following text color.</li>
</ol>