### PR TITLE
Navigate to "manage plans" for the specific site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
@@ -22,11 +22,15 @@ import android.widget.Toast;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.models.Blog;
 import org.wordpress.android.ui.plans.adapters.PlansPagerAdapter;
 import org.wordpress.android.ui.plans.models.Plan;
+import org.wordpress.android.ui.reader.ReaderActivityLauncher;
+import org.wordpress.android.ui.reader.ReaderActivityLauncher.OpenUrlType;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DisplayUtils;
+import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.widgets.WPViewPager;
 
 import java.io.Serializable;
@@ -98,6 +102,18 @@ public class PlansActivity extends AppCompatActivity {
         } else {
             setupPlansUI();
         }
+
+        // navigate to the "manage plans" page for this blog when the user clicks the manage bar
+        mManageBar.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                Blog blog = WordPress.getBlog(mLocalBlogID);
+                if (blog == null) return;
+                String domain = UrlUtils.getHost(blog.getUrl());
+                String managePlansUrl = "https://wordpress.com/plans/" + domain;
+                ReaderActivityLauncher.openUrl(view.getContext(), managePlansUrl, OpenUrlType.EXTERNAL);
+            }
+        });
     }
 
     @Override

--- a/WordPress/src/main/res/layout/plans_activity.xml
+++ b/WordPress/src/main/res/layout/plans_activity.xml
@@ -60,13 +60,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:autoLink="web"
-            android:textColorLink="@color/blue_light"
             android:gravity="center"
+            android:linksClickable="false"
             android:minHeight="@dimen/toolbar_height"
             android:paddingLeft="@dimen/content_margin"
             android:paddingRight="@dimen/content_margin"
             android:text="@string/plans_manage"
             android:textColor="@color/white"
+            android:textColorLink="@color/blue_light"
             android:textSize="@dimen/text_sz_large" />
     </FrameLayout>
 


### PR DESCRIPTION
Fixes #4425

To test: Click the "manage" link at the bottom of the plans activity. It should now take you to the plans page for the current blog.

