### PR TITLE
Enable FAQ search for new conversations in Helpshift

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
@@ -241,6 +241,7 @@ public class HelpshiftHelper {
         addDefaultMetaData(context);
         HashMap config = new HashMap ();
         config.put(Support.CustomMetadataKey, mMetadata);
+        config.put("showSearchOnNewConversation", true);
         return config;
     }
 }


### PR DESCRIPTION
Fixes #4628 

To test:
* Go to Me screen
* Tap on "Help & Support" and then on "Contact us"
* Enter some chat query
* Tap the Send action button
* A screen comes up offering some FAQ articles that may match the query

h/t to @rachelmcr for suggesting enabling this feature!