### PR TITLE
Autosave the content of the post when the app is going to be killed by system

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -411,6 +411,16 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     }
 
     @Override
+    public void onLowMemory() {
+        // Autosave the content of the post when the app is being to be killed by the system.
+        // This could happen when the user start a new post/edit a post, and send the app to background (home button)
+        // before saving locally or publishing the post.
+        super.onLowMemory();
+        updatePostObject(true);
+        savePostToDb();
+    }
+
+    @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         // Saves both post objects so we can restore them in onCreate()


### PR DESCRIPTION
Fixes #4846

Post content can be lost if the user taps the home button to dismiss the WordPress Editor (the whole app actually), and than starts a lot of other apps. The device can go under low memory  condition and kill our app. 

To test:
- Ensure you have a PIN set in the WordPress app
- Open an existing post for editing
- Tap the Home button
- Open ~20 different apps to force WordPress to be booted out of memory.
- Re-open WP and input your PIN

You should see a local draft in the list of the post with your latest changes.
