### PR TITLE
Add additional checks on "new notifs" button

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -596,13 +596,15 @@ public class NotificationsListFragment extends Fragment
 
     private void showNewUnseenNotificationsUI() {
         if (!isAdded()) return;
-        mRecyclerView.clearOnScrollListeners(); // Just one listener. Multiple notes received here add multiple listeners.
 
-        if(!isFirstItemVisible()) {
-            showNewNotificationsBar();
+        // Make sure the RecyclerView is configured
+        if (mRecyclerView == null || mRecyclerView.getLayoutManager() == null) {
+            return;
         }
 
-        // assign the scroll listener to hide the bar when the recycler is scrolled, but don't assign
+        mRecyclerView.clearOnScrollListeners(); // Just one listener. Multiple notes received here add multiple listeners.
+
+        // Assign the scroll listener to hide the bar when the recycler is scrolled, but don't assign
         // it right away since the user may be scrolling when the bar appears (which would cause it
         // to disappear as soon as it's displayed)
         mRecyclerView.postDelayed(new Runnable() {
@@ -614,7 +616,15 @@ public class NotificationsListFragment extends Fragment
             }
         }, 1000L);
 
+        View child = mRecyclerView.getLayoutManager().getChildAt(0);
+        if (child == null) {
+            return;
+        }
 
+        // Check if the first item is visible on the screen
+        if (mRecyclerView.getLayoutManager().getPosition(child) > 0) {
+            showNewNotificationsBar();
+        }
     }
 
     /*
@@ -653,19 +663,5 @@ public class NotificationsListFragment extends Fragment
             public void onAnimationRepeat(Animation animation) { }
         };
         AniUtils.startAnimation(mNewNotificationsBar, R.anim.notifications_bottom_bar_out, listener);
-    }
-
-    /*
-     * returns true if the first item is still visible in the RecyclerView - will return
-     * false if the first item is scrolled out of view, or if the list is empty
-     */
-    private boolean isFirstItemVisible() {
-        if (mRecyclerView == null
-                || mRecyclerView.getLayoutManager() == null) {
-            return false;
-        }
-
-        View child = mRecyclerView.getLayoutManager().getChildAt(0);
-        return (child != null && mRecyclerView.getLayoutManager().getPosition(child) == 0);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -616,13 +616,9 @@ public class NotificationsListFragment extends Fragment
             }
         }, 1000L);
 
-        View child = mRecyclerView.getLayoutManager().getChildAt(0);
-        if (child == null) {
-            return;
-        }
-
         // Check if the first item is visible on the screen
-        if (mRecyclerView.getLayoutManager().getPosition(child) > 0) {
+        View child = mRecyclerView.getLayoutManager().getChildAt(0);
+        if (child != null && mRecyclerView.getLayoutManager().getPosition(child) > 0) {
             showNewNotificationsBar();
         }
     }


### PR DESCRIPTION
Refactored the code that's used to show the "New Notifications" button. This should fix the issue where the "New Notifs" button is shown on the screen at startup.

In details, I've removed the method `isFirstItemVisible` since it was returning the value `false` when the RecyclerView wasn't yet configured, and moved the code that checks if the first item is visible on the screen in `showNewUnseenNotificationsUI`.

@mzorz 