### PR TITLE
Order followers & viewers by row id

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/PeopleTable.java
@@ -180,9 +180,11 @@ public class PeopleTable {
                     String where = "local_blog_id=" + localTableBlogId;
                     String[] columns = {"person_id"};
                     String limit = Integer.toString(size - fetchLimit);
-                    String orderBy = null;
+                    String orderBy;
                     if (shouldOrderAlphabetically(table)) {
-                        orderBy = " lower(display_name) DESC, lower(user_name) DESC";
+                        orderBy = "lower(display_name) DESC, lower(user_name) DESC";
+                    } else {
+                        orderBy = "ROWID DESC";
                     }
                     String inQuery = SQLiteQueryBuilder.buildQueryString(false, table, columns, where, null, null,
                             orderBy, limit);
@@ -241,9 +243,12 @@ public class PeopleTable {
 
     private static List<Person> getPeople(String table, int localTableBlogId) {
         String[] args = {Integer.toString(localTableBlogId)};
-        String orderBy = "";
+        String orderBy;
         if (shouldOrderAlphabetically(table)) {
             orderBy = " ORDER BY lower(display_name), lower(user_name)";
+        } else {
+            // we want the server-side order for followers & viewers
+            orderBy = " ORDER BY ROWID";
         }
         Cursor c = getReadableDb().rawQuery("SELECT * FROM " + table + " WHERE local_blog_id=?" + orderBy, args);
 


### PR DESCRIPTION
Fixes #4469. Previously in `deletePeopleExceptForFirstPage` we were not defining the "first page" correctly since the data was not ordered. We currently can't order followers or viewers endpoints, so we are using the default order the data is returned in. TIL you can order things in sqlite by `rowid` which made this fix really simple.

To test:
* Select a blog where you have more than 20 followers or change `PeopleUtils.FETCH_LIMIT` if you don't have such a blog
* Before the change, go into people page and select followers, browse the list at least for 2 pages (make sure we make a request to server to load more)
* Come back to my site and go back into the people page and depending on your data, you might see some insertions being made in the middle of your list
* Test after the change and the issue should be resolved

P.S: I was not able to test the viewers because it's hard to find a blog that has that many viewers. Even if I changed the limit, it's still hard to test. Having said that followers & viewers work exactly the same way for this, so it should fix viewers as well.

@maxme This should be the last fix for the people management issues and since you're already familiar with the latest fixes, I am assigning it to you again. Thanks a lot for all the reviews!

If anyone else wants to tackle the review and help Maxime, I am completely fine with it. Let me know if you have any questions if you do tackle it!