### PR TITLE
adding the correct empty view with the  message type when loading posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -223,6 +223,10 @@ public class PostsListFragment extends Fragment
             return;
         }
 
+        if (getPostListAdapter().getItemCount() == 0) {
+            updateEmptyView(EmptyViewMessageType.LOADING);
+        }
+
         mIsFetchingPosts = true;
         if (loadMore) {
             showLoadMoreProgress();


### PR DESCRIPTION
Fixes #4859 

To test:
1. Log out from the app, to erase the local database
2. log back in
3. go to Blog Posts and confirm there's the "Fetching posts..." message in the center of the screen.


