### PR TITLE
Add Two-Step Authentication Code Automatically if Present

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -240,11 +240,9 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
 
                 @Override
                 public void onPaste() {
-                    String code = getAuthCodeFromClipboard();
+                    mTwoStepEditText.setText(getAuthCodeFromClipboard());
 
-                    if (!TextUtils.isEmpty(code)) {
-                        mTwoStepEditText.setText(code);
-                    } else {
+                    if (TextUtils.isEmpty(mTwoStepEditText.getText().toString())) {
                         showTwoStepCodeError(R.string.invalid_verification_code_format);
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/widgets/ContextMenuEditText.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/ContextMenuEditText.java
@@ -1,0 +1,86 @@
+package org.wordpress.android.widgets;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+/**
+ * WPEditText which notifies when text is cut, copied, or pasted.
+ */
+public class ContextMenuEditText extends WPEditText {
+    public interface OnContextMenuListener {
+        void onCut();
+        void onCopy();
+        void onPaste();
+    }
+
+    private OnContextMenuListener mOnContextMenuListener;
+
+    /**
+     * Set a listener to interface with activity or fragment.
+     * @param listener object listening for cut, copy, and paste events
+     */
+    public void setOnContextMenuListener(OnContextMenuListener listener) {
+        mOnContextMenuListener = listener;
+    }
+
+    public ContextMenuEditText(Context context) {
+        super(context);
+    }
+
+    public ContextMenuEditText(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public ContextMenuEditText(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    /**
+     * ContextMenu used to cut, copy, or paste which overwrites the consuming method.
+     */
+    @Override
+    public boolean onTextContextMenuItem(int id) {
+        boolean consumed = super.onTextContextMenuItem(id);
+
+        switch (id) {
+            case android.R.id.cut:
+                onCut();
+                break;
+            case android.R.id.copy:
+                onCopy();
+                break;
+            case android.R.id.paste:
+                onPaste();
+                break;
+        }
+
+        return consumed;
+    }
+
+    /**
+     * Text cut from WPEditText.
+     */
+    public void onCut(){
+        if (mOnContextMenuListener != null) {
+            mOnContextMenuListener.onCut();
+        }
+    }
+
+    /**
+     * Text copied from WPEditText.
+     */
+    public void onCopy(){
+        if (mOnContextMenuListener != null) {
+            mOnContextMenuListener.onCopy();
+        }
+    }
+
+    /**
+     * Text pasted into WPEditText.
+     */
+    public void onPaste(){
+        if (mOnContextMenuListener != null) {
+            mOnContextMenuListener.onPaste();
+        }
+    }
+}

--- a/WordPress/src/main/res/layout/signin_fragment.xml
+++ b/WordPress/src/main/res/layout/signin_fragment.xml
@@ -165,7 +165,7 @@
                 android:animateLayoutChanges="true"
                 android:visibility="gone">
 
-                <org.wordpress.android.widgets.WPEditText
+                <org.wordpress.android.widgets.ContextMenuEditText
                     android:id="@+id/nux_two_step"
                     style="@style/WordPress.NUXEditText"
                     android:layout_width="fill_parent"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1307,6 +1307,7 @@
     <string name="ptr_tip_message">Tip: Pull down to refresh</string>
     <string name="verification_code">Verification code</string>
     <string name="invalid_verification_code">Invalid verification code</string>
+    <string name="invalid_verification_code_format">Must be six-digit number</string>
     <string name="verify">Verify</string>
     <string name="two_step_footer_label">Enter the code from your authenticator app.</string>
     <string name="two_step_footer_button">Send code via text message</string>


### PR DESCRIPTION
### Fix
If a six-digit number is copied to the device clipboard, it will be automatically inserted into the two-step authentication code verification field when the field is empty.  This occurs when first presenting the two-step authentication code verification field on the Login screen and when resuming the WordPress app from another app.

### Test
0. Enable two-step authentication for account.
1. Enter username and password in <i><b>Login</b></i> screen.
2. Notice <i><b>Verification code</b></i> field is empty.
3. Exit WordPress app.
4. Copy first six-digit number from another app (e.g. Google Authenticator).
5. Open WordPress app.
6. Notice <i><b>Verification code</b></i> field is filled with first number.
7. Exit WordPress app.
8. Copy second six-digit number from another app (e.g. Google Authenticator).
9. Open WordPress app.
10. Notice <i><b>Verification code</b></i> field is filled with first number.
11. Delete first number from <i><b>Verification code</b></i> field.
12. Exit WordPress app.
13. Open WordPress app.
14. Notice <i><b>Verification code</b></i> field is filled with second number.
15. Delete second number from <i><b>Verification code</b></i> field.
16. Exit WordPress app.
17. Copy text which is not a six-digit number from another app (e.g. Simplenote).
18. Open WordPress app.
19. Notice <i><b>Verification code</b></i> field is empty.