### PR TITLE
Always enable JavaScript in reader post detail

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -63,9 +63,9 @@ class ReaderPostRenderer {
         mMinFullSizeWidthDp = pxToDp(mResourceVars.fullSizeImageWidthPx / 3);
         mMinMidSizeWidthDp = mMinFullSizeWidthDp / 2;
 
-        // enable JavaScript in the webView if it's safe to do so, otherwise videos
-        // and other embedded content won't work
-        webView.getSettings().setJavaScriptEnabled(canEnableJavaScript());
+        // enable JavaScript in the webView, otherwise videos and other embedded content won't
+        // work - note that the content is scrubbed on the backend so this is considered safe
+        webView.getSettings().setJavaScriptEnabled(true);
     }
 
     void beginRender() {
@@ -576,15 +576,5 @@ class ReaderPostRenderer {
         }
         return DisplayUtils.pxToDp(WordPress.getContext(), px);
     }
-
-    /*
-     * javascript should only be enabled for WordPress.com blogs (not feeds or Jetpack blogs)
-     */
-    private boolean canEnableJavaScript() {
-        return mPost.isWP() && !mPost.isJetpack;
-    }
-
-
-
 
 }


### PR DESCRIPTION
Fixes #4419 - JavaScript is now always enabled in reader post detail. Previously it was disabled for security reasons, which caused embeds to break, but due to better scrubbing on the backend it's safe to enable it now.

To test: Follow [Jeremy Herve's blog](https://jeremy.hu/) in the reader, then view [this post](https://jeremy.hu/tv-marvel-the-defenders/). Prior to this change, the embedded YouTube video wouldn't work.
