### PR TITLE
Issue/4755 quick actions wrap up

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -308,7 +308,10 @@ public class GCMMessageService extends GcmListenerService {
     }
 
     private boolean canAddActionsToNotifications() {
-        return (!isDeviceLocked() && !isWPPinLockEnabled());
+        if (isWPPinLockEnabled()) {
+            return !isDeviceLocked();
+        }
+        return true;
     }
 
     private boolean isWPPinLockEnabled() {

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -69,6 +69,7 @@ public class GCMMessageService extends GcmListenerService {
     public static final int ACTIONS_PROGRESS_NOTIFICATION_ID = 50000;
     private static final int AUTH_PUSH_REQUEST_CODE_APPROVE = 0;
     private static final int AUTH_PUSH_REQUEST_CODE_IGNORE = 1;
+    private static final int AUTH_PUSH_REQUEST_CODE_OPEN_DIALOG = 2;
     public static final String EXTRA_VOICE_OR_INLINE_REPLY = "extra_voice_or_inline_reply";
     private static final int MAX_INBOX_ITEMS = 5;
 
@@ -944,21 +945,29 @@ public class GCMMessageService extends GcmListenerService {
                     .setStyle(new NotificationCompat.BigTextStyle().bigText(message))
                     .setPriority(NotificationCompat.PRIORITY_MAX);
 
-            PendingIntent pendingIntent = PendingIntent.getActivity(context, 1, pushAuthIntent,
+            PendingIntent pendingIntent = PendingIntent.getActivity(context, AUTH_PUSH_REQUEST_CODE_OPEN_DIALOG, pushAuthIntent,
                     PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_UPDATE_CURRENT);
             builder.setContentIntent(pendingIntent);
 
 
             if (canAddActionsToNotifications()) {
                 // adding ignore / approve quick actions
-                Intent authApproveIntent = new Intent(context, NotificationsProcessingService.class);
+                Intent authApproveIntent = new Intent(context, WPMainActivity.class);
+                authApproveIntent.putExtra(WPMainActivity.ARG_OPENED_FROM_PUSH, true);
                 authApproveIntent.putExtra(NotificationsProcessingService.ARG_ACTION_TYPE, NotificationsProcessingService.ARG_ACTION_AUTH_APPROVE);
                 authApproveIntent.putExtra(NotificationsUtils.ARG_PUSH_AUTH_TOKEN, pushAuthToken);
                 authApproveIntent.putExtra(NotificationsUtils.ARG_PUSH_AUTH_TITLE, title);
                 authApproveIntent.putExtra(NotificationsUtils.ARG_PUSH_AUTH_MESSAGE, message);
                 authApproveIntent.putExtra(NotificationsUtils.ARG_PUSH_AUTH_EXPIRES, expirationTimestamp);
-                PendingIntent authApprovePendingIntent =  PendingIntent.getService(context,
-                        AUTH_PUSH_REQUEST_CODE_APPROVE, authApproveIntent, PendingIntent.FLAG_CANCEL_CURRENT);
+
+                authApproveIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK
+                        | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+                authApproveIntent.setAction("android.intent.action.MAIN");
+                authApproveIntent.addCategory("android.intent.category.LAUNCHER");
+
+                PendingIntent authApprovePendingIntent = PendingIntent.getActivity(context, AUTH_PUSH_REQUEST_CODE_APPROVE, authApproveIntent,
+                        PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_UPDATE_CURRENT);
+
                 builder.addAction(R.drawable.ic_action_approve, getText(R.string.approve),
                         authApprovePendingIntent);
 


### PR DESCRIPTION
Fixes #4755 

To test:
CASE A: comment notifications, WP PIN disabled
1. log in to the WPAndroid app
2. have another account comment on a post of your own
3. check the notification has REPLY/APPROVE or REPLY/LIKE quick actions set (depending on your blog's moderation settings).
4.  lock the phone screen and check the quick actions for such notification are still in place
5. unlock the phone screen and check the quick actions for such notification are still in place


CASE B: comment notifications, WP PIN enabled
1. log in to the WPAndroid app
2. have another account comment on a post of your own
3. check the notification has REPLY/APPROVE or REPLY/LIKE quick actions set (depending on your blog's moderation settings).
4.  lock the phone screen and check the quick actions for such notification are gone
5. unlock the phone screen and check the quick actions for such notification are there again


CASE C: 2fa push notification
1. log in to the WPAndroid app
2. try to log in to wp.com using 2fa
3. upon receiving the 2fa notification, check it has the APPROVE/IGNORE actions
4. with the screen locked, tapping on APPROVE or on the notification body will prompt the android screen unlock gesture/pin to the user
5. enter your pin / unlock gesture and:
5.a if you tapped on the notification body, the push auth dialog appears as usual, with a message and APPROVE/IGNORE actions again
5.b if you tapped on the APPROVE quick action, the app opens on the notification list and the approval message is sent to the backend in the background.

cc @kwonye @daniloercoli 