### PR TITLE
Don't block "Uncategorized" category

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
@@ -10,8 +10,6 @@ import android.util.SparseBooleanArray;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.view.View;
-import android.widget.AdapterView;
 import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -75,20 +73,6 @@ public class SelectCategoriesActivity extends AppCompatActivity {
 
         mEmptyView = (TextView) findViewById(R.id.empty_view);
         mListView.setEmptyView(mEmptyView);
-
-        mListView.setOnItemClickListener(new AdapterView.OnItemClickListener(){
-            @Override
-            public void onItemClick(AdapterView<?> arg0, View arg1, int position, long arg3) {
-                if (getCheckedItemCount(mListView) > 1) {
-                    boolean uncategorizedNeedToBeSelected = false;
-                    for (int i = 0; i < mCategoryLevels.size(); i++) {
-                        if (mCategoryLevels.get(i).getName().equalsIgnoreCase("uncategorized")) {
-                            mListView.setItemChecked(i, uncategorizedNeedToBeSelected);
-                        }
-                    }
-                }
-            }
-        });
 
         mSelectedCategories = new HashSet<String>();
 


### PR DESCRIPTION
Fixes #4649 

To test:
* Go to the editor to edit a post
* Tap the "gear" action to edit the post settings
* If "uncategorized" is already added, remove it
* Tap the "+" icon in the categories section to add some categories
* If "Uncategorized" is the only one shown in the list, tap the "+" action and create an additional one and select it
* Tap the "Uncategorized" list item to select it
* ""Uncategorized" should be added along with the other categories

