### PR TITLE
Adds .bak to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ WordPress/src/main/res/values/com_crashlytics_export_strings.xml
 WordPress/src/androidTest/monkeys/settings.py
 *.pyc
 WordPress/src/androidTest/monkeys/*.png
+
+# Windows Backup
+*.bak


### PR DESCRIPTION
The indexing fix we're using that @maxme proposed has been creating .bak files on Windows which has been driving me crazy. So, just adding it to `.gitignore` so I don't have to deal with again. (well, at least after `develop` is merged into other branches :sigh:)