### PR TITLE
Hiding only the Admin row, not the entire section

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -67,7 +67,7 @@ public class MySiteFragment extends Fragment
     private RelativeLayout mPlanContainer;
     private View mConfigurationHeader;
     private View mSettingsView;
-    private LinearLayout mAdminView;
+    private RelativeLayout mAdminView;
     private View mFabView;
     private LinearLayout mNoSiteView;
     private ScrollView mScrollView;
@@ -149,7 +149,7 @@ public class MySiteFragment extends Fragment
         mPlanContainer = (RelativeLayout) rootView.findViewById(R.id.row_plan);
         mConfigurationHeader = rootView.findViewById(R.id.row_configuration);
         mSettingsView = rootView.findViewById(R.id.row_settings);
-        mAdminView = (LinearLayout) rootView.findViewById(R.id.admin_section);
+        mAdminView = (RelativeLayout) rootView.findViewById(R.id.row_admin);
         mScrollView = (ScrollView) rootView.findViewById(R.id.scroll_view);
         mNoSiteView = (LinearLayout) rootView.findViewById(R.id.no_site_view);
         mNoSiteDrakeImageView = (ImageView) rootView.findViewById(R.id.my_site_no_site_view_drake);


### PR DESCRIPTION
Fixes #4439 

To test:
1. Create a new account
2. Go to "My Sites" tab and verify that "View Site" is visible at the bottom "External" section.
3. Also verify that "View Admin" row is not visible under "View Site".
4. Using an account created before Sep 9, 2015, make sure both "View Site" and "View Admin" are visible


Needs review: @maxme 

