### PR TITLE
Fix double backspace call in some text fields when using hardware keyboard

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/SuggestionAutoCompleteText.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/SuggestionAutoCompleteText.java
@@ -145,7 +145,7 @@ public class SuggestionAutoCompleteText extends MultiAutoCompleteTextView {
             }
         }
 
-        return super.dispatchKeyEvent(event);
+        return super.onKeyPreIme(keyCode,event);
     }
 
     @Override


### PR DESCRIPTION
Fixes #4737 

To test:
1. Prepare android with hardware keyboard (or use you computer keyboard with genymotion)
2. Navigate to tag field in post settings or into Reader comment text field.
3. Type some text.
4. Press backspace on hardware keyboard.
5. Only one character should be removed.

This PR removes the call to wrong super method inside `onKeyPreIme` of `SuggestionAutoCompleteText`. We should not call `dispatchKeyEvent` from `onKeyPreIme` - we are only using this method to detect press of back button before IME.
