### PR TITLE
Update library to Passcode Lock v1.3.0

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     // Provided by the WordPress-Android Repository
     compile 'org.wordpress:drag-sort-listview:0.6.1' // not found in maven central
     compile 'org.wordpress:slidinguppanel:1.0.0' // not found in maven central
-    compile 'org.wordpress:passcodelock:1.2.0'
+    compile 'org.wordpress:passcodelock:1.3.0'
 
     // Simperium
     compile 'com.simperium.android:simperium:0.6.8'


### PR DESCRIPTION
### Fix
Update Passcode Lock library to [v1.3.0](https://github.com/wordpress-mobile/PasscodeLock-Android/releases/tag/1.3.0) which fixes bugs described in https://github.com/wordpress-mobile/WordPress-Android/issues/4487 and https://github.com/wordpress-mobile/WordPress-Android/issues/4022.

### Test
1. Go to **Me** tab.
2. Tap **App Settings** option.
3. Tap **Turn PIN lock on** option.
4. Enter four-digit PIN.
5. Enter same four-digit PIN.
6. Tap **Change PIN** option.
7. Enter incorrect four-digit PIN.
8. Notice screen shake.
9. Press **Home** navigation button.
10. Wait five seconds.
11. Open WordPress app.
12. Enter incorrect four-digit PIN.
13. Notice screen shake.