### PR TITLE
Deleted notification can result in blank screen when resumed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -3,6 +3,7 @@
  */
 package org.wordpress.android.ui.notifications;
 
+import android.app.Activity;
 import android.app.ListFragment;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -39,6 +40,7 @@ import org.wordpress.android.ui.reader.services.ReaderCommentService;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.JSONUtils;
+import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.widgets.WPNetworkImageView.ImageType;
 
 import java.util.ArrayList;
@@ -144,14 +146,30 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
         mNote = note;
     }
 
-    private boolean setNoteWithNoteId(String noteId) {
+    private void setNoteWithNoteId(String noteId) {
         Note note = NotificationsTable.getNoteById(noteId);
         if (note != null) {
             mIsUnread = note.isUnread();
             setNote(note);
-            return true;
         }
-        return false;
+    }
+
+    private void showErrorToastAndFinish() {
+        AppLog.e(AppLog.T.NOTIFS, "Note could not be found.");
+        if (getActivity() != null) {
+            ToastUtils.showToast(getActivity(), R.string.error_notification_open);
+            getActivity().finish();
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+
+        if (getNote() == null) {
+            showErrorToastAndFinish();
+        }
     }
 
     @Override


### PR DESCRIPTION
There is an edge case when a notification is deleted outside the app, and the app was left open on the notification details page resulting in a blank page.

There different ways to repro this issue, the most common is described below:
- Open the app
- Open a comment notification
- Stay in the details screen and tap the home button
- Delete the comment notification on the web
- Resume the app in FG (The notification is still there)
- On resume the synch service starts and synchs notes. The note you're seeing on the screen is removed from the DB
- (Now any action on the note results on a server error)
- Close the app again
- Reopen the app, now the details screen is empty. (*with this patch in, a toast is shown and the activity closed).


cc @mzorz Using your branch (notifs up/down) as base.