### PR TITLE
Issue/3481 notifications horizontal scrolling for filter

### DIFF
--- a/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
+++ b/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
@@ -73,17 +73,19 @@
             app:layout_scrollFlags="scroll|enterAlways">
 
             <HorizontalScrollView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content">
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginBottom="@dimen/margin_medium"
+                android:layout_marginLeft="@dimen/margin_extra_large"
+                android:layout_marginRight="@dimen/margin_extra_large"
+                android:layout_marginTop="@dimen/margin_medium"
+                android:fillViewport="true">
 
                 <RadioGroup
                     android:id="@+id/notifications_radio_group"
-                    android:layout_width="match_parent"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="@dimen/margin_medium"
-                    android:layout_marginLeft="@dimen/margin_extra_large"
-                    android:layout_marginRight="@dimen/margin_extra_large"
-                    android:layout_marginTop="@dimen/margin_medium"
                     android:background="@drawable/calypso_segmented_control_background"
                     android:checkedButton="@+id/notifications_filter_all"
                     android:orientation="horizontal">

--- a/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
+++ b/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
@@ -72,56 +72,61 @@
             android:orientation="vertical"
             app:layout_scrollFlags="scroll|enterAlways">
 
-            <RadioGroup
-                android:id="@+id/notifications_radio_group"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_medium"
-                android:layout_marginLeft="@dimen/margin_extra_large"
-                android:layout_marginRight="@dimen/margin_extra_large"
-                android:layout_marginTop="@dimen/margin_medium"
-                android:background="@drawable/calypso_segmented_control_background"
-                android:checkedButton="@+id/notifications_filter_all"
-                android:orientation="horizontal">
+            <HorizontalScrollView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content">
 
-                <org.wordpress.android.widgets.WPRadioButton
-                    android:id="@+id/notifications_filter_all"
-                    style="@style/Calypso.SegmentedControl"
-                    android:background="@drawable/calypso_segmented_control_button_start"
-                    android:text="@string/all" />
+                <RadioGroup
+                    android:id="@+id/notifications_radio_group"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/margin_medium"
+                    android:layout_marginLeft="@dimen/margin_extra_large"
+                    android:layout_marginRight="@dimen/margin_extra_large"
+                    android:layout_marginTop="@dimen/margin_medium"
+                    android:background="@drawable/calypso_segmented_control_background"
+                    android:checkedButton="@+id/notifications_filter_all"
+                    android:orientation="horizontal">
 
-                <org.wordpress.android.widgets.WPRadioButton
-                    android:id="@+id/notifications_filter_unread"
-                    style="@style/Calypso.SegmentedControl"
-                    android:layout_marginLeft="-1dp"
-                    android:layout_marginStart="-1dp"
-                    android:background="@drawable/calypso_segmented_control_button"
-                    android:text="@string/unread" />
+                    <org.wordpress.android.widgets.WPRadioButton
+                        android:id="@+id/notifications_filter_all"
+                        style="@style/Calypso.SegmentedControl"
+                        android:background="@drawable/calypso_segmented_control_button_start"
+                        android:text="@string/all" />
 
-                <org.wordpress.android.widgets.WPRadioButton
-                    android:id="@+id/notifications_filter_comments"
-                    style="@style/Calypso.SegmentedControl"
-                    android:layout_marginLeft="-1dp"
-                    android:layout_marginStart="-1dp"
-                    android:background="@drawable/calypso_segmented_control_button"
-                    android:text="@string/tab_comments" />
+                    <org.wordpress.android.widgets.WPRadioButton
+                        android:id="@+id/notifications_filter_unread"
+                        style="@style/Calypso.SegmentedControl"
+                        android:layout_marginLeft="-1dp"
+                        android:layout_marginStart="-1dp"
+                        android:background="@drawable/calypso_segmented_control_button"
+                        android:text="@string/unread" />
 
-                <org.wordpress.android.widgets.WPRadioButton
-                    android:id="@+id/notifications_filter_follows"
-                    style="@style/Calypso.SegmentedControl"
-                    android:layout_marginLeft="-1dp"
-                    android:layout_marginStart="-1dp"
-                    android:background="@drawable/calypso_segmented_control_button"
-                    android:text="@string/follows" />
+                    <org.wordpress.android.widgets.WPRadioButton
+                        android:id="@+id/notifications_filter_comments"
+                        style="@style/Calypso.SegmentedControl"
+                        android:layout_marginLeft="-1dp"
+                        android:layout_marginStart="-1dp"
+                        android:background="@drawable/calypso_segmented_control_button"
+                        android:text="@string/tab_comments" />
 
-                <org.wordpress.android.widgets.WPRadioButton
-                    android:id="@+id/notifications_filter_likes"
-                    style="@style/Calypso.SegmentedControl"
-                    android:layout_marginLeft="-1dp"
-                    android:layout_marginStart="-1dp"
-                    android:background="@drawable/calypso_segmented_control_button_end"
-                    android:text="@string/stats_likes" />
-            </RadioGroup>
+                    <org.wordpress.android.widgets.WPRadioButton
+                        android:id="@+id/notifications_filter_follows"
+                        style="@style/Calypso.SegmentedControl"
+                        android:layout_marginLeft="-1dp"
+                        android:layout_marginStart="-1dp"
+                        android:background="@drawable/calypso_segmented_control_button"
+                        android:text="@string/follows" />
+
+                    <org.wordpress.android.widgets.WPRadioButton
+                        android:id="@+id/notifications_filter_likes"
+                        style="@style/Calypso.SegmentedControl"
+                        android:layout_marginLeft="-1dp"
+                        android:layout_marginStart="-1dp"
+                        android:background="@drawable/calypso_segmented_control_button_end"
+                        android:text="@string/stats_likes" />
+                </RadioGroup>
+            </HorizontalScrollView>
 
             <View
                 android:id="@+id/notifications_filter_divider"


### PR DESCRIPTION
Fixes #3481 

By using the horizontal scroll approach as first suggested by @drw158 

To test:
1. Using a small screen device, go to the Notifications screen (4th tab to the right)
2. The filters group shown right below the action bar should now be all visible (no strings truncated) and the group is horizontally scrollable.

cc @maxme 
