### PR TITLE
Adjust basic margins based on window width

### DIFF
--- a/WordPress/src/main/res/values-land/dimens.xml
+++ b/WordPress/src/main/res/values-land/dimens.xml
@@ -1,3 +1,0 @@
-<resources>
-    <dimen name="tabstrip_icon_spacing">@dimen/tabstrip_icon_spacing_landscape</dimen>
-</resources>

--- a/WordPress/src/main/res/values-land/dimens.xml
+++ b/WordPress/src/main/res/values-land/dimens.xml
@@ -1,6 +1,4 @@
 <resources>
-    <dimen name="reader_detail_margin">@dimen/reader_detail_margin_normal_landscape</dimen>
-    <dimen name="reader_card_margin">@dimen/reader_card_margin_normal_landscape</dimen>
     <dimen name="notifications_content_margin">@dimen/content_margin_normal_landscape</dimen>
     <dimen name="tabstrip_icon_spacing">@dimen/tabstrip_icon_spacing_landscape</dimen>
 </resources>

--- a/WordPress/src/main/res/values-land/dimens.xml
+++ b/WordPress/src/main/res/values-land/dimens.xml
@@ -1,4 +1,3 @@
 <resources>
-    <dimen name="notifications_content_margin">@dimen/content_margin_normal_landscape</dimen>
     <dimen name="tabstrip_icon_spacing">@dimen/tabstrip_icon_spacing_landscape</dimen>
 </resources>

--- a/WordPress/src/main/res/values-land/dimens.xml
+++ b/WordPress/src/main/res/values-land/dimens.xml
@@ -1,7 +1,6 @@
 <resources>
     <dimen name="reader_detail_margin">@dimen/reader_detail_margin_normal_landscape</dimen>
-    <dimen name="content_margin">@dimen/content_margin_normal_landscape</dimen>
     <dimen name="reader_card_margin">@dimen/reader_card_margin_normal_landscape</dimen>
-    <dimen name="notifications_content_margin">@dimen/content_margin</dimen>
+    <dimen name="notifications_content_margin">@dimen/content_margin_normal_landscape</dimen>
     <dimen name="tabstrip_icon_spacing">@dimen/tabstrip_icon_spacing_landscape</dimen>
 </resources>

--- a/WordPress/src/main/res/values-sw600dp-land/dimens.xml
+++ b/WordPress/src/main/res/values-sw600dp-land/dimens.xml
@@ -1,6 +1,5 @@
 <resources>
     <dimen name="reader_detail_margin">@dimen/reader_detail_margin_tablet_landscape</dimen>
-    <dimen name="content_margin">@dimen/content_margin_tablet_landscape</dimen>
     <dimen name="reader_card_margin">@dimen/reader_card_margin_tablet_landscape</dimen>
     <dimen name="notifications_list_margin">192dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values-sw600dp-land/dimens.xml
+++ b/WordPress/src/main/res/values-sw600dp-land/dimens.xml
@@ -1,5 +1,3 @@
 <resources>
-    <dimen name="reader_detail_margin">@dimen/reader_detail_margin_tablet_landscape</dimen>
-    <dimen name="reader_card_margin">@dimen/reader_card_margin_tablet_landscape</dimen>
     <dimen name="notifications_list_margin">192dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values-sw600dp/dimens.xml
+++ b/WordPress/src/main/res/values-sw600dp/dimens.xml
@@ -5,7 +5,6 @@
     <dimen name="reader_featured_image_height">@dimen/reader_featured_image_height_tablet</dimen>
     <dimen name="postlist_featured_image_height">@dimen/postlist_featured_image_height_tablet</dimen>
     <dimen name="notifications_list_margin">48dp</dimen>
-    <dimen name="notifications_content_margin">@dimen/content_margin_tablet</dimen>
     <dimen name="tabstrip_icon_spacing">@dimen/tabstrip_icon_spacing_tablet</dimen>
     <dimen name="fab_margin">@dimen/fab_margin_tablet</dimen>
     <dimen name="menu_item_margin">@dimen/menu_item_margin_tablet</dimen>

--- a/WordPress/src/main/res/values-sw600dp/dimens.xml
+++ b/WordPress/src/main/res/values-sw600dp/dimens.xml
@@ -6,9 +6,8 @@
     <dimen name="reader_featured_image_height">@dimen/reader_featured_image_height_tablet</dimen>
     <dimen name="postlist_featured_image_height">@dimen/postlist_featured_image_height_tablet</dimen>
     <dimen name="notifications_list_margin">48dp</dimen>
-    <dimen name="content_margin">@dimen/content_margin_tablet</dimen>
     <dimen name="reader_card_margin">@dimen/reader_card_margin_tablet</dimen>
-    <dimen name="notifications_content_margin">@dimen/content_margin</dimen>
+    <dimen name="notifications_content_margin">@dimen/content_margin_tablet</dimen>
     <dimen name="tabstrip_icon_spacing">@dimen/tabstrip_icon_spacing_tablet</dimen>
     <dimen name="fab_margin">@dimen/fab_margin_tablet</dimen>
     <dimen name="menu_item_margin">@dimen/menu_item_margin_tablet</dimen>

--- a/WordPress/src/main/res/values-sw600dp/dimens.xml
+++ b/WordPress/src/main/res/values-sw600dp/dimens.xml
@@ -5,7 +5,6 @@
     <dimen name="reader_featured_image_height">@dimen/reader_featured_image_height_tablet</dimen>
     <dimen name="postlist_featured_image_height">@dimen/postlist_featured_image_height_tablet</dimen>
     <dimen name="notifications_list_margin">48dp</dimen>
-    <dimen name="tabstrip_icon_spacing">@dimen/tabstrip_icon_spacing_tablet</dimen>
     <dimen name="fab_margin">@dimen/fab_margin_tablet</dimen>
     <dimen name="menu_item_margin">@dimen/menu_item_margin_tablet</dimen>
 </resources>

--- a/WordPress/src/main/res/values-sw600dp/dimens.xml
+++ b/WordPress/src/main/res/values-sw600dp/dimens.xml
@@ -2,11 +2,9 @@
 <resources>
     <dimen name="default_dialog_width">480dp</dimen>
 
-    <dimen name="reader_detail_margin">@dimen/reader_detail_margin_tablet</dimen>
     <dimen name="reader_featured_image_height">@dimen/reader_featured_image_height_tablet</dimen>
     <dimen name="postlist_featured_image_height">@dimen/postlist_featured_image_height_tablet</dimen>
     <dimen name="notifications_list_margin">48dp</dimen>
-    <dimen name="reader_card_margin">@dimen/reader_card_margin_tablet</dimen>
     <dimen name="notifications_content_margin">@dimen/content_margin_tablet</dimen>
     <dimen name="tabstrip_icon_spacing">@dimen/tabstrip_icon_spacing_tablet</dimen>
     <dimen name="fab_margin">@dimen/fab_margin_tablet</dimen>

--- a/WordPress/src/main/res/values-w400dp/dimens.xml
+++ b/WordPress/src/main/res/values-w400dp/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="tabstrip_icon_spacing">@dimen/tabstrip_icon_spacing_medium</dimen>
+</resources>

--- a/WordPress/src/main/res/values-w600dp/dimens.xml
+++ b/WordPress/src/main/res/values-w600dp/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="content_margin">@dimen/content_margin_tablet</dimen>
+</resources>

--- a/WordPress/src/main/res/values-w600dp/dimens.xml
+++ b/WordPress/src/main/res/values-w600dp/dimens.xml
@@ -3,5 +3,4 @@
     <dimen name="reader_card_margin">@dimen/reader_card_margin_tablet</dimen>
     <dimen name="reader_detail_margin">@dimen/reader_detail_margin_tablet</dimen>
     <dimen name="notifications_content_margin">@dimen/content_margin_tablet</dimen>
-    <dimen name="tabstrip_icon_spacing">@dimen/tabstrip_icon_spacing_tablet</dimen>
 </resources>

--- a/WordPress/src/main/res/values-w600dp/dimens.xml
+++ b/WordPress/src/main/res/values-w600dp/dimens.xml
@@ -1,3 +1,5 @@
 <resources>
     <dimen name="content_margin">@dimen/content_margin_tablet</dimen>
+    <dimen name="reader_card_margin">@dimen/reader_card_margin_tablet</dimen>
+    <dimen name="reader_detail_margin">@dimen/reader_detail_margin_tablet</dimen>
 </resources>

--- a/WordPress/src/main/res/values-w600dp/dimens.xml
+++ b/WordPress/src/main/res/values-w600dp/dimens.xml
@@ -3,4 +3,5 @@
     <dimen name="reader_card_margin">@dimen/reader_card_margin_tablet</dimen>
     <dimen name="reader_detail_margin">@dimen/reader_detail_margin_tablet</dimen>
     <dimen name="notifications_content_margin">@dimen/content_margin_tablet</dimen>
+    <dimen name="tabstrip_icon_spacing">@dimen/tabstrip_icon_spacing_tablet</dimen>
 </resources>

--- a/WordPress/src/main/res/values-w600dp/dimens.xml
+++ b/WordPress/src/main/res/values-w600dp/dimens.xml
@@ -2,4 +2,5 @@
     <dimen name="content_margin">@dimen/content_margin_tablet</dimen>
     <dimen name="reader_card_margin">@dimen/reader_card_margin_tablet</dimen>
     <dimen name="reader_detail_margin">@dimen/reader_detail_margin_tablet</dimen>
+    <dimen name="notifications_content_margin">@dimen/content_margin_tablet</dimen>
 </resources>

--- a/WordPress/src/main/res/values-w720dp/dimens.xml
+++ b/WordPress/src/main/res/values-w720dp/dimens.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <dimen name="content_margin">@dimen/content_margin_tablet_big</dimen>
+    <dimen name="reader_card_margin">@dimen/reader_card_margin_tablet_big</dimen>
+    <dimen name="reader_detail_margin">@dimen/reader_detail_margin_tablet_big</dimen>
     <dimen name="reader_webview_width">680dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values-w720dp/dimens.xml
+++ b/WordPress/src/main/res/values-w720dp/dimens.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <dimen name="content_margin">@dimen/content_margin_tablet_big</dimen>
     <dimen name="reader_webview_width">680dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values-w720dp/dimens.xml
+++ b/WordPress/src/main/res/values-w720dp/dimens.xml
@@ -4,4 +4,5 @@
     <dimen name="reader_card_margin">@dimen/reader_card_margin_tablet_big</dimen>
     <dimen name="reader_detail_margin">@dimen/reader_detail_margin_tablet_big</dimen>
     <dimen name="reader_webview_width">680dp</dimen>
+    <dimen name="notifications_content_margin">@dimen/content_margin_tablet_big</dimen>
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -53,10 +53,9 @@
     <dimen name="content_margin">@dimen/content_margin_normal</dimen>
 
     <!-- spacing between icons in main tab strip -->
-    <dimen name="tabstrip_icon_spacing_normal">0dp</dimen>
-    <dimen name="tabstrip_icon_spacing_landscape">24dp</dimen>
-    <dimen name="tabstrip_icon_spacing_tablet">24dp</dimen>
-    <dimen name="tabstrip_icon_spacing">@dimen/tabstrip_icon_spacing_normal</dimen>
+    <dimen name="tabstrip_icon_spacing_zero">0dp</dimen>
+    <dimen name="tabstrip_icon_spacing_medium">24dp</dimen>
+    <dimen name="tabstrip_icon_spacing">@dimen/tabstrip_icon_spacing_zero</dimen>
 
     <!--
         native reader dimens

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -74,16 +74,14 @@
 
     <!-- left/right margin for reader cards -->
     <dimen name="reader_card_margin_normal">0dp</dimen>
-    <dimen name="reader_card_margin_normal_landscape">48dp</dimen>
     <dimen name="reader_card_margin_tablet">48dp</dimen>
-    <dimen name="reader_card_margin_tablet_landscape">96dp</dimen>
+    <dimen name="reader_card_margin_tablet_big">96dp</dimen>
     <dimen name="reader_card_margin">@dimen/reader_card_margin_normal</dimen>
 
     <!-- left/right margin for reader detail -->
     <dimen name="reader_detail_margin_normal">24dp</dimen>
-    <dimen name="reader_detail_margin_normal_landscape">48dp</dimen>
     <dimen name="reader_detail_margin_tablet">48dp</dimen>
-    <dimen name="reader_detail_margin_tablet_landscape">96dp</dimen>
+    <dimen name="reader_detail_margin_tablet_big">96dp</dimen>
     <dimen name="reader_detail_margin">@dimen/reader_detail_margin_normal</dimen>
 
     <dimen name="reader_related_post_margin">@dimen/margin_extra_large</dimen>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -49,7 +49,7 @@
     <dimen name="content_margin_normal">@dimen/margin_medium</dimen>
     <dimen name="content_margin_normal_landscape">48dp</dimen>
     <dimen name="content_margin_tablet">48dp</dimen>
-    <dimen name="content_margin_tablet_landscape">96dp</dimen>
+    <dimen name="content_margin_tablet_big">96dp</dimen>
     <dimen name="content_margin">@dimen/content_margin_normal</dimen>
 
     <!-- spacing between icons in main tab strip -->


### PR DESCRIPTION
Fixes #4505 

Instead of relying on `swXXX` qualifiers, use the `wXXX` ones to adjust some basic margin/padding values. Using current window width plays better with multi-window mode engaged.

To test:

* On a phone running Android 7, open the app while holding the device in portrait
* Navigate the top level app sections (MySite, Reader, Notifications) and notice the small (or zero) margins on the left and right side of the screen
* Engage multi-window mode (Tap the Overview button a.k.a Recent apps button and then drag and drop the app's title bar to the top of the device)
* Notice the right/left margins not changing
 