### PR TITLE
Issue/supportlib 24.2

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -89,11 +89,11 @@ dependencies {
     compile 'com.android.support:support-fragment:24.2.0'
 
     compile 'com.android.support:multidex:1.0.1'
-    compile 'com.android.support:appcompat-v7:24.1.0'
-    compile 'com.android.support:cardview-v7:24.1.1'
-    compile 'com.android.support:recyclerview-v7:24.1.1'
-    compile 'com.android.support:design:24.1.1'
-    compile 'com.android.support:percent:24.1.1'
+    compile 'com.android.support:appcompat-v7:24.2.0'
+    compile 'com.android.support:cardview-v7:24.2.0'
+    compile 'com.android.support:recyclerview-v7:24.2.0'
+    compile 'com.android.support:design:24.2.0'
+    compile 'com.android.support:percent:24.2.0'
 
     compile 'com.google.android.gms:play-services-gcm:9.0.2'
     compile 'com.google.android.gms:play-services-auth:9.0.2'

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -83,13 +83,18 @@ dependencies {
     }
     compile 'com.google.code.gson:gson:2.6.+'
     compile 'org.ccil.cowan.tagsoup:tagsoup:1.2.1'
+
+    compile 'com.android.support:support-compat:24.2.0'
+    compile 'com.android.support:support-core-ui:24.2.0'
+    compile 'com.android.support:support-fragment:24.2.0'
+
     compile 'com.android.support:multidex:1.0.1'
-    compile 'com.android.support:support-v13:24.1.1'
-    compile 'com.android.support:appcompat-v7:24.1.1'
+    compile 'com.android.support:appcompat-v7:24.1.0'
     compile 'com.android.support:cardview-v7:24.1.1'
     compile 'com.android.support:recyclerview-v7:24.1.1'
     compile 'com.android.support:design:24.1.1'
     compile 'com.android.support:percent:24.1.1'
+
     compile 'com.google.android.gms:play-services-gcm:9.0.2'
     compile 'com.google.android.gms:play-services-auth:9.0.2'
     compile 'com.github.chrisbanes.photoview:library:1.2.4'


### PR DESCRIPTION
Updates the Android support library to [v24.2.0](https://developer.android.com/topic/libraries/support-library/revisions.html). Now that the support library has been split into smaller modules, we only list the three we require in build.gradle:
```
    compile 'com.android.support:support-compat:24.2.0'
    compile 'com.android.support:support-core-ui:24.2.0'
    compile 'com.android.support:support-fragment:24.2.0'
```
Note that we could get away with only `support-fragment:24.2.0` here since that module has dependencies on all the others, but I decided to be explicit about what the app requires.

