### PR TITLE
Upgrade image cropping library to latest version

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -105,13 +105,14 @@ dependencies {
     compile 'org.wordpress:persistentedittext:1.0.1'
     compile 'org.wordpress:emailchecker2:1.1.0'
 
-    compile 'com.yalantis:ucrop:1.5.0'
+    compile 'com.yalantis:ucrop:2.2.0'
     compile 'com.github.xizzhu:simple-tool-tip:0.5.0'
 
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.0'
     androidTestCompile 'org.objenesis:objenesis:2.1'
     androidTestCompile 'org.mockito:mockito-core:+'
     androidTestCompile 'com.squareup.okhttp:mockwebserver:2.7.5'
+    androidTestCompile 'com.squareup.okio:okio:1.9.0' // explicitly compile okio to match the version needed by ucrop
 
     // Provided by the WordPress-Android Repository
     compile 'org.wordpress:drag-sort-listview:0.6.1' // not found in maven central

--- a/WordPress/lint.xml
+++ b/WordPress/lint.xml
@@ -5,7 +5,7 @@
     <issue id="RtlCompat" severity="warning" />
 
     <issue id="InvalidPackage">
-        <ignore regexp="okio-1.6.0.jar" />
+        <ignore regexp="okio-1.9.0.jar" />
     </issue>
 
     <issue id="NewApi">

--- a/WordPress/proguard.cfg
+++ b/WordPress/proguard.cfg
@@ -24,3 +24,7 @@
 
 -keepattributes Signature
 -keepattributes *Annotation*
+
+-dontwarn com.yalantis.ucrop**
+-keep class com.yalantis.ucrop** { *; }
+-keep interface com.yalantis.ucrop** { *; }


### PR DESCRIPTION
Fixes #4454 

To test:

No specific steps to test as there are no steps to reproduce the original issue. Instead, try to change your Gravatar through the app by cropping some picture. It should work.