### PR TITLE
Allow navigating to parent post when deeplinked

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -371,8 +371,8 @@ public class ReaderCommentListActivity extends AppCompatActivity {
                 }
             });
 
-            // Enable post title click if we came from notifications with a commentId
-            if (mCommentId > 0) {
+            // Enable post title click if we came here directly from notifications or deep linking
+            if (mDirectOperation != null) {
                 mCommentAdapter.enableHeaderClicks();
             }
 


### PR DESCRIPTION
Fixes #4797 

Matches the behaviour of the comments list when opened via a notification.

To test:
* Tap on a "View comments" link from a notification email that will open the app to view the comments
* Tap the header of the comments list, where the post title is
* The parent post should be displayed
* Tap the on-screen back button (or the "hardware" back button)
* The comments list should be visible again
* Tap "back" again to exit the WordPress app and return to the origin app
