### PR TITLE
Align the invites related error messages to the API ones

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -580,8 +580,8 @@ public class PeopleInviteFragment extends Fragment implements
         enableSendButton(false);
 
         String dotComBlogId = getArguments().getString(ARG_BLOGID);
-        PeopleUtils.sendInvitations(new ArrayList<>(mUsernameButtons.keySet()), mRole, mCustomMessage,
-                dotComBlogId, new PeopleUtils.InvitationsSendCallback() {
+        PeopleUtils.sendInvitations(new ArrayList<>(mUsernameButtons.keySet()), mRole, mCustomMessage, dotComBlogId,
+                new PeopleUtils.InvitationsSendCallback() {
                     @Override
                     public void onSent(List<String> succeededUsernames, Map<String, String> failedUsernameErrors) {
                         if (!isAdded()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -58,7 +58,7 @@ public class PeopleInviteFragment extends Fragment implements
 
     private final Map<String, ViewGroup> mUsernameButtons = new LinkedHashMap<>();
     private final HashMap<String, String> mUsernameResults = new HashMap<>();
-    private final Map<String, View> mUsernameErrorViews = new Hashtable<>();
+    private final Map<String, TextView> mUsernameErrorViews = new Hashtable<>();
     private Role mRole;
     private String mCustomMessage = "";
     private boolean mInviteOperationInProgress = false;
@@ -334,9 +334,7 @@ public class PeopleInviteFragment extends Fragment implements
         mUsernameResults.remove(username);
         usernamesView.removeView(removedButton);
 
-        final ViewGroup usernamesContainer = (ViewGroup) getView().findViewById(R.id.usernames_container);
-        View removedErrorView = mUsernameErrorViews.remove(username);
-        usernamesContainer.removeView(removedErrorView);
+        updateUsernameError(username, null);
     }
 
     private boolean isUserInInvitees(String username) {
@@ -365,6 +363,13 @@ public class PeopleInviteFragment extends Fragment implements
     @Override
     public void onRoleSelected(Role newRole) {
         setRole(newRole);
+
+        if (!mUsernameButtons.keySet().isEmpty()) {
+            // clear the username results list and let the 'validate' routine do the updates
+            mUsernameResults.clear();
+
+            validateAndStyleUsername(mUsernameButtons.keySet(), null);
+        }
     }
 
     private void setRole(Role newRole) {
@@ -374,21 +379,17 @@ public class PeopleInviteFragment extends Fragment implements
 
     private void validateAndStyleUsername(Collection<String> usernames, final ValidationEndListener validationEndListener) {
         List<String> usernamesToCheck = new ArrayList<>();
-        List<String> usernamesChecked = new ArrayList<>();
 
         for (String username : usernames) {
             if (mUsernameResults.containsKey(username)) {
-                usernamesChecked.add(username);
-            } else {
-                usernamesToCheck.add(username);
-            }
-        }
-
-        for (String username : usernamesChecked) {
-            String resultMessage = mUsernameResults.get(username);
-            if (!resultMessage.equals(FLAG_SUCCESS)) {
+                String resultMessage = mUsernameResults.get(username);
                 styleButton(username, resultMessage);
-                appendError(username, resultMessage);
+                updateUsernameError(username, resultMessage);
+            } else {
+                styleButton(username, null);
+                updateUsernameError(username, null);
+
+                usernamesToCheck.add(username);
             }
         }
 
@@ -410,10 +411,8 @@ public class PeopleInviteFragment extends Fragment implements
                     final String usernameResultString = getValidationErrorString(username, validationResult);
                     mUsernameResults.put(username, usernameResultString);
 
-                    if (validationResult != ValidationResult.USER_FOUND) {
-                        styleButton(username, usernameResultString);
-                        appendError(username, usernameResultString);
-                    }
+                    styleButton(username, usernameResultString);
+                    updateUsernameError(username, usernameResultString);
                 }
 
                 @Override
@@ -439,18 +438,15 @@ public class PeopleInviteFragment extends Fragment implements
         void onValidationEnd();
     }
 
-    private void styleButton(String username, String validationResultMessage) {
+    private void styleButton(String username, @Nullable String validationResultMessage) {
         if (!isAdded()) {
             return;
         }
 
         TextView textView = (TextView) mUsernameButtons.get(username).findViewById(R.id.username);
-
-        if (!validationResultMessage.equals(FLAG_SUCCESS)) {
-            textView.setTextColor(ContextCompat.getColor(getActivity(), R.color.alert_red));
-        } else {
-            // properly style the button
-        }
+        textView.setTextColor(ContextCompat.getColor(getActivity(),
+                validationResultMessage == null ? R.color.grey_dark :
+                        (validationResultMessage.equals(FLAG_SUCCESS) ? R.color.blue_wordpress : R.color.alert_red)));
     }
 
     private
@@ -474,17 +470,37 @@ public class PeopleInviteFragment extends Fragment implements
         return null;
     }
 
-    private void appendError(String username, String error) {
-        if (!isAdded() || error == null) {
+    private void updateUsernameError(String username, @Nullable String usernameResult) {
+        if (!isAdded()) {
             return;
         }
 
-        final ViewGroup usernamesContainer = (ViewGroup) getView().findViewById(R.id.usernames_container);
-        final TextView usernameError = (TextView) LayoutInflater.from(getActivity()).inflate(R.layout
-                .people_invite_error_view, null);
-        usernameError.setText(error);
-        usernamesContainer.addView(usernameError);
-        mUsernameErrorViews.put(username, usernameError);
+        TextView usernameErrorTextView;
+        if (mUsernameErrorViews.containsKey(username)) {
+            usernameErrorTextView = mUsernameErrorViews.get(username);
+
+            if (usernameResult == null || usernameResult.equals(FLAG_SUCCESS)) {
+                // no error so we need to remove the existing error view
+                ((ViewGroup) usernameErrorTextView.getParent()).removeView(usernameErrorTextView);
+                mUsernameErrorViews.remove(username);
+                return;
+            }
+        } else {
+            if (usernameResult == null || usernameResult.equals(FLAG_SUCCESS)) {
+                // no error so no need to create a new error view
+                return;
+            }
+
+            usernameErrorTextView = (TextView) LayoutInflater.from(getActivity())
+                    .inflate(R.layout.people_invite_error_view, null);
+
+            final ViewGroup usernameErrorsContainer = (ViewGroup) getView()
+                    .findViewById(R.id.username_errors_container);
+            usernameErrorsContainer.addView(usernameErrorTextView);
+
+            mUsernameErrorViews.put(username, usernameErrorTextView);
+        }
+        usernameErrorTextView.setText(usernameResult);
     }
 
     private void clearUsernames(Collection<String> usernames) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -461,6 +461,10 @@ public class PeopleInviteFragment extends Fragment implements
                 return getString(R.string.invite_username_not_found, username);
             case ALREADY_MEMBER:
                 return getString(R.string.invite_already_a_member, username);
+            case ALREADY_FOLLOWING:
+                return getString(R.string.invite_already_following, username);
+            case BLOCKED_INVITES:
+                return getString(R.string.invite_user_blocked_invites, username);
             case INVALID_EMAIL:
                 return getString(R.string.invite_invalid_email, username);
             case USER_FOUND:

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -395,7 +395,7 @@ public class PeopleInviteFragment extends Fragment implements
         if (usernamesToCheck.size() > 0) {
 
             String dotComBlogId = getArguments().getString(ARG_BLOGID);
-            PeopleUtils.validateUsernames(usernamesToCheck, dotComBlogId, new PeopleUtils.ValidateUsernameCallback() {
+            PeopleUtils.validateUsernames(usernamesToCheck, mRole, dotComBlogId, new PeopleUtils.ValidateUsernameCallback() {
                 @Override
                 public void onUsernameValidation(String username, ValidationResult validationResult) {
                     if (!isAdded()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -602,7 +602,8 @@ public class PeopleInviteFragment extends Fragment implements
 
                             populateUsernameButtons(failedUsernameErrors.keySet());
 
-                            ToastUtils.showToast(getActivity(), R.string.invite_error_some_failed);
+                            ToastUtils.showToast(getActivity(), succeededUsernames.isEmpty()
+                                    ? R.string.invite_error_sending : R.string.invite_error_some_failed);
                         } else {
                             ToastUtils.showToast(getActivity(), R.string.invite_sent, ToastUtils.Duration.LONG);
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
@@ -342,7 +342,7 @@ public class PeopleUtils {
         void onError();
     }
 
-    public static void validateUsernames(final List<String> usernames, String dotComBlogId, final
+    public static void validateUsernames(final List<String> usernames, Role role, String dotComBlogId, final
             ValidateUsernameCallback callback) {
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
@@ -432,7 +432,7 @@ public class PeopleUtils {
         for (String username : usernames) {
             params.put("invitees[" + username + "]", username); // specify an array key so to make the map key unique
         }
-        params.put("role", "follower"); // the specific role is not important, just needs to be a valid one
+        params.put("role", role.toRESTString());
         WordPress.getRestClientUtilsV1_1().post(path, params, null, listener, errorListener);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
@@ -376,6 +376,12 @@ public class PeopleUtils {
                                 case "invalid_input_has_role":
                                     callback.onUsernameValidation(username, ValidationResult.ALREADY_MEMBER);
                                     continue;
+                                case "invalid_input_following":
+                                    callback.onUsernameValidation(username, ValidationResult.ALREADY_FOLLOWING);
+                                    continue;
+                                case "invalid_user_blocked_invites":
+                                    callback.onUsernameValidation(username, ValidationResult.BLOCKED_INVITES);
+                                    continue;
                             }
 
                             callback.onError();
@@ -434,6 +440,8 @@ public class PeopleUtils {
         enum ValidationResult {
             USER_NOT_FOUND,
             ALREADY_MEMBER,
+            ALREADY_FOLLOWING,
+            BLOCKED_INVITES,
             INVALID_EMAIL,
             USER_FOUND
         }

--- a/WordPress/src/main/res/layout/people_invite_fragment.xml
+++ b/WordPress/src/main/res/layout/people_invite_fragment.xml
@@ -54,7 +54,7 @@
                     android:paddingLeft="@dimen/margin_medium"
                     android:paddingRight="@dimen/margin_medium"
                     android:singleLine="true"
-                    android:textColor="#444444"
+                    android:textColor="@color/grey_dark"
                     android:textColorHint="#AAAAAA"
                     android:textSize="@dimen/text_sz_medium"
                     tools:text="sdfwefef"
@@ -71,6 +71,14 @@
                 android:textSize="@dimen/text_sz_small"
                 android:textStyle="italic"
                 android:text="@string/invite_message_usernames_limit"/>
+
+            <LinearLayout
+                android:id="@+id/username_errors_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="5dp"
+                android:animateLayoutChanges="true"
+                android:orientation="vertical" />
         </LinearLayout>
 
         <LinearLayout

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1413,9 +1413,9 @@
     <string name="invite_names_title">Usernames or Emails</string>
     <string name="invite">Invite</string>
     <string name="button_invite" translatable="false">@string/invite</string>
-    <string name="invite_username_not_found">No user was found for username \'%s\'</string>
-    <string name="invite_already_a_member">There\'s already a member with username \'%s\'</string>
-    <string name="invite_invalid_email">The email address \'%s\' is invalid</string>
+    <string name="invite_username_not_found">%s: User not found</string>
+    <string name="invite_already_a_member">%s: Already a member</string>
+    <string name="invite_invalid_email">%s: Invalid email</string>
     <string name="invite_message_title">Custom Message</string>
     <string name="invite_message_remaining_zero">0 characters remaining</string>
     <string name="invite_message_remaining_one">1 character remaining</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1415,6 +1415,8 @@
     <string name="button_invite" translatable="false">@string/invite</string>
     <string name="invite_username_not_found">%s: User not found</string>
     <string name="invite_already_a_member">%s: Already a member</string>
+    <string name="invite_already_following">%s: Already following</string>
+    <string name="invite_user_blocked_invites">%s: User blocked invites</string>
     <string name="invite_invalid_email">%s: Invalid email</string>
     <string name="invite_message_title">Custom Message</string>
     <string name="invite_message_remaining_zero">0 characters remaining</string>


### PR DESCRIPTION
Fixes #4351 

Aligns the invites related error messages with the ones returned from the API.

To test messages alignment:
* Go into the people invites screen for a site you're the admin of
* Type a username you know is already a member of the site **and hit "space"**
* Notice the error message that appears (it should be `<username>: Already a member` or `<username>: Already following`)
* Delete/remove the username
* Type it again but this time **don't hit Space or Enter**. Instead, tap in the "SEND" button.
* Notice the error message that appears. It should be the same as above.

This PR adds support for the "User blocked invites" and "Already following" errors.