### PR TITLE
Fix wordpress-mobile/WordPress-Editor-Android#454: getActionBar() was returning null on Android 7

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -214,10 +214,6 @@ public class ImageSettingsDialogFragment extends DialogFragment {
     }
 
     private ActionBar getActionBar() {
-        if (!isAdded()) {
-            return null;
-        }
-
         if (getActivity() instanceof AppCompatActivity) {
             return ((AppCompatActivity) getActivity()).getSupportActionBar();
         } else {


### PR DESCRIPTION
Fix wordpress-mobile/WordPress-Editor-Android#454: getActionBar() was returning null on Android 7