### PR TITLE
Issue/4857 make upload error notification expandable

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -1,8 +1,8 @@
 package org.wordpress.android.ui.posts.services;
 
 import android.app.Notification;
-import android.app.Notification.Builder;
-import android.app.NotificationManager;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.app.NotificationManagerCompat;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
@@ -855,8 +855,8 @@ public class PostUploadService extends Service {
     }
 
     private class PostUploadNotifier {
-        private final NotificationManager mNotificationManager;
-        private final Builder mNotificationBuilder;
+        private final NotificationManagerCompat mNotificationManager;
+        private final NotificationCompat.Builder mNotificationBuilder;
         private final int mNotificationId;
         private int mNotificationErrorId = 0;
         private int mTotalMediaItems;
@@ -865,9 +865,9 @@ public class PostUploadService extends Service {
 
         public PostUploadNotifier(Post post, String title, String message) {
             // add the uploader to the notification bar
-            mNotificationManager = (NotificationManager) SystemServiceFactory.get(mContext,
-                    Context.NOTIFICATION_SERVICE);
-            mNotificationBuilder = new Notification.Builder(getApplicationContext());
+            mNotificationManager = NotificationManagerCompat.from(PostUploadService.this);
+
+            mNotificationBuilder = new NotificationCompat.Builder(getApplicationContext());
             mNotificationBuilder.setSmallIcon(android.R.drawable.stat_sys_upload);
             if (title != null) {
                 mNotificationBuilder.setContentTitle(title);
@@ -900,7 +900,7 @@ public class PostUploadService extends Service {
             }
 
             // Notification builder
-            Builder notificationBuilder = new Notification.Builder(getApplicationContext());
+            NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(getApplicationContext());
             String notificationTitle = (String) (post.isPage() ? mContext.getResources().getText(R.string
                     .page_published) : mContext.getResources().getText(R.string.post_published));
             if (!isFirstPublishing) {
@@ -953,7 +953,7 @@ public class PostUploadService extends Service {
         public void updateNotificationError(String mErrorMessage, boolean isMediaError, boolean isPage) {
             AppLog.d(T.POSTS, "updateNotificationError: " + mErrorMessage);
 
-            Builder notificationBuilder = new Notification.Builder(getApplicationContext());
+            NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(getApplicationContext());
             String postOrPage = (String) (isPage ? mContext.getResources().getText(R.string.page_id)
                     : mContext.getResources().getText(R.string.post_id));
             Intent notificationIntent = new Intent(mContext, PostsListActivity.class);
@@ -970,11 +970,14 @@ public class PostUploadService extends Service {
                         + mContext.getResources().getText(R.string.error);
             }
 
+            String message = (isMediaError) ? mErrorMessage : postOrPage + " " + errorText
+                    + ": " + mErrorMessage;
             notificationBuilder.setSmallIcon(android.R.drawable.stat_notify_error);
             notificationBuilder.setContentTitle((isMediaError) ? errorText :
                     mContext.getResources().getText(R.string.upload_failed));
             notificationBuilder.setContentText((isMediaError) ? mErrorMessage : postOrPage + " " + errorText
                     + ": " + mErrorMessage);
+            notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(message));
             notificationBuilder.setContentIntent(pendingIntent);
             notificationBuilder.setAutoCancel(true);
             if (mNotificationErrorId == 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -766,7 +766,7 @@ public class PostUploadService extends Service {
         private void setUploadPostErrorMessage(Exception e) {
             mErrorMessage = String.format(mContext.getResources().getText(R.string.error_upload).toString(),
                     mPost.isPage() ? mContext.getResources().getText(R.string.page).toString() :
-                            mContext.getResources().getText(R.string.post).toString()) + " " + e.getMessage();
+                            mContext.getResources().getText(R.string.post).toString()) + " - " + e.getMessage();
             mIsMediaError = false;
             AppLog.e(T.EDITOR, mErrorMessage, e);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -916,6 +916,7 @@ public class PostUploadService extends Service {
             }
             notificationBuilder.setContentTitle(notificationTitle);
             notificationBuilder.setContentText(post.getTitle());
+            notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(post.getTitle()));
             notificationBuilder.setAutoCancel(true);
 
             // Tap notification intent (open the post list)
@@ -975,8 +976,7 @@ public class PostUploadService extends Service {
             notificationBuilder.setSmallIcon(android.R.drawable.stat_notify_error);
             notificationBuilder.setContentTitle((isMediaError) ? errorText :
                     mContext.getResources().getText(R.string.upload_failed));
-            notificationBuilder.setContentText((isMediaError) ? mErrorMessage : postOrPage + " " + errorText
-                    + ": " + mErrorMessage);
+            notificationBuilder.setContentText(message);
             notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(message));
             notificationBuilder.setContentIntent(pendingIntent);
             notificationBuilder.setAutoCancel(true);


### PR DESCRIPTION
Fixes #4857 

Makes notifications expandable so users can read the full detail of an error right away on the notification

![goodnotif](https://cloud.githubusercontent.com/assets/6597771/20789591/c498fb96-b793-11e6-9cdf-564330769d51.png)


To test:

This is not easy to test without making an actual error happen server side or making a proxied request fail.
What I did for testing purposes is actually throw an exception right after our XML RPC call to update the post, so to trigger the error path in the code when it should happen, like this:

add this line in line 393 in PostUploadService.java:

```
               testException();
```

Then add this method right below `doInBackground()`

```
        //FIXME delete this method
        private void testException() throws XMLRPCException{
            throw new XMLRPCException("HTTP status code: 503 was returned. Service Temporarily Unavailable");
        }
```

1. Write a new draft / edit a blog post
2. Tap on PUBLISH / UPDATE
3. you should see a notification like the above

cc @daniloercoli would you like to try this one? 😄 