### PR TITLE
adding voice reply support and handling

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
@@ -12,6 +12,7 @@ import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
+import android.support.v4.app.RemoteInput;
 import android.support.v4.util.ArrayMap;
 import android.text.TextUtils;
 
@@ -55,6 +56,7 @@ public class GCMMessageService extends GcmListenerService {
     private static final int PUSH_NOTIFICATION_ID = 10000;
     private static final int AUTH_PUSH_NOTIFICATION_ID = 20000;
     public static final int GROUP_NOTIFICATION_ID = 30000;
+    public static final String EXTRA_VOICE_REPLY = "extra_voice_reply";
     private static final int MAX_INBOX_ITEMS = 5;
 
     private static final String PUSH_ARG_USER = "user";
@@ -300,6 +302,19 @@ public class GCMMessageService extends GcmListenerService {
                 PendingIntent.FLAG_CANCEL_CURRENT);
         builder.addAction(R.drawable.ic_reply_white_24dp, getText(R.string.reply),
                 commentReplyPendingIntent);
+
+        //add wearable remoteInput to enable voice-reply
+        String replyLabel = getResources().getString(R.string.reply);
+        RemoteInput remoteInput = new RemoteInput.Builder(EXTRA_VOICE_REPLY)
+                .setLabel(replyLabel)
+                .build();
+        NotificationCompat.Action action =
+                new NotificationCompat.Action.Builder(R.drawable.ic_reply_white_24dp,
+                        getString(R.string.reply), commentReplyPendingIntent)
+                        .addRemoteInput(remoteInput)
+                        .build();
+        builder.extend(new NotificationCompat.WearableExtender().addAction(action));
+
     }
 
     private void addCommentLikeActionForCommentNotification(NotificationCompat.Builder builder, String noteId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -145,9 +145,10 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     /*
      * used when called from notification list for a comment notification
      */
-    public static CommentDetailFragment newInstance(final String noteId) {
+    public static CommentDetailFragment newInstance(final String noteId, final String replyText) {
         CommentDetailFragment fragment = new CommentDetailFragment();
         fragment.setNoteWithNoteId(noteId);
+        fragment.setReplyText(replyText);
         return fragment;
     }
 
@@ -155,7 +156,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
      * used when called from a comment notification 'like' action
      */
     public static CommentDetailFragment newInstanceForInstantLike(final String noteId) {
-        CommentDetailFragment fragment = newInstance(noteId);
+        CommentDetailFragment fragment = newInstance(noteId, null);
         //here tell the fragment to trigger the Like action when ready
         fragment.setLikeCommentWhenReady();
         return fragment;
@@ -165,7 +166,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
      * used when called from a comment notification 'approve' action
      */
     public static CommentDetailFragment newInstanceForInstantApprove(final String noteId) {
-        CommentDetailFragment fragment = newInstance(noteId);
+        CommentDetailFragment fragment = newInstance(noteId, null);
         //here tell the fragment to trigger the Like action when ready
         fragment.setApproveCommentWhenReady();
         return fragment;
@@ -175,7 +176,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
      * used when called from notifications to load a comment that doesn't already exist in the note
      */
     public static CommentDetailFragment newInstanceForRemoteNoteComment(final String noteId) {
-        CommentDetailFragment fragment = newInstance(noteId);
+        CommentDetailFragment fragment = newInstance(noteId, null);
         fragment.enableShouldRequestCommentFromNote();
         return fragment;
     }
@@ -428,6 +429,11 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
                 showErrorToastAndFinish();
             }
         }
+    }
+
+    private void setReplyText(String replyText) {
+        if (replyText == null) return;
+        mRestoredReplyText = replyText;
     }
 
     private void showErrorToastAndFinish() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -9,6 +9,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.design.widget.TabLayout;
+import android.support.v4.app.RemoteInput;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
@@ -58,6 +59,8 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.widgets.WPViewPager;
 
 import de.greenrobot.event.EventBus;
+
+import static org.wordpress.android.GCMMessageService.EXTRA_VOICE_REPLY;
 
 /**
  * Main activity which hosts sites, reader, me and notifications tabs
@@ -277,8 +280,20 @@ public class WPMainActivity extends AppCompatActivity implements Bucket.Listener
                     if (doApproveNote) {
                         NotificationsListFragment.openNoteForApprove(this, noteId);
                     } else {
+
+                        //if voice reply is enabled in a wearable, it will come through the remoteInput
+                        //extra EXTRA_VOICE_REPLY
+                        String voiceReply = null;
+                        Bundle remoteInput = RemoteInput.getResultsFromIntent(getIntent());
+                        if (remoteInput != null) {
+                            CharSequence replyText = remoteInput.getCharSequence(EXTRA_VOICE_REPLY);
+                            if (replyText != null) {
+                                voiceReply = replyText.toString();
+                            }
+                        }
+
                         boolean shouldShowKeyboard = getIntent().getBooleanExtra(NotificationsListFragment.NOTE_INSTANT_REPLY_EXTRA, false);
-                        NotificationsListFragment.openNoteForReply(this, noteId, shouldShowKeyboard);
+                        NotificationsListFragment.openNoteForReply(this, noteId, shouldShowKeyboard, voiceReply);
                     }
                 }
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -171,7 +171,7 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
                         CommentDetailFragment.newInstanceForInstantLike(note.getId()) :
                         isInstantApprove ?
                             CommentDetailFragment.newInstanceForInstantApprove(note.getId()) :
-                            CommentDetailFragment.newInstance(note.getId());
+                            CommentDetailFragment.newInstance(note.getId(), getIntent().getStringExtra(NotificationsListFragment.NOTE_PREFILLED_REPLY_EXTRA));
         } else if (note.isAutomattcherType()) {
             // show reader post detail for automattchers about posts - note that comment
             // automattchers are handled by note.isCommentType() above

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -40,6 +40,7 @@ public class NotificationsListFragment extends Fragment
                    WPMainActivity.OnScrollToTopListener, RadioGroup.OnCheckedChangeListener {
     public static final String NOTE_ID_EXTRA = "noteId";
     public static final String NOTE_INSTANT_REPLY_EXTRA = "instantReply";
+    public static final String NOTE_PREFILLED_REPLY_EXTRA = "prefilledReplyText";
     public static final String NOTE_INSTANT_LIKE_EXTRA = "instantLike";
     public static final String NOTE_INSTANT_APPROVE_EXTRA = "instantApprove";
     public static final String NOTE_MODERATE_ID_EXTRA = "moderateNoteId";
@@ -177,7 +178,7 @@ public class NotificationsListFragment extends Fragment
             // open the latest version of this note just in case it has changed - this can
             // happen if the note was tapped from the list fragment after it was updated
             // by another fragment (such as NotificationCommentLikeFragment)
-            openNoteForReply(getActivity(), noteId, false);
+            openNoteForReply(getActivity(), noteId, false, null);
         }
     };
 
@@ -193,7 +194,8 @@ public class NotificationsListFragment extends Fragment
      */
     public static void openNoteForReply(Activity activity,
                                         String noteId,
-                                        boolean shouldShowKeyboard) {
+                                        boolean shouldShowKeyboard,
+                                        String replyText) {
         if (noteId == null || activity == null) {
             return;
         }
@@ -204,6 +206,9 @@ public class NotificationsListFragment extends Fragment
 
         Intent detailIntent = getOpenNoteIntent(activity, noteId);
         detailIntent.putExtra(NOTE_INSTANT_REPLY_EXTRA, shouldShowKeyboard);
+        if (!TextUtils.isEmpty(replyText)) {
+            detailIntent.putExtra(NOTE_PREFILLED_REPLY_EXTRA, replyText);
+        }
         activity.startActivityForResult(detailIntent, RequestCodes.NOTE_DETAIL);
     }
 


### PR DESCRIPTION
Fixes #4032 

To test:

**Prerequisites**
Follow the steps in the following link to create a wearable emulator virtual device and pairing using `adb`:
https://developer.android.com/training/wearables/apps/creating.html
Also have this in mind, might save you some time:

On your phone, give the wearable access to the phone’s notifications.

In 4.4: **Settings > Security > Notification Access** 
In L **Preview: Settings > Sound & Notifications > Notification Access**

Within the Notification access screen, make sure that Android Wear is checked.


**Steps to test, with your Android wearable paired to your handset**
1. log in to the WP Android app with your credentials
2. have another user comment on a blog you're an admin of
3. a notification should be received on both the handset and the wearable device / emulator
4. swipe the notification left to show the "REPLY" action. Tap on it
5. choose to either speak or use emojis
6. once you're done, the comment detail screen will open on the handset, and the edit text control will be pre-filled with the recognized text provided by the wearable to the handheld device.


