### PR TITLE
 Removing username before it's validated leads to crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -336,6 +336,10 @@ public class PeopleInviteFragment extends Fragment implements
         usernamesContainer.removeView(removedErrorView);
     }
 
+    private boolean isUserInInvitees(String username) {
+        return mUsernameButtons.get(username) != null;
+    }
+
     /**
      * Deletes the last entered username.
      * @return true if the username was deleted
@@ -392,6 +396,11 @@ public class PeopleInviteFragment extends Fragment implements
                 @Override
                 public void onUsernameValidation(String username, ValidationResult validationResult) {
                     if (!isAdded()) {
+                        return;
+                    }
+
+                    if(!isUserInInvitees(username)){
+                        //user is removed from invitees before validation
                         return;
                     }
 


### PR DESCRIPTION
Fixes #4367 

To test: add username and immediately press X to remove it.

Needs review: @khaykov 