### PR TITLE
Issue/4387 Scroll directly to new comments in ReaderCommentListActivity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderCommentTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderCommentTable.java
@@ -129,7 +129,11 @@ public class ReaderCommentTable {
             return new ReaderCommentList();
         }
 
-        String[] args = {Long.toString(post.blogId), Long.toString(post.postId)};
+        return getCommentsForPost(post.blogId, post.postId);
+    }
+
+    public static ReaderCommentList getCommentsForPost(long blogId,long postId){
+        String[] args = {Long.toString(blogId), Long.toString(postId)};
         Cursor c = ReaderDatabase.getReadableDb().rawQuery("SELECT * FROM tbl_comments WHERE blog_id=? AND post_id=? ORDER BY timestamp", args);
         try {
             ReaderCommentList comments = new ReaderCommentList();

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderCommentList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderCommentList.java
@@ -1,8 +1,15 @@
 package org.wordpress.android.models;
 
 import java.util.ArrayList;
+import java.util.Collection;
 
 public class ReaderCommentList extends ArrayList<ReaderComment> {
+
+    public ReaderCommentList(){}
+
+    public ReaderCommentList(Collection<ReaderComment> list){
+        super(list);
+    }
 
     private boolean commentIdExists(long commentId) {
         return (indexOfCommentId(commentId) > -1);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -589,7 +589,7 @@ public class ReaderCommentListActivity extends AppCompatActivity implements Read
 
         // not connected to internet we are not able to load new comments
         if( !NetworkUtils.isNetworkAvailable(this) ){
-            Toast.makeText(this, R.string.reader_toast_not_connected_to_internet, Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, R.string.no_network_message, Toast.LENGTH_SHORT).show();
             return;
         }
 
@@ -613,7 +613,7 @@ public class ReaderCommentListActivity extends AppCompatActivity implements Read
 
         // not connected to internet we are not able to load new comments
         if( !NetworkUtils.isNetworkAvailable(this) ){
-            Toast.makeText(this, R.string.reader_toast_not_connected_to_internet, Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, R.string.no_network_message, Toast.LENGTH_SHORT).show();
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -307,7 +307,7 @@ public class ReaderCommentListActivity extends AppCompatActivity {
 
     private ReaderCommentAdapter getCommentAdapter() {
         if (mCommentAdapter == null) {
-            mCommentAdapter = new ReaderCommentAdapter(WPActivityUtils.getThemedContext(this), getPost());
+            mCommentAdapter = new ReaderCommentAdapter(WPActivityUtils.getThemedContext(this), getPost(), null);
 
             // adapter calls this when user taps reply icon
             mCommentAdapter.setReplyListener(new ReaderCommentAdapter.RequestReplyListener() {

--- a/WordPress/src/main/res/drawable/double_down.xml
+++ b/WordPress/src/main/res/drawable/double_down.xml
@@ -1,0 +1,8 @@
+<!-- drawable/chevron_double_down.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#fff" android:pathData="M16.59,5.59L18,7L12,13L6,7L7.41,5.59L12,10.17L16.59,5.59M16.59,11.59L18,13L12,19L6,13L7.41,11.59L12,16.17L16.59,11.59Z" />
+</vector>

--- a/WordPress/src/main/res/drawable/double_up.xml
+++ b/WordPress/src/main/res/drawable/double_up.xml
@@ -1,0 +1,8 @@
+<!-- drawable/chevron_double_up.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#fff" android:pathData="M7.41,18.41L6,17L12,11L18,17L16.59,18.41L12,13.83L7.41,18.41M7.41,12.41L6,11L12,5L18,11L16.59,12.41L12,7.83L7.41,12.41Z" />
+</vector>

--- a/WordPress/src/main/res/layout/reader_listitem_comment.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_comment.xml
@@ -41,6 +41,8 @@
                 android:layout_marginRight="@dimen/margin_small"
                 tools:src="@drawable/gravatar_placeholder" />
 
+            <!--NOTE: Color of text is set in ReaderCommentAdapter based on new and old comments,
+                        See mColorOldCommentText and mColorNewCommentText in ReaderCommentAdapter-->
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/text_comment_author"
                 android:layout_width="wrap_content"

--- a/WordPress/src/main/res/menu/reader_comments_list.xml
+++ b/WordPress/src/main/res/menu/reader_comments_list.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto" >
+
+    <item
+        android:id="@+id/menu_prev_new_comment"
+        android:title="@string/reader_menu_prev_new_comment"
+        android:icon="@drawable/double_up"
+        app:showAsAction="always" />
+
+    <item
+        android:id="@+id/menu_next_new_comment"
+        android:title="@string/reader_menu_next_new_comment"
+        android:icon="@drawable/double_down"
+        app:showAsAction="always" />
+
+</menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1100,6 +1100,8 @@
     <!-- menu text -->
     <string name="reader_menu_tags">Edit tags and blogs</string>
     <string name="reader_menu_block_blog">Block this blog</string>
+    <string name="reader_menu_next_new_comment">Next new comment</string>
+    <string name="reader_menu_prev_new_comment">Previous new comment</string>
 
     <!-- button text -->
     <string name="reader_btn_share">Share</string>
@@ -1170,6 +1172,9 @@
     <string name="reader_toast_blog_blocked">Posts from this blog will no longer be shown</string>
     <string name="reader_toast_err_block_blog">Unable to block this blog</string>
     <string name="reader_toast_err_generic">Unable to perform this action</string>
+    <string name="reader_toast_no_more_new_comments">No more new comments</string>
+    <string name="reader_toast_no_new_comments">No new comments</string>
+    <string name="reader_toast_not_connected_to_internet">Not connected to internet</string>
 
     <!-- failure messages when retrieving a single reader post -->
     <string name="reader_err_get_post_generic">Unable to retrieve this post</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1174,7 +1174,6 @@
     <string name="reader_toast_err_generic">Unable to perform this action</string>
     <string name="reader_toast_no_more_new_comments">No more new comments</string>
     <string name="reader_toast_no_new_comments">No new comments</string>
-    <string name="reader_toast_not_connected_to_internet">Not connected to internet</string>
 
     <!-- failure messages when retrieving a single reader post -->
     <string name="reader_err_get_post_generic">Unable to retrieve this post</string>


### PR DESCRIPTION
Fixes #4387 

To test:
1. Go to Followed Sites in Reader Tab on MainActivity
2. Tap on number of comments in any post
3. Read some comments than press back
4. Again Tap on number of comments in that post
5. You can press up and down option menu items to skip old comments and directly scrolled to new comments.
6. As we are using vector drawables test it specially on pre-lollipop devices

https://cloudup.com/c_Vh70I69jN

Needs review: @nbradbury 

