### PR TITLE
No X mark for long usernames in invite people field

### DIFF
--- a/WordPress/src/main/res/layout/invite_username_button.xml
+++ b/WordPress/src/main/res/layout/invite_username_button.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:paddingLeft="6dp"
-    android:paddingRight="12dp">
+    android:paddingRight="12dp"
+    android:paddingTop="@dimen/margin_large">
 
     <TextView
         android:id="@+id/username"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:layout_gravity="center_vertical"
         android:layout_marginRight="5dp"
-        android:paddingTop="@dimen/margin_large"
         android:gravity="center_vertical"
         android:textColor="@color/grey_dark"
         android:textSize="@dimen/text_sz_medium"/>
@@ -19,10 +21,7 @@
         android:id="@+id/username_delete"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_toRightOf="@+id/username"
-        android:paddingTop="@dimen/margin_large"
-        android:layout_alignTop="@+id/username"
-        android:layout_alignBottom="@+id/username"
+        android:layout_gravity="top"
         android:src="@drawable/ic_close_grey600_24dp"
         android:background="?attr/selectableItemBackgroundBorderless"/>
-</RelativeLayout>
+</LinearLayout>


### PR DESCRIPTION
Fixes #4369 

To test: Add the long username to invite text field.

Needs review: @khaykov 

![screenshot_2016-07-21-23-05-26_org wordpress android](https://cloud.githubusercontent.com/assets/8322032/17032882/22b92966-4f99-11e6-93ee-4c0a6cbfa7c2.png)
