### PR TITLE
Fixes converting string to role crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/Role.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Role.java
@@ -4,6 +4,8 @@ import android.support.annotation.StringRes;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.CrashlyticsUtils;
 
 public enum Role {
     ADMIN(R.string.role_admin),
@@ -38,7 +40,12 @@ public enum Role {
             case "viewer":
                 return VIEWER;
         }
-        throw new IllegalArgumentException("All roles must be handled");
+        Exception e = new IllegalArgumentException("All roles must be handled");
+        CrashlyticsUtils.logException(e, CrashlyticsUtils.ExceptionType.SPECIFIC, AppLog.T.PEOPLE);
+
+        // All roles should have been handled, but in case an edge case occurs,
+        // using "Contributor" role is the safest option
+        return CONTRIBUTOR;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/models/Role.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Role.java
@@ -40,7 +40,7 @@ public enum Role {
             case "viewer":
                 return VIEWER;
         }
-        Exception e = new IllegalArgumentException("All roles must be handled");
+        Exception e = new IllegalArgumentException("All roles must be handled: " + role);
         CrashlyticsUtils.logException(e, CrashlyticsUtils.ExceptionType.SPECIFIC, AppLog.T.PEOPLE);
 
         // All roles should have been handled, but in case an edge case occurs,


### PR DESCRIPTION
Fixes #4549. Both the network request & the DB table is separate for users & followers. The `Role.fromString` method should only be triggered for users, so the safest option until we can figure out the cause of this crash is to return `contributor` as the role if an unexpected string is converted. As per @maxme's great suggestion, I've also added the `role` string to the exception, so we can track what the unexpected string is and hopefully find the cause for it.

To test:
Unfortunately there is no real way to test this out as I don't even know how to reproduce the crash.

Please note that I still kept the exceptions in the `toString` & `toRESTString` because I think the AS shouldn't event complain when all the cases for an enum is handled. The exception should at least help if we ever add a new role in the `Role` enum and forget to handle that case.