### PR TITLE
Integrating 2FA support from AccountStore

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -567,10 +567,10 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     }
 
     private void signInAndFetchBlogListWPCom() {
-        // TODO: STORES: mTwoStepCode
-        // TODO: STORES: mShouldSendTwoStepSMS
         startProgress(getString(R.string.connecting_wpcom));
         AuthenticatePayload payload = new AuthenticatePayload(mUsername, mPassword);
+        payload.twoStepCode = mTwoStepCode;
+        payload.shouldSendTwoStepSms = mShouldSendTwoStepSMS;
         mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
     }
 
@@ -840,7 +840,8 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                 showTwoStepCodeError(R.string.invalid_verification_code);
                 break;
             case NEEDS_2FA:
-                // TODO: STORES: 2fa support
+                setTwoStepAuthVisibility(true);
+                break;
             case INVALID_REQUEST:
                 // TODO: STORES: could be specific?
             default:


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Stores-Android/issues/23

Adds 2FA support including SMS code delivery.

To test:
* update the branch used by `Jitpack` to `issue~23-wpcom-2fa-support`
* login to account with 2FA enabled

Needs review: @maxme 