### PR TITLE
Issue/4401 direct reply notif

### DIFF
--- a/WordPress/src/androidTest/java/org/wordpress/android/ui/notifications/GCMIntentServiceTest.java
+++ b/WordPress/src/androidTest/java/org/wordpress/android/ui/notifications/GCMIntentServiceTest.java
@@ -34,18 +34,6 @@ public class GCMIntentServiceTest extends ServiceTestCase<GCMMessageService> {
         super.tearDown();
     }
 
-    public void testShouldCircularizeNoteIcon() {
-        GCMMessageService intentService = new GCMMessageService();
-
-        String type = "c";
-        assertTrue(intentService.shouldCircularizeNoteIcon(type));
-
-        assertFalse(intentService.shouldCircularizeNoteIcon(null));
-
-        type = "invalidType";
-        assertFalse(intentService.shouldCircularizeNoteIcon(type));
-    }
-
     public void testOnMessageReceived() throws InterruptedException {
         org.wordpress.android.models.Account account = AccountHelper.getDefaultAccount();
         account.setAccessToken("secret token");

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -60,7 +60,7 @@ public class GCMMessageService extends GcmListenerService {
     private static final int AUTH_PUSH_NOTIFICATION_ID = 20000;
     public static final int GROUP_NOTIFICATION_ID = 30000;
     public static final int ACTIONS_RESULT_NOTIFICATION_ID = 40000;
-    public static final String EXTRA_VOICE_REPLY = "extra_voice_reply";
+    public static final String EXTRA_VOICE_OR_INLINE_REPLY = "extra_voice_or_inline_reply";
     private static final int MAX_INBOX_ITEMS = 5;
 
     private static final String PUSH_ARG_USER = "user";
@@ -309,9 +309,29 @@ public class GCMMessageService extends GcmListenerService {
         builder.addAction(R.drawable.ic_reply_white_24dp, getText(R.string.reply),
                 commentReplyPendingIntent);
 
-        //add wearable remoteInput to enable voice-reply
+//        /*
+//        The following code adds the behavior for Direct reply, available on Android N (7.0) and on.
+//        Using backward compatibility with NotificationCompat.
+//         */
+//        // now add the remoteInput corresponding to direct-reply
         String replyLabel = getResources().getString(R.string.reply);
-        RemoteInput remoteInput = new RemoteInput.Builder(EXTRA_VOICE_REPLY)
+//        RemoteInput remoteInputInlineReply = new RemoteInput.Builder(EXTRA_VOICE_OR_INLINE_REPLY)
+//                .setLabel(replyLabel)
+//                .build();
+//
+//        // Create the reply action and add the remote input.
+//        NotificationCompat.Action inlineAction =
+//                new NotificationCompat.Action.Builder(R.drawable.ic_reply_white_24dp,
+//                        getString(R.string.reply), commentReplyPendingIntent)
+//                        .addRemoteInput(remoteInputInlineReply)
+//                        .build();
+//
+//        builder.addAction(inlineAction);
+
+
+
+        //add wearable remoteInput to enable voice-reply
+        RemoteInput remoteInput = new RemoteInput.Builder(EXTRA_VOICE_OR_INLINE_REPLY)
                 .setLabel(replyLabel)
                 .build();
         NotificationCompat.Action action =
@@ -320,6 +340,7 @@ public class GCMMessageService extends GcmListenerService {
                         .addRemoteInput(remoteInput)
                         .build();
         builder.extend(new NotificationCompat.WearableExtender().addAction(action));
+
 
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -144,7 +144,6 @@ public class GCMMessageService extends GcmListenerService {
             //get the corresponding bundle for this noteId
             for(Iterator<Map.Entry<Integer, Bundle>> it = sActiveNotificationsMap.entrySet().iterator(); it.hasNext(); ) {
                 Map.Entry<Integer, Bundle> row = it.next();
-                Integer pushId = row.getKey();
                 Bundle noteBundle = row.getValue();
                 if (noteBundle.getString(PUSH_ARG_NOTE_ID, "").equals(noteId)) {
                     sNotificationHelpers.rebuildAndUpdateNotificationsOnSystemBar(noteBundle);

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -305,32 +305,14 @@ public class GCMMessageService extends GcmListenerService {
         if (noteId != null) {
             commentReplyIntent.putExtra(NotificationsProcessingService.ARG_NOTE_ID, noteId);
         }
+
         PendingIntent commentReplyPendingIntent =  PendingIntent.getService(this, 0, commentReplyIntent, PendingIntent.FLAG_UPDATE_CURRENT);
-        builder.addAction(R.drawable.ic_reply_white_24dp, getText(R.string.reply),
-                commentReplyPendingIntent);
 
-//        /*
-//        The following code adds the behavior for Direct reply, available on Android N (7.0) and on.
-//        Using backward compatibility with NotificationCompat.
-//         */
-//        // now add the remoteInput corresponding to direct-reply
+        /*
+        The following code adds the behavior for Direct reply, available on Android N (7.0) and on.
+        Using backward compatibility with NotificationCompat.
+         */
         String replyLabel = getResources().getString(R.string.reply);
-//        RemoteInput remoteInputInlineReply = new RemoteInput.Builder(EXTRA_VOICE_OR_INLINE_REPLY)
-//                .setLabel(replyLabel)
-//                .build();
-//
-//        // Create the reply action and add the remote input.
-//        NotificationCompat.Action inlineAction =
-//                new NotificationCompat.Action.Builder(R.drawable.ic_reply_white_24dp,
-//                        getString(R.string.reply), commentReplyPendingIntent)
-//                        .addRemoteInput(remoteInputInlineReply)
-//                        .build();
-//
-//        builder.addAction(inlineAction);
-
-
-
-        //add wearable remoteInput to enable voice-reply
         RemoteInput remoteInput = new RemoteInput.Builder(EXTRA_VOICE_OR_INLINE_REPLY)
                 .setLabel(replyLabel)
                 .build();
@@ -339,8 +321,11 @@ public class GCMMessageService extends GcmListenerService {
                         getString(R.string.reply), commentReplyPendingIntent)
                         .addRemoteInput(remoteInput)
                         .build();
-        builder.extend(new NotificationCompat.WearableExtender().addAction(action));
+        // now add the action corresponding to direct-reply
+        builder.addAction(action);
 
+        //also add wearable remoteInput to enable voice-reply
+        builder.extend(new NotificationCompat.WearableExtender().addAction(action));
 
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -31,7 +31,7 @@ import org.wordpress.android.util.AppLog;
 import java.util.HashMap;
 
 import static org.wordpress.android.push.GCMMessageService.ACTIONS_RESULT_NOTIFICATION_ID;
-import static org.wordpress.android.push.GCMMessageService.EXTRA_VOICE_REPLY;
+import static org.wordpress.android.push.GCMMessageService.EXTRA_VOICE_OR_INLINE_REPLY;
 import static org.wordpress.android.ui.notifications.NotificationsListFragment.NOTE_INSTANT_REPLY_EXTRA;
 
 /**
@@ -117,13 +117,10 @@ public class NotificationsProcessingService extends Service {
 
         if (TextUtils.isEmpty(mReplyText)) {
             //if voice reply is enabled in a wearable, it will come through the remoteInput
-            //extra EXTRA_VOICE_REPLY
+            //extra EXTRA_VOICE_OR_INLINE_REPLY
             Bundle remoteInput = RemoteInput.getResultsFromIntent(intent);
             if (remoteInput != null) {
-                CharSequence replyText = remoteInput.getCharSequence(EXTRA_VOICE_REPLY);
-                if (replyText != null) {
-                    mReplyText = replyText.toString();
-                }
+                obtainReplyTextFromRemoteInputBundle(remoteInput);
             }
         }
 
@@ -157,6 +154,13 @@ public class NotificationsProcessingService extends Service {
         }
 
         return START_NOT_STICKY;
+    }
+
+    private void obtainReplyTextFromRemoteInputBundle(Bundle bundle) {
+        CharSequence replyText = bundle.getCharSequence(EXTRA_VOICE_OR_INLINE_REPLY);
+        if (replyText != null) {
+            mReplyText = replyText.toString();
+        }
     }
 
     private void buildNoteFromJSONObject(JSONObject jsonObject) {

--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -426,7 +426,7 @@ public class NotificationsProcessingService extends Service {
         }
 
         private void resetOriginalNotification(){
-            GCMMessageService.rebuildAndUpdateNotificationsOnSystemBarForThisNote(mNoteId);
+            GCMMessageService.rebuildAndUpdateNotificationsOnSystemBarForThisNote(mContext, mNoteId);
         }
 
     }

--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -125,9 +125,9 @@ public class NotificationsProcessingService extends Service {
         private String mReplyText;
         private String mActionType;
         private Note mNote;
-        private int mTaskId;
-        private Context mContext;
-        private Intent mIntent;
+        private final int mTaskId;
+        private final Context mContext;
+        private final Intent mIntent;
 
         public QuickActionProcessor(Context ctx, Intent intent, int taskId) {
             mContext = ctx;
@@ -279,16 +279,18 @@ public class NotificationsProcessingService extends Service {
                 //show generic error here
                 errorMessage = getString(R.string.error_generic);
             }
+            resetOriginalNotification();
             showFinalMessageToUser(errorMessage);
 
             stopSelf(mTaskId);
         }
 
-        private void requestFailedWithMessage(String actionType, String errorMessage) {
+        private void requestFailedWithMessage(String errorMessage) {
             if (errorMessage == null) {
                 //show generic error here
                 errorMessage = getString(R.string.error_generic);
             }
+            resetOriginalNotification();
             showFinalMessageToUser(errorMessage);
 
             stopSelf(mTaskId);
@@ -385,7 +387,7 @@ public class NotificationsProcessingService extends Service {
                             requestCompleted(ARG_ACTION_REPLY);
                         } else {
                             if (result != null && result.getMessage() != null) {
-                                requestFailedWithMessage(ARG_ACTION_REPLY, result.getMessage());
+                                requestFailedWithMessage(result.getMessage());
                             } else {
                                 requestFailed(ARG_ACTION_REPLY);
                             }
@@ -421,6 +423,10 @@ public class NotificationsProcessingService extends Service {
         private void hideStatusBar() {
             Intent closeIntent = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
             sendBroadcast(closeIntent);
+        }
+
+        private void resetOriginalNotification(){
+            GCMMessageService.rebuildAndUpdateNotificationsOnSystemBarForThisNote(mNoteId);
         }
 
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -30,6 +30,7 @@ import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.models.Note;
 import org.wordpress.android.networking.ConnectionChangeReceiver;
 import org.wordpress.android.networking.SelfSignedSSLCertsManager;
+import org.wordpress.android.push.NotificationsProcessingService;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
@@ -285,8 +286,16 @@ public class WPMainActivity extends AppCompatActivity implements Bucket.Listener
                     }
                 }
 
-                boolean shouldShowKeyboard = getIntent().getBooleanExtra(NotificationsListFragment.NOTE_INSTANT_REPLY_EXTRA, false);
-                NotificationsListFragment.openNoteForReply(this, noteId, shouldShowKeyboard, voiceReply);
+                if (voiceReply != null) {
+                    NotificationsProcessingService.startServiceForReply(this, noteId, voiceReply);
+                    finish();
+                    return; //we don't want this notification to be dismissed as we still have to make sure
+                    // we processed the voice reply, so we exit this function immediately
+                } else {
+                    boolean shouldShowKeyboard = getIntent().getBooleanExtra(NotificationsListFragment.NOTE_INSTANT_REPLY_EXTRA, false);
+                    NotificationsListFragment.openNoteForReply(this, noteId, shouldShowKeyboard, voiceReply);
+                }
+
             } else {
                 SimperiumUtils.trackBucketObjectMissingWarning("No note id found in PN", "");
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -60,7 +60,7 @@ import org.wordpress.android.widgets.WPViewPager;
 
 import de.greenrobot.event.EventBus;
 
-import static org.wordpress.android.push.GCMMessageService.EXTRA_VOICE_REPLY;
+import static org.wordpress.android.push.GCMMessageService.EXTRA_VOICE_OR_INLINE_REPLY;
 
 /**
  * Main activity which hosts sites, reader, me and notifications tabs
@@ -273,11 +273,11 @@ public class WPMainActivity extends AppCompatActivity implements Bucket.Listener
             if (!TextUtils.isEmpty(noteId)) {
                 GCMMessageService.bumpPushNotificationsTappedAnalytics(noteId);
                 //if voice reply is enabled in a wearable, it will come through the remoteInput
-                //extra EXTRA_VOICE_REPLY
+                //extra EXTRA_VOICE_OR_INLINE_REPLY
                 String voiceReply = null;
                 Bundle remoteInput = RemoteInput.getResultsFromIntent(getIntent());
                 if (remoteInput != null) {
-                    CharSequence replyText = remoteInput.getCharSequence(EXTRA_VOICE_REPLY);
+                    CharSequence replyText = remoteInput.getCharSequence(EXTRA_VOICE_OR_INLINE_REPLY);
                     if (replyText != null) {
                         voiceReply = replyText.toString();
                     }


### PR DESCRIPTION
Fixes #4401 

I'm chaining this PR to #4667 as we need the service to implement this one.

![notif_direct_reply](https://cloud.githubusercontent.com/assets/6597771/19571829/eafccfd0-96d5-11e6-9b3f-ccd9fa071b97.gif)


To test:
1. Log in to the Android WordPress app on an Android 7.x device or emulator
2. Have someone like/comment on a blog post of yours
3. See the notification arrive at your device
4. Click on the "REPLY" quick action
5. the edittext appears where you can type the reply
6. tap the SEND button
7. watch the comment being sent and check the comment arrives at the other end (i.e. is received by the first commenter)

cc @kwonye 