### PR TITLE
Upgrade PasscodeLock library to 1.5.1

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     // Provided by the WordPress-Android Repository
     compile 'org.wordpress:drag-sort-listview:0.6.1' // not found in maven central
     compile 'org.wordpress:slidinguppanel:1.0.0' // not found in maven central
-    compile 'org.wordpress:passcodelock:1.5.0'
+    compile 'org.wordpress:passcodelock:1.5.1'
 
     releaseCompile project(path:':libs:utils:WordPressUtils', configuration: 'release')
     debugCompile project(path:':libs:utils:WordPressUtils', configuration: 'debug')


### PR DESCRIPTION
Fixes #4504 

Needs https://github.com/wordpress-mobile/PasscodeLock-Android/pull/51

To test:
1. Switch PIN lock on
2. Exit the app
3. Wait a few seconds and then reopen the app - you should see the PIN/fingerprint screen
4. Press your phone's back button
5. _Quickly_ reopen the app - you should see the PIN/fingerprint screen




