### PR TITLE
Fixes crash in PeopleTable due to malformed query

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
@@ -179,7 +179,7 @@ public class PeopleTable {
                     int deleteCount = size - fetchLimit;
                     String[] args = new String[] {Integer.toString(localTableBlogId), Integer.toString(deleteCount)};
                     getWritableDb().delete(table, "local_blog_id=?1 AND person_id IN (SELECT person_id FROM "
-                            + table + " WHERE local_blog_id=?1" + orderByString(table) + " DESC LIMIT ?2)", args);
+                            + table + " WHERE local_blog_id=?1" + orderByString(table, true) + " LIMIT ?2)", args);
                 }
             }
             getWritableDb().setTransactionSuccessful();
@@ -232,7 +232,7 @@ public class PeopleTable {
 
     private static List<Person> getPeople(String table, int localTableBlogId) {
         String[] args = {Integer.toString(localTableBlogId)};
-        String orderBy = orderByString(table);
+        String orderBy = orderByString(table, false);
         Cursor c = getReadableDb().rawQuery("SELECT * FROM " + table + " WHERE local_blog_id=?" + orderBy, args);
 
         List<Person> people = new ArrayList<>();
@@ -312,9 +312,9 @@ public class PeopleTable {
     }
 
     // order is disabled for followers & viewers for now since the API is not supporting it
-    private static String orderByString(String table) {
+    private static String orderByString(String table, boolean isDescending) {
         if (table.equals(TEAM_TABLE)) {
-            return " ORDER BY lower(display_name), lower(user_name)";
+            return " ORDER BY lower(display_name), lower(user_name)" + (isDescending ? " DESC" : "");
         }
         return "";
     }

--- a/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
@@ -314,7 +314,8 @@ public class PeopleTable {
     // order is disabled for followers & viewers for now since the API is not supporting it
     private static String orderByString(String table, boolean isDescending) {
         if (table.equals(TEAM_TABLE)) {
-            return " ORDER BY lower(display_name), lower(user_name)" + (isDescending ? " DESC" : "");
+            String descQuery = (isDescending ? " DESC" : "");
+            return " ORDER BY lower(display_name)" + descQuery + ", lower(user_name)" + descQuery;
         }
         return "";
     }


### PR DESCRIPTION
Fixes #4464. We used to have "DESC" in our query even if the query didn't have an "order by" component. To fix, the descending order component moved to the `orderByString` helper function.

To test:
* In `release/5.7` build, change `PeopleUtils.FETCH_LIMIT` to something small for testing purposes.
* Go into people section of a site with more followers than the `FETCH_LIMIT` you have set and select the followers from the dropdown. Scroll to the bottom until you hit the end of the list.
* Go back to My Site screen and try going into the People page again which should crash.
* After you reproduce the crash, change to the `issue/4464-people-table-crash` and try to go into the people page and it should work without any issues now.

/cc @maxme: Thanks for the heads up for the crash!

Anyone can review this!