### PR TITLE
Only offer Like as an action in comment notification if note can be liked

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
@@ -23,6 +23,7 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.analytics.AnalyticsTrackerMixpanel;
 import org.wordpress.android.models.AccountHelper;
+import org.wordpress.android.models.Blog;
 import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.models.Note;
 import org.wordpress.android.ui.main.WPMainActivity;
@@ -270,7 +271,10 @@ public class GCMMessageService extends GcmListenerService {
                         }
                     } else {
                         //else offer REPLY / LIKE actions
-                        if (note.canLike()) {
+                        //LIKE can only be enabled for wp.com sites, so if this is a Jetpack site don't enable LIKEs
+                        Blog blog = WordPress.wpDB.instantiateBlogByRemoteId(note.getSiteId());
+                        boolean isJetPackSite = blog != null ? blog.isJetpackPowered() : false;
+                        if (note.canLike() && !isJetPackSite) {
                             addCommentLikeActionForCommentNotification(builder, noteId);
                         }
                     }
@@ -281,7 +285,7 @@ public class GCMMessageService extends GcmListenerService {
             }
         }
 
-        // if we could not set the actions, set the default one REPLY as it' then only safe bet
+        // if we could not set the actions, set the default one REPLY as it's then only safe bet
         // we can make at this point
         if (!areActionsSet) {
             addCommentReplyActionForCommentNotification(builder, noteId);

--- a/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/GCMMessageService.java
@@ -281,10 +281,10 @@ public class GCMMessageService extends GcmListenerService {
             }
         }
 
-        // if we could not set the actions, set the default ones REPLY / LIKE
+        // if we could not set the actions, set the default one REPLY as it' then only safe bet
+        // we can make at this point
         if (!areActionsSet) {
             addCommentReplyActionForCommentNotification(builder, noteId);
-            addCommentLikeActionForCommentNotification(builder, noteId);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -907,9 +907,27 @@ public class WordPressDB {
      * self-hosted blogs that don't use jetpack)
      */
     public boolean isRemoteBlogIdDotComOrJetpack(int remoteBlogId) {
-        int localId = getLocalTableBlogIdForRemoteBlogId(remoteBlogId);
-        Blog blog = instantiateBlogByLocalId(localId);
+        Blog blog = instantiateBlogByRemoteId(remoteBlogId);
         return blog != null && (blog.isDotcomFlag() || blog.isJetpackPowered());
+    }
+
+    public Blog instantiateBlogByRemoteId(int remoteBlogId) {
+        int localId = getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(remoteBlogId);
+        Blog blog = instantiateBlogByLocalId(localId);
+        return blog;
+    }
+
+    public int getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(int remoteBlogId) {
+        //first try checking if a jetpack site is configured on this device site list with that remote id
+        // workaround: There are 2 entries in the DB for each Jetpack blog linked with
+        // the current wpcom account. We need to load the correct localID here, otherwise options are
+        // blank
+        int localId = getLocalTableBlogIdForJetpackRemoteID(remoteBlogId, null);
+
+        if (localId == 0) {
+            localId = getLocalTableBlogIdForRemoteBlogId(remoteBlogId);
+        }
+        return localId;
     }
 
     public Blog getBlogForDotComBlogId(String dotComBlogId) {

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -925,7 +925,7 @@ public class WordPressDB {
         int localId = getLocalTableBlogIdForJetpackRemoteID(remoteBlogId, null);
 
         if (localId == 0) {
-            localId = getLocalTableBlogIdForRemoteBlogId(remoteBlogId);
+            localId = getLocalTableBlogIdForWpComRemoteBlogId(remoteBlogId);
         }
         return localId;
     }
@@ -977,6 +977,15 @@ public class WordPressDB {
 
     public int getLocalTableBlogIdForRemoteBlogId(int remoteBlogId) {
         int localBlogID = SqlUtils.intForQuery(db, "SELECT id FROM accounts WHERE blogId=?",
+                new String[]{Integer.toString(remoteBlogId)});
+        if (localBlogID == 0) {
+            localBlogID = this.getLocalTableBlogIdForJetpackRemoteID(remoteBlogId, null);
+        }
+        return localBlogID;
+    }
+
+    public int getLocalTableBlogIdForWpComRemoteBlogId(int remoteBlogId) {
+        int localBlogID = SqlUtils.intForQuery(db, "SELECT id FROM accounts WHERE blogId=? and dotcomFlag=1",
                 new String[]{Integer.toString(remoteBlogId)});
         if (localBlogID == 0) {
             localBlogID = this.getLocalTableBlogIdForJetpackRemoteID(remoteBlogId, null);

--- a/WordPress/src/main/java/org/wordpress/android/models/Note.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Note.java
@@ -384,7 +384,7 @@ public class Note extends Syncable {
         if (jsonActions.has(ACTION_KEY_SPAM)) {
             actions.add(EnabledActions.ACTION_SPAM);
         }
-        if (jsonActions.has(ACTION_KEY_LIKE) && jsonActions.optBoolean(ACTION_KEY_LIKE, false)) {
+        if (jsonActions.has(ACTION_KEY_LIKE)) {
             actions.add(EnabledActions.ACTION_LIKE);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/models/Note.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Note.java
@@ -384,7 +384,7 @@ public class Note extends Syncable {
         if (jsonActions.has(ACTION_KEY_SPAM)) {
             actions.add(EnabledActions.ACTION_SPAM);
         }
-        if (jsonActions.has(ACTION_KEY_LIKE)) {
+        if (jsonActions.has(ACTION_KEY_LIKE) && jsonActions.optBoolean(ACTION_KEY_LIKE, false)) {
             actions.add(EnabledActions.ACTION_LIKE);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -39,6 +39,7 @@ import org.wordpress.android.datasets.CommentTable;
 import org.wordpress.android.datasets.ReaderPostTable;
 import org.wordpress.android.datasets.SuggestionTable;
 import org.wordpress.android.models.AccountHelper;
+import org.wordpress.android.models.Blog;
 import org.wordpress.android.models.Comment;
 import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.models.Note;
@@ -85,6 +86,7 @@ import de.greenrobot.event.EventBus;
  * prior to this there were separate comment detail screens for each list
  */
 public class CommentDetailFragment extends Fragment implements NotificationFragment {
+    private static final String KEY_REMOTE_BLOG_ID = "remote_blog_id";
     private static final String KEY_LOCAL_BLOG_ID = "local_blog_id";
     private static final String KEY_COMMENT_ID = "comment_id";
     private static final String KEY_NOTE_ID = "note_id";
@@ -193,6 +195,8 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
                 long commentId = savedInstanceState.getLong(KEY_COMMENT_ID);
                 setComment(localBlogId, commentId);
             }
+
+            mRemoteBlogId = savedInstanceState.getInt(KEY_REMOTE_BLOG_ID);
         }
 
         setHasOptionsMenu(true);
@@ -209,6 +213,9 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         if (mNote != null) {
             outState.putString(KEY_NOTE_ID, mNote.getId());
         }
+
+        outState.putInt(KEY_REMOTE_BLOG_ID, mRemoteBlogId);
+
     }
 
     @Override
@@ -1103,7 +1110,16 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         }
 
         // note that the local blog id won't be found if the comment is from someone else's blog
-        int localBlogId = WordPress.wpDB.getLocalTableBlogIdForRemoteBlogId(mRemoteBlogId);
+        int localBlogId = WordPress.wpDB.getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(mRemoteBlogId);
+
+        //adjust enabledActions if this is a Jetpack site
+        if (canLike()) {
+            Blog blog = WordPress.wpDB.instantiateBlogByLocalId(localBlogId);
+            if (blog != null && blog.isJetpackPowered()) {
+                //delete LIKE action from enabledActions for Jetpack sites
+                mEnabledActions.remove(EnabledActions.ACTION_LIKE);
+            }
+        }
 
         setComment(localBlogId, note.buildComment());
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/ReferrerSpamHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/ReferrerSpamHelper.java
@@ -119,7 +119,7 @@ class ReferrerSpamHelper {
                 boolean success = response.optBoolean("success");
                 if (success) {
                     mReferrerGroup.isMarkedAsSpam = isMarkingAsSpamInProgress;
-                    int localBlogID = StatsUtils.getLocalBlogIdFromRemoteBlogId(
+                    int localBlogID = WordPress.wpDB.getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(
                             Integer.parseInt(mReferrerGroup.getBlogId())
                     );
                     StatsTable.deleteStatsForBlog(mActivityRef.get(), localBlogID, StatsService.StatsEndpointsEnum.REFERRERS);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
@@ -292,22 +292,6 @@ public class StatsUtils {
         return WordPress.getContext().getResources().getInteger(R.integer.smallest_width_dp);
     }
 
-    public static int getLocalBlogIdFromRemoteBlogId(int remoteBlogID) {
-        // workaround: There are 2 entries in the DB for each Jetpack blog linked with
-        // the current wpcom account. We need to load the correct localID here, otherwise options are
-        // blank
-        int localId = WordPress.wpDB.getLocalTableBlogIdForJetpackRemoteID(
-                remoteBlogID,
-                null);
-        if (localId == 0) {
-            localId = WordPress.wpDB.getLocalTableBlogIdForRemoteBlogId(
-                    remoteBlogID
-            );
-        }
-
-        return localId;
-    }
-
     public static synchronized void logVolleyErrorDetails(final VolleyError volleyError) {
         if (volleyError == null) {
             AppLog.e(T.STATS, "Tried to log a VolleyError, but the error obj was null!");

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetProvider.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetProvider.java
@@ -46,7 +46,7 @@ public class StatsWidgetProvider extends AppWidgetProvider {
         for (int widgetId : allWidgets) {
             RemoteViews remoteViews = new RemoteViews(context.getPackageName(), R.layout.stats_widget_layout);
             int remoteBlogID = getRemoteBlogIDFromWidgetID(widgetId);
-            int localId = StatsUtils.getLocalBlogIdFromRemoteBlogId(remoteBlogID);
+            int localId = WordPress.wpDB.getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(remoteBlogID);
             Blog blog = WordPress.getBlog(localId);
             String name;
             if (blog != null) {
@@ -127,7 +127,7 @@ public class StatsWidgetProvider extends AppWidgetProvider {
             return;
         }
 
-        int localId = StatsUtils.getLocalBlogIdFromRemoteBlogId(remoteBlogID);
+        int localId = WordPress.wpDB.getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(remoteBlogID);
         Blog blog = WordPress.getBlog(localId);
         if (blog == null) {
             AppLog.e(AppLog.T.STATS, "No blog found in the db!");
@@ -168,7 +168,7 @@ public class StatsWidgetProvider extends AppWidgetProvider {
             }
 
             // Check if Jetpack or .com
-            int localId = StatsUtils.getLocalBlogIdFromRemoteBlogId(remoteBlogID);
+            int localId = WordPress.wpDB.getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(remoteBlogID);
             Blog blog = WordPress.getBlog(localId);
             if (blog == null) {
                 return;
@@ -206,7 +206,7 @@ public class StatsWidgetProvider extends AppWidgetProvider {
             return;
         }
 
-        int localId = StatsUtils.getLocalBlogIdFromRemoteBlogId(remoteBlogID);
+        int localId = WordPress.wpDB.getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(remoteBlogID);
         Blog blog = WordPress.getBlog(localId);
         if (blog == null) {
             AppLog.e(AppLog.T.STATS, "No blog found in the db!");
@@ -501,7 +501,7 @@ public class StatsWidgetProvider extends AppWidgetProvider {
             ArrayList<Integer> widgetsList = blogsToWidgetIDs.get(remoteBlogID);
             int[] currentWidgets = ArrayUtils.toPrimitive(widgetsList.toArray(new Integer[widgetsList.size()]));
 
-            int localId = StatsUtils.getLocalBlogIdFromRemoteBlogId(remoteBlogID);
+            int localId = WordPress.wpDB.getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(remoteBlogID);
             Blog blog = WordPress.getBlog(localId);
             if (localId == 0 || blog == null) {
                 // No blog in the app

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -567,7 +567,7 @@ public class StatsService extends Service {
                     // Check here if this is an authentication error
                     // .com authentication errors are handled automatically by the app
                     if (volleyError instanceof com.android.volley.AuthFailureError) {
-                        int localId = StatsUtils.getLocalBlogIdFromRemoteBlogId(
+                        int localId = WordPress.wpDB.getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(
                                 Integer.parseInt(mRequestBlogId)
                         );
                         Blog blog = WordPress.wpDB.instantiateBlogByLocalId(localId);


### PR DESCRIPTION
Fixes #4642 

With the enhancements we made in #4590 we could most probably have the Note payload and look into it to see if the Note is "likeable" by this user, and so we can safely decide whether we need to offer/hide the `Like` button on the Notification layout itself.
If by any chance we can't figure this out by the time we need to draw the notification layout, this PR makes a safe bet by only offering the `Reply` action (which is really the only thing we can know is doable for a Comment at this point).

To test:
1. On a Jetpack site, make sure the site is set to approve incoming comments
2. From another account, make a comment on the site to trigger a notification
3. Check the notification and confirm it doesn't show the "Like" action

Also, repeat the steps 2 and 3 on a wp.com site to get to see the "like" or "approve" actions

