### PR TITLE
Include plans as tags in Helpshift conversations

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
@@ -188,4 +188,20 @@ public class BlogUtils {
             s.replace(0, s.length(), lowerCase);
         }
     }
+
+    public static Set<String> planTags() {
+        List<Map<String, Object>> blogs = WordPress.wpDB.getBlogsBy("dotcomFlag=1",new String[]{"plan_product_id"});
+        Set<String> tags = new HashSet<String>();
+
+        for (Map<String, Object> blog : blogs) {
+            Integer planId = MapUtils.getMapInt(blog, "plan_product_id");
+            if (planId == null) {
+                continue;
+            }
+            String tag = String.format("plan:%d", planId);
+            tags.add(tag);
+        }
+
+        return tags;
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
@@ -192,12 +192,13 @@ public class BlogUtils {
 
     @NonNull
     public static Set<String> planTags() {
-        List<Map<String, Object>> blogs = WordPress.wpDB.getBlogsBy("dotcomFlag=1",new String[]{"plan_product_id"});
-        Set<String> tags = new HashSet<String>();
+        String[] extraFields = {"plan_product_id"};
+        List<Map<String, Object>> blogs = WordPress.wpDB.getBlogsBy("dotcomFlag=1", extraFields);
+        Set<String> tags = new HashSet<>();
 
         for (Map<String, Object> blog : blogs) {
             Integer planId = MapUtils.getMapInt(blog, "plan_product_id");
-            if (planId == null) {
+            if (planId == 0) {
                 continue;
             }
             String tag = String.format("plan:%d", planId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.accounts;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.text.Editable;
 
 import org.wordpress.android.WordPress;
@@ -189,6 +190,7 @@ public class BlogUtils {
         }
     }
 
+    @NonNull
     public static Set<String> planTags() {
         List<Map<String, Object>> blogs = WordPress.wpDB.getBlogsBy("dotcomFlag=1",new String[]{"plan_product_id"});
         Set<String> tags = new HashSet<String>();

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
@@ -197,8 +197,9 @@ public class BlogUtils {
         Set<String> tags = new HashSet<>();
 
         for (Map<String, Object> blog : blogs) {
-            Integer planId = MapUtils.getMapInt(blog, "plan_product_id");
+            int planId = MapUtils.getMapInt(blog, "plan_product_id");
             if (planId == 0) {
+                // Skip unknown plans, MapUtils will turn any missing plan ID into 0
                 continue;
             }
             String tag = String.format("plan:%d", planId);

--- a/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
@@ -145,7 +145,6 @@ public class HelpshiftHelper {
         properties.put(HELPSHIFT_ORIGIN_KEY, origin.toString());
         AnalyticsTracker.track(Stat.SUPPORT_OPENED_HELPSHIFT_SCREEN, properties);
         // Add tags to Helpshift metadata
-        addPlanTags();
         addTags(new Tag[]{origin});
         HashMap config = getHelpshiftConfig(activity);
         Support.showConversation(activity, config);
@@ -165,7 +164,6 @@ public class HelpshiftHelper {
         properties.put(HELPSHIFT_ORIGIN_KEY, origin.toString());
         AnalyticsTracker.track(Stat.SUPPORT_OPENED_HELPSHIFT_SCREEN, properties);
         // Add tags to Helpshift metadata
-        addPlanTags();
         addTags(new Tag[]{origin});
         HashMap config = getHelpshiftConfig(activity);
         Support.showFAQs(activity, config);
@@ -258,6 +256,7 @@ public class HelpshiftHelper {
         }
         Core.setNameAndEmail(name, emailAddress);
         addDefaultMetaData(context);
+        addPlanTags();
         HashMap config = new HashMap ();
         config.put(Support.CustomMetadataKey, mMetadata);
         config.put("showSearchOnNewConversation", true);

--- a/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
@@ -235,9 +235,11 @@ public class HelpshiftHelper {
 
         // List blogs name and url
         int counter = 1;
-        for (Map<String, Object> account : WordPress.wpDB.getAllBlogs()) {
+        String[] extraFields = {"plan_product_id"};
+        for (Map<String, Object> account : WordPress.wpDB.getBlogsBy(null, extraFields)) {
             mMetadata.put("blog-name-" + counter, MapUtils.getMapStr(account, "blogName"));
             mMetadata.put("blog-url-" + counter, MapUtils.getMapStr(account, "url"));
+            mMetadata.put("blog-plan-" + counter, MapUtils.getMapInt(account, "plan_product_id"));
             counter += 1;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
@@ -18,11 +18,13 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.models.AccountHelper;
+import org.wordpress.android.ui.accounts.BlogUtils;
 import org.wordpress.android.util.AppLog.T;
 
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class HelpshiftHelper {
     public static String ORIGIN_KEY = "ORIGIN_KEY";
@@ -143,6 +145,7 @@ public class HelpshiftHelper {
         properties.put(HELPSHIFT_ORIGIN_KEY, origin.toString());
         AnalyticsTracker.track(Stat.SUPPORT_OPENED_HELPSHIFT_SCREEN, properties);
         // Add tags to Helpshift metadata
+        addPlanTags();
         addTags(new Tag[]{origin});
         HashMap config = getHelpshiftConfig(activity);
         Support.showConversation(activity, config);
@@ -162,6 +165,7 @@ public class HelpshiftHelper {
         properties.put(HELPSHIFT_ORIGIN_KEY, origin.toString());
         AnalyticsTracker.track(Stat.SUPPORT_OPENED_HELPSHIFT_SCREEN, properties);
         // Add tags to Helpshift metadata
+        addPlanTags();
         addTags(new Tag[]{origin});
         HashMap config = getHelpshiftConfig(activity);
         Support.showFAQs(activity, config);
@@ -179,13 +183,28 @@ public class HelpshiftHelper {
     }
 
     public void setTags(Tag[] tags) {
-        mMetadata.put(Support.TagsKey, Tag.toString(tags));
+        setTags(Tag.toString(tags));
+    }
+
+    public void setTags(String[] tags) {
+        mMetadata.put(Support.TagsKey, tags);
     }
 
     public void addTags(Tag[] tags) {
+        addTags(Tag.toString(tags));
+    }
+
+    public void addTags(String[] tags) {
         String[] oldTags = (String[]) mMetadata.get(Support.TagsKey);
         // Concatenate arrays
-        mMetadata.put(Support.TagsKey, ArrayUtils.addAll(oldTags, Tag.toString(tags)));
+        mMetadata.put(Support.TagsKey, ArrayUtils.addAll(oldTags, tags));
+    }
+
+    public void addPlanTags() {
+        Set<String> planTags = BlogUtils.planTags();
+        if (planTags != null) {
+            addTags(planTags.toArray(new String[planTags.size()]));
+        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
@@ -202,9 +202,7 @@ public class HelpshiftHelper {
 
     public void addPlanTags() {
         Set<String> planTags = BlogUtils.planTags();
-        if (planTags != null) {
-            addTags(planTags.toArray(new String[planTags.size()]));
-        }
+        addTags(planTags.toArray(new String[planTags.size()]));
     }
 
     /**


### PR DESCRIPTION
If there's a WordPress.com account, go through every blog and add a tag for each plan.

I've also added the plan ID to the metadata.

Fixes #4631 
