### PR TITLE
Role label shouldn't be visible if not applicable in People list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -344,7 +344,10 @@ public class PeopleListFragment extends Fragment {
                 peopleViewHolder.imgAvatar.setImageUrl(avatarUrl, WPNetworkImageView.ImageType.AVATAR);
                 peopleViewHolder.txtDisplayName.setText(StringUtils.unescapeHTML(person.getDisplayName()));
                 if (person.getRole() != null) {
+                    peopleViewHolder.txtRole.setVisibility(View.VISIBLE);
                     peopleViewHolder.txtRole.setText(StringUtils.capitalize(person.getRole().toDisplayString()));
+                } else {
+                    peopleViewHolder.txtRole.setVisibility(View.GONE);
                 }
                 if (!person.getUsername().isEmpty()) {
                     peopleViewHolder.txtUsername.setVisibility(View.VISIBLE);


### PR DESCRIPTION
Fixes #4551

To reproduce, do the following in `release/5.8`:
* Go into people page for a blog and select the "TEAM" filter
* Go back and switch the site (this is only necessary to reliably reproduce it, you might still be able to without it)
* Go into people page and wait for the users to load
* Select "Followers" filter and once the list loads you'll see that the role label is filled in whereas it should be empty

Follow the same steps in this PR to see it's fixed now.

/cc @maxme 