### PR TITLE
Issue/4666 force lowercase email on registration

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -38,6 +38,7 @@ import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.UserEmailUtils;
+import org.wordpress.android.util.WPLowerCaseTextWatcher;
 import org.wordpress.android.widgets.WPTextView;
 import org.wordpress.emailchecker2.EmailChecker;
 import org.wordpress.persistentedittext.PersistentEditTextHelper;
@@ -448,6 +449,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
         mProgressBarSignIn = (RelativeLayout) rootView.findViewById(R.id.nux_sign_in_progress_bar);
 
         mEmailTextField = (EditText) rootView.findViewById(R.id.email_address);
+        mEmailTextField.addTextChangedListener(new WPLowerCaseTextWatcher());
         mEmailTextField.setText(UserEmailUtils.getPrimaryEmail(getActivity()));
         mEmailTextField.setSelection(EditTextUtils.getText(mEmailTextField).length());
         mPasswordTextField = (EditText) rootView.findViewById(R.id.password);
@@ -455,6 +457,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
         mSiteUrlTextField = (EditText) rootView.findViewById(R.id.site_url);
 
         mEmailTextField.addTextChangedListener(this);
+        mEmailTextField.addTextChangedListener(new WPLowerCaseTextWatcher());
         mPasswordTextField.addTextChangedListener(this);
         mUsernameTextField.addTextChangedListener(this);
         mSiteUrlTextField.setOnKeyListener(mSiteUrlKeyListener);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -449,7 +449,6 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
         mProgressBarSignIn = (RelativeLayout) rootView.findViewById(R.id.nux_sign_in_progress_bar);
 
         mEmailTextField = (EditText) rootView.findViewById(R.id.email_address);
-        mEmailTextField.addTextChangedListener(new WPLowerCaseTextWatcher());
         mEmailTextField.setText(UserEmailUtils.getPrimaryEmail(getActivity()));
         mEmailTextField.setSelection(EditTextUtils.getText(mEmailTextField).length());
         mPasswordTextField = (EditText) rootView.findViewById(R.id.password);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
@@ -24,6 +24,7 @@ import org.wordpress.android.util.BlogUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.WPLowerCaseTextWatcher;
 
 import java.util.HashMap;
 import java.util.List;
@@ -52,6 +53,7 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
         mWebAddressPreference = (EditTextPreferenceWithValidation) findPreference(getString(R.string.pref_key_web_address));
 
         mEmailPreference.getEditText().setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS);
+        mEmailPreference.getEditText().addTextChangedListener(new WPLowerCaseTextWatcher());
         mEmailPreference.setValidationType(EditTextPreferenceWithValidation.ValidationType.EMAIL);
         mWebAddressPreference.getEditText().setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_URI);
         mWebAddressPreference.setValidationType(EditTextPreferenceWithValidation.ValidationType.URL);

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLowerCaseTextWatcher.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLowerCaseTextWatcher.java
@@ -1,0 +1,31 @@
+package org.wordpress.android.util;
+
+
+import android.text.Editable;
+import android.text.TextWatcher;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class WPLowerCaseTextWatcher implements TextWatcher {
+
+    private static final Pattern UPPER_CASE_REGEX = Pattern.compile("[A-Z]");
+
+    @Override
+    public void onTextChanged(CharSequence s, int start, int before, int count) {
+    }
+
+    @Override
+    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+    }
+
+    @Override
+    public void afterTextChanged(Editable s) {
+        Matcher matcher = UPPER_CASE_REGEX.matcher(s);
+        while (matcher.find()) {
+            CharSequence upperCaseRegion = s.subSequence(matcher.start(), matcher.end());
+            s.replace(matcher.start(), matcher.end(), upperCaseRegion.toString().toLowerCase());
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes #4666

This PR forces lowercase email address during new user registration and during change of existing email address.

To test:
1. On the new account creation screen try typing uppercase characters in email field.
2. On the account settings screen, try typing uppercase characters in the Email Address dialog.