### PR TITLE
Add Device Settings Option to App Settings

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/util/ApiHelperTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/util/ApiHelperTest.java
@@ -34,7 +34,7 @@ public class ApiHelperTest extends InstrumentationTestCase {
         // Init contexts
         XMLRPCFactoryTest.sContext = getInstrumentation().getContext();
         RestClientFactoryTest.sContext = getInstrumentation().getContext();
-        AppLog.v(T.TESTS, "Contexts set");
+        AppLog.d(T.TESTS, "Contexts set");
 
         // Set mode to Customizable
         XMLRPCFactoryTest.sMode = XMLRPCFactoryTest.Mode.CUSTOMIZABLE_JSON;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -1,9 +1,11 @@
 package org.wordpress.android.ui.prefs;
 
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.net.Uri;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceClickListener;
@@ -21,6 +23,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.util.AnalyticsUtils;
+import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.LanguageUtils;
 import org.wordpress.android.util.WPPrefUtils;
 
@@ -47,6 +50,8 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
 
         findPreference(getString(R.string.pref_key_language))
                 .setOnPreferenceClickListener(this);
+        findPreference(getString(R.string.pref_key_device_settings))
+                .setOnPreferenceClickListener(this);
         findPreference(getString(R.string.pref_key_app_about))
                 .setOnPreferenceClickListener(this);
         findPreference(getString(R.string.pref_key_oss_licenses))
@@ -68,7 +73,9 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
     public boolean onPreferenceClick(Preference preference) {
         String preferenceKey = preference != null ? preference.getKey() : "";
 
-        if (preferenceKey.equals(getString(R.string.pref_key_app_about))) {
+        if (preferenceKey.equals(getString(R.string.pref_key_device_settings))) {
+            return handleDevicePreferenceClick();
+        } else if (preferenceKey.equals(getString(R.string.pref_key_app_about))) {
             return handleAboutPreferenceClick();
         } else if (preferenceKey.equals(getString(R.string.pref_key_oss_licenses))) {
             return handleOssPreferenceClick();
@@ -184,6 +191,22 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
 
     private boolean handleAboutPreferenceClick() {
         startActivity(new Intent(getActivity(), AboutActivity.class));
+        return true;
+    }
+
+    private boolean handleDevicePreferenceClick() {
+        try {
+            // open specific app info screen
+            Intent intent = new Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+            intent.setData(Uri.parse("package:" + getActivity().getPackageName()));
+            startActivity(intent);
+        } catch (ActivityNotFoundException exception) {
+            AppLog.w(AppLog.T.SETTINGS, exception.getMessage());
+            // open generic apps screen
+            Intent intent = new Intent(android.provider.Settings.ACTION_MANAGE_APPLICATIONS_SETTINGS);
+            startActivity(intent);
+        }
+
         return true;
     }
 

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -13,6 +13,7 @@
     <string name="pref_key_passlock_section" translatable="false">wp_passcode_lock_category</string>
     <string name="pref_key_passlock" translatable="false">wp_pref_passlock_enabled</string>
     <string name="pref_key_send_usage" translatable="false">wp_pref_send_usage_stats</string>
+    <string name="pref_key_device_settings" translatable="false">wp_pref_device_settings</string>
     <string name="pref_key_about_section" translatable="false">wp_pref_app_about_section</string>
     <string name="pref_key_language" translatable="false">wp_pref_language</string>
     <string name="pref_key_app_about" translatable="false">wp_pref_app_about</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -618,6 +618,7 @@
 
     <!-- preferences -->
     <string name="open_source_licenses">Open source licenses</string>
+    <string name="preference_open_device_settings">Open device settings</string>
     <string name="preference_send_usage_stats">Send statistics</string>
     <string name="preference_send_usage_stats_summary">Automatically send usage statistics to help us improve WordPress for Android</string>
     <string name="preference_editor">Editor</string>

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -15,6 +15,11 @@
         android:summary="@string/preference_send_usage_stats_summary"
         android:title="@string/preference_send_usage_stats" />
 
+    <Preference
+        android:key="@string/pref_key_device_settings"
+        android:layout="@layout/preference_layout"
+        android:title="@string/preference_open_device_settings" />
+
     <PreferenceCategory
         android:key="@string/pref_key_editor"
         android:layout="@layout/preference_category"


### PR DESCRIPTION
### Fix
Add a link to the app's information screen under the device's operating system settings as described in https://github.com/wordpress-mobile/WordPress-Android/issues/4624.

### Test
1. Go to ***Me*** tab.
2. Tap ***App Settings*** option.
3. Tap ***Open device settings*** option.