### PR TITLE
issue/4828-reader-photo-viewer-npe

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -232,7 +232,7 @@ public class ReaderActivityLauncher {
             intent.putExtra(ReaderConstants.ARG_CONTENT, content);
         }
 
-        if (context instanceof Activity) {
+        if (context instanceof Activity && sourceView != null) {
             Activity activity = (Activity) context;
             ActivityOptionsCompat options =
                     ActivityOptionsCompat.makeScaleUpAnimation(sourceView, startX, startY, 0, 0);


### PR DESCRIPTION
Fixes #4828 

To test: Go to Media, tap an image, then tap the image in the detail view to show it in the photo viewer. Prior to this fix that would cause the app to crash.

