### PR TITLE
Update Library to Passcode Lock v1.4.0

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     // Provided by the WordPress-Android Repository
     compile 'org.wordpress:drag-sort-listview:0.6.1' // not found in maven central
     compile 'org.wordpress:slidinguppanel:1.0.0' // not found in maven central
-    compile 'org.wordpress:passcodelock:1.3.0'
+    compile 'org.wordpress:passcodelock:1.4.0'
 
     // Simperium
     compile 'com.simperium.android:simperium:0.6.8'


### PR DESCRIPTION
### Fix
Update Passcode Lock library to [v1.4.0](https://github.com/wordpress-mobile/PasscodeLock-Android/releases/tag/1.4.0) as described in https://github.com/wordpress-mobile/WordPress-Android/issues/4687.