### PR TITLE
Add "String Resources" section to Contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,8 @@ We use `values/strings.xml` file for *ALL* translatable strings including string
 
 We also have string resources outside of `strings.xml` such as `key_strings`. These strings are not user-facing and should be used as static strings such as preference keys.
 
+To help ease the translation process we ask that you mark alias string resources - as well as other strings where appropriate - as not translatable. For example `<string name="foo" translatable="false">@string/bar</string>'
+
 # Drawable Resources
 
 The Android support library [v23.2.1](http://android-developers.blogspot.com/2016/02/android-support-library-232.html) added support for drawable resources to be provided exclusively in vector format. Adding a vector drawable (to `WordPress/src/main/res/drawable/`) should be the first option when adding assets. Only if a vector drawable is not available should pngs be added to the project. Also make sure to use `app:srcCompat` in place of `android:src` in XML files.
@@ -109,5 +111,3 @@ The [WordPress-HealthCheck-Common][healthcheck] project is used in the tests and
 # Contribute to translations
 
 We use a tool called GlotPress to manage translations. The WordPress-Android GlotPress instance lives here: http://translate.wordpress.org/projects/apps/android/dev. To add new translations or fix existing ones, create an account over at GlotPress and submit your changes over at the GlotPress site.
-
-To help ease the translation process we ask that you mark alias string resources - as well as other strings where appropriate - as not translatable. For example `<string name="foo" translatable="false">@string/bar</string>'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,21 @@ Here are the libraries currently maintained and subtree'd:
 * Stores
 * Utils
 
+# String Resources
+
+We use `values/strings.xml` file for *ALL* translatable strings including string arrays. Each element in a string array should be defined as separate string resource first and then the string array should be defined with `translatable="false"` flag. Here is a basic example:
+
+```
+<string name="element1">Element 1</string>
+<string name="element2">Element 2</string>
+<string-array name="elements_array" translatable="false">
+    <item>@string/element1</item>
+    <item>@string/element2</item>
+</string-array>
+```
+
+We also have string resources outside of `strings.xml` such as `key_strings`. These strings are not user-facing and are not translated. These should be used for static strings such as preference keys.
+
 # Drawable Resources
 
 The Android support library [v23.2.1](http://android-developers.blogspot.com/2016/02/android-support-library-232.html) added support for drawable resources to be provided exclusively in vector format. Adding a vector drawable (to `WordPress/src/main/res/drawable/`) should be the first option when adding assets. Only if a vector drawable is not available should pngs be added to the project. Also make sure to use `app:srcCompat` in place of `android:src` in XML files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ We use `values/strings.xml` file for *ALL* translatable strings including string
 </string-array>
 ```
 
-We also have string resources outside of `strings.xml` such as `key_strings`. These strings are not user-facing and are not translated. These should be used for static strings such as preference keys.
+We also have string resources outside of `strings.xml` such as `key_strings`. These strings are not user-facing and should be used as static strings such as preference keys.
 
 # Drawable Resources
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Here are the libraries currently maintained and subtree'd:
 
 # String Resources
 
-We use `values/strings.xml` file for *ALL* translatable strings including string arrays. Each element in a string array should be defined as separate string resource first and then the string array should be defined with `translatable="false"` flag. Here is a basic example:
+We use `values/strings.xml` file for *ALL* translatable strings including string arrays. Each element in a string array should be defined as separate string resource first and then the string array should be defined with `translatable="false"` flag. This is due to a GlotPress limitation where translating arrays directly could generate smaller arrays if some elements are not translated. Here is a basic example:
 
 ```
 <string name="element1">Element 1</string>


### PR DESCRIPTION
This PR adds a section to Contributing guide for the correct usage & placement of `string-array`s in the project.