### PR TITLE
Issue/4852 re add samsung multiwindow launcher category

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -71,6 +71,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.MULTIWINDOW_LAUNCHER" />
             </intent-filter>
         </activity>
 

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -71,6 +71,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <!-- Samsung multiwindow support -->
                 <category android:name="android.intent.category.MULTIWINDOW_LAUNCHER" />
             </intent-filter>
         </activity>
@@ -486,11 +487,11 @@
             android:exported="false"
             android:label="Notifications Screen Lock watch Service" />
 
-
+        <!-- Samsung multiwindow support -->
         <uses-library
             android:name="com.sec.android.app.multiwindow"
             android:required="false" />
-
+        <!-- Samsung multiwindow support -->
         <meta-data
             android:name="com.sec.android.support.multiwindow"
             android:value="true" />


### PR DESCRIPTION
Fixes #4852 

So this commit is where support for Samsung's Multiwindow has been added
https://github.com/wordpress-mobile/WordPress-Android/commit/3c0ece820869b7ad6ee1b901c9213e0b63e2e80e

And here’s where it seems to have been accidentally deleted:
https://github.com/wordpress-mobile/WordPress-Android/commit/3d6437d17aaeac893b7de44b850c7783c12d0f7c

To test:

Using a Samsung device with multiwindow support, uninstall then reinstall this version of WPAndroid. 
WPAndroid should be listed in the Samsung split screen menu when using other apps. The split screen only allows you to access certain apps (that are set up to be available in the split screen). 
cc'ing possible testers here @oguzkocer @hypest 