### PR TITLE
Explicit locale during xml serialization/deserialization.

### DIFF
--- a/WordPress/src/main/java/org/xmlrpc/android/XMLRPCSerializer.java
+++ b/WordPress/src/main/java/org/xmlrpc/android/XMLRPCSerializer.java
@@ -26,6 +26,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SimpleTimeZone;
@@ -47,7 +48,7 @@ class XMLRPCSerializer {
     static final String TYPE_ARRAY = "array";
     static final String TYPE_STRUCT = "struct";
 
-    static SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd'T'HH:mm:ss");
+    static SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd'T'HH:mm:ss", Locale.US);
     static Calendar cal = Calendar.getInstance(new SimpleTimeZone(0, "GMT"));
 
     private static final XmlSerializer serializeTester;
@@ -90,7 +91,7 @@ class XMLRPCSerializer {
         } else
         if (object instanceof Date || object instanceof Calendar) {
             Date date = (Date) object;
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd'T'HH:mm:ss");
+            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd'T'HH:mm:ss", Locale.US);
             dateFormat.setCalendar(cal);
             String sDate = dateFormat.format(date);
             serializer.startTag(null, TYPE_DATE_TIME_ISO8601).text(sDate).endTag(null, TYPE_DATE_TIME_ISO8601);


### PR DESCRIPTION
Fixes #4620 

To test:
1. Switch device locale to Arabic or Farsi (Persian)
2. Edit any page
3. Make sure that last modified date on page is "Now".

This PR sets explicit locale during xml serialization/deserialization of Date. 
I checked some other places with SimpleDateFormat, and looks like this is the only place that causes problems.
