### PR TITLE
Fixed issue #4506: User role from Team shows up next to non-user viewer

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -283,6 +283,7 @@ public class PeopleListFragment extends Fragment {
 
     public interface OnFetchPeopleListener {
         boolean onFetchFirstPage(PeopleListFilter filter);
+
         boolean onFetchMorePeople(PeopleListFilter filter);
     }
 
@@ -345,6 +346,8 @@ public class PeopleListFragment extends Fragment {
                 peopleViewHolder.txtDisplayName.setText(StringUtils.unescapeHTML(person.getDisplayName()));
                 if (person.getRole() != null) {
                     peopleViewHolder.txtRole.setText(StringUtils.capitalize(person.getRole().toDisplayString()));
+                } else {
+                    peopleViewHolder.txtRole.setText("");
                 }
                 if (!person.getUsername().isEmpty()) {
                     peopleViewHolder.txtUsername.setVisibility(View.VISIBLE);


### PR DESCRIPTION
Fixes #4506 


