### PR TITLE
issue/4702-reader-related-post-mystery-man

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/models/ReaderRelatedPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/models/ReaderRelatedPost.java
@@ -54,7 +54,10 @@ public class ReaderRelatedPost {
         JSONObject jsonAuthor = json.optJSONObject("author");
         if (jsonAuthor != null) {
             post.mAuthorName = JSONUtils.getStringDecoded(jsonAuthor, "name");
-            post.mAuthorAvatarUrl = JSONUtils.getString(jsonAuthor, "avatar_URL");
+            // don't read the avatar field unless "has_avatar" is true
+            if (JSONUtils.getBool(jsonAuthor, "has_avatar")) {
+                post.mAuthorAvatarUrl = JSONUtils.getString(jsonAuthor, "avatar_URL");
+            }
         }
 
         // if there's no featured image, check if featured media has been set to an image

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderRelatedPostsView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderRelatedPostsView.java
@@ -107,10 +107,11 @@ public class ReaderRelatedPostsView extends LinearLayout {
                 txtSiteName.setText(relatedPost.getSiteName());
                 txtAuthorName.setText(relatedPost.getAuthorName());
                 if (relatedPost.hasAuthorAvatarUrl()) {
+                    imgAvatar.setVisibility(View.VISIBLE);
                     String avatarUrl = GravatarUtils.fixGravatarUrl(relatedPost.getAuthorAvatarUrl(), avatarSize);
                     imgAvatar.setImageUrl(avatarUrl, WPNetworkImageView.ImageType.AVATAR);
                 } else {
-                    imgAvatar.showDefaultGravatarImage();
+                    imgAvatar.setVisibility(View.GONE);
                 }
 
                 final ReaderFollowButton btnFollow = (ReaderFollowButton) siteHeader.findViewById(R.id.related_post_follow_button);


### PR DESCRIPTION
Fixes #4702 - in the reader full post view, related wp.com posts ("More on WordPress.com") no longer show the default "mystery man" avatar when the author doesn't have an avatar. 

This screencrop shows an example - the second related post shows no avatar, because the author doesn't have one:

![device-2016-10-26-191329](https://cloud.githubusercontent.com/assets/3903757/19748574/9c1e0b56-9bb0-11e6-9dda-7e4614ae2ea3.png)

Note that this doesn't completely address the issue since the site blavatar should be shown if there's a blavatar but no avatar. That will be addressed if/when the blavatar is included in the related posts response (I started a discussion with reader squad about this).

