### PR TITLE
fixed notifications being cleared on device rotation / on resume

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -162,6 +162,8 @@ public class WPMainActivity extends AppCompatActivity implements Bucket.Listener
                     case WPMainTabAdapter.TAB_NOTIFS:
                         setTabLayoutElevation(mAppBarElevation);
                         new UpdateLastSeenTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+                        // Removes app notifications from the system bar as we're looking at them right now
+                        GCMMessageService.removeAllNotifications(WPMainActivity.this);
                         break;
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -327,7 +327,14 @@ public class WPMainActivity extends AppCompatActivity implements Bucket.Listener
 
         // We need to track the current item on the screen when this activity is resumed.
         // Ex: Notifications -> notifications detail -> back to notifications
-        trackLastVisibleTab(mViewPager.getCurrentItem(), false);
+        int currentItem = mViewPager.getCurrentItem();
+        trackLastVisibleTab(currentItem, false);
+
+        if (currentItem == WPMainTabAdapter.TAB_NOTIFS) {
+            //if we are presenting the notifications list, it's safe to clear any outstanding
+            // notifications
+            GCMMessageService.removeAllNotifications(this);
+        }
 
         checkConnection();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -132,7 +132,7 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            finish();
+            onBackPressed();
             return true;
         }
 
@@ -146,6 +146,14 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
         }
 
         super.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        //if coming back from a comment that has been tapped on, clear the notification icons
+        // just in case there are any new notifications
+        GCMMessageService.removeAllNotifications(this);
     }
 
     private void showErrorToastAndFinish() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -132,7 +132,7 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
-            onBackPressed();
+            finish();
             return true;
         }
 
@@ -146,14 +146,6 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
         }
 
         super.onSaveInstanceState(outState);
-    }
-
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        //if coming back from a comment that has been tapped on, clear the notification icons
-        // just in case there are any new notifications
-        GCMMessageService.removeAllNotifications(this);
     }
 
     private void showErrorToastAndFinish() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -109,13 +109,6 @@ public class NotificationsListFragment extends Fragment
             mBucket.addListener(this);
         }
 
-        // Removes app notifications from the system bar
-        new Thread(new Runnable() {
-            public void run() {
-                GCMMessageService.removeAllNotifications(getActivity());
-            }
-        }).start();
-
         if (SimperiumUtils.isUserAuthorized()) {
             SimperiumUtils.startBuckets();
             AppLog.i(AppLog.T.NOTIFS, "Starting Simperium buckets");


### PR DESCRIPTION
Fixes #4647 by moving the notification removal code from NotificationsListFragment.onResume() to the onPageSelected event for the viewpager.

To test:
1. Open the app and leave it in the foreground
2. make something happen in the outside that triggers a push notification (for example, have some other user comment on a blog post you're an admin of)
3. observe the notification icon appear
4. rotate the device
5. observe the notification icon is still there in the system bar

Repeat steps 4-5 while switching the tabs in the app. Notification icon should only be dismissed when the Notifications tab is selected.

Needs review @daniloercoli 