### PR TITLE
Re-validate on user invite role change

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -334,9 +334,9 @@ public class PeopleInviteFragment extends Fragment implements
         mUsernameResults.remove(username);
         usernamesView.removeView(removedButton);
 
-        final ViewGroup usernamesContainer = (ViewGroup) getView().findViewById(R.id.usernames_container);
+        final ViewGroup usernameErrorsContainer = (ViewGroup) getView().findViewById(R.id.username_errors_container);
         View removedErrorView = mUsernameErrorViews.remove(username);
-        usernamesContainer.removeView(removedErrorView);
+        usernameErrorsContainer.removeView(removedErrorView);
     }
 
     private boolean isUserInInvitees(String username) {
@@ -365,6 +365,12 @@ public class PeopleInviteFragment extends Fragment implements
     @Override
     public void onRoleSelected(Role newRole) {
         setRole(newRole);
+
+        clearUsernamesStyling(mUsernameButtons.keySet());
+        mUsernameResults.clear();
+        clearErrorViews();
+
+        validateAndStyleUsername(new ArrayList<>(mUsernameButtons.keySet()), null);
     }
 
     private void setRole(Role newRole) {
@@ -395,7 +401,8 @@ public class PeopleInviteFragment extends Fragment implements
         if (usernamesToCheck.size() > 0) {
 
             String dotComBlogId = getArguments().getString(ARG_BLOGID);
-            PeopleUtils.validateUsernames(usernamesToCheck, dotComBlogId, new PeopleUtils.ValidateUsernameCallback() {
+            PeopleUtils
+                    .validateUsernames(usernamesToCheck, mRole, dotComBlogId, new PeopleUtils.ValidateUsernameCallback() {
                 @Override
                 public void onUsernameValidation(String username, ValidationResult validationResult) {
                     if (!isAdded()) {
@@ -410,8 +417,9 @@ public class PeopleInviteFragment extends Fragment implements
                     final String usernameResultString = getValidationErrorString(username, validationResult);
                     mUsernameResults.put(username, usernameResultString);
 
+                    styleButton(username, usernameResultString);
+
                     if (validationResult != ValidationResult.USER_FOUND) {
-                        styleButton(username, usernameResultString);
                         appendError(username, usernameResultString);
                     }
                 }
@@ -449,7 +457,7 @@ public class PeopleInviteFragment extends Fragment implements
         if (!validationResultMessage.equals(FLAG_SUCCESS)) {
             textView.setTextColor(ContextCompat.getColor(getActivity(), R.color.alert_red));
         } else {
-            // properly style the button
+            textView.setTextColor(ContextCompat.getColor(getActivity(), R.color.nux_text_grey));
         }
     }
 
@@ -475,11 +483,11 @@ public class PeopleInviteFragment extends Fragment implements
             return;
         }
 
-        final ViewGroup usernamesContainer = (ViewGroup) getView().findViewById(R.id.usernames_container);
+        final ViewGroup usernameErrorsContainer = (ViewGroup) getView().findViewById(R.id.username_errors_container);
         final TextView usernameError = (TextView) LayoutInflater.from(getActivity()).inflate(R.layout
                 .people_invite_error_view, null);
         usernameError.setText(error);
-        usernamesContainer.addView(usernameError);
+        usernameErrorsContainer.addView(usernameError);
         mUsernameErrorViews.put(username, usernameError);
     }
 
@@ -492,6 +500,17 @@ public class PeopleInviteFragment extends Fragment implements
             setRole(getDefaultRole());
             resetEditTextContent(mCustomMessageEditText);
         }
+    }
+
+    private void clearUsernamesStyling(Collection<String> usernames) {
+        for (String username : usernames) {
+            styleButton(username, FLAG_SUCCESS);
+        }
+    }
+
+    private void clearErrorViews() {
+        final ViewGroup usernameErrorsContainer = (ViewGroup) getView().findViewById(R.id.username_errors_container);
+        usernameErrorsContainer.removeAllViews();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
@@ -342,7 +342,7 @@ public class PeopleUtils {
         void onError();
     }
 
-    public static void validateUsernames(final List<String> usernames, String dotComBlogId, final
+    public static void validateUsernames(final List<String> usernames, Role role, String dotComBlogId, final
             ValidateUsernameCallback callback) {
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
@@ -426,7 +426,7 @@ public class PeopleUtils {
         for (String username : usernames) {
             params.put("invitees[" + username + "]", username); // specify an array key so to make the map key unique
         }
-        params.put("role", "follower"); // the specific role is not important, just needs to be a valid one
+        params.put("role", role.toRESTString());
         WordPress.getRestClientUtilsV1_1().post(path, params, null, listener, errorListener);
     }
 

--- a/WordPress/src/main/res/layout/people_invite_fragment.xml
+++ b/WordPress/src/main/res/layout/people_invite_fragment.xml
@@ -54,8 +54,8 @@
                     android:paddingLeft="@dimen/margin_medium"
                     android:paddingRight="@dimen/margin_medium"
                     android:singleLine="true"
-                    android:textColor="#444444"
-                    android:textColorHint="#AAAAAA"
+                    android:textColor="@color/nux_text_grey"
+                    android:textColorHint="@color/nux_text_hint_grey"
                     android:textSize="@dimen/text_sz_medium"
                     tools:text="sdfwefef"
                     android:inputType="text"
@@ -71,6 +71,12 @@
                 android:textSize="@dimen/text_sz_small"
                 android:textStyle="italic"
                 android:text="@string/invite_message_usernames_limit"/>
+
+            <LinearLayout
+                android:id="@+id/username_errors_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"/>
         </LinearLayout>
 
         <LinearLayout

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -130,6 +130,8 @@
     <color name="nux_background">@color/blue_wordpress</color>
     <color name="nux_eye_icon_color_closed">@color/grey_lighten_20</color>
     <color name="nux_eye_icon_color_open">@color/grey_lighten_10</color>
+    <color name="nux_text_grey">#444444</color>
+    <color name="nux_text_hint_grey">#AAAAAA</color>
 
     <!-- Editor -->
     <color name="image_options_label">@color/grey_lighten_20</color>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -199,8 +199,8 @@
     <style name="WordPress.NUXEditText">
         <item name="android:background">@color/white</item>
         <item name="android:singleLine">true</item>
-        <item name="android:textColor">#444444</item>
-        <item name="android:textColorHint">#AAAAAA</item>
+        <item name="android:textColor">@color/nux_text_grey</item>
+        <item name="android:textColorHint">@color/nux_text_hint_grey</item>
         <item name="android:padding">12dp</item>
         <item name="android:layout_marginLeft">40dp</item>
     </style>


### PR DESCRIPTION
Fixes #4347 

Allows a user to be re-invited under a different role. This supports "promoting" a Viewer into a member with additional user rights.

To test:
* On a private site
* Go to the User Invite screen and try to invite a user that is currently a `Viewer`
* The username should not be accepted and a "already member" style error should be shown
* Tap and change the Role to "Editor" or anything else besides "Viewer"
* The error message should be gone and the username should have lost its red colour
