### PR TITLE
Fix #4721: fix the incorrect ORDER BY syntax in DELETE

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -207,7 +207,7 @@ public class ReaderPostTable {
         }
 
         String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt()), Integer.toString(MAX_POSTS_PER_TAG)};
-        String where = "post_id NOT IN (SELECT DISTINCT post_id FROM tbl_posts WHERE tag_name=? AND "
+        String where = "pseudo_id NOT IN (SELECT DISTINCT pseudo_id FROM tbl_posts WHERE tag_name=? AND "
                        + "tag_type=? ORDER BY " + getSortColumnForTag(tag) + " DESC LIMIT ?)";
         int numDeleted = db.delete("tbl_posts", where, args);
         AppLog.d(AppLog.T.READER, String.format("reader post table > purged %d posts in tag %s", numDeleted, tag.getTagNameForLog()));

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -206,9 +206,9 @@ public class ReaderPostTable {
             return 0;
         }
 
-        int numToPurge = numPosts - MAX_POSTS_PER_TAG;
-        String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt()), Integer.toString(numToPurge)};
-        String where = "tag_name=? AND tag_type=? ORDER BY " + getSortColumnForTag(tag) + " LIMIT ?";
+        String[] args = {tag.getTagSlug(), Integer.toString(tag.tagType.toInt()), Integer.toString(MAX_POSTS_PER_TAG)};
+        String where = "post_id NOT IN (SELECT DISTINCT post_id FROM tbl_posts WHERE tag_name=? AND "
+                       + "tag_type=? ORDER BY " + getSortColumnForTag(tag) + " DESC LIMIT ?)";
         int numDeleted = db.delete("tbl_posts", where, args);
         AppLog.d(AppLog.T.READER, String.format("reader post table > purged %d posts in tag %s", numDeleted, tag.getTagNameForLog()));
         return numDeleted;


### PR DESCRIPTION
Fixes #4721

Similar to what we have in the [CommentsTable](https://github.com/wordpress-mobile/WordPress-Android/blob/05b18fe96802a93a0e1f7a4840beff1948408e8c/WordPress/src/main/java/org/wordpress/android/datasets/CommentTable.java#L73-L78).

Note: I'll update the beta and alpha when this is merged.