### PR TITLE
Improve delete people query

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
@@ -3,6 +3,7 @@ package org.wordpress.android.datasets;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteQueryBuilder;
 import android.support.annotation.Nullable;
 
 import org.wordpress.android.WordPress;
@@ -176,10 +177,14 @@ public class PeopleTable {
             for (String table : tables) {
                 int size = getPeopleCountForLocalBlogId(table, localTableBlogId);
                 if (size > fetchLimit) {
-                    int deleteCount = size - fetchLimit;
-                    String[] args = new String[] {Integer.toString(localTableBlogId), Integer.toString(deleteCount)};
-                    getWritableDb().delete(table, "local_blog_id=?1 AND person_id IN (SELECT person_id FROM "
-                            + table + " WHERE local_blog_id=?1" + orderByString(table, true) + " LIMIT ?2)", args);
+                    String where = "local_blog_id=" + localTableBlogId;
+                    String[] columns = {"person_id"};
+                    String limit = Integer.toString(size - fetchLimit);
+                    String query = SQLiteQueryBuilder.buildQueryString(false, table, columns, where, null, null, null,
+                            limit);
+
+                    String[] args = new String[] {Integer.toString(localTableBlogId)};
+                    getWritableDb().delete(table, "local_blog_id=?1 AND person_id IN (" + query + ")", args);
                 }
             }
             getWritableDb().setTransactionSuccessful();

--- a/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
@@ -181,7 +181,7 @@ public class PeopleTable {
                     String[] columns = {"person_id"};
                     String limit = Integer.toString(size - fetchLimit);
                     String orderBy = null;
-                    if (shouldOrder(table)) {
+                    if (shouldOrderAlphabetically(table)) {
                         orderBy = " lower(display_name) DESC, lower(user_name) DESC";
                     }
                     String inQuery = SQLiteQueryBuilder.buildQueryString(false, table, columns, where, null, null,
@@ -242,7 +242,7 @@ public class PeopleTable {
     private static List<Person> getPeople(String table, int localTableBlogId) {
         String[] args = {Integer.toString(localTableBlogId)};
         String orderBy = "";
-        if (shouldOrder(table)) {
+        if (shouldOrderAlphabetically(table)) {
             orderBy = " ORDER BY lower(display_name), lower(user_name)";
         }
         Cursor c = getReadableDb().rawQuery("SELECT * FROM " + table + " WHERE local_blog_id=?" + orderBy, args);
@@ -324,7 +324,7 @@ public class PeopleTable {
     }
 
     // order is disabled for followers & viewers for now since the API is not supporting it
-    private static boolean shouldOrder(String table) {
+    private static boolean shouldOrderAlphabetically(String table) {
        return table.equals(TEAM_TABLE);
     }
 


### PR DESCRIPTION
This PR addresses @maxme's [comment](https://github.com/wordpress-mobile/WordPress-Android/pull/4465#issuecomment-237172827) in #4465.

To test:
There is no change to test as the sql query stays the same, but just uses `SQLiteQueryBuilder` to make it less error-prone. Here are the steps for testing the page:
* Go into people section for a blog with a lot of users and followers (at least 20). You can also manually change the `PeopleUtils.FETCH_LIMIT` if you don't have such a blog.
* Make sure the users are ordered alphabetically and the rest (followers, viewers) are using default order
* Scroll to the end of list, or at least a couple pages, and go back to my site screen
* Go back into the people page and the first page should be cached, the rest should be deleted and requested from the server again, make sure there is no jumping around

While testing it myself I found that there is actually jumping around for followers & possibly viewers. We might be able to fix the followers one by just using ascending order on the `subscribed` property, but couldn't find a clear way of doing it for the viewers yet. So, I created a new issue to handle this separately #4469.

Needs review: @maxme 
