### PR TITLE
Issue/4824 enable push notifications sound

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -461,13 +461,13 @@ public class GCMMessageService extends GcmListenerService {
             }
 
 
-            showGroupNotificationForActiveNotificationsMap(context, pushId, wpcomNoteID,
+            showNotification(context, pushId, wpcomNoteID,
                     noteType, data.getString("icon"), title, message, dontPlaySound);
         }
 
-        private void showGroupNotificationForActiveNotificationsMap(Context context, int pushId, String wpcomNoteID, String noteType,
-                                                                    String largeIconUri, String title, String message,
-                                                                    boolean dontPlaySound) {
+        private void showNotification(Context context, int pushId, String wpcomNoteID, String noteType,
+                                      String largeIconUri, String title, String message,
+                                      boolean dontPlaySound) {
 
             // Build the new notification, add group to support wearable stacking
             NotificationCompat.Builder builder = getNotificationBuilder(context, title, message);
@@ -480,7 +480,8 @@ public class GCMMessageService extends GcmListenerService {
             showIndividualNotificationForBuilder(context, builder, noteType, wpcomNoteID, pushId, dontPlaySound);
 
             // Also add a group summary notification, which is required for non-wearable devices
-            showGroupNotificationForBuilder(context, builder, wpcomNoteID, message, dontPlaySound);
+            // Do not need to play the sound again. We've already played it in the individual builder.
+            showGroupNotificationForBuilder(context, builder, wpcomNoteID, message, true);
         }
 
         private void addActionsForCommentNotification(Context context, NotificationCompat.Builder builder, String noteId) {
@@ -767,17 +768,13 @@ public class GCMMessageService extends GcmListenerService {
 
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
 
-            boolean shouldPlaySound = prefs.getBoolean("wp_pref_notification_sound", false);
-            boolean shouldVibrate = prefs.getBoolean("wp_pref_notification_vibrate", false);
-            boolean shouldBlinkLight = prefs.getBoolean("wp_pref_notification_light", false);
-            String notificationSound = prefs.getString("wp_pref_custom_notification_sound", null); //"" if None is selected
-
-
             if (!dontPlaySound) {
-                // use default sound if the legacy sound preference was ON but the custom sound was not selected (null)
-                if (shouldPlaySound && notificationSound == null) {
-                    builder.setSound(Uri.parse("content://settings/system/notification_sound"));
-                } else if (!TextUtils.isEmpty(notificationSound)) {
+
+                boolean shouldVibrate = prefs.getBoolean("wp_pref_notification_vibrate", false);
+                boolean shouldBlinkLight = prefs.getBoolean("wp_pref_notification_light", true);
+                String notificationSound = prefs.getString("wp_pref_custom_notification_sound", "content://settings/system/notification_sound"); //"" if None is selected
+
+                if (!TextUtils.isEmpty(notificationSound)) {
                     builder.setSound(Uri.parse(notificationSound));
                 }
 

--- a/WordPress/src/main/res/xml/notifications_settings.xml
+++ b/WordPress/src/main/res/xml/notifications_settings.xml
@@ -19,13 +19,14 @@
             android:key="wp_pref_custom_notification_sound"
             android:ringtoneType="notification"
             android:showDefault="true"
+            android:defaultValue="content://settings/system/notification_sound"
             android:title="@string/notification_sound"/>
         <SwitchPreference
             android:defaultValue="false"
             android:key="wp_pref_notification_vibrate"
             android:title="@string/notification_vibrate"/>
         <SwitchPreference
-            android:defaultValue="false"
+            android:defaultValue="true"
             android:key="wp_pref_notification_light"
             android:title="@string/notification_blink"/>
     </PreferenceCategory>


### PR DESCRIPTION
Fixes #4824 and #4823 

This PR changes the default settings for push notifications sound & blink light flag to the following values:
- Push notifications sound is set by default to the device notifications sound.
- Blink light is set to `TRUE`.

This means that "by default" (first installation or for users that have never changed those settings) the device will play the sound and will blink the light when a push notification is received.

To test:
- Uninstall the app & reinstall it
- Log in to wpcom
- Receive a PN
- The device should play the sound ONCE.
