### PR TITLE
Fix #4724: update the textview unique id when comment is updated

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -228,9 +228,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
 
         mLayoutReply = (ViewGroup) view.findViewById(R.id.layout_comment_box);
         mEditReply = (SuggestionAutoCompleteText) mLayoutReply.findViewById(R.id.edit_comment);
-        mEditReply.getAutoSaveTextHelper().setUniqueId(String.format(LanguageUtils.getCurrentDeviceLanguage(getActivity()), "%s%d%d",
-                AccountHelper.getCurrentUsernameForBlog(WordPress.getCurrentBlog()),
-                getRemoteBlogId(), getCommentId()));
+        setReplyUniqueId();
 
         mSubmitReplyBtn = mLayoutReply.findViewById(R.id.btn_submit_reply);
 
@@ -356,6 +354,13 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         setComment(localBlogId, CommentTable.getComment(localBlogId, commentId));
     }
 
+    private void setReplyUniqueId() {
+        mEditReply.getAutoSaveTextHelper().setUniqueId(
+                String.format(LanguageUtils.getCurrentDeviceLanguage(getActivity()), "%s%d%d",
+                AccountHelper.getCurrentUsernameForBlog(WordPress.getCurrentBlog()),
+                getRemoteBlogId(), getCommentId()));
+    }
+
     private void setComment(int localBlogId, final Comment comment) {
         mComment = comment;
         mLocalBlogId = localBlogId;
@@ -364,11 +369,16 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         // notification about a reply to a comment this user posted on someone else's blog
         mIsUsersBlog = (comment != null && WordPress.wpDB.isLocalBlogIdInDatabase(mLocalBlogId));
 
-        if (mIsUsersBlog)
+        if (mIsUsersBlog) {
             mRemoteBlogId = WordPress.wpDB.getRemoteBlogIdForLocalTableBlogId(mLocalBlogId);
+        }
 
-        if (isAdded())
+        if (isAdded()) {
             showComment();
+        }
+
+        // Reset the reply unique id since mComment just changed.
+        setReplyUniqueId();
     }
 
     private void disableShouldFocusReplyField() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -68,7 +68,6 @@ import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.HtmlUtils;
-import org.wordpress.android.util.LanguageUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.VolleyUtils;
@@ -355,10 +354,11 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     }
 
     private void setReplyUniqueId() {
-        mEditReply.getAutoSaveTextHelper().setUniqueId(
-                String.format(LanguageUtils.getCurrentDeviceLanguage(getActivity()), "%s%d%d",
-                AccountHelper.getCurrentUsernameForBlog(WordPress.getCurrentBlog()),
-                getRemoteBlogId(), getCommentId()));
+        if (mEditReply != null && isAdded()) {
+            mEditReply.getAutoSaveTextHelper().setUniqueId(String.format(Locale.US, "%s%d%d",
+                            AccountHelper.getCurrentUsernameForBlog(WordPress.getCurrentBlog()),
+                            getRemoteBlogId(), getCommentId()));
+        }
     }
 
     private void setComment(int localBlogId, final Comment comment) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -39,7 +39,6 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.EditTextUtils;
-import org.wordpress.android.util.LanguageUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
@@ -49,6 +48,7 @@ import org.wordpress.android.widgets.RecyclerItemDecoration;
 import org.wordpress.android.widgets.SuggestionAutoCompleteText;
 
 import java.util.List;
+import java.util.Locale;
 
 import de.greenrobot.event.EventBus;
 
@@ -133,9 +133,7 @@ public class ReaderCommentListActivity extends AppCompatActivity {
 
         mCommentBox = (ViewGroup) findViewById(R.id.layout_comment_box);
         mEditComment = (SuggestionAutoCompleteText) mCommentBox.findViewById(R.id.edit_comment);
-        mEditComment.getAutoSaveTextHelper().setUniqueId(
-                String.format(LanguageUtils.getCurrentDeviceLanguage(this),
-                        "%s%d%d",
+        mEditComment.getAutoSaveTextHelper().setUniqueId(String.format(Locale.US, "%s%d%d",
                         AccountHelper.getCurrentUsernameForBlog(null), mPostId, mBlogId));
         mSubmitReplyBtn = mCommentBox.findViewById(R.id.btn_submit_reply);
 


### PR DESCRIPTION
Fix #4724: update the textview unique id when comment is updated

Before the fix, comment was null during `onCreateView` when CommentDetailFragment was created in Notifications.