### PR TITLE
Invite followers & viewers

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -21,7 +21,6 @@ import android.widget.TextView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
-import org.wordpress.android.WordPressDB;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.ui.people.utils.PeopleUtils;
 import org.wordpress.android.ui.people.utils.PeopleUtils.ValidateUsernameCallback.ValidationResult;
@@ -194,9 +193,7 @@ public class PeopleInviteFragment extends Fragment implements
             populateUsernameButtons(usernames);
         }
 
-        String dotComBlogId = getArguments().getString(ARG_BLOGID);
-        Blog blog = WordPress.wpDB.getBlogForDotComBlogId(dotComBlogId);
-        final boolean isPrivateSite = blog != null && blog.isPrivate();
+        final boolean isPrivateSite = isPrivateSite();
 
         View roleContainer = view.findViewById(R.id.role_container);
         roleContainer.setOnClickListener(new View.OnClickListener() {
@@ -268,8 +265,9 @@ public class PeopleInviteFragment extends Fragment implements
     }
 
     private String loadDefaultRole() {
-        final String[] roles = getResources().getStringArray(R.array.roles);
-        return roles[roles.length - 1];
+        int roleRes = isPrivateSite() ? R.array.invite_roles_private : R.array.invite_roles_public;
+        final String[] roles = getResources().getStringArray(roleRes);
+        return roles[0];
     }
 
     private void updateRemainingCharsView(TextView remainingCharsTextView, String currentString, int limit) {
@@ -627,5 +625,11 @@ public class PeopleInviteFragment extends Fragment implements
         if (mUsernameEditText != null) {
             mUsernameEditText.setOnFocusChangeListener(null);
         }
+    }
+
+    private boolean isPrivateSite() {
+        String dotComBlogId = getArguments().getString(ARG_BLOGID);
+        Blog blog = WordPress.wpDB.getBlogForDotComBlogId(dotComBlogId);
+        return blog != null && blog.isPrivate();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -20,6 +20,9 @@ import android.widget.ImageButton;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.WordPressDB;
+import org.wordpress.android.models.Blog;
 import org.wordpress.android.ui.people.utils.PeopleUtils;
 import org.wordpress.android.ui.people.utils.PeopleUtils.ValidateUsernameCallback.ValidationResult;
 import org.wordpress.android.util.EditTextUtils;
@@ -191,11 +194,15 @@ public class PeopleInviteFragment extends Fragment implements
             populateUsernameButtons(usernames);
         }
 
+        String dotComBlogId = getArguments().getString(ARG_BLOGID);
+        Blog blog = WordPress.wpDB.getBlogForDotComBlogId(dotComBlogId);
+        final boolean isPrivateSite = blog != null && blog.isPrivate();
+
         View roleContainer = view.findViewById(R.id.role_container);
         roleContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                RoleSelectDialogFragment.show(PeopleInviteFragment.this, 0);
+                RoleSelectDialogFragment.show(PeopleInviteFragment.this, 0, isPrivateSite);
             }
         });
         mRoleTextView = (TextView) view.findViewById(R.id.role);

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -193,13 +193,11 @@ public class PeopleInviteFragment extends Fragment implements
             populateUsernameButtons(usernames);
         }
 
-        final boolean isPrivateSite = isPrivateSite();
-
         View roleContainer = view.findViewById(R.id.role_container);
         roleContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                RoleSelectDialogFragment.show(PeopleInviteFragment.this, 0, isPrivateSite);
+                RoleSelectDialogFragment.show(PeopleInviteFragment.this, 0, isPrivateSite());
             }
         });
         mRoleTextView = (TextView) view.findViewById(R.id.role);

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/RoleSelectDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/RoleSelectDialogFragment.java
@@ -15,8 +15,9 @@ public class RoleSelectDialogFragment extends DialogFragment {
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        final String[] roles = getResources().getStringArray(R.array.roles);
         boolean isPrivateSite = getArguments().getBoolean(IS_PRIVATE_TAG);
+        int roleRes = isPrivateSite ? R.array.invite_roles_private : R.array.invite_roles_public;
+        final String[] roles = getResources().getStringArray(roleRes);
 
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(), R.style.Calypso_AlertDialog);
         builder.setTitle(R.string.role);

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/RoleSelectDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/RoleSelectDialogFragment.java
@@ -1,7 +1,5 @@
 package org.wordpress.android.ui.people;
 
-import org.wordpress.android.R;
-
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
@@ -10,11 +8,15 @@ import android.app.Fragment;
 import android.content.DialogInterface;
 import android.os.Bundle;
 
+import org.wordpress.android.R;
+
 public class RoleSelectDialogFragment extends DialogFragment {
+    private static final String IS_PRIVATE_TAG = "is_private";
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         final String[] roles = getResources().getStringArray(R.array.roles);
+        boolean isPrivateSite = getArguments().getBoolean(IS_PRIVATE_TAG);
 
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(), R.style.Calypso_AlertDialog);
         builder.setTitle(R.string.role);
@@ -36,8 +38,12 @@ public class RoleSelectDialogFragment extends DialogFragment {
         return builder.create();
     }
 
-    public static <T extends Fragment & OnRoleSelectListener> void show(T parentFragment, int requestCode) {
+    public static <T extends Fragment & OnRoleSelectListener> void show(T parentFragment, int requestCode,
+                                                                        boolean isPrivateSite) {
         RoleSelectDialogFragment roleChangeDialogFragment = new RoleSelectDialogFragment();
+        Bundle args = new Bundle();
+        args.putBoolean(IS_PRIVATE_TAG, isPrivateSite);
+        roleChangeDialogFragment.setArguments(args);
         roleChangeDialogFragment.setTargetFragment(parentFragment, requestCode);
         roleChangeDialogFragment.show(parentFragment.getFragmentManager(), null);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
@@ -22,6 +22,8 @@ public class PeopleUtils {
     // We limit followers we display to 1000 to avoid API performance issues
     public static int FOLLOWER_PAGE_LIMIT = 50;
     public static int FETCH_LIMIT = 20;
+    private static String ROLE_FOLLOWER = "follower";
+    private static String ROLE_VIEWER = "viewer";
 
     public static void fetchUsers(final String blogId, final int localTableBlogId, final int offset,
                                   final FetchUsersCallback callback) {
@@ -500,6 +502,11 @@ public class PeopleUtils {
                 }
             }
         };
+
+        // This is an ugly hack but the remote accepts "follower" as parameter when you're inviting a viewer
+        if (role.toLowerCase().equals(ROLE_VIEWER)) {
+            role = ROLE_FOLLOWER;
+        }
 
         String path = String.format("sites/%s/invites/new", dotComBlogId);
         Map<String, String> params = new HashMap<>();

--- a/WordPress/src/main/res/values/invite_roles_private.xml
+++ b/WordPress/src/main/res/values/invite_roles_private.xml
@@ -2,6 +2,9 @@
 <resources>
     <string-array name="invite_roles_private" translatable="true">
         <item>
+            Viewer
+        </item>
+        <item>
             Administrator
         </item>
         <item>

--- a/WordPress/src/main/res/values/invite_roles_private.xml
+++ b/WordPress/src/main/res/values/invite_roles_private.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="invite_roles_private" translatable="true">
+        <item>
+            Administrator
+        </item>
+        <item>
+            Editor
+        </item>
+        <item>
+            Author
+        </item>
+        <item>
+            Contributor
+        </item>
+    </string-array>
+</resources>

--- a/WordPress/src/main/res/values/invite_roles_public.xml
+++ b/WordPress/src/main/res/values/invite_roles_public.xml
@@ -2,6 +2,9 @@
 <resources>
     <string-array name="invite_roles_public" translatable="true">
         <item>
+            Follower
+        </item>
+        <item>
             Administrator
         </item>
         <item>

--- a/WordPress/src/main/res/values/invite_roles_public.xml
+++ b/WordPress/src/main/res/values/invite_roles_public.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="invite_roles_public" translatable="true">
+        <item>
+            Administrator
+        </item>
+        <item>
+            Editor
+        </item>
+        <item>
+            Author
+        </item>
+        <item>
+            Contributor
+        </item>
+    </string-array>
+</resources>


### PR DESCRIPTION
Closes #4458. This PR introduces "Follower" and "Viewer" roles to invite feature. The default selected role for invite has been set to "Follower" for public sites and "Viewer" for private ones to match the Calypso behavior.

To test:
* Select a public site and go into people section
* Open the invite page with + sign and send a "Follower" invite.
* Repeat the process for private site and "Viewer" role

/cc @hypest & @astralbodies 

Anyone can review this!