### PR TITLE
Upgrade to Support Lib, build tools v25.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ android:
     - extra-android-support
     - platform-tools
     - tools
-    - build-tools-25.0.0
+    - build-tools-25.0.1
     - android-25
 
 env:
@@ -30,6 +30,8 @@ env:
 before_install:
   # TODO: Remove the following line when Travis' platform-tools are updated to v25+
   - echo yes | android update sdk -a --filter platform-tools --no-ui --force
+  - echo yes | android update sdk -a --filter build-tools-25.0.1 --no-ui --force
+  - echo yes | android update sdk -a --filter build-tools-25.0.0 --no-ui --force
 
 install:
   # Setup gradle.properties

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ env:
 before_install:
   # TODO: Remove the following line when Travis' platform-tools are updated to v25+
   - echo yes | android update sdk -a --filter platform-tools --no-ui --force
-  - echo yes | android update sdk -a --filter build-tools-25.0.1 --no-ui --force
-  - echo yes | android update sdk -a --filter build-tools-25.0.0 --no-ui --force
 
 install:
   # Setup gradle.properties

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -30,7 +30,7 @@ android {
     }
 
     compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    buildToolsVersion "25.0.1"
 
     defaultConfig {
         applicationId "org.wordpress.android"
@@ -84,16 +84,16 @@ dependencies {
     compile 'com.google.code.gson:gson:2.6.+'
     compile 'org.ccil.cowan.tagsoup:tagsoup:1.2.1'
 
-    compile 'com.android.support:support-compat:25.0.0'
-    compile 'com.android.support:support-core-ui:25.0.0'
-    compile 'com.android.support:support-fragment:25.0.0'
+    compile 'com.android.support:support-compat:25.0.1'
+    compile 'com.android.support:support-core-ui:25.0.1'
+    compile 'com.android.support:support-fragment:25.0.1'
 
     compile 'com.android.support:multidex:1.0.1'
-    compile 'com.android.support:appcompat-v7:25.0.0'
-    compile 'com.android.support:cardview-v7:25.0.0'
-    compile 'com.android.support:recyclerview-v7:25.0.0'
-    compile 'com.android.support:design:25.0.0'
-    compile 'com.android.support:percent:25.0.0'
+    compile 'com.android.support:appcompat-v7:25.0.1'
+    compile 'com.android.support:cardview-v7:25.0.1'
+    compile 'com.android.support:recyclerview-v7:25.0.1'
+    compile 'com.android.support:design:25.0.1'
+    compile 'com.android.support:percent:25.0.1'
 
     compile 'com.google.android.gms:play-services-gcm:9.0.2'
     compile 'com.google.android.gms:play-services-auth:9.0.2'

--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -25,7 +25,7 @@ android {
     publishNonDefault true
 
     compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    buildToolsVersion "25.0.1"
 
     defaultConfig {
         versionName "1.2.0"

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -19,7 +19,7 @@ android {
     publishNonDefault true
 
     compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    buildToolsVersion "25.0.1"
 
     defaultConfig {
         versionCode 13
@@ -45,9 +45,9 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.0.0'
-    compile 'com.android.support:support-v4:25.0.0'
-    compile 'com.android.support:design:25.0.0'
+    compile 'com.android.support:appcompat-v7:25.0.1'
+    compile 'com.android.support:support-v4:25.0.1'
+    compile 'com.android.support:design:25.0.1'
     compile 'org.wordpress:utils:1.11.0'
 }
 

--- a/libs/editor/example/build.gradle
+++ b/libs/editor/example/build.gradle
@@ -15,7 +15,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion "25.0.1"
 
     defaultConfig {
         applicationId "org.wordpress.editorexample"

--- a/libs/networking/WordPressNetworking/build.gradle
+++ b/libs/networking/WordPressNetworking/build.gradle
@@ -19,7 +19,7 @@ android {
     publishNonDefault true
 
     compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    buildToolsVersion "25.0.1"
 
     defaultConfig {
         minSdkVersion 14

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -20,7 +20,7 @@ dependencies {
         exclude group: 'commons-logging'
     }
     compile 'com.mcxiaoke.volley:library:1.0.18'
-    compile 'com.android.support:support-v13:25.0.0'
+    compile 'com.android.support:support-v13:25.0.1'
 }
 
 android {
@@ -29,7 +29,7 @@ android {
     publishNonDefault true
 
     compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    buildToolsVersion "25.0.1"
 
     defaultConfig {
         versionName "1.14.0"


### PR DESCRIPTION
Fixes http://stackoverflow.com/questions/40161934/exception-raised-during-rendering-unable-to-locate-mode-0 happening while previewing `layout/notifications_fragment_notes_list.xml`

To test:
* Open `layout/notifications_fragment_notes_list.xml` in AndroidStudio
* The layout preview should be rendered correctly in the `Preview` pane
