### PR TITLE
URL encode the query email before check

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -1026,7 +1026,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     }
 
     private void requestWPComEmailCheck() {
-        WordPress.getRestClientUtilsV0().isAvailable(mUsername, new RestRequest.Listener() {
+        WordPress.getRestClientUtilsV0().isAvailable(UrlUtils.urlEncode(mUsername), new RestRequest.Listener() {
             @Override
             public void onResponse(JSONObject response) {
                 try {


### PR DESCRIPTION
Fixes #4794 

To test:
* While signed out, try to log in with an email that contains a plus sign (`+`) and is known to belong to a WordPress.com account
* The app should move on to the next step in the magic-login flow and offer to send an email

