### PR TITLE
added handling for the like case, so the Note in the list view is ref…

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -47,6 +47,7 @@ import org.wordpress.android.ui.comments.CommentActions.ChangeType;
 import org.wordpress.android.ui.comments.CommentActions.OnCommentActionListener;
 import org.wordpress.android.ui.comments.CommentActions.OnCommentChangeListener;
 import org.wordpress.android.ui.comments.CommentActions.OnNoteCommentActionListener;
+import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.notifications.NotificationFragment;
 import org.wordpress.android.ui.notifications.NotificationsDetailListFragment;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
@@ -1161,14 +1162,20 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
                 new RestRequest.Listener() {
                     @Override
                     public void onResponse(JSONObject response) {
-                        if (response != null && !response.optBoolean("success")) {
-                            if (!isAdded()) return;
+                        if (response != null) {
+                            if (response.optBoolean("success")) {
+                                // send signal for listeners to perform any needed updates
+                                EventBus.getDefault().postSticky(new NotificationEvents.NoteLikeStatusChanged(mNote.getId()));
+                            } else {
+                                //rollback op in UI
+                                if (!isAdded()) return;
 
-                            // Failed, so switch the button state back
-                            toggleLikeButton(!mBtnLikeComment.isActivated());
+                                // Failed, so switch the button state back
+                                toggleLikeButton(!mBtnLikeComment.isActivated());
 
-                            if (commentStatusShouldRevert) {
-                                setCommentStatusUnapproved();
+                                if (commentStatusShouldRevert) {
+                                    setCommentStatusUnapproved();
+                                }
                             }
                         }
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
@@ -25,6 +25,12 @@ public class NotificationEvents {
             this.isModerating = isModerating;
         }
     }
+    public static class NoteLikeStatusChanged {
+        final String noteId;
+        public NoteLikeStatusChanged(String noteId) {
+            this.noteId = noteId;
+        }
+    }
     public static class NoteVisibilityChanged {
         final boolean isHidden;
         final String noteId;

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -578,7 +578,9 @@ public class NotificationsListFragment extends Fragment
                         EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteLikeStatusChanged.class);
                         //now re-set the object in our list adapter with the note saved in the updated DB
                         Note note = NotificationsTable.getNoteById(event.noteId);
-                        mNotesAdapter.replaceNote(note);
+                        if (note != null) {
+                            mNotesAdapter.replaceNote(note);
+                        }
                     }
                 }, new RestRequest.ErrorListener() {
                     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -169,8 +169,10 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
     }
 
     public void replaceNote(Note newNote) {
-        int position = getPositionForNoteUnfiltered(newNote.getId());
-        mNotes.set(position, newNote);
+        if (newNote != null) {
+            int position = getPositionForNoteUnfiltered(newNote.getId());
+            mNotes.set(position, newNote);
+        }
     }
 
     private boolean isValidPosition(int position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -168,6 +168,11 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         return null;
     }
 
+    public void replaceNote(Note newNote) {
+        int position = getPositionForNoteUnfiltered(newNote.getId());
+        mNotes.set(position, newNote);
+    }
+
     private boolean isValidPosition(int position) {
         return (position >= 0 && position < mFilteredNotes.size());
     }
@@ -299,6 +304,17 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
     public int getPositionForNote(String noteId) {
         for (int i = 0; i < mFilteredNotes.size(); i++) {
             String noteKey = mFilteredNotes.get(i).getId();
+            if (noteKey != null && noteKey.equals(noteId)) {
+                return i;
+            }
+        }
+
+        return RecyclerView.NO_POSITION;
+    }
+
+    private int getPositionForNoteUnfiltered(String noteId) {
+        for (int i = 0; i < mNotes.size(); i++) {
+            String noteKey = mNotes.get(i).getId();
             if (noteKey != null && noteKey.equals(noteId)) {
                 return i;
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -171,7 +171,9 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
     public void replaceNote(Note newNote) {
         if (newNote != null) {
             int position = getPositionForNoteUnfiltered(newNote.getId());
-            mNotes.set(position, newNote);
+            if (position != RecyclerView.NO_POSITION && position < mNotes.size()) {
+                mNotes.set(position, newNote);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #4818

The like action was only being sent to the server and reflected on the detail view UI, but when coming back to the notifications list then tapping again, the object in the list adapter would still remain with the old data (i.e. unliked or liked, correspondingly).

So, what this PR does is:
- user likes a comment and the endpoint is hit
- when the call to the server returns successfully, we issue an EventBus signal with this information (which note has been liked)
- in the Notifications list screen, the signal is received and the note is re-fetched from the server and saved to the local DB.
- once in the DB, we get that note and update the list adapter with the newly fetched note.

This way, when the user taps on that note again, the right Like status will be shown.


**NOTE:** I tried an approach to save the note immediately to DB after hitting the like endpoint in the detail view (which would naturally be the simplest way), but that would mean re-building the note locally when it is safer to get the note build by the server, also following the general architecture for moderation (approve/unapprove/spam/trash) as it is in the app as of now.

To test:
1. go to notifications tab
2. choose a comment
3. tap on it
4. like the comment
5. go back to the list
6. tap on the same comment
7. see the 'like' option should be the way you left it on step 4 (liked or unliked respectively)

cc @daniloercoli 
also cc'ing @kwonye as this was first observed while tackling this issue #4782 ([see this comment](https://github.com/wordpress-mobile/WordPress-Android/pull/4782#issuecomment-262546706))

