### PR TITLE
Issue/4583 reader pdf links

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -1139,16 +1139,29 @@ public class ReaderPostDetailFragment extends Fragment
             return true;
         }
 
-        // open YouTube videos in external app so they launch the YouTube player, open all other
-        // urls using an AuthenticatedWebViewActivity
-        final OpenUrlType openUrlType;
-        if (ReaderVideoUtils.isYouTubeVideoLink(url)) {
-            openUrlType = OpenUrlType.EXTERNAL;
-        } else {
-            openUrlType = OpenUrlType.INTERNAL;
-        }
+        OpenUrlType openUrlType = shouldOpenExternal(url) ? OpenUrlType.EXTERNAL : OpenUrlType.INTERNAL;
         ReaderActivityLauncher.openUrl(getActivity(), url, openUrlType);
         return true;
+    }
+
+    /*
+     * returns True if the passed URL should be opened in the external browser app
+     */
+    private boolean shouldOpenExternal(String url) {
+        // open YouTube videos in external app so they launch the YouTube player
+        if (ReaderVideoUtils.isYouTubeVideoLink(url)) {
+            return true;
+        }
+
+        // if the mime type starts with "application" then show externally so associated
+        // app (if any) has a chance to handle it
+        String mimeType = UrlUtils.getUrlMimeType(url);
+        if (mimeType != null && mimeType.startsWith("application")) {
+            return true;
+        }
+
+        // open all other urls using an AuthenticatedWebViewActivity
+        return false;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -1153,9 +1153,9 @@ public class ReaderPostDetailFragment extends Fragment
             return true;
         }
 
-        // if the mime type starts with "application" open externally - if there's an associated
-        // app it will handle it, otherwise the default browser will (which is still better than
-        // showing it internally)
+        // if the mime type starts with "application" open it externally - this will either
+        // open it in the associated app or the default browser (which will enable the user
+        // to download it)
         String mimeType = UrlUtils.getUrlMimeType(url);
         if (mimeType != null && mimeType.startsWith("application")) {
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -1153,8 +1153,9 @@ public class ReaderPostDetailFragment extends Fragment
             return true;
         }
 
-        // if the mime type starts with "application" then show externally so associated
-        // app (if any) has a chance to handle it
+        // if the mime type starts with "application" open externally - if there's an associated
+        // app it will handle it, otherwise the default browser will (which is still better than
+        // showing it internally)
         String mimeType = UrlUtils.getUrlMimeType(url);
         if (mimeType != null && mimeType.startsWith("application")) {
             return true;


### PR DESCRIPTION
Fixes #4583 by detecting when the mime type of the clicked link starts with `application` and if so opens it in the external browser instead of internally. The browser will offer to download the file and enable the user to view it. This works for PDFs and any other application file type.

Note: if you test this in the emulator there's a good chance the browser will crash. To resolve this, go to Settings > Apps > Browser > Permissions and enable storage.

![screenshot_1480191231](https://cloud.githubusercontent.com/assets/3903757/20643019/76c732bc-b3eb-11e6-9a60-9f23c343ba07.png)

