### PR TITLE
Remove quick actions from Push Notifications when PIN Code protection is in place

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -200,7 +200,12 @@ public class WordPress extends MultiDexApplication {
         // Volley networking setup
         setupVolleyQueue();
 
-        AppLockManager.getInstance().enableDefaultAppLockIfAvailable(this);
+        // PasscodeLock setup
+        if(!AppLockManager.getInstance().isAppLockFeatureEnabled()) {
+            // Make sure that PasscodeLock isn't already in place.
+            // Notifications services can enable it before the app is started.
+            AppLockManager.getInstance().enableDefaultAppLockIfAvailable(this);
+        }
         if (AppLockManager.getInstance().isAppLockFeatureEnabled()) {
             AppLockManager.getInstance().getAppLock().setExemptActivities(
                     new String[]{"org.wordpress.android.ui.ShareIntentReceiverActivity"});

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -42,6 +42,9 @@ import org.wordpress.android.util.HelpshiftHelper;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.passcodelock.AbstractAppLock;
+import org.wordpress.passcodelock.AppLockManager;
+import org.wordpress.passcodelock.DefaultAppLock;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -255,8 +258,28 @@ public class GCMMessageService extends GcmListenerService {
         showGroupNotificationForBuilder(builder, wpcomNoteID, message);
     }
 
+    private boolean canAddActionsToNotifications() {
+        AppLockManager appLockManager = AppLockManager.getInstance();
+        if(!appLockManager.isAppLockFeatureEnabled()) {
+            // Make sure PasscodeLock isn't already in place
+            appLockManager.enableDefaultAppLockIfAvailable(this.getApplication());
+        }
+        AbstractAppLock abstractAppLock = appLockManager.getAppLock();
+        if (abstractAppLock instanceof DefaultAppLock) {
+            DefaultAppLock dLock = (DefaultAppLock) abstractAppLock;
+            if (appLockManager.isAppLockFeatureEnabled() && dLock.isPasswordLocked()) {
+                return Boolean.FALSE;
+            }
+        }
+        return Boolean.TRUE;
+    }
+
     private void addActionsForCommentNotification(NotificationCompat.Builder builder, String noteId) {
         // Add some actions if this is a comment notification
+
+        if (!canAddActionsToNotifications()) {
+            return;
+        }
 
         boolean areActionsSet = false;
 
@@ -298,6 +321,10 @@ public class GCMMessageService extends GcmListenerService {
     }
 
     private void addCommentReplyActionForCommentNotification(NotificationCompat.Builder builder, String noteId) {
+        if (!canAddActionsToNotifications()) {
+            return;
+        }
+
         // adding comment reply action
         Intent commentReplyIntent = getCommentActionIntent();
         commentReplyIntent.addCategory(KEY_CATEGORY_COMMENT_REPLY);
@@ -324,6 +351,10 @@ public class GCMMessageService extends GcmListenerService {
     }
 
     private void addCommentLikeActionForCommentNotification(NotificationCompat.Builder builder, String noteId) {
+        if (!canAddActionsToNotifications()) {
+            return;
+        }
+
         // adding comment like action
         Intent commentLikeIntent = getCommentActionIntent();
         commentLikeIntent.addCategory(KEY_CATEGORY_COMMENT_LIKE);
@@ -337,6 +368,10 @@ public class GCMMessageService extends GcmListenerService {
     }
 
     private void addCommentApproveActionForCommentNotification(NotificationCompat.Builder builder, String noteId) {
+        if (!canAddActionsToNotifications()) {
+            return;
+        }
+
         // adding comment approve action
         Intent commentApproveIntent = getCommentActionIntent();
         commentApproveIntent.addCategory(KEY_CATEGORY_COMMENT_MODERATE);

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -260,16 +260,14 @@ public class GCMMessageService extends GcmListenerService {
 
     private boolean canAddActionsToNotifications() {
         AppLockManager appLockManager = AppLockManager.getInstance();
+        // Make sure PasscodeLock isn't already in place
         if(!appLockManager.isAppLockFeatureEnabled()) {
-            // Make sure PasscodeLock isn't already in place
             appLockManager.enableDefaultAppLockIfAvailable(this.getApplication());
         }
-        AbstractAppLock abstractAppLock = appLockManager.getAppLock();
-        if (abstractAppLock instanceof DefaultAppLock) {
-            DefaultAppLock dLock = (DefaultAppLock) abstractAppLock;
-            if (appLockManager.isAppLockFeatureEnabled() && dLock.isPasswordLocked()) {
-                return Boolean.FALSE;
-            }
+
+        // Make sure the locker was correctly enabled, and it's active
+        if (appLockManager.isAppLockFeatureEnabled() && appLockManager.getAppLock().isPasswordLocked()) {
+            return Boolean.FALSE;
         }
         return Boolean.TRUE;
     }

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -332,7 +332,7 @@ public class GCMMessageService extends GcmListenerService {
         if (noteId != null) {
             commentReplyIntent.putExtra(NotificationsProcessingService.ARG_NOTE_ID, noteId);
         }
-        PendingIntent commentReplyPendingIntent =  PendingIntent.getService(this, 0, commentReplyIntent, PendingIntent.FLAG_CANCEL_CURRENT);
+        PendingIntent commentReplyPendingIntent = PendingIntent.getService(this, 0, commentReplyIntent, PendingIntent.FLAG_CANCEL_CURRENT);
         builder.addAction(R.drawable.ic_reply_white_24dp, getText(R.string.reply),
                 commentReplyPendingIntent);
 
@@ -362,7 +362,7 @@ public class GCMMessageService extends GcmListenerService {
         if (noteId != null) {
             commentLikeIntent.putExtra(NotificationsProcessingService.ARG_NOTE_ID, noteId);
         }
-        PendingIntent commentLikePendingIntent =  PendingIntent.getService(this, 0, commentLikeIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent commentLikePendingIntent = PendingIntent.getService(this, 0, commentLikeIntent, PendingIntent.FLAG_UPDATE_CURRENT);
         builder.addAction(R.drawable.ic_action_like, getText(R.string.like),
                 commentLikePendingIntent);
     }
@@ -379,7 +379,7 @@ public class GCMMessageService extends GcmListenerService {
         if (noteId != null) {
             commentApproveIntent.putExtra(NotificationsProcessingService.ARG_NOTE_ID, noteId);
         }
-        PendingIntent commentApprovePendingIntent =  PendingIntent.getService(this, 0, commentApproveIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent commentApprovePendingIntent = PendingIntent.getService(this, 0, commentApproveIntent, PendingIntent.FLAG_UPDATE_CURRENT);
         builder.addAction(R.drawable.ic_action_approve, getText(R.string.approve),
                 commentApprovePendingIntent);
     }

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -43,6 +43,7 @@ import org.wordpress.android.util.HelpshiftHelper;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.passcodelock.AppLockManager;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -258,6 +259,21 @@ public class GCMMessageService extends GcmListenerService {
         }
     }
 
+    private boolean canAddActionsToNotifications() {
+        AppLockManager appLockManager = AppLockManager.getInstance();
+        // Make sure PasscodeLock isn't already in place
+        if (!appLockManager.isAppLockFeatureEnabled()) {
+            appLockManager.enableDefaultAppLockIfAvailable(this.getApplication());
+        }
+
+        // Make sure the locker was correctly enabled, and it's active
+        if (appLockManager.isAppLockFeatureEnabled() && appLockManager.getAppLock().isPasswordLocked()) {
+            return Boolean.FALSE;
+        }
+        return Boolean.TRUE;
+    }
+
+
     private class NotificationHelper {
 
         private void handleDefaultPush(Context context, @NonNull Bundle data) {
@@ -421,10 +437,12 @@ public class GCMMessageService extends GcmListenerService {
             showGroupNotificationForBuilder(context, builder, wpcomNoteID, message);
         }
 
-        
         private void addActionsForCommentNotification(Context context, NotificationCompat.Builder builder, String noteId) {
-            // Add some actions if this is a comment notification
+            if (!canAddActionsToNotifications()) {
+                return;
+            }
 
+            // Add some actions if this is a comment notification
             boolean areActionsSet = false;
 
             if (SimperiumUtils.getNotesBucket() != null) {
@@ -465,6 +483,10 @@ public class GCMMessageService extends GcmListenerService {
         }
 
         private void addCommentReplyActionForCommentNotification(Context context, NotificationCompat.Builder builder, String noteId) {
+            if (!canAddActionsToNotifications()) {
+                return;
+            }
+
             // adding comment reply action
             Intent commentReplyIntent = getCommentActionReplyIntent(context, noteId);
             commentReplyIntent.addCategory(KEY_CATEGORY_COMMENT_REPLY);
@@ -496,6 +518,10 @@ public class GCMMessageService extends GcmListenerService {
         }
 
         private void addCommentLikeActionForCommentNotification(Context context, NotificationCompat.Builder builder, String noteId) {
+            if (!canAddActionsToNotifications()) {
+                return;
+            }
+
             // adding comment like action
             Intent commentLikeIntent = getCommentActionIntent(context);
             commentLikeIntent.addCategory(KEY_CATEGORY_COMMENT_LIKE);
@@ -509,6 +535,10 @@ public class GCMMessageService extends GcmListenerService {
         }
 
         private void addCommentApproveActionForCommentNotification(Context context, NotificationCompat.Builder builder, String noteId) {
+            if (!canAddActionsToNotifications()) {
+                return;
+            }
+
             // adding comment approve action
             Intent commentApproveIntent = getCommentActionIntent(context);
             commentApproveIntent.addCategory(KEY_CATEGORY_COMMENT_MODERATE);


### PR DESCRIPTION
Fixes #4690
This PR checks whether PIN code protection is active on the app, and doesn't add quick actions to Push Notifications accordingly. 

To test:
- Enable PIN code protection in wp-android
- Close the app
- Make a comment on a blog and wait the PN
- Open the PN in the notifications center and quick actions must no be there

