### PR TITLE
Issue/4466 plan tabs not enough room 5.7

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
@@ -159,8 +159,9 @@ public class PlansActivity extends AppCompatActivity {
                 mTabLayout.getViewTreeObserver().removeOnGlobalLayoutListener(this);
 
                 int tabLayoutWidth = 0;
+                LinearLayout tabFirstChild = (LinearLayout) mTabLayout.getChildAt(0);
                 for (int i = 0; i < mTabLayout.getTabCount(); i++){
-                    LinearLayout tabView = ((LinearLayout)((LinearLayout) mTabLayout.getChildAt(0)).getChildAt(i));
+                    LinearLayout tabView = (LinearLayout)(tabFirstChild.getChildAt(i));
                     tabLayoutWidth += (tabView.getMeasuredWidth() + tabView.getPaddingLeft() + tabView.getPaddingRight());
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
@@ -158,17 +158,19 @@ public class PlansActivity extends AppCompatActivity {
             public void onGlobalLayout() {
                 mTabLayout.getViewTreeObserver().removeOnGlobalLayoutListener(this);
 
-                int tabLayoutWidth = 0;
-                LinearLayout tabFirstChild = (LinearLayout) mTabLayout.getChildAt(0);
-                for (int i = 0; i < mTabLayout.getTabCount(); i++){
-                    LinearLayout tabView = (LinearLayout)(tabFirstChild.getChildAt(i));
-                    tabLayoutWidth += (tabView.getMeasuredWidth() + tabView.getPaddingLeft() + tabView.getPaddingRight());
-                }
+                if (mTabLayout.getChildCount() > 0) {
+                    int tabLayoutWidth = 0;
+                    LinearLayout tabFirstChild = (LinearLayout) mTabLayout.getChildAt(0);
+                    for (int i = 0; i < mTabLayout.getTabCount(); i++) {
+                        LinearLayout tabView = (LinearLayout) (tabFirstChild.getChildAt(i));
+                        tabLayoutWidth += (tabView.getMeasuredWidth() + tabView.getPaddingLeft() + tabView.getPaddingRight());
+                    }
 
-                int displayWidth = DisplayUtils.getDisplayPixelWidth(PlansActivity.this);
-                if (tabLayoutWidth < displayWidth) {
-                    mTabLayout.setTabMode(TabLayout.MODE_FIXED);
-                    mTabLayout.setTabGravity(TabLayout.GRAVITY_FILL);
+                    int displayWidth = DisplayUtils.getDisplayPixelWidth(PlansActivity.this);
+                    if (tabLayoutWidth < displayWidth) {
+                        mTabLayout.setTabMode(TabLayout.MODE_FIXED);
+                        mTabLayout.setTabGravity(TabLayout.GRAVITY_FILL);
+                    }
                 }
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
@@ -17,6 +17,7 @@ import android.view.ViewAnimationUtils;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
 import android.view.animation.AccelerateInterpolator;
+import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.Toast;
 
@@ -146,12 +147,30 @@ public class PlansActivity extends AppCompatActivity {
 
         mViewPager.setAdapter(getPageAdapter());
 
-        mTabLayout.setTabMode(TabLayout.MODE_FIXED);
-
         int normalColor = ContextCompat.getColor(this, R.color.blue_light);
         int selectedColor = ContextCompat.getColor(this, R.color.white);
         mTabLayout.setTabTextColors(normalColor, selectedColor);
         mTabLayout.setupWithViewPager(mViewPager);
+
+        // tabMode is set to scrollable in layout, set to fixed if there's enough space to show them all
+        mTabLayout.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
+            @Override
+            public void onGlobalLayout() {
+                mTabLayout.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+
+                int tabLayoutWidth = 0;
+                for (int i = 0; i < mTabLayout.getTabCount(); i++){
+                    LinearLayout tabView = ((LinearLayout)((LinearLayout) mTabLayout.getChildAt(0)).getChildAt(i));
+                    tabLayoutWidth += (tabView.getMeasuredWidth() + tabView.getPaddingLeft() + tabView.getPaddingRight());
+                }
+
+                int displayWidth = DisplayUtils.getDisplayPixelWidth(PlansActivity.this);
+                if (tabLayoutWidth < displayWidth) {
+                    mTabLayout.setTabMode(TabLayout.MODE_FIXED);
+                    mTabLayout.setTabGravity(TabLayout.GRAVITY_FILL);
+                }
+            }
+        });
 
         if (mViewPager.getVisibility() != View.VISIBLE) {
             // use a circular reveal on API 21+

--- a/WordPress/src/main/res/layout/plans_activity.xml
+++ b/WordPress/src/main/res/layout/plans_activity.xml
@@ -23,6 +23,7 @@
             android:background="@color/tab_background"
             android:visibility="gone"
             app:tabIndicatorColor="@color/tab_indicator"
+            app:tabMode="scrollable"
             tools:visibility="visible" />
 
     </android.support.design.widget.AppBarLayout>


### PR DESCRIPTION
Fixes #4466 - the plan tabs are now scrollable when there's not enough room to fit them all

To test: run on an emulator that has a smaller screen size (such as 480x800). The plan tabs should be scrollable when in portrait mode.

**Before this fix**
![before](https://cloud.githubusercontent.com/assets/3903757/17382064/1e57fe8e-599d-11e6-8a90-b2a7546788f3.png)

**After this fix**
![after](https://cloud.githubusercontent.com/assets/3903757/17382085/2a9eb8b8-599d-11e6-8f29-d85270001096.png)

