### PR TITLE
Issue/4704 replace signin with login

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -825,7 +825,7 @@ public class GCMMessageService extends GcmListenerService {
             EventBus.getDefault().post(new NotificationEvents.NotificationsChanged());
         }
 
-        // Show a notification for two-step auth users who sign in from a web browser
+        // Show a notification for two-step auth users who log in from a web browser
         private void handlePushAuth(Context context, Bundle data) {
             if (data == null) {
                 return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -106,7 +106,7 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
     }
 
     private void finishIfNoVisibleBlogs() {
-        // If not signed in, then ask to sign in, else inform the user to set at least one blog
+        // If not logged in, then ask to log in, else inform the user to set at least one blog
         // visible
         if (!AccountHelper.isSignedIn()) {
             ToastUtils.showToast(getBaseContext(), R.string.no_account, ToastUtils.Duration.LONG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -288,7 +288,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
                     @Override
                     public void onSuccess(JSONObject createSiteResponse) {
                         // User has been created. From this point, all errors should close this screen and display the
-                        // sign in screen
+                        // log in screen
                         AnalyticsUtils.refreshMetadata(mUsername, email);
                         AnalyticsTracker.track(AnalyticsTracker.Stat.CREATED_ACCOUNT);
                         AnalyticsTracker.track(AnalyticsTracker.Stat.CREATED_SITE);
@@ -328,7 +328,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
             @Override
             public void onError(int errorMessageId, boolean twoStepCodeRequired, boolean httpAuthRequired,
                                 boolean erroneousSslCertificate) {
-                // Should not happen (excepted for a timeout), go back to the sign in screen
+                // Should not happen (excepted for a timeout), go back to the log in screen
                 finishAndShowSignInScreen();
             }
         });
@@ -348,7 +348,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
 
     /**
      * In case an error happened after the user creation steps, we don't want to show the sign up screen.
-     * Show the sign in screen with username and password prefilled, plus a toast message to explain what happened.
+     * Show the log in screen with username and password prefilled, plus a toast message to explain what happened.
      *
      * Note: this should be called only if the user has been created.
      */
@@ -366,7 +366,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
         } catch (IllegalStateException e) {
             // Catch the ISE exception, because we can't check for the fragment state here
             // finishAndShowSignInScreen will be called in an Network onError callback so we can't guarantee, the
-            // fragment transaction will be executed. In that case the user already is back on the Sign In screen.
+            // fragment transaction will be executed. In that case the user already is back on the Log In screen.
             AppLog.e(T.NUX, e);
         }
         ToastUtils.showToast(getActivity(), R.string.signup_succeed_signin_failed, Duration.LONG);
@@ -393,7 +393,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
         @Override
         public void onError(final int messageId, final boolean twoStepCodeRequired, final boolean httpAuthRequired,
                             final boolean erroneousSslCertificate, final String clientResponse) {
-            // Should not happen (excepted for a timeout), go back to the sign in screen
+            // Should not happen (excepted for a timeout), go back to the log in screen
             finishAndShowSignInScreen();
         }
     };

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -224,7 +224,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     }
 
     /**
-     * Hide toggle button "add self hosted / sign in with WordPress.com" and show self hosted URL
+     * Hide toggle button "add self hosted / log in with WordPress.com" and show self hosted URL
      * edit box
      */
     public void forceSelfHostedMode(@NonNull String prefillUrl) {
@@ -558,7 +558,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                         String displayName = JSONUtils.getStringDecoded(jsonObject, "display_name");
                         Uri profilePicture = Uri.parse(JSONUtils.getString(jsonObject, "avatar_URL"));
                         SmartLockHelper smartLockHelper = getSmartLockHelper();
-                        // mUsername and mPassword are null when the user sign in with a magic link
+                        // mUsername and mPassword are null when the user log in with a magic link
                         if (smartLockHelper != null && mUsername != null && mPassword != null) {
                             smartLockHelper.saveCredentialsInSmartLock(mUsername, mPassword, displayName,
                                     profilePicture);
@@ -721,12 +721,12 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         mPassword = EditTextUtils.getText(mPasswordEditText).trim();
         mTwoStepCode = EditTextUtils.getText(mTwoStepEditText).trim();
         if (isWPComLogin()) {
-            AppLog.i(T.NUX, "User tries to sign in on WordPress.com with username: " + mUsername);
+            AppLog.i(T.NUX, "User tries to log in on WordPress.com with username: " + mUsername);
             startProgress(getString(R.string.connecting_wpcom));
             signInAndFetchBlogListWPCom();
         } else {
             String selfHostedUrl = EditTextUtils.getText(mUrlEditText).trim();
-            AppLog.i(T.NUX, "User tries to sign in on Self Hosted: " + selfHostedUrl + " with username: " + mUsername);
+            AppLog.i(T.NUX, "User tries to log in on Self Hosted: " + selfHostedUrl + " with username: " + mUsername);
             startProgress(getString(R.string.signing_in));
             signInAndFetchBlogListWPOrg();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SmartLockHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SmartLockHelper.java
@@ -94,7 +94,7 @@ public class SmartLockHelper {
                                     AppLog.d(T.NUX, "SmartLock: Failed to send resolution for credential request");
                                 }
                             } else {
-                                // The user must create an account or sign in manually.
+                                // The user must create an account or log in manually.
                                 AppLog.d(T.NUX, "SmartLock: Unsuccessful credential request.");
                             }
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/CreateUserAndBlog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/CreateUserAndBlog.java
@@ -160,7 +160,7 @@ public class CreateUserAndBlog {
 
             @Override
             public void onError(int errorMessageId, boolean twoStepCodeRequired, boolean httpAuthRequired, boolean erroneousSslCertificate) {
-                mErrorListener.onErrorResponse(new VolleyError("Sign in failed."));
+                mErrorListener.onErrorResponse(new VolleyError("Log in failed."));
             }
         });
 

--- a/WordPress/src/main/java/org/wordpress/android/util/AuthenticationDialogUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AuthenticationDialogUtils.java
@@ -77,7 +77,7 @@ public class AuthenticationDialogUtils {
             return;
         }
 
-        // WP.com errors will show the sign in activity
+        // WP.com errors will show the log in activity
         if (WordPress.getCurrentBlog() == null || (WordPress.getCurrentBlog() != null && WordPress.getCurrentBlog().isDotcomFlag())) {
             Intent signInIntent = new Intent(activity, SignInActivity.class);
             signInIntent.putExtra(SignInActivity.EXTRA_IS_AUTH_ERROR, true);

--- a/WordPress/src/main/res/values-en-rAU/strings.xml
+++ b/WordPress/src/main/res/values-en-rAU/strings.xml
@@ -537,7 +537,7 @@
 	<string name="stats_insights">Insights</string>
 	<string name="stats_sign_in_jetpack_different_com_account">To view your stats, log in to the WordPress.com account you used to connect Jetpack.</string>
 	<string name="stats_other_recent_stats_moved_label">Looking for your Other Recent Stats? We\'ve moved them to the Insights page.</string>
-	<string name="me_disconnect_from_wordpress_com">Disconnect from WordPress.com</string>
+	<string name="me_disconnect_from_wordpress_com">Log out from WordPress.com</string>
 	<string name="me_btn_login_logout">Login/Logout</string>
 	<string name="me_connect_to_wordpress_com">Connect to WordPress.com</string>
 	<string name="site_picker_cant_hide_current_site">"%s" wasn\'t hidden because it\'s the current site</string>

--- a/WordPress/src/main/res/values-en-rAU/strings.xml
+++ b/WordPress/src/main/res/values-en-rAU/strings.xml
@@ -87,7 +87,7 @@
 	<string name="invite_people">Invite People</string>
 	<string name="my_site_header_external">External</string>
 	<string name="send_link">Send link</string>
-	<string name="signup_succeed_signin_failed">Your account has been created but an error occured while we signed you\n        in. Try to sign in with your newly created username and password.</string>
+	<string name="signup_succeed_signin_failed">Your account has been created but an error occured while we signed you\n        in. Try to log in with your newly created username and password.</string>
 	<string name="label_clear_search_history">Clear search history</string>
 	<string name="dlg_confirm_clear_search_history">Clear search history?</string>
 	<string name="reader_empty_posts_in_search_description">No posts found for %s for your language</string>
@@ -123,7 +123,7 @@
 	<string name="check_your_email">Check your email</string>
 	<string name="magic_link_unavailable_error_message">Currently unavailable. Please enter your password</string>
 	<string name="logging_in">Logging in</string>
-	<string name="get_a_link_sent_to_your_email_to_sign_in_instantly">Get a link sent to your email to sign in instantly</string>
+	<string name="get_a_link_sent_to_your_email_to_sign_in_instantly">Get a link sent to your email to log in instantly</string>
 	<string name="enter_your_password_instead">Enter your password instead</string>
 	<string name="web_address_dialog_hint">Shown publicly when you comment.</string>
 	<string name="username_email">Email or username</string>
@@ -525,7 +525,7 @@
 	<string name="tabbar_accessibility_label_my_site">My Site</string>
 	<string name="editor_toast_changes_saved">Changes saved</string>
 	<string name="passcodelock_prompt_message">Enter your PIN</string>
-	<string name="push_auth_expired">The request has expired. Sign in to WordPress.com to try again.</string>
+	<string name="push_auth_expired">The request has expired. Log in to WordPress.com to try again.</string>
 	<string name="stats_insights_most_popular_percent_views">%1$d%% of views</string>
 	<string name="ignore">Ignore</string>
 	<string name="stats_insights_best_ever">Best Views Ever</string>
@@ -535,7 +535,7 @@
 	<string name="stats_insights_popular">Most popular day and hour</string>
 	<string name="stats_insights_all_time">All-time posts, views, and visitors</string>
 	<string name="stats_insights">Insights</string>
-	<string name="stats_sign_in_jetpack_different_com_account">To view your stats, sign in to the WordPress.com account you used to connect Jetpack.</string>
+	<string name="stats_sign_in_jetpack_different_com_account">To view your stats, log in to the WordPress.com account you used to connect Jetpack.</string>
 	<string name="stats_other_recent_stats_moved_label">Looking for your Other Recent Stats? We\'ve moved them to the Insights page.</string>
 	<string name="me_disconnect_from_wordpress_com">Disconnect from WordPress.com</string>
 	<string name="me_btn_login_logout">Login/Logout</string>
@@ -557,7 +557,7 @@
 	<string name="my_site_btn_blog_posts">Blog Posts</string>
 	<string name="reader_label_new_posts_subtitle">Tap to show them</string>
 	<string name="my_site_header_configuration">Configuration</string>
-	<string name="notifications_account_required">Sign in to WordPress.com for notifications</string>
+	<string name="notifications_account_required">Log in to WordPress.com for notifications</string>
 	<string name="stats_unknown_author">Unknown Author</string>
 	<string name="signout">Disconnect</string>
 	<string name="image_added">Image added</string>
@@ -582,8 +582,8 @@
 	<string name="no_media">No media</string>
 	<string name="loading_images">Loading images</string>
 	<string name="loading_videos">Loading videos</string>
-	<string name="auth_required">Sign in again to continue.</string>
-	<string name="sign_in_jetpack">Sign in to your WordPress.com account to connect to Jetpack.</string>
+	<string name="auth_required">Log in again to continue.</string>
+	<string name="sign_in_jetpack">Log in to your WordPress.com account to connect to Jetpack.</string>
 	<string name="two_step_sms_sent">Check your text messages for the verification code.</string>
 	<string name="two_step_footer_button">Send code via text message</string>
 	<string name="two_step_footer_label">Enter the code from your authenticator app.</string>
@@ -972,7 +972,7 @@
 	<string name="reader_empty_followed_blogs_description">But don\'t worry, just tap the icon at the top right to start exploring!</string>
 	<string name="reader_likes_you_and_one">You and one other like this</string>
 	<string name="select_time">Select time</string>
-	<string name="nux_oops_not_selfhosted_blog">Sign in to WordPress.com</string>
+	<string name="nux_oops_not_selfhosted_blog">Log in to WordPress.com</string>
 	<string name="nux_add_selfhosted_blog">Add self-hosted site</string>
 	<string name="signing_in">Signing in…</string>
 	<string name="nux_welcome_create_account">Create account</string>
@@ -1072,7 +1072,7 @@
 	<string name="follows">Follows</string>
 	<string name="note_reply_successful">Reply published</string>
 	<string name="notifications">Notifications</string>
-	<string name="sign_in">Sign in</string>
+	<string name="sign_in">Log in</string>
 	<string name="loading">Loading…</string>
 	<string name="httppassword">HTTP password</string>
 	<string name="httpuser">HTTP username</string>

--- a/WordPress/src/main/res/values-en-rAU/strings.xml
+++ b/WordPress/src/main/res/values-en-rAU/strings.xml
@@ -87,7 +87,7 @@
 	<string name="invite_people">Invite People</string>
 	<string name="my_site_header_external">External</string>
 	<string name="send_link">Send link</string>
-	<string name="signup_succeed_signin_failed">Your account has been created but an error occured while we signed you\n        in. Try to log in with your newly created username and password.</string>
+	<string name="signup_succeed_signin_failed">Your account has been created but an error occured while we logged you\n        in. Try to log in with your newly created username and password.</string>
 	<string name="label_clear_search_history">Clear search history</string>
 	<string name="dlg_confirm_clear_search_history">Clear search history?</string>
 	<string name="reader_empty_posts_in_search_description">No posts found for %s for your language</string>
@@ -361,7 +361,7 @@
 	<string name="site_settings_paging_title">Paging</string>
 	<string name="site_settings_threading_title">Threading</string>
 	<string name="site_settings_sort_by_title">Sort by</string>
-	<string name="site_settings_account_required_title">Users must be signed in</string>
+	<string name="site_settings_account_required_title">Users must be logged in</string>
 	<string name="site_settings_identity_required_title">Must include name and email</string>
 	<string name="site_settings_receive_pingbacks_title">Receive Pingbacks</string>
 	<string name="site_settings_send_pingbacks_title">Send Pingbacks</string>
@@ -699,7 +699,7 @@
 	<string name="delete_sure_page">Delete this page</string>
 	<string name="delete_sure">Delete this draft</string>
 	<string name="delete_sure_post">Delete this post</string>
-	<string name="signing_out">Signing out…</string>
+	<string name="signing_out">Logging out…</string>
 	<string name="posting_post">Posting "%s"</string>
 	<string name="media_empty_list_custom_date">No media in this time interval</string>
 	<string name="pages_empty_list">No pages yet. Why not create one?</string>
@@ -974,7 +974,7 @@
 	<string name="select_time">Select time</string>
 	<string name="nux_oops_not_selfhosted_blog">Log in to WordPress.com</string>
 	<string name="nux_add_selfhosted_blog">Add self-hosted site</string>
-	<string name="signing_in">Signing in…</string>
+	<string name="signing_in">Logging in…</string>
 	<string name="nux_welcome_create_account">Create account</string>
 	<string name="nux_tap_continue">Continue</string>
 	<string name="password_invalid">You need a more secure password. Make sure to use 7 or more characters, mix uppercase and lowercase letters, numbers or special characters.</string>

--- a/WordPress/src/main/res/values-en-rAU/strings.xml
+++ b/WordPress/src/main/res/values-en-rAU/strings.xml
@@ -294,7 +294,7 @@
 	<string name="error_post_remote_site_settings">Couldn\'t save site info</string>
 	<string name="error_fetch_remote_site_settings">Couldn\'t retrieve site info</string>
 	<string name="error_media_upload_connection">A connection error occurred while uploading media</string>
-	<string name="site_settings_disconnected_toast">Disconnected, editing disabled.</string>
+	<string name="site_settings_disconnected_toast">Logged out, editing disabled.</string>
 	<string name="site_settings_unsupported_version_error">Unsupported WordPress version</string>
 	<string name="site_settings_multiple_links_dialog_description">Require approval for comments that include more than this number of links.</string>
 	<string name="site_settings_close_after_dialog_switch_text">Automatically close</string>
@@ -539,7 +539,7 @@
 	<string name="stats_other_recent_stats_moved_label">Looking for your Other Recent Stats? We\'ve moved them to the Insights page.</string>
 	<string name="me_disconnect_from_wordpress_com">Log out from WordPress.com</string>
 	<string name="me_btn_login_logout">Login/Logout</string>
-	<string name="me_connect_to_wordpress_com">Connect to WordPress.com</string>
+	<string name="me_connect_to_wordpress_com">Log in to WordPress.com</string>
 	<string name="site_picker_cant_hide_current_site">"%s" wasn\'t hidden because it\'s the current site</string>
 	<string name="me_btn_support">Help &amp; Support</string>
 	<string name="account_settings">Account Settings</string>
@@ -559,9 +559,9 @@
 	<string name="my_site_header_configuration">Configuration</string>
 	<string name="notifications_account_required">Log in to WordPress.com for notifications</string>
 	<string name="stats_unknown_author">Unknown Author</string>
-	<string name="signout">Disconnect</string>
+	<string name="signout">Log out</string>
 	<string name="image_added">Image added</string>
-	<string name="sign_out_wpcom_confirm">Disconnecting your account will remove all of @%s’s WordPress.com data from this device, including local drafts and local changes.</string>
+	<string name="sign_out_wpcom_confirm">Logging out from your account will remove all of @%s’s WordPress.com data from this device, including local drafts and local changes.</string>
 	<string name="select_all">Select all</string>
 	<string name="hide">Hide</string>
 	<string name="show">Show</string>
@@ -981,7 +981,7 @@
 	<string name="nux_tutorial_get_started_title">Get started!</string>
 	<string name="limit_reached">Limit reached. You can try again in 1 minute. Trying again before that will only increase the time you have to wait before the ban is lifted. If you think this is in error, contact support.</string>
 	<string name="username_invalid">Invalid username</string>
-	<string name="connecting_wpcom">Connecting to WordPress.com</string>
+	<string name="connecting_wpcom">Logging in to WordPress.com</string>
 	<string name="button_next">Next</string>
 	<string name="create_account_wpcom">Create an account on WordPress.com</string>
 	<string name="reader_empty_followed_tags">You don\'t follow any tags</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -537,7 +537,7 @@
 	<string name="stats_insights">Insights</string>
 	<string name="stats_sign_in_jetpack_different_com_account">To view your stats, log in to the WordPress.com account you used to connect Jetpack.</string>
 	<string name="stats_other_recent_stats_moved_label">Looking for your Other Recent Stats? We\'ve moved them to the Insights page.</string>
-	<string name="me_disconnect_from_wordpress_com">Disconnect from WordPress.com</string>
+	<string name="me_disconnect_from_wordpress_com">Log out from WordPress.com</string>
 	<string name="me_btn_login_logout">Login/Logout</string>
 	<string name="me_connect_to_wordpress_com">Connect to WordPress.com</string>
 	<string name="site_picker_cant_hide_current_site">"%s" wasn\'t hidden because it\'s the current site</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -87,7 +87,7 @@
 	<string name="invite_people">Invite People</string>
 	<string name="my_site_header_external">External</string>
 	<string name="send_link">Send link</string>
-	<string name="signup_succeed_signin_failed">Your account has been created but an error occured while we signed you\n        in. Try to sign in with your newly created username and password.</string>
+	<string name="signup_succeed_signin_failed">Your account has been created but an error occured while we signed you\n        in. Try to log in with your newly created username and password.</string>
 	<string name="label_clear_search_history">Clear search history</string>
 	<string name="dlg_confirm_clear_search_history">Clear search history?</string>
 	<string name="reader_empty_posts_in_search_description">No posts found for %s for your language</string>
@@ -123,7 +123,7 @@
 	<string name="check_your_email">Check your email</string>
 	<string name="magic_link_unavailable_error_message">Currently unavailable. Please enter your password</string>
 	<string name="logging_in">Logging in</string>
-	<string name="get_a_link_sent_to_your_email_to_sign_in_instantly">Get a link sent to your email to sign in instantly</string>
+	<string name="get_a_link_sent_to_your_email_to_sign_in_instantly">Get a link sent to your email to log in instantly</string>
 	<string name="enter_your_password_instead">Enter your password instead</string>
 	<string name="web_address_dialog_hint">Shown publicly when you comment.</string>
 	<string name="username_email">Email or username</string>
@@ -525,7 +525,7 @@
 	<string name="tabbar_accessibility_label_my_site">My Site</string>
 	<string name="editor_toast_changes_saved">Changes saved</string>
 	<string name="passcodelock_prompt_message">Enter your PIN</string>
-	<string name="push_auth_expired">The request has expired. Sign in to WordPress.com to try again.</string>
+	<string name="push_auth_expired">The request has expired. Log in to WordPress.com to try again.</string>
 	<string name="stats_insights_most_popular_percent_views">%1$d%% of views</string>
 	<string name="ignore">Ignore</string>
 	<string name="stats_insights_best_ever">Best Views Ever</string>
@@ -535,7 +535,7 @@
 	<string name="stats_insights_popular">Most popular day and hour</string>
 	<string name="stats_insights_all_time">All-time posts, views, and visitors</string>
 	<string name="stats_insights">Insights</string>
-	<string name="stats_sign_in_jetpack_different_com_account">To view your stats, sign in to the WordPress.com account you used to connect Jetpack.</string>
+	<string name="stats_sign_in_jetpack_different_com_account">To view your stats, log in to the WordPress.com account you used to connect Jetpack.</string>
 	<string name="stats_other_recent_stats_moved_label">Looking for your Other Recent Stats? We\'ve moved them to the Insights page.</string>
 	<string name="me_disconnect_from_wordpress_com">Disconnect from WordPress.com</string>
 	<string name="me_btn_login_logout">Login/Logout</string>
@@ -557,7 +557,7 @@
 	<string name="my_site_btn_blog_posts">Blog Posts</string>
 	<string name="reader_label_new_posts_subtitle">Tap to show them</string>
 	<string name="my_site_header_configuration">Configuration</string>
-	<string name="notifications_account_required">Sign in to WordPress.com for notifications</string>
+	<string name="notifications_account_required">Log in to WordPress.com for notifications</string>
 	<string name="stats_unknown_author">Unknown Author</string>
 	<string name="signout">Disconnect</string>
 	<string name="image_added">Image added</string>
@@ -582,8 +582,8 @@
 	<string name="no_media">No media</string>
 	<string name="loading_images">Loading images</string>
 	<string name="loading_videos">Loading videos</string>
-	<string name="auth_required">Sign in again to continue.</string>
-	<string name="sign_in_jetpack">Sign in to your WordPress.com account to connect to Jetpack.</string>
+	<string name="auth_required">Log in again to continue.</string>
+	<string name="sign_in_jetpack">Log in to your WordPress.com account to connect to Jetpack.</string>
 	<string name="two_step_sms_sent">Check your text messages for the verification code.</string>
 	<string name="two_step_footer_button">Send code via text message</string>
 	<string name="two_step_footer_label">Enter the code from your authenticator app.</string>
@@ -972,7 +972,7 @@
 	<string name="reader_empty_followed_blogs_description">But don\'t worry, just tap the icon at the top right to start exploring!</string>
 	<string name="reader_likes_you_and_one">You and one other like this</string>
 	<string name="select_time">Select time</string>
-	<string name="nux_oops_not_selfhosted_blog">Sign in to WordPress.com</string>
+	<string name="nux_oops_not_selfhosted_blog">Log in to WordPress.com</string>
 	<string name="nux_add_selfhosted_blog">Add self-hosted site</string>
 	<string name="signing_in">Signing in…</string>
 	<string name="nux_welcome_create_account">Create account</string>
@@ -1072,7 +1072,7 @@
 	<string name="follows">Follows</string>
 	<string name="note_reply_successful">Reply published</string>
 	<string name="notifications">Notifications</string>
-	<string name="sign_in">Sign in</string>
+	<string name="sign_in">Log in</string>
 	<string name="loading">Loading…</string>
 	<string name="httppassword">HTTP password</string>
 	<string name="httpuser">HTTP username</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -87,7 +87,7 @@
 	<string name="invite_people">Invite People</string>
 	<string name="my_site_header_external">External</string>
 	<string name="send_link">Send link</string>
-	<string name="signup_succeed_signin_failed">Your account has been created but an error occured while we signed you\n        in. Try to log in with your newly created username and password.</string>
+	<string name="signup_succeed_signin_failed">Your account has been created but an error occured while we logged you\n        in. Try to log in with your newly created username and password.</string>
 	<string name="label_clear_search_history">Clear search history</string>
 	<string name="dlg_confirm_clear_search_history">Clear search history?</string>
 	<string name="reader_empty_posts_in_search_description">No posts found for %s for your language</string>
@@ -361,7 +361,7 @@
 	<string name="site_settings_paging_title">Paging</string>
 	<string name="site_settings_threading_title">Threading</string>
 	<string name="site_settings_sort_by_title">Sort by</string>
-	<string name="site_settings_account_required_title">Users must be signed in</string>
+	<string name="site_settings_account_required_title">Users must be logged in</string>
 	<string name="site_settings_identity_required_title">Must include name and email</string>
 	<string name="site_settings_receive_pingbacks_title">Receive Pingbacks</string>
 	<string name="site_settings_send_pingbacks_title">Send Pingbacks</string>
@@ -699,7 +699,7 @@
 	<string name="delete_sure_page">Delete this page</string>
 	<string name="delete_sure">Delete this draft</string>
 	<string name="delete_sure_post">Delete this post</string>
-	<string name="signing_out">Signing out…</string>
+	<string name="signing_out">Logging out…</string>
 	<string name="posting_post">Posting "%s"</string>
 	<string name="media_empty_list_custom_date">No media in this time interval</string>
 	<string name="pages_empty_list">No pages yet. Why not create one?</string>
@@ -974,7 +974,7 @@
 	<string name="select_time">Select time</string>
 	<string name="nux_oops_not_selfhosted_blog">Log in to WordPress.com</string>
 	<string name="nux_add_selfhosted_blog">Add self-hosted site</string>
-	<string name="signing_in">Signing in…</string>
+	<string name="signing_in">Logging in…</string>
 	<string name="nux_welcome_create_account">Create account</string>
 	<string name="nux_tap_continue">Continue</string>
 	<string name="password_invalid">You need a more secure password. Make sure to use 7 or more characters, mix uppercase and lowercase letters, numbers or special characters.</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -294,7 +294,7 @@
 	<string name="error_post_remote_site_settings">Couldn\'t save site info</string>
 	<string name="error_fetch_remote_site_settings">Couldn\'t retrieve site info</string>
 	<string name="error_media_upload_connection">A connection error occurred while uploading media</string>
-	<string name="site_settings_disconnected_toast">Disconnected, editing disabled.</string>
+	<string name="site_settings_disconnected_toast">Logged out, editing disabled.</string>
 	<string name="site_settings_unsupported_version_error">Unsupported WordPress version</string>
 	<string name="site_settings_multiple_links_dialog_description">Require approval for comments that include more than this number of links.</string>
 	<string name="site_settings_close_after_dialog_switch_text">Automatically close</string>
@@ -539,7 +539,7 @@
 	<string name="stats_other_recent_stats_moved_label">Looking for your Other Recent Stats? We\'ve moved them to the Insights page.</string>
 	<string name="me_disconnect_from_wordpress_com">Log out from WordPress.com</string>
 	<string name="me_btn_login_logout">Login/Logout</string>
-	<string name="me_connect_to_wordpress_com">Connect to WordPress.com</string>
+	<string name="me_connect_to_wordpress_com">Log in to WordPress.com</string>
 	<string name="site_picker_cant_hide_current_site">"%s" wasn\'t hidden because it\'s the current site</string>
 	<string name="me_btn_support">Help &amp; Support</string>
 	<string name="account_settings">Account Settings</string>
@@ -559,9 +559,9 @@
 	<string name="my_site_header_configuration">Configuration</string>
 	<string name="notifications_account_required">Log in to WordPress.com for notifications</string>
 	<string name="stats_unknown_author">Unknown Author</string>
-	<string name="signout">Disconnect</string>
+	<string name="signout">Log out</string>
 	<string name="image_added">Image added</string>
-	<string name="sign_out_wpcom_confirm">Disconnecting your account will remove all of @%s’s WordPress.com data from this device, including local drafts and local changes.</string>
+	<string name="sign_out_wpcom_confirm">Logging out from your account will remove all of @%s’s WordPress.com data from this device, including local drafts and local changes.</string>
 	<string name="select_all">Select all</string>
 	<string name="hide">Hide</string>
 	<string name="show">Show</string>
@@ -981,7 +981,7 @@
 	<string name="nux_tutorial_get_started_title">Get started!</string>
 	<string name="limit_reached">Limit reached. You can try again in 1 minute. Trying again before that will only increase the time you have to wait before the ban is lifted. If you think this is in error, contact support.</string>
 	<string name="username_invalid">Invalid username</string>
-	<string name="connecting_wpcom">Connecting to WordPress.com</string>
+	<string name="connecting_wpcom">Logging in to WordPress.com</string>
 	<string name="button_next">Next</string>
 	<string name="create_account_wpcom">Create an account on WordPress.com</string>
 	<string name="reader_empty_followed_tags">You don\'t follow any tags</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -537,7 +537,7 @@
 	<string name="stats_insights">Insights</string>
 	<string name="stats_sign_in_jetpack_different_com_account">To view your stats, log in to the WordPress.com account you used to connect Jetpack.</string>
 	<string name="stats_other_recent_stats_moved_label">Looking for your Other Recent Stats? We\'ve moved them to the Insights page.</string>
-	<string name="me_disconnect_from_wordpress_com">Disconnect from WordPress.com</string>
+	<string name="me_disconnect_from_wordpress_com">Log out from WordPress.com</string>
 	<string name="me_btn_login_logout">Login/Logout</string>
 	<string name="me_connect_to_wordpress_com">Connect to WordPress.com</string>
 	<string name="site_picker_cant_hide_current_site">"%s" wasn\'t hidden because it\'s the current site</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -559,7 +559,7 @@
 	<string name="my_site_header_configuration">Configuration</string>
 	<string name="notifications_account_required">Log in to WordPress.com for notifications</string>
 	<string name="stats_unknown_author">Unknown Author</string>
-	<string name="signout">Logged out</string>
+	<string name="signout">Log out</string>
 	<string name="image_added">Image added</string>
 	<string name="sign_out_wpcom_confirm">Logging out from your account will remove all of @%s’s WordPress.com data from this device, including local drafts and local changes.</string>
 	<string name="select_all">Select all</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -87,7 +87,7 @@
 	<string name="invite_people">Invite People</string>
 	<string name="my_site_header_external">External</string>
 	<string name="send_link">Send link</string>
-	<string name="signup_succeed_signin_failed">Your account has been created but an error occurred while we signed you\n        in. Try to log in with your newly created username and password.</string>
+	<string name="signup_succeed_signin_failed">Your account has been created but an error occurred while we logged you\n        in. Try to log in with your newly created username and password.</string>
 	<string name="label_clear_search_history">Clear search history</string>
 	<string name="dlg_confirm_clear_search_history">Clear search history?</string>
 	<string name="reader_empty_posts_in_search_description">No posts found for %s for your language</string>
@@ -361,7 +361,7 @@
 	<string name="site_settings_paging_title">Paging</string>
 	<string name="site_settings_threading_title">Threading</string>
 	<string name="site_settings_sort_by_title">Sort by</string>
-	<string name="site_settings_account_required_title">Users must be signed in</string>
+	<string name="site_settings_account_required_title">Users must be logged in</string>
 	<string name="site_settings_identity_required_title">Must include name and email</string>
 	<string name="site_settings_receive_pingbacks_title">Receive Pingbacks</string>
 	<string name="site_settings_send_pingbacks_title">Send Pingbacks</string>
@@ -699,7 +699,7 @@
 	<string name="delete_sure_page">Delete this page</string>
 	<string name="delete_sure">Delete this draft</string>
 	<string name="delete_sure_post">Delete this post</string>
-	<string name="signing_out">Signing out…</string>
+	<string name="signing_out">Logging out…</string>
 	<string name="posting_post">Posting "%s"</string>
 	<string name="media_empty_list_custom_date">No media in this time interval</string>
 	<string name="pages_empty_list">No pages yet. Why not create one?</string>
@@ -974,7 +974,7 @@
 	<string name="select_time">Select time</string>
 	<string name="nux_oops_not_selfhosted_blog">Log in to WordPress.com</string>
 	<string name="nux_add_selfhosted_blog">Add self-hosted site</string>
-	<string name="signing_in">Signing in…</string>
+	<string name="signing_in">Logging in…</string>
 	<string name="nux_welcome_create_account">Create account</string>
 	<string name="nux_tap_continue">Continue</string>
 	<string name="password_invalid">You need a more secure password. Make sure to use 7 or more characters, mix uppercase and lowercase letters, numbers or special characters.</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -294,7 +294,7 @@
 	<string name="error_post_remote_site_settings">Couldn\'t save site info</string>
 	<string name="error_fetch_remote_site_settings">Couldn\'t retrieve site info</string>
 	<string name="error_media_upload_connection">A connection error occurred while uploading media</string>
-	<string name="site_settings_disconnected_toast">Disconnected, editing disabled.</string>
+	<string name="site_settings_disconnected_toast">Logged out, editing disabled.</string>
 	<string name="site_settings_unsupported_version_error">Unsupported WordPress version</string>
 	<string name="site_settings_multiple_links_dialog_description">Require approval for comments that include more than this number of links.</string>
 	<string name="site_settings_close_after_dialog_switch_text">Automatically close</string>
@@ -539,7 +539,7 @@
 	<string name="stats_other_recent_stats_moved_label">Looking for your Other Recent Stats? We\'ve moved them to the Insights page.</string>
 	<string name="me_disconnect_from_wordpress_com">Log out from WordPress.com</string>
 	<string name="me_btn_login_logout">Login/Logout</string>
-	<string name="me_connect_to_wordpress_com">Connect to WordPress.com</string>
+	<string name="me_connect_to_wordpress_com">Log in to WordPress.com</string>
 	<string name="site_picker_cant_hide_current_site">"%s" wasn\'t hidden because it\'s the current site</string>
 	<string name="me_btn_support">Help &amp; Support</string>
 	<string name="account_settings">Account Settings</string>
@@ -559,9 +559,9 @@
 	<string name="my_site_header_configuration">Configuration</string>
 	<string name="notifications_account_required">Log in to WordPress.com for notifications</string>
 	<string name="stats_unknown_author">Unknown Author</string>
-	<string name="signout">Disconnect</string>
+	<string name="signout">Logged out</string>
 	<string name="image_added">Image added</string>
-	<string name="sign_out_wpcom_confirm">Disconnecting your account will remove all of @%s’s WordPress.com data from this device, including local drafts and local changes.</string>
+	<string name="sign_out_wpcom_confirm">Logging out from your account will remove all of @%s’s WordPress.com data from this device, including local drafts and local changes.</string>
 	<string name="select_all">Select all</string>
 	<string name="hide">Hide</string>
 	<string name="show">Show</string>
@@ -981,7 +981,7 @@
 	<string name="nux_tutorial_get_started_title">Get started!</string>
 	<string name="limit_reached">Limit reached. You can try again in 1 minute. Trying again before that will only increase the time you have to wait before the ban is lifted. If you think this is in error, contact support.</string>
 	<string name="username_invalid">Invalid username</string>
-	<string name="connecting_wpcom">Connecting to WordPress.com</string>
+	<string name="connecting_wpcom">Logging in to WordPress.com</string>
 	<string name="button_next">Next</string>
 	<string name="create_account_wpcom">Create an account on WordPress.com</string>
 	<string name="reader_empty_followed_tags">You don\'t follow any tags</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -87,7 +87,7 @@
 	<string name="invite_people">Invite People</string>
 	<string name="my_site_header_external">External</string>
 	<string name="send_link">Send link</string>
-	<string name="signup_succeed_signin_failed">Your account has been created but an error occurred while we signed you\n        in. Try to sign in with your newly created username and password.</string>
+	<string name="signup_succeed_signin_failed">Your account has been created but an error occurred while we signed you\n        in. Try to log in with your newly created username and password.</string>
 	<string name="label_clear_search_history">Clear search history</string>
 	<string name="dlg_confirm_clear_search_history">Clear search history?</string>
 	<string name="reader_empty_posts_in_search_description">No posts found for %s for your language</string>
@@ -123,7 +123,7 @@
 	<string name="check_your_email">Check your email</string>
 	<string name="magic_link_unavailable_error_message">Currently unavailable. Please enter your password</string>
 	<string name="logging_in">Logging in</string>
-	<string name="get_a_link_sent_to_your_email_to_sign_in_instantly">Get a link sent to your email to sign in instantly</string>
+	<string name="get_a_link_sent_to_your_email_to_sign_in_instantly">Get a link sent to your email to log in instantly</string>
 	<string name="enter_your_password_instead">Enter your password instead</string>
 	<string name="web_address_dialog_hint">Shown publicly when you comment.</string>
 	<string name="username_email">Email or username</string>
@@ -525,7 +525,7 @@
 	<string name="tabbar_accessibility_label_my_site">My Site</string>
 	<string name="editor_toast_changes_saved">Changes saved</string>
 	<string name="passcodelock_prompt_message">Enter your PIN</string>
-	<string name="push_auth_expired">The request has expired. Sign in to WordPress.com to try again.</string>
+	<string name="push_auth_expired">The request has expired. Log in to WordPress.com to try again.</string>
 	<string name="stats_insights_most_popular_percent_views">%1$d%% of views</string>
 	<string name="ignore">Ignore</string>
 	<string name="stats_insights_best_ever">Best Views Ever</string>
@@ -535,7 +535,7 @@
 	<string name="stats_insights_popular">Most popular day and hour</string>
 	<string name="stats_insights_all_time">All-time posts, views, and visitors</string>
 	<string name="stats_insights">Insights</string>
-	<string name="stats_sign_in_jetpack_different_com_account">To view your stats, sign in to the WordPress.com account you used to connect Jetpack.</string>
+	<string name="stats_sign_in_jetpack_different_com_account">To view your stats, log in to the WordPress.com account you used to connect Jetpack.</string>
 	<string name="stats_other_recent_stats_moved_label">Looking for your Other Recent Stats? We\'ve moved them to the Insights page.</string>
 	<string name="me_disconnect_from_wordpress_com">Disconnect from WordPress.com</string>
 	<string name="me_btn_login_logout">Login/Logout</string>
@@ -557,7 +557,7 @@
 	<string name="my_site_btn_blog_posts">Blog Posts</string>
 	<string name="reader_label_new_posts_subtitle">Tap to show them</string>
 	<string name="my_site_header_configuration">Configuration</string>
-	<string name="notifications_account_required">Sign in to WordPress.com for notifications</string>
+	<string name="notifications_account_required">Log in to WordPress.com for notifications</string>
 	<string name="stats_unknown_author">Unknown Author</string>
 	<string name="signout">Disconnect</string>
 	<string name="image_added">Image added</string>
@@ -582,8 +582,8 @@
 	<string name="no_media">No media</string>
 	<string name="loading_images">Loading images</string>
 	<string name="loading_videos">Loading videos</string>
-	<string name="auth_required">Sign in again to continue.</string>
-	<string name="sign_in_jetpack">Sign in to your WordPress.com account to connect to Jetpack.</string>
+	<string name="auth_required">Log in again to continue.</string>
+	<string name="sign_in_jetpack">Log in to your WordPress.com account to connect to Jetpack.</string>
 	<string name="two_step_sms_sent">Check your text messages for the verification code.</string>
 	<string name="two_step_footer_button">Send code via text message</string>
 	<string name="two_step_footer_label">Enter the code from your authenticator app.</string>
@@ -972,7 +972,7 @@
 	<string name="reader_empty_followed_blogs_description">But don\'t worry, just tap the icon at the top right to start exploring!</string>
 	<string name="reader_likes_you_and_one">You and one other like this</string>
 	<string name="select_time">Select time</string>
-	<string name="nux_oops_not_selfhosted_blog">Sign in to WordPress.com</string>
+	<string name="nux_oops_not_selfhosted_blog">Log in to WordPress.com</string>
 	<string name="nux_add_selfhosted_blog">Add self-hosted site</string>
 	<string name="signing_in">Signing in…</string>
 	<string name="nux_welcome_create_account">Create account</string>
@@ -1072,7 +1072,7 @@
 	<string name="follows">Follows</string>
 	<string name="note_reply_successful">Reply published</string>
 	<string name="notifications">Notifications</string>
-	<string name="sign_in">Sign in</string>
+	<string name="sign_in">Log in</string>
 	<string name="loading">Loading…</string>
 	<string name="httppassword">HTTP password</string>
 	<string name="httpuser">HTTP username</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1355,7 +1355,7 @@
     <string name="me_btn_support">Help &amp; Support</string>
     <string name="me_btn_login_logout">Login/Logout</string>
     <string name="me_connect_to_wordpress_com">Connect to WordPress.com</string>
-    <string name="me_disconnect_from_wordpress_com">Disconnect from WordPress.com</string>
+    <string name="me_disconnect_from_wordpress_com">Log out from WordPress.com</string>
 
     <!--TabBar Accessibility Labels-->
     <string name="tabbar_accessibility_label_my_site">My Site</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="site_timeout_error">Couldn\'t connect to the WordPress site due to Timeout error.</string>
     <string name="no_network_title">No network available</string>
     <string name="no_network_message">There is no network available</string>
-    <string name="sign_out_wpcom_confirm">Disconnecting your account will remove all of @%s’s WordPress.com data from this device, including local drafts and local changes.</string>
+    <string name="sign_out_wpcom_confirm">Logging out from your account will remove all of @%s’s WordPress.com data from this device, including local drafts and local changes.</string>
     <string name="account_two_step_auth_enabled">This account has two step authentication enabled. Visit your security settings on WordPress.com and generate an application-specific password.</string>
 
     <!-- form labels -->
@@ -76,7 +76,7 @@
     <string name="posting_post">Posting \"%s\"</string>
     <string name="language">Language</string>
     <string name="interface_language">Interface Language</string>
-    <string name="signout">Disconnect</string>
+    <string name="signout">Log out</string>
     <string name="undo">Undo</string>
     <string name="never">Never</string>
     <string name="unknown">Unknown</string>
@@ -613,7 +613,7 @@
     <!-- Errors -->
     <string name="site_settings_unsupported_version_error">Unsupported WordPress version</string>
     <string name="site_settings_unknown_language_code_error">Language code not recognized</string>
-    <string name="site_settings_disconnected_toast">Disconnected, editing disabled.</string>
+    <string name="site_settings_disconnected_toast">Logged out, editing disabled.</string>
 
     <!--               -->
     <!-- Site Settings -->
@@ -1246,7 +1246,7 @@
     <string name="agree_terms_of_service">By creating an account you agree to the fascinating %1$sTerms of Service%2$s</string>
     <string name="username_email">Email or username</string>
     <string name="site_address">Your self-hosted address (URL)</string>
-    <string name="connecting_wpcom">Connecting to WordPress.com</string>
+    <string name="connecting_wpcom">Logging in to WordPress.com</string>
     <string name="username_only_lowercase_letters_and_numbers">Username can only contain lowercase letters (a-z) and numbers</string>
     <string name="username_required">Enter a username</string>
     <string name="username_not_allowed">Username not allowed</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1354,7 +1354,7 @@
     <string name="me_btn_app_settings">App Settings</string>
     <string name="me_btn_support">Help &amp; Support</string>
     <string name="me_btn_login_logout">Login/Logout</string>
-    <string name="me_connect_to_wordpress_com">Connect to WordPress.com</string>
+    <string name="me_connect_to_wordpress_com">Log in to WordPress.com</string>
     <string name="me_disconnect_from_wordpress_com">Log out from WordPress.com</string>
 
     <!--TabBar Accessibility Labels-->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -69,8 +69,8 @@
     <string name="refresh">Refresh</string>
     <string name="blog_not_found">An error occurred when accessing this blog</string>
     <string name="post_not_found">An error occurred when loading the post. Refresh your posts and try again.</string>
-    <string name="sign_in">Sign in</string>
-    <string name="signing_out">Signing out…</string>
+    <string name="sign_in">Log in</string>
+    <string name="signing_out">Logging out…</string>
     <string name="upload">Upload</string>
     <string name="learn_more">Learn more</string>
     <string name="posting_post">Posting \"%s\"</string>
@@ -641,7 +641,7 @@
     <!-- stats: errors -->
     <string name="stats_no_blog">Stats couldn\'t be loaded for the required blog</string>
     <string name="stats_generic_error">Required Stats couldn\'t be loaded</string>
-    <string name="stats_sign_in_jetpack_different_com_account">To view your stats, sign in to the WordPress.com account you used to connect Jetpack.</string>
+    <string name="stats_sign_in_jetpack_different_com_account">To view your stats, log in to the WordPress.com account you used to connect Jetpack.</string>
     <string name="stats_enable_rest_api_in_jetpack">To view your stats, enable the JSON API module in Jetpack.</string>
 
     <!-- stats: Widget labels -->
@@ -839,14 +839,14 @@
     <string name="notifications_empty_action_unread">Reignite the conversation: write a new post.</string>
     <string name="notifications_empty_action_comments">Join a conversation: comment on posts from blogs you follow.</string>
     <string name="notifications_empty_action_followers_likes">Get noticed: comment on posts you\'ve read.</string>
-    <string name="notifications_account_required">Sign in to WordPress.com for notifications</string>
+    <string name="notifications_account_required">Log in to WordPress.com for notifications</string>
     <string name="notifications_empty_view_reader">View Reader</string>
     <string name="older_two_days">Older than 2 days</string>
     <string name="older_last_week">Older than a week</string>
     <string name="older_month">Older than a month</string>
     <string name="error_notification_open">Could not open notification</string>
     <string name="ignore">Ignore</string>
-    <string name="push_auth_expired">The request has expired. Sign in to WordPress.com to try again.</string>
+    <string name="push_auth_expired">The request has expired. Log in to WordPress.com to try again.</string>
     <string name="unread">Unread</string>
     <string name="follows">Follows</string>
 
@@ -1283,7 +1283,7 @@
     <string name="nux_tutorial_get_started_title">Get started!</string>
     <string name="nux_welcome_create_account">Create account</string>
     <string name="nux_add_selfhosted_blog">Add self-hosted site</string>
-    <string name="nux_oops_not_selfhosted_blog">Sign in to WordPress.com</string>
+    <string name="nux_oops_not_selfhosted_blog">Log in to WordPress.com</string>
     <string name="ssl_certificate_details">Details</string>
     <string name="ssl_certificate_error">Invalid SSL certificate</string>
     <string name="ssl_certificate_ask_trust">If you usually connect to this site without problems, this error could mean that someone is trying to impersonate the site, and you shouldn\'t continue. Would you like to trust the certificate anyway?</string>
@@ -1294,12 +1294,12 @@
     <string name="two_step_footer_label">Enter the code from your authenticator app.</string>
     <string name="two_step_footer_button">Send code via text message</string>
     <string name="two_step_sms_sent">Check your text messages for the verification code.</string>
-    <string name="sign_in_jetpack">Sign in to your WordPress.com account to connect to Jetpack.</string>
-    <string name="auth_required">Sign in again to continue.</string>
+    <string name="sign_in_jetpack">Log in to your WordPress.com account to connect to Jetpack.</string>
+    <string name="auth_required">Log in again to continue.</string>
     <string name="signup_succeed_signin_failed">Your account has been created but an error occured while we signed you
-        in. Try to sign in with your newly created username and password.</string>
+        in. Try to log in with your newly created username and password.</string>
     <string name="send_link">Send link</string>
-    <string name="get_a_link_sent_to_your_email_to_sign_in_instantly">Get a link sent to your email to sign in instantly</string>
+    <string name="get_a_link_sent_to_your_email_to_sign_in_instantly">Get a link sent to your email to log in instantly</string>
     <string name="logging_in">Logging in</string>
     <string name="magic_link_unavailable_error_message">Currently unavailable. Please enter your password</string>
     <string name="check_your_email">Check your email</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -378,7 +378,7 @@
     <string name="uploading_total">Uploading %1$d of %2$d</string>
 
     <!-- new account view -->
-    <string name="signing_in">Signing in…</string>
+    <string name="signing_in">Logging in…</string>
     <string name="no_site_error">Couldn\'t connect to the WordPress site</string>
 
     <!-- media selection -->
@@ -474,7 +474,7 @@
     <string name="site_settings_send_pingbacks_title">Send Pingbacks</string>
     <string name="site_settings_receive_pingbacks_title">Receive Pingbacks</string>
     <string name="site_settings_identity_required_title">Must include name and email</string>
-    <string name="site_settings_account_required_title">Users must be signed in</string>
+    <string name="site_settings_account_required_title">Users must be logged in</string>
     <string name="site_settings_close_after_title" translatable="false">@string/close_after</string>
     <string name="site_settings_sort_by_title">Sort by</string>
     <string name="site_settings_threading_title">Threading</string>
@@ -1296,7 +1296,7 @@
     <string name="two_step_sms_sent">Check your text messages for the verification code.</string>
     <string name="sign_in_jetpack">Log in to your WordPress.com account to connect to Jetpack.</string>
     <string name="auth_required">Log in again to continue.</string>
-    <string name="signup_succeed_signin_failed">Your account has been created but an error occured while we signed you
+    <string name="signup_succeed_signin_failed">Your account has been created but an error occured while we loggged you
         in. Try to log in with your newly created username and password.</string>
     <string name="send_link">Send link</string>
     <string name="get_a_link_sent_to_your_email_to_sign_in_instantly">Get a link sent to your email to log in instantly</string>


### PR DESCRIPTION
Fixes #4704 

This PR changes all occurrences of "Sign in" anda variants to  "Log in".


**Important:**
- This commit changes the visible strings https://github.com/wordpress-mobile/WordPress-Android/commit/269f254a4a4aecd15d3eeeec7fd5c5c6fe1811e1

- This other commit changes all occurrences in code (class names, variable names, comments, etc.).
https://github.com/wordpress-mobile/WordPress-Android/commit/8a5bdf1e520b730a2ca07adf2ddb525490a48f1f

Feel free to only merge the first commit if the second commit seems to add too much noise to an otherwise small change.

