### PR TITLE
Feature/reader full post refresh featured image

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderRelatedPostsView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderRelatedPostsView.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.reader.views;
 
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.graphics.Point;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
@@ -205,7 +206,9 @@ public class ReaderRelatedPostsView extends LinearLayout {
             @Override
             public void onGlobalLayout() {
                 postView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                Point pt = new Point(mFeaturedImageWidth, postView.getHeight());
                 String photonUrl = PhotonUtils.getPhotonImageUrl(relatedPost.getFeaturedImageUrl(), mFeaturedImageWidth, postView.getHeight());
+                imgFeatured.setCropping(pt);
                 imgFeatured.setImageUrl(photonUrl, WPNetworkImageView.ImageType.PHOTO);
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderRelatedPostsView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderRelatedPostsView.java
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.reader.views;
 
 import android.annotation.TargetApi;
 import android.content.Context;
-import android.graphics.Point;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
@@ -201,15 +200,22 @@ public class ReaderRelatedPostsView extends LinearLayout {
         }
 
         // featured image has height set to MATCH_PARENT so wait for parent view's layout to complete
-        // before loading image so we can set the image height correctly
+        // before loading image so we can set the image height correctly, then tell the imageView
+        // to crop the downloaded image to fit the exact width/height of the view
         postView.getViewTreeObserver().addOnGlobalLayoutListener(new ViewTreeObserver.OnGlobalLayoutListener() {
             @Override
             public void onGlobalLayout() {
                 postView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
-                Point pt = new Point(mFeaturedImageWidth, postView.getHeight());
-                String photonUrl = PhotonUtils.getPhotonImageUrl(relatedPost.getFeaturedImageUrl(), mFeaturedImageWidth, postView.getHeight());
-                imgFeatured.setCropping(pt);
-                imgFeatured.setImageUrl(photonUrl, WPNetworkImageView.ImageType.PHOTO);
+                int cropWidth = mFeaturedImageWidth;
+                int cropHeight = postView.getHeight();
+                String photonUrl = PhotonUtils.getPhotonImageUrl(
+                        relatedPost.getFeaturedImageUrl(), cropWidth, cropHeight);
+                imgFeatured.setImageUrl(
+                        photonUrl,
+                        WPNetworkImageView.ImageType.PHOTO,
+                        null,
+                        cropWidth,
+                        cropHeight);
             }
         });
 

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
@@ -316,6 +316,11 @@ public class WPNetworkImageView extends AppCompatImageView {
         int bmpWidth = bitmap.getWidth();
         int bmpHeight = bitmap.getHeight();
 
+        if (bmpWidth == 0 || bmpHeight == 0) {
+            AppLog.w(AppLog.T.READER, "WPNetworkImageView > cannot crop an empty bitmap");
+            return null;
+        }
+
         float scaleWidth = ((float) newWidth) / bmpWidth;
         float scaleHeight = ((float) newHeight) / bmpHeight;
 

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
@@ -5,8 +5,8 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
-import android.graphics.Matrix;
 import android.graphics.drawable.ColorDrawable;
+import android.media.ThumbnailUtils;
 import android.os.AsyncTask;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DrawableRes;
@@ -280,7 +280,7 @@ public class WPNetworkImageView extends AppCompatImageView {
 
             // if cropping is requested, do it before further manipulation
             if (mCropWidth > 0 && mCropHeight > 0) {
-                bitmap = cropBitmap(bitmap, mCropWidth, mCropHeight);
+                bitmap = ThumbnailUtils.extractThumbnail(bitmap, mCropWidth, mCropHeight);
             }
 
             // Apply circular rounding to avatars in a background task
@@ -301,33 +301,6 @@ public class WPNetworkImageView extends AppCompatImageView {
         } else {
             showDefaultImage();
         }
-    }
-
-    /*
-     * crops the passed bitmap to fit the passed width/height - bitmap will be resized if
-     * necessary to ensure it fills the desired size before cropping
-     */
-    private static Bitmap cropBitmap(Bitmap bitmap, int newWidth, int newHeight) {
-        if (bitmap == null) {
-            AppLog.w(AppLog.T.READER, "WPNetworkImageView > cannot crop a null bitmap");
-            return null;
-        }
-
-        int bmpWidth = bitmap.getWidth();
-        int bmpHeight = bitmap.getHeight();
-
-        if (bmpWidth == 0 || bmpHeight == 0) {
-            AppLog.w(AppLog.T.READER, "WPNetworkImageView > cannot crop an empty bitmap");
-            return null;
-        }
-
-        float scaleWidth = ((float) newWidth) / bmpWidth;
-        float scaleHeight = ((float) newHeight) / bmpHeight;
-
-        Matrix matrix = new Matrix();
-        matrix.postScale(scaleWidth, scaleHeight);
-
-        return Bitmap.createBitmap(bitmap, 0, 0, bmpWidth, bmpHeight, matrix, false);
     }
 
     public void invalidateImage() {

--- a/WordPress/src/main/res/layout/reader_related_post.xml
+++ b/WordPress/src/main/res/layout/reader_related_post.xml
@@ -17,7 +17,7 @@
         android:layout_width="@dimen/reader_related_post_image_width"
         android:layout_height="match_parent"
         android:layout_marginRight="@dimen/margin_large"
-        android:scaleType="fitXY"
+        android:scaleType="centerCrop"
         android:visibility="gone"
         tools:src="@drawable/box_with_pages_top"
         tools:visibility="visible" />


### PR DESCRIPTION
Fixes #4640 - in #4626 we redesigned how related posts appear in the reader detail, but featured images on those related posts were stretched rather than cropped. This PR corrects that problem.

Before & after pics below:
![before-and-after](https://cloud.githubusercontent.com/assets/3903757/19357209/a33ff966-913e-11e6-8fd2-32ba4fe3b094.png)

