### PR TITLE
Ensure sign-in flow recognizes schemeless .com urls

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -59,6 +59,7 @@ import org.wordpress.android.util.JSONUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.widgets.WPTextView;
 import org.wordpress.emailchecker2.EmailChecker;
@@ -386,7 +387,8 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
 
     private boolean isWPComLogin() {
         String selfHostedUrl = EditTextUtils.getText(mUrlEditText).trim();
-        return !mSelfHosted || TextUtils.isEmpty(selfHostedUrl) || WPUrlUtils.isWordPressCom(selfHostedUrl);
+        return !mSelfHosted || TextUtils.isEmpty(selfHostedUrl) ||
+                WPUrlUtils.isWordPressCom(UrlUtils.addUrlSchemeIfNeeded(selfHostedUrl, false));
     }
 
     private boolean isJetpackAuth() {


### PR DESCRIPTION
Fixes #4379, allowing sign in to a WordPress.com account from the self-hosted screen when entering a `wordpress.com` URL.

#### To test:

Actual fix:

1. Go to self-hosted sign-in screen
2. Sign in with .com account username/password and a .com URL (e.g. `youractualsite.wordpress.com`, `notyoursite.wordpress.com`, `wordpress.com`)
3. Check that you are signed in
4. Check that the `Me` tab shows the usual logged-in .com screen

Regression checks:

1. Self-hosted sign-in screen, .com user, URL field left empty (should login .com normally)
2. .com sign-in screen, .com user (should login .com normally)
3. Normal self-hosted sign-in (should login self-hosted normally)
4. Invalid login versions of the above that should give errors