### PR TITLE
Update follow and following icons

### DIFF
--- a/WordPress/src/main/res/drawable/reader_follow.xml
+++ b/WordPress/src/main/res/drawable/reader_follow.xml
@@ -2,12 +2,12 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:height="@dimen/reader_button_icon"
     android:width="@dimen/reader_button_icon"
-    android:viewportHeight="512.0"
-    android:viewportWidth="512.0" >
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
 
     <path
         android:fillColor="@color/reader_follow"
-        android:pathData="M490.7,341.3V384h-64v64H384v-64h-64v-42.7h64v-64h42.7v64H490.7zM426.7,42.7v192h-85.3v64h-64V384h-192c-23.5,0 -42.7,-19.2 -42.7,-42.7V42.7H426.7zM170.7,277.3V256H85.3v21.3H170.7zM234.7,213.3H85.3v21.3h149.3V213.3zM234.7,170.7H85.3V192h149.3V170.7zM384,85.3H85.3V128H384V85.3z" >
+        android:pathData="M23,19v2h-3v3h-2v-3h-3v-2h3v-3h2v3H23zM20,5v9h-4v3h-3v4H4c-1.1,0 -2,-0.9 -2,-2V5H20zM8,16v-1H4v1H8zM11,13H4v1h7V13zM11,11H4v1h7V11zM18,7H4v2h14V7z" >
     </path>
 
 </vector>

--- a/WordPress/src/main/res/drawable/reader_following.xml
+++ b/WordPress/src/main/res/drawable/reader_following.xml
@@ -2,12 +2,12 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:height="@dimen/reader_button_icon"
     android:width="@dimen/reader_button_icon"
-    android:viewportHeight="512.0"
-    android:viewportWidth="512.0" >
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
 
     <path
         android:fillColor="@color/reader_following"
-        android:pathData="M490.7,287.6L330.8,448L256,371.2l30.1,-29.6l44.9,46.7l130,-130L490.7,287.6zM331.6,327.3l95,-95V42.7h-384v298.7c0,23.5 19.2,42.7 42.7,42.7h96.8L287,280.9L331.6,327.3zM170.7,277.3H85.3V256h85.3V277.3zM234.7,234.7H85.3v-21.3h149.3V234.7zM234.7,192H85.3v-21.3h149.3V192zM384,128H85.3V85.3H384V128z" >
+        android:pathData="M23,16.5L15.5,24L12,20.4l1.4,-1.4l2.1,2.2l6.1,-6.1L23,16.5zM15.5,18.3l4.5,-4.5V5H2v14c0,1.1 0.9,2 2,2h4.5l4.9,-4.8L15.5,18.3zM8,16H4v-1h4V16zM11,14H4v-1h7V14zM11,12H4v-1h7V12zM18,9H4V7h14V9z" >
     </path>
 
 </vector>


### PR DESCRIPTION
### Fix
Update icons for Follow and Following buttons with new images which remove bottom padding as described in https://github.com/wordpress-mobile/WordPress-Android/issues/4354.

### Test
<ol><b>Follow</b>
<li>Go to Reader tab.</li>
<li>Tap Search action.</li>
<li>Enter random word.</li>
<li>Tap unfollowed site.</li>
<li>Notice Follow icon and color.</li>
</ol>

<ol><b>Following</b>
<li>Go to Reader tab.</li>
<li>Choose Followed Sites from the dropdown list.</li>
<li>Tap first post in list.</li>
<li>Notice Following icon and color.</li>
</ol>