### PR TITLE
issue/4560-reader-saved-search-text-color

### DIFF
--- a/WordPress/src/main/res/layout/reader_listitem_suggestion.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_suggestion.xml
@@ -20,6 +20,7 @@
         android:lines="1"
         android:minHeight="?android:attr/listPreferredItemHeightSmall"
         android:textAppearance="?android:attr/textAppearanceListItemSmall"
+        android:textColor="@color/grey_dark"
         tools:text="Suggestion" />
 
     <ImageView


### PR DESCRIPTION
Fixes #4560 

To test: 
* Run this branch on an Android 4.4 emulator
* Switch to the reader tab and enter a search phrase
* Click the "x" icon after the search completes to start a new search
* Type the first letter of the last phrase you entered to force it to appear as a suggestion

The suggestion should have a dark grey text color rather than white.

![screenshot_1474735443](https://cloud.githubusercontent.com/assets/3903757/18809846/0df27fe8-8255-11e6-8259-e5802164968d.png)


