### PR TITLE
Notifications small rafactoring

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -367,11 +367,11 @@ public class GCMMessageService extends GcmListenerService {
                 return;
             }
 
-            buildAndShowNotificationFromNoteData(context, data, false);
+            buildAndShowNotificationFromNoteData(context, data);
         }
 
 
-        private void buildAndShowNotificationFromNoteData(Context context, Bundle data, boolean dontPlaySound) {
+        private void buildAndShowNotificationFromNoteData(Context context, Bundle data) {
 
             if (data == null) {
                 AppLog.e(T.NOTIFS, "Push notification received without a valid Bundle!");
@@ -461,27 +461,19 @@ public class GCMMessageService extends GcmListenerService {
             }
 
 
-            showNotification(context, pushId, wpcomNoteID,
-                    noteType, data.getString("icon"), title, message, dontPlaySound);
-        }
-
-        private void showNotification(Context context, int pushId, String wpcomNoteID, String noteType,
-                                      String largeIconUri, String title, String message,
-                                      boolean dontPlaySound) {
-
             // Build the new notification, add group to support wearable stacking
             NotificationCompat.Builder builder = getNotificationBuilder(context, title, message);
-
+            String largeIconUri = data.getString("icon");
             Bitmap largeIconBitmap = getLargeIconBitmap(largeIconUri, shouldCircularizeNoteIcon(noteType));
             if (largeIconBitmap != null) {
                 builder.setLargeIcon(largeIconBitmap);
             }
 
-            showIndividualNotificationForBuilder(context, builder, noteType, wpcomNoteID, pushId, dontPlaySound);
+            showSingleNotificationForBuilder(context, builder, noteType, wpcomNoteID, pushId, true);
 
             // Also add a group summary notification, which is required for non-wearable devices
             // Do not need to play the sound again. We've already played it in the individual builder.
-            showGroupNotificationForBuilder(context, builder, wpcomNoteID, message, true);
+            showGroupNotificationForBuilder(context, builder, wpcomNoteID, message, false);
         }
 
         private void addActionsForCommentNotification(Context context, NotificationCompat.Builder builder, String noteId) {
@@ -673,9 +665,9 @@ public class GCMMessageService extends GcmListenerService {
         }
 
         private void showGroupNotificationForBuilder(Context context, NotificationCompat.Builder builder,
-                                                     String wpcomNoteID, String message, boolean dontPlaySound) {
+                                                     String wpcomNoteID, String message, boolean notifyUser) {
 
-            if (builder == null) {
+            if (builder == null || context == null) {
                 return;
             }
 
@@ -723,12 +715,12 @@ public class GCMMessageService extends GcmListenerService {
                         .setContentText(subject)
                         .setStyle(inboxStyle);
 
-                showNotificationForBuilder(groupBuilder, context, wpcomNoteID, GROUP_NOTIFICATION_ID, dontPlaySound);
+                showNotificationForBuilder(groupBuilder, context, wpcomNoteID, GROUP_NOTIFICATION_ID, notifyUser);
 
             } else {
                 // Set the individual notification we've already built as the group summary
                 builder.setGroupSummary(true);
-                showNotificationForBuilder(builder, context, wpcomNoteID, GROUP_NOTIFICATION_ID, dontPlaySound);
+                showNotificationForBuilder(builder, context, wpcomNoteID, GROUP_NOTIFICATION_ID, notifyUser);
             }
             //reinsert 2fa bundle if it was present
             if (authPNBundle != null) {
@@ -737,10 +729,9 @@ public class GCMMessageService extends GcmListenerService {
 
         }
 
-        private void showIndividualNotificationForBuilder(Context context, NotificationCompat.Builder builder,
-                                                          String noteType, String wpcomNoteID, int pushId,
-                                                          boolean dontPlaySound) {
-            if (builder == null) {
+        private void showSingleNotificationForBuilder(Context context, NotificationCompat.Builder builder,
+                                                      String noteType, String wpcomNoteID, int pushId, boolean notifyUser) {
+            if (builder == null || context == null) {
                 return;
             }
 
@@ -748,12 +739,12 @@ public class GCMMessageService extends GcmListenerService {
                 addActionsForCommentNotification(context, builder, wpcomNoteID);
             }
 
-            showNotificationForBuilder(builder, context, wpcomNoteID, pushId, dontPlaySound);
+            showNotificationForBuilder(builder, context, wpcomNoteID, pushId, notifyUser);
         }
 
         // Displays a notification to the user
         private void showNotificationForBuilder(NotificationCompat.Builder builder, Context context,
-                                                String wpcomNoteID, int pushId, boolean dontPlaySound) {
+                                                String wpcomNoteID, int pushId, boolean notifyUser) {
             if (builder == null || context == null) {
                 return;
             }
@@ -768,7 +759,7 @@ public class GCMMessageService extends GcmListenerService {
 
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
 
-            if (!dontPlaySound) {
+            if (notifyUser) {
 
                 boolean shouldVibrate = prefs.getBoolean("wp_pref_notification_vibrate", false);
                 boolean shouldBlinkLight = prefs.getBoolean("wp_pref_notification_light", true);
@@ -852,7 +843,7 @@ public class GCMMessageService extends GcmListenerService {
                     noteType = StringUtils.notNullStr(remainingNote.getString(PUSH_ARG_TYPE));
                     wpcomNoteID = remainingNote.getString(PUSH_ARG_NOTE_ID, "");
                     if (!sActiveNotificationsMap.isEmpty()) {
-                        showIndividualNotificationForBuilder(context, builder, noteType, wpcomNoteID, sActiveNotificationsMap.keyAt(0), true);
+                        showSingleNotificationForBuilder(context, builder, noteType, wpcomNoteID, sActiveNotificationsMap.keyAt(0), false);
                     }
                 }
             }
@@ -873,7 +864,7 @@ public class GCMMessageService extends GcmListenerService {
                 builder.setLargeIcon(largeIconBitmap);
             }
 
-            showGroupNotificationForBuilder(context, builder,  wpcomNoteID, message, true);
+            showGroupNotificationForBuilder(context, builder,  wpcomNoteID, message, false);
 
             //reinsert 2fa bundle if it was present
             if (authPNBundle != null) {

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -463,8 +463,7 @@ public class GCMMessageService extends GcmListenerService {
 
             // Build the new notification, add group to support wearable stacking
             NotificationCompat.Builder builder = getNotificationBuilder(context, title, message);
-            String largeIconUri = data.getString("icon");
-            Bitmap largeIconBitmap = getLargeIconBitmap(largeIconUri, shouldCircularizeNoteIcon(noteType));
+            Bitmap largeIconBitmap = getLargeIconBitmap(data.getString("icon"), shouldCircularizeNoteIcon(noteType));
             if (largeIconBitmap != null) {
                 builder.setLargeIcon(largeIconBitmap);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -438,7 +438,8 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             setIdForCommentContainer();
             showComment();
         }
-        setRemoteBlogId(note.getSiteId());
+
+        mRemoteBlogId = note.getSiteId();
     }
 
     private void setIdForFragmentContainer(int id){
@@ -532,10 +533,6 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
 
     private int getRemoteBlogId() {
         return mRemoteBlogId;
-    }
-
-    private void setRemoteBlogId(int remoteBlogId) {
-        mRemoteBlogId = remoteBlogId;
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -150,7 +150,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
      */
     public static CommentDetailFragment newInstance(final String noteId, final String replyText, final int idForFragmentContainer) {
         CommentDetailFragment fragment = new CommentDetailFragment();
-        fragment.setNoteWithNoteId(noteId);
+        fragment.setNote(noteId);
         fragment.setReplyText(replyText);
         fragment.setIdForFragmentContainer(idForFragmentContainer + R.id.note_comment_fragment_container_base_id);
         return fragment;
@@ -355,7 +355,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
 
         // Set the note if we retrieved the noteId from savedInstanceState
         if (!TextUtils.isEmpty(mRestoredNoteId)) {
-            setNoteWithNoteId(mRestoredNoteId);
+            setNote(mRestoredNoteId);
             mRestoredNoteId = null;
         }
     }
@@ -421,7 +421,8 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         return mNote;
     }
 
-    private void setNoteWithNoteId(String noteId) {
+    @Override
+    public void setNote(String noteId) {
         if (noteId == null) {
             showErrorToastAndFinish();
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -421,15 +421,6 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         return mNote;
     }
 
-    @Override
-    public void setNote(Note note) {
-        mNote = note;
-        if (isAdded() && mNote != null) {
-            setIdForCommentContainer();
-            showComment();
-        }
-    }
-
     private void setNoteWithNoteId(String noteId) {
         if (noteId == null) {
             showErrorToastAndFinish();
@@ -441,7 +432,12 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             showErrorToastAndFinish();
             return;
         }
-        setNote(note);
+
+        mNote = note;
+        if (isAdded()) {
+            setIdForCommentContainer();
+            showComment();
+        }
         setRemoteBlogId(note.getSiteId());
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationFragment.java
@@ -15,5 +15,4 @@ public interface NotificationFragment {
     }
 
     Note getNote();
-    void setNote(Note note);
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationFragment.java
@@ -15,4 +15,5 @@ public interface NotificationFragment {
     }
 
     Note getNote();
+    void setNote(String noteId);
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -3,6 +3,7 @@
  */
 package org.wordpress.android.ui.notifications;
 
+import android.app.Activity;
 import android.app.ListFragment;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -51,6 +52,10 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
 
     private int mRestoredListPosition;
 
+    public interface OnNoteChangeListener {
+        void onNoteChanged(Note note);
+    }
+
     private Note mNote;
     private LinearLayout mRootLayout;
     private ViewGroup mFooterView;
@@ -58,8 +63,10 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
     private String mRestoredNoteId;
     private int mBackgroundColor;
     private int mCommentListPosition = ListView.INVALID_POSITION;
+    private boolean mIsUnread;
 
     private CommentUserNoteBlock.OnCommentStatusChangeListener mOnCommentStatusChangeListener;
+    private OnNoteChangeListener mOnNoteChangeListener;
     private NoteBlockAdapter mNoteBlockAdapter;
 
     public NotificationsDetailListFragment() {
@@ -146,6 +153,7 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
     private void setNoteWithNoteId(String noteId) {
         Note note = NotificationsTable.getNoteById(noteId);
         if (note != null) {
+            mIsUnread = note.isUnread();
             setNote(note);
         }
     }
@@ -166,6 +174,10 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
         }
 
         super.onSaveInstanceState(outState);
+    }
+
+    public void setOnNoteChangeListener(OnNoteChangeListener listener) {
+        mOnNoteChangeListener = listener;
     }
 
     private void reloadNoteBlocks() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -3,7 +3,6 @@
  */
 package org.wordpress.android.ui.notifications;
 
-import android.app.Activity;
 import android.app.ListFragment;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -52,10 +51,6 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
 
     private int mRestoredListPosition;
 
-    public interface OnNoteChangeListener {
-        void onNoteChanged(Note note);
-    }
-
     private Note mNote;
     private LinearLayout mRootLayout;
     private ViewGroup mFooterView;
@@ -63,10 +58,8 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
     private String mRestoredNoteId;
     private int mBackgroundColor;
     private int mCommentListPosition = ListView.INVALID_POSITION;
-    private boolean mIsUnread;
 
     private CommentUserNoteBlock.OnCommentStatusChangeListener mOnCommentStatusChangeListener;
-    private OnNoteChangeListener mOnNoteChangeListener;
     private NoteBlockAdapter mNoteBlockAdapter;
 
     public NotificationsDetailListFragment() {
@@ -153,7 +146,6 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
     private void setNoteWithNoteId(String noteId) {
         Note note = NotificationsTable.getNoteById(noteId);
         if (note != null) {
-            mIsUnread = note.isUnread();
             setNote(note);
         }
     }
@@ -174,10 +166,6 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
         }
 
         super.onSaveInstanceState(outState);
-    }
-
-    public void setOnNoteChangeListener(OnNoteChangeListener listener) {
-        mOnNoteChangeListener = listener;
     }
 
     private void reloadNoteBlocks() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -3,7 +3,6 @@
  */
 package org.wordpress.android.ui.notifications;
 
-import android.app.Activity;
 import android.app.ListFragment;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -63,7 +62,6 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
     private String mRestoredNoteId;
     private int mBackgroundColor;
     private int mCommentListPosition = ListView.INVALID_POSITION;
-    private boolean mIsUnread;
 
     private CommentUserNoteBlock.OnCommentStatusChangeListener mOnCommentStatusChangeListener;
     private OnNoteChangeListener mOnNoteChangeListener;
@@ -153,7 +151,6 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
     private void setNoteWithNoteId(String noteId) {
         Note note = NotificationsTable.getNoteById(noteId);
         if (note != null) {
-            mIsUnread = note.isUnread();
             setNote(note);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -72,7 +72,7 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
 
     public static NotificationsDetailListFragment newInstance(final String noteId) {
         NotificationsDetailListFragment fragment = new NotificationsDetailListFragment();
-        fragment.setNoteWithNoteId(noteId);
+        fragment.setNote(noteId);
         return fragment;
     }
 
@@ -120,7 +120,7 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
 
         // Set the note if we retrieved the noteId from savedInstanceState
         if (!TextUtils.isEmpty(mRestoredNoteId)) {
-            setNoteWithNoteId(mRestoredNoteId);
+            setNote(mRestoredNoteId);
             reloadNoteBlocks();
             mRestoredNoteId = null;
         }
@@ -143,7 +143,8 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
         return mNote;
     }
 
-    private void setNoteWithNoteId(String noteId) {
+    @Override
+    public void setNote(String noteId) {
         if (noteId == null) {
             showErrorToastAndFinish();
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailListFragment.java
@@ -143,16 +143,18 @@ public class NotificationsDetailListFragment extends ListFragment implements Not
         return mNote;
     }
 
-    @Override
-    public void setNote(Note note) {
-        mNote = note;
-    }
-
     private void setNoteWithNoteId(String noteId) {
-        Note note = NotificationsTable.getNoteById(noteId);
-        if (note != null) {
-            setNote(note);
+        if (noteId == null) {
+            showErrorToastAndFinish();
+            return;
         }
+
+        Note note = NotificationsTable.getNoteById(noteId);
+        if (note == null) {
+            showErrorToastAndFinish();
+            return;
+        }
+        mNote = note;
     }
 
     private void showErrorToastAndFinish() {


### PR DESCRIPTION
Tried to remove unused, and "sort of duplicate" code in Notifications.

- Changed the name of the variable `dontPlaySound` to something more generic, since there isn't only the sound involved in notifying the user, of new notifications. Also made it "positive".
- Refactored the code that sets the Note object in fragments.