### PR TITLE
[Utils] Remove hardcoded values in the log file header

### DIFF
--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -251,7 +251,7 @@ public class AppLog {
         }
 
         // add version & device info - be sure to change HEADER_LINE_COUNT if additional lines are added
-        items.add("<strong>" + appName + " - " + PackageUtils.getVersionName(context) + " - Version code:" +   PackageUtils.getVersionCode(context) + "</strong>");
+        items.add("<strong>" + appName + " - " + PackageUtils.getVersionName(context) + " - Version code: " +   PackageUtils.getVersionCode(context) + "</strong>");
         items.add("<strong>Android device name: " + DeviceUtils.getInstance().getDeviceName(context) + "</strong>");
 
         Iterator<LogEntry> it = mLogEntries.iterator();
@@ -282,7 +282,7 @@ public class AppLog {
 
         // add version & device info
         sb.append(appName).append(" - ").append(PackageUtils.getVersionName(context))
-                .append(" - Version code:").append(PackageUtils.getVersionCode(context)).append("\n")
+                .append(" - Version code: ").append(PackageUtils.getVersionCode(context)).append("\n")
                 .append("Android device name: ").append(DeviceUtils.getInstance().getDeviceName(context)).append("\n\n");
 
         Iterator<LogEntry> it = mLogEntries.iterator();

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -1,6 +1,9 @@
 package org.wordpress.android.util;
 
 import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -236,8 +239,19 @@ public class AppLog {
     public static ArrayList<String> toHtmlList(Context context) {
         ArrayList<String> items = new ArrayList<String>();
 
+        PackageManager packageManager = context.getPackageManager();
+        PackageInfo pkInfo = PackageUtils.getPackageInfo(context);
+
+        ApplicationInfo applicationInfo =  pkInfo != null ? pkInfo.applicationInfo : null;
+        String appName;
+        if (applicationInfo != null && packageManager.getApplicationLabel(applicationInfo) != null) {
+            appName =  packageManager.getApplicationLabel(applicationInfo).toString();
+        } else {
+            appName = "Unknown";
+        }
+
         // add version & device info - be sure to change HEADER_LINE_COUNT if additional lines are added
-        items.add("<strong>WordPress Android version: " + PackageUtils.getVersionName(context) + "</strong>");
+        items.add("<strong>" + appName + " - " + PackageUtils.getVersionName(context) + " - Version code:" +   PackageUtils.getVersionCode(context) + "</strong>");
         items.add("<strong>Android device name: " + DeviceUtils.getInstance().getDeviceName(context) + "</strong>");
 
         Iterator<LogEntry> it = mLogEntries.iterator();
@@ -255,9 +269,21 @@ public class AppLog {
     public static String toPlainText(Context context) {
         StringBuilder sb = new StringBuilder();
 
+        PackageManager packageManager = context.getPackageManager();
+        PackageInfo pkInfo = PackageUtils.getPackageInfo(context);
+
+        ApplicationInfo applicationInfo =  pkInfo != null ? pkInfo.applicationInfo : null;
+        String appName;
+        if (applicationInfo != null && packageManager.getApplicationLabel(applicationInfo) != null) {
+            appName =  packageManager.getApplicationLabel(applicationInfo).toString();
+        } else {
+            appName = "Unknown";
+        }
+
         // add version & device info
-        sb.append("WordPress Android version: " + PackageUtils.getVersionName(context)).append("\n")
-                .append("Android device name: " + DeviceUtils.getInstance().getDeviceName(context)).append("\n\n");
+        sb.append(appName).append(" - ").append(PackageUtils.getVersionName(context))
+                .append(" - Version code:").append(PackageUtils.getVersionCode(context)).append("\n")
+                .append("Android device name: ").append(DeviceUtils.getInstance().getDeviceName(context)).append("\n\n");
 
         Iterator<LogEntry> it = mLogEntries.iterator();
         int lineNum = 1;

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -231,14 +231,9 @@ public class AppLog {
         return errors.toString();
     }
 
-    /**
-     * Returns entire log as html for display (see AppLogViewerActivity)
-     * @param  context
-     * @return Arraylist of Strings containing log messages
-     */
-    public static ArrayList<String> toHtmlList(Context context) {
-        ArrayList<String> items = new ArrayList<String>();
 
+    private static String getAppInfoHeaderText(Context context) {
+        StringBuilder sb = new StringBuilder();
         PackageManager packageManager = context.getPackageManager();
         PackageInfo pkInfo = PackageUtils.getPackageInfo(context);
 
@@ -249,10 +244,26 @@ public class AppLog {
         } else {
             appName = "Unknown";
         }
+        sb.append(appName).append(" - ").append(PackageUtils.getVersionName(context))
+                .append(" - Version code: ").append(PackageUtils.getVersionCode(context));
+        return sb.toString();
+    }
+
+    private static String getDeviceInfoHeaderText(Context context) {
+        return "Android device name: " + DeviceUtils.getInstance().getDeviceName(context);
+    }
+
+    /**
+     * Returns entire log as html for display (see AppLogViewerActivity)
+     * @param  context
+     * @return Arraylist of Strings containing log messages
+     */
+    public static ArrayList<String> toHtmlList(Context context) {
+        ArrayList<String> items = new ArrayList<String>();
 
         // add version & device info - be sure to change HEADER_LINE_COUNT if additional lines are added
-        items.add("<strong>" + appName + " - " + PackageUtils.getVersionName(context) + " - Version code: " +   PackageUtils.getVersionCode(context) + "</strong>");
-        items.add("<strong>Android device name: " + DeviceUtils.getInstance().getDeviceName(context) + "</strong>");
+        items.add("<strong>" + getAppInfoHeaderText(context) + "</strong>");
+        items.add("<strong>" + getDeviceInfoHeaderText(context) + "</strong>");
 
         Iterator<LogEntry> it = mLogEntries.iterator();
         while (it.hasNext()) {
@@ -269,21 +280,9 @@ public class AppLog {
     public static String toPlainText(Context context) {
         StringBuilder sb = new StringBuilder();
 
-        PackageManager packageManager = context.getPackageManager();
-        PackageInfo pkInfo = PackageUtils.getPackageInfo(context);
-
-        ApplicationInfo applicationInfo = pkInfo != null ? pkInfo.applicationInfo : null;
-        String appName;
-        if (applicationInfo != null && packageManager.getApplicationLabel(applicationInfo) != null) {
-            appName =  packageManager.getApplicationLabel(applicationInfo).toString();
-        } else {
-            appName = "Unknown";
-        }
-
         // add version & device info
-        sb.append(appName).append(" - ").append(PackageUtils.getVersionName(context))
-                .append(" - Version code: ").append(PackageUtils.getVersionCode(context)).append("\n")
-                .append("Android device name: ").append(DeviceUtils.getInstance().getDeviceName(context)).append("\n\n");
+        sb.append(getAppInfoHeaderText(context)).append("\n")
+                .append(getDeviceInfoHeaderText(context)).append("\n\n");
 
         Iterator<LogEntry> it = mLogEntries.iterator();
         int lineNum = 1;

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -242,7 +242,7 @@ public class AppLog {
         PackageManager packageManager = context.getPackageManager();
         PackageInfo pkInfo = PackageUtils.getPackageInfo(context);
 
-        ApplicationInfo applicationInfo =  pkInfo != null ? pkInfo.applicationInfo : null;
+        ApplicationInfo applicationInfo = pkInfo != null ? pkInfo.applicationInfo : null;
         String appName;
         if (applicationInfo != null && packageManager.getApplicationLabel(applicationInfo) != null) {
             appName =  packageManager.getApplicationLabel(applicationInfo).toString();
@@ -272,7 +272,7 @@ public class AppLog {
         PackageManager packageManager = context.getPackageManager();
         PackageInfo pkInfo = PackageUtils.getPackageInfo(context);
 
-        ApplicationInfo applicationInfo =  pkInfo != null ? pkInfo.applicationInfo : null;
+        ApplicationInfo applicationInfo = pkInfo != null ? pkInfo.applicationInfo : null;
         String appName;
         if (applicationInfo != null && packageManager.getApplicationLabel(applicationInfo) != null) {
             appName =  packageManager.getApplicationLabel(applicationInfo).toString();

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/DeviceUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/DeviceUtils.java
@@ -67,7 +67,9 @@ public class DeviceUtils {
                 model = decodedModel;
             }
         } catch (IOException e) {
-            AppLog.e(T.UTILS, e.getMessage());
+            AppLog.e(T.UTILS, "Can't read `android_models.properties` file from assets, or it's in the wrong form.", e);
+            AppLog.d(T.UTILS, "If you need more info about the file, please check the reference implementation available " +
+                    "here: https://github.com/wordpress-mobile/WordPress-Android/blob/dd989429bd701a66bcba911de08f2e8d336798ef/WordPress/src/main/assets/android_models.properties");
         }
 
         if (model == null) {  //Device model not found in the list


### PR DESCRIPTION
WordPress-Utils-Android has some hardcoded values in it, that were displayed in the log file. Removed. 

Also added more info about the file `android_models.properties` that is used in the header of the log file.