### PR TITLE
Make sure Stats service receive a valid list of sections to update be…

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -241,7 +241,14 @@ public class StatsService extends Service {
 
         final String blogId = intent.getStringExtra(ARG_BLOG_ID);
         if (TextUtils.isEmpty(blogId)) {
-            AppLog.e(T.STATS, "StatsService was started with a blank blog_id ");
+            AppLog.e(T.STATS, "StatsService was started with a blank blog_id");
+            return START_NOT_STICKY;
+        }
+
+        int[] sectionFromIntent = intent.getIntArrayExtra(ARG_SECTION);
+        if (sectionFromIntent == null || sectionFromIntent.length == 0) {
+            // No sections to update
+            AppLog.e(T.STATS, "StatsService was started without valid sections info");
             return START_NOT_STICKY;
         }
 
@@ -265,8 +272,6 @@ public class StatsService extends Service {
 
         final int maxResultsRequested = intent.getIntExtra(ARG_MAX_RESULTS, DEFAULT_NUMBER_OF_RESULTS);
         final int pageRequested = intent.getIntExtra(ARG_PAGE_REQUESTED, -1);
-
-        int[] sectionFromIntent = intent.getIntArrayExtra(ARG_SECTION);
 
         this.mServiceStartId = startId;
         for (int i=0; i < sectionFromIntent.length; i++){


### PR DESCRIPTION
Fixes #4791 by adding a null-check on the requested sections in StatsService.
I've tried to replicate the issue with no luck. Tried by using self-hosted, wpcom, and Jetpack test sites on a 4.x device.
