### PR TITLE
Newest comments are shown first in ReaderCommentListActivity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderCommentTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderCommentTable.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.datasets;
 
+import android.annotation.SuppressLint;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
@@ -25,6 +26,7 @@ public class ReaderCommentTable {
     public static final int ORDER_BY_TIME_OF_COMMENT = 2;
     public static final int ORDER_BY_DEFAULT = ORDER_BY_NEWEST_COMMENT_FIRST;
 
+    @SuppressLint("UniqueConstants")
     @IntDef({ ORDER_BY_NEWEST_COMMENT_FIRST , ORDER_BY_TIME_OF_COMMENT , ORDER_BY_DEFAULT })
     @Retention(RetentionPolicy.SOURCE)
     public @interface CommentsOrderBy{}

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderCommentTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderCommentTable.java
@@ -121,9 +121,11 @@ public class ReaderCommentTable {
             int currPage = c.getInt(0);
             int currPageComments = c.getInt(1);
             if( currPage != pageNumber || currPageComments < commentsPerPage ){
-                return pageNumber;
+                break;
             }
         }
+
+        c.close();
         return pageNumber;
     }
 
@@ -143,6 +145,7 @@ public class ReaderCommentTable {
 
 
         if( !c.moveToNext() ){
+            c.close();
             return 1;
         }
 
@@ -158,10 +161,13 @@ public class ReaderCommentTable {
             currPage = c.getInt(0);
             int currPageComments = c.getInt(1);
             if( currPage + 1 != lastPage || currPageComments < commentsPerPage){
+                c.close();
                 return backwardPageNumber;
             }
             lastPage = currPage;
         }
+
+        c.close();
 
         if(currPage == 1){
             //all comments are loaded

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -605,10 +605,11 @@ public class ReaderCommentListActivity extends AppCompatActivity {
             otherwise load comments from database
          */
         if(NetworkUtils.isNetworkAvailable(this)){
-            mCommentAdapter.setCommentsOrder(commentsOrder,false);
-            updateComments(true,false);
+            ReaderCommentTable.purgeCommentsForPost(mBlogId, mPostId);
+            mCommentAdapter.setCommentsOrder(commentsOrder, false);
+            updateComments(true, false);
         }else{
-            mCommentAdapter.setCommentsOrder(commentsOrder,true);
+            mCommentAdapter.setCommentsOrder(commentsOrder, true);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -8,6 +8,9 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.view.KeyEvent;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
@@ -78,6 +81,8 @@ public class ReaderCommentListActivity extends AppCompatActivity {
     private long mReplyToCommentId;
     private long mCommentId;
     private int mRestorePosition;
+
+    private int mCommentsOrder = ReaderCommentTable.ORDER_BY_DEFAULT;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -315,7 +320,7 @@ public class ReaderCommentListActivity extends AppCompatActivity {
 
     private ReaderCommentAdapter getCommentAdapter() {
         if (mCommentAdapter == null) {
-            mCommentAdapter = new ReaderCommentAdapter(WPActivityUtils.getThemedContext(this), getPost());
+            mCommentAdapter = new ReaderCommentAdapter(WPActivityUtils.getThemedContext(this), getPost(), mCommentsOrder);
 
             // adapter calls this when user taps reply icon
             mCommentAdapter.setReplyListener(new ReaderCommentAdapter.RequestReplyListener() {
@@ -424,7 +429,7 @@ public class ReaderCommentListActivity extends AppCompatActivity {
         if (showProgress) {
             showProgress();
         }
-        ReaderCommentService.startService(this, mPost.blogId, mPost.postId, requestNextPage);
+        ReaderCommentService.startService(this, mPost.blogId, mPost.postId, requestNextPage, mCommentsOrder);
     }
 
     private void checkEmptyView() {
@@ -551,5 +556,59 @@ public class ReaderCommentListActivity extends AppCompatActivity {
 
     private void setRefreshing(boolean refreshing) {
         mSwipeToRefreshHelper.setRefreshing(refreshing);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        super.onCreateOptionsMenu(menu);
+
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.reader_comments_list,menu);
+
+        MenuItem newestCommentFirst = menu.findItem(R.id.menu_newest_comments_first);
+        newestCommentFirst.setChecked(mCommentsOrder == ReaderCommentTable.ORDER_BY_NEWEST_COMMENT_FIRST);
+
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+
+        switch(item.getItemId()){
+            case R.id.menu_newest_comments_first:
+                handleNewestCommentMenuItem(item);
+                return true;
+
+        }
+
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void handleNewestCommentMenuItem(MenuItem item){
+        if(item.isChecked()){
+            setCommentsOrder(ReaderCommentTable.ORDER_BY_TIME_OF_COMMENT);
+            item.setChecked(false);
+        }else{
+            setCommentsOrder(ReaderCommentTable.ORDER_BY_NEWEST_COMMENT_FIRST);
+            item.setChecked(true);
+        }
+    }
+
+    private void setCommentsOrder(@ReaderCommentTable.CommentsOrderBy int commentsOrder){
+        if(mCommentsOrder == commentsOrder){
+            return;
+        }
+
+        mCommentsOrder = commentsOrder;
+
+        /* if connected to network then load fresh first page from server
+            otherwise load comments from database
+         */
+        if(NetworkUtils.isNetworkAvailable(this)){
+            mCommentAdapter.setCommentsOrder(commentsOrder,false);
+            updateComments(true,false);
+        }else{
+            mCommentAdapter.setCommentsOrder(commentsOrder,true);
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -4,6 +4,13 @@ public class ReaderConstants {
     public static final int  READER_MAX_POSTS_TO_REQUEST        = 20;       // max # posts to request when updating posts
     public static final int  READER_MAX_SEARCH_POSTS_TO_REQUEST = 10;       // max # posts to request when searching posts
     public static final int  READER_MAX_POSTS_TO_DISPLAY        = 200;      // max # posts to display
+    /**
+     * <p>
+     * NOTE : if you are changing this constant make sure you remove all comments from database
+     * otherwise their will be inconsistency in page number of previous loaded comments
+     * </p>
+     * @see org.wordpress.android.datasets.ReaderCommentTable#COMMENTS_PER_PAGE
+     */
     public static final int  READER_MAX_COMMENTS_TO_REQUEST     = 20;       // max # top-level comments to request when updating comments
     public static final int  READER_MAX_USERS_TO_DISPLAY        = 500;      // max # users to show in ReaderUserListActivity
     public static final long READER_AUTO_UPDATE_DELAY_MINUTES   = 10;       // 10 minute delay between automatic updates

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -467,7 +467,19 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
             int numLocalComments = ReaderCommentTable.getNumCommentsForPost(mPost);
             tmpMoreCommentsExist = (numServerComments > numLocalComments);
 
-            tmpComments = ReaderCommentTable.getCommentsForPost(mPost,mCommentsOrder);
+            int lastPageNumber;
+            switch (mCommentsOrder){
+                case ReaderCommentTable.ORDER_BY_NEWEST_COMMENT_FIRST:
+                    lastPageNumber = ReaderCommentTable.getLastNotLoadedPage(mPost.blogId, mPost.postId, false);
+                    break;
+                case ReaderCommentTable.ORDER_BY_TIME_OF_COMMENT:
+                    lastPageNumber = ReaderCommentTable.getFirstNotLoadedPage(mPost.blogId, mPost.postId);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown mCommentsOrder");
+            }
+
+            tmpComments = ReaderCommentTable.getCommentsForPost(mPost, mCommentsOrder, lastPageNumber);
             return !mComments.isSameList(tmpComments);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -73,6 +73,8 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
     private ReaderInterfaces.DataLoadedListener mDataLoadedListener;
     private ReaderActions.DataRequestedListener mDataRequestedListener;
 
+    private int mCommentsOrder = ReaderCommentTable.ORDER_BY_DEFAULT;
+
     class CommentHolder extends RecyclerView.ViewHolder {
         private final ViewGroup container;
         private final TextView txtAuthor;
@@ -120,8 +122,10 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         }
     }
 
-    public ReaderCommentAdapter(Context context, ReaderPost post) {
+    public ReaderCommentAdapter(Context context, ReaderPost post,
+                                @ReaderCommentTable.CommentsOrderBy int commentsOrder) {
         mPost = post;
+        mCommentsOrder = commentsOrder;
         mIsPrivatePost = (post != null && post.isPrivate);
         mIsLoggedOutReader = ReaderUtils.isLoggedOutReader();
 
@@ -463,7 +467,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
             int numLocalComments = ReaderCommentTable.getNumCommentsForPost(mPost);
             tmpMoreCommentsExist = (numServerComments > numLocalComments);
 
-            tmpComments = ReaderCommentTable.getCommentsForPost(mPost);
+            tmpComments = ReaderCommentTable.getCommentsForPost(mPost,mCommentsOrder);
             return !mComments.isSameList(tmpComments);
         }
 
@@ -492,5 +496,25 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
             notifyItemChanged(0); //notify header to update itself
         }
 
+    }
+
+    public void setCommentsOrder(@ReaderCommentTable.CommentsOrderBy int commentsOrder,
+                                 boolean loadCommentsFromDb){
+        if(mCommentsOrder == commentsOrder){
+            return;
+        }
+
+        mCommentsOrder = commentsOrder;
+
+        clearData();
+        if(loadCommentsFromDb){
+            refreshComments();
+        }
+    }
+
+    private void clearData(){
+        int numOfComments = mComments.size();
+        mComments.clear();
+        notifyItemRangeRemoved(NUM_HEADERS,numOfComments);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderCommentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderCommentService.java
@@ -104,7 +104,7 @@ public class ReaderCommentService extends Service {
 
         if(requestNextPage){
             if( commentsOrder == ReaderCommentTable.ORDER_BY_NEWEST_COMMENT_FIRST ){
-                currentPage = ReaderCommentTable.getLastNotLoadedPage(blogId, postId, COMMENTS_PER_PAGE);
+                currentPage = ReaderCommentTable.getLastNotLoadedPage(blogId, postId, COMMENTS_PER_PAGE, true);
             }else if(commentsOrder == ReaderCommentTable.ORDER_BY_TIME_OF_COMMENT){
                 currentPage = ReaderCommentTable.getFirstNotLoadedPage(blogId, postId, COMMENTS_PER_PAGE);
             }else{
@@ -114,8 +114,12 @@ public class ReaderCommentService extends Service {
             currentPage = 1;
         }
 
-        if(currentPage <= 0){
+        if( currentPage < 0 ){
+            //all pages are loaded
             return START_NOT_STICKY;
+        }else if( currentPage == 0 ){
+            //no any comment is loaded yet
+            currentPage = 1;
         }
 
         updateCommentsForPost(blogId, postId, currentPage, commentsOrder, new UpdateResultListener() {
@@ -129,9 +133,9 @@ public class ReaderCommentService extends Service {
                         // Comment not found yet, request the next page
                         int nextPage;
                         if(commentsOrder == ReaderCommentTable.ORDER_BY_NEWEST_COMMENT_FIRST){
-                            nextPage = ReaderCommentTable.getLastNotLoadedPage(blogId,postId,COMMENTS_PER_PAGE);
+                            nextPage = ReaderCommentTable.getLastNotLoadedPage(blogId, postId, COMMENTS_PER_PAGE, true);
                         }else{
-                            nextPage = ReaderCommentTable.getFirstNotLoadedPage(blogId,postId,COMMENTS_PER_PAGE);
+                            nextPage = ReaderCommentTable.getFirstNotLoadedPage(blogId, postId, COMMENTS_PER_PAGE);
                         }
 
                         updateCommentsForPost(blogId, postId, nextPage , commentsOrder, this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderCommentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderCommentService.java
@@ -30,8 +30,6 @@ import de.greenrobot.event.EventBus;
 
 public class ReaderCommentService extends Service {
 
-    public static final int COMMENTS_PER_PAGE = ReaderConstants.READER_MAX_COMMENTS_TO_REQUEST;
-
     private static final String ARG_POST_ID     = "post_id";
     private static final String ARG_BLOG_ID     = "blog_id";
     private static final String ARG_COMMENT_ID  = "comment_id";
@@ -104,9 +102,9 @@ public class ReaderCommentService extends Service {
 
         if(requestNextPage){
             if( commentsOrder == ReaderCommentTable.ORDER_BY_NEWEST_COMMENT_FIRST ){
-                currentPage = ReaderCommentTable.getLastNotLoadedPage(blogId, postId, COMMENTS_PER_PAGE, true);
+                currentPage = ReaderCommentTable.getLastNotLoadedPage(blogId, postId, true);
             }else if(commentsOrder == ReaderCommentTable.ORDER_BY_TIME_OF_COMMENT){
-                currentPage = ReaderCommentTable.getFirstNotLoadedPage(blogId, postId, COMMENTS_PER_PAGE);
+                currentPage = ReaderCommentTable.getFirstNotLoadedPage(blogId, postId);
             }else{
                 throw new IllegalArgumentException("Unknown commentsOrder");
             }
@@ -133,9 +131,9 @@ public class ReaderCommentService extends Service {
                         // Comment not found yet, request the next page
                         int nextPage;
                         if(commentsOrder == ReaderCommentTable.ORDER_BY_NEWEST_COMMENT_FIRST){
-                            nextPage = ReaderCommentTable.getLastNotLoadedPage(blogId, postId, COMMENTS_PER_PAGE, true);
+                            nextPage = ReaderCommentTable.getLastNotLoadedPage(blogId, postId, true);
                         }else{
-                            nextPage = ReaderCommentTable.getFirstNotLoadedPage(blogId, postId, COMMENTS_PER_PAGE);
+                            nextPage = ReaderCommentTable.getFirstNotLoadedPage(blogId, postId);
                         }
 
                         updateCommentsForPost(blogId, postId, nextPage , commentsOrder, this);
@@ -156,7 +154,7 @@ public class ReaderCommentService extends Service {
                                               final int commentOrder,
                                               final ReaderActions.UpdateResultListener resultListener) {
         String path = "sites/" + blogId + "/posts/" + postId + "/replies/"
-                    + "?number=" + Integer.toString(COMMENTS_PER_PAGE)
+                    + "?number=" + Integer.toString(ReaderConstants.READER_MAX_COMMENTS_TO_REQUEST)
                     + "&meta=likes"
                     + "&hierarchical=true"
                     + "&page=" + pageNumber;
@@ -215,9 +213,10 @@ public class ReaderCommentService extends Service {
 
                             if( commentOrder == ReaderCommentTable.ORDER_BY_NEWEST_COMMENT_FIRST ){
                                 //calculate forward page number of comment
-                                int commentIndex = ( pageNumber - 1 )*COMMENTS_PER_PAGE + i;
+                                int commentIndex = ( pageNumber - 1 )*ReaderCommentTable.COMMENTS_PER_PAGE + i;
                                 int forwardCommentIndex = commentsFound - commentIndex;
-                                comment.pageNumber = ( forwardCommentIndex + COMMENTS_PER_PAGE - 1 )/COMMENTS_PER_PAGE;
+                                comment.pageNumber = ( forwardCommentIndex + ReaderCommentTable.COMMENTS_PER_PAGE - 1 )/
+                                                            ReaderCommentTable.COMMENTS_PER_PAGE;
                             }else {
                                 comment.pageNumber = pageNumber;
                             }

--- a/WordPress/src/main/res/menu/reader_comments_list.xml
+++ b/WordPress/src/main/res/menu/reader_comments_list.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/menu_newest_comments_first"
+        android:title="@string/newest_comments_first"
+        android:checkable="true" />
+
+</menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -311,6 +311,8 @@
     <string name="mnu_comment_delete_permanently">Delete</string>
     <string name="mnu_comment_liked">Liked</string>
 
+    <string name="newest_comments_first">Newest Comments First</string>
+
     <!-- comment dialogs - must be worded to work for moderation of single/multiple comments -->
     <string name="dlg_approving_comments">Approving</string>
     <string name="dlg_unapproving_comments">Unapproving</string>


### PR DESCRIPTION
Fixes #4387 

To test:
1. Go to Followed Sites in Reader Tab on MainActivity
2. Tap on number of comments in any post
3. comments are ordered from newest to oldest by default
4. you can also change the ordering from option menu item checkbox

Needs review:
newest_comment_first menu in ReaderCommentListActivity
ReaderCommentService can load comments from newest to oldest

![screenshot_2016-07-20-15-06-52_org wordpress android](https://cloud.githubusercontent.com/assets/8322032/16982208/48258450-4e8c-11e6-9eb3-33d963bd37f1.png)