### PR TITLE
issue/4709-reader-wrong-gravatar-v6.1

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -384,8 +384,9 @@ public class MeFragment extends Fragment {
                 EventBus.getDefault().post(new GravatarLoadFinished(false));
             }
 
-            // invalidate the WPNetworkImageView
-            mAvatarImageView.invalidateImage();
+            // reset the WPNetworkImageView
+            mAvatarImageView.resetImage();
+            mAvatarImageView.removeCurrentUrlFromSkiplist();
         }
 
         mAvatarImageView.setImageUrl(avatarUrl, WPNetworkImageView.ImageType.AVATAR, new WPNetworkImageView

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
@@ -15,7 +15,6 @@ import android.support.v7.widget.AppCompatImageView;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
-import android.view.ViewGroup.LayoutParams;
 
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.ImageLoader;
@@ -101,7 +100,7 @@ public class WPNetworkImageView extends AppCompatImageView {
         }
 
         // The URL has potentially changed. See if we need to load it.
-        loadImageIfNecessary(false, imageLoadListener);
+        loadImageIfNecessary(imageLoadListener);
     }
 
     /*
@@ -160,28 +159,10 @@ public class WPNetworkImageView extends AppCompatImageView {
 
     /**
      * Loads the image for the view if it isn't already loaded.
-     * @param isInLayoutPass True if this was invoked from a layout pass, false otherwise.
      */
-    private void loadImageIfNecessary(final boolean isInLayoutPass, final ImageLoadListener imageLoadListener) {
+    private void loadImageIfNecessary(final ImageLoadListener imageLoadListener) {
         // do nothing if image type hasn't been set yet
         if (mImageType == ImageType.NONE) {
-            return;
-        }
-
-        int width = getWidth();
-        int height = getHeight();
-        ScaleType scaleType = getScaleType();
-
-        boolean wrapWidth = false, wrapHeight = false;
-        if (getLayoutParams() != null) {
-            wrapWidth = getLayoutParams().width == LayoutParams.WRAP_CONTENT;
-            wrapHeight = getLayoutParams().height == LayoutParams.WRAP_CONTENT;
-        }
-
-        // if the view's bounds aren't known yet, and this is not a wrap-content/wrap-content
-        // view, hold off on loading the image.
-        boolean isFullyWrapContent = wrapWidth && wrapHeight;
-        if (width == 0 && height == 0 && !isFullyWrapContent && mImageType != ImageType.GONE_UNTIL_AVAILABLE) {
             return;
         }
 
@@ -219,10 +200,6 @@ public class WPNetworkImageView extends AppCompatImageView {
             return;
         }
 
-        // Calculate the max image width / height to use while ignoring WRAP_CONTENT dimens.
-        int maxWidth = wrapWidth ? 0 : width;
-        int maxHeight = wrapHeight ? 0 : height;
-
         // The pre-existing content of this view didn't match the current URL. Load the new image
         // from the network.
         ImageLoader.ImageContainer newContainer = WordPress.imageLoader.get(mUrl,
@@ -243,22 +220,9 @@ public class WPNetworkImageView extends AppCompatImageView {
 
                     @Override
                     public void onResponse(final ImageLoader.ImageContainer response, boolean isImmediate) {
-                        // If this was an immediate response that was delivered inside of a layout
-                        // pass do not set the image immediately as it will trigger a requestLayout
-                        // inside of a layout. Instead, defer setting the image by posting back to
-                        // the main thread.
-                        if (isImmediate && isInLayoutPass) {
-                            post(new Runnable() {
-                                @Override
-                                public void run() {
-                                    handleResponse(response, true, imageLoadListener);
-                                }
-                            });
-                        } else {
-                            handleResponse(response, isImmediate, imageLoadListener);
-                        }
+                        handleResponse(response, isImmediate, imageLoadListener);
                     }
-                }, maxWidth, maxHeight, scaleType);
+                }, 0, 0, getScaleType());
 
         // update the ImageContainer to be the new bitmap container.
         mImageContainer = newContainer;
@@ -266,7 +230,7 @@ public class WPNetworkImageView extends AppCompatImageView {
 
     private static boolean canFadeInImageType(ImageType imageType) {
         return imageType == ImageType.PHOTO
-            || imageType == ImageType.VIDEO;
+                || imageType == ImageType.VIDEO;
     }
 
     private void handleResponse(ImageLoader.ImageContainer response, boolean isCached, ImageLoadListener
@@ -303,9 +267,7 @@ public class WPNetworkImageView extends AppCompatImageView {
         }
     }
 
-    public void invalidateImage() {
-        mUrlSkipList.clear();
-
+    public void resetImage() {
         if (mImageContainer != null) {
             // If the view was bound to an image request, cancel it and clear
             // out the image from the view.
@@ -316,17 +278,15 @@ public class WPNetworkImageView extends AppCompatImageView {
         }
     }
 
-    @Override
-    protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
-        super.onLayout(changed, left, top, right, bottom);
-        if (!isInEditMode()) {
-            loadImageIfNecessary(true, null);
+    public void removeCurrentUrlFromSkiplist() {
+        if (!TextUtils.isEmpty(mUrl)) {
+            mUrlSkipList.remove(mUrl);
         }
     }
 
     @Override
     protected void onDetachedFromWindow() {
-        invalidateImage();
+        resetImage();
 
         super.onDetachedFromWindow();
     }


### PR DESCRIPTION
Fixes #4709

This one took a while to track down, but in the end I discovered it was somehow caused by the way image requests are delayed until after the view has finished layout. 

Looking at it, this delay seems to be unnecessary. It appears to simply be a way to cache images at the size of the ImageView, which isn't needed since we always request images at the desired size. 

Removing this delay simplified the code and prevented the wrong gravatars from appearing.