### PR TITLE
Improve notes moderation flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/NotificationsTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/NotificationsTable.java
@@ -95,8 +95,8 @@ public class NotificationsTable {
             }
 
             for (Note note: notes) {
-                // No need to check if the row already exists, since we've just dropped the table.
-                putNote(note, false);
+                // No need to check if the row already exists if we've just dropped the table.
+                putNote(note, !clearBeforeSaving);
             }
 
             getDb().setTransactionSuccessful();

--- a/WordPress/src/main/java/org/wordpress/android/datasets/NotificationsTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/NotificationsTable.java
@@ -60,20 +60,31 @@ public class NotificationsTable {
         return notes;
     }
 
-    public static boolean putNote(Note note) {
+    private static boolean putNote(Note note, boolean checkBeforeInsert) {
         ContentValues values = new ContentValues();
         values.put("type", note.getType());
         values.put("timestamp", note.getTimestamp());
-        values.put("raw_note_data", note.getJSON().toString()); // easiest way to store schema-less data
-        values.put("note_id", note.getId());
+        values.put("raw_note_data", note.getJSON().toString());
 
-        long result = getDb().insertWithOnConflict(NOTIFICATIONS_TABLE, null, values, SQLiteDatabase.CONFLICT_REPLACE);
-
-        if (result == -1) {
-            AppLog.e(AppLog.T.DB, "An error occurred while saving the note into the DB -  note_id:" + note.getId());
+        long result;
+        if(checkBeforeInsert && isNoteAvailable(note.getId())) {
+            // Update
+            String[] args = {note.getId()};
+            result = getDb().update(
+                    NOTIFICATIONS_TABLE,
+                    values,
+                    "note_id=?",
+                    args);
+            return result == 1;
+        }  else {
+            // insert
+            values.put("note_id", note.getId());
+            result = getDb().insertWithOnConflict(NOTIFICATIONS_TABLE, null, values, SQLiteDatabase.CONFLICT_REPLACE);
+            if (result == -1) {
+                AppLog.e(AppLog.T.DB, "An error occurred while saving the note into the DB -  note_id:" + note.getId());
+            }
+            return result != -1;
         }
-
-        return result != -1;
     }
 
     public static void saveNotes(List<Note> notes, boolean clearBeforeSaving) {
@@ -84,7 +95,8 @@ public class NotificationsTable {
             }
 
             for (Note note: notes) {
-                putNote(note);
+                // No need to check if the row already exists, since we've just dropped the table.
+                putNote(note, false);
             }
 
             getDb().setTransactionSuccessful();
@@ -93,15 +105,11 @@ public class NotificationsTable {
         }
     }
 
-    public static boolean saveNote(Note note, boolean shouldUpdate) {
+    public static boolean saveNote(Note note) {
         getDb().beginTransaction();
         boolean saved = false;
         try {
-             if (!shouldUpdate && isNoteAvailable(note.getId())) {
-                 // there is already a note with this ID in the database!
-                 return false;
-             }
-             saved = putNote(note);
+             saved = putNote(note, true);
              getDb().setTransactionSuccessful();
         } finally {
             getDb().endTransaction();

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -359,34 +359,13 @@ public class GCMMessageService extends GcmListenerService {
             if (!buildNoteObjectFromPNPayloadAndSaveIt(data)) {
                 // PN payload doesn't have the note or there was an error.
                 // Retrieve the Note obj by calling the REST API
-
-                WordPress.getRestClientUtilsV1_1().getNotification(
-                        wpcomNoteID,
+                NotificationsActions.downloadNoteAndUpdateDB(wpcomNoteID,
                         new RestRequest.Listener() {
                             @Override
                             public void onResponse(JSONObject response) {
-                                if (response == null) {
-                                    //Not sure this could ever happen, but make sure we're catching all response types
-                                    AppLog.w(AppLog.T.NOTIFS, "Success, but did not receive any notes");
-                                }
-                                try {
-                                    List<Note> notes = NotificationsActions.parseNotes(response);
-                                    if (notes.size() > 0) {
-                                        NotificationsTable.saveNote(notes.get(0), true);
-                                    } else {
-                                        AppLog.e(AppLog.T.NOTIFS, "Success, but no note!!!???");
-                                    }
-                                    EventBus.getDefault().post(new NotificationEvents.NotificationsChanged());
-                                } catch (JSONException e) {
-                                    AppLog.e(AppLog.T.NOTIFS, "Success, but can't parse the response for the note_id " + wpcomNoteID , e);
-                                }
+                                EventBus.getDefault().post(new NotificationEvents.NotificationsChanged());
                             }
-                        }, new RestRequest.ErrorListener() {
-                            @Override
-                            public void onErrorResponse(VolleyError error) {
-                                AppLog.e(AppLog.T.NOTIFS, "Error retrieving note with ID " + wpcomNoteID, error);
-                            }
-                        });
+                        }, null);
             } else {
                 EventBus.getDefault().post(new NotificationEvents.NotificationsChanged());
             }

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -17,12 +17,10 @@ import android.support.v4.app.RemoteInput;
 import android.support.v4.util.ArrayMap;
 import android.text.TextUtils;
 
-import com.android.volley.VolleyError;
 import com.google.android.gms.gcm.GcmListenerService;
 import com.wordpress.rest.RestRequest;
 
 import org.apache.commons.lang.StringEscapeUtils;
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -53,7 +51,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -330,7 +327,7 @@ public class GCMMessageService extends GcmListenerService {
                 String base64FullData = data.getString(PUSH_ARG_NOTE_FULL_DATA);
                 Note note = Note.buildFromBase64EncodedData(noteId, base64FullData);
                 if (note != null) {
-                    return NotificationsTable.saveNote(note, true);
+                    return NotificationsTable.saveNote(note);
                 }
             }
 
@@ -356,7 +353,7 @@ public class GCMMessageService extends GcmListenerService {
 
             // Always do this, since a note can be updated!!
             // The PN payload 99% of times contains the most recent version of the note.
-            if (!buildNoteObjectFromPNPayloadAndSaveIt(data)) {
+             if (!buildNoteObjectFromPNPayloadAndSaveIt(data)) {
                 // PN payload doesn't have the note or there was an error.
                 // Retrieve the Note obj by calling the REST API
                 NotificationsActions.downloadNoteAndUpdateDB(wpcomNoteID,

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -353,7 +353,7 @@ public class GCMMessageService extends GcmListenerService {
 
             // Always do this, since a note can be updated!!
             // The PN payload 99% of times contains the most recent version of the note.
-             if (!buildNoteObjectFromPNPayloadAndSaveIt(data)) {
+            if (!buildNoteObjectFromPNPayloadAndSaveIt(data)) {
                 // PN payload doesn't have the note or there was an error.
                 // Retrieve the Note obj by calling the REST API
                 NotificationsActions.downloadNoteAndUpdateDB(wpcomNoteID,

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -9,13 +9,18 @@ import android.text.TextUtils;
 import android.view.MenuItem;
 import android.view.WindowManager;
 
-import org.wordpress.android.push.GCMMessageService;
+import com.android.volley.VolleyError;
+import com.wordpress.rest.RestRequest;
+
+import org.json.JSONObject;
 import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.datasets.NotificationsTable;
 import org.wordpress.android.models.AccountHelper;
 import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.models.Note;
+import org.wordpress.android.push.GCMMessageService;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.comments.CommentActions;
@@ -35,6 +40,7 @@ import org.wordpress.android.util.ToastUtils;
 
 import java.util.HashMap;
 import java.util.Map;
+
 import de.greenrobot.event.EventBus;
 
 import static org.wordpress.android.models.Note.NOTE_COMMENT_LIKE_TYPE;
@@ -71,6 +77,24 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
                 showErrorToastAndFinish();
                 return;
             }
+
+            // If `note.getTimestamp()` is not the most recent seen note, the server will discard the value.
+            WordPress.getRestClientUtilsV1_1().markNotificationsSeen(
+                    String.valueOf(note.getTimestamp()),
+                    new RestRequest.Listener() {
+                        @Override
+                        public void onResponse(JSONObject response) {
+                            // Assuming that we've marked the most recent notification as seen. (Beware, seen != read).
+                            EventBus.getDefault().post(new NotificationEvents.NotificationsUnseenStatus(false));
+                        }
+                    },
+                    new RestRequest.ErrorListener() {
+                        @Override
+                        public void onErrorResponse(VolleyError error) {
+                            AppLog.e(AppLog.T.NOTIFS, "Could not mark notifications/seen' value via API.", error);
+                        }
+                    }
+            );
 
             Map<String, String> properties = new HashMap<>();
             properties.put("notification_type", note.getType());

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -134,12 +134,12 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
                 getSupportActionBar().setTitle(title);
             }
 
-            NotificationsActions.markNoteAsRead(note);
             GCMMessageService.removeNotificationWithNoteIdFromSystemBar(this, noteId);
             // mark the note as read if it's unread
             if (note.isUnread()) {
+                NotificationsActions.markNoteAsRead(note);
                 note.setRead();
-                NotificationsTable.putNote(note);
+                NotificationsTable.saveNote(note);
                 EventBus.getDefault().post(new NotificationEvents.NotificationsChanged());
             }
         } else if (savedInstanceState.containsKey(ARG_TITLE) && getSupportActionBar() != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -572,7 +572,7 @@ public class NotificationsListFragment extends Fragment
             return;
         }
         mRestoredScrollNoteID = getFirstVisibleItemID(); // Remember the ID of the first note visible on the screen
-        getNotesAdapter().reloadNotesFromDBAsync();
+ //       getNotesAdapter().reloadNotesFromDBAsync();
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -572,7 +572,7 @@ public class NotificationsListFragment extends Fragment
             return;
         }
         mRestoredScrollNoteID = getFirstVisibleItemID(); // Remember the ID of the first note visible on the screen
- //       getNotesAdapter().reloadNotesFromDBAsync();
+        getNotesAdapter().reloadNotesFromDBAsync();
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -90,7 +90,9 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
 
     public void removeModeratingNoteId(String noteId) {
         mModeratingNoteIds.remove(noteId);
-        myNotifyDatasetChanged();
+        // Reload the notifications from DB since the state of at least one of them is changed.
+        // DB already has the fresh value in it.
+        reloadNotesFromDBAsync();
     }
 
     public void addAll(List<Note> notes, boolean clearBeforeAdding) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsActions.java
@@ -60,7 +60,7 @@ public class NotificationsActions {
                 @Override
                 public void onResponse(JSONObject response) {
                     note.setRead();
-                    NotificationsTable.putNote(note);
+                    NotificationsTable.saveNote(note);
                 }
             }, new RestRequest.ErrorListener() {
                 @Override
@@ -84,7 +84,7 @@ public class NotificationsActions {
                         try {
                             List<Note> notes = NotificationsActions.parseNotes(response);
                             if (notes.size() > 0) {
-                                NotificationsTable.saveNote(notes.get(0), true);
+                                NotificationsTable.saveNote(notes.get(0));
                             } else {
                                 AppLog.e(AppLog.T.NOTIFS, "Success, but no note!!!???");
                             }


### PR DESCRIPTION
Update the note in the DB when the moderation ends with success, and refresh the UI immediately.
Previously we were waiting for a full refresh of notes. Note that the full refresh is still there, and it's OK to have it in place to catch glitches.

cc @roundhill Since you've worked on this feature a lot before Simperium.

cc @mzorz @kwonye 


