### PR TITLE
Refactor ProfileInputDialogFragment Callback to be handled in the fragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileActivity.java
@@ -6,7 +6,7 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
-public class MyProfileActivity extends AppCompatActivity implements ProfileInputDialogFragment.Callback {
+public class MyProfileActivity extends AppCompatActivity {
     private static final String KEY_MY_PROFILE_FRAGMENT = "my-profile-fragment";
 
     @Override
@@ -38,14 +38,5 @@ public class MyProfileActivity extends AppCompatActivity implements ProfileInput
             return true;
         }
         return super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    public void onSuccessfulInput(String input, int callbackId) {
-        MyProfileFragment myProfileFragment =
-                (MyProfileFragment) getFragmentManager().findFragmentByTag(KEY_MY_PROFILE_FRAGMENT);
-        if (myProfileFragment != null) {
-            myProfileFragment.onSuccessfulInput(input, callbackId);
-        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileFragment.java
@@ -127,6 +127,7 @@ public class MyProfileFragment extends Fragment implements ProfileInputDialogFra
             public void onClick(View v) {
                 ProfileInputDialogFragment inputDialog = ProfileInputDialogFragment.newInstance(dialogTitle,
                         textView.getText().toString(), hint, isMultiline, textView.getId());
+                inputDialog.setTargetFragment(MyProfileFragment.this, 0);
                 inputDialog.show(getFragmentManager(), DIALOG_TAG);
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/MyProfileFragment.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 import de.greenrobot.event.EventBus;
 
-public class MyProfileFragment extends Fragment {
+public class MyProfileFragment extends Fragment implements ProfileInputDialogFragment.Callback {
     private final String DIALOG_TAG = "DIALOG";
 
     private WPTextView mFirstName;
@@ -132,6 +132,7 @@ public class MyProfileFragment extends Fragment {
         };
     }
 
+    @Override
     public void onSuccessfulInput(String input, int callbackId) {
         View rootView = getView();
         if (rootView == null) return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ProfileInputDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ProfileInputDialogFragment.java
@@ -23,8 +23,6 @@ public class ProfileInputDialogFragment extends DialogFragment {
     private static final String IS_MULTILINE_TAG = "is_multiline";
     private static final String CALLBACK_ID_TAG = "callback_id";
 
-    private Callback mCallback;
-
     public static ProfileInputDialogFragment newInstance(String title,
                                                          String initialText,
                                                          String hint,
@@ -42,17 +40,6 @@ public class ProfileInputDialogFragment extends DialogFragment {
 
         profileInputDialogFragment.setArguments(args);
         return profileInputDialogFragment;
-    }
-
-    @Override
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        if (getTargetFragment() instanceof Callback) {
-            mCallback = (Callback) getTargetFragment();
-        } else {
-            AppLog.e(AppLog.T.UTILS, "Target fragment doesn't implement ProfileInputDialogFragment.Callback");
-        }
     }
 
     @Override
@@ -91,8 +78,10 @@ public class ProfileInputDialogFragment extends DialogFragment {
         alertDialogBuilder.setCancelable(true)
                 .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
-                        if (mCallback != null) {
-                            mCallback.onSuccessfulInput(editText.getText().toString(), callbackId);
+                        if (getTargetFragment() instanceof Callback) {
+                            ((Callback) getTargetFragment()).onSuccessfulInput(editText.getText().toString(), callbackId);
+                        } else {
+                            AppLog.e(AppLog.T.UTILS, "Target fragment doesn't implement ProfileInputDialogFragment.Callback");
                         }
                     }
                 })

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ProfileInputDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ProfileInputDialogFragment.java
@@ -17,12 +17,13 @@ import org.wordpress.android.widgets.WPEditText;
 import org.wordpress.android.widgets.WPTextView;
 
 public class ProfileInputDialogFragment extends DialogFragment {
-
     private static final String TITLE_TAG = "title";
     private static final String INITIAL_TEXT_TAG = "initial_text";
     private static final String HINT_TAG = "hint";
     private static final String IS_MULTILINE_TAG = "is_multiline";
     private static final String CALLBACK_ID_TAG = "callback_id";
+
+    private Callback mCallback;
 
     public static ProfileInputDialogFragment newInstance(String title,
                                                          String initialText,
@@ -41,6 +42,17 @@ public class ProfileInputDialogFragment extends DialogFragment {
 
         profileInputDialogFragment.setArguments(args);
         return profileInputDialogFragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (getTargetFragment() instanceof Callback) {
+            mCallback = (Callback) getTargetFragment();
+        } else {
+            AppLog.e(AppLog.T.UTILS, "Target fragment doesn't implement ProfileInputDialogFragment.Callback");
+        }
     }
 
     @Override
@@ -79,11 +91,8 @@ public class ProfileInputDialogFragment extends DialogFragment {
         alertDialogBuilder.setCancelable(true)
                 .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
-                        if (getActivity() instanceof Callback) {
-                            ((Callback) getActivity()).onSuccessfulInput(editText.getText().toString(), callbackId);
-                        } else {
-                            AppLog.e(AppLog.T.UTILS, getActivity().getClass().getName()
-                                    + " doesn't implement ProfileInputDialogFragment.Callback");
+                        if (mCallback != null) {
+                            mCallback.onSuccessfulInput(editText.getText().toString(), callbackId);
                         }
                     }
                 })


### PR DESCRIPTION
During #4418 I was not really happy to handle the dialog callback inside the activity just to pass it back to fragment. Thankfully @hypest pointed out that we could use `setTargetFragment` & `getTargetFragment` for it, so this PR does just that.

To test:
* Go into My Profile page and change display name, go back and see if it is changed on Me screen
* You can change the other fields and check it on remote as well, but checking the display name should be good enough.

Anyone can review this. Thanks!
