### PR TITLE
Helpshift FAQ should fallback to English version

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
@@ -91,6 +91,7 @@ public class HelpshiftHelper {
     public static void init(Application application) {
         InstallConfig installConfig = new InstallConfig.Builder()
                 .setEnableInAppNotification(true)
+                .setEnableDefaultFallbackLanguage(true)
                 .build();
         Core.init(Support.getInstance());
         try {


### PR DESCRIPTION
Fixes #4758.

To test:
* Change your device language to something other than English
* Make sure the FAQ section shows up in Help page

Credit goes to @rachelmcr for this fix :)
