### PR TITLE
Mark the note as read upon quick-actions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NotificationsProcessingService.java
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.comments.CommentActionResult;
 import org.wordpress.android.ui.comments.CommentActions;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
+import org.wordpress.android.ui.notifications.utils.NotificationsActions;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.util.AppLog;
 
@@ -37,7 +38,6 @@ import static org.wordpress.android.push.GCMMessageService.ACTIONS_RESULT_NOTIFI
 import static org.wordpress.android.push.GCMMessageService.AUTH_PUSH_NOTIFICATION_ID;
 import static org.wordpress.android.push.GCMMessageService.EXTRA_VOICE_OR_INLINE_REPLY;
 import static org.wordpress.android.push.GCMMessageService.GROUP_NOTIFICATION_ID;
-import static org.wordpress.android.push.GCMMessageService.PUSH_ARG_NOTE_FULL_DATA;
 import static org.wordpress.android.ui.notifications.NotificationsListFragment.NOTE_INSTANT_REPLY_EXTRA;
 
 /**
@@ -331,6 +331,8 @@ public class NotificationsProcessingService extends Service {
                 //show generic success message here
                 successMessage = getString(R.string.comment_q_action_done_generic);
             }
+
+            NotificationsActions.markNoteAsRead(mNote);
 
             //dismiss any other pending result notification
             dismissNotification(ACTIONS_RESULT_NOTIFICATION_ID);


### PR DESCRIPTION
Fixes #4790

To test: 
- As usual, make a comment with another account on a test blog. 
- Receive the PN and (quick-reply|quick-like|approve) the note. 
- Open the app, and go to notifications. The note should be marked as read.
