### PR TITLE
Update Library to Passcode Lock v1.5.1

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     // Provided by the WordPress-Android Repository
     compile 'org.wordpress:drag-sort-listview:0.6.1' // not found in maven central
     compile 'org.wordpress:slidinguppanel:1.0.0' // not found in maven central
-    compile 'org.wordpress:passcodelock:1.5.0'
+    compile 'org.wordpress:passcodelock:1.5.1'
 
     releaseCompile project(path:':libs:utils:WordPressUtils', configuration: 'release')
     debugCompile project(path:':libs:utils:WordPressUtils', configuration: 'debug')


### PR DESCRIPTION
### Fix
Update Passcode Lock library to [v1.5.1](https://github.com/wordpress-mobile/PasscodeLock-Android/releases/tag/1.5.1) as described in https://github.com/wordpress-mobile/WordPress-Android/issues/4855.