### PR TITLE
Remove unneeded padding

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -447,11 +447,6 @@ public class PeopleInviteFragment extends Fragment implements
         }
     }
 
-
-    public interface ValidationEndListener {
-        void onValidationEnd();
-    }
-
     private void styleButton(String username, @Nullable String validationResultMessage) {
         if (!isAdded()) {
             return;
@@ -666,4 +661,7 @@ public class PeopleInviteFragment extends Fragment implements
         return blog != null && blog.isPrivate();
     }
 
+    public interface ValidationEndListener {
+        void onValidationEnd();
+    }
 }

--- a/WordPress/src/main/res/layout/people_invite_fragment.xml
+++ b/WordPress/src/main/res/layout/people_invite_fragment.xml
@@ -126,10 +126,6 @@
                 android:ellipsize="end"
                 android:gravity="center_vertical"
                 android:maxLines="1"
-                android:paddingBottom="@dimen/margin_medium"
-                android:paddingLeft="@dimen/margin_medium"
-                android:paddingRight="@dimen/margin_medium"
-                android:paddingTop="@dimen/margin_medium"
                 android:textColor="@color/grey"
                 android:textSize="@dimen/text_sz_medium"
                 tools:text="@string/role" />


### PR DESCRIPTION
Removed unneeded padding around the Invites screen role "dropdown".

To test:
* Navigate to the invites screen
* Notice how the "Follower" role (that's the default selected anyway) has its left side aligned with the "Role" header above it.