### PR TITLE
Disable smart lock during FluxC token migration

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInActivity.java
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.accounts.SmartLockHelper.Callback;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -68,7 +69,9 @@ public class SignInActivity extends AppCompatActivity implements ConnectionCallb
         }
 
         mSmartLockHelper = new SmartLockHelper(this);
-        mSmartLockHelper.initSmartLockForPasswords();
+        if (!AppPrefs.wasAccessTokenMigrated()) {
+            mSmartLockHelper.initSmartLockForPasswords();
+        }
 
         ActivityId.trackLastActivity(ActivityId.LOGIN);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -335,9 +335,9 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
 
     public boolean canAutofillUsernameAndPassword() {
         return EditTextUtils.getText(mUsernameEditText).isEmpty()
-               && EditTextUtils.getText(mPasswordEditText).isEmpty()
-               && mUsernameEditText != null
-               && mPasswordEditText != null;
+                && EditTextUtils.getText(mPasswordEditText).isEmpty()
+                && mUsernameEditText != null
+                && mPasswordEditText != null;
     }
 
     public void onCredentialRetrieved(Credential credential) {


### PR DESCRIPTION
Fix https://github.com/wordpress-mobile/WordPress-Android/issues/4675

Disable smart lock during FluxC token migration
