### PR TITLE
Show a View button instead of Preview button for drafts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -395,7 +395,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     private void configurePostButtons(final PostViewHolder holder,
                                       final PostsListPost post) {
         // posts with local changes have preview rather than view button
-        if (post.isLocalDraft() || post.hasLocalChanges() || post.getStatusEnum() == PostStatus.DRAFT) {
+        if (post.isLocalDraft() || post.hasLocalChanges()) {
             holder.btnView.setButtonType(PostListButton.BUTTON_PREVIEW);
         } else {
             holder.btnView.setButtonType(PostListButton.BUTTON_VIEW);


### PR DESCRIPTION
Fixes #4437

To test:

1. Open the app and go to the Blog Posts list
2. Find a saved draft (marked "Draft" in the list)
3. Tap the "View" link to view an on-site preview

Needs review: @maxme 

