### PR TITLE
Mark role_info_url as untranslatable

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1358,6 +1358,7 @@
     <!-- Static URLs -->
     <string name="privacy_settings_url" translatable="false">https://en.support.wordpress.com/privacy-settings</string>
     <string name="language_settings_url" translatable="false">https://en.support.wordpress.com/language-settings</string>
+    <string name="role_info_url" translatable="false">https://en.support.wordpress.com/user-roles/</string>
 
     <string name="date_range_start_date">Start Date</string>
     <string name="date_range_end_date">End Date</string>
@@ -1574,6 +1575,5 @@
     <string name="editor_toast_failed_uploads">Some media uploads have failed. You can\'t save or publish
         your post in this state. Would you like to remove all failed media?</string>
     <string name="editor_remove_failed_uploads">Remove failed uploads</string>
-    <string name="role_info_url">https://en.support.wordpress.com/user-roles/</string>
 
 </resources>


### PR DESCRIPTION
`role_info_url` is a URL and needs to be marked as untranslatable.

h/t @maxme 