### PR TITLE
removed line that prevented like/approve actions to appear on wearables

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -529,9 +529,6 @@ public class GCMMessageService extends GcmListenerService {
             // now add the action corresponding to direct-reply
             builder.addAction(action);
 
-            //also add wearable remoteInput to enable voice-reply
-            builder.extend(new NotificationCompat.WearableExtender().addAction(action));
-
         }
 
         private void addCommentLikeActionForCommentNotification(Context context, NotificationCompat.Builder builder, String noteId) {


### PR DESCRIPTION
Fixes #4723 

To test:
Have someone comment on a post of yours, and wait for the notification appear on your handset and wearable. The notification on the handset should have REPLY and LIKE / APPROVE (these latter depend on your blog settings for comments). The notif on the wearable should also have the same actions as seen on the handset.
