### PR TITLE
Issue/4513 reader discover empty

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -709,7 +709,8 @@ public class ReaderPostTable {
 
         String columns = (excludeTextColumn ? COLUMN_NAMES_NO_TEXT : "tbl_posts.*");
         String sql = "SELECT " + columns + " FROM tbl_posts, tbl_post_tags"
-                   + " WHERE tbl_posts.pseudo_id = tbl_post_tags.pseudo_id"
+                   + " WHERE tbl_posts.post_id = tbl_post_tags.post_id"
+                   + " AND tbl_posts.blog_id = tbl_post_tags.blog_id"
                    + " AND tbl_post_tags.tag_name=?"
                    + " AND tbl_post_tags.tag_type=?";
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -426,13 +426,17 @@ public class ReaderPostTable {
      * set to true
      */
     public static void updateFollowedStatus() {
-        String sql = "UPDATE tbl_posts SET is_followed = 0"
-                  + " WHERE is_followed != 0"
-                  + " AND blog_id NOT IN (SELECT DISTINCT blog_id FROM tbl_blog_info WHERE is_followed != 0)";
+        SQLiteStatement statement = ReaderDatabase.getWritableDb().compileStatement(
+                  "UPDATE tbl_posts SET is_followed = 0"
+                + " WHERE is_followed != 0"
+                + " AND blog_id NOT IN (SELECT DISTINCT blog_id FROM tbl_blog_info WHERE is_followed != 0)");
         try {
-            ReaderDatabase.getWritableDb().execSQL(sql);
-        } catch (Exception e) {
-            AppLog.e(AppLog.T.READER, e);
+            int count = statement.executeUpdateDelete();
+            if (count > 0) {
+                AppLog.d(AppLog.T.READER, String.format("reader post table > marked %d posts unfollowed", count));
+            }
+        } finally {
+            statement.close();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -416,14 +416,6 @@ public class ReaderPostTable {
         return numDeleted;
     }
 
-    /*
-    * delete all the posts from the blogs we no longer follow
-    */
-    public static int deletePostsFromUnfollowedBlogs() {
-       return ReaderDatabase.getWritableDb().delete("tbl_posts",
-                "blog_id NOT IN (SELECT DISTINCT blog_id FROM tbl_blog_info WHERE tbl_blog_info.is_following != 0)", null);
-    }
-
     public static int deletePostsInBlog(long blogId) {
         String[] args = {Long.toString(blogId)};
         return ReaderDatabase.getWritableDb().delete("tbl_posts", "blog_id = ?", args);

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -422,6 +422,21 @@ public class ReaderPostTable {
     }
 
     /*
+     * ensure that posts in blogs that are no longer followed don't have their followed status
+     * set to true
+     */
+    public static void updateFollowedStatus() {
+        String sql = "UPDATE tbl_posts SET is_followed = 0"
+                  + " WHERE is_followed != 0"
+                  + " AND blog_id NOT IN (SELECT DISTINCT blog_id FROM tbl_blog_info WHERE is_followed != 0)";
+        try {
+            ReaderDatabase.getWritableDb().execSQL(sql);
+        } catch (Exception e) {
+            AppLog.e(AppLog.T.READER, e);
+        }
+    }
+
+    /*
      * returns the iso8601 published date of the oldest post with the passed tag
      */
     public static String getOldestPubDateWithTag(final ReaderTag tag) {

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -702,8 +702,7 @@ public class ReaderPostTable {
 
         String columns = (excludeTextColumn ? COLUMN_NAMES_NO_TEXT : "tbl_posts.*");
         String sql = "SELECT " + columns + " FROM tbl_posts, tbl_post_tags"
-                   + " WHERE tbl_posts.post_id = tbl_post_tags.post_id"
-                   + " AND tbl_posts.blog_id = tbl_post_tags.blog_id"
+                   + " WHERE tbl_posts.pseudo_id = tbl_post_tags.pseudo_id"
                    + " AND tbl_post_tags.tag_name=?"
                    + " AND tbl_post_tags.tag_type=?";
 

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderBlogList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderBlogList.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.models;
 
+import android.support.annotation.NonNull;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -44,15 +46,6 @@ public class ReaderBlogList extends ArrayList<ReaderBlog> {
         return -1;
     }
 
-    private int indexOfFeedId(long feedId) {
-        for (int i = 0; i < size(); i++) {
-            if (this.get(i).feedId == feedId) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
     public boolean isSameList(ReaderBlogList blogs) {
         if (blogs == null || blogs.size() != this.size()) {
             return false;
@@ -65,6 +58,26 @@ public class ReaderBlogList extends ArrayList<ReaderBlog> {
             }
             ReaderBlog thisInfo = this.get(index);
             if (!thisInfo.isSameAs(blogInfo)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /*
+     * returns true if the passed blog list has the same blogs that are in this list - differs
+     * from isSameList() in that isSameList() checks for *any* changes (subscription count, etc.)
+     * whereas this only checks if the passed list has any blogs that are not in this list, or
+     * this list has any blogs that are not in the passed list
+     */
+    public boolean hasSameBlogs(@NonNull ReaderBlogList blogs) {
+        if (blogs.size() != this.size()) {
+            return false;
+        }
+
+        for (ReaderBlog blogInfo: blogs) {
+            if (indexOfBlogId(blogInfo.blogId) == -1) {
                 return false;
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderBlogList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderBlogList.java
@@ -59,13 +59,12 @@ public class ReaderBlogList extends ArrayList<ReaderBlog> {
         }
 
         for (ReaderBlog blogInfo: blogs) {
-            int index;
-            if (blogInfo.feedId != 0) {
-                index = indexOfFeedId(blogInfo.feedId);
-            } else {
-                index = indexOfBlogId(blogInfo.blogId);
+            int index = indexOfBlogId(blogInfo.blogId);
+            if (index == -1) {
+                return false;
             }
-            if (index == -1 || !this.get(index).isSameAs(blogInfo)) {
+            ReaderBlog thisInfo = this.get(index);
+            if (!thisInfo.isSameAs(blogInfo)) {
                 return false;
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -271,6 +271,7 @@ public class ReaderUpdateService extends Service {
 
                 if (!localBlogs.isSameList(serverBlogs)) {
                     ReaderBlogTable.setFollowedBlogs(serverBlogs);
+                    ReaderPostTable.updateFollowedStatus();
                     AppLog.d(AppLog.T.READER, "reader blogs service > followed blogs changed");
                     EventBus.getDefault().post(new ReaderEvents.FollowedBlogsChanged());
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -269,9 +269,7 @@ public class ReaderUpdateService extends Service {
                 ReaderBlogList serverBlogs = ReaderBlogList.fromJson(jsonObject);
                 ReaderBlogList localBlogs = ReaderBlogTable.getFollowedBlogs();
 
-                boolean followedBlogsChanged = !localBlogs.isSameList(serverBlogs);
-
-                if (followedBlogsChanged) {
+                if (!localBlogs.isSameList(serverBlogs)) {
                     ReaderBlogTable.setFollowedBlogs(serverBlogs);
                     AppLog.d(AppLog.T.READER, "reader blogs service > followed blogs changed");
                     EventBus.getDefault().post(new ReaderEvents.FollowedBlogsChanged());

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -274,11 +274,6 @@ public class ReaderUpdateService extends Service {
                 if (followedBlogsChanged) {
                     ReaderBlogTable.setFollowedBlogs(serverBlogs);
                     AppLog.d(AppLog.T.READER, "reader blogs service > followed blogs changed");
-                }
-
-                int numberOfDeletedPosts = ReaderPostTable.deletePostsFromUnfollowedBlogs();
-
-                if (followedBlogsChanged || numberOfDeletedPosts > 0) {
                     EventBus.getDefault().post(new ReaderEvents.FollowedBlogsChanged());
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderUpdateService.java
@@ -270,10 +270,17 @@ public class ReaderUpdateService extends Service {
                 ReaderBlogList localBlogs = ReaderBlogTable.getFollowedBlogs();
 
                 if (!localBlogs.isSameList(serverBlogs)) {
+                    // always update the list of followed blogs if there are *any* changes between
+                    // server and local (including subscription count, description, etc.)
                     ReaderBlogTable.setFollowedBlogs(serverBlogs);
-                    ReaderPostTable.updateFollowedStatus();
-                    AppLog.d(AppLog.T.READER, "reader blogs service > followed blogs changed");
-                    EventBus.getDefault().post(new ReaderEvents.FollowedBlogsChanged());
+                    // ...but only update the follow status and alert that followed blogs have
+                    // changed if the server list doesn't have the same blogs as the local list
+                    // (ie: a blog has been followed/unfollowed since local was last updated)
+                    if (!localBlogs.hasSameBlogs(serverBlogs)) {
+                        ReaderPostTable.updateFollowedStatus();
+                        AppLog.i(AppLog.T.READER, "reader blogs service > followed blogs changed");
+                        EventBus.getDefault().post(new ReaderEvents.FollowedBlogsChanged());
+                    }
                 }
 
                 taskCompleted(UpdateTask.FOLLOWED_BLOGS);


### PR DESCRIPTION
Resolves #4513 - The problem was due to the reader calling `deletePostsFromUnfollowedBlogs()` when the list of followed blogs has changed. That method incorrectly removed posts in followed tags, causing the post list to be empty when refreshed after returning to it.

In addition, that method was being called even when the list of followed blogs is the same but a blog's subscriber count, description, etc., has changed. 

This PR addresses both problems by:

1. Instead of **deleting** posts in unfollowed blogs, we now simply make sure the `is_followed` field of posts in unfollowed blogs is set correctly

2. Only calling the above when the server says any blogs have been followed or unfollowed since the last time we updated the list of followed blogs