### PR TITLE
Issue/4801 reader hide follow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -155,10 +155,6 @@ public class ReaderTag implements Serializable, FilterCriteria {
         return tagType == ReaderTagType.DEFAULT && getEndpoint().endsWith("/read/following");
     }
 
-    public boolean isAutomattic() {
-        return tagType == ReaderTagType.DEFAULT && getTagTitle().equals("Automattic");
-    }
-
     public boolean isDiscover() {
         return tagType == ReaderTagType.DEFAULT && getTagSlug().equals(TAG_TITLE_DISCOVER);
     }

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -155,6 +155,10 @@ public class ReaderTag implements Serializable, FilterCriteria {
         return tagType == ReaderTagType.DEFAULT && getEndpoint().endsWith("/read/following");
     }
 
+    public boolean isAutomattic() {
+        return tagType == ReaderTagType.DEFAULT && getTagTitle().equals("Automattic");
+    }
+
     public boolean isDiscover() {
         return tagType == ReaderTagType.DEFAULT && getTagSlug().equals(TAG_TITLE_DISCOVER);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -437,15 +437,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             holder.imgMore.setOnClickListener(null);
         }
 
-        // follow button doesn't show for "Followed Sites" or lists or when there's a site header (Discover, site preview)
-        boolean showFollowButton;
-        if (mCurrentTag != null && (mCurrentTag.isFollowedSites() || mCurrentTag.isAutomattic() || mCurrentTag.isListTopic())) {
-            showFollowButton = false;
-        } else {
-            showFollowButton = !hasSiteHeader() && !mIsLoggedOutReader;
-        }
-
-        if (showFollowButton) {
+        if (shouldShowFollowButton()) {
             holder.followButton.setIsFollowed(post.isFollowedByCurrentUser);
             holder.followButton.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -482,6 +474,16 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             mRenderedIds.add(post.getPseudoId());
             AnalyticsUtils.trackRailcarRender(post.getRailcarJson());
         }
+    }
+
+    /*
+     * follow button only shows for tags and "Posts I Like" - it doesn't show for Followed Sites,
+     * Discover, lists, etc.
+     */
+    private boolean shouldShowFollowButton() {
+        return mCurrentTag != null
+                && (mCurrentTag.isTagTopic() || mCurrentTag.isPostsILike())
+                && !mIsLoggedOutReader;
     }
 
     /*
@@ -588,10 +590,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     private boolean isDiscover() {
         return mCurrentTag != null && mCurrentTag.isDiscover();
-    }
-
-    private boolean isFollowedSites() {
-        return mCurrentTag != null && mCurrentTag.isFollowedSites();
     }
 
     public void setOnPostSelectedListener(ReaderInterfaces.OnPostSelectedListener listener) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -437,10 +437,14 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             holder.imgMore.setOnClickListener(null);
         }
 
-        // follow button doesn't show for "Followed Sites" or when there's a site header (Discover, site preview)
-        boolean showFollowButton = !hasSiteHeader()
-                && !mIsLoggedOutReader
-                && !isFollowedSites();
+        // follow button doesn't show for "Followed Sites" or lists or when there's a site header (Discover, site preview)
+        boolean showFollowButton;
+        if (mCurrentTag != null && (mCurrentTag.isFollowedSites() || mCurrentTag.isAutomattic() || mCurrentTag.isListTopic())) {
+            showFollowButton = false;
+        } else {
+            showFollowButton = !hasSiteHeader() && !mIsLoggedOutReader;
+        }
+
         if (showFollowButton) {
             holder.followButton.setIsFollowed(post.isFollowedByCurrentUser);
             holder.followButton.setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
Fixes #4801 - updates the reader stream view so that the follow button only appears for tags and "Posts I Like." It should not appear for "Followed Sites," Discover, lists, or a8c.
