### PR TITLE
Use default order for viewers

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
@@ -311,12 +311,12 @@ public class PeopleTable {
         return person;
     }
 
-    // order is disabled for followers for now since the API is not supporting it
+    // order is disabled for followers & viewers for now since the API is not supporting it
     private static String orderByString(String table) {
-        if (table.equals(FOLLOWERS_TABLE) || table.equals(EMAIL_FOLLOWERS_TABLE)) {
-            return "";
+        if (table.equals(TEAM_TABLE)) {
+            return " ORDER BY lower(display_name), lower(user_name)";
         }
-        return " ORDER BY lower(display_name), lower(user_name)";
+        return "";
     }
 
     @Nullable


### PR DESCRIPTION
Fixes #4457. We don't have the ability to sort followers & viewers endpoints, so those shouldn't be ordered in the DB query. I missed that in the initial Viewers implementation.

To test:
Go into the people section for a private site and select "Viewers" from the dropdown. It should be ordered as newest first (exactly as the REST api returns it).

/cc @rachelmcr 

Needs review: @hypest 

