### PR TITLE
Issue/reader move post detail tag

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -661,32 +661,6 @@ public class ReaderPostDetailFragment extends Fragment
         mLikingUsersView.showLikingUsers(mPost);
     }
 
-    /*
-     * show the primary tag for this post
-     */
-    private void refreshTag() {
-        if (!isAdded() || !hasPost()) return;
-
-        TextView txtTag = (TextView) getView().findViewById(R.id.text_tag);
-
-        final String tagToDisplay = mPost.getTagForDisplay(null);
-        if (TextUtils.isEmpty(tagToDisplay)) {
-            txtTag.setVisibility(View.GONE);
-            return;
-        }
-
-        txtTag.setText(ReaderUtils.makeHashTag(tagToDisplay));
-        txtTag.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                ReaderTag tag = ReaderUtils.getTagFromTagName(tagToDisplay, ReaderTagType.FOLLOWED);
-                ReaderActivityLauncher.showReaderTagPreview(v.getContext(), tag);
-            }
-        });
-
-        txtTag.setVisibility(View.VISIBLE);
-    }
-
     private boolean showPhotoViewer(String imageUrl, View sourceView, int startX, int startY) {
         if (!isAdded() || TextUtils.isEmpty(imageUrl)) {
             return false;
@@ -964,7 +938,6 @@ public class ReaderPostDetailFragment extends Fragment
                         return;
                     }
                     refreshLikes();
-                    refreshTag();
                     if (!mHasAlreadyUpdatedPost) {
                         mHasAlreadyUpdatedPost = true;
                         updatePost();
@@ -1037,6 +1010,16 @@ public class ReaderPostDetailFragment extends Fragment
             long blogId = ReaderUtils.getBlogIdFromBlogPreviewUrl(url);
             if (blogId != 0) {
                 ReaderActivityLauncher.showReaderBlogPreview(getActivity(), blogId);
+            }
+            return true;
+        }
+
+        // if this is a "wordpress://tagpreview?" link, show tag preview for the tag
+        if (ReaderUtils.isTagPreviewUrl(url)) {
+            String tagName = ReaderUtils.getTagNameFromTagPreviewUrl(url);
+            if (!TextUtils.isEmpty(tagName)) {
+                ReaderTag tag = ReaderUtils.getTagFromTagName(tagName, ReaderTagType.FOLLOWED);
+                ReaderActivityLauncher.showReaderTagPreview(getActivity(), tag);
             }
             return true;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -661,6 +661,32 @@ public class ReaderPostDetailFragment extends Fragment
         mLikingUsersView.showLikingUsers(mPost);
     }
 
+    /*
+     * show the primary tag for this post
+     */
+    private void refreshTag() {
+        if (!isAdded() || !hasPost()) return;
+
+        TextView txtTag = (TextView) getView().findViewById(R.id.text_tag);
+
+        final String tagToDisplay = mPost.getTagForDisplay(null);
+        if (TextUtils.isEmpty(tagToDisplay)) {
+            txtTag.setVisibility(View.GONE);
+            return;
+        }
+
+        txtTag.setText(ReaderUtils.makeHashTag(tagToDisplay));
+        txtTag.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                ReaderTag tag = ReaderUtils.getTagFromTagName(tagToDisplay, ReaderTagType.FOLLOWED);
+                ReaderActivityLauncher.showReaderTagPreview(v.getContext(), tag);
+            }
+        });
+
+        txtTag.setVisibility(View.VISIBLE);
+    }
+
     private boolean showPhotoViewer(String imageUrl, View sourceView, int startX, int startY) {
         if (!isAdded() || TextUtils.isEmpty(imageUrl)) {
             return false;
@@ -830,7 +856,6 @@ public class ReaderPostDetailFragment extends Fragment
             TextView txtBlogName = (TextView) getView().findViewById(R.id.text_blog_name);
             TextView txtDomain = (TextView) getView().findViewById(R.id.text_domain);
             TextView txtDateline = (TextView) getView().findViewById(R.id.text_dateline);
-            TextView txtTag = (TextView) getView().findViewById(R.id.text_tag);
 
             WPNetworkImageView imgBlavatar = (WPNetworkImageView) getView().findViewById(R.id.image_blavatar);
             WPNetworkImageView imgAvatar = (WPNetworkImageView) getView().findViewById(R.id.image_avatar);
@@ -912,18 +937,6 @@ public class ReaderPostDetailFragment extends Fragment
                 txtDateline.setText(timestamp);
             }
 
-            final String tagToDisplay = mPost.getTagForDisplay(null);
-            if (!TextUtils.isEmpty(tagToDisplay)) {
-                txtTag.setText(ReaderUtils.makeHashTag(tagToDisplay));
-                txtTag.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        ReaderTag tag = ReaderUtils.getTagFromTagName(tagToDisplay, ReaderTagType.FOLLOWED);
-                        ReaderActivityLauncher.showReaderTagPreview(v.getContext(), tag);
-                    }
-                });
-            }
-
             if (canShowFooter() && mLayoutFooter.getVisibility() != View.VISIBLE) {
                 AniUtils.fadeIn(mLayoutFooter, AniUtils.Duration.LONG);
             }
@@ -951,6 +964,7 @@ public class ReaderPostDetailFragment extends Fragment
                         return;
                     }
                     refreshLikes();
+                    refreshTag();
                     if (!mHasAlreadyUpdatedPost) {
                         mHasAlreadyUpdatedPost = true;
                         updatePost();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.reader;
 import android.annotation.SuppressLint;
 import android.net.Uri;
 import android.os.Handler;
+import android.text.TextUtils;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -257,6 +258,14 @@ class ReaderPostRenderer {
                         + "</div>";
                 content += htmlDiscover;
             }
+        }
+
+        // add primary tag (if any) - this uses a custom URL scheme which will display
+        // tag preview when clicked
+        String tagToDisplay = mPost.getTagForDisplay(null);
+        if (!TextUtils.isEmpty(tagToDisplay)) {
+            String tagUrl = ReaderUtils.makeTagPreviewUrl(tagToDisplay);
+            content += "<p><a href='" + tagUrl + "'>#" + tagToDisplay + "</a></p>";
         }
 
         return content;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -237,7 +237,7 @@ class ReaderPostRenderer {
      */
     private String getPostContent() {
         // some content (such as Vimeo embeds) don't have "http:" before links
-        String content = mPost.getText().replace("src=\"//", "src=\"http://");
+        String content = mPost.getText().trim().replace("src=\"//", "src=\"http://");
 
         // add the featured image (if any)
         if (shouldAddFeaturedImage()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -166,6 +166,25 @@ public class ReaderUtils {
     }
 
     /*
+     * used by post detail to display a link to the tag preview for a specific tag
+     */
+    public static String makeTagPreviewUrl(String tagName) {
+        return "wordpress://tagpreview?tag=" + UrlUtils.urlEncode(tagName);
+    }
+
+    public static boolean isTagPreviewUrl(String url) {
+        return (url != null && url.startsWith("wordpress://tagpreview"));
+    }
+
+    public static String getTagNameFromTagPreviewUrl(String url) {
+        if (isTagPreviewUrl(url)) {
+            return Uri.parse(url).getQueryParameter("tag");
+        } else {
+            return "";
+        }
+    }
+
+    /*
      * returns the passed string prefixed with a "#" if it's non-empty and isn't already
      * prefixed with a "#"
      */

--- a/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
@@ -52,32 +52,13 @@
         android:layout_marginTop="@dimen/margin_large"
         android:scrollbars="none" />
 
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/text_tag"
-        style="@style/ReaderTextView"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/reader_detail_tag_height"
-        android:layout_alignLeft="@+id/reader_webview"
-        android:layout_alignRight="@+id/reader_webview"
-        android:layout_below="@id/reader_webview"
-        android:layout_centerVertical="true"
-        android:background="?android:selectableItemBackground"
-        android:ellipsize="end"
-        android:gravity="center_vertical"
-        android:maxLines="1"
-        android:textColor="@color/reader_hyperlink"
-        android:textSize="@dimen/text_sz_large"
-        android:visibility="gone"
-        tools:text="#text_tag"
-        tools:visibility="visible" />
-
     <View
         android:id="@+id/layout_liking_users_divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_alignLeft="@+id/reader_webview"
         android:layout_alignRight="@+id/reader_webview"
-        android:layout_below="@id/text_tag"
+        android:layout_below="@id/reader_webview"
         android:layout_marginTop="@dimen/margin_medium"
         android:background="@color/reader_divider_grey"
         android:visibility="gone"

--- a/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
@@ -52,13 +52,32 @@
         android:layout_marginTop="@dimen/margin_large"
         android:scrollbars="none" />
 
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/text_tag"
+        style="@style/ReaderTextView"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/reader_detail_tag_height"
+        android:layout_alignLeft="@+id/reader_webview"
+        android:layout_alignRight="@+id/reader_webview"
+        android:layout_below="@id/reader_webview"
+        android:layout_centerVertical="true"
+        android:background="?android:selectableItemBackground"
+        android:ellipsize="end"
+        android:gravity="center_vertical"
+        android:maxLines="1"
+        android:textColor="@color/reader_hyperlink"
+        android:textSize="@dimen/text_sz_large"
+        android:visibility="gone"
+        tools:text="#text_tag"
+        tools:visibility="visible" />
+
     <View
         android:id="@+id/layout_liking_users_divider"
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_alignLeft="@+id/reader_webview"
         android:layout_alignRight="@+id/reader_webview"
-        android:layout_below="@id/reader_webview"
+        android:layout_below="@id/text_tag"
         android:layout_marginTop="@dimen/margin_medium"
         android:background="@color/reader_divider_grey"
         android:visibility="gone"

--- a/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
@@ -27,21 +27,6 @@
         android:layout_marginRight="@dimen/reader_detail_margin"
         android:layout_marginTop="@dimen/margin_medium">
 
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/text_tag"
-            style="@style/ReaderTextView"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/reader_detail_tag_height"
-            android:layout_centerVertical="true"
-            android:layout_toLeftOf="@+id/layout_icons"
-            android:background="?android:selectableItemBackground"
-            android:ellipsize="end"
-            android:gravity="center_vertical"
-            android:maxLines="1"
-            android:textColor="@color/reader_hyperlink"
-            android:textSize="@dimen/text_sz_large"
-            tools:text="#text_tag" />
-
         <LinearLayout
             android:id="@+id/layout_icons"
             android:layout_width="wrap_content"
@@ -63,10 +48,10 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
+                android:paddingBottom="@dimen/margin_medium"
                 android:paddingLeft="@dimen/margin_medium"
                 android:paddingRight="0dp"
                 android:paddingTop="@dimen/margin_medium"
-                android:paddingBottom="@dimen/margin_medium"
                 wp:readerIcon="like" />
 
         </LinearLayout>

--- a/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
@@ -3,13 +3,14 @@
 <!--
     included by ReaderPostDetailFragment
 -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:wp="http://schemas.android.com/apk/res-auto"
     android:id="@+id/layout_post_detail_footer"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/white"
+    android:orientation="vertical"
     android:paddingBottom="@dimen/margin_medium">
 
     <View
@@ -19,42 +20,34 @@
         android:layout_marginBottom="@dimen/margin_large"
         android:background="@color/reader_divider_grey" />
 
-    <RelativeLayout
+    <LinearLayout
         android:layout_width="@dimen/reader_webview_width"
         android:layout_height="wrap_content"
-        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true"
         android:layout_marginLeft="@dimen/reader_detail_margin"
         android:layout_marginRight="@dimen/reader_detail_margin"
-        android:layout_marginTop="@dimen/margin_medium">
+        android:gravity="right"
+        android:orientation="horizontal">
 
-        <LinearLayout
-            android:id="@+id/layout_icons"
+        <org.wordpress.android.ui.reader.views.ReaderIconCountView
+            android:id="@+id/count_comments"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
-            android:layout_centerVertical="true"
-            android:orientation="horizontal">
+            android:layout_gravity="center_vertical"
+            android:padding="@dimen/margin_medium"
+            wp:readerIcon="comment" />
 
-            <org.wordpress.android.ui.reader.views.ReaderIconCountView
-                android:id="@+id/count_comments"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:padding="@dimen/margin_medium"
-                wp:readerIcon="comment" />
+        <org.wordpress.android.ui.reader.views.ReaderIconCountView
+            android:id="@+id/count_likes"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:paddingBottom="@dimen/margin_medium"
+            android:paddingLeft="@dimen/margin_medium"
+            android:paddingRight="0dp"
+            android:paddingTop="@dimen/margin_medium"
+            wp:readerIcon="like" />
 
-            <org.wordpress.android.ui.reader.views.ReaderIconCountView
-                android:id="@+id/count_likes"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:paddingBottom="@dimen/margin_medium"
-                android:paddingLeft="@dimen/margin_medium"
-                android:paddingRight="0dp"
-                android:paddingTop="@dimen/margin_medium"
-                wp:readerIcon="like" />
+    </LinearLayout>
 
-        </LinearLayout>
-    </RelativeLayout>
-
-</RelativeLayout>
+</LinearLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -117,8 +117,6 @@
     <dimen name="reader_follow_icon">16dp</dimen>
     <dimen name="reader_more_icon">48dp</dimen>
 
-    <dimen name="reader_detail_tag_height">48dp</dimen>
-
     <dimen name="reader_featured_image_height_default">220dp</dimen>
     <dimen name="reader_featured_image_height_tablet">280dp</dimen>
     <dimen name="reader_featured_image_height_tablet_large">340dp</dimen>


### PR DESCRIPTION
Moves the tag in the reader post detail from the bottom toolbar to below the post content. This is being done as a precursor to #4352, which requires moving the tag.

**BEFORE**
![before](https://cloud.githubusercontent.com/assets/3903757/17494693/dc35be2a-5d83-11e6-936d-d66c43ceda6d.png)

**AFTER**
![after](https://cloud.githubusercontent.com/assets/3903757/17494488/e8e52c92-5d82-11e6-8313-975e7b738e56.png)

