### PR TITLE
Issue/4689 quick actions enhancements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -64,6 +64,7 @@ public class GCMMessageService extends GcmListenerService {
     public static final int PUSH_NOTIFICATION_ID = 10000;
     public static final int AUTH_PUSH_NOTIFICATION_ID = 20000;
     public static final int GROUP_NOTIFICATION_ID = 30000;
+    public static final int ACTIONS_RESULT_NOTIFICATION_ID = 40000;
     public static final String EXTRA_VOICE_OR_INLINE_REPLY = "extra_voice_or_inline_reply";
     private static final int MAX_INBOX_ITEMS = 5;
 
@@ -522,7 +523,6 @@ public class GCMMessageService extends GcmListenerService {
                 commentReplyIntent.putExtra(NotificationsProcessingService.ARG_NOTE_ID, noteId);
             }
             commentReplyIntent.putExtra(NotificationsProcessingService.ARG_NOTE_BUNDLE, getCurrentNoteBundleForNoteId(noteId));
-            commentReplyIntent.putExtra(NotificationsProcessingService.ARG_PUSH_ID, getCurrentPushIdForNoteId(noteId));
 
 
             PendingIntent commentReplyPendingIntent = getCommentActionPendingIntent(context, commentReplyIntent);
@@ -561,7 +561,6 @@ public class GCMMessageService extends GcmListenerService {
                 commentLikeIntent.putExtra(NotificationsProcessingService.ARG_NOTE_ID, noteId);
             }
             commentLikeIntent.putExtra(NotificationsProcessingService.ARG_NOTE_BUNDLE, getCurrentNoteBundleForNoteId(noteId));
-            commentLikeIntent.putExtra(NotificationsProcessingService.ARG_PUSH_ID, getCurrentPushIdForNoteId(noteId));
 
             PendingIntent commentLikePendingIntent =  getCommentActionPendingIntenForService(context, commentLikeIntent);
             builder.addAction(R.drawable.ic_action_like, getText(R.string.like),
@@ -581,7 +580,6 @@ public class GCMMessageService extends GcmListenerService {
                 commentApproveIntent.putExtra(NotificationsProcessingService.ARG_NOTE_ID, noteId);
             }
             commentApproveIntent.putExtra(NotificationsProcessingService.ARG_NOTE_BUNDLE, getCurrentNoteBundleForNoteId(noteId));
-            commentApproveIntent.putExtra(NotificationsProcessingService.ARG_PUSH_ID, getCurrentPushIdForNoteId(noteId));
 
             PendingIntent commentApprovePendingIntent =  getCommentActionPendingIntenForService(context, commentApproveIntent);
             builder.addAction(R.drawable.ic_action_approve, getText(R.string.approve),

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -73,7 +73,7 @@ public class GCMMessageService extends GcmListenerService {
     private static final String PUSH_ARG_TITLE = "title";
     private static final String PUSH_ARG_MSG = "msg";
     private static final String PUSH_ARG_NOTE_ID = "note_id";
-    private static final String PUSH_ARG_NOTE_FULL_DATA = "note_full_data";
+    public static final String PUSH_ARG_NOTE_FULL_DATA = "note_full_data";
 
     private static final String PUSH_TYPE_COMMENT = "c";
     private static final String PUSH_TYPE_LIKE = "like";
@@ -155,6 +155,34 @@ public class GCMMessageService extends GcmListenerService {
                 }
             }
         }
+    }
+
+    public static synchronized Bundle getCurrentNoteBundleForNoteId(String noteId){
+        if (sActiveNotificationsMap.size() > 0) {
+            //get the corresponding bundle for this noteId
+            for(Iterator<Map.Entry<Integer, Bundle>> it = sActiveNotificationsMap.entrySet().iterator(); it.hasNext(); ) {
+                Map.Entry<Integer, Bundle> row = it.next();
+                Bundle noteBundle = row.getValue();
+                if (noteBundle.getString(PUSH_ARG_NOTE_ID, "").equals(noteId)) {
+                    return noteBundle;
+                }
+            }
+        }
+        return null;
+    }
+
+    public static synchronized Integer getCurrentPushIdForNoteId(String noteId){
+        if (sActiveNotificationsMap.size() > 0) {
+            //get the corresponding push id for this noteId
+            for(Iterator<Map.Entry<Integer, Bundle>> it = sActiveNotificationsMap.entrySet().iterator(); it.hasNext(); ) {
+                Map.Entry<Integer, Bundle> row = it.next();
+                Bundle noteBundle = row.getValue();
+                if (noteBundle.getString(PUSH_ARG_NOTE_ID, "").equals(noteId)) {
+                    return row.getKey();
+                }
+            }
+        }
+        return null;
     }
 
     public static synchronized void clearNotifications() {
@@ -494,6 +522,10 @@ public class GCMMessageService extends GcmListenerService {
             if (noteId != null) {
                 commentReplyIntent.putExtra(NotificationsProcessingService.ARG_NOTE_ID, noteId);
             }
+            commentReplyIntent.putExtra(NotificationsProcessingService.ARG_NOTE_BUNDLE, getCurrentNoteBundleForNoteId(noteId));
+            commentReplyIntent.putExtra(NotificationsProcessingService.ARG_PUSH_ID, getCurrentPushIdForNoteId(noteId));
+
+
             PendingIntent commentReplyPendingIntent = getCommentActionPendingIntent(context, commentReplyIntent);
 
             /*
@@ -529,6 +561,9 @@ public class GCMMessageService extends GcmListenerService {
             if (noteId != null) {
                 commentLikeIntent.putExtra(NotificationsProcessingService.ARG_NOTE_ID, noteId);
             }
+            commentLikeIntent.putExtra(NotificationsProcessingService.ARG_NOTE_BUNDLE, getCurrentNoteBundleForNoteId(noteId));
+            commentLikeIntent.putExtra(NotificationsProcessingService.ARG_PUSH_ID, getCurrentPushIdForNoteId(noteId));
+
             PendingIntent commentLikePendingIntent =  getCommentActionPendingIntenForService(context, commentLikeIntent);
             builder.addAction(R.drawable.ic_action_like, getText(R.string.like),
                     commentLikePendingIntent);
@@ -546,6 +581,9 @@ public class GCMMessageService extends GcmListenerService {
             if (noteId != null) {
                 commentApproveIntent.putExtra(NotificationsProcessingService.ARG_NOTE_ID, noteId);
             }
+            commentApproveIntent.putExtra(NotificationsProcessingService.ARG_NOTE_BUNDLE, getCurrentNoteBundleForNoteId(noteId));
+            commentApproveIntent.putExtra(NotificationsProcessingService.ARG_PUSH_ID, getCurrentPushIdForNoteId(noteId));
+
             PendingIntent commentApprovePendingIntent =  getCommentActionPendingIntenForService(context, commentApproveIntent);
             builder.addAction(R.drawable.ic_action_approve, getText(R.string.approve),
                     commentApprovePendingIntent);

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -171,20 +171,6 @@ public class GCMMessageService extends GcmListenerService {
         return null;
     }
 
-    public static synchronized Integer getCurrentPushIdForNoteId(String noteId){
-        if (sActiveNotificationsMap.size() > 0) {
-            //get the corresponding push id for this noteId
-            for(Iterator<Map.Entry<Integer, Bundle>> it = sActiveNotificationsMap.entrySet().iterator(); it.hasNext(); ) {
-                Map.Entry<Integer, Bundle> row = it.next();
-                Bundle noteBundle = row.getValue();
-                if (noteBundle.getString(PUSH_ARG_NOTE_ID, "").equals(noteId)) {
-                    return row.getKey();
-                }
-            }
-        }
-        return null;
-    }
-
     public static synchronized void clearNotifications() {
         sActiveNotificationsMap.clear();
     }

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -61,10 +61,9 @@ public class GCMMessageService extends GcmListenerService {
     private static NotificationHelper sNotificationHelpers;
 
     private static final String NOTIFICATION_GROUP_KEY = "notification_group_key";
-    private static final int PUSH_NOTIFICATION_ID = 10000;
-    private static final int AUTH_PUSH_NOTIFICATION_ID = 20000;
+    public static final int PUSH_NOTIFICATION_ID = 10000;
+    public static final int AUTH_PUSH_NOTIFICATION_ID = 20000;
     public static final int GROUP_NOTIFICATION_ID = 30000;
-    public static final int ACTIONS_RESULT_NOTIFICATION_ID = 40000;
     public static final String EXTRA_VOICE_OR_INLINE_REPLY = "extra_voice_or_inline_reply";
     private static final int MAX_INBOX_ITEMS = 5;
 

--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -163,9 +163,9 @@ public class NotificationsProcessingService extends Service {
                 }
             }
 
-            showIntermediateMessageToUser(getString(R.string.comment_q_action_updating));
-
             if (mActionType != null) {
+
+                showIntermediateMessageToUser(getProcessingTitleForAction(mActionType));
 
                 //we probably have the note in the PN payload and such it's passed in the intent extras
                 // bundle. If we have it, no need to go fetch it through REST API.
@@ -209,6 +209,19 @@ public class NotificationsProcessingService extends Service {
                 requestFailed(null);
             }
 
+        }
+
+        private String getProcessingTitleForAction(String actionType) {
+            if (actionType.equals(ARG_ACTION_LIKE)) {
+                return getString(R.string.comment_q_action_liking);
+            } else if (actionType.equals(ARG_ACTION_APPROVE)) {
+                return getString(R.string.comment_q_action_approving);
+            } else if (actionType.equals(ARG_ACTION_REPLY)) {
+                return getString(R.string.comment_q_action_replying);
+            } else {
+                //default, generic  "processing"
+                return getString(R.string.comment_q_action_processing);
+            }
         }
 
         private void obtainReplyTextFromRemoteInputBundle(Bundle bundle) {

--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -227,6 +227,9 @@ public class NotificationsProcessingService extends Service {
                         return getString(R.string.comment_q_action_approving);
                     case ARG_ACTION_REPLY:
                         return getString(R.string.comment_q_action_replying);
+                    default:
+                        //default, generic  "processing"
+                        return getString(R.string.comment_q_action_processing);
                 }
             } else {
                 //default, generic  "processing"
@@ -262,10 +265,17 @@ public class NotificationsProcessingService extends Service {
                     switch (mActionType) {
                         case ARG_ACTION_LIKE:
                             likeComment();
+                            break;
                         case ARG_ACTION_APPROVE:
                             approveComment();
+                            break;
                         case ARG_ACTION_REPLY:
                             replyToComment();
+                            break;
+                        default:
+                            //no op
+                            requestFailed(null);
+                            break;
                     }
                 } else {
                     // add other actions here
@@ -295,6 +305,8 @@ public class NotificationsProcessingService extends Service {
                 successMessage = getString(R.string.comment_q_action_done_generic);
             }
 
+            //dismiss any other pending result notification
+            dismissNotification(ACTIONS_RESULT_NOTIFICATION_ID);
             //update notification indicating the operation succeeded
             showFinalMessageToUser(successMessage, GROUP_NOTIFICATION_ID);
 

--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -11,7 +11,6 @@ import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 import android.support.v4.app.RemoteInput;
 import android.text.TextUtils;
-import android.widget.Toast;
 
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
@@ -57,7 +56,6 @@ public class NotificationsProcessingService extends Service {
 
     //bundle and push ID, as they are held in the system dashboard
     public static final String ARG_NOTE_BUNDLE = "note_bundle";
-    public static final String ARG_PUSH_ID= "push_id";
 
     /*
     * Use this if you want the service to handle a background note Like.
@@ -221,12 +219,15 @@ public class NotificationsProcessingService extends Service {
         }
 
         private String getProcessingTitleForAction(String actionType) {
-            if (actionType.equals(ARG_ACTION_LIKE)) {
-                return getString(R.string.comment_q_action_liking);
-            } else if (actionType.equals(ARG_ACTION_APPROVE)) {
-                return getString(R.string.comment_q_action_approving);
-            } else if (actionType.equals(ARG_ACTION_REPLY)) {
-                return getString(R.string.comment_q_action_replying);
+            if (actionType != null) {
+                switch (actionType) {
+                    case ARG_ACTION_LIKE:
+                        return getString(R.string.comment_q_action_liking);
+                    case ARG_ACTION_APPROVE:
+                        return getString(R.string.comment_q_action_approving);
+                    case ARG_ACTION_REPLY:
+                        return getString(R.string.comment_q_action_replying);
+                }
             } else {
                 //default, generic  "processing"
                 return getString(R.string.comment_q_action_processing);
@@ -257,12 +258,15 @@ public class NotificationsProcessingService extends Service {
 
         private void performRequestedAction(){
             if (mNote != null) {
-                if (mActionType.equals(ARG_ACTION_LIKE)) {
-                    likeComment();
-                } else if (mActionType.equals(ARG_ACTION_APPROVE)) {
-                    approveComment();
-                } else if (mActionType.equals(ARG_ACTION_REPLY)) {
-                    replyToComment();
+                if (mActionType != null) {
+                    switch (mActionType) {
+                        case ARG_ACTION_LIKE:
+                            likeComment();
+                        case ARG_ACTION_APPROVE:
+                            approveComment();
+                        case ARG_ACTION_REPLY:
+                            replyToComment();
+                    }
                 } else {
                     // add other actions here
                     //no op

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -330,7 +330,10 @@
     <string name="comment_moderated_unapproved">Comment unapproved</string>
     <string name="comment_liked">Comment liked</string>
     <string name="comment_q_action_done_generic">Action done!</string>
-    <string name="comment_q_action_updating">Updating…</string>
+    <string name="comment_q_action_processing">Processing…</string>
+    <string name="comment_q_action_liking">Liking…</string>
+    <string name="comment_q_action_approving">Approving…</string>
+    <string name="comment_q_action_replying">Replying…</string>
 
     <!-- edit comment view -->
     <string name="author_name">Author name</string>


### PR DESCRIPTION
Fixes #4689 

Here's how it looks like for Android N:
![notif2_replyn](https://cloud.githubusercontent.com/assets/6597771/19788928/f334976c-9c81-11e6-91be-2670596474b2.gif)

Android N in case of error:
![notif2_error](https://cloud.githubusercontent.com/assets/6597771/19788929/f336ee4a-9c81-11e6-9349-aab0490fef2f.gif)


Android 6 or less, successful:
![notif6_ok](https://cloud.githubusercontent.com/assets/6597771/19788946/0be11812-9c82-11e6-85ad-74bde4c42a84.gif)

Android 6 or less, error:
![notif6_error](https://cloud.githubusercontent.com/assets/6597771/19788954/198183ee-9c82-11e6-9c32-8539e00f6707.gif)


Note that, instead of an actual system toast I'm using a notification that we're dismissing after 3 seconds, in order to show the result of an action. System toasts are shown _behind_ the notification dashboard, that means they're invisible when the action is being carried on.

cc @drw158, @daniloercoli 