### PR TITLE
Assign click listener on bind instead of on create

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -78,22 +78,6 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
             imgBlavatar = (WPNetworkImageView) view.findViewById(R.id.image_blavatar);
             divider = view.findViewById(R.id.divider);
             isSiteHidden = null;
-
-            itemView.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    int clickedPosition = getAdapterPosition();
-                    if (isValidPosition(clickedPosition)) {
-                        if (mIsMultiSelectEnabled) {
-                            toggleSelection(clickedPosition);
-                        } else if (mSiteSelectedListener != null) {
-                            mSiteSelectedListener.onSiteClick(getItem(clickedPosition));
-                        }
-                    } else {
-                        AppLog.w(AppLog.T.MAIN, "site picker > invalid clicked position " + clickedPosition);
-                    }
-                }
-            });
         }
     }
 
@@ -146,7 +130,7 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
     }
 
     @Override
-    public void onBindViewHolder(SiteViewHolder holder, int position) {
+    public void onBindViewHolder(final SiteViewHolder holder, int position) {
         SiteRecord site = getItem(position);
 
         holder.txtTitle.setText(site.getBlogNameOrHomeURL());
@@ -170,6 +154,23 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
         // hide the divider for the last item
         boolean isLastItem = (position == getItemCount() - 1);
         holder.divider.setVisibility(isLastItem ?  View.INVISIBLE : View.VISIBLE);
+
+
+        holder.itemView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                int clickedPosition = holder.getAdapterPosition();
+                if (isValidPosition(clickedPosition)) {
+                    if (mIsMultiSelectEnabled) {
+                        toggleSelection(clickedPosition);
+                    } else if (mSiteSelectedListener != null) {
+                        mSiteSelectedListener.onSiteClick(getItem(clickedPosition));
+                    }
+                } else {
+                    AppLog.w(AppLog.T.MAIN, "site picker > invalid clicked position " + clickedPosition);
+                }
+            }
+        });
     }
 
     public String getLastSearch() {


### PR DESCRIPTION
Fixes #4328 , #4614 

To test:
* Make sure you have more than one sites (hidden or not) connected to your account
* Go to the Site picker (under the Me screen)
* Tap search
* Enter a search term that will result in the first item on the list to be excluded (e.g. put in the exact name of a site down the list)
* Tap the new first item on the list
* The tapped site should now be selected and visible on the Me screen
