### PR TITLE
Issue/4525 reader sort by tagged date

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -19,7 +19,7 @@ import java.io.OutputStream;
  */
 public class ReaderDatabase extends SQLiteOpenHelper {
     protected static final String DB_NAME = "wpreader.db";
-    private static final int DB_VERSION = 123;
+    private static final int DB_VERSION = 124;
 
     /*
      * version history
@@ -75,6 +75,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      *  121 - removed word_count from tbl_posts
      *  122 - changed tbl_posts primary key to pseudo_id
      *  123 - changed tbl_posts.published to tbl_posts.date
+     *  124 - returned tbl_posts.published
      */
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderDatabase.java
@@ -19,7 +19,7 @@ import java.io.OutputStream;
  */
 public class ReaderDatabase extends SQLiteOpenHelper {
     protected static final String DB_NAME = "wpreader.db";
-    private static final int DB_VERSION = 122;
+    private static final int DB_VERSION = 123;
 
     /*
      * version history
@@ -74,6 +74,7 @@ public class ReaderDatabase extends SQLiteOpenHelper {
      *  120 - added "format" to tbl_posts
      *  121 - removed word_count from tbl_posts
      *  122 - changed tbl_posts primary key to pseudo_id
+     *  123 - changed tbl_posts.published to tbl_posts.date
      */
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -667,7 +667,7 @@ public class ReaderPostTable {
                 stmtPosts.bindString(18, post.getFeaturedVideo());
                 stmtPosts.bindString(19, post.getPostAvatar());
                 stmtPosts.bindDouble(20, post.sortIndex);
-                stmtPosts.bindString(21, post.getPublished());
+                stmtPosts.bindString(21, post.getDate());
                 stmtPosts.bindLong  (22, post.numReplies);
                 stmtPosts.bindLong  (23, post.numLikes);
                 stmtPosts.bindLong  (24, SqlUtils.boolToSql(post.isLikedByCurrentUser));
@@ -880,7 +880,7 @@ public class ReaderPostTable {
         post.setPostAvatar(c.getString(c.getColumnIndex("post_avatar")));
 
         post.sortIndex = c.getDouble(c.getColumnIndex("sort_index"));
-        post.setPublished(c.getString(c.getColumnIndex("published")));
+        post.setDate(c.getString(c.getColumnIndex("published")));
 
         post.numReplies = c.getInt(c.getColumnIndex("num_replies"));
         post.numLikes = c.getInt(c.getColumnIndex("num_likes"));

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -47,7 +47,7 @@ public class ReaderPostTable {
           + "featured_video,"       // 18
           + "post_avatar,"          // 19
           + "sort_index,"           // 20
-          + "published,"            // 21
+          + "date,"                 // 21
           + "num_replies,"          // 22
           + "num_likes,"            // 23
           + "is_liked,"             // 24
@@ -85,7 +85,7 @@ public class ReaderPostTable {
           + "tbl_posts.short_url,"            // 17
           + "tbl_posts.post_avatar,"          // 18
           + "tbl_posts.sort_index,"           // 19
-          + "tbl_posts.published,"            // 20
+          + "tbl_posts.date,"                 // 20
           + "tbl_posts.num_replies,"          // 21
           + "tbl_posts.num_likes,"            // 22
           + "tbl_posts.is_liked,"             // 23
@@ -124,7 +124,7 @@ public class ReaderPostTable {
                 + " featured_video      TEXT,"
                 + " post_avatar         TEXT,"
                 + " sort_index          REAL DEFAULT 0,"
-                + " published           TEXT,"
+                + " date                TEXT,"
                 + " num_replies         INTEGER DEFAULT 0,"
                 + " num_likes           INTEGER DEFAULT 0,"
                 + " is_liked            INTEGER DEFAULT 0,"
@@ -445,35 +445,35 @@ public class ReaderPostTable {
     }
 
     /*
-     * returns the iso8601 published date of the oldest post with the passed tag
+     * returns the iso8601 date of the oldest post with the passed tag
      */
-    public static String getOldestPubDateWithTag(final ReaderTag tag) {
+    public static String getOldestDateWithTag(final ReaderTag tag) {
         if (tag == null) {
             return "";
         }
 
-        String sql = "SELECT tbl_posts.published FROM tbl_posts, tbl_post_tags"
+        String sql = "SELECT tbl_posts.date FROM tbl_posts, tbl_post_tags"
                    + " WHERE tbl_posts.pseudo_id = tbl_post_tags.pseudo_id"
                    + " AND tbl_post_tags.tag_name=? AND tbl_post_tags.tag_type=?"
-                   + " ORDER BY published LIMIT 1";
+                   + " ORDER BY date LIMIT 1";
         String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt())};
         return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(), sql, args);
     }
 
     /*
-     * returns the iso8601 published date of the oldest post in the passed blog
+     * returns the iso8601 date of the oldest post in the passed blog
      */
-    public static String getOldestPubDateInBlog(long blogId) {
-        String sql = "SELECT published FROM tbl_posts"
+    public static String getOldestDateInBlog(long blogId) {
+        String sql = "SELECT date FROM tbl_posts"
                   + " WHERE blog_id = ?"
-                  + " ORDER BY published LIMIT 1";
+                  + " ORDER BY date LIMIT 1";
         return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(), sql, new String[]{Long.toString(blogId)});
     }
 
-    public static String getOldestPubDateInFeed(long feedId) {
-        String sql = "SELECT published FROM tbl_posts"
+    public static String getOldestDateInFeed(long feedId) {
+        String sql = "SELECT date FROM tbl_posts"
                   + " WHERE feed_id = ?"
-                  + " ORDER BY published LIMIT 1";
+                  + " ORDER BY date LIMIT 1";
         return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(), sql, new String[]{Long.toString(feedId)});
     }
 
@@ -522,13 +522,13 @@ public class ReaderPostTable {
         ReaderDatabase.getWritableDb().execSQL(sql, args);
     }
 
-    public static String getGapMarkerPubDateForTag(ReaderTag tag) {
+    public static String getGapMarkerDateForTag(ReaderTag tag) {
         ReaderBlogIdPostId ids = getGapMarkerIdsForTag(tag);
         if (ids == null) {
             return null;
         }
         String[] args = {Long.toString(ids.getBlogId()), Long.toString(ids.getPostId())};
-        String sql = "SELECT published FROM tbl_posts WHERE blog_id=? AND post_id=?";
+        String sql = "SELECT date FROM tbl_posts WHERE blog_id=? AND post_id=?";
         return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(), sql, args);
     }
 
@@ -880,7 +880,7 @@ public class ReaderPostTable {
         post.setPostAvatar(c.getString(c.getColumnIndex("post_avatar")));
 
         post.sortIndex = c.getDouble(c.getColumnIndex("sort_index"));
-        post.setDate(c.getString(c.getColumnIndex("published")));
+        post.setDate(c.getString(c.getColumnIndex("date")));
 
         post.numReplies = c.getInt(c.getColumnIndex("num_replies"));
         post.numLikes = c.getInt(c.getColumnIndex("num_likes"));

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -48,21 +48,22 @@ public class ReaderPostTable {
           + "post_avatar,"          // 19
           + "sort_index,"           // 20
           + "date,"                 // 21
-          + "num_replies,"          // 22
-          + "num_likes,"            // 23
-          + "is_liked,"             // 24
-          + "is_followed,"          // 25
-          + "is_comments_open,"     // 26
-          + "is_external,"          // 27
-          + "is_private,"           // 28
-          + "is_videopress,"        // 29
-          + "is_jetpack,"           // 30
-          + "primary_tag,"          // 31
-          + "secondary_tag,"        // 32
-          + "attachments_json,"     // 33
-          + "discover_json,"        // 34
-          + "xpost_post_id,"        // 35
-          + "xpost_blog_id";        // 36
+          + "published,"            // 22
+          + "num_replies,"          // 23
+          + "num_likes,"            // 24
+          + "is_liked,"             // 25
+          + "is_followed,"          // 26
+          + "is_comments_open,"     // 27
+          + "is_external,"          // 28
+          + "is_private,"           // 29
+          + "is_videopress,"        // 30
+          + "is_jetpack,"           // 31
+          + "primary_tag,"          // 32
+          + "secondary_tag,"        // 33
+          + "attachments_json,"     // 34
+          + "discover_json,"        // 35
+          + "xpost_post_id,"        // 36
+          + "xpost_blog_id";        // 37
 
     // used when querying multiple rows and skipping tbl_posts.text
     private static final String COLUMN_NAMES_NO_TEXT =
@@ -86,21 +87,22 @@ public class ReaderPostTable {
           + "tbl_posts.post_avatar,"          // 18
           + "tbl_posts.sort_index,"           // 19
           + "tbl_posts.date,"                 // 20
-          + "tbl_posts.num_replies,"          // 21
-          + "tbl_posts.num_likes,"            // 22
-          + "tbl_posts.is_liked,"             // 23
-          + "tbl_posts.is_followed,"          // 24
-          + "tbl_posts.is_comments_open,"     // 25
-          + "tbl_posts.is_external,"          // 26
-          + "tbl_posts.is_private,"           // 27
-          + "tbl_posts.is_videopress,"        // 28
-          + "tbl_posts.is_jetpack,"           // 29
-          + "tbl_posts.primary_tag,"          // 30
-          + "tbl_posts.secondary_tag,"        // 31
-          + "tbl_posts.attachments_json,"     // 32
-          + "tbl_posts.discover_json,"        // 33
-          + "tbl_posts.xpost_post_id,"        // 34
-          + "tbl_posts.xpost_blog_id";        // 35
+          + "tbl_posts.published,"            // 21
+          + "tbl_posts.num_replies,"          // 22
+          + "tbl_posts.num_likes,"            // 23
+          + "tbl_posts.is_liked,"             // 24
+          + "tbl_posts.is_followed,"          // 25
+          + "tbl_posts.is_comments_open,"     // 26
+          + "tbl_posts.is_external,"          // 27
+          + "tbl_posts.is_private,"           // 28
+          + "tbl_posts.is_videopress,"        // 29
+          + "tbl_posts.is_jetpack,"           // 30
+          + "tbl_posts.primary_tag,"          // 31
+          + "tbl_posts.secondary_tag,"        // 32
+          + "tbl_posts.attachments_json,"     // 33
+          + "tbl_posts.discover_json,"        // 34
+          + "tbl_posts.xpost_post_id,"        // 35
+          + "tbl_posts.xpost_blog_id";        // 36
 
     protected static void createTables(SQLiteDatabase db) {
         db.execSQL("CREATE TABLE tbl_posts ("
@@ -125,6 +127,7 @@ public class ReaderPostTable {
                 + " post_avatar         TEXT,"
                 + " sort_index          REAL DEFAULT 0,"
                 + " date                TEXT,"
+                + " published           TEXT,"
                 + " num_replies         INTEGER DEFAULT 0,"
                 + " num_likes           INTEGER DEFAULT 0,"
                 + " is_liked            INTEGER DEFAULT 0,"
@@ -639,7 +642,7 @@ public class ReaderPostTable {
         SQLiteStatement stmtPosts = db.compileStatement(
                 "INSERT OR REPLACE INTO tbl_posts ("
                 + COLUMN_NAMES
-                + ") VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28,?29,?30,?31,?32,?33,?34,?35,?36)");
+                + ") VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20,?21,?22,?23,?24,?25,?26,?27,?28,?29,?30,?31,?32,?33,?34,?35,?36,?37)");
         SQLiteStatement stmtTags = db.compileStatement(
                 "INSERT OR REPLACE INTO tbl_post_tags (post_id, blog_id, feed_id, pseudo_id, tag_name, tag_type) VALUES (?1,?2,?3,?4,?5,?6)");
 
@@ -668,21 +671,22 @@ public class ReaderPostTable {
                 stmtPosts.bindString(19, post.getPostAvatar());
                 stmtPosts.bindDouble(20, post.sortIndex);
                 stmtPosts.bindString(21, post.getDate());
-                stmtPosts.bindLong  (22, post.numReplies);
-                stmtPosts.bindLong  (23, post.numLikes);
-                stmtPosts.bindLong  (24, SqlUtils.boolToSql(post.isLikedByCurrentUser));
-                stmtPosts.bindLong  (25, SqlUtils.boolToSql(post.isFollowedByCurrentUser));
-                stmtPosts.bindLong  (26, SqlUtils.boolToSql(post.isCommentsOpen));
-                stmtPosts.bindLong  (27, SqlUtils.boolToSql(post.isExternal));
-                stmtPosts.bindLong  (28, SqlUtils.boolToSql(post.isPrivate));
-                stmtPosts.bindLong  (29, SqlUtils.boolToSql(post.isVideoPress));
-                stmtPosts.bindLong  (30, SqlUtils.boolToSql(post.isJetpack));
-                stmtPosts.bindString(31, post.getPrimaryTag());
-                stmtPosts.bindString(32, post.getSecondaryTag());
-                stmtPosts.bindString(33, post.getAttachmentsJson());
-                stmtPosts.bindString(34, post.getDiscoverJson());
-                stmtPosts.bindLong  (35, post.xpostPostId);
-                stmtPosts.bindLong  (36, post.xpostBlogId);
+                stmtPosts.bindString(22, post.getPubDate());
+                stmtPosts.bindLong  (23, post.numReplies);
+                stmtPosts.bindLong  (24, post.numLikes);
+                stmtPosts.bindLong  (25, SqlUtils.boolToSql(post.isLikedByCurrentUser));
+                stmtPosts.bindLong  (26, SqlUtils.boolToSql(post.isFollowedByCurrentUser));
+                stmtPosts.bindLong  (27, SqlUtils.boolToSql(post.isCommentsOpen));
+                stmtPosts.bindLong  (28, SqlUtils.boolToSql(post.isExternal));
+                stmtPosts.bindLong  (29, SqlUtils.boolToSql(post.isPrivate));
+                stmtPosts.bindLong  (30, SqlUtils.boolToSql(post.isVideoPress));
+                stmtPosts.bindLong  (31, SqlUtils.boolToSql(post.isJetpack));
+                stmtPosts.bindString(32, post.getPrimaryTag());
+                stmtPosts.bindString(33, post.getSecondaryTag());
+                stmtPosts.bindString(34, post.getAttachmentsJson());
+                stmtPosts.bindString(35, post.getDiscoverJson());
+                stmtPosts.bindLong  (36, post.xpostPostId);
+                stmtPosts.bindLong  (37, post.xpostBlogId);
                 stmtPosts.execute();
             }
 
@@ -881,6 +885,7 @@ public class ReaderPostTable {
 
         post.sortIndex = c.getDouble(c.getColumnIndex("sort_index"));
         post.setDate(c.getString(c.getColumnIndex("date")));
+        post.setPubDate(c.getString(c.getColumnIndex("published")));
 
         post.numReplies = c.getInt(c.getColumnIndex("num_replies"));
         post.numLikes = c.getInt(c.getColumnIndex("num_likes"));

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -645,14 +645,14 @@ public class ReaderPost {
     }
 
     /*
-     * converts iso8601 pubDate to an actual java date
+     * converts iso8601 pubDate to a java date for display - this is the date that appears on posts
      */
-    private transient java.util.Date dtPublished;
-    public java.util.Date getDatePublished() {
-        if (dtPublished == null) {
-            dtPublished = DateTimeUtils.iso8601ToJavaDate(this.pubDate);
+    private transient java.util.Date dtDisplay;
+    public java.util.Date getDisplayDate() {
+        if (dtDisplay == null) {
+            dtDisplay = DateTimeUtils.iso8601ToJavaDate(this.pubDate);
         }
-        return dtPublished;
+        return dtDisplay;
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -117,7 +117,6 @@ public class ReaderPost {
         post.featuredImage = JSONUtils.getString(json, "featured_image");
         post.blogName = JSONUtils.getStringDecoded(json, "site_name");
         post.pubDate = JSONUtils.getString(json, "date");
-        AppLog.w(AppLog.T.READER, post.pubDate);
 
         // a post's date is the liked date for liked posts, tagged date for tag streams, and
         // published date for all others

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -40,9 +40,17 @@ public class ReaderPost {
     private String primaryTag;    // most popular tag on this post based on usage in blog
     private String secondaryTag;  // second most popular tag on this post based on usage in blog
 
-    public double sortIndex;      // determines how posts are sorted for display
-    private String date;          // generic date - depends on the stream the post is from
-    private String pubDate;       // date the post was actually published
+    /*
+     * the "date" field is a generic date which depends on the stream the post is from:
+     *   - for tagged posts, this is the date the post was tagged
+     *   - for liked posts, this is the date the post was liked
+     *   - for other posts, this is the date the post was published
+     * this date is used when requesting older posts from the backend, and is also used
+     * to generate the sortIndex below (which determines how posts are sorted for display)
+     */
+    private String date;
+    private String pubDate;
+    public double sortIndex;
 
     private String url;
     private String shortUrl;

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -10,6 +10,7 @@ import org.wordpress.android.ui.reader.models.ReaderBlogIdPostId;
 import org.wordpress.android.ui.reader.utils.ImageSizeMap;
 import org.wordpress.android.ui.reader.utils.ReaderImageScanner;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
+import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.HtmlUtils;
@@ -116,6 +117,7 @@ public class ReaderPost {
         post.featuredImage = JSONUtils.getString(json, "featured_image");
         post.blogName = JSONUtils.getStringDecoded(json, "site_name");
         post.pubDate = JSONUtils.getString(json, "date");
+        AppLog.w(AppLog.T.READER, post.pubDate);
 
         // a post's date is the liked date for liked posts, tagged date for tag streams, and
         // published date for all others
@@ -439,8 +441,8 @@ public class ReaderPost {
     public String getPubDate() {
         return StringUtils.notNullStr(pubDate);
     }
-    public void setPubDate(String dateStr) {
-        this.pubDate = StringUtils.notNullStr(pubDate);
+    public void setPubDate(String published) {
+        this.pubDate = StringUtils.notNullStr(published);
     }
 
     public String getPrimaryTag() {

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -39,9 +39,9 @@ public class ReaderPost {
     private String primaryTag;    // most popular tag on this post based on usage in blog
     private String secondaryTag;  // second most popular tag on this post based on usage in blog
 
-    public double sortIndex;
-    private String date;
-    private String pubDate;
+    public double sortIndex;      // determines how posts are sorted for display
+    private String date;          // generic date - depends on the stream the post is from
+    private String pubDate;       // date the post was actually published
 
     private String url;
     private String shortUrl;

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -40,7 +40,7 @@ public class ReaderPost {
     private String secondaryTag;  // second most popular tag on this post based on usage in blog
 
     public double sortIndex;
-    private String published;
+    private String date;
 
     private String url;
     private String shortUrl;
@@ -114,7 +114,7 @@ public class ReaderPost {
 
         post.featuredImage = JSONUtils.getString(json, "featured_image");
         post.blogName = JSONUtils.getStringDecoded(json, "site_name");
-        post.published = JSONUtils.getString(json, "date");
+        post.date = JSONUtils.getString(json, "date");
 
         // sort index determines how posts are sorted - this is a liked date for liked
         // posts, tagged date for tag streams, and published date for all others
@@ -125,7 +125,7 @@ public class ReaderPost {
             String taggedDate = JSONUtils.getString(json, "tagged_on");
             post.sortIndex = DateTimeUtils.iso8601ToTimestamp(taggedDate);
         } else {
-            post.sortIndex = DateTimeUtils.iso8601ToTimestamp(post.published);
+            post.sortIndex = DateTimeUtils.iso8601ToTimestamp(post.date);
         }
 
         // if the post is untitled, make up a title from the excerpt
@@ -427,11 +427,11 @@ public class ReaderPost {
         this.pseudoId = StringUtils.notNullStr(pseudoId);
     }
 
-    public String getPublished() {
-        return StringUtils.notNullStr(published);
+    public String getDate() {
+        return StringUtils.notNullStr(date);
     }
-    public void setPublished(String published) {
-        this.published = StringUtils.notNullStr(published);
+    public void setDate(String dateStr) {
+        this.date = StringUtils.notNullStr(dateStr);
     }
 
     public String getPrimaryTag() {
@@ -636,14 +636,14 @@ public class ReaderPost {
     }
 
     /*
-     * converts iso8601 published date to an actual java date
+     * converts iso8601 date to an actual java date
      */
-    private transient java.util.Date dtPublished;
-    public java.util.Date getDatePublished() {
-        if (dtPublished == null) {
-            dtPublished = DateTimeUtils.iso8601ToJavaDate(published);
+    private transient java.util.Date dtJava;
+    public java.util.Date getJavaDate() {
+        if (dtJava == null) {
+            dtJava = DateTimeUtils.iso8601ToJavaDate(this.date);
         }
-        return dtPublished;
+        return dtJava;
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -114,19 +114,19 @@ public class ReaderPost {
 
         post.featuredImage = JSONUtils.getString(json, "featured_image");
         post.blogName = JSONUtils.getStringDecoded(json, "site_name");
-        post.date = JSONUtils.getString(json, "date");
 
-        // sort index determines how posts are sorted - this is a liked date for liked
-        // posts, tagged date for tag streams, and published date for all others
+        // a post's date is the liked date for liked posts, tagged date for tag streams, and
+        // published date for all others
         if (json.has("date_liked")) {
-            String likeDate = JSONUtils.getString(json, "date_liked");
-            post.sortIndex = DateTimeUtils.iso8601ToTimestamp(likeDate);
+            post.date = JSONUtils.getString(json, "date_liked");
         } else if (json.has("tagged_on")) {
-            String taggedDate = JSONUtils.getString(json, "tagged_on");
-            post.sortIndex = DateTimeUtils.iso8601ToTimestamp(taggedDate);
+            post.date = JSONUtils.getString(json, "tagged_on");
         } else {
-            post.sortIndex = DateTimeUtils.iso8601ToTimestamp(post.date);
+            post.date = JSONUtils.getString(json, "date");
         }
+
+        // sort index determines how posts are sorted
+        post.sortIndex = DateTimeUtils.iso8601ToTimestamp(post.date);
 
         // if the post is untitled, make up a title from the excerpt
         if (!post.hasTitle() && post.hasExcerpt()) {

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -41,6 +41,7 @@ public class ReaderPost {
 
     public double sortIndex;
     private String date;
+    private String pubDate;
 
     private String url;
     private String shortUrl;
@@ -114,6 +115,7 @@ public class ReaderPost {
 
         post.featuredImage = JSONUtils.getString(json, "featured_image");
         post.blogName = JSONUtils.getStringDecoded(json, "site_name");
+        post.pubDate = JSONUtils.getString(json, "date");
 
         // a post's date is the liked date for liked posts, tagged date for tag streams, and
         // published date for all others
@@ -122,10 +124,10 @@ public class ReaderPost {
         } else if (json.has("tagged_on")) {
             post.date = JSONUtils.getString(json, "tagged_on");
         } else {
-            post.date = JSONUtils.getString(json, "date");
+            post.date = post.pubDate;
         }
 
-        // sort index determines how posts are sorted
+        // sort index determines how posts are sorted, which is based on the date retrieved above
         post.sortIndex = DateTimeUtils.iso8601ToTimestamp(post.date);
 
         // if the post is untitled, make up a title from the excerpt
@@ -434,6 +436,13 @@ public class ReaderPost {
         this.date = StringUtils.notNullStr(dateStr);
     }
 
+    public String getPubDate() {
+        return StringUtils.notNullStr(pubDate);
+    }
+    public void setPubDate(String dateStr) {
+        this.pubDate = StringUtils.notNullStr(pubDate);
+    }
+
     public String getPrimaryTag() {
         return StringUtils.notNullStr(primaryTag);
     }
@@ -636,14 +645,14 @@ public class ReaderPost {
     }
 
     /*
-     * converts iso8601 date to an actual java date
+     * converts iso8601 pubDate to an actual java date
      */
-    private transient java.util.Date dtJava;
-    public java.util.Date getJavaDate() {
-        if (dtJava == null) {
-            dtJava = DateTimeUtils.iso8601ToJavaDate(this.date);
+    private transient java.util.Date dtPublished;
+    public java.util.Date getDatePublished() {
+        if (dtPublished == null) {
+            dtPublished = DateTimeUtils.iso8601ToJavaDate(this.pubDate);
         }
-        return dtJava;
+        return dtPublished;
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -117,10 +117,13 @@ public class ReaderPost {
         post.published = JSONUtils.getString(json, "date");
 
         // sort index determines how posts are sorted - this is a liked date for liked
-        // posts, and published date for all others
+        // posts, tagged date for tag streams, and published date for all others
         if (json.has("date_liked")) {
             String likeDate = JSONUtils.getString(json, "date_liked");
             post.sortIndex = DateTimeUtils.iso8601ToTimestamp(likeDate);
+        } else if (json.has("tagged_on")) {
+            String taggedDate = JSONUtils.getString(json, "tagged_on");
+            post.sortIndex = DateTimeUtils.iso8601ToTimestamp(taggedDate);
         } else {
             post.sortIndex = DateTimeUtils.iso8601ToTimestamp(post.published);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -910,7 +910,7 @@ public class ReaderPostDetailFragment extends Fragment
                 imgAvatar.showDefaultGravatarImage();
             }
 
-            String timestamp = DateTimeUtils.javaDateToTimeSpan(mPost.getDatePublished());
+            String timestamp = DateTimeUtils.javaDateToTimeSpan(mPost.getDisplayDate());
             if (mPost.hasAuthorName()) {
                 txtDateline.setText(mPost.getAuthorName() + ReaderConstants.UNICODE_BULLET_WITH_SPACE + timestamp);
             } else if (mPost.hasBlogName()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -910,7 +910,7 @@ public class ReaderPostDetailFragment extends Fragment
                 imgAvatar.showDefaultGravatarImage();
             }
 
-            String timestamp = DateTimeUtils.javaDateToTimeSpan(mPost.getJavaDate());
+            String timestamp = DateTimeUtils.javaDateToTimeSpan(mPost.getDatePublished());
             if (mPost.hasAuthorName()) {
                 txtDateline.setText(mPost.getAuthorName() + ReaderConstants.UNICODE_BULLET_WITH_SPACE + timestamp);
             } else if (mPost.hasBlogName()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -910,7 +910,7 @@ public class ReaderPostDetailFragment extends Fragment
                 imgAvatar.showDefaultGravatarImage();
             }
 
-            String timestamp = DateTimeUtils.javaDateToTimeSpan(mPost.getDatePublished());
+            String timestamp = DateTimeUtils.javaDateToTimeSpan(mPost.getJavaDate());
             if (mPost.hasAuthorName()) {
                 txtDateline.setText(mPost.getAuthorName() + ReaderConstants.UNICODE_BULLET_WITH_SPACE + timestamp);
             } else if (mPost.hasBlogName()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -304,7 +304,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         holder.txtTitle.setText(post.getTitle());
 
-        String timestamp = DateTimeUtils.javaDateToTimeSpan(post.getDatePublished());
+        String timestamp = DateTimeUtils.javaDateToTimeSpan(post.getDisplayDate());
         if (post.hasAuthorName()) {
             holder.txtDateline.setText(post.getAuthorName() + ReaderConstants.UNICODE_BULLET_WITH_SPACE + timestamp);
         } else if (post.hasBlogName()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -304,7 +304,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         holder.txtTitle.setText(post.getTitle());
 
-        String timestamp = DateTimeUtils.javaDateToTimeSpan(post.getJavaDate());
+        String timestamp = DateTimeUtils.javaDateToTimeSpan(post.getDatePublished());
         if (post.hasAuthorName()) {
             holder.txtDateline.setText(post.getAuthorName() + ReaderConstants.UNICODE_BULLET_WITH_SPACE + timestamp);
         } else if (post.hasBlogName()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -304,7 +304,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         holder.txtTitle.setText(post.getTitle());
 
-        String timestamp = DateTimeUtils.javaDateToTimeSpan(post.getDatePublished());
+        String timestamp = DateTimeUtils.javaDateToTimeSpan(post.getJavaDate());
         if (post.hasAuthorName()) {
             holder.txtDateline.setText(post.getAuthorName() + ReaderConstants.UNICODE_BULLET_WITH_SPACE + timestamp);
         } else if (post.hasBlogName()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderPostService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderPostService.java
@@ -178,11 +178,11 @@ public class ReaderPostService extends Service {
         switch (updateAction) {
             case REQUEST_OLDER:
                 // request posts older than the oldest existing post with this tag
-                beforeDate = ReaderPostTable.getOldestPubDateWithTag(tag);
+                beforeDate = ReaderPostTable.getOldestDateWithTag(tag);
                 break;
             case REQUEST_OLDER_THAN_GAP:
                 // request posts older than the post with the gap marker for this tag
-                beforeDate = ReaderPostTable.getGapMarkerPubDateForTag(tag);
+                beforeDate = ReaderPostTable.getGapMarkerDateForTag(tag);
                 break;
             default:
                 beforeDate = null;
@@ -220,7 +220,7 @@ public class ReaderPostService extends Service {
 
         // append the date of the oldest cached post in this blog when requesting older posts
         if (updateAction == UpdateAction.REQUEST_OLDER) {
-            String dateOldest = ReaderPostTable.getOldestPubDateInBlog(blogId);
+            String dateOldest = ReaderPostTable.getOldestDateInBlog(blogId);
             if (!TextUtils.isEmpty(dateOldest)) {
                 path += "&before=" + UrlUtils.urlEncode(dateOldest);
             }
@@ -248,7 +248,7 @@ public class ReaderPostService extends Service {
                                             final UpdateResultListener resultListener) {
         String path = "read/feed/" + feedId + "/posts/?meta=site,likes";
         if (updateAction == UpdateAction.REQUEST_OLDER) {
-            String dateOldest = ReaderPostTable.getOldestPubDateInFeed(feedId);
+            String dateOldest = ReaderPostTable.getOldestDateInFeed(feedId);
             if (!TextUtils.isEmpty(dateOldest)) {
                 path += "&before=" + UrlUtils.urlEncode(dateOldest);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderCommentsPostHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderCommentsPostHeaderView.java
@@ -51,8 +51,8 @@ public class ReaderCommentsPostHeaderView extends LinearLayout {
             txtBlogName.setText(R.string.reader_untitled_post);
         }
 
-        java.util.Date dtPublished = DateTimeUtils.iso8601ToJavaDate(post.getPublished());
-        String dateLine = DateTimeUtils.javaDateToTimeSpan(dtPublished);
+        java.util.Date dtPost = DateTimeUtils.iso8601ToJavaDate(post.getDate());
+        String dateLine = DateTimeUtils.javaDateToTimeSpan(dtPost);
         if (post.isCommentsOpen || post.numReplies > 0) {
             dateLine += "  \u2022  " + ReaderUtils.getShortCommentLabelText(getContext(), post.numReplies);
         }


### PR DESCRIPTION
Fixes #4525 - based on [this comment](https://github.com/Automattic/wp-calypso/issues/7731#issuecomment-244070453) and on Slack discussions, posts in reader tag streams should be sorted by the date they were tagged. This is how they're sorted on the backend, and not doing this in the app (we sort by pubDate) results in some posts appearing out of order compared to Calypso.

This PR adds a generic `date` field to the post model which is set to the tagged date when available. This date field is then used to determine how posts are sorted, and is used when requesting older posts (the `before` param passed to `/read/tags/{tagName}/posts`).

The `published` date, which existed previously, is now only used for display.