### PR TITLE
Set explicit locale when constructing rest path.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/Note.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Note.java
@@ -534,7 +534,7 @@ public class Note extends Syncable {
             restPath = String.format(Locale.US, "sites/%d/posts/%d", getSiteId(), getPostId());
         }
 
-        return new Reply(String.format("%s/replies/new", restPath), content);
+        return new Reply(String.format(Locale.US, "%s/replies/new", restPath), content);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/models/Note.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Note.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
 
@@ -528,9 +529,9 @@ public class Note extends Syncable {
     public Reply buildReply(String content) {
         String restPath;
         if (this.isCommentType()) {
-            restPath = String.format("sites/%d/comments/%d", getSiteId(), getCommentId());
+            restPath = String.format(Locale.US, "sites/%d/comments/%d", getSiteId(), getCommentId());
         } else {
-            restPath = String.format("sites/%d/posts/%d", getSiteId(), getPostId());
+            restPath = String.format(Locale.US, "sites/%d/posts/%d", getSiteId(), getPostId());
         }
 
         return new Reply(String.format("%s/replies/new", restPath), content);

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderBlog.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderBlog.java
@@ -7,6 +7,8 @@ import org.wordpress.android.util.JSONUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.UrlUtils;
 
+import java.util.Locale;
+
 public class ReaderBlog {
     public long blogId;
     public long feedId;
@@ -150,7 +152,7 @@ public class ReaderBlog {
     public String getMshotsUrl(int width) {
         return "http://s.wordpress.com/mshots/v1/"
              + UrlUtils.urlEncode(getUrl())
-             + String.format("?w=%d", width);
+             + String.format(Locale.US, "?w=%d", width);
     }
 
     public boolean isSameAs(ReaderBlog blogInfo) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/BlogUtils.java
@@ -16,6 +16,7 @@ import org.wordpress.android.util.WPUrlUtils;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -202,7 +203,7 @@ public class BlogUtils {
                 // Skip unknown plans, MapUtils will turn any missing plan ID into 0
                 continue;
             }
-            String tag = String.format("plan:%d", planId);
+            String tag = String.format(Locale.US, "plan:%d", planId);
             tags.add(tag);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -78,6 +78,7 @@ import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 
 import de.greenrobot.event.EventBus;
 
@@ -1229,7 +1230,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             }
         };
 
-        final String path = String.format("/sites/%s/comments/%s", remoteBlogId, commentId);
+        final String path = String.format(Locale.US, "/sites/%s/comments/%s", remoteBlogId, commentId);
         WordPress.getRestClientUtils().get(path, restListener, restErrListener);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
@@ -45,6 +45,7 @@ import org.xmlrpc.android.XMLRPCFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public class EditCommentActivity extends AppCompatActivity {
@@ -408,7 +409,7 @@ public class EditCommentActivity extends AppCompatActivity {
             }
         };
 
-        final String path = String.format("/sites/%s/comments/%s", note.getSiteId(), note.getCommentId());
+        final String path = String.format(Locale.US, "/sites/%s/comments/%s", note.getSiteId(), note.getCommentId());
         WordPress.getRestClientUtils().get(path, restListener, restErrListener);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class PeopleUtils {
@@ -60,7 +61,7 @@ public class PeopleUtils {
         params.put("offset", Integer.toString(offset));
         params.put("order_by", "display_name");
         params.put("order", "ASC");
-        String path = String.format("sites/%s/users", blogId);
+        String path = String.format(Locale.US, "sites/%s/users", blogId);
         WordPress.getRestClientUtilsV1_1().get(path, params, null, listener, errorListener);
     }
 
@@ -113,7 +114,7 @@ public class PeopleUtils {
         params.put("max", Integer.toString(FETCH_LIMIT));
         params.put("page", Integer.toString(page));
         params.put("type", isEmailFollower ? "email" : "wp_com");
-        String path = String.format("sites/%s/stats/followers", blogId);
+        String path = String.format(Locale.US, "sites/%s/stats/followers", blogId);
         WordPress.getRestClientUtilsV1_1().get(path, params, null, listener, errorListener);
     }
 
@@ -153,7 +154,7 @@ public class PeopleUtils {
         Map<String, String> params = new HashMap<>();
         params.put("number", Integer.toString(FETCH_LIMIT));
         params.put("page", Integer.toString(page));
-        String path = String.format("sites/%s/viewers", blogId);
+        String path = String.format(Locale.US,"sites/%s/viewers", blogId);
         WordPress.getRestClientUtilsV1_1().get(path, params, null, listener, errorListener);
     }
 
@@ -190,7 +191,7 @@ public class PeopleUtils {
 
         Map<String, String> params = new HashMap<>();
         params.put("roles", newRole.toRESTString());
-        String path = String.format("sites/%s/users/%d", blogId, personID);
+        String path = String.format(Locale.US, "sites/%s/users/%d", blogId, personID);
         WordPress.getRestClientUtilsV1_1().post(path, params, null, listener, errorListener);
     }
 
@@ -221,7 +222,7 @@ public class PeopleUtils {
             }
         };
 
-        String path = String.format("sites/%s/users/%d/delete", blogId, personID);
+        String path = String.format(Locale.US, "sites/%s/users/%d/delete", blogId, personID);
         WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
     }
 
@@ -254,9 +255,9 @@ public class PeopleUtils {
 
         String path;
         if (personType == Person.PersonType.EMAIL_FOLLOWER) {
-            path = String.format("sites/%s/email-followers/%d/delete", blogId, personID);
+            path = String.format(Locale.US, "sites/%s/email-followers/%d/delete", blogId, personID);
         } else {
-            path = String.format("sites/%s/followers/%d/delete", blogId, personID);
+            path = String.format(Locale.US, "sites/%s/followers/%d/delete", blogId, personID);
         }
         WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
     }
@@ -288,7 +289,7 @@ public class PeopleUtils {
             }
         };
 
-        String path = String.format("sites/%s/viewers/%d/delete", blogId, personID);
+        String path = String.format(Locale.US, "sites/%s/viewers/%d/delete", blogId, personID);
         WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
     }
 
@@ -427,7 +428,7 @@ public class PeopleUtils {
             }
         };
 
-        String path = String.format("sites/%s/invites/validate", dotComBlogId);
+        String path = String.format(Locale.US, "sites/%s/invites/validate", dotComBlogId);
         Map<String, String> params = new HashMap<>();
         for (String username : usernames) {
             params.put("invitees[" + username + "]", username); // specify an array key so to make the map key unique
@@ -510,7 +511,7 @@ public class PeopleUtils {
             }
         };
 
-        String path = String.format("sites/%s/invites/new", dotComBlogId);
+        String path = String.format(Locale.US, "sites/%s/invites/new", dotComBlogId);
         Map<String, String> params = new HashMap<>();
         for (String username : usernames) {
             params.put("invitees[" + username + "]", username); // specify an array key so to make the map key unique

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/FollowHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/FollowHelper.java
@@ -18,6 +18,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ToastUtils;
 
 import java.lang.ref.WeakReference;
+import java.util.Locale;
 
 class FollowHelper {
 
@@ -55,9 +56,9 @@ class FollowHelper {
                 final RestClientUtils restClientUtils = WordPress.getRestClientUtils();
                 final String restPath;
                 if (!followData.isFollowing()) {
-                    restPath = String.format("/sites/%s/follows/new", followData.getSiteID());
+                    restPath = String.format(Locale.US, "/sites/%s/follows/new", followData.getSiteID());
                 } else {
-                    restPath = String.format("/sites/%s/follows/mine/delete", followData.getSiteID());
+                    restPath = String.format(Locale.US, "/sites/%s/follows/mine/delete", followData.getSiteID());
                 }
 
                 followData.isRestCallInProgress = true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/ReferrerSpamHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/ReferrerSpamHelper.java
@@ -21,6 +21,7 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
 
 import java.lang.ref.WeakReference;
+import java.util.Locale;
 
 class ReferrerSpamHelper {
 
@@ -78,10 +79,10 @@ class ReferrerSpamHelper {
                 final String restPath;
                 final boolean isMarkingAsSpamInProgress;
                 if (referrerGroup.isMarkedAsSpam) {
-                    restPath = String.format("/sites/%s/stats/referrers/spam/delete/?domain=%s", referrerGroup.getBlogId(), getDomain(referrerGroup));
+                    restPath = String.format(Locale.US, "/sites/%s/stats/referrers/spam/delete/?domain=%s", referrerGroup.getBlogId(), getDomain(referrerGroup));
                     isMarkingAsSpamInProgress = false;
                 } else {
-                    restPath = String.format("/sites/%s/stats/referrers/spam/new/?domain=%s", referrerGroup.getBlogId(), getDomain(referrerGroup));
+                    restPath = String.format(Locale.US, "/sites/%s/stats/referrers/spam/new/?domain=%s", referrerGroup.getBlogId(), getDomain(referrerGroup));
                     isMarkingAsSpamInProgress = true;
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -46,6 +46,7 @@ import java.io.Serializable;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -348,11 +349,11 @@ public class StatsService extends Service {
 
         final String periodDateMaxPlaceholder =  "?period=%s&date=%s&max=%s";
 
-        String path = String.format("/sites/%s/stats/" + sectionToUpdate.getRestEndpointPath(), blogId);
+        String path = String.format(Locale.US, "/sites/%s/stats/" + sectionToUpdate.getRestEndpointPath(), blogId);
         synchronized (mStatsNetworkRequests) {
             switch (sectionToUpdate) {
                 case VISITS:
-                    path = String.format(path + "?unit=%s&quantity=15&date=%s", period, date);
+                    path = String.format(Locale.US, path + "?unit=%s&quantity=15&date=%s", period, date);
                     break;
                 case TOP_POSTS:
                 case REFERRERS:
@@ -361,36 +362,36 @@ public class StatsService extends Service {
                 case AUTHORS:
                 case VIDEO_PLAYS:
                 case SEARCH_TERMS:
-                    path = String.format(path + periodDateMaxPlaceholder, period, date, maxResultsRequested);
+                    path = String.format(Locale.US, path + periodDateMaxPlaceholder, period, date, maxResultsRequested);
                     break;
                 case TAGS_AND_CATEGORIES:
                 case PUBLICIZE:
-                    path = String.format(path + "?max=%s", maxResultsRequested);
+                    path = String.format(Locale.US, path + "?max=%s", maxResultsRequested);
                     break;
                 case COMMENTS:
                     // No parameters
                     break;
                 case FOLLOWERS_WPCOM:
                     if (pageRequested < 1) {
-                        path = String.format(path + "&max=%s", maxResultsRequested);
+                        path = String.format(Locale.US, path + "&max=%s", maxResultsRequested);
                     } else {
-                        path = String.format(path + "&period=%s&date=%s&max=%s&page=%s",
+                        path = String.format(Locale.US, path + "&period=%s&date=%s&max=%s&page=%s",
                                 period, date, maxResultsRequested, pageRequested);
                     }
                     break;
                 case FOLLOWERS_EMAIL:
                     if (pageRequested < 1) {
-                        path = String.format(path + "&max=%s", maxResultsRequested);
+                        path = String.format(Locale.US, path + "&max=%s", maxResultsRequested);
                     } else {
-                        path = String.format(path + "&period=%s&date=%s&max=%s&page=%s",
+                        path = String.format(Locale.US, path + "&period=%s&date=%s&max=%s&page=%s",
                                 period, date, maxResultsRequested, pageRequested);
                     }
                     break;
                 case COMMENT_FOLLOWERS:
                     if (pageRequested < 1) {
-                        path = String.format(path + "?max=%s", maxResultsRequested);
+                        path = String.format(Locale.US, path + "?max=%s", maxResultsRequested);
                     } else {
-                        path = String.format(path + "?period=%s&date=%s&max=%s&page=%s", period,
+                        path = String.format(Locale.US, path + "?period=%s&date=%s&max=%s&page=%s", period,
                                 date, maxResultsRequested, pageRequested);
                     }
                     break;
@@ -398,16 +399,16 @@ public class StatsService extends Service {
                 case INSIGHTS_POPULAR:
                     break;
                 case INSIGHTS_TODAY:
-                    path = String.format(path + "?period=day&date=%s", date);
+                    path = String.format(Locale.US, path + "?period=day&date=%s", date);
                     break;
                 case INSIGHTS_LATEST_POST_SUMMARY:
                     // This is an edge cases since  we're not loading stats but posts
-                    path = String.format("/sites/%s/%s", blogId, sectionToUpdate.getRestEndpointPath()
+                    path = String.format(Locale.US, "/sites/%s/%s", blogId, sectionToUpdate.getRestEndpointPath()
                             + "?order_by=date&number=1&type=post&fields=ID,title,URL,discussion,like_count,date");
                     break;
                 case INSIGHTS_LATEST_POST_VIEWS:
                     // This is a kind of edge case, since we used the pageRequested parameter to request a single postID
-                    path = String.format(path + "/%s?fields=views", pageRequested);
+                    path = String.format(Locale.US, path + "/%s?fields=views", pageRequested);
                     break;
                 default:
                     AppLog.i(T.STATS, "Called an update of Stats of unknown section!?? " + sectionToUpdate.name());

--- a/WordPress/src/main/java/org/wordpress/android/util/WPHtml.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPHtml.java
@@ -422,7 +422,7 @@ public class WPHtml {
                 int xRes = mediaFile.getWidth();
                 int yRes = mediaFile.getHeight();
                 String mimeType = mediaFile.getMimeType();
-                content = String.format("<video width=\"%s\" height=\"%s\" controls=\"controls\"><source src=\"%s\" type=\"%s\" /><a href=\"%s\">Click to view video</a>.</video>",
+                content = String.format(Locale.US, "<video width=\"%s\" height=\"%s\" controls=\"controls\"><source src=\"%s\" type=\"%s\" /><a href=\"%s\">Click to view video</a>.</video>",
                         xRes, yRes, url, mimeType, url);
             }
         } else {

--- a/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
+++ b/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
@@ -24,6 +24,7 @@ import org.wordpress.android.util.LanguageUtils;
 
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -85,7 +86,7 @@ public class RestClientUtils {
     }
 
     public void getCategories(String siteId, Listener listener, ErrorListener errorListener) {
-        String path = String.format("sites/%s/categories", siteId);
+        String path = String.format(Locale.US, "sites/%s/categories", siteId);
         get(path, null, null, listener, errorListener);
     }
 
@@ -95,7 +96,7 @@ public class RestClientUtils {
      * https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/comments/
      */
     public void getComments(String siteId, Map<String, String> params, final Listener listener, ErrorListener errorListener) {
-        String path = String.format("sites/%s/comments", siteId);
+        String path = String.format(Locale.US, "sites/%s/comments", siteId);
         get(path, params, null, listener, errorListener);
     }
 
@@ -119,7 +120,7 @@ public class RestClientUtils {
                                ErrorListener errorListener) {
         Map<String, String> params = new HashMap<String, String>();
         params.put(COMMENT_REPLY_CONTENT_FIELD, content);
-        String path = String.format("sites/%d/comments/%d/replies/new", siteId, commentId);
+        String path = String.format(Locale.US, "sites/%d/comments/%d/replies/new", siteId, commentId);
         post(path, params, null, listener, errorListener);
     }
 
@@ -129,7 +130,7 @@ public class RestClientUtils {
      * https://developer.wordpress.com/docs/api/1/post/sites/%24site/follows/new/
      */
     public void followSite(String siteId, Listener listener, ErrorListener errorListener) {
-        String path = String.format("sites/%s/follows/new", siteId);
+        String path = String.format(Locale.US, "sites/%s/follows/new", siteId);
         post(path, listener, errorListener);
     }
 
@@ -139,7 +140,7 @@ public class RestClientUtils {
      * https://developer.wordpress.com/docs/api/1/post/sites/%24site/follows/mine/delete/
      */
     public void unfollowSite(String siteId, Listener listener, ErrorListener errorListener) {
-        String path = String.format("sites/%s/follows/mine/delete", siteId);
+        String path = String.format(Locale.US, "sites/%s/follows/mine/delete", siteId);
         post(path, listener, errorListener);
     }
 
@@ -161,7 +162,7 @@ public class RestClientUtils {
      */
     public void getNotification(Map<String, String> params, String noteId, Listener listener, ErrorListener errorListener) {
         params.put("fields", NOTIFICATION_FIELDS);
-        String path = String.format("notifications/%s/", noteId);
+        String path = String.format(Locale.US, "notifications/%s/", noteId);
         get(path, params, null, listener, errorListener);
     }
 
@@ -194,7 +195,7 @@ public class RestClientUtils {
                                 ErrorListener errorListener) {
         Map<String, String> params = new HashMap<String, String>();
         params.put("status", status);
-        String path = String.format("sites/%s/comments/%s/", siteId, commentId);
+        String path = String.format(Locale.US, "sites/%s/comments/%s/", siteId, commentId);
         post(path, params, null, listener, errorListener);
     }
 
@@ -205,7 +206,7 @@ public class RestClientUtils {
                                 ErrorListener errorListener) {
         Map<String, String> params = new HashMap<String, String>();
         params.put("content", content);
-        String path = String.format("sites/%d/comments/%d/", siteId, commentId);
+        String path = String.format(Locale.US, "sites/%d/comments/%d/", siteId, commentId);
         post(path, params, null, listener, errorListener);
     }
 
@@ -215,7 +216,7 @@ public class RestClientUtils {
     public void likeComment(String siteId, String commentId, boolean isLiked, Listener listener,
                                 ErrorListener errorListener) {
         Map<String, String> params = new HashMap<String, String>();
-        String path = String.format("sites/%s/comments/%s/likes/", siteId, commentId);
+        String path = String.format(Locale.US, "sites/%s/comments/%s/likes/", siteId, commentId);
 
         if (!isLiked) {
             path += "mine/delete";
@@ -231,7 +232,7 @@ public class RestClientUtils {
     }
 
     public void getSearchThemes(String tier, String siteId, int limit, int offset, String searchTerm, Listener listener, ErrorListener errorListener) {
-        String path = String.format("sites/%s/themes?tier=" + tier + "&number=%d&offset=%d&search=%s", siteId, limit, offset, searchTerm);
+        String path = String.format(Locale.US, "sites/%s/themes?tier=" + tier + "&number=%d&offset=%d&search=%s", siteId, limit, offset, searchTerm);
         get(path, listener, errorListener);
     }
 
@@ -240,7 +241,7 @@ public class RestClientUtils {
     }
 
     public void getPurchasedThemes(String siteId, Listener listener, ErrorListener errorListener) {
-        String path = String.format("sites/%s/themes/purchased", siteId);
+        String path = String.format(Locale.US, "sites/%s/themes/purchased", siteId);
         get(path, listener, errorListener);
     }
 
@@ -248,7 +249,7 @@ public class RestClientUtils {
      * Get all a site's themes
      */
     public void getThemes(String tier, String siteId, int limit, int offset, Listener listener, ErrorListener errorListener) {
-        String path = String.format("sites/%s/themes/?tier=" + tier + "&number=%d&offset=%d", siteId, limit, offset);
+        String path = String.format(Locale.US, "sites/%s/themes/?tier=" + tier + "&number=%d&offset=%d", siteId, limit, offset);
         get(path, listener, errorListener);
     }
 
@@ -258,7 +259,7 @@ public class RestClientUtils {
     public void setTheme(String siteId, String themeId, Listener listener, ErrorListener errorListener) {
         Map<String, String> params = new HashMap<>();
         params.put("theme", themeId);
-        String path = String.format("sites/%s/themes/mine", siteId);
+        String path = String.format(Locale.US, "sites/%s/themes/mine", siteId);
         post(path, params, null, listener, errorListener);
     }
 
@@ -266,19 +267,19 @@ public class RestClientUtils {
      * Get a site's current theme
      */
     public void getCurrentTheme(String siteId, Listener listener, ErrorListener errorListener) {
-        String path = String.format("sites/%s/themes/mine", siteId);
+        String path = String.format(Locale.US, "sites/%s/themes/mine", siteId);
         get(path, listener, errorListener);
     }
 
     public void getGeneralSettings(String siteId, Listener listener, ErrorListener errorListener) {
-        String path = String.format("sites/%s/settings", siteId);
+        String path = String.format(Locale.US, "sites/%s/settings", siteId);
         Map<String, String> params = new HashMap<String, String>();
         get(path, params, null, listener, errorListener);
     }
 
     public void setGeneralSiteSettings(String siteId, Listener listener, ErrorListener errorListener,
                                        Map<String, String> params) {
-        String path = String.format("sites/%s/settings", siteId);
+        String path = String.format(Locale.US, "sites/%s/settings", siteId);
         post(path, params, null, listener, errorListener);
     }
 
@@ -286,17 +287,17 @@ public class RestClientUtils {
      * Delete a site
      */
     public void deleteSite(String siteId, Listener listener, ErrorListener errorListener) {
-        String path = String.format("sites/%s/delete", siteId);
+        String path = String.format(Locale.US, "sites/%s/delete", siteId);
         post(path, listener, errorListener);
     }
 
     public void getSitePurchases(String siteId, Listener listener, ErrorListener errorListener) {
-        String path = String.format("sites/%s/purchases", siteId);
+        String path = String.format(Locale.US, "sites/%s/purchases", siteId);
         get(path, listener, errorListener);
     }
 
     public void exportContentAll(String siteId, Listener listener, ErrorListener errorListener) {
-        String path = String.format("sites/%s/exports/start", siteId);
+        String path = String.format(Locale.US, "sites/%s/exports/start", siteId);
         post(path, listener, errorListener);
     }
 
@@ -305,7 +306,7 @@ public class RestClientUtils {
     }
 
     public void isAvailable(String email, Listener listener, ErrorListener errorListener) {
-        String path = String.format("is-available/email?q=%s", email);
+        String path = String.format(Locale.US, "is-available/email?q=%s", email);
         get(path, listener, errorListener);
     }
 

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/MediaFile.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/MediaFile.java
@@ -7,6 +7,7 @@ import org.wordpress.android.util.MapUtils;
 import org.wordpress.android.util.StringUtils;
 
 import java.util.Date;
+import java.util.Locale;
 import java.util.Map;
 
 public class MediaFile {
@@ -326,11 +327,11 @@ public class MediaFile {
 
         String mediaTitle = StringUtils.notNullStr(getTitle());
 
-        String content = String.format("<a href=\"%s\"><img title=\"%s\" %s alt=\"image\" src=\"%s\" /></a>",
+        String content = String.format(Locale.US, "<a href=\"%s\"><img title=\"%s\" %s alt=\"image\" src=\"%s\" /></a>",
                 fullSizeUrl, mediaTitle, alignmentCSS, resizedPictureURL);
 
         if (!TextUtils.isEmpty(getCaption())) {
-            content = String.format("[caption id=\"\" align=\"%s\" width=\"%d\"]%s%s[/caption]",
+            content = String.format(Locale.US, "[caption id=\"\" align=\"%s\" width=\"%d\"]%s%s[/caption]",
                     alignment, getWidth(), content, TextUtils.htmlEncode(getCaption()));
         }
 


### PR DESCRIPTION
Fixes #4342 

To test:

1. On a WordPress.com or Jetpack blog, leave a comment (to trigger a notification)
2. In the app, open the comment notification and approve the comment if needed
3. Reply to the comment. Result: Comment is successfully published.
4. In the device settings, switch the language to Arabic or Farsi (Persian)
5. Return to the app and reply to the comment. Result:Comment is successfully published


Because we didn't explicitly set a locale while making a rest path for notification comment reply, the resulting url might have contained non latin numbers.

