### PR TITLE
[Remove - Simperium] Remove deleted note from local DB

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/NotificationsTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/NotificationsTable.java
@@ -129,18 +129,18 @@ public class NotificationsTable {
                 args);
     }
 
-    public static Note getNoteById(String id) {
-        if (TextUtils.isEmpty(id)) {
-            AppLog.e(AppLog.T.DB, "Asking for a note with null Id. Really?" + id);
+    public static Note getNoteById(String noteID) {
+        if (TextUtils.isEmpty(noteID)) {
+            AppLog.e(AppLog.T.DB, "Asking for a note with null Id. Really?" + noteID);
             return null;
         }
-        Cursor cursor = getDb().query(NOTIFICATIONS_TABLE, new String[] {"raw_note_data"},  "note_id=" + id, null, null, null, null);
+        Cursor cursor = getDb().query(NOTIFICATIONS_TABLE, new String[] {"raw_note_data"},  "note_id=" + noteID, null, null, null, null);
         try {
             if (cursor.moveToFirst()) {
                 JSONObject jsonNote = new JSONObject(cursor.getString(0));
-                return new Note(id, jsonNote);
+                return new Note(noteID, jsonNote);
             } else {
-                AppLog.v(AppLog.T.DB, "No Note found in the DB with this id: " + id);
+                AppLog.v(AppLog.T.DB, "No Note found in the DB with this id: " + noteID);
                 return null;
             }
         } catch (JSONException e) {
@@ -151,6 +151,22 @@ public class NotificationsTable {
             return null;
         } finally {
             cursor.close();
+        }
+    }
+
+    public static boolean deleteNoteById(String noteID) {
+        if (TextUtils.isEmpty(noteID)) {
+            AppLog.e(AppLog.T.DB, "Asking to delete a note with null Id. Really?" + noteID);
+            return false;
+        }
+        getDb().beginTransaction();
+        try {
+            String[] args = {noteID};
+            int result = getDb().delete(NOTIFICATIONS_TABLE, "note_id=?", args);
+            getDb().setTransactionSuccessful();
+            return result != 0;
+        } finally {
+            getDb().endTransaction();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -35,6 +35,7 @@ import org.json.JSONObject;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.datasets.NotificationsTable;
 import org.wordpress.android.datasets.ReaderPostTable;
 import org.wordpress.android.models.AccountHelper;
 import org.wordpress.android.models.Blog;
@@ -489,8 +490,8 @@ public class NotificationsUtils {
         Snackbar snackbar = Snackbar.make(parentView, message, Snackbar.LENGTH_LONG)
                 .setAction(R.string.undo, undoListener);
 
-        // Deleted notifications in Simperium never come back, so we won't
-        // make the request until the undo bar fades away
+
+
         snackbar.setCallback(new Snackbar.Callback() {
             @Override
             public void onDismissed(Snackbar snackbar, int event) {
@@ -498,6 +499,8 @@ public class NotificationsUtils {
                 if (mSnackbarDidUndo) {
                     return;
                 }
+                // Delete the notifications from the local DB as soon as the undo bar fades away.
+                NotificationsTable.deleteNoteById(note.getId());
                 CommentActions.moderateCommentForNote(note, status,
                         new CommentActions.CommentActionListener() {
                             @Override


### PR DESCRIPTION
We should remove the local copy of the trashed note as soon as possible. Don't need to wait the end of the network call, since it could take time and the user could rotate the device, go back and forth in notifications, and the note could be again there in the list.

cc @roundhill 

