### PR TITLE
issue/4802-reader-single-line-dividers

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -94,7 +94,7 @@ public class PostsListFragment extends Fragment
         Context context = getActivity();
         mRecyclerView.setLayoutManager(new LinearLayoutManager(context));
 
-        int spacingVertical = mIsPage ? 0 : context.getResources().getDimensionPixelSize(R.dimen.reader_card_gutters);
+        int spacingVertical = mIsPage ? 0 : context.getResources().getDimensionPixelSize(R.dimen.card_gutters);
         int spacingHorizontal = context.getResources().getDimensionPixelSize(R.dimen.content_margin);
         mRecyclerView.addItemDecoration(new RecyclerItemDecoration(spacingHorizontal, spacingVertical));
 

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -11,7 +11,7 @@
     android:stateListAnimator="@anim/pressed_card"
     card_view:cardBackgroundColor="@color/white"
     card_view:cardCornerRadius="@dimen/cardview_default_radius"
-    card_view:cardElevation="@dimen/card_elevation"
+    card_view:cardElevation="@dimen/reader_card_elevation"
     tools:targetApi="LOLLIPOP">
 
     <LinearLayout

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -18,6 +18,7 @@
 
     <dimen name="card_elevation">2dp</dimen>
     <dimen name="card_elevation_pressed">8dp</dimen>
+    <dimen name="card_gutters">12dp</dimen>
 
     <dimen name="message_bar_elevation">2dp</dimen>
     <dimen name="tabs_elevation">4dp</dimen>
@@ -90,8 +91,8 @@
 
     <dimen name="reader_thumbnail_strip_image_size">48dp</dimen>
 
-    <!-- height of divider between cards -->
-    <dimen name="reader_card_gutters">12dp</dimen>
+    <dimen name="reader_card_gutters">1dp</dimen>
+    <dimen name="reader_card_elevation">0dp</dimen>
 
     <!-- padding inside the card (space between card border and card content) -->
     <dimen name="reader_card_content_padding">16dp</dimen>


### PR DESCRIPTION
Fixes #4802 - changes cards in the reader stream to have 1dp dividers to better match the Calypso reader. Note that this is part of the reader stream refresh.

