### PR TITLE
Intercept WPCOM Reader URLs

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -258,6 +258,25 @@
                     android:host="viewpost"
                     android:scheme="wordpress" />
             </intent-filter>
+
+            <intent-filter>
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/read/feeds/.*/posts/.*"
+                    android:scheme="https" >
+                </data>
+
+                <data
+                    android:host="wordpress.com"
+                    android:pathPattern="/read/feeds/.*/posts/.*"
+                    android:scheme="http" >
+                </data>
+
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
         </activity>
 
         <!-- Reader Activities -->

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -269,11 +269,15 @@ public class ReaderPostTable {
         addOrUpdatePosts(null, posts);
     }
 
-    public static ReaderPost getPost(long blogId, long postId, boolean excludeTextColumn) {
+    public static ReaderPost getBlogPost(long blogId, long postId, boolean excludeTextColumn) {
         return getPost(false, blogId, postId, excludeTextColumn);
     }
 
-    public static ReaderPost getPost(boolean isFeed, long blogOrFeedId, long postOrItemId, boolean excludeTextColumn) {
+    public static ReaderPost getFeedPost(long feedId, long feedItemId, boolean excludeTextColumn) {
+        return getPost(true, feedId, feedItemId, excludeTextColumn);
+    }
+
+    private static ReaderPost getPost(boolean isFeed, long blogOrFeedId, long postOrItemId, boolean excludeTextColumn) {
         String columns = (excludeTextColumn ? COLUMN_NAMES_NO_TEXT : "*");
         String sql = "SELECT " + columns + " FROM tbl_posts WHERE "
                 + (isFeed ? "feed_id" : "blog_id") + "=? AND " + (isFeed ? "feed_item_id" : "post_id") + "=? LIMIT 1";
@@ -321,7 +325,7 @@ public class ReaderPostTable {
 
         boolean hasChanges = false;
         for (ReaderPost post: posts) {
-            ReaderPost existingPost = getPost(post.blogId, post.postId, true);
+            ReaderPost existingPost = getBlogPost(post.blogId, post.postId, true);
             if (existingPost == null) {
                 return ReaderActions.UpdateResult.HAS_NEW;
             } else if (!hasChanges && !post.isSamePost(existingPost)) {

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -270,11 +270,15 @@ public class ReaderPostTable {
     }
 
     public static ReaderPost getPost(long blogId, long postId, boolean excludeTextColumn) {
+        return getPost(false, blogId, postId, excludeTextColumn);
+    }
 
+    public static ReaderPost getPost(boolean isFeed, long blogOrFeedId, long postOrItemId, boolean excludeTextColumn) {
         String columns = (excludeTextColumn ? COLUMN_NAMES_NO_TEXT : "*");
-        String sql = "SELECT " + columns + " FROM tbl_posts WHERE blog_id=? AND post_id=? LIMIT 1";
+        String sql = "SELECT " + columns + " FROM tbl_posts WHERE "
+                + (isFeed ? "feed_id" : "blog_id") + "=? AND " + (isFeed ? "feed_item_id" : "post_id") + "=? LIMIT 1";
 
-        String[] args = new String[] {Long.toString(blogId), Long.toString(postId)};
+        String[] args = new String[] {Long.toString(blogOrFeedId), Long.toString(postOrItemId)};
         Cursor c = ReaderDatabase.getReadableDb().rawQuery(sql, args);
         try {
             if (!c.moveToFirst()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
@@ -50,6 +50,8 @@ public class DeepLinkingIntentReceiverActivity extends AppCompatActivity {
                 case "https":
                     List<String> segments = uri.getPathSegments();
 
+                    // Handled URLs look like this: http[s]://wordpress.com/read/feeds/{feedId}/posts/{feedItemId}
+                    //  with the first segment being 'read'.
                     if (segments != null && segments.get(0).equals("read")) {
                         if (segments.size() > 2 && segments.get(1).equals("feeds")) {
                             mIsFeed = true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -723,7 +723,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             // the title if it wasn't set above
             if (!postExists) {
                 AppLog.d(T.COMMENTS, "comment detail > retrieving post");
-                ReaderPostActions.requestPost(blogId, postId, new ReaderActions.OnRequestListener() {
+                ReaderPostActions.requestBlogPost(blogId, postId, new ReaderActions.OnRequestListener() {
                     @Override
                     public void onSuccess() {
                         if (!isAdded()) return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -439,7 +439,7 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
 
         // Request the reader post so that loading reader activities will work.
         if (mNote.isUserList() && !ReaderPostTable.postExists(mNote.getSiteId(), mNote.getPostId())) {
-            ReaderPostActions.requestPost(mNote.getSiteId(), mNote.getPostId(), null);
+            ReaderPostActions.requestBlogPost(mNote.getSiteId(), mNote.getPostId(), null);
         }
 
         // Request reader comments until we retrieve the comment for this note

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -35,13 +35,16 @@ public class ReaderActivityLauncher {
      * with a single post
      */
     public static void showReaderPostDetail(Context context, long blogId, long postId) {
-        showReaderPostDetail(context, blogId, postId, false);
+        showReaderPostDetail(context, false, blogId, postId, false);
     }
+
     public static void showReaderPostDetail(Context context,
+                                            boolean isFeed,
                                             long blogId,
                                             long postId,
                                             boolean isRelatedPost) {
         Intent intent = new Intent(context, ReaderPostPagerActivity.class);
+        intent.putExtra(ReaderConstants.ARG_IS_FEED, isFeed);
         intent.putExtra(ReaderConstants.ARG_BLOG_ID, blogId);
         intent.putExtra(ReaderConstants.ARG_POST_ID, postId);
         intent.putExtra(ReaderConstants.ARG_IS_SINGLE_POST, true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -112,20 +112,16 @@ public class ReaderActivityLauncher {
         }
     }
 
-    public static Intent getReaderFeedPreviewIntent(Context context, long feedId) {
-        Intent intent = new Intent(context, ReaderPostListActivity.class);
-        intent.putExtra(ReaderConstants.ARG_FEED_ID, feedId);
-        intent.putExtra(ReaderConstants.ARG_POST_LIST_TYPE, ReaderPostListType.BLOG_PREVIEW);
-        return intent;
-    }
-
     public static void showReaderFeedPreview(Context context, long feedId) {
         if (feedId == 0) {
             return;
         }
 
         AnalyticsTracker.track(AnalyticsTracker.Stat.READER_BLOG_PREVIEWED);
-        context.startActivity(getReaderFeedPreviewIntent(context, feedId));
+        Intent intent = new Intent(context, ReaderPostListActivity.class);
+        intent.putExtra(ReaderConstants.ARG_FEED_ID, feedId);
+        intent.putExtra(ReaderConstants.ARG_POST_LIST_TYPE, ReaderPostListType.BLOG_PREVIEW);
+        context.startActivity(intent);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -112,16 +112,20 @@ public class ReaderActivityLauncher {
         }
     }
 
+    public static Intent getReaderFeedPreviewIntent(Context context, long feedId) {
+        Intent intent = new Intent(context, ReaderPostListActivity.class);
+        intent.putExtra(ReaderConstants.ARG_FEED_ID, feedId);
+        intent.putExtra(ReaderConstants.ARG_POST_LIST_TYPE, ReaderPostListType.BLOG_PREVIEW);
+        return intent;
+    }
+
     public static void showReaderFeedPreview(Context context, long feedId) {
         if (feedId == 0) {
             return;
         }
 
         AnalyticsTracker.track(AnalyticsTracker.Stat.READER_BLOG_PREVIEWED);
-        Intent intent = new Intent(context, ReaderPostListActivity.class);
-        intent.putExtra(ReaderConstants.ARG_FEED_ID, feedId);
-        intent.putExtra(ReaderConstants.ARG_POST_LIST_TYPE, ReaderPostListType.BLOG_PREVIEW);
-        context.startActivity(intent);
+        context.startActivity(getReaderFeedPreviewIntent(context, feedId));
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -256,7 +256,7 @@ public class ReaderCommentListActivity extends AppCompatActivity {
     }
 
     private boolean loadPost() {
-        mPost = ReaderPostTable.getPost(mBlogId, mPostId, true);
+        mPost = ReaderPostTable.getBlogPost(mBlogId, mPostId, true);
         if (mPost == null) {
             return false;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -23,6 +23,7 @@ public class ReaderConstants {
 
     // intent arguments / keys
     static final String ARG_TAG               = "tag";
+    static final String ARG_IS_FEED           = "is_feed";
     static final String ARG_BLOG_ID           = "blog_id";
     static final String ARG_FEED_ID           = "feed_id";
     static final String ARG_POST_ID           = "post_id";

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -78,6 +78,7 @@ public class ReaderPostDetailFragment extends Fragment
 
     private long mPostId;
     private long mBlogId;
+    private boolean mIsFeed;
     private ReaderPost mPost;
     private ReaderPostRenderer mRenderer;
     private ReaderPostListType mPostListType;
@@ -108,16 +109,18 @@ public class ReaderPostDetailFragment extends Fragment
     private static final float MIN_SCROLL_DISTANCE_Y = 10;
 
     public static ReaderPostDetailFragment newInstance(long blogId, long postId) {
-        return newInstance(blogId, postId, false, null);
+        return newInstance(false, blogId, postId, false, null);
     }
 
-    public static ReaderPostDetailFragment newInstance(long blogId,
+    public static ReaderPostDetailFragment newInstance(boolean isFeed,
+                                                       long blogId,
                                                        long postId,
                                                        boolean isRelatedPost,
                                                        ReaderPostListType postListType) {
         AppLog.d(T.READER, "reader post detail > newInstance");
 
         Bundle args = new Bundle();
+        args.putBoolean(ReaderConstants.ARG_IS_FEED, isFeed);
         args.putLong(ReaderConstants.ARG_BLOG_ID, blogId);
         args.putLong(ReaderConstants.ARG_POST_ID, postId);
         args.putBoolean(ReaderConstants.ARG_IS_RELATED_POST, isRelatedPost);
@@ -144,6 +147,7 @@ public class ReaderPostDetailFragment extends Fragment
     public void setArguments(Bundle args) {
         super.setArguments(args);
         if (args != null) {
+            mIsFeed = args.getBoolean(ReaderConstants.ARG_IS_FEED);
             mBlogId = args.getLong(ReaderConstants.ARG_BLOG_ID);
             mPostId = args.getLong(ReaderConstants.ARG_POST_ID);
             mIsRelatedPost = args.getBoolean(ReaderConstants.ARG_IS_RELATED_POST);
@@ -264,6 +268,7 @@ public class ReaderPostDetailFragment extends Fragment
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
+        outState.putBoolean(ReaderConstants.ARG_IS_FEED, mIsFeed);
         outState.putLong(ReaderConstants.ARG_BLOG_ID, mBlogId);
         outState.putLong(ReaderConstants.ARG_POST_ID, mPostId);
 
@@ -291,6 +296,7 @@ public class ReaderPostDetailFragment extends Fragment
 
     private void restoreState(Bundle savedInstanceState) {
         if (savedInstanceState != null) {
+            mIsFeed = savedInstanceState.getBoolean(ReaderConstants.ARG_IS_FEED);
             mBlogId = savedInstanceState.getLong(ReaderConstants.ARG_BLOG_ID);
             mPostId = savedInstanceState.getLong(ReaderConstants.ARG_POST_ID);
             mIsRelatedPost = savedInstanceState.getBoolean(ReaderConstants.ARG_IS_RELATED_POST);
@@ -349,7 +355,7 @@ public class ReaderPostDetailFragment extends Fragment
         }
 
         // get the post again since it has changed, then refresh to show changes
-        mPost = ReaderPostTable.getPost(mBlogId, mPostId, false);
+        mPost = ReaderPostTable.getPost(mPost.blogId, mPost.postId, false);
         refreshLikes();
         refreshIconCounts();
 
@@ -435,6 +441,7 @@ public class ReaderPostDetailFragment extends Fragment
      * replace the current post with the passed one
      */
     private void replacePost(long blogId, long postId) {
+        mIsFeed = false;
         mBlogId = blogId;
         mPostId = postId;
         mHasAlreadyRequestedPost = false;
@@ -477,7 +484,7 @@ public class ReaderPostDetailFragment extends Fragment
         if (!isAdded() || !hasPost()) return;
 
         // make sure this is for the current post
-        if (event.getSourcePost().postId == mPostId && event.getSourcePost().blogId == mBlogId) {
+        if (event.getSourcePost().postId == mPost.postId && event.getSourcePost().blogId == mPost.blogId) {
             showRelatedPosts(event.getRelatedPosts());
         }
     }
@@ -547,7 +554,7 @@ public class ReaderPostDetailFragment extends Fragment
             mPostHistory.push(new ReaderBlogIdPostId(mPost.blogId, mPost.postId));
             replacePost(blogId, postId);
         } else {
-            ReaderActivityLauncher.showReaderPostDetail(getActivity(), blogId, postId, true);
+            ReaderActivityLauncher.showReaderPostDetail(getActivity(), false, blogId, postId, true);
         }
     }
 
@@ -583,7 +590,7 @@ public class ReaderPostDetailFragment extends Fragment
                 }
                 // if the post has changed, reload it from the db and update the like/comment counts
                 if (result.isNewOrChanged()) {
-                    mPost = ReaderPostTable.getPost(mBlogId, mPostId, false);
+                    mPost = ReaderPostTable.getPost(mPost.blogId, mPost.postId, false);
                     refreshIconCounts();
                 }
                 // refresh likes if necessary - done regardless of whether the post has changed
@@ -749,7 +756,7 @@ public class ReaderPostDetailFragment extends Fragment
                 }
             }
         };
-        ReaderPostActions.requestPost(mBlogId, mPostId, listener);
+        ReaderPostActions.requestPost(mIsFeed, mBlogId, mPostId, listener);
     }
 
     /*
@@ -793,7 +800,7 @@ public class ReaderPostDetailFragment extends Fragment
 
         @Override
         protected Boolean doInBackground(Void... params) {
-            mPost = ReaderPostTable.getPost(mBlogId, mPostId, false);
+            mPost = ReaderPostTable.getPost(mIsFeed, mBlogId, mPostId, false);
             if (mPost == null) {
                 return false;
             }
@@ -805,6 +812,7 @@ public class ReaderPostDetailFragment extends Fragment
                         && discoverData.getDiscoverType() == ReaderPostDiscoverData.DiscoverType.EDITOR_PICK
                         && discoverData.getBlogId() != 0
                         && discoverData.getPostId() != 0) {
+                    mIsFeed = false;
                     mBlogId = discoverData.getBlogId();
                     mPostId = discoverData.getPostId();
                     mPost = ReaderPostTable.getPost(mBlogId, mPostId, false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -355,7 +355,7 @@ public class ReaderPostDetailFragment extends Fragment
         }
 
         // get the post again since it has changed, then refresh to show changes
-        mPost = ReaderPostTable.getPost(mPost.blogId, mPost.postId, false);
+        mPost = ReaderPostTable.getBlogPost(mPost.blogId, mPost.postId, false);
         refreshLikes();
         refreshIconCounts();
 
@@ -590,7 +590,7 @@ public class ReaderPostDetailFragment extends Fragment
                 }
                 // if the post has changed, reload it from the db and update the like/comment counts
                 if (result.isNewOrChanged()) {
-                    mPost = ReaderPostTable.getPost(mPost.blogId, mPost.postId, false);
+                    mPost = ReaderPostTable.getBlogPost(mPost.blogId, mPost.postId, false);
                     refreshIconCounts();
                 }
                 // refresh likes if necessary - done regardless of whether the post has changed
@@ -756,7 +756,11 @@ public class ReaderPostDetailFragment extends Fragment
                 }
             }
         };
-        ReaderPostActions.requestPost(mIsFeed, mBlogId, mPostId, listener);
+        if (mIsFeed) {
+            ReaderPostActions.requestFeedPost(mBlogId, mPostId, listener);
+        } else {
+            ReaderPostActions.requestBlogPost(mBlogId, mPostId, listener);
+        }
     }
 
     /*
@@ -800,7 +804,8 @@ public class ReaderPostDetailFragment extends Fragment
 
         @Override
         protected Boolean doInBackground(Void... params) {
-            mPost = ReaderPostTable.getPost(mIsFeed, mBlogId, mPostId, false);
+            mPost = mIsFeed ? ReaderPostTable.getFeedPost(mBlogId, mPostId, false)
+                    : ReaderPostTable.getBlogPost(mBlogId, mPostId, false);
             if (mPost == null) {
                 return false;
             }
@@ -815,7 +820,7 @@ public class ReaderPostDetailFragment extends Fragment
                     mIsFeed = false;
                     mBlogId = discoverData.getBlogId();
                     mPostId = discoverData.getPostId();
-                    mPost = ReaderPostTable.getPost(mBlogId, mPostId, false);
+                    mPost = ReaderPostTable.getBlogPost(mBlogId, mPostId, false);
                     if (mPost == null) {
                         return false;
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -49,6 +49,7 @@ public class ReaderPostPagerActivity extends AppCompatActivity
     private Toolbar mToolbar;
 
     private ReaderTag mCurrentTag;
+    private boolean mIsFeed;
     private long mBlogId;
     private long mPostId;
     private int mLastSelectedPosition = -1;
@@ -78,6 +79,7 @@ public class ReaderPostPagerActivity extends AppCompatActivity
         mProgress = (ProgressBar) findViewById(R.id.progress_loading);
 
         if (savedInstanceState != null) {
+            mIsFeed = savedInstanceState.getBoolean(ReaderConstants.ARG_IS_FEED);
             mBlogId = savedInstanceState.getLong(ReaderConstants.ARG_BLOG_ID);
             mPostId = savedInstanceState.getLong(ReaderConstants.ARG_POST_ID);
             mIsSinglePostView = savedInstanceState.getBoolean(ReaderConstants.ARG_IS_SINGLE_POST);
@@ -89,6 +91,7 @@ public class ReaderPostPagerActivity extends AppCompatActivity
                 mCurrentTag = (ReaderTag) savedInstanceState.getSerializable(ReaderConstants.ARG_TAG);
             }
         } else {
+            mIsFeed = getIntent().getBooleanExtra(ReaderConstants.ARG_IS_FEED, false);
             mBlogId = getIntent().getLongExtra(ReaderConstants.ARG_BLOG_ID, 0);
             mPostId = getIntent().getLongExtra(ReaderConstants.ARG_POST_ID, 0);
             mIsSinglePostView = getIntent().getBooleanExtra(ReaderConstants.ARG_IS_SINGLE_POST, false);
@@ -483,6 +486,7 @@ public class ReaderPostPagerActivity extends AppCompatActivity
             }
 
             return ReaderPostDetailFragment.newInstance(
+                    mIsFeed,
                     mIdList.get(position).getBlogId(),
                     mIdList.get(position).getPostId(),
                     mIsRelatedPostView,

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -173,6 +173,8 @@ public class ReaderPostPagerActivity extends AppCompatActivity
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
+
+            // offer "UP" navigation to the feed list instead of returning to the launching app
             if (mIsFeed) {
                 Intent feedListIntent = ReaderActivityLauncher.getReaderFeedPreviewIntent(this, mBlogId);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -272,7 +272,7 @@ public class ReaderPostPagerActivity extends AppCompatActivity
         // analytics tracking
         AnalyticsUtils.trackWithReaderPostDetails(
                 AnalyticsTracker.Stat.READER_ARTICLE_OPENED,
-                ReaderPostTable.getPost(idPair.getBlogId(), idPair.getPostId(), true));
+                ReaderPostTable.getBlogPost(idPair.getBlogId(), idPair.getPostId(), true));
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -2,10 +2,13 @@ package org.wordpress.android.ui.reader;
 
 import android.app.Fragment;
 import android.app.FragmentManager;
+import android.content.Intent;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.v13.app.FragmentStatePagerAdapter;
+import android.support.v4.app.NavUtils;
+import android.support.v4.app.TaskStackBuilder;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -170,6 +173,17 @@ public class ReaderPostPagerActivity extends AppCompatActivity
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
+            if (mIsFeed) {
+                Intent feedListIntent = ReaderActivityLauncher.getReaderFeedPreviewIntent(this, mBlogId);
+
+                if (NavUtils.shouldUpRecreateTask(this, feedListIntent) || isTaskRoot()) {
+                    TaskStackBuilder.create(this)
+                            .addNextIntentWithParentStack(feedListIntent)
+                            .startActivities();
+                    return true;
+                }
+            }
+
             onBackPressed();
             return true;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -173,19 +173,6 @@ public class ReaderPostPagerActivity extends AppCompatActivity
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-
-            // offer "UP" navigation to the feed list instead of returning to the launching app
-            if (mIsFeed) {
-                Intent feedListIntent = ReaderActivityLauncher.getReaderFeedPreviewIntent(this, mBlogId);
-
-                if (NavUtils.shouldUpRecreateTask(this, feedListIntent) || isTaskRoot()) {
-                    TaskStackBuilder.create(this)
-                            .addNextIntentWithParentStack(feedListIntent)
-                            .startActivities();
-                    return true;
-                }
-            }
-
             onBackPressed();
             return true;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -221,7 +221,7 @@ public class ReaderPostActions {
     /**
      * similar to updatePost, but used when post doesn't already exist in local db
      **/
-    public static void requestPost(final long blogId,
+    public static void requestBlogPost(final long blogId,
             final long postId,
             final ReaderActions.OnRequestListener requestListener) {
         requestPost(false, blogId, postId, requestListener);
@@ -230,7 +230,13 @@ public class ReaderPostActions {
     /**
      * similar to updatePost, but used when post doesn't already exist in local db
      **/
-    public static void requestPost(final boolean isFeed,
+    public static void requestFeedPost(final long blogId,
+            final long postId,
+            final ReaderActions.OnRequestListener requestListener) {
+        requestPost(true, blogId, postId, requestListener);
+    }
+
+    private static void requestPost(final boolean isFeed,
             final long blogOrFeedId,
             final long postOrItemId,
             final ReaderActions.OnRequestListener requestListener) {
@@ -288,7 +294,7 @@ public class ReaderPostActions {
     }
 
     public static void bumpPageViewForPost(long blogId, long postId) {
-        bumpPageViewForPost(ReaderPostTable.getPost(blogId, postId, true));
+        bumpPageViewForPost(ReaderPostTable.getBlogPost(blogId, postId, true));
     }
     public static void bumpPageViewForPost(ReaderPost post) {
         if (post == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderPostActions.java
@@ -222,9 +222,20 @@ public class ReaderPostActions {
      * similar to updatePost, but used when post doesn't already exist in local db
      **/
     public static void requestPost(final long blogId,
-                                   final long postId,
-                                   final ReaderActions.OnRequestListener requestListener) {
-        String path = "read/sites/" + blogId + "/posts/" + postId + "/?meta=site,likes";
+            final long postId,
+            final ReaderActions.OnRequestListener requestListener) {
+        requestPost(false, blogId, postId, requestListener);
+    }
+
+    /**
+     * similar to updatePost, but used when post doesn't already exist in local db
+     **/
+    public static void requestPost(final boolean isFeed,
+            final long blogOrFeedId,
+            final long postOrItemId,
+            final ReaderActions.OnRequestListener requestListener) {
+        String path = isFeed ? "read/feed/" + blogOrFeedId + "/posts/" + postOrItemId + "/?meta=site,likes" :
+                "read/sites/" + blogOrFeedId + "/posts/" + postOrItemId + "/?meta=site,likes";
 
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
@@ -257,8 +268,14 @@ public class ReaderPostActions {
                 }
             }
         };
-        AppLog.d(T.READER, "requesting post");
-        WordPress.getRestClientUtilsV1_2().get(path, null, null, listener, errorListener);
+
+        if (isFeed) {
+            AppLog.d(T.READER, "requesting feed post");
+            WordPress.getRestClientUtilsV1_3().get(path, null, null, listener, errorListener);
+        } else {
+            AppLog.d(T.READER, "requesting post");
+            WordPress.getRestClientUtilsV1_2().get(path, null, null, listener, errorListener);
+        }
     }
 
     private static String getTrackingPixelForPost(@NonNull ReaderPost post) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -796,7 +796,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
         // update post in array and on screen
         int position = mPosts.indexOfPost(post);
-        ReaderPost updatedPost = ReaderPostTable.getPost(post.blogId, post.postId, true);
+        ReaderPost updatedPost = ReaderPostTable.getBlogPost(post.blogId, post.postId, true);
         if (updatedPost != null && position > -1) {
             mPosts.set(position, updatedPost);
             showLikes(holder, updatedPost);

--- a/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
@@ -212,7 +212,7 @@ public class AnalyticsUtils {
     }
 
     public static void trackWithReaderPostDetails(AnalyticsTracker.Stat stat, long blogId, long postId) {
-        trackWithReaderPostDetails(stat, ReaderPostTable.getPost(blogId, postId, true));
+        trackWithReaderPostDetails(stat, ReaderPostTable.getBlogPost(blogId, postId, true));
     }
 
   /**


### PR DESCRIPTION
This will intercept the wordpress.com Reader URLs and open the post directly in the in-app Reader.

To test:

* Open this PR in the mobile browser
* Tap this URL: https://wordpress.com/read/feeds/41325786/posts/1176614193
* The app should come up and display the post in its Reader