### PR TITLE
Media library image editor enhancements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -468,8 +468,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
     public void onSavedEdit(String mediaId, boolean result) {
         if (mMediaEditFragment != null && mMediaEditFragment.isVisible() && result) {
-            FragmentManager fm = getFragmentManager();
-            fm.popBackStack();
+            doPopBackStack(getFragmentManager());
 
             // refresh media item details (phone-only)
             if (mMediaItemFragment != null)
@@ -552,7 +551,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                 if (mMediaEditFragment.isInLayout()) {
                     mMediaEditFragment.loadMedia(null);
                 } else {
-                    getFragmentManager().popBackStack();
+                    doPopBackStack(getFragmentManager());
                 }
             }
         }
@@ -575,7 +574,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         Set<String> sanitizedIds = new HashSet<>(ids.size());
 
         // phone layout: pop the item fragment if it's visible
-        getFragmentManager().popBackStack();
+        doPopBackStack(getFragmentManager());
 
         // Make sure there are no media in "uploading"
         for (String currentID : ids) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -494,7 +494,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             if (mMediaEditFragment != null && mMediaEditFragment.isVisible() && mMediaEditFragment.isDirty()) {
                 // alert the user that there are unsaved changes
                 new AlertDialog.Builder(this)
-                        .setTitle(R.string.confirm_discard_changes_title)
                         .setMessage(R.string.confirm_discard_changes)
                         .setCancelable(true)
                         .setPositiveButton(R.string.discard, new DialogInterface.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -71,6 +71,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     private MediaAddFragment mMediaAddFragment;
     private PopupWindow mAddMediaPopup;
 
+    private Toolbar mToolbar;
     private SearchView mSearchView;
     private MenuItem mSearchMenuItem;
     private Menu mMenu;
@@ -102,8 +103,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
         setContentView(R.layout.media_browser_activity);
 
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-        setSupportActionBar(toolbar);
+        mToolbar = (Toolbar) findViewById(R.id.toolbar);
+        setSupportActionBar(mToolbar);
         getSupportActionBar().setDisplayShowTitleEnabled(true);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setTitle(R.string.media);
@@ -428,6 +429,11 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     }
 
     @Override
+    public void setLookClosable() {
+        mToolbar.setNavigationIcon(R.drawable.ic_close_white_24dp);
+    }
+
+    @Override
     public void onPause(Fragment fragment) {
         invalidateOptionsMenu();
     }
@@ -482,6 +488,9 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         FragmentManager fm = getFragmentManager();
         if (fm.getBackStackEntryCount() > 0) {
             fm.popBackStack();
+
+            // reset the button to "back" as it may have been altered by a fragment
+            mToolbar.setNavigationIcon(R.drawable.ic_arrow_back_white_24dp);
         } else {
             super.onBackPressed();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -1,10 +1,12 @@
 package org.wordpress.android.ui.media;
 
+import android.app.AlertDialog;
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
 import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
@@ -46,6 +48,7 @@ import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.WPActivityUtils;
 import org.xmlrpc.android.ApiHelper;
 import org.xmlrpc.android.ApiHelper.GetFeatures.Callback;
 
@@ -487,13 +490,38 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     public void onBackPressed() {
         FragmentManager fm = getFragmentManager();
         if (fm.getBackStackEntryCount() > 0) {
-            fm.popBackStack();
 
-            // reset the button to "back" as it may have been altered by a fragment
-            mToolbar.setNavigationIcon(R.drawable.ic_arrow_back_white_24dp);
+            if (mMediaEditFragment != null && mMediaEditFragment.isVisible() && mMediaEditFragment.isDirty()) {
+                // alert the user that there are unsaved changes
+                new AlertDialog.Builder(this)
+                        .setTitle(R.string.confirm_discard_changes_title)
+                        .setMessage(R.string.confirm_discard_changes)
+                        .setCancelable(true)
+                        .setPositiveButton(R.string.discard, new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    // make sure the keyboard is dimissed
+                                    WPActivityUtils.hideKeyboard(getCurrentFocus());
+
+                                    // pop the edit fragment
+                                    doPopBackStack(getFragmentManager());
+                                }})
+                        .setNegativeButton(R.string.cancel, null)
+                        .create()
+                        .show();
+            } else {
+                doPopBackStack(fm);
+            }
         } else {
             super.onBackPressed();
         }
+    }
+
+    private void doPopBackStack(FragmentManager fm) {
+        fm.popBackStack();
+
+        // reset the button to "back" as it may have been altered by a fragment
+        mToolbar.setNavigationIcon(R.drawable.ic_arrow_back_white_24dp);
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.media;
 
 import android.app.Activity;
-import android.app.DialogFragment;
 import android.app.Fragment;
 import android.database.Cursor;
 import android.graphics.Bitmap;
@@ -11,10 +10,8 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.ViewGroup.LayoutParams;
-import android.widget.Button;
 import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
@@ -33,7 +30,6 @@ import org.wordpress.android.util.ImageUtils.BitmapWorkerCallback;
 import org.wordpress.android.util.ImageUtils.BitmapWorkerTask;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.StringUtils;
-import org.wordpress.android.util.WPUrlUtils;
 import org.xmlrpc.android.ApiHelper;
 
 import java.util.ArrayList;
@@ -52,7 +48,6 @@ public class MediaEditFragment extends Fragment {
     private EditText mTitleView;
     private EditText mCaptionView;
     private EditText mDescriptionView;
-    private Button mSaveButton;
 
     private String mTitleOriginal;
     private String mDescriptionOriginal;
@@ -156,13 +151,6 @@ public class MediaEditFragment extends Fragment {
         mDescriptionView = (EditText) mScrollView.findViewById(R.id.media_edit_fragment_description);
         mLocalImageView = (ImageView) mScrollView.findViewById(R.id.media_edit_fragment_image_local);
         mNetworkImageView = (NetworkImageView) mScrollView.findViewById(R.id.media_edit_fragment_image_network);
-        mSaveButton = (Button) mScrollView.findViewById(R.id.media_edit_save_button);
-        mSaveButton.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                editMedia();
-            }
-        });
 
         disableEditingOnOldVersion();
 
@@ -176,7 +164,6 @@ public class MediaEditFragment extends Fragment {
             return;
         }
 
-        mSaveButton.setEnabled(false);
         mTitleView.setEnabled(false);
         mCaptionView.setEnabled(false);
         mDescriptionView.setEnabled(false);
@@ -221,7 +208,7 @@ public class MediaEditFragment extends Fragment {
                         if (getActivity() != null) {
                             Toast.makeText(getActivity(), R.string.media_edit_success, Toast.LENGTH_LONG).show();
                         }
-                        setMediaUpdating(false);
+                        mIsMediaUpdating = false;
                         if (hasCallback()) {
                             mCallback.onSavedEdit(mediaId, true);
                         }
@@ -233,7 +220,7 @@ public class MediaEditFragment extends Fragment {
                             Toast.makeText(getActivity(), R.string.media_edit_failure, Toast.LENGTH_LONG).show();
                             getActivity().invalidateOptionsMenu();
                         }
-                        setMediaUpdating(false);
+                        mIsMediaUpdating = false;
                         if (hasCallback()) {
                             mCallback.onSavedEdit(mediaId, false);
                         }
@@ -245,19 +232,8 @@ public class MediaEditFragment extends Fragment {
         apiArgs.add(currentBlog);
 
         if (!isMediaUpdating()) {
-            setMediaUpdating(true);
+            mIsMediaUpdating = true;
             task.execute(apiArgs);
-        }
-    }
-
-    private void setMediaUpdating(boolean isUpdating) {
-        mIsMediaUpdating = isUpdating;
-        mSaveButton.setEnabled(!isUpdating);
-
-        if (isUpdating) {
-            mSaveButton.setText(R.string.saving);
-        } else {
-            mSaveButton.setText(R.string.save);
         }
     }
 
@@ -325,7 +301,6 @@ public class MediaEditFragment extends Fragment {
         }
 
         // user can't edit local files
-        mSaveButton.setEnabled(!isLocal);
         mTitleView.setEnabled(!isLocal);
         mCaptionView.setEnabled(!isLocal);
         mDescriptionView.setEnabled(!isLocal);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -62,6 +62,7 @@ public class MediaEditFragment extends Fragment {
 
     public interface MediaEditFragmentCallback {
         void onResume(Fragment fragment);
+        void setLookClosable();
         void onPause(Fragment fragment);
         void onSavedEdit(String mediaId, boolean result);
     }
@@ -115,6 +116,7 @@ public class MediaEditFragment extends Fragment {
         super.onResume();
         if (hasCallback()) {
             mCallback.onResume(this);
+            mCallback.setLookClosable();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.media;
 
 import android.app.Activity;
+import android.app.DialogFragment;
 import android.app.Fragment;
 import android.database.Cursor;
 import android.graphics.Bitmap;
@@ -31,6 +32,8 @@ import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.ImageUtils.BitmapWorkerCallback;
 import org.wordpress.android.util.ImageUtils.BitmapWorkerTask;
 import org.wordpress.android.util.MediaUtils;
+import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.WPUrlUtils;
 import org.xmlrpc.android.ApiHelper;
 
 import java.util.ArrayList;
@@ -50,6 +53,10 @@ public class MediaEditFragment extends Fragment {
     private EditText mCaptionView;
     private EditText mDescriptionView;
     private Button mSaveButton;
+
+    private String mTitleOriginal;
+    private String mDescriptionOriginal;
+    private String mCaptionOriginal;
 
     private MediaEditFragmentCallback mCallback;
 
@@ -324,11 +331,17 @@ public class MediaEditFragment extends Fragment {
         mDescriptionView.setEnabled(!isLocal);
 
         mMediaId = cursor.getString(cursor.getColumnIndex(WordPressDB.COLUMN_NAME_MEDIA_ID));
-        mTitleView.setText(cursor.getString(cursor.getColumnIndex(WordPressDB.COLUMN_NAME_TITLE)));
+
+        mTitleOriginal = cursor.getString(cursor.getColumnIndex(WordPressDB.COLUMN_NAME_TITLE));
+        mTitleView.setText(mTitleOriginal);
         mTitleView.requestFocus();
         mTitleView.setSelection(mTitleView.getText().length());
-        mCaptionView.setText(cursor.getString(cursor.getColumnIndex(WordPressDB.COLUMN_NAME_CAPTION)));
-        mDescriptionView.setText(cursor.getString(cursor.getColumnIndex(WordPressDB.COLUMN_NAME_DESCRIPTION)));
+
+        mCaptionOriginal = cursor.getString(cursor.getColumnIndex(WordPressDB.COLUMN_NAME_CAPTION));
+        mCaptionView.setText(mCaptionOriginal);
+
+        mDescriptionOriginal = cursor.getString(cursor.getColumnIndex(WordPressDB.COLUMN_NAME_DESCRIPTION));
+        mDescriptionView.setText(mDescriptionOriginal);
 
         refreshImageView(cursor, isLocal);
         disableEditingOnOldVersion();
@@ -383,5 +396,12 @@ public class MediaEditFragment extends Fragment {
                 task.execute(filePath);
             }
         }
+    }
+
+    public boolean isDirty() {
+        return mMediaId != null &&
+                (!StringUtils.equals(mTitleOriginal, mTitleView.getText().toString())
+                || !StringUtils.equals(mCaptionOriginal, mCaptionView.getText().toString())
+                || !StringUtils.equals(mDescriptionOriginal, mDescriptionView.getText().toString()));
     }
 }

--- a/WordPress/src/main/res/layout/media_edit_fragment.xml
+++ b/WordPress/src/main/res/layout/media_edit_fragment.xml
@@ -21,33 +21,12 @@
             android:text="@string/media_edit_title_text"
             android:textSize="@dimen/text_sz_large" />
 
-        <RelativeLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content">
-
-            <Button
-                android:id="@+id/media_edit_save_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                android:layout_marginLeft="20dp"
-                android:background="@drawable/media_blue_button_selector"
-                android:paddingLeft="20dp"
-                android:paddingRight="20dp"
-                android:text="@string/save"
-                android:textColor="@color/white"
-                android:visibility="@integer/media_editor_save_button_visibility"
-                tools:visibility="visible"/>
-
-            <org.wordpress.android.widgets.WPEditText
-                android:id="@+id/media_edit_fragment_title"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_alignBaseline="@id/media_edit_save_button"
-                android:layout_toLeftOf="@id/media_edit_save_button"
-                android:hint="@string/media_edit_title_hint"
-                android:inputType="textCapSentences|textAutoCorrect" />
-        </RelativeLayout>
+        <org.wordpress.android.widgets.WPEditText
+            android:id="@+id/media_edit_fragment_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/media_edit_title_hint"
+            android:inputType="textCapSentences|textAutoCorrect" />
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/media_edit_caption_text"

--- a/WordPress/src/main/res/menu/media_edit.xml
+++ b/WordPress/src/main/res/menu/media_edit.xml
@@ -4,8 +4,7 @@
 
 	<item
         android:id="@+id/menu_save_media"
-        android:icon="@drawable/ic_save_white_24dp"
         app:showAsAction="ifRoom"
-        android:title="@string/new_media"/>
+        android:title="@string/save"/>
 
 </menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -173,8 +173,7 @@
     <string name="media_edit_success">Updated</string>
     <string name="media_edit_failure">Failed to update</string>
     <string name="saving">Saving…</string>
-    <string name="confirm_discard_changes_title">Unsaved changes</string>
-    <string name="confirm_discard_changes">Are you sure you want to discard the changes?</string>
+    <string name="confirm_discard_changes">Discard unsaved changes?</string>
 
     <!-- Delete Media -->
     <string name="confirm_delete_media">Delete selected item?</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -173,6 +173,8 @@
     <string name="media_edit_success">Updated</string>
     <string name="media_edit_failure">Failed to update</string>
     <string name="saving">Saving…</string>
+    <string name="confirm_discard_changes_title">Unsaved changes</string>
+    <string name="confirm_discard_changes">Are you sure you want to discard the changes?</string>
 
     <!-- Delete Media -->
     <string name="confirm_delete_media">Delete selected item?</string>


### PR DESCRIPTION
Fixes #3352

To test:
* Go into the media library of a site you own
* Tap on an image
* Tap on the "pencil" icon to edit the image metadata
* Notice the button on the appbar being the textual "SAVE" instead of the "floppy" icon
* Notice the "X" button to close the screen
* Try to edit any of the text fields and exit the screen
* A dialog should appear that asks for confirmation to discard changes.

/cc @maxme , but up for anyone to review.