### PR TITLE
Issue/4471 reader remove word count

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -19,7 +19,7 @@ import java.io.OutputStream;
  */
 public class ReaderDatabase extends SQLiteOpenHelper {
     protected static final String DB_NAME = "wpreader.db";
-    private static final int DB_VERSION = 120;
+    private static final int DB_VERSION = 121;
 
     /*
      * version history
@@ -72,6 +72,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      *  118 - renamed tbl_search_history to tbl_search_suggestions
      *  119 - renamed tbl_posts.timestamp to sort_index
      *  120 - added "format" to tbl_posts
+     *  121 - removed word_count from tbl_posts
      */
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -61,9 +61,8 @@ public class ReaderPostTable {
           + "secondary_tag,"        // 32
           + "attachments_json,"     // 33
           + "discover_json,"        // 34
-          + "word_count,"           // 35
-          + "xpost_post_id,"        // 36
-          + "xpost_blog_id";        // 37
+          + "xpost_post_id,"        // 35
+          + "xpost_blog_id";        // 36
 
     // used when querying multiple rows and skipping tbl_posts.text
     private static final String COLUMN_NAMES_NO_TEXT =
@@ -100,9 +99,8 @@ public class ReaderPostTable {
           + "tbl_posts.secondary_tag,"        // 31
           + "tbl_posts.attachments_json,"     // 32
           + "tbl_posts.discover_json,"        // 33
-          + "tbl_posts.word_count,"           // 34
-          + "tbl_posts.xpost_post_id,"        // 35
-          + "tbl_posts.xpost_blog_id";        // 36
+          + "tbl_posts.xpost_post_id,"        // 34
+          + "tbl_posts.xpost_blog_id";        // 35
 
     protected static void createTables(SQLiteDatabase db) {
         db.execSQL("CREATE TABLE tbl_posts ("
@@ -129,7 +127,6 @@ public class ReaderPostTable {
                 + " published           TEXT,"
                 + " num_replies         INTEGER DEFAULT 0,"
                 + " num_likes           INTEGER DEFAULT 0,"
-                + " word_count          INTEGER DEFAULT 0,"
                 + " is_liked            INTEGER DEFAULT 0,"
                 + " is_followed         INTEGER DEFAULT 0,"
                 + " is_comments_open    INTEGER DEFAULT 0,"
@@ -627,7 +624,7 @@ public class ReaderPostTable {
         SQLiteStatement stmtPosts = db.compileStatement(
                 "INSERT OR REPLACE INTO tbl_posts ("
                 + COLUMN_NAMES
-                + ") VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28,?29,?30,?31,?32,?33,?34,?35,?36,?37)");
+                + ") VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28,?29,?30,?31,?32,?33,?34,?35,?36)");
         SQLiteStatement stmtTags = db.compileStatement(
                 "INSERT OR REPLACE INTO tbl_post_tags (post_id, blog_id, feed_id, pseudo_id, tag_name, tag_type) VALUES (?1,?2,?3,?4,?5,?6)");
 
@@ -669,9 +666,8 @@ public class ReaderPostTable {
                 stmtPosts.bindString(32, post.getSecondaryTag());
                 stmtPosts.bindString(33, post.getAttachmentsJson());
                 stmtPosts.bindString(34, post.getDiscoverJson());
-                stmtPosts.bindLong  (35, post.wordCount);
-                stmtPosts.bindLong  (36, post.xpostPostId);
-                stmtPosts.bindLong  (37, post.xpostBlogId);
+                stmtPosts.bindLong  (35, post.xpostPostId);
+                stmtPosts.bindLong  (36, post.xpostBlogId);
                 stmtPosts.execute();
             }
 
@@ -875,7 +871,6 @@ public class ReaderPostTable {
 
         post.numReplies = c.getInt(c.getColumnIndex("num_replies"));
         post.numLikes = c.getInt(c.getColumnIndex("num_likes"));
-        post.wordCount = c.getInt(c.getColumnIndex("word_count"));
 
         post.isLikedByCurrentUser = SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("is_liked")));
         post.isFollowedByCurrentUser = SqlUtils.sqlToBool(c.getInt( c.getColumnIndex("is_followed")));

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -49,7 +49,6 @@ public class ReaderPost {
 
     public int numReplies;        // includes comments, trackbacks & pingbacks
     public int numLikes;
-    public int wordCount;
 
     public boolean isLikedByCurrentUser;
     public boolean isFollowedByCurrentUser;
@@ -95,7 +94,6 @@ public class ReaderPost {
         post.setBlogUrl(JSONUtils.getString(json, "site_URL"));
 
         post.numLikes = json.optInt("like_count");
-        post.wordCount = json.optInt("word_count");
         post.isLikedByCurrentUser = JSONUtils.getBool(json, "i_like");
         post.isFollowedByCurrentUser = JSONUtils.getBool(json, "is_following");
         post.isExternal = JSONUtils.getBool(json, "is_external");

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -57,9 +57,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private final int mAvatarSzTiny;
     private final int mMarginLarge;
 
-    private final String mWordCountFmtStr;
-    private final String mReadingTimeFmtStr;
-
     private boolean mCanRequestMorePosts;
     private final boolean mIsLoggedOutReader;
 
@@ -76,10 +73,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     // the large "tbl_posts.text" column is unused here, so skip it when querying
     private static final boolean EXCLUDE_TEXT_COLUMN = true;
     private static final int MAX_ROWS = ReaderConstants.READER_MAX_POSTS_TO_DISPLAY;
-
-    // Longreads says that people can read 250 words per minute
-    private static final int READING_WORDS_PER_MINUTE = 250;
-    private static final int MIN_READING_TIME_MINUTES = 2;
 
     private static final int VIEW_TYPE_POST        = 0;
     private static final int VIEW_TYPE_XPOST       = 1;
@@ -121,7 +114,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         private final TextView txtDomain;
         private final TextView txtDateline;
         private final TextView txtTag;
-        private final TextView txtWordCount;
 
         private final ReaderIconCountView commentCount;
         private final ReaderIconCountView likeCount;
@@ -151,7 +143,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             txtDomain = (TextView) itemView.findViewById(R.id.text_domain);
             txtDateline = (TextView) itemView.findViewById(R.id.text_dateline);
             txtTag = (TextView) itemView.findViewById(R.id.text_tag);
-            txtWordCount = (TextView) itemView.findViewById(R.id.text_word_count);
 
             commentCount = (ReaderIconCountView) itemView.findViewById(R.id.count_comments);
             likeCount = (ReaderIconCountView) itemView.findViewById(R.id.count_likes);
@@ -387,19 +378,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         LinearLayout.LayoutParams params = (LinearLayout.LayoutParams) holder.txtTitle.getLayoutParams();
         params.topMargin = titleMargin;
 
-        // show word count when appropriate, include reading time if at least two minutes
-        if (post.wordCount > 0 && !post.isDiscoverPost()) {
-            String wordCountStr = String.format(mWordCountFmtStr, post.wordCount);
-            int readingTimeInMinutes = post.wordCount / READING_WORDS_PER_MINUTE;
-            if (readingTimeInMinutes >= MIN_READING_TIME_MINUTES) {
-                wordCountStr += " (~" + String.format(mReadingTimeFmtStr, readingTimeInMinutes) + ")";
-            }
-            holder.txtWordCount.setText(wordCountStr);
-            holder.txtWordCount.setVisibility(View.VISIBLE);
-        } else {
-            holder.txtWordCount.setVisibility(View.GONE);
-        }
-
         // show the best tag for this post
         final String tagToDisplay = (mCurrentTag != null ? post.getTagForDisplay(mCurrentTag.getTagSlug()) : null);
         if (!TextUtils.isEmpty(tagToDisplay)) {
@@ -547,9 +525,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         mAvatarSzTiny = context.getResources().getDimensionPixelSize(R.dimen.avatar_sz_tiny);
         mMarginLarge = context.getResources().getDimensionPixelSize(R.dimen.margin_large);
         mIsLoggedOutReader = ReaderUtils.isLoggedOutReader();
-
-        mWordCountFmtStr = context.getString(R.string.reader_label_word_count);
-        mReadingTimeFmtStr = context.getString(R.string.reader_label_reading_time_in_minutes);
 
         int displayWidth = DisplayUtils.getDisplayPixelWidth(context);
         int cardMargin = context.getResources().getDimensionPixelSize(R.dimen.reader_card_margin);

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -130,17 +130,6 @@
             android:layout_marginTop="@dimen/margin_medium"
             tools:text="text_excerpt" />
 
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/text_word_count"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/reader_card_content_padding"
-            android:layout_marginRight="@dimen/reader_card_content_padding"
-            android:layout_marginTop="@dimen/margin_large"
-            android:textColor="@color/grey"
-            android:textSize="@dimen/text_sz_medium"
-            tools:text="text_word_count" />
-
         <org.wordpress.android.ui.reader.views.ReaderThumbnailStrip
             android:id="@+id/thumbnail_strip"
             android:layout_width="match_parent"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1125,8 +1125,6 @@
     <string name="reader_label_comment_count_single">One comment</string>
     <string name="reader_label_comment_count_multi">%,d comments</string>
     <string name="reader_label_view_original">View original article</string>
-    <string name="reader_label_word_count">%,d words</string>
-    <string name="reader_label_reading_time_in_minutes">%,d min</string>
     <string name="reader_label_follow_count">%,d followers</string>
     <string name="reader_label_submit_comment">SEND</string>
     <string name="reader_label_gap_marker">Load more posts</string>


### PR DESCRIPTION
Fixes #4471 - removes the word count from the reader post list (since it was dropped from the Calypso reader).

To test: View the reader post list. If you still see the word count, either I screwed up or you pulled the wrong branch :)
