### PR TITLE
Drop the word "likes" from the like count

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderIconCountView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderIconCountView.java
@@ -86,10 +86,6 @@ public class ReaderIconCountView extends LinearLayout {
     }
 
     public void setCount(int count) {
-        if (mIconType == ICON_LIKE) {
-            mTextCount.setText(ReaderUtils.getShortLikeLabelText(getContext(), count));
-        } else {
-            mTextCount.setText(FormatUtils.formatInt(count));
-        }
+        mTextCount.setText(FormatUtils.formatInt(count));
     }
 }


### PR DESCRIPTION
Fixes #4449 - drops the word "likes" from the like count in the reader post list, so only the count shows (for consistency with the comment count).

