### PR TITLE
Issue/4515 reader use pseudo

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -19,7 +19,7 @@ import java.io.OutputStream;
  */
 public class ReaderDatabase extends SQLiteOpenHelper {
     protected static final String DB_NAME = "wpreader.db";
-    private static final int DB_VERSION = 121;
+    private static final int DB_VERSION = 122;
 
     /*
      * version history
@@ -73,6 +73,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      *  119 - renamed tbl_posts.timestamp to sort_index
      *  120 - added "format" to tbl_posts
      *  121 - removed word_count from tbl_posts
+     *  122 - changed tbl_posts primary key to pseudo_id
      */
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -105,7 +105,6 @@ public class ReaderDatabase extends SQLiteOpenHelper {
     public void onOpen(SQLiteDatabase db) {
         super.onOpen(db);
         //copyDatabase(db);
-        reset();
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -105,6 +105,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
     public void onOpen(SQLiteDatabase db) {
         super.onOpen(db);
         //copyDatabase(db);
+        reset();
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -414,7 +414,7 @@ public class ReaderPostTable {
 
         if (numDeleted > 0)
             ReaderDatabase.getWritableDb().delete("tbl_posts",
-                    "post_id NOT IN (SELECT DISTINCT post_id FROM tbl_post_tags)",
+                    "pseudo_id NOT IN (SELECT DISTINCT pseudo_id FROM tbl_post_tags)",
                     null);
 
         return numDeleted;

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -154,7 +154,7 @@ public class ReaderPostTable {
                 + "   tag_name          TEXT NOT NULL COLLATE NOCASE,"
                 + "   tag_type          INTEGER DEFAULT 0,"
                 + "   has_gap_marker    INTEGER DEFAULT 0,"
-                + "   PRIMARY KEY (post_id, blog_id, tag_name, tag_type)"
+                + "   PRIMARY KEY (pseudo_id, tag_name, tag_type)"
                 + ")");
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -775,8 +775,7 @@ public class ReaderPostTable {
         }
 
         String sql = "SELECT tbl_posts.blog_id, tbl_posts.post_id FROM tbl_posts, tbl_post_tags"
-                + " WHERE tbl_posts.post_id = tbl_post_tags.post_id"
-                + " AND tbl_posts.blog_id = tbl_post_tags.blog_id"
+                + " WHERE tbl_posts.pseudo_id = tbl_post_tags.pseudo_id"
                 + " AND tbl_post_tags.tag_name=?"
                 + " AND tbl_post_tags.tag_type=?";
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -140,8 +140,10 @@ public class ReaderPostTable {
                 + " discover_json       TEXT,"
                 + "	xpost_post_id		INTEGER DEFAULT 0,"
                 + " xpost_blog_id       INTEGER DEFAULT 0,"
-                + " PRIMARY KEY (post_id, blog_id)"
+                + " PRIMARY KEY (pseudo_id)"
                 + ")");
+
+        db.execSQL("CREATE UNIQUE INDEX idx_posts_post_id_blog_id ON tbl_posts(post_id, blog_id)");
         db.execSQL("CREATE INDEX idx_posts_sort_index ON tbl_posts(sort_index)");
 
         db.execSQL("CREATE TABLE tbl_post_tags ("

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -704,8 +704,7 @@ public class ReaderPostTable {
 
         String columns = (excludeTextColumn ? COLUMN_NAMES_NO_TEXT : "tbl_posts.*");
         String sql = "SELECT " + columns + " FROM tbl_posts, tbl_post_tags"
-                   + " WHERE tbl_posts.post_id = tbl_post_tags.post_id"
-                   + " AND tbl_posts.blog_id = tbl_post_tags.blog_id"
+                   + " WHERE tbl_posts.pseudo_id = tbl_post_tags.pseudo_id"
                    + " AND tbl_post_tags.tag_name=?"
                    + " AND tbl_post_tags.tag_type=?";
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -156,6 +156,8 @@ public class ReaderPostTable {
                 + "   has_gap_marker    INTEGER DEFAULT 0,"
                 + "   PRIMARY KEY (pseudo_id, tag_name, tag_type)"
                 + ")");
+
+        db.execSQL("CREATE INDEX idx_post_tags_tag_name ON tbl_post_tags(tag_name)");
     }
 
     protected static void dropTables(SQLiteDatabase db) {

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -440,7 +440,7 @@ public class ReaderPostTable {
         }
 
         String sql = "SELECT tbl_posts.published FROM tbl_posts, tbl_post_tags"
-                   + " WHERE tbl_posts.post_id = tbl_post_tags.post_id AND tbl_posts.blog_id = tbl_post_tags.blog_id"
+                   + " WHERE tbl_posts.pseudo_id = tbl_post_tags.pseudo_id"
                    + " AND tbl_post_tags.tag_name=? AND tbl_post_tags.tag_type=?"
                    + " ORDER BY published LIMIT 1";
         String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};


### PR DESCRIPTION
Fixes #4515 - where possible, we now match posts using the globally unique `pseudo_id` rather than a combination of `post_id` + `blog_id`. As part of this, we now use `pseudo_id` as the primary key of the reader posts table, and as part of the primary key of the reader post tags table.