### PR TITLE
Small refactoring of the GCM code

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
@@ -121,6 +121,11 @@ public class GCMMessageService extends GcmListenerService {
 
     private void trySaveNoteIfNotAlreadyInBucket(Bundle data) {
         if (SimperiumUtils.getNotesBucket() != null) {
+            if (data == null) {
+                AppLog.e(T.NOTIFS, "Bundle is null! Cannot read '" + PUSH_ARG_NOTE_ID +"'.");
+                return;
+            }
+
             String noteId = data.getString(PUSH_ARG_NOTE_ID, "");
             try {
                 SimperiumUtils.getNotesBucket().get(noteId);

--- a/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
@@ -31,6 +31,7 @@ import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.notifications.utils.SimperiumUtils;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.HelpshiftHelper;
@@ -49,8 +50,6 @@ import de.greenrobot.event.EventBus;
 
 public class GCMMessageService extends GcmListenerService {
     private static final ArrayMap<Integer, Bundle> sActiveNotificationsMap = new ArrayMap<>();
-    private static String sPreviousNoteId = null;
-    private static long sPreviousNoteTime = 0L;
 
     private static final String NOTIFICATION_GROUP_KEY = "notification_group_key";
     private static final int PUSH_NOTIFICATION_ID = 10000;
@@ -80,7 +79,7 @@ public class GCMMessageService extends GcmListenerService {
 
 
     // Add to the analytics properties map a subset of the push notification payload.
-    private static String[] propertiesToCopyIntoAnalytics = {PUSH_ARG_NOTE_ID, PUSH_ARG_TYPE, "blog_id", "post_id",
+    private static final String[] propertiesToCopyIntoAnalytics = {PUSH_ARG_NOTE_ID, PUSH_ARG_TYPE, "blog_id", "post_id",
             "comment_id"};
 
     private void synchronizedHandleDefaultPush(String from, @NonNull Bundle data) {
@@ -122,20 +121,19 @@ public class GCMMessageService extends GcmListenerService {
 
     private void trySaveNoteIfNotAlreadyInBucket(Bundle data) {
         if (SimperiumUtils.getNotesBucket() != null) {
-            Note note = null;
             String noteId = data.getString(PUSH_ARG_NOTE_ID, "");
             try {
-                note = SimperiumUtils.getNotesBucket().get(noteId);
+                SimperiumUtils.getNotesBucket().get(noteId);
                 // all good if we got here
             } catch (BucketObjectMissingException e) {
                 AppLog.e(T.NOTIFS, e);
                 SimperiumUtils.trackBucketObjectMissingWarning(e.getMessage(), noteId);
 
-                if (data != null && data.containsKey(PUSH_ARG_NOTE_FULL_DATA)) {
+                if (data.containsKey(PUSH_ARG_NOTE_FULL_DATA)) {
                     //if note doesn't exist, try taking it from the PN payload, build it and save it
                     // Simperium will take care of syncing local and server versions up at a later point
                     String base64FullData = data.getString(PUSH_ARG_NOTE_FULL_DATA);
-                    note = new Note.Schema().buildFromBase64EncodedData(noteId, base64FullData);
+                    Note note = new Note.Schema().buildFromBase64EncodedData(noteId, base64FullData);
                     SimperiumUtils.saveNote(note);
                 }
             }
@@ -144,8 +142,16 @@ public class GCMMessageService extends GcmListenerService {
 
     private void buildAndShowNotificationFromNoteData(Bundle data) {
 
-        if (data == null)
+        if (data == null) {
+            AppLog.e(T.NOTIFS, "Push notification received without a valid Bundle!");
             return;
+        }
+
+        if (TextUtils.isEmpty(data.getString(PUSH_ARG_NOTE_ID, ""))) {
+            // At this point 'note_id' is always available in the notification bundle.
+            AppLog.e(T.NOTIFS, "Push notification received without a valid note_id in in payload!");
+            return;
+        }
 
         trySaveNoteIfNotAlreadyInBucket(data);
 
@@ -156,7 +162,7 @@ public class GCMMessageService extends GcmListenerService {
             title = getString(R.string.app_name);
         }
         String message = StringEscapeUtils.unescapeHtml(data.getString(PUSH_ARG_MSG));
-        String noteId = data.getString(PUSH_ARG_NOTE_ID, "");
+        String wpcomNoteID = data.getString(PUSH_ARG_NOTE_ID, "");
 
         /*
          * if this has the same note_id as the previous notification, and the previous notification
@@ -172,16 +178,16 @@ public class GCMMessageService extends GcmListenerService {
          * on the same post will have the same note_id, so don't assume that the note_id is unique
          */
         long thisTime = System.currentTimeMillis();
-        if (sPreviousNoteId != null && sPreviousNoteId.equals(noteId)) {
-            long seconds = TimeUnit.MILLISECONDS.toSeconds(thisTime - sPreviousNoteTime);
+        if (AppPrefs.getLastPushNotificationWpcomNoteId().equals(wpcomNoteID)) {
+            long seconds = TimeUnit.MILLISECONDS.toSeconds(thisTime - AppPrefs.getLastPushNotificationTime());
             if (seconds <= 1) {
                 AppLog.w(T.NOTIFS, "skipped potential duplicate notification");
                 return;
             }
         }
 
-        sPreviousNoteId = noteId;
-        sPreviousNoteTime = thisTime;
+        AppPrefs.setLastPushNotificationTime(thisTime);
+        AppPrefs.setLastPushNotificationWpcomNoteId(wpcomNoteID);
 
         // Update notification content for the same noteId if it is already showing
         int pushId = 0;
@@ -190,7 +196,7 @@ public class GCMMessageService extends GcmListenerService {
                 continue;
             }
             Bundle noteBundle = sActiveNotificationsMap.get(id);
-            if (noteBundle != null && noteBundle.getString(PUSH_ARG_NOTE_ID, "").equals(noteId)) {
+            if (noteBundle != null && noteBundle.getString(PUSH_ARG_NOTE_ID, "").equals(wpcomNoteID)) {
                 pushId = id;
                 sActiveNotificationsMap.put(pushId, data);
                 break;
@@ -218,10 +224,10 @@ public class GCMMessageService extends GcmListenerService {
             AnalyticsTracker.flush();
         }
 
-        showGroupNotificationForActiveNotificationsMap(pushId, noteId, noteType, data.getString("icon"), title, message);
+        showGroupNotificationForActiveNotificationsMap(pushId, wpcomNoteID, noteType, data.getString("icon"), title, message);
     }
 
-    private void showGroupNotificationForActiveNotificationsMap(int pushId, String noteId, String noteType,
+    private void showGroupNotificationForActiveNotificationsMap(int pushId, String wpcomNoteID, String noteType,
                                                                 String largeIconUri, String title, String message) {
 
         // Build the new notification, add group to support wearable stacking
@@ -232,10 +238,10 @@ public class GCMMessageService extends GcmListenerService {
             builder.setLargeIcon(largeIconBitmap);
         }
 
-        showIndividualNotificationForBuilder(builder, noteType, noteId, pushId);
+        showIndividualNotificationForBuilder(builder, noteType, wpcomNoteID, pushId);
 
         // Also add a group summary notification, which is required for non-wearable devices
-        showGroupNotificationForBuilder(builder, message);
+        showGroupNotificationForBuilder(builder, wpcomNoteID, message);
     }
 
     private void addActionsForCommentNotification(NotificationCompat.Builder builder, String noteId) {
@@ -350,7 +356,7 @@ public class GCMMessageService extends GcmListenerService {
 
     private NotificationCompat.Builder getNotificationBuilder(String title, String message){
         // Build the new notification, add group to support wearable stacking
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(this)
+       return new NotificationCompat.Builder(this)
                 .setSmallIcon(R.drawable.notification_icon)
                 .setColor(getResources().getColor(R.color.blue_wordpress))
                 .setContentTitle(title)
@@ -359,11 +365,9 @@ public class GCMMessageService extends GcmListenerService {
                 .setAutoCancel(true)
                 .setStyle(new NotificationCompat.BigTextStyle().bigText(message))
                 .setGroup(NOTIFICATION_GROUP_KEY);
-
-        return builder;
     }
 
-    private void showGroupNotificationForBuilder(NotificationCompat.Builder builder, String message) {
+    private void showGroupNotificationForBuilder(NotificationCompat.Builder builder, String wpcomNoteID, String message) {
 
         if (builder == null) {
             return;
@@ -410,28 +414,28 @@ public class GCMMessageService extends GcmListenerService {
                     .setContentText(subject)
                     .setStyle(inboxStyle);
 
-            showNotificationForBuilder(groupBuilder, this, GROUP_NOTIFICATION_ID);
+            showNotificationForBuilder(groupBuilder, this, wpcomNoteID, GROUP_NOTIFICATION_ID);
 
         } else {
             // Set the individual notification we've already built as the group summary
             builder.setGroupSummary(true);
-            showNotificationForBuilder(builder, this, GROUP_NOTIFICATION_ID);
+            showNotificationForBuilder(builder, this, wpcomNoteID, GROUP_NOTIFICATION_ID);
         }
     }
 
-    private void showIndividualNotificationForBuilder(NotificationCompat.Builder builder, String noteType, String noteId, int pushId) {
+    private void showIndividualNotificationForBuilder(NotificationCompat.Builder builder, String noteType, String wpcomNoteID, int pushId) {
         if (builder == null) {
             return;
         }
 
         if (noteType.equals(PUSH_TYPE_COMMENT)) {
-            addActionsForCommentNotification(builder, noteId);
+            addActionsForCommentNotification(builder, wpcomNoteID);
         }
-        showNotificationForBuilder(builder, this, pushId);
+        showNotificationForBuilder(builder, this, wpcomNoteID, pushId);
     }
 
     // Displays a notification to the user
-    private void showNotificationForBuilder(NotificationCompat.Builder builder, Context context, int notificationId) {
+    private void showNotificationForBuilder(NotificationCompat.Builder builder, Context context, String wpcomNoteID, int pushId) {
         if (builder == null || context == null) {
             return;
         }
@@ -442,9 +446,7 @@ public class GCMMessageService extends GcmListenerService {
                 | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         resultIntent.setAction("android.intent.action.MAIN");
         resultIntent.addCategory("android.intent.category.LAUNCHER");
-        if (sPreviousNoteId != null) {
-            resultIntent.putExtra(NotificationsListFragment.NOTE_ID_EXTRA, sPreviousNoteId);
-        }
+        resultIntent.putExtra(NotificationsListFragment.NOTE_ID_EXTRA, wpcomNoteID);
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
 
@@ -470,19 +472,19 @@ public class GCMMessageService extends GcmListenerService {
 
         // Call broadcast receiver when notification is dismissed
         Intent notificationDeletedIntent = new Intent(this, NotificationDismissBroadcastReceiver.class);
-        notificationDeletedIntent.putExtra("notificationId", notificationId);
-        notificationDeletedIntent.setAction(String.valueOf(notificationId));
+        notificationDeletedIntent.putExtra("notificationId", pushId);
+        notificationDeletedIntent.setAction(String.valueOf(pushId));
         PendingIntent pendingDeleteIntent =
-                PendingIntent.getBroadcast(context, notificationId, notificationDeletedIntent, 0);
+                PendingIntent.getBroadcast(context, pushId, notificationDeletedIntent, 0);
         builder.setDeleteIntent(pendingDeleteIntent);
 
         builder.setCategory(NotificationCompat.CATEGORY_SOCIAL);
 
-        PendingIntent pendingIntent = PendingIntent.getActivity(context, notificationId, resultIntent,
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, pushId, resultIntent,
                 PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_UPDATE_CURRENT);
         builder.setContentIntent(pendingIntent);
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(this);
-        notificationManager.notify(notificationId, builder.build());
+        notificationManager.notify(pushId, builder.build());
     }
 
     private void rebuildAndUpdateNotificationsOnSystemBar(Bundle data) {
@@ -492,6 +494,7 @@ public class GCMMessageService extends GcmListenerService {
         String message = StringEscapeUtils.unescapeHtml(data.getString(PUSH_ARG_MSG));
 
         NotificationCompat.Builder builder = null;
+        String wpcomNoteID = null;
 
         if (sActiveNotificationsMap.size() == 1) {
             //only one notification remains, so get the proper message for it and re-instate in the system dashboard
@@ -511,9 +514,9 @@ public class GCMMessageService extends GcmListenerService {
                 builder = getNotificationBuilder(title, message);
 
                 String noteType = StringUtils.notNullStr(remainingNote.getString(PUSH_ARG_TYPE));
-                String noteId = remainingNote.getString(PUSH_ARG_NOTE_ID, "");
+                wpcomNoteID = remainingNote.getString(PUSH_ARG_NOTE_ID, "");
                 if (!sActiveNotificationsMap.isEmpty()) {
-                    showIndividualNotificationForBuilder(builder, noteType, noteId, sActiveNotificationsMap.keyAt(0));
+                    showIndividualNotificationForBuilder(builder, noteType, wpcomNoteID, sActiveNotificationsMap.keyAt(0));
                 }
             }
         }
@@ -526,12 +529,15 @@ public class GCMMessageService extends GcmListenerService {
             largeIconBitmap = getLargeIconBitmap(data.getString("icon"), shouldCircularizeNoteIcon(PUSH_TYPE_BADGE_RESET));
         }
 
+        if (wpcomNoteID == null) {
+            wpcomNoteID = AppPrefs.getLastPushNotificationWpcomNoteId();
+        }
+
         if (largeIconBitmap != null) {
             builder.setLargeIcon(largeIconBitmap);
         }
 
-        showGroupNotificationForBuilder(builder, message);
-
+        showGroupNotificationForBuilder(builder,  wpcomNoteID, message);
     }
 
     private String getNotificationTitleOrAppNameFromBundle(Bundle data){

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -63,6 +63,12 @@ public class AppPrefs {
 
         // index of the last active people list filter in People Management activity
         PEOPLE_LIST_FILTER_INDEX,
+
+        // wpcom ID of the last push notification received
+        PUSH_NOTIFICATIONS_LAST_NOTE_ID,
+
+        // local time of the last push notification received
+        PUSH_NOTIFICATIONS_LAST_NOTE_TIME,
     }
 
     /**
@@ -403,5 +409,18 @@ public class AppPrefs {
     }
     public static void setInAppPurchaseRefreshRequired(boolean required) {
         setBoolean(UndeletablePrefKey.IAP_SYNC_REQUIRED, required);
+    }
+
+    public static String getLastPushNotificationWpcomNoteId() {
+        return getString(DeletablePrefKey.PUSH_NOTIFICATIONS_LAST_NOTE_ID);
+    }
+    public static void setLastPushNotificationWpcomNoteId(String noteID) {
+        setString(DeletablePrefKey.PUSH_NOTIFICATIONS_LAST_NOTE_ID, noteID);
+    }
+    public static long getLastPushNotificationTime() {
+        return getLong(DeletablePrefKey.PUSH_NOTIFICATIONS_LAST_NOTE_TIME);
+    }
+    public static void setLastPushNotificationTime(long time) {
+        setLong(DeletablePrefKey.PUSH_NOTIFICATIONS_LAST_NOTE_ID, time);
     }
 }


### PR DESCRIPTION
@mzorz - This is a quick refactoring/cleaning of GCM code. 
I've removed those 2 static variables (that were used to keep a reference to the last PN received), and moved to AppPrefs for consistence with other parts of the app.
Those variable were error prone, and had found one place in the code where the static version of `note_id` were used instead of the actual value. 
Also removed/moved/deleted code around.

