### PR TITLE
Issue/4679 reader follow button padding

### DIFF
--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -44,7 +44,8 @@
                 android:layout_height="wrap_content"
                 android:layout_alignParentRight="true"
                 android:layout_centerVertical="true"
-                android:layout_marginLeft="@dimen/margin_large" />
+                android:layout_marginLeft="@dimen/margin_large"
+                android:padding="@dimen/reader_follow_button_padding" />
 
             <LinearLayout
                 android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/reader_follow_button.xml
+++ b/WordPress/src/main/res/layout/reader_follow_button.xml
@@ -6,10 +6,10 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="horizontal"
-    android:paddingBottom="@dimen/margin_small"
-    android:paddingLeft="@dimen/margin_small"
-    android:paddingRight="@dimen/margin_small"
-    android:paddingTop="@dimen/margin_small">
+    android:paddingBottom="@dimen/reader_follow_button_padding"
+    android:paddingLeft="@dimen/reader_follow_button_padding"
+    android:paddingRight="@dimen/reader_follow_button_padding"
+    android:paddingTop="@dimen/reader_follow_button_padding">
 
     <ImageView
         android:id="@+id/image_follow_button"

--- a/WordPress/src/main/res/layout/reader_follow_button.xml
+++ b/WordPress/src/main/res/layout/reader_follow_button.xml
@@ -5,11 +5,7 @@
     android:id="@+id/frame_follow_button"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:paddingBottom="@dimen/reader_follow_button_padding"
-    android:paddingLeft="@dimen/reader_follow_button_padding"
-    android:paddingRight="@dimen/reader_follow_button_padding"
-    android:paddingTop="@dimen/reader_follow_button_padding">
+    android:orientation="horizontal">
 
     <ImageView
         android:id="@+id/image_follow_button"

--- a/WordPress/src/main/res/layout/reader_related_post.xml
+++ b/WordPress/src/main/res/layout/reader_related_post.xml
@@ -38,6 +38,7 @@
             android:layout_alignParentRight="true"
             android:layout_centerVertical="true"
             android:layout_marginLeft="@dimen/margin_medium"
+            android:padding="@dimen/reader_follow_button_padding"
             app:wpShowFollowButtonCaption="false" />
 
         <org.wordpress.android.widgets.WPNetworkImageView

--- a/WordPress/src/main/res/layout/reader_site_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_site_header_view.xml
@@ -54,6 +54,7 @@
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
             android:layout_centerVertical="true"
+            android:padding="@dimen/reader_follow_button_padding"
             android:visibility="gone"
             tools:visibility="visible" />
 

--- a/WordPress/src/main/res/layout/reader_tag_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_tag_header_view.xml
@@ -34,7 +34,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:layout_centerVertical="true" />
+            android:layout_centerVertical="true"
+            android:padding="@dimen/reader_follow_button_padding" />
 
     </RelativeLayout>
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -115,6 +115,7 @@
     <dimen name="reader_more_icon">48dp</dimen>
     <dimen name="reader_follow_icon">16dp</dimen>
     <dimen name="reader_follow_icon_no_caption">24dp</dimen>
+    <dimen name="reader_follow_button_padding">@dimen/margin_small</dimen>
 
     <dimen name="reader_detail_tag_height">48dp</dimen>
 


### PR DESCRIPTION
Fixes #4679 - padding is now applied to the follow button in individual layouts where it is used.

To test: Open the new full-post view (reader detail). The follow button should now be left-aligned with the text above it.
