### PR TITLE
issue/4509-site-picker-out-of-bounds-v5.8

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -83,10 +83,14 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
                 @Override
                 public void onClick(View view) {
                     int clickedPosition = getAdapterPosition();
-                    if (mIsMultiSelectEnabled) {
-                        toggleSelection(clickedPosition);
-                    } else if (mSiteSelectedListener != null) {
-                        mSiteSelectedListener.onSiteClick(getItem(clickedPosition));
+                    if (isValidPosition(clickedPosition)) {
+                        if (mIsMultiSelectEnabled) {
+                            toggleSelection(clickedPosition);
+                        } else if (mSiteSelectedListener != null) {
+                            mSiteSelectedListener.onSiteClick(getItem(clickedPosition));
+                        }
+                    } else {
+                        AppLog.w(AppLog.T.MAIN, "site picker > invalid clicked position " + clickedPosition);
                     }
                 }
             });


### PR DESCRIPTION
Fixes #4509 - we now ensure that the clicked position in the site picker is valid before accessing the clicked item.

[Relevant SO link](http://stackoverflow.com/a/29689852/1673548)

