### PR TITLE
Issue/4448 reader move more icon

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -170,16 +170,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             layoutPostHeader = (ViewGroup) itemView.findViewById(R.id.layout_post_header);
 
             // post header isn't shown when there's a site header
-            if (!hasSiteHeader()) {
-                // adjust the right padding of the post header to allow right padding of the  "..." icon
-                // https://github.com/wordpress-mobile/WordPress-Android/issues/3078
-                layoutPostHeader.setPadding(
-                        layoutPostHeader.getPaddingLeft(),
-                        layoutPostHeader.getPaddingTop(),
-                        layoutPostHeader.getPaddingRight() - imgMore.getPaddingRight(),
-                        layoutPostHeader.getPaddingBottom());
-            } else {
-                // hide the header
+            if (hasSiteHeader()) {
                 layoutPostHeader.setVisibility(View.GONE);
                 // add a bit more padding above the title
                 int extraPadding = itemView.getContext().getResources().getDimensionPixelSize(R.dimen.margin_medium);

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -223,10 +223,8 @@
                 android:layout_centerVertical="true"
                 android:background="?android:selectableItemBackground"
                 android:contentDescription="@string/more"
-                android:paddingBottom="@dimen/margin_large"
-                android:paddingLeft="@dimen/margin_small"
-                android:paddingRight="@dimen/margin_small"
-                android:paddingTop="@dimen/margin_large"
+                android:paddingBottom="@dimen/margin_medium"
+                android:paddingTop="@dimen/margin_medium"
                 app:srcCompat="@drawable/ic_action_more_grey" />
 
         </RelativeLayout>

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -43,7 +43,6 @@
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
                 android:layout_marginRight="@dimen/margin_large"
-                android:layout_toLeftOf="@+id/image_more"
                 android:layout_toRightOf="@+id/image_blavatar"
                 android:orientation="vertical">
 
@@ -66,20 +65,6 @@
                     android:textSize="@dimen/text_sz_small"
                     tools:text="text_domain" />
             </LinearLayout>
-
-            <ImageView
-                android:id="@+id/image_more"
-                android:layout_width="@dimen/reader_more_icon"
-                android:layout_height="@dimen/reader_more_icon"
-                android:layout_alignParentRight="true"
-                android:layout_centerVertical="true"
-                android:background="?android:selectableItemBackground"
-                android:contentDescription="@string/more"
-                android:paddingBottom="@dimen/margin_large"
-                android:paddingLeft="@dimen/margin_large"
-                android:paddingRight="@dimen/margin_large"
-                android:paddingTop="@dimen/margin_large"
-                app:srcCompat="@drawable/ic_action_more_grey" />
 
         </RelativeLayout>
 
@@ -224,10 +209,25 @@
                 android:id="@+id/count_likes"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
+                android:layout_alignWithParentIfMissing="true"
                 android:layout_centerVertical="true"
+                android:layout_toLeftOf="@+id/image_more"
                 android:padding="@dimen/margin_medium"
                 wp:readerIcon="like" />
+
+            <ImageView
+                android:id="@+id/image_more"
+                android:layout_width="@dimen/reader_more_icon"
+                android:layout_height="@dimen/reader_more_icon"
+                android:layout_alignParentRight="true"
+                android:layout_centerVertical="true"
+                android:background="?android:selectableItemBackground"
+                android:contentDescription="@string/more"
+                android:paddingBottom="@dimen/margin_large"
+                android:paddingLeft="@dimen/margin_small"
+                android:paddingRight="@dimen/margin_small"
+                android:paddingTop="@dimen/margin_large"
+                app:srcCompat="@drawable/ic_action_more_grey" />
 
         </RelativeLayout>
 


### PR DESCRIPTION
Fixes #4448 - moves the "more" (ellipsis) icon in the reader post list from the post header to the post footer (next to the comment & like icons) for consistency with the Calypso reader.

**Before**
![before](https://cloud.githubusercontent.com/assets/3903757/17383503/41e39dde-59a4-11e6-8572-d81ebf62fed9.png)


**After**
![after](https://cloud.githubusercontent.com/assets/3903757/17383404/c40c929e-59a3-11e6-9f34-1c202136a6f8.png)

