### PR TITLE
issue/4715-reader-legacy-sharing-links

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -496,6 +496,9 @@ class ReaderPostRenderer {
         .append("     width: ").append(pxToDp(mResourceVars.videoWidthPx)).append("px !important;")
         .append("     height: ").append(pxToDp(mResourceVars.videoHeightPx)).append("px !important; }")
 
+        // hide legacy RSS sharing links
+        .append("   div.feedflare { display: none; }")
+
         .append("</style>");
 
         // add a custom CSS class to (any) tiled gallery elements to make them easier selectable for various rules

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -496,8 +496,11 @@ class ReaderPostRenderer {
         .append("     width: ").append(pxToDp(mResourceVars.videoWidthPx)).append("px !important;")
         .append("     height: ").append(pxToDp(mResourceVars.videoHeightPx)).append("px !important; }")
 
-        // hide legacy RSS sharing links
+        // hide forms, form-related elements, legacy RSS sharing links and other ad-related content
+        // https://github.com/Automattic/wp-calypso/blob/f51293caa87edcd4f0c117aaea8cf65d26e33520/client/lib/post-normalizer/rule-content-sanitize.js
+        .append("   form, input, select, button textarea { display: none; }")
         .append("   div.feedflare { display: none; }")
+        .append("   .sharedaddy, .jp-relatedposts, .mc4wp-form, .wpcnt, .OUTBRAIN, .adsbygoogle { display: none; }")
 
         .append("</style>");
 


### PR DESCRIPTION
Fixes #4715 by hiding the `feedflare` DIV containing the legacy sharing links.

To test:
- View this feed in the web reader and then follow it: [https://wordpress.com/read/feeds/5649174](https://wordpress.com/read/feeds/5649174)
- Open the Android reader to "Followed Sites"
- Locate a post from this feed and view it in full post view
- The "feedflare" section at the bottom should no longer appear

![before-and-after](https://cloud.githubusercontent.com/assets/3903757/19804896/37c0b8e0-9cdf-11e6-93dd-a8f254202a70.png)
