### PR TITLE
Issue/4477 reader follow color in menu

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
@@ -59,18 +59,22 @@ public class ReaderMenuAdapter extends BaseAdapter {
         }
 
         int textRes;
+        int textColorRes;
         int iconRes;
         switch (mMenuItems.get(position)) {
             case ITEM_FOLLOW:
                 textRes = R.string.reader_btn_follow;
+                textColorRes = R.color.reader_follow;
                 iconRes = R.drawable.reader_follow;
                 break;
             case ITEM_UNFOLLOW:
                 textRes = R.string.reader_btn_unfollow;
+                textColorRes = R.color.reader_following;
                 iconRes = R.drawable.reader_following;
                 break;
             case ITEM_BLOCK:
                 textRes = R.string.reader_menu_block_blog;
+                textColorRes = R.color.grey_dark;
                 iconRes = 0;
                 break;
             default:
@@ -79,6 +83,8 @@ public class ReaderMenuAdapter extends BaseAdapter {
 
 
         holder.text.setText(textRes);
+        holder.text.setTextColor(parent.getContext().getColor(textColorRes));
+
         if (iconRes != 0) {
             holder.icon.setImageResource(iconRes);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
@@ -51,7 +51,7 @@ public class ReaderMenuAdapter extends BaseAdapter {
     public View getView(int position, View convertView, ViewGroup parent) {
         ReaderMenuHolder holder;
         if (convertView == null) {
-            convertView = mInflater.inflate(R.layout.popup_menu_item, parent, false);
+            convertView = mInflater.inflate(R.layout.reader_popup_menu_item, parent, false);
             holder = new ReaderMenuHolder(convertView);
             convertView.setTag(holder);
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderMenuAdapter.java
@@ -81,9 +81,8 @@ public class ReaderMenuAdapter extends BaseAdapter {
                 return convertView;
         }
 
-
         holder.text.setText(textRes);
-        holder.text.setTextColor(parent.getContext().getColor(textColorRes));
+        holder.text.setTextColor(convertView.getContext().getResources().getColor(textColorRes));
 
         if (iconRes != 0) {
             holder.icon.setImageResource(iconRes);

--- a/WordPress/src/main/res/layout/reader_popup_menu_item.xml
+++ b/WordPress/src/main/res/layout/reader_popup_menu_item.xml
@@ -1,0 +1,24 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/menu_item_height"
+    android:gravity="left|center_vertical"
+    android:orientation="horizontal"
+    android:paddingLeft="@dimen/menu_item_margin"
+    android:paddingRight="@dimen/menu_item_margin">
+
+    <ImageView
+        android:id="@+id/image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginRight="@dimen/margin_large"
+        tools:src="@drawable/reader_following" />
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?textAppearanceSmallPopupMenu"
+        tools:text="Menu item" />
+
+</LinearLayout>


### PR DESCRIPTION
Fixes #4477 - the "Following" item in the reader list's popup menu is now correctly colored green.

![after](https://cloud.githubusercontent.com/assets/3903757/17384124/c6f5e01a-59a7-11e6-9288-f0c52f2714a6.png)

