### PR TITLE
Show Single Message for Pass or Fail when Adding Tag

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -30,7 +30,6 @@ import org.wordpress.android.datasets.ReaderBlogTable;
 import org.wordpress.android.datasets.ReaderTagTable;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.ReaderTagType;
-import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderBlogActions;
@@ -326,7 +325,7 @@ public class ReaderSubsActivity extends AppCompatActivity
             return;
         }
 
-        showAddUrlProgress();
+        showProgress();
         final ReaderTag tag = ReaderUtils.createTagFromTagName(tagName, ReaderTagType.FOLLOWED);
 
         ReaderActions.ActionListener actionListener = new ReaderActions.ActionListener() {
@@ -336,7 +335,7 @@ public class ReaderSubsActivity extends AppCompatActivity
                     return;
                 }
 
-                hideAddUrlProgress();
+                hideProgress();
                 getPageAdapter().refreshFollowedTagFragment();
 
                 if (succeeded) {
@@ -364,7 +363,7 @@ public class ReaderSubsActivity extends AppCompatActivity
             return;
         }
 
-        showAddUrlProgress();
+        showProgress();
 
         ReaderActions.OnRequestListener requestListener = new ReaderActions.OnRequestListener() {
             @Override
@@ -376,7 +375,7 @@ public class ReaderSubsActivity extends AppCompatActivity
             @Override
             public void onFailure(int statusCode) {
                 if (!isFinishing()) {
-                    hideAddUrlProgress();
+                    hideProgress();
                     String errMsg;
                     switch (statusCode) {
                         case 401:
@@ -404,7 +403,7 @@ public class ReaderSubsActivity extends AppCompatActivity
                 if (isFinishing()) {
                     return;
                 }
-                hideAddUrlProgress();
+                hideProgress();
                 if (succeeded) {
                     // clear the edit text and hide the soft keyboard
                     mEditAdd.setText(null);
@@ -423,9 +422,9 @@ public class ReaderSubsActivity extends AppCompatActivity
     }
 
     /*
-     * called prior to following a url to show progress and disable controls
+     * called prior to following to show progress and disable controls
      */
-    private void showAddUrlProgress() {
+    private void showProgress() {
         final ProgressBar progress = (ProgressBar) findViewById(R.id.progress_follow);
         progress.setVisibility(View.VISIBLE);
         mEditAdd.setEnabled(false);
@@ -433,9 +432,9 @@ public class ReaderSubsActivity extends AppCompatActivity
     }
 
     /*
-     * called after following a url to hide progress and re-enable controls
+     * called after following to hide progress and re-enable controls
      */
-    private void hideAddUrlProgress() {
+    private void hideProgress() {
         final ProgressBar progress = (ProgressBar) findViewById(R.id.progress_follow);
         progress.setVisibility(View.GONE);
         mEditAdd.setEnabled(true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -326,6 +326,8 @@ public class ReaderSubsActivity extends AppCompatActivity
             return;
         }
 
+        final ReaderTag tag = ReaderUtils.createTagFromTagName(tagName, ReaderTagType.FOLLOWED);
+
         ReaderActions.ActionListener actionListener = new ReaderActions.ActionListener() {
             @Override
             public void onActionResult(boolean succeeded) {
@@ -333,23 +335,18 @@ public class ReaderSubsActivity extends AppCompatActivity
 
                 getPageAdapter().refreshFollowedTagFragment();
 
-                if (!succeeded) {
+                if (succeeded) {
+                    AnalyticsTracker.track(AnalyticsTracker.Stat.READER_TAG_FOLLOWED);
+                    showInfoToast(getString(R.string.reader_label_added_tag, tag.getLabel()));
+                    mLastAddedTagName = tag.getTagSlug();
+                } else {
                     ToastUtils.showToast(ReaderSubsActivity.this, R.string.reader_toast_err_add_tag);
                     mLastAddedTagName = null;
                 }
             }
         };
 
-        ReaderTag tag = ReaderUtils.createTagFromTagName(tagName, ReaderTagType.FOLLOWED);
-
-        if (ReaderTagActions.addTag(tag, actionListener)) {
-            AnalyticsTracker.track(AnalyticsTracker.Stat.READER_TAG_FOLLOWED);
-            mLastAddedTagName = tag.getTagSlug();
-            // make sure addition is reflected on followed tags
-            getPageAdapter().refreshFollowedTagFragment();
-            String labelAddedTag = getString(R.string.reader_label_added_tag);
-            showInfoToast(String.format(labelAddedTag, tag.getLabel()));
-        }
+        ReaderTagActions.addTag(tag, actionListener);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderSubsActivity.java
@@ -326,13 +326,17 @@ public class ReaderSubsActivity extends AppCompatActivity
             return;
         }
 
+        showAddUrlProgress();
         final ReaderTag tag = ReaderUtils.createTagFromTagName(tagName, ReaderTagType.FOLLOWED);
 
         ReaderActions.ActionListener actionListener = new ReaderActions.ActionListener() {
             @Override
             public void onActionResult(boolean succeeded) {
-                if (isFinishing()) return;
+                if (isFinishing()) {
+                    return;
+                }
 
+                hideAddUrlProgress();
                 getPageAdapter().refreshFollowedTagFragment();
 
                 if (succeeded) {

--- a/WordPress/src/main/res/layout/comment_edit_activity.xml
+++ b/WordPress/src/main/res/layout/comment_edit_activity.xml
@@ -63,7 +63,7 @@
 
         <ProgressBar
             android:id="@+id/edit_comment_progress"
-            style="@android:style/Widget.Holo.Light.ProgressBar.Large"
+            style="@style/Widget.AppCompat.ProgressBar"
             android:layout_centerInParent="true"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -113,7 +113,7 @@
     </style>
 
     <!-- progress bars -->
-    <style name="ReaderProgressBar" parent="@android:style/Widget.Holo.Light.ProgressBar" />
+    <style name="ReaderProgressBar" parent="Widget.AppCompat.ProgressBar" />
 
     <style name="ReaderTabStripTextAppearance">
         <item name="android:textSize">@dimen/text_sz_medium</item>


### PR DESCRIPTION
### Fix
Avoid confusion from conflicting messages as described in https://github.com/wordpress-mobile/WordPress-Android/issues/4612 by showing a single message when adding a tag passes or fails.

### Test
**Pass**
1. Go to ***Reader*** tab.
2. Tap gear icon in the action bar.
3. Enter "a8c" in tag input field.
4. Tap done button in the keyboard.
5. Notice single, successful message.

**Fail**
1. Go to ***Reader*** tab.
2. Tap gear icon in the action bar.
3. Enter "a8c4dayz" in tag input field.
4. Tap done button in the keyboard.
5. Notice single, unsuccessful message.