### PR TITLE
refactored method that looks for jetpack site id first into the WP Db class

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/ReferrerSpamHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/ReferrerSpamHelper.java
@@ -119,7 +119,7 @@ class ReferrerSpamHelper {
                 boolean success = response.optBoolean("success");
                 if (success) {
                     mReferrerGroup.isMarkedAsSpam = isMarkingAsSpamInProgress;
-                    int localBlogID = StatsUtils.getLocalBlogIdFromRemoteBlogId(
+                    int localBlogID = WordPress.wpDB.getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(
                             Integer.parseInt(mReferrerGroup.getBlogId())
                     );
                     StatsTable.deleteStatsForBlog(mActivityRef.get(), localBlogID, StatsService.StatsEndpointsEnum.REFERRERS);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
@@ -292,22 +292,6 @@ public class StatsUtils {
         return WordPress.getContext().getResources().getInteger(R.integer.smallest_width_dp);
     }
 
-    public static int getLocalBlogIdFromRemoteBlogId(int remoteBlogID) {
-        // workaround: There are 2 entries in the DB for each Jetpack blog linked with
-        // the current wpcom account. We need to load the correct localID here, otherwise options are
-        // blank
-        int localId = WordPress.wpDB.getLocalTableBlogIdForJetpackRemoteID(
-                remoteBlogID,
-                null);
-        if (localId == 0) {
-            localId = WordPress.wpDB.getLocalTableBlogIdForRemoteBlogId(
-                    remoteBlogID
-            );
-        }
-
-        return localId;
-    }
-
     public static synchronized void logVolleyErrorDetails(final VolleyError volleyError) {
         if (volleyError == null) {
             AppLog.e(T.STATS, "Tried to log a VolleyError, but the error obj was null!");

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetProvider.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetProvider.java
@@ -46,7 +46,7 @@ public class StatsWidgetProvider extends AppWidgetProvider {
         for (int widgetId : allWidgets) {
             RemoteViews remoteViews = new RemoteViews(context.getPackageName(), R.layout.stats_widget_layout);
             int remoteBlogID = getRemoteBlogIDFromWidgetID(widgetId);
-            int localId = StatsUtils.getLocalBlogIdFromRemoteBlogId(remoteBlogID);
+            int localId = WordPress.wpDB.getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(remoteBlogID);
             Blog blog = WordPress.getBlog(localId);
             String name;
             if (blog != null) {
@@ -127,7 +127,7 @@ public class StatsWidgetProvider extends AppWidgetProvider {
             return;
         }
 
-        int localId = StatsUtils.getLocalBlogIdFromRemoteBlogId(remoteBlogID);
+        int localId = WordPress.wpDB.getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(remoteBlogID);
         Blog blog = WordPress.getBlog(localId);
         if (blog == null) {
             AppLog.e(AppLog.T.STATS, "No blog found in the db!");
@@ -168,7 +168,7 @@ public class StatsWidgetProvider extends AppWidgetProvider {
             }
 
             // Check if Jetpack or .com
-            int localId = StatsUtils.getLocalBlogIdFromRemoteBlogId(remoteBlogID);
+            int localId = WordPress.wpDB.getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(remoteBlogID);
             Blog blog = WordPress.getBlog(localId);
             if (blog == null) {
                 return;
@@ -206,7 +206,7 @@ public class StatsWidgetProvider extends AppWidgetProvider {
             return;
         }
 
-        int localId = StatsUtils.getLocalBlogIdFromRemoteBlogId(remoteBlogID);
+        int localId = WordPress.wpDB.getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(remoteBlogID);
         Blog blog = WordPress.getBlog(localId);
         if (blog == null) {
             AppLog.e(AppLog.T.STATS, "No blog found in the db!");
@@ -501,7 +501,7 @@ public class StatsWidgetProvider extends AppWidgetProvider {
             ArrayList<Integer> widgetsList = blogsToWidgetIDs.get(remoteBlogID);
             int[] currentWidgets = ArrayUtils.toPrimitive(widgetsList.toArray(new Integer[widgetsList.size()]));
 
-            int localId = StatsUtils.getLocalBlogIdFromRemoteBlogId(remoteBlogID);
+            int localId = WordPress.wpDB.getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(remoteBlogID);
             Blog blog = WordPress.getBlog(localId);
             if (localId == 0 || blog == null) {
                 // No blog in the app

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -567,7 +567,7 @@ public class StatsService extends Service {
                     // Check here if this is an authentication error
                     // .com authentication errors are handled automatically by the app
                     if (volleyError instanceof com.android.volley.AuthFailureError) {
-                        int localId = StatsUtils.getLocalBlogIdFromRemoteBlogId(
+                        int localId = WordPress.wpDB.getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(
                                 Integer.parseInt(mRequestBlogId)
                         );
                         Blog blog = WordPress.wpDB.instantiateBlogByLocalId(localId);


### PR DESCRIPTION
This refactors to avoid duplicating logic

cc @daniloercoli I'd love if you can check this out and make sure the Stats part isn't affected (shouldn't affect any functionality as I only moved the logic to some other class out of the StatsUtils and within WordPressDB)