### PR TITLE
Retain self-hosted site URL field when minimizing the app

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -9,6 +9,7 @@ import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.FragmentTransaction;
 import android.text.Editable;
 import android.text.Html;
@@ -225,11 +226,13 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
      * Hide toggle button "add self hosted / sign in with WordPress.com" and show self hosted URL
      * edit box
      */
-    public void forceSelfHostedMode(String prefillUrl) {
+    public void forceSelfHostedMode(@NonNull String prefillUrl) {
         mUrlButtonLayout.setVisibility(View.VISIBLE);
         mAddSelfHostedButton.setVisibility(View.GONE);
         mCreateAccountButton.setVisibility(View.GONE);
-        mUrlEditText.setText(prefillUrl);
+        if (!prefillUrl.isEmpty()) {
+            mUrlEditText.setText(prefillUrl);
+        }
         mSelfHosted = true;
     }
 


### PR DESCRIPTION
Fixes #4584, preventing the "Add self-hosted site" screen from erasing the self-hosted site URL field when minimized and re-opened.

To test:

1. While logged into the app, choose to add another self-hosted site
2. Enter a URL in the URL field
3. Minimize the app and re-open it
4. The URL field should retain the value

Also worth testing: logging in to a fresh app install, as well as [deep linking](https://github.com/wordpress-mobile/WordPress-Android/pull/4211).