### PR TITLE
Replace unicode arrows with "<" and ">"

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPSwipeSnackbar.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPSwipeSnackbar.java
@@ -43,8 +43,8 @@ public class WPSwipeSnackbar {
     private static Snackbar show(@NonNull ViewPager viewPager, @NonNull SwipeArrows arrows) {
         Context context = viewPager.getContext();
         String swipeText = context.getResources().getString(R.string.swipe_for_more);
-        String arrowLeft = context.getResources().getString(R.string.arrow_left);
-        String arrowRight = context.getResources().getString(R.string.arrow_right);
+        String arrowLeft = context.getResources().getString(R.string.previous_button);
+        String arrowRight = context.getResources().getString(R.string.next_button);
 
         String text;
         switch (arrows) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1397,8 +1397,6 @@
     <string name="previous_button" translatable="false">&lt;</string>
     <string name="next_button" translatable="false">&gt;</string>
     <string name="vertical_line" translatable="false">\u007C</string>
-    <string name="arrow_left" translatable="false">\uffe9</string>
-    <string name="arrow_right" translatable="false">\uffeb</string>
 
     <!-- Noticons -->
     <string name="noticon_clock" translatable="false">\uf303</string>


### PR DESCRIPTION
Replaces the faulty unicode arrows added in #4837 with simple "<" and ">" characters.

![screenshot_1480522656](https://cloud.githubusercontent.com/assets/3903757/20760777/e8087b9c-b6ee-11e6-8453-c5ceb6711b90.png)

