### PR TITLE
Issue/4556 gcm update notifs on system bar crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
@@ -76,7 +76,7 @@ public class GCMMessageService extends GcmListenerService {
 
     private void synchronizedHandleDefaultPush(String from, @NonNull Bundle data) {
         // sActiveNotificationsMap being static, we can't just synchronize the method
-        synchronized (sActiveNotificationsMap) {
+        synchronized (GCMMessageService.class) {
             handleDefaultPush(from, data);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
@@ -407,7 +407,9 @@ public class GCMMessageService extends GcmListenerService {
 
                 String noteType = StringUtils.notNullStr(remainingNote.getString(PUSH_ARG_TYPE));
                 String noteId = remainingNote.getString(PUSH_ARG_NOTE_ID, "");
-                showIndividualNotificationForBuilder(builder, noteType, noteId, sActiveNotificationsMap.keyAt(0));
+                if (!sActiveNotificationsMap.isEmpty()) {
+                    showIndividualNotificationForBuilder(builder, noteType, noteId, sActiveNotificationsMap.keyAt(0));
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #4556 

I’ve checked and this code path is only reached in the case of a `badge-reset` PN.
ok so, the only way this block here https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java#L391 gets here https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java#L410 with an empty `sActiveNotificationsMap` would be if another thread was accessing it in the middle and taking the only item off from such array.

So the first hypothesis I have is: what’s happening here is we’re getting another `badge-reset` type notification coming in, at practically the same moment.

BUT, I find that all this code is already synchronized as can be seen here https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java#L77


So if we have this main method synchronized, how could it be possible that in this short code block `sActiveNotificationsMap` has 1 element and then has no more elements. The code in between does not remove such existing element, so the only option left is: another thread is removing such an item from that ArrayMap.

Having that assertion in mind, started to look for the very definition - looking to see if I understood `synchronised` correctly  here: http://docs.oracle.com/javase/tutorial/essential/concurrency/locksync.html


```
When a thread invokes a synchronized method, it automatically acquires the intrinsic lock for that method's object and releases it when the method returns.
```

This implies that there is one different lock object for each different method.

Then also this:

```
You might wonder what happens when a static synchronized method is invoked, since a static method is associated with a class, not an object. In this case, the thread acquires the intrinsic lock for the Class object associated with the class. Thus access to class's static fields is controlled by a lock that's distinct from the lock for any instance of the class.
```

So basically:
1) static methods are being locked on the implicit Class object
2) non-static methods and inner `synchronized` blocks are being locked on the intrinsic lock for the instance of the class
3) Also, the `handleDefaultPush`method is wrapped in a `synchronized (sActiveNotificationsMap) ` inside `synchronizedHandleDefaultPush`, so we are sure that whole code execution path is locked on that object

Ok so basically the thread that is coming from the GcmListener itself is synchronised using the actual `sActiveNotificationsMap` object as a lock, so the thread that is deleting/erasing/clearing the array map *HAS* to be something else entirely

Looking into it, we have this:

Static methods that remove something from the array map:
so here we have one static method that locks on the intrinsic Class lock, but 

- `public static synchronized void removeNotification(int notificationId)`
- `public static synchronized void removeNotificationWithNoteIdFromSystemBar(Context context, Bundle data)`
- `public static synchronized void clearNotifications()`
- `public static synchronized void removeNotification(int notificationId)`

The ones that might be called from other places except the gcmlistenerservice thread are these two:
- `public static synchronized void clearNotifications()`
- `public static synchronized void removeNotification(int notificationId)`


So, basically we need to lock both threads on the same object. I suggest we just make the lock on the Class intrinsic lock so in a way to still keep our static synchronised method the same.

I'm also adding a `isEmpty()` check that would ultimately prevent the app from crashing, minimsing the impact (i.e. the notification that was already viewed on some other client won't be dismissed, which is far better than crashing). Please note this only happens with `reset` notifications, so the user still gets to see all other kinds of notifications properly.

To test: it's very difficult to test as I'd have to dismiss the notification manually (_to trigger the gcmlistenerservice thread_) *and* get a badge-reset at the same time (_to trigger the path that was suddenly finding no elements in the `sActiveNotificationsMap`_). Might do by adding breakpoints here and there, but not sure yet

Needs review: @maxme 


