### PR TITLE
Issue/wpnetworkimageview dont clear skiplist

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -1,12 +1,5 @@
 package org.wordpress.android.ui.main;
 
-import com.android.volley.Cache;
-import com.android.volley.Request;
-import com.github.xizzhu.simpletooltip.ToolTip;
-import com.github.xizzhu.simpletooltip.ToolTipView;
-import com.yalantis.ucrop.UCrop;
-import com.yalantis.ucrop.UCropActivity;
-
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -36,6 +29,13 @@ import android.view.ViewGroup;
 import android.view.ViewOutlineProvider;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import com.android.volley.Cache;
+import com.android.volley.Request;
+import com.github.xizzhu.simpletooltip.ToolTip;
+import com.github.xizzhu.simpletooltip.ToolTipView;
+import com.yalantis.ucrop.UCrop;
+import com.yalantis.ucrop.UCropActivity;
 
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
@@ -386,7 +386,7 @@ public class MeFragment extends Fragment {
 
             // reset the WPNetworkImageView
             mAvatarImageView.resetImage();
-            WPNetworkImageView.removeUrlFromSkiplist(avatarUrl);
+            mAvatarImageView.removeCurrentUrlFromSkiplist();
         }
 
         mAvatarImageView.setImageUrl(avatarUrl, WPNetworkImageView.ImageType.AVATAR, new WPNetworkImageView

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -384,8 +384,9 @@ public class MeFragment extends Fragment {
                 EventBus.getDefault().post(new GravatarLoadFinished(false));
             }
 
-            // invalidate the WPNetworkImageView
-            mAvatarImageView.invalidateImage();
+            // reset the WPNetworkImageView
+            mAvatarImageView.resetImage();
+            WPNetworkImageView.removeUrlFromSkiplist(avatarUrl);
         }
 
         mAvatarImageView.setImageUrl(avatarUrl, WPNetworkImageView.ImageType.AVATAR, new WPNetworkImageView

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
@@ -314,9 +314,9 @@ public class WPNetworkImageView extends AppCompatImageView {
         }
     }
 
-    public static void removeUrlFromSkiplist(String url) {
-        if (!TextUtils.isEmpty(url)) {
-            mUrlSkipList.remove(url);
+    public void removeCurrentUrlFromSkiplist() {
+        if (!TextUtils.isEmpty(mUrl)) {
+            mUrlSkipList.remove(mUrl);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
@@ -303,9 +303,7 @@ public class WPNetworkImageView extends AppCompatImageView {
         }
     }
 
-    public void invalidateImage() {
-        mUrlSkipList.clear();
-
+    public void resetImage() {
         if (mImageContainer != null) {
             // If the view was bound to an image request, cancel it and clear
             // out the image from the view.
@@ -313,6 +311,12 @@ public class WPNetworkImageView extends AppCompatImageView {
             setImageBitmap(null);
             // also clear out the container so we can reload the image if necessary.
             mImageContainer = null;
+        }
+    }
+
+    public static void removeUrlFromSkiplist(String url) {
+        if (!TextUtils.isEmpty(url)) {
+            mUrlSkipList.remove(url);
         }
     }
 
@@ -326,7 +330,7 @@ public class WPNetworkImageView extends AppCompatImageView {
 
     @Override
     protected void onDetachedFromWindow() {
-        invalidateImage();
+        resetImage();
 
         super.onDetachedFromWindow();
     }


### PR DESCRIPTION
Fixes a problem with WPNetworkImageView where the list of URLs to skip is cleared every time the view is detached.