### PR TITLE
issue/4517-reader-missing-post-header

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -164,10 +164,9 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             layoutPostHeader = (ViewGroup) itemView.findViewById(R.id.layout_post_header);
             followButton = (ReaderFollowButton) layoutPostHeader.findViewById(R.id.follow_button);
 
-            // post header isn't shown when there's a site header
+            // post header isn't shown when there's a site header, so add a bit more
+            // padding above the title
             if (hasSiteHeader()) {
-                layoutPostHeader.setVisibility(View.GONE);
-                // add a bit more padding above the title
                 int extraPadding = itemView.getContext().getResources().getDimensionPixelSize(R.dimen.margin_medium);
                 txtTitle.setPadding(
                         txtTitle.getPaddingLeft(),
@@ -321,7 +320,11 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             holder.imgAvatar.showDefaultGravatarImage();
         }
 
-        if (!hasSiteHeader()) {
+        // post header isn't show when there's a site header
+        if (hasSiteHeader()) {
+            holder.layoutPostHeader.setVisibility(View.GONE);
+        } else {
+            holder.layoutPostHeader.setVisibility(View.VISIBLE);
             // show blog preview when post header is tapped
             holder.layoutPostHeader.setOnClickListener(new View.OnClickListener() {
                 @Override


### PR DESCRIPTION
Fixes #4517 - this was an embarrassing bug on my part caused by not taking view recycling into account. I was setting the visibility of the post header when the view holder was created, but instead I should have set it when the view holder was bound to a post.

To test: View the "Discover" topic in the reader. The post header should not appear for any posts. Then view any other topic (such as "Followed Sites"). The post header should appear for all posts.

(The post header is the section above the post containing the blavatar and blog title - example below)

![screenshot_1472596094](https://cloud.githubusercontent.com/assets/3903757/18109505/b5e730b0-6edf-11e6-96d6-5a23e5efe41a.png)


