### PR TITLE
Issue/4498 reader search offset

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -46,7 +46,7 @@ public class ReaderPostTable {
           + "featured_image,"       // 17
           + "featured_video,"       // 18
           + "post_avatar,"          // 19
-          + "sort_index,"           // 20 - this is a score for search results, otherwise it's a timestamp
+          + "sort_index,"           // 20
           + "published,"            // 21
           + "num_replies,"          // 22
           + "num_likes,"            // 23

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -116,11 +116,9 @@ public class ReaderPost {
         post.blogName = JSONUtils.getStringDecoded(json, "site_name");
         post.published = JSONUtils.getString(json, "date");
 
-        // sort index determines how posts are sorted - this is a "score" for search results,
-        // liked date for liked posts, and published date for all others
-        if (json.has("score")) {
-            post.sortIndex = json.optDouble("score");
-        } else if (json.has("date_liked")) {
+        // sort index determines how posts are sorted - this is a liked date for liked
+        // posts, and published date for all others
+        if (json.has("date_liked")) {
             String likeDate = JSONUtils.getString(json, "date_liked");
             post.sortIndex = DateTimeUtils.iso8601ToTimestamp(likeDate);
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1310,7 +1310,7 @@ public class ReaderPostListFragment extends Fragment
 
     /*
      * swipe-to-refresh isn't supported for search results since they're really brief snapshots
-     * and are unlikely to show new posts due to the way they're sorted by score
+     * and are unlikely to show new posts due to the way they're sorted
      */
     private boolean isSwipeToRefreshSupported() {
         return getPostListType() != ReaderPostListType.SEARCH_RESULTS;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderSearchService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderSearchService.java
@@ -114,10 +114,10 @@ public class ReaderSearchService extends Service {
                 ReaderPostList serverPosts = ReaderPostList.fromJson(jsonObject);
 
                 // we want search results to be sorted based on their offset
-                int sortIndex = offset + 1;
+                int sortIndex = offset;
                 for (ReaderPost post: serverPosts) {
                     post.sortIndex = sortIndex;
-                    sortIndex++;
+                    sortIndex--;
                 }
 
                 ReaderPostTable.addOrUpdatePosts(getTagForSearchQuery(query), serverPosts);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderSearchService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderSearchService.java
@@ -12,6 +12,7 @@ import com.wordpress.rest.RestRequest;
 import org.json.JSONObject;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.ReaderPostTable;
+import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderPostList;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.ReaderTagType;
@@ -19,7 +20,6 @@ import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.ui.reader.ReaderEvents;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.UrlUtils;
 
 import de.greenrobot.event.EventBus;
@@ -112,9 +112,15 @@ public class ReaderSearchService extends Service {
             @Override
             public void run() {
                 ReaderPostList serverPosts = ReaderPostList.fromJson(jsonObject);
-                if (ReaderPostTable.comparePosts(serverPosts).isNewOrChanged()) {
-                    ReaderPostTable.addOrUpdatePosts(getTagForSearchQuery(query), serverPosts);
+
+                // we want search results to be sorted based on their offset
+                int sortIndex = offset + 1;
+                for (ReaderPost post: serverPosts) {
+                    post.sortIndex = sortIndex;
+                    sortIndex++;
                 }
+
+                ReaderPostTable.addOrUpdatePosts(getTagForSearchQuery(query), serverPosts);
                 EventBus.getDefault().post(new ReaderEvents.SearchPostsEnded(query, offset, true));
             }
         }.start();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderSearchService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderSearchService.java
@@ -113,8 +113,9 @@ public class ReaderSearchService extends Service {
             public void run() {
                 ReaderPostList serverPosts = ReaderPostList.fromJson(jsonObject);
 
-                // we want search results to be sorted based on their offset
-                int sortIndex = offset;
+                // we want search results to be sorted based on their offset - this works because
+                // ReaderPostTable.getPostsWithTag() sorts by sort_index in descending order
+                int sortIndex = -offset - 1;
                 for (ReaderPost post: serverPosts) {
                     post.sortIndex = sortIndex;
                     sortIndex--;


### PR DESCRIPTION
Fixes #4498 - The "sortIndex" for search results is now based on their offset rather than their score, which is more reliable. This is the field that determines how reader posts are sorted in the list view.

@aerych Does the logic here look correct to you?
