### PR TITLE
Issue/1603 pn read signal

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
@@ -365,10 +365,9 @@ public class GCMMessageService extends GcmListenerService {
     private void handleBadgeResetPN(Bundle data) {
         if (data != null && data.containsKey(PUSH_ARG_NOTE_ID)) {
             removeNotificationWithNoteIdFromSystemBar(this, data);
-            //once we're done iterating through activeNotifications to see which notifications are affected by this noteId,
-            //(that is, which ones needed be cancelled/cleared) we can check and rebuild it visually
+            //now that we cleared the specific notif, we can check and make any visual updates
             if (sActiveNotificationsMap.size() > 0) {
-                // here notify the existing group notification by eliminating the line that is gone
+                // here notify the existing group notification by eliminating the line that is now gone
                 String title = StringEscapeUtils.unescapeHtml(data.getString(PUSH_ARG_TITLE));
                 if (title == null) {
                     title = getString(R.string.app_name);
@@ -376,19 +375,16 @@ public class GCMMessageService extends GcmListenerService {
                 String message = StringEscapeUtils.unescapeHtml(data.getString(PUSH_ARG_MSG));
 
                 if (sActiveNotificationsMap.size() == 1) {
-                    //only one notification remains, so get the proper message for it and re-instante in the system dashboard
-                    for (Integer pushId : sActiveNotificationsMap.keySet()) {
-                        Bundle dataRemainingNote = sActiveNotificationsMap.get(pushId);
-                        if (dataRemainingNote != null) {
-
-                            String titleRemainingNote = StringEscapeUtils.unescapeHtml(dataRemainingNote.getString(PUSH_ARG_TITLE));
-                            if (!TextUtils.isEmpty(titleRemainingNote)) {
-                                title = titleRemainingNote;
-                            }
-                            String messageRemainingNote = StringEscapeUtils.unescapeHtml(dataRemainingNote.getString(PUSH_ARG_MSG));
-                            if (!TextUtils.isEmpty(messageRemainingNote)) {
-                                message = messageRemainingNote;
-                            }
+                    //only one notification remains, so get the proper message for it and re-instate in the system dashboard
+                    Bundle remainingNote = sActiveNotificationsMap.values().iterator().next();
+                    if (remainingNote != null) {
+                        String remainingNoteTitle = StringEscapeUtils.unescapeHtml(remainingNote.getString(PUSH_ARG_TITLE));
+                        if (!TextUtils.isEmpty(remainingNoteTitle)) {
+                            title = remainingNoteTitle;
+                        }
+                        String remainingNoteMessage = StringEscapeUtils.unescapeHtml(remainingNote.getString(PUSH_ARG_MSG));
+                        if (!TextUtils.isEmpty(remainingNoteMessage)) {
+                            message = remainingNoteMessage;
                         }
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
@@ -340,7 +340,7 @@ public class GCMMessageService extends GcmListenerService {
             String noteId = data.getString(PUSH_ARG_NOTE_ID, "");
             removeNotificationFromSystemBar(this, noteId);
         } else {
-            removeAllNotifications(this);
+            //removeAllNotifications(this);
         }
         EventBus.getDefault().post(new NotificationEvents.NotificationsChanged());
     }
@@ -475,6 +475,10 @@ public class GCMMessageService extends GcmListenerService {
             if (noteBundle.getString(PUSH_ARG_NOTE_ID, "").equals(noteID)) {
                 notificationManager.cancel(pushId);
                 removeNotification(pushId);
+                // if it also was the only one notification, clear the group notification id added at first
+                if (sActiveNotificationsMap.size() == 0) {
+                    notificationManager.cancel(GCMMessageService.GROUP_NOTIFICATION_ID);
+                }
                 return;
             }
         }


### PR DESCRIPTION
Fixes #1603 

To test:
- using another account, write comments on a blog you’re an admin of, write 1, 2 and 3 comments, and watch how the notifications are stacked on Android (first it’s shown completely, then you’ll read “2 new notifications”, then “3 new notifications”. Do not open these on the device please.
- open the Notifications tab on the web client, and open one of the comments you’ve just stacked on Android
- the Android app should decrement the count:
-- when it reaches 1 it should show that only notification as usual, and 
-- if that pending notification is also read on the web client, it should just dismiss the notification completely, in a transparent manner.

Pinging @kwonye to review
