### PR TITLE
Issue/4860 site chooser progress

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -228,7 +228,21 @@ public class SitePickerActivity extends AppCompatActivity
     }
 
     private void setNewAdapter(String lastSearch, boolean isInSearchMode) {
-        mAdapter = new SitePickerAdapter(this, mCurrentLocalId, lastSearch, isInSearchMode);
+        mAdapter = new SitePickerAdapter(
+                this,
+                mCurrentLocalId,
+                lastSearch,
+                isInSearchMode,
+                new SitePickerAdapter.OnDataLoadedListener() {
+            @Override
+            public void onBeforeLoad() {
+                showProgress(true);
+            }
+            @Override
+            public void onAfterLoad() {
+                showProgress(false);
+            }
+        });
         mAdapter.setOnSiteClickListener(this);
         mAdapter.setOnSelectedCountChangedListener(this);
     }
@@ -368,6 +382,11 @@ public class SitePickerActivity extends AppCompatActivity
         getAdapter().setLastSearch(s);
         getAdapter().searchSites(s);
         return true;
+    }
+
+    public void showProgress(boolean show) {
+        View progress = findViewById(R.id.progress);
+        progress.setVisibility(show ? View.VISIBLE : View.GONE);
     }
 
     private final class ActionModeCallback implements ActionMode.Callback {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -235,8 +235,10 @@ public class SitePickerActivity extends AppCompatActivity
                 isInSearchMode,
                 new SitePickerAdapter.OnDataLoadedListener() {
             @Override
-            public void onBeforeLoad() {
-                showProgress(true);
+            public void onBeforeLoad(boolean isEmpty) {
+                if (isEmpty) {
+                    showProgress(true);
+                }
             }
             @Override
             public void onAfterLoad() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -387,8 +387,7 @@ public class SitePickerActivity extends AppCompatActivity
     }
 
     public void showProgress(boolean show) {
-        View progress = findViewById(R.id.progress);
-        progress.setVisibility(show ? View.VISIBLE : View.GONE);
+        findViewById(R.id.progress).setVisibility(show ? View.VISIBLE : View.GONE);
     }
 
     private final class ActionModeCallback implements ActionMode.Callback {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -39,6 +39,11 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
         void onSelectedCountChanged(int numSelected);
     }
 
+    interface OnDataLoadedListener {
+        void onBeforeLoad();
+        void onAfterLoad();
+    }
+
     private final int mTextColorNormal;
     private final int mTextColorHidden;
 
@@ -61,6 +66,7 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
 
     private OnSiteClickListener mSiteSelectedListener;
     private OnSelectedCountChangedListener mSelectedCountListener;
+    private OnDataLoadedListener mDataLoadedListener;
 
     class SiteViewHolder extends RecyclerView.ViewHolder {
         private final ViewGroup layoutContainer;
@@ -81,7 +87,11 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
         }
     }
 
-    public  SitePickerAdapter(Context context, int currentLocalBlogId, String lastSearch, boolean isInSearchMode) {
+    public  SitePickerAdapter(Context context,
+                              int currentLocalBlogId,
+                              String lastSearch,
+                              boolean isInSearchMode,
+                              OnDataLoadedListener dataLoadedListener) {
         super();
 
         setHasStableIds(true);
@@ -91,6 +101,7 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
         mIsInSearchMode = isInSearchMode;
         mCurrentLocalId = currentLocalBlogId;
         mInflater = LayoutInflater.from(context);
+        mDataLoadedListener = dataLoadedListener;
 
         mBlavatarSz = context.getResources().getDimensionPixelSize(R.dimen.blavatar_sz);
         mTextColorNormal = context.getResources().getColor(R.color.grey_dark);
@@ -368,6 +379,9 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
         protected void onPreExecute() {
             super.onPreExecute();
             mIsTaskRunning = true;
+            if (mDataLoadedListener != null) {
+                mDataLoadedListener.onBeforeLoad();
+            }
         }
 
         @Override
@@ -416,6 +430,9 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
         protected void onPostExecute(Void results) {
             notifyDataSetChanged();
             mIsTaskRunning = false;
+            if (mDataLoadedListener != null) {
+                mDataLoadedListener.onAfterLoad();
+            }
         }
 
         private List<Map<String, Object>> getBlogsForCurrentView(String[] extraFields) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -40,7 +40,7 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
     }
 
     interface OnDataLoadedListener {
-        void onBeforeLoad();
+        void onBeforeLoad(boolean isEmpty);
         void onAfterLoad();
     }
 
@@ -380,7 +380,8 @@ class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.SiteViewH
             super.onPreExecute();
             mIsTaskRunning = true;
             if (mDataLoadedListener != null) {
-                mDataLoadedListener.onBeforeLoad();
+                boolean isEmpty = mSites == null || mSites.size() == 0;
+                mDataLoadedListener.onBeforeLoad(isEmpty);
             }
         }
 

--- a/WordPress/src/main/res/layout/site_picker_activity.xml
+++ b/WordPress/src/main/res/layout/site_picker_activity.xml
@@ -4,12 +4,21 @@
     xmlns:fab="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="match_parent">
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbars="vertical" />
+
+    <ProgressBar
+        android:id="@+id/progress"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
 </FrameLayout>


### PR DESCRIPTION
Fixes #4860 - when the site picker is displayed, a progress spinner now appears while the list of sites is loaded if the list is currently empty.
