### PR TITLE
changes use of Fragment for support.v4 fragments to make use of nested fragments in API < 17

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -2,9 +2,9 @@ package org.wordpress.android.ui.comments;
 
 import android.app.Activity;
 import android.app.AlertDialog;
-import android.app.Fragment;
-import android.app.FragmentManager;
-import android.app.FragmentTransaction;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
@@ -629,7 +629,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             }
         }
 
-        getFragmentManager().invalidateOptionsMenu();
+        getActivity().invalidateOptionsMenu();
     }
 
     /*
@@ -1088,7 +1088,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
 
         setComment(localBlogId, note.buildComment());
 
-        getFragmentManager().invalidateOptionsMenu();
+        getActivity().invalidateOptionsMenu();
     }
 
     // Like or unlike a comment via the REST API

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -1,9 +1,9 @@
 package org.wordpress.android.ui.comments;
 
 import android.app.Dialog;
-import android.app.Fragment;
-import android.app.FragmentManager;
-import android.app.FragmentTransaction;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -21,7 +21,6 @@ import org.wordpress.android.models.CommentList;
 import org.wordpress.android.models.CommentStatus;
 import org.wordpress.android.models.Note;
 import org.wordpress.android.ui.ActivityId;
-import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.comments.CommentsListFragment.OnCommentSelectedListener;
 import org.wordpress.android.ui.notifications.NotificationFragment;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -71,7 +70,7 @@ public class CommentsActivity extends AppCompatActivity
             CommentsListFragment commentsListFragment = new CommentsListFragment();
             // initialize comment status filter first time
             commentsListFragment.setCommentStatusFilter(mCurrentCommentStatusType);
-            getFragmentManager().beginTransaction()
+            getSupportFragmentManager().beginTransaction()
                     .add(R.id.layout_fragment_container, commentsListFragment, getString(R.string
                             .fragment_tag_comment_list))
                     .commitAllowingStateLoss();
@@ -107,7 +106,7 @@ public class CommentsActivity extends AppCompatActivity
 
 
     private CommentDetailFragment getDetailFragment() {
-        Fragment fragment = getFragmentManager().findFragmentByTag(getString(
+        Fragment fragment = getSupportFragmentManager().findFragmentByTag(getString(
                 R.string.fragment_tag_comment_detail));
         if (fragment == null) {
             return null;
@@ -120,7 +119,7 @@ public class CommentsActivity extends AppCompatActivity
     }
 
     private CommentsListFragment getListFragment() {
-        Fragment fragment = getFragmentManager().findFragmentByTag(getString(
+        Fragment fragment = getSupportFragmentManager().findFragmentByTag(getString(
                 R.string.fragment_tag_comment_list));
         if (fragment == null) {
             return null;
@@ -133,7 +132,7 @@ public class CommentsActivity extends AppCompatActivity
     }
 
     private void showReaderFragment(long remoteBlogId, long postId) {
-        FragmentManager fm = getFragmentManager();
+        FragmentManager fm = getSupportFragmentManager();
         fm.executePendingTransactions();
 
         Fragment fragment = ReaderPostDetailFragment.newInstance(remoteBlogId, postId);
@@ -153,7 +152,7 @@ public class CommentsActivity extends AppCompatActivity
     @Override
     public void onCommentSelected(long commentId) {
         mSelectedCommentId = commentId;
-        FragmentManager fm = getFragmentManager();
+        FragmentManager fm = getSupportFragmentManager();
         if (fm == null) return;
 
         fm.executePendingTransactions();
@@ -230,7 +229,7 @@ public class CommentsActivity extends AppCompatActivity
 
     @Override
     public void onModerateComment(final int accountId, final Comment comment, final CommentStatus newStatus) {
-        FragmentManager fm = getFragmentManager();
+        FragmentManager fm = getSupportFragmentManager();
         if (fm.getBackStackEntryCount() > 0) {
             fm.popBackStack();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -1,7 +1,7 @@
 package org.wordpress.android.ui.comments;
 
 import android.app.AlertDialog;
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 import android.content.DialogInterface;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -1,11 +1,11 @@
 package org.wordpress.android.ui.notifications;
 
-import android.app.Fragment;
-import android.app.FragmentManager;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Parcelable;
-import android.support.v13.app.FragmentStatePagerAdapter;
+import android.support.v4.app.FragmentStatePagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -229,11 +229,11 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
         if (allowNavigateList) {
             //apply filter to the list so we show the same items that the list show vertically, but horizontally
             NotesAdapter.buildFilteredNotesList(filteredNotes, notes, filter);
-            adapter = new NotificationDetailFragmentAdapter(getFragmentManager(), filteredNotes);
+            adapter = new NotificationDetailFragmentAdapter(getSupportFragmentManager(), filteredNotes);
         } else {
             ArrayList<Note> oneNoteList = new ArrayList<>();
             oneNoteList.add(note);
-            adapter = new NotificationDetailFragmentAdapter(getFragmentManager(),
+            adapter = new NotificationDetailFragmentAdapter(getSupportFragmentManager(),
                     oneNoteList);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -3,7 +3,7 @@
  */
 package org.wordpress.android.ui.notifications;
 
-import android.app.ListFragment;
+import android.support.v4.app.ListFragment;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -1,7 +1,7 @@
 package org.wordpress.android.ui.reader;
 
 import android.app.Activity;
-import android.app.Fragment;
+import android.support.v4.app.Fragment;
 import android.content.Intent;
 import android.graphics.Rect;
 import android.os.AsyncTask;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -1,14 +1,14 @@
 package org.wordpress.android.ui.reader;
 
 import android.app.Activity;
-import android.app.Fragment;
-import android.app.FragmentManager;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
-import android.support.v13.app.FragmentStatePagerAdapter;
+import android.support.v4.app.FragmentStatePagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -622,7 +622,7 @@ public class ReaderPostPagerActivity extends AppCompatActivity
                     public void run() {
                         AppLog.d(AppLog.T.READER, "reader pager > creating adapter");
                         PostPagerAdapter adapter =
-                                new PostPagerAdapter(getFragmentManager(), idList);
+                                new PostPagerAdapter(getSupportFragmentManager(), idList);
                         mViewPager.setAdapter(adapter);
                         if (adapter.isValidPosition(newPosition)) {
                             mViewPager.setCurrentItem(newPosition);


### PR DESCRIPTION
@nbradbury  @daniloercoli  thanks for chiming in regarding on that PR #4796 - wondering how to cope with the `getChildFragmentManager` and API min stuff. I realized I could get away with it by using the supportv4 library version of Fragment and related classes, but then it seems I need to change references in several parts of the app (from `Fragment` to `app.v4.Fragment` and such). 

At this point I think I need some more information from what you guys have seen in the past and whether you think it's ok to go the support.v4 way or not, and why. For that, I prepared this new PR so we can discuss that specific problem in isolation. Please feel free to make any comments (even ditching this PR completely if needed) so I can learn what the best way to go forward is :)
