### PR TITLE
issue/add-comment-to-reader-post-table

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -24,8 +24,8 @@ import org.wordpress.android.util.SqlUtils;
 /**
  * tbl_posts contains all reader posts - the primary key is pseudo_id + tag_name + tag_type,
  * which allows the same post to appear in multiple streams (ex: it can exist in followed
- * sites, liked posts, and tag streams. note that posts in a specific blog or feed are
- * stored here with an empty tag_name
+ * sites, liked posts, and tag streams). note that posts in a specific blog or feed are
+ * stored here with an empty tag_name.
  */
 public class ReaderPostTable {
     private static final String COLUMN_NAMES =

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -22,8 +22,10 @@ import org.wordpress.android.util.CrashlyticsUtils;
 import org.wordpress.android.util.SqlUtils;
 
 /**
- * tbl_posts contains all reader posts - note that the same post can occur multiple times in this
- * table if it exists in multiple tag streams (ex: it exists in both followed sites and liked posts)
+ * tbl_posts contains all reader posts - the primary key is pseudo_id + tag_name + tag_type,
+ * which allows the same post to appear in multiple streams (ex: it can exist in followed
+ * sites, liked posts, and tag streams. note that posts in a specific blog or feed are
+ * stored here with an empty tag_name
  */
 public class ReaderPostTable {
     private static final String COLUMN_NAMES =


### PR DESCRIPTION
This is a minor, code-free PR which simply updates the comment header in `ReaderPostTable.java` to explain that posts in a specific blog are stored without a tag. This was added after #4707, which fixed a bug caused by not limiting posts to those without a tag when querying for posts in a specific blog.
