### PR TITLE
Issue/4872 plans menu item viseble to all userlevel

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -105,7 +105,7 @@ public class WordPress extends MultiDexApplication {
     private static RestClientUtils mRestClientUtilsVersion0;
 
     private static final int SECONDS_BETWEEN_OPTIONS_UPDATE = 10 * 60;
-    private static final int SECONDS_BETWEEN_BLOGLIST_UPDATE = 6 * 60 * 60;
+    private static final int SECONDS_BETWEEN_BLOGLIST_UPDATE = 15 * 60;
     private static final int SECONDS_BETWEEN_DELETE_STATS = 5 * 60; // 5 minutes
 
     private static Context mContext;

--- a/WordPress/src/main/java/org/wordpress/android/models/Capability.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Capability.java
@@ -7,7 +7,8 @@ package org.wordpress.android.models;
 public enum Capability {
     LIST_USERS("list_users"), // Check if user can visit People page
     PROMOTE_USERS("promote_users"), // Check if user can change another user's role
-    REMOVE_USERS("remove_users"); // Check if user can remove another user
+    REMOVE_USERS("remove_users"), // Check if user can remove another user
+    EDIT_PAGES("edit_pages"); // Check if user can edit Pages
 
     private final String label;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -64,6 +64,7 @@ public class MySiteFragment extends Fragment
     private LinearLayout mLookAndFeelHeader;
     private RelativeLayout mThemesContainer;
     private RelativeLayout mPeopleView;
+    private RelativeLayout mPageView;
     private RelativeLayout mPlanContainer;
     private View mConfigurationHeader;
     private View mSettingsView;
@@ -147,6 +148,7 @@ public class MySiteFragment extends Fragment
         mNoSiteDrakeImageView = (ImageView) rootView.findViewById(R.id.my_site_no_site_view_drake);
         mFabView = rootView.findViewById(R.id.fab_button);
         mCurrentPlanNameTextView = (WPTextView) rootView.findViewById(R.id.my_site_current_plan_text_view);
+        mPageView = (RelativeLayout) rootView.findViewById(R.id.row_pages);
 
         // hide the FAB the first time the fragment is created in order to animate it in onResume()
         if (savedInstanceState == null) {
@@ -381,6 +383,10 @@ public class MySiteFragment extends Fragment
         } else {
             mPlanContainer.setVisibility(View.GONE);
         }
+
+        // Do not show pages menu item to Collaborators.
+        int pageVisibility = (isAdminOrSelfHosted || blog.hasCapability(Capability.EDIT_PAGES)) ? View.VISIBLE : View.GONE;
+        mPageView.setVisibility(pageVisibility);
     }
 
     private void toggleAdminVisibility(@Nullable final Blog blog) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -375,7 +375,7 @@ public class MySiteFragment extends Fragment
 
         // Hide the Plan item if the Plans feature is not available for this blog
         String planShortName = blog.getPlanShortName();
-        if (!TextUtils.isEmpty(planShortName)) {
+        if (!TextUtils.isEmpty(planShortName) && blog.isAdmin()) {
             mCurrentPlanNameTextView.setText(planShortName);
             mPlanContainer.setVisibility(View.VISIBLE);
         } else {


### PR DESCRIPTION
Fixes #4872 by showing Plans menu item to Admins only.

Also changed the blog lists refresh frequency to 15 mins - It was set to 6hrs - and fixed an issue where Pages menu item was shown to .com users, even if they didn't have "edit_pages" capability.
