### PR TITLE
Stop persisting self-hosted URL field after login

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -552,6 +552,8 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                     public void onResponse(JSONObject jsonObject) {
                         // Set primary blog
                         setPrimaryBlog(jsonObject);
+                        // Clear the URL on login so it's not persisted the next time we add a self-hosted site
+                        mUrlEditText.setText("");
                         finishCurrentActivity(userBlogList);
                         String displayName = JSONUtils.getStringDecoded(jsonObject, "display_name");
                         Uri profilePicture = Uri.parse(JSONUtils.getString(jsonObject, "avatar_URL"));
@@ -564,7 +566,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                     }
                 }, null);
             } else {
-                // Clear the URL on successful login so it's not persisted the next time we add a self-hosted site
+                // Clear the URL on login so it's not persisted the next time we add a self-hosted site
                 mUrlEditText.setText("");
                 finishCurrentActivity(userBlogList);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -564,6 +564,8 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                     }
                 }, null);
             } else {
+                // Clear the URL on successful login so it's not persisted the next time we add a self-hosted site
+                mUrlEditText.setText("");
                 finishCurrentActivity(userBlogList);
             }
         }


### PR DESCRIPTION
Fixes #3947, so that we don't prefill the URL field with the last self-hosted site the user logged into when adding a new self-hosted site.

The ultimate cause is that the URL text field is [persisted](https://github.com/wordpress-mobile/WordPress-Android/blob/9ef65d8a59a1371ad3e2a1fdec99664fffc53935/WordPress/src/main/res/layout/signin_fragment.xml#L196), so that any text entered will be saved even if the user leaves the activity and comes back. For example, if the user navigates back to the post list (perhaps to check the sites they're already logged into), and goes back to the "Add self-hosted site" screen, we'll retain what they had typed in.

The solution I opted for was to keep persistence, but clear the field on successful login so that we start with a blank URL field the next time we add a self-hosted site.

To test:

1. From a fresh install, sign in with a self hosted blog
2. On the blog details screen tap "Switch Site"
3. On the Choose site screen, tap the + button to add a new site
4. The sign in screen should launch with all fields empty
5. Fill in all fields, then exit the sign in screen and return to the post list
6. Tap the + button again to add a new site
7. The sign in screen should launch with username/password empty, but the URL field persisted