### PR TITLE
Issue/4404 reader layout differences

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -17,6 +17,8 @@ public class ReaderConstants {
 
     public static final String HTTP_REFERER_URL = "https://wordpress.com";  // referrer url for reader posts opened in a browser
 
+    public static final String UNICODE_BULLET_WITH_SPACE = " \u2022 ";
+
     // intent arguments / keys
     static final String ARG_TAG               = "tag";
     static final String ARG_BLOG_ID           = "blog_id";

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -908,7 +908,7 @@ public class ReaderPostDetailFragment extends Fragment
             if (mPost.hasAuthorName()) {
                 txtDateline.setText(mPost.getAuthorName() + ReaderConstants.UNICODE_BULLET_WITH_SPACE + timestamp);
             } else if (mPost.hasBlogName()) {
-                txtDateline.setText(mPost.getBlogName() +  ReaderConstants.UNICODE_BULLET_WITH_SPACE + timestamp);
+                txtDateline.setText(mPost.getBlogName() + ReaderConstants.UNICODE_BULLET_WITH_SPACE + timestamp);
             } else {
                 txtDateline.setText(timestamp);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -888,8 +888,10 @@ public class ReaderPostDetailFragment extends Fragment
             if (mPost.hasBlogUrl()) {
                 String imageUrl = GravatarUtils.blavatarFromUrl(mPost.getBlogUrl(), avatarSz);
                 imgAvatar.setImageUrl(imageUrl, WPNetworkImageView.ImageType.BLAVATAR);
+                txtDomain.setText(UrlUtils.getHost(mPost.getBlogUrl()));
             } else {
                 imgAvatar.setImageUrl(mPost.getPostAvatarForDisplay(avatarSz), WPNetworkImageView.ImageType.AVATAR);
+                txtDomain.setText(null);
             }
 
             if (mPost.hasAuthorName()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -832,9 +832,11 @@ public class ReaderPostDetailFragment extends Fragment
             TextView txtDateline = (TextView) getView().findViewById(R.id.text_dateline);
             TextView txtTag = (TextView) getView().findViewById(R.id.text_tag);
 
+            WPNetworkImageView imgBlavatar = (WPNetworkImageView) getView().findViewById(R.id.image_blavatar);
+            WPNetworkImageView imgAvatar = (WPNetworkImageView) getView().findViewById(R.id.image_avatar);
+
             ViewGroup layoutHeader = (ViewGroup) getView().findViewById(R.id.layout_post_detail_header);
             ReaderFollowButton followButton = (ReaderFollowButton) layoutHeader.findViewById(R.id.follow_button);
-            WPNetworkImageView imgBlavatar = (WPNetworkImageView) getView().findViewById(R.id.image_blavatar);
 
             if (!canShowFooter()) {
                 mLayoutFooter.setVisibility(View.GONE);
@@ -892,6 +894,14 @@ public class ReaderPostDetailFragment extends Fragment
             } else {
                 imgBlavatar.showDefaultBlavatarImage();
                 txtDomain.setText(null);
+            }
+
+            if (mPost.hasPostAvatar()) {
+                int avatarSz = getResources().getDimensionPixelSize(R.dimen.avatar_sz_tiny);
+                imgAvatar.setVisibility(View.VISIBLE);
+                imgAvatar.setImageUrl(mPost.getPostAvatarForDisplay(avatarSz), WPNetworkImageView.ImageType.AVATAR);
+            } else {
+                imgAvatar.setVisibility(View.GONE);
             }
 
             String timestamp = DateTimeUtils.javaDateToTimeSpan(mPost.getDatePublished());

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -903,7 +903,9 @@ public class ReaderPostDetailFragment extends Fragment
 
             String dateLine;
             if (mPost.hasBlogUrl()) {
-                dateLine = UrlUtils.getHost(mPost.getBlogUrl()) + " \u2022 " + DateTimeUtils.javaDateToTimeSpan(mPost.getDatePublished());
+                dateLine = UrlUtils.getHost(mPost.getBlogUrl())
+                        + ReaderConstants.UNICODE_BULLET_WITH_SPACE
+                        + DateTimeUtils.javaDateToTimeSpan(mPost.getDatePublished());
             } else {
                 dateLine = DateTimeUtils.javaDateToTimeSpan(mPost.getDatePublished());
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -829,7 +829,7 @@ public class ReaderPostDetailFragment extends Fragment
             TextView txtTitle = (TextView) getView().findViewById(R.id.text_title);
             TextView txtBlogName = (TextView) getView().findViewById(R.id.text_blog_name);
             TextView txtAuthor = (TextView) getView().findViewById(R.id.text_author);
-            TextView txtDateLine = (TextView) getView().findViewById(R.id.text_dateline);
+            TextView txtDomain = (TextView) getView().findViewById(R.id.text_domain);
             TextView txtTag = (TextView) getView().findViewById(R.id.text_tag);
 
             ViewGroup layoutHeader = (ViewGroup) getView().findViewById(R.id.layout_post_detail_header);
@@ -878,12 +878,10 @@ public class ReaderPostDetailFragment extends Fragment
 
             if (mPost.hasBlogName()) {
                 txtBlogName.setText(mPost.getBlogName());
-                txtBlogName.setVisibility(View.VISIBLE);
-            } else if (mPost.hasBlogUrl()) {
-                txtBlogName.setText(UrlUtils.getHost(mPost.getBlogUrl()));
-                txtBlogName.setVisibility(View.VISIBLE);
+            } else if (mPost.hasAuthorName()) {
+                txtBlogName.setText(mPost.getAuthorName());
             } else {
-                txtBlogName.setVisibility(View.GONE);
+                txtBlogName.setText(null);
             }
 
             int avatarSz = getResources().getDimensionPixelSize(R.dimen.avatar_sz_medium);
@@ -907,7 +905,7 @@ public class ReaderPostDetailFragment extends Fragment
             } else {
                 dateLine = DateTimeUtils.javaDateToTimeSpan(mPost.getDatePublished());
             }
-            txtDateLine.setText(dateLine);
+            //txtDateLine.setText(dateLine); // TODO
 
             final String tagToDisplay = mPost.getTagForDisplay(null);
             if (!TextUtils.isEmpty(tagToDisplay)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -828,8 +828,8 @@ public class ReaderPostDetailFragment extends Fragment
 
             TextView txtTitle = (TextView) getView().findViewById(R.id.text_title);
             TextView txtBlogName = (TextView) getView().findViewById(R.id.text_blog_name);
-            TextView txtAuthor = (TextView) getView().findViewById(R.id.text_author);
             TextView txtDomain = (TextView) getView().findViewById(R.id.text_domain);
+            TextView txtDateline = (TextView) getView().findViewById(R.id.text_dateline);
             TextView txtTag = (TextView) getView().findViewById(R.id.text_tag);
 
             ViewGroup layoutHeader = (ViewGroup) getView().findViewById(R.id.layout_post_detail_header);
@@ -894,22 +894,14 @@ public class ReaderPostDetailFragment extends Fragment
                 txtDomain.setText(null);
             }
 
+            String timestamp = DateTimeUtils.javaDateToTimeSpan(mPost.getDatePublished());
             if (mPost.hasAuthorName()) {
-                txtAuthor.setText(mPost.getAuthorName());
-                txtAuthor.setVisibility(View.VISIBLE);
+                txtDateline.setText(mPost.getAuthorName() + ReaderConstants.UNICODE_BULLET_WITH_SPACE + timestamp);
+            } else if (mPost.hasBlogName()) {
+                txtDateline.setText(mPost.getBlogName() +  ReaderConstants.UNICODE_BULLET_WITH_SPACE + timestamp);
             } else {
-                txtAuthor.setVisibility(View.GONE);
+                txtDateline.setText(timestamp);
             }
-
-            String dateLine;
-            if (mPost.hasBlogUrl()) {
-                dateLine = UrlUtils.getHost(mPost.getBlogUrl())
-                        + ReaderConstants.UNICODE_BULLET_WITH_SPACE
-                        + DateTimeUtils.javaDateToTimeSpan(mPost.getDatePublished());
-            } else {
-                dateLine = DateTimeUtils.javaDateToTimeSpan(mPost.getDatePublished());
-            }
-            //txtDateLine.setText(dateLine); // TODO
 
             final String tagToDisplay = mPost.getTagForDisplay(null);
             if (!TextUtils.isEmpty(tagToDisplay)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -834,7 +834,7 @@ public class ReaderPostDetailFragment extends Fragment
 
             ViewGroup layoutHeader = (ViewGroup) getView().findViewById(R.id.layout_post_detail_header);
             ReaderFollowButton followButton = (ReaderFollowButton) layoutHeader.findViewById(R.id.follow_button);
-            WPNetworkImageView imgAvatar = (WPNetworkImageView) getView().findViewById(R.id.image_avatar);
+            WPNetworkImageView imgBlavatar = (WPNetworkImageView) getView().findViewById(R.id.image_blavatar);
 
             if (!canShowFooter()) {
                 mLayoutFooter.setVisibility(View.GONE);
@@ -884,13 +884,13 @@ public class ReaderPostDetailFragment extends Fragment
                 txtBlogName.setText(null);
             }
 
-            int avatarSz = getResources().getDimensionPixelSize(R.dimen.avatar_sz_medium);
             if (mPost.hasBlogUrl()) {
-                String imageUrl = GravatarUtils.blavatarFromUrl(mPost.getBlogUrl(), avatarSz);
-                imgAvatar.setImageUrl(imageUrl, WPNetworkImageView.ImageType.BLAVATAR);
+                int blavatarSz = getResources().getDimensionPixelSize(R.dimen.avatar_sz_medium);
+                String imageUrl = GravatarUtils.blavatarFromUrl(mPost.getBlogUrl(), blavatarSz);
+                imgBlavatar.setImageUrl(imageUrl, WPNetworkImageView.ImageType.BLAVATAR);
                 txtDomain.setText(UrlUtils.getHost(mPost.getBlogUrl()));
             } else {
-                imgAvatar.setImageUrl(mPost.getPostAvatarForDisplay(avatarSz), WPNetworkImageView.ImageType.AVATAR);
+                imgBlavatar.showDefaultBlavatarImage();
                 txtDomain.setText(null);
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -898,10 +898,9 @@ public class ReaderPostDetailFragment extends Fragment
 
             if (mPost.hasPostAvatar()) {
                 int avatarSz = getResources().getDimensionPixelSize(R.dimen.avatar_sz_tiny);
-                imgAvatar.setVisibility(View.VISIBLE);
                 imgAvatar.setImageUrl(mPost.getPostAvatarForDisplay(avatarSz), WPNetworkImageView.ImageType.AVATAR);
             } else {
-                imgAvatar.setVisibility(View.GONE);
+                imgAvatar.showDefaultGravatarImage();
             }
 
             String timestamp = DateTimeUtils.javaDateToTimeSpan(mPost.getDatePublished());

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -129,6 +129,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         private final WPNetworkImageView imgFeatured;
         private final WPNetworkImageView imgAvatar;
+        private final WPNetworkImageView imgBlavatar;
 
         private final ViewGroup layoutPostHeader;
 
@@ -155,6 +156,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             likeCount = (ReaderIconCountView) itemView.findViewById(R.id.count_likes);
 
             imgFeatured = (WPNetworkImageView) itemView.findViewById(R.id.image_featured);
+            imgBlavatar = (WPNetworkImageView) itemView.findViewById(R.id.image_blavatar);
             imgAvatar = (WPNetworkImageView) itemView.findViewById(R.id.image_avatar);
             imgMore = (ImageView) itemView.findViewById(R.id.image_more);
 
@@ -321,6 +323,13 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             holder.txtDateline.setText(timestamp);
         }
 
+        if (post.hasPostAvatar()) {
+            holder.imgAvatar.setImageUrl(
+                    post.getPostAvatarForDisplay(mAvatarSzSmall), WPNetworkImageView.ImageType.AVATAR);
+        } else {
+            holder.imgAvatar.showDefaultGravatarImage();
+        }
+
         if (!isBlogPreview()) {
             // show blog preview when post header is tapped
             holder.layoutPostHeader.setOnClickListener(new View.OnClickListener() {
@@ -333,10 +342,10 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         if (post.hasBlogUrl()) {
             String imageUrl = GravatarUtils.blavatarFromUrl(post.getBlogUrl(), mAvatarSzMedium);
-            holder.imgAvatar.setImageUrl(imageUrl, WPNetworkImageView.ImageType.BLAVATAR);
+            holder.imgBlavatar.setImageUrl(imageUrl, WPNetworkImageView.ImageType.BLAVATAR);
             holder.txtDomain.setText(UrlUtils.getHost(post.getBlogUrl()));
         } else {
-            holder.imgAvatar.setImageUrl(post.getPostAvatarForDisplay(mAvatarSzMedium), WPNetworkImageView.ImageType.AVATAR);
+            holder.imgBlavatar.showDefaultBlavatarImage();
             holder.txtDomain.setText(null);
         }
         if (post.hasBlogName()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -41,6 +41,7 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
 public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
@@ -116,6 +117,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         private final TextView txtTitle;
         private final TextView txtText;
         private final TextView txtBlogName;
+        private final TextView txtDomain;
         private final TextView txtDateline;
         private final TextView txtTag;
         private final TextView txtWordCount;
@@ -144,6 +146,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             txtTitle = (TextView) itemView.findViewById(R.id.text_title);
             txtText = (TextView) itemView.findViewById(R.id.text_excerpt);
             txtBlogName = (TextView) itemView.findViewById(R.id.text_blog_name);
+            txtDomain = (TextView) itemView.findViewById(R.id.text_domain);
             txtDateline = (TextView) itemView.findViewById(R.id.text_dateline);
             txtTag = (TextView) itemView.findViewById(R.id.text_tag);
             txtWordCount = (TextView) itemView.findViewById(R.id.text_word_count);
@@ -331,8 +334,10 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         if (post.hasBlogUrl()) {
             String imageUrl = GravatarUtils.blavatarFromUrl(post.getUrl(), mAvatarSzMedium);
             holder.imgAvatar.setImageUrl(imageUrl, WPNetworkImageView.ImageType.BLAVATAR);
+            holder.txtDomain.setText(UrlUtils.getHost(post.getBlogUrl()));
         } else {
             holder.imgAvatar.setImageUrl(post.getPostAvatarForDisplay(mAvatarSzMedium), WPNetworkImageView.ImageType.AVATAR);
+            holder.txtDomain.setText(null);
         }
         if (post.hasBlogName()) {
             holder.txtBlogName.setText(post.getBlogName());

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -325,11 +325,10 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
 
         if (post.hasPostAvatar()) {
-            holder.imgAvatar.setVisibility(View.VISIBLE);
             holder.imgAvatar.setImageUrl(
                     post.getPostAvatarForDisplay(mAvatarSzTiny), WPNetworkImageView.ImageType.AVATAR);
         } else {
-            holder.imgAvatar.setVisibility(View.GONE);
+            holder.imgAvatar.showDefaultGravatarImage();
         }
 
         if (!isBlogPreview()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -333,7 +333,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
 
         if (post.hasBlogUrl()) {
-            String imageUrl = GravatarUtils.blavatarFromUrl(post.getUrl(), mAvatarSzMedium);
+            String imageUrl = GravatarUtils.blavatarFromUrl(post.getBlogUrl(), mAvatarSzMedium);
             holder.imgAvatar.setImageUrl(imageUrl, WPNetworkImageView.ImageType.BLAVATAR);
             holder.txtDomain.setText(UrlUtils.getHost(post.getBlogUrl()));
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -306,20 +306,21 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         checkLoadMore(position);
     }
 
+    private static final String UNICODE_BULLET_WITH_SPACE = " \u2022 ";
     private void renderPost(int position, ReaderPostViewHolder holder) {
         final ReaderPost post = getItem(position);
         ReaderTypes.ReaderPostListType postListType = getPostListType();
 
         holder.txtTitle.setText(post.getTitle());
 
-        // dateline includes author name if different than blog name
-        String dateLine;
-        if (post.hasAuthorName() && !post.getAuthorName().equalsIgnoreCase(post.getBlogName())) {
-            dateLine = post.getAuthorName() + " \u2022 " + DateTimeUtils.javaDateToTimeSpan(post.getDatePublished());
+        String timestamp = DateTimeUtils.javaDateToTimeSpan(post.getDatePublished());
+        if (post.hasAuthorName()) {
+            holder.txtDateline.setText(post.getAuthorName() + UNICODE_BULLET_WITH_SPACE + timestamp);
+        } else if (post.hasBlogName()) {
+            holder.txtDateline.setText(post.getBlogName() + UNICODE_BULLET_WITH_SPACE + timestamp);
         } else {
-            dateLine = DateTimeUtils.javaDateToTimeSpan(post.getDatePublished());
+            holder.txtDateline.setText(timestamp);
         }
-        holder.txtDateline.setText(dateLine);
 
         if (!isBlogPreview()) {
             // show blog preview when post header is tapped

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -116,10 +116,9 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         private final TextView txtTitle;
         private final TextView txtText;
         private final TextView txtBlogName;
-        private final TextView txtDate;
+        private final TextView txtDateline;
         private final TextView txtTag;
         private final TextView txtWordCount;
-        private final TextView txtDateBelowTitle;
 
         private final ReaderIconCountView commentCount;
         private final ReaderIconCountView likeCount;
@@ -145,10 +144,9 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             txtTitle = (TextView) itemView.findViewById(R.id.text_title);
             txtText = (TextView) itemView.findViewById(R.id.text_excerpt);
             txtBlogName = (TextView) itemView.findViewById(R.id.text_blog_name);
-            txtDate = (TextView) itemView.findViewById(R.id.text_date);
+            txtDateline = (TextView) itemView.findViewById(R.id.text_dateline);
             txtTag = (TextView) itemView.findViewById(R.id.text_tag);
             txtWordCount = (TextView) itemView.findViewById(R.id.text_word_count);
-            txtDateBelowTitle = (TextView) itemView.findViewById(R.id.text_date_below_title);
 
             commentCount = (ReaderIconCountView) itemView.findViewById(R.id.count_comments);
             likeCount = (ReaderIconCountView) itemView.findViewById(R.id.count_likes);
@@ -184,8 +182,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                         txtTitle.getPaddingTop() + extraPadding,
                         txtTitle.getPaddingRight(),
                         txtTitle.getPaddingBottom());
-                // show the dateline that appears below the title (hidden in layout)
-                txtDateBelowTitle.setVisibility(View.VISIBLE);
             }
 
             ReaderUtils.setBackgroundToRoundRipple(imgMore);
@@ -320,11 +316,9 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         } else {
             dateLine = DateTimeUtils.javaDateToTimeSpan(post.getDatePublished());
         }
+        holder.txtDateline.setText(dateLine);
 
-        // when post header is visible (which it shouldn't be for blog preview), the dateline
-        // appears within it - otherwise a separate dateline appears below the title
         if (!isBlogPreview()) {
-            holder.txtDate.setText(dateLine);
             // show blog preview when post header is tapped
             holder.layoutPostHeader.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -332,8 +326,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                     ReaderActivityLauncher.showReaderBlogPreview(view.getContext(), post);
                 }
             });
-        } else {
-            holder.txtDateBelowTitle.setText(dateLine);
         }
 
         if (post.hasBlogUrl()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -319,7 +319,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         if (post.hasAuthorName()) {
             holder.txtDateline.setText(post.getAuthorName() + ReaderConstants.UNICODE_BULLET_WITH_SPACE + timestamp);
         } else if (post.hasBlogName()) {
-            holder.txtDateline.setText(post.getBlogName() +  ReaderConstants.UNICODE_BULLET_WITH_SPACE + timestamp);
+            holder.txtDateline.setText(post.getBlogName() + ReaderConstants.UNICODE_BULLET_WITH_SPACE + timestamp);
         } else {
             holder.txtDateline.setText(timestamp);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -306,7 +306,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         checkLoadMore(position);
     }
 
-    private static final String UNICODE_BULLET_WITH_SPACE = " \u2022 ";
     private void renderPost(int position, ReaderPostViewHolder holder) {
         final ReaderPost post = getItem(position);
         ReaderTypes.ReaderPostListType postListType = getPostListType();
@@ -315,9 +314,9 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         String timestamp = DateTimeUtils.javaDateToTimeSpan(post.getDatePublished());
         if (post.hasAuthorName()) {
-            holder.txtDateline.setText(post.getAuthorName() + UNICODE_BULLET_WITH_SPACE + timestamp);
+            holder.txtDateline.setText(post.getAuthorName() + ReaderConstants.UNICODE_BULLET_WITH_SPACE + timestamp);
         } else if (post.hasBlogName()) {
-            holder.txtDateline.setText(post.getBlogName() + UNICODE_BULLET_WITH_SPACE + timestamp);
+            holder.txtDateline.setText(post.getBlogName() +  ReaderConstants.UNICODE_BULLET_WITH_SPACE + timestamp);
         } else {
             holder.txtDateline.setText(timestamp);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -54,6 +54,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private final int mPhotonHeight;
     private final int mAvatarSzMedium;
     private final int mAvatarSzSmall;
+    private final int mAvatarSzExtraSmall;
     private final int mMarginLarge;
 
     private final String mWordCountFmtStr;
@@ -324,10 +325,11 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
 
         if (post.hasPostAvatar()) {
+            holder.imgAvatar.setVisibility(View.VISIBLE);
             holder.imgAvatar.setImageUrl(
-                    post.getPostAvatarForDisplay(mAvatarSzSmall), WPNetworkImageView.ImageType.AVATAR);
+                    post.getPostAvatarForDisplay(mAvatarSzExtraSmall), WPNetworkImageView.ImageType.AVATAR);
         } else {
-            holder.imgAvatar.showDefaultGravatarImage();
+            holder.imgAvatar.setVisibility(View.GONE);
         }
 
         if (!isBlogPreview()) {
@@ -539,6 +541,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         mPostListType = postListType;
         mAvatarSzMedium = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_medium);
         mAvatarSzSmall = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_small);
+        mAvatarSzExtraSmall = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_extra_small);
         mMarginLarge = context.getResources().getDimensionPixelSize(R.dimen.margin_large);
         mIsLoggedOutReader = ReaderUtils.isLoggedOutReader();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -54,7 +54,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private final int mPhotonHeight;
     private final int mAvatarSzMedium;
     private final int mAvatarSzSmall;
-    private final int mAvatarSzExtraSmall;
+    private final int mAvatarSzTiny;
     private final int mMarginLarge;
 
     private final String mWordCountFmtStr;
@@ -327,7 +327,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         if (post.hasPostAvatar()) {
             holder.imgAvatar.setVisibility(View.VISIBLE);
             holder.imgAvatar.setImageUrl(
-                    post.getPostAvatarForDisplay(mAvatarSzExtraSmall), WPNetworkImageView.ImageType.AVATAR);
+                    post.getPostAvatarForDisplay(mAvatarSzTiny), WPNetworkImageView.ImageType.AVATAR);
         } else {
             holder.imgAvatar.setVisibility(View.GONE);
         }
@@ -541,7 +541,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         mPostListType = postListType;
         mAvatarSzMedium = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_medium);
         mAvatarSzSmall = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_small);
-        mAvatarSzExtraSmall = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_extra_small);
+        mAvatarSzTiny = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_tiny);
         mMarginLarge = context.getResources().getDimensionPixelSize(R.dimen.margin_large);
         mIsLoggedOutReader = ReaderUtils.isLoggedOutReader();
 

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -107,7 +107,7 @@
 
             <org.wordpress.android.widgets.WPNetworkImageView
                 android:id="@+id/image_avatar"
-                style="@style/ReaderImageView.Avatar.ExtraSmall"
+                style="@style/ReaderImageView.Avatar.Tiny"
                 android:layout_gravity="center_vertical"
                 android:layout_marginRight="@dimen/margin_medium"
                 tools:src="@drawable/gravatar_placeholder" />

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -32,11 +32,11 @@
             android:paddingTop="@dimen/margin_large">
 
             <org.wordpress.android.widgets.WPNetworkImageView
-                android:id="@+id/image_avatar"
+                android:id="@+id/image_blavatar"
                 style="@style/ReaderImageView.Avatar"
                 android:layout_centerVertical="true"
                 android:layout_marginRight="@dimen/margin_large"
-                tools:src="@drawable/gravatar_placeholder" />
+                tools:src="@drawable/blavatar_placeholder" />
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -44,7 +44,7 @@
                 android:layout_centerVertical="true"
                 android:layout_marginRight="@dimen/margin_large"
                 android:layout_toLeftOf="@+id/image_more"
-                android:layout_toRightOf="@+id/image_avatar"
+                android:layout_toRightOf="@+id/image_blavatar"
                 android:orientation="vertical">
 
                 <org.wordpress.android.widgets.WPTextView
@@ -96,15 +96,30 @@
             android:layout_marginTop="@dimen/margin_large"
             tools:text="text_title" />
 
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/text_dateline"
-            style="@style/ReaderTextView.Label"
+        <LinearLayout
+            android:id="@+id/layout_dateline"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/reader_card_content_padding"
             android:layout_marginRight="@dimen/reader_card_content_padding"
             android:layout_marginTop="@dimen/margin_extra_small"
-            tools:text="text_dateline" />
+            android:orientation="horizontal">
+
+            <org.wordpress.android.widgets.WPNetworkImageView
+                android:id="@+id/image_avatar"
+                style="@style/ReaderImageView.Avatar.ExtraSmall"
+                android:layout_gravity="center_vertical"
+                android:layout_marginRight="@dimen/margin_medium"
+                tools:src="@drawable/gravatar_placeholder" />
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/text_dateline"
+                style="@style/ReaderTextView.Label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                tools:text="text_dateline" />
+        </LinearLayout>
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/text_excerpt"

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -59,12 +59,12 @@
                     tools:text="text_blog_name" />
 
                 <org.wordpress.android.widgets.WPTextView
-                    android:id="@+id/text_date"
+                    android:id="@+id/text_domain"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:textColor="@color/grey"
                     android:textSize="@dimen/text_sz_small"
-                    tools:text="text_date" />
+                    tools:text="text_domain" />
             </LinearLayout>
 
             <ImageView
@@ -97,16 +97,14 @@
             tools:text="text_title" />
 
         <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/text_date_below_title"
+            android:id="@+id/text_dateline"
             style="@style/ReaderTextView.Label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/reader_card_content_padding"
             android:layout_marginRight="@dimen/reader_card_content_padding"
             android:layout_marginTop="@dimen/margin_extra_small"
-            android:visibility="gone"
-            tools:text="text_dateline_below_title"
-            tools:visibility="visible" />
+            tools:text="text_dateline" />
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/text_excerpt"

--- a/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
@@ -4,12 +4,12 @@
     included by ReaderPostDetailFragment
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/layout_post_detail_content"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
-    android:paddingTop="@dimen/margin_large" >
+    android:paddingTop="@dimen/margin_large">
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/text_title"
@@ -18,23 +18,38 @@
         android:layout_alignRight="@+id/reader_webview"
         tools:text="text_title" />
 
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/text_dateline"
+
+    <LinearLayout
+        android:id="@+id/layout_dateline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@id/text_title"
         android:layout_alignLeft="@+id/reader_webview"
         android:layout_alignRight="@+id/reader_webview"
-        android:layout_marginTop="@dimen/margin_medium"
-        android:textColor="@color/grey"
-        android:textSize="@dimen/text_sz_medium"
-        tools:text="text_dateline" />
+        android:layout_below="@id/text_title"
+        android:layout_marginTop="@dimen/margin_extra_small"
+        android:orientation="horizontal">
+
+        <org.wordpress.android.widgets.WPNetworkImageView
+            android:id="@+id/image_avatar"
+            style="@style/ReaderImageView.Avatar.Tiny"
+            android:layout_gravity="center_vertical"
+            android:layout_marginRight="@dimen/margin_medium"
+            tools:src="@drawable/gravatar_placeholder" />
+
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/text_dateline"
+            style="@style/ReaderTextView.Label"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            tools:text="text_dateline" />
+    </LinearLayout>
 
     <org.wordpress.android.ui.reader.views.ReaderWebView
         android:id="@+id/reader_webview"
         android:layout_width="@dimen/reader_webview_width"
         android:layout_height="wrap_content"
-        android:layout_below="@id/text_dateline"
+        android:layout_below="@id/layout_dateline"
         android:layout_marginTop="@dimen/margin_large"
         android:scrollbars="none" />
 
@@ -42,10 +57,10 @@
         android:id="@+id/layout_liking_users_divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_below="@id/reader_webview"
-        android:layout_marginTop="@dimen/margin_medium"
         android:layout_alignLeft="@+id/reader_webview"
         android:layout_alignRight="@+id/reader_webview"
+        android:layout_below="@id/reader_webview"
+        android:layout_marginTop="@dimen/margin_medium"
         android:background="@color/reader_divider_grey"
         android:visibility="gone"
         tools:visibility="visible" />
@@ -55,9 +70,9 @@
         android:id="@+id/layout_liking_users_view"
         android:layout_width="match_parent"
         android:layout_height="@dimen/avatar_sz_small"
-        android:layout_below="@id/layout_liking_users_divider"
         android:layout_alignLeft="@+id/reader_webview"
         android:layout_alignRight="@+id/reader_webview"
+        android:layout_below="@id/layout_liking_users_divider"
         android:layout_marginBottom="@dimen/margin_medium"
         android:layout_marginTop="@dimen/margin_medium"
         android:background="?android:selectableItemBackground"

--- a/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
@@ -9,7 +9,7 @@
     android:id="@+id/layout_post_detail_content"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
-    android:paddingTop="@dimen/margin_large">
+    android:paddingTop="@dimen/margin_medium">
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/text_title"
@@ -17,7 +17,6 @@
         android:layout_alignLeft="@+id/reader_webview"
         android:layout_alignRight="@+id/reader_webview"
         tools:text="text_title" />
-
 
     <LinearLayout
         android:id="@+id/layout_dateline"

--- a/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
@@ -19,7 +19,7 @@
         tools:text="text_title" />
 
     <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/text_author"
+        android:id="@+id/text_dateline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@id/text_title"
@@ -28,13 +28,13 @@
         android:layout_marginTop="@dimen/margin_medium"
         android:textColor="@color/grey"
         android:textSize="@dimen/text_sz_medium"
-        tools:text="text_author" />
+        tools:text="text_dateline" />
 
     <org.wordpress.android.ui.reader.views.ReaderWebView
         android:id="@+id/reader_webview"
         android:layout_width="@dimen/reader_webview_width"
         android:layout_height="wrap_content"
-        android:layout_below="@id/text_author"
+        android:layout_below="@id/text_dateline"
         android:layout_marginTop="@dimen/margin_large"
         android:scrollbars="none" />
 

--- a/WordPress/src/main/res/layout/reader_include_post_detail_header.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_header.xml
@@ -39,7 +39,7 @@
             tools:text="text_blog_name" />
 
         <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/text_dateline"
+            android:id="@+id/text_domain"
             style="@style/ReaderTextView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -48,7 +48,7 @@
             android:layout_below="@+id/text_blog_name"
             android:textColor="@color/grey"
             android:textSize="@dimen/text_sz_small"
-            tools:text="text_dateline" />
+            tools:text="text_domain" />
     </LinearLayout>
 
     <org.wordpress.android.ui.reader.views.ReaderFollowButton

--- a/WordPress/src/main/res/layout/reader_include_post_detail_header.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_header.xml
@@ -12,18 +12,18 @@
     android:background="?android:selectableItemBackground">
 
     <org.wordpress.android.widgets.WPNetworkImageView
-        android:id="@+id/image_avatar"
+        android:id="@+id/image_blavatar"
         style="@style/ReaderImageView.Avatar"
         android:layout_centerVertical="true"
         android:layout_marginRight="@dimen/margin_large"
-        tools:src="@drawable/gravatar_placeholder" />
+        tools:src="@drawable/blavatar_placeholder" />
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
         android:layout_toLeftOf="@+id/follow_button"
-        android:layout_toRightOf="@+id/image_avatar"
+        android:layout_toRightOf="@+id/image_blavatar"
         android:orientation="vertical">
 
         <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -105,6 +105,7 @@
     <dimen name="text_sz_double_extra_large">24sp</dimen>
     <dimen name="text_sz_triple_extra_large">26sp</dimen>
 
+    <dimen name="avatar_sz_tiny">18dp</dimen>
     <dimen name="avatar_sz_extra_small">24dp</dimen>
     <dimen name="avatar_sz_small">32dp</dimen>
     <dimen name="avatar_sz_medium">38dp</dimen>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -107,6 +107,10 @@
         <item name="android:layout_width">@dimen/avatar_sz_extra_small</item>
         <item name="android:layout_height">@dimen/avatar_sz_extra_small</item>
     </style>
+    <style name="ReaderImageView.Avatar.Tiny" parent="ReaderImageView">
+        <item name="android:layout_width">@dimen/avatar_sz_tiny</item>
+        <item name="android:layout_height">@dimen/avatar_sz_tiny</item>
+    </style>
 
     <!-- progress bars -->
     <style name="ReaderProgressBar" parent="@android:style/Widget.Holo.Light.ProgressBar" />


### PR DESCRIPTION
Fixes #4404 - addresses the following issues:
* In the reader list, show gravatar, author & timestamp below the post title (and remove the timestamp from the post header)
* In the reader list,  show the full domain in the post header, and make sure it shows for non-wpcom sites
* In the reader list, show the blog name in the dateline when there's no author name (to match Calypso)
* In the reader detail, move the timestamp to the right of the author name
* In the reader detail, show the blavatar in the header and the gravatar in the dateline