### PR TITLE
Process direct operation even when mCommentId == 0

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -383,9 +383,11 @@ public class ReaderCommentListActivity extends AppCompatActivity {
                     if (!isFinishing()) {
                         if (isEmpty || !mHasUpdatedComments) {
                             updateComments(isEmpty, false);
-                        } else if (mCommentId > 0) {
-                            // Scroll to the commentId once if it was passed to this activity
-                            smoothScrollToCommentId(mCommentId);
+                        } else if (mCommentId > 0 || mDirectOperation != null) {
+                            if (mCommentId > 0) {
+                                // Scroll to the commentId once if it was passed to this activity
+                                smoothScrollToCommentId(mCommentId);
+                            }
 
                             doDirectOperation();
                         } else if (mRestorePosition > 0) {


### PR DESCRIPTION
Fixes #4799 

To test:

* Open this PR page in Chrome and tap a `#respond` link this this one: https://gingerandchorizo.wordpress.com/2016/08/18/almond-maple-plum-cake/#respond and let the system open it up in the WordPress Reader if asked to select
* The post comments should become visible in the app and the comment edit box at the bottom should become focused
