### PR TITLE
Feature/viewpager swipe indicator

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -5,7 +5,6 @@ import android.app.FragmentManager;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Parcelable;
-import android.support.design.widget.Snackbar;
 import android.support.v13.app.FragmentStatePagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
@@ -31,7 +30,6 @@ import org.wordpress.android.ui.notifications.utils.NotificationsActions;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
-import org.wordpress.android.widgets.WPViewPagerTransformer;
 import org.wordpress.android.ui.stats.StatsAbstractFragment;
 import org.wordpress.android.ui.stats.StatsActivity;
 import org.wordpress.android.ui.stats.StatsTimeframe;
@@ -40,7 +38,9 @@ import org.wordpress.android.ui.stats.StatsViewType;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.widgets.WPSwipeSnackbar;
 import org.wordpress.android.widgets.WPViewPager;
+import org.wordpress.android.widgets.WPViewPagerTransformer;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -124,7 +124,7 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
             @Override
             public void onPageSelected(int position) {
                 AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATION_SWIPE_PAGE_CHANGED);
-                AppPrefs.setSwipeToNavigateShown(true);
+                AppPrefs.setNotificationsSwipeToNavigateShown(true);
                 //change the action bar title for the current note
                 Note currentNote = mAdapter.getNoteAtPosition(position);
                 if (currentNote != null) {
@@ -166,8 +166,8 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
         super.onStart();
         //if the user hasn't used swipe yet, hint the user they can navigate through notifications detail
         //using swipe on the ViewPager
-        if (!AppPrefs.isSwipeToNavigateShown() && mAllowHorizontalNavigation && (mAdapter.getCount() > 1)) {
-            Snackbar.make(mViewPager, getString(R.string.notifications_label_swipe_for_more_snackbar), Snackbar.LENGTH_LONG).show();
+        if (!AppPrefs.isNotificationsSwipeToNavigateShown() && mAllowHorizontalNavigation && (mAdapter.getCount() > 1)) {
+            WPSwipeSnackbar.show(mViewPager);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -99,6 +99,9 @@ public class AppPrefs {
 
         // When we need to show the snackbar indicating how notifications can be navigated through
         SWIPE_TO_NAVIGATE_NOTIFICATIONS,
+
+        // Same as above but for the reader
+        SWIPE_TO_NAVIGATE_READER,
     }
 
     private static SharedPreferences prefs() {
@@ -433,6 +436,14 @@ public class AppPrefs {
 
     public static void setNotificationsSwipeToNavigateShown(boolean alreadyShown) {
         setBoolean(UndeletablePrefKey.SWIPE_TO_NAVIGATE_NOTIFICATIONS, alreadyShown);
+    }
+
+    public static boolean isReaderSwipeToNavigateShown() {
+        return getBoolean(UndeletablePrefKey.SWIPE_TO_NAVIGATE_READER, false);
+    }
+
+    public static void setReaderSwipeToNavigateShown(boolean alreadyShown) {
+        setBoolean(UndeletablePrefKey.SWIPE_TO_NAVIGATE_READER, alreadyShown);
     }
 
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -428,8 +428,7 @@ public class AppPrefs {
     }
 
     public static boolean isNotificationsSwipeToNavigateShown() {
-        // TODO:
-        return false;// getBoolean(UndeletablePrefKey.SWIPE_TO_NAVIGATE_NOTIFICATIONS, false);
+        return getBoolean(UndeletablePrefKey.SWIPE_TO_NAVIGATE_NOTIFICATIONS, false);
     }
 
     public static void setNotificationsSwipeToNavigateShown(boolean alreadyShown) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -427,11 +427,12 @@ public class AppPrefs {
         setLong(DeletablePrefKey.PUSH_NOTIFICATIONS_LAST_NOTE_ID, time);
     }
 
-    public static boolean isSwipeToNavigateShown() {
-        return getBoolean(UndeletablePrefKey.SWIPE_TO_NAVIGATE_NOTIFICATIONS, false);
+    public static boolean isNotificationsSwipeToNavigateShown() {
+        // TODO:
+        return false;// getBoolean(UndeletablePrefKey.SWIPE_TO_NAVIGATE_NOTIFICATIONS, false);
     }
 
-    public static void setSwipeToNavigateShown(boolean alreadyShown) {
+    public static void setNotificationsSwipeToNavigateShown(boolean alreadyShown) {
         setBoolean(UndeletablePrefKey.SWIPE_TO_NAVIGATE_NOTIFICATIONS, alreadyShown);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -28,6 +28,7 @@ import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.WPLaunchActivity;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderPostActions;
@@ -190,6 +191,9 @@ public class ReaderPostPagerActivity extends AppCompatActivity
                 super.onPageSelected(position);
                 onShowHideToolbar(true);
                 trackPostAtPositionIfNeeded(position);
+
+                // don't show the swipe indicator in the future since the user knows how to swipe
+                AppPrefs.setReaderSwipeToNavigateShown(true);
 
                 // pause the previous web view - important because otherwise embedded content
                 // will continue to play
@@ -635,7 +639,7 @@ public class ReaderPostPagerActivity extends AppCompatActivity
                         }
 
                         // let the user know they can swipe between posts
-                        if (adapter.getCount() > 1) {
+                        if (adapter.getCount() > 1 && !AppPrefs.isReaderSwipeToNavigateShown()) {
                             WPSwipeSnackbar.show(mViewPager);
                         }
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -192,16 +192,16 @@ public class ReaderPostPagerActivity extends AppCompatActivity
                 onShowHideToolbar(true);
                 trackPostAtPositionIfNeeded(position);
 
-                // don't show the swipe indicator in the future since the user knows how to swipe
-                AppPrefs.setReaderSwipeToNavigateShown(true);
-
-                // pause the previous web view - important because otherwise embedded content
-                // will continue to play
                 if (mLastSelectedPosition > -1 && mLastSelectedPosition != position) {
+                    // pause the previous web view - important because otherwise embedded content
+                    // will continue to play
                     ReaderPostDetailFragment lastFragment = getDetailFragmentAtPosition(mLastSelectedPosition);
                     if (lastFragment != null) {
                         lastFragment.pauseWebView();
                     }
+
+                    // don't show the swipe indicator in the future since the user knows how to swipe
+                    AppPrefs.setReaderSwipeToNavigateShown(true);
                 }
 
                 // resume the newly active webView if it was previously paused

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -39,8 +39,9 @@ import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.widgets.WPViewPagerTransformer;
+import org.wordpress.android.widgets.WPSwipeSnackbar;
 import org.wordpress.android.widgets.WPViewPager;
+import org.wordpress.android.widgets.WPViewPagerTransformer;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -631,6 +632,11 @@ public class ReaderPostPagerActivity extends AppCompatActivity
                         } else if (adapter.isValidPosition(currentPosition)) {
                             mViewPager.setCurrentItem(currentPosition);
                             trackPostAtPositionIfNeeded(currentPosition);
+                        }
+
+                        // let the user know they can swipe between posts
+                        if (adapter.getCount() > 1) {
+                            WPSwipeSnackbar.show(mViewPager);
                         }
                     }
                 });

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPSwipeSnackbar.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPSwipeSnackbar.java
@@ -48,13 +48,13 @@ public class WPSwipeSnackbar {
         String text;
         switch (arrows) {
             case LEFT:
-                text = arrowLeft + " " + swipeText;
+                text = arrowLeft + "  " + swipeText;
                 break;
             case RIGHT:
-                text = swipeText + " " + arrowRight;
+                text = swipeText + "  " + arrowRight;
                 break;
             case BOTH:
-                text = arrowLeft + " " + swipeText + " " + arrowRight;
+                text = arrowLeft + "  " + swipeText + "  " + arrowRight;
                 break;
             default:
                 text = swipeText;

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPSwipeSnackbar.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPSwipeSnackbar.java
@@ -1,0 +1,83 @@
+package org.wordpress.android.widgets;
+
+import android.content.Context;
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
+import android.support.v4.view.PagerAdapter;
+import android.support.v4.view.ViewPager;
+import android.view.Gravity;
+import android.view.View;
+import android.widget.TextView;
+
+import org.wordpress.android.R;
+
+/*
+ * Snackbar used with a ViewPager to indicate to the user they can swipe to see more pages
+ */
+public class WPSwipeSnackbar {
+
+    public enum SwipeArrows {
+        LEFT, RIGHT, BOTH, NONE
+    }
+
+    private WPSwipeSnackbar() {
+        throw new AssertionError();
+    }
+
+    public static Snackbar show(@NonNull ViewPager viewPager) {
+        SwipeArrows arrows;
+        PagerAdapter adapter = viewPager.getAdapter();
+        if (adapter == null || adapter.getCount() <= 1) {
+            arrows = SwipeArrows.NONE;
+        } else if (viewPager.getCurrentItem() == 0) {
+            arrows = SwipeArrows.RIGHT;
+        } else if (viewPager.getCurrentItem() == (adapter.getCount() - 1)) {
+            arrows = SwipeArrows.LEFT;
+        } else {
+            arrows = SwipeArrows.BOTH;
+        }
+        return show(viewPager, arrows);
+    }
+    private static Snackbar show(@NonNull ViewPager viewPager, @NonNull SwipeArrows arrows) {
+        Context context = viewPager.getContext();
+        String swipeText = context.getResources().getString(R.string.swipe_for_more);
+        String arrowLeft = context.getResources().getString(R.string.arrow_left);
+        String arrowRight = context.getResources().getString(R.string.arrow_right);
+
+        String text;
+        switch (arrows) {
+            case LEFT:
+                text = arrowLeft + " " + swipeText;
+                break;
+            case RIGHT:
+                text = swipeText + " " + arrowRight;
+                break;
+            case BOTH:
+                text = arrowLeft + " " + swipeText + " " + arrowRight;
+                break;
+            default:
+                text = swipeText;
+                break;
+        }
+
+        Snackbar snackbar = Snackbar.make(viewPager, text, Snackbar.LENGTH_LONG);
+        centerSnackbarText(snackbar);
+        snackbar.show();
+
+        return snackbar;
+    }
+
+    /*
+     * horizontally center the snackbar's text
+     */
+    private static void centerSnackbarText(@NonNull Snackbar snackbar) {
+        TextView textView = (TextView) snackbar.getView().findViewById(android.support.design.R.id.snackbar_text);
+        if (textView != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                textView.setTextAlignment(View.TEXT_ALIGNMENT_CENTER);
+            }
+            textView.setGravity(Gravity.CENTER_HORIZONTAL);
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPSwipeSnackbar.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPSwipeSnackbar.java
@@ -39,6 +39,7 @@ public class WPSwipeSnackbar {
         }
         return show(viewPager, arrows);
     }
+
     private static Snackbar show(@NonNull ViewPager viewPager, @NonNull SwipeArrows arrows) {
         Context context = viewPager.getContext();
         String swipeText = context.getResources().getString(R.string.swipe_for_more);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -84,6 +84,7 @@
     <string name="off">Off</string>
     <string name="could_not_load_page">Could not load page</string>
     <string name="send">Send</string>
+    <string name="swipe_for_more">Swipe for more</string>
 
     <string name="button_skip">Skip</string>
     <string name="button_next">Next</string>
@@ -855,7 +856,6 @@
     <string name="follows">Follows</string>
     <string name="notifications_label_new_notifications">New notifications</string>
     <string name="notifications_label_new_notifications_subtitle">Tap to show them</string>
-    <string name="notifications_label_swipe_for_more_snackbar">Swipe for more notifications</string>
 
     <!-- Notification Settings -->
     <string name="notification_settings">Notification Settings</string>
@@ -1396,6 +1396,8 @@
     <string name="previous_button" translatable="false">&lt;</string>
     <string name="next_button" translatable="false">&gt;</string>
     <string name="vertical_line" translatable="false">\u007C</string>
+    <string name="arrow_left" translatable="false">\u2190</string>
+    <string name="arrow_right" translatable="false">\u2192</string>
 
     <!-- Noticons -->
     <string name="noticon_clock" translatable="false">\uf303</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1396,8 +1396,8 @@
     <string name="previous_button" translatable="false">&lt;</string>
     <string name="next_button" translatable="false">&gt;</string>
     <string name="vertical_line" translatable="false">\u007C</string>
-    <string name="arrow_left" translatable="false">\u2190</string>
-    <string name="arrow_right" translatable="false">\u2192</string>
+    <string name="arrow_left" translatable="false">\u21d0</string>
+    <string name="arrow_right" translatable="false">\u21d2</string>
 
     <!-- Noticons -->
     <string name="noticon_clock" translatable="false">\uf303</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1396,8 +1396,8 @@
     <string name="previous_button" translatable="false">&lt;</string>
     <string name="next_button" translatable="false">&gt;</string>
     <string name="vertical_line" translatable="false">\u007C</string>
-    <string name="arrow_left" translatable="false">\u21d0</string>
-    <string name="arrow_right" translatable="false">\u21d2</string>
+    <string name="arrow_left" translatable="false">\uffe9</string>
+    <string name="arrow_right" translatable="false">\uffeb</string>
 
     <!-- Noticons -->
     <string name="noticon_clock" translatable="false">\uf303</string>


### PR DESCRIPTION
Adds a "swipe snackbar" to the reader, and replaces the existing one in notifications, letting the user know they can swipe between pages. Automatically detects whether left/right arrows should be shown based on the ViewPager adapter's contents.

cc: @mzorz 

![screenshot_1480195588](https://cloud.githubusercontent.com/assets/3903757/20644163/836c174a-b3f9-11e6-84b9-48df0cce0512.png)
