### PR TITLE
Keep FAB on pause, slide in on first creation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -97,14 +97,6 @@ public class MySiteFragment extends Fragment
     }
 
     @Override
-    public void onPause() {
-        super.onPause();
-        if (mFabView.getVisibility() == View.VISIBLE) {
-            AniUtils.showFab(mFabView, false);
-        }
-    }
-
-    @Override
     public void onResume() {
         super.onResume();
 
@@ -155,6 +147,11 @@ public class MySiteFragment extends Fragment
         mNoSiteDrakeImageView = (ImageView) rootView.findViewById(R.id.my_site_no_site_view_drake);
         mFabView = rootView.findViewById(R.id.fab_button);
         mCurrentPlanNameTextView = (WPTextView) rootView.findViewById(R.id.my_site_current_plan_text_view);
+
+        // hide the FAB the first time the fragment is created in order to animate it in onResume()
+        if (savedInstanceState == null) {
+            mFabView.setVisibility(View.INVISIBLE);
+        }
 
         mFabView.setOnClickListener(new View.OnClickListener() {
             @Override


### PR DESCRIPTION
Fixes #4532 

Avoid hiding the FAB on pause while in the MySite screen. It makes little sense anyway and it is problematic when in multi-window mode. Instead, keep in in screen all the time and slide it in only at first creation.

To test:

* Put the app in multi-window mode (needs Android 7)
* Make sure the MySite screen/tab is selected
* Tap on the other app's window to bring the focus to that
* Notice the FAB keeping its position

