### PR TITLE
issue/4884-gravatar-error-toast

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -659,11 +659,10 @@ public class MeFragment extends Fragment {
     }
 
     public void onEventMainThread(GravatarLoadFinished event) {
-        showGravatarProgressBar(false);
-
-        if (!event.success) {
+        if (!event.success && mIsUpdatingGravatar) {
             Toast.makeText(getActivity(), getString(R.string.error_refreshing_gravatar), Toast.LENGTH_SHORT).show();
         }
+        showGravatarProgressBar(false);
     }
 
     // injects a fabricated cache entry to the request cache

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -660,10 +660,6 @@ public class MeFragment extends Fragment {
 
     public void onEventMainThread(GravatarLoadFinished event) {
         showGravatarProgressBar(false);
-
-        if (!event.success) {
-            Toast.makeText(getActivity(), getString(R.string.error_refreshing_gravatar), Toast.LENGTH_SHORT).show();
-        }
     }
 
     // injects a fabricated cache entry to the request cache

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -660,6 +660,10 @@ public class MeFragment extends Fragment {
 
     public void onEventMainThread(GravatarLoadFinished event) {
         showGravatarProgressBar(false);
+
+        if (!event.success) {
+            Toast.makeText(getActivity(), getString(R.string.error_refreshing_gravatar), Toast.LENGTH_SHORT).show();
+        }
     }
 
     // injects a fabricated cache entry to the request cache

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1557,7 +1557,6 @@
     <string name="gravatar_tip">New! Tap your Gravatar to change it!</string>
     <string name="error_cropping_image">Error cropping the image</string>
     <string name="error_locating_image">Error locating the cropped image</string>
-    <string name="error_refreshing_gravatar">Error reloading your Gravatar</string>
     <string name="error_updating_gravatar">Error updating your Gravatar</string>
     <string name="gravatar_camera_and_media_permission_required">Permissions required in order to select or capture a photo</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1557,6 +1557,7 @@
     <string name="gravatar_tip">New! Tap your Gravatar to change it!</string>
     <string name="error_cropping_image">Error cropping the image</string>
     <string name="error_locating_image">Error locating the cropped image</string>
+    <string name="error_refreshing_gravatar">Error reloading your Gravatar</string>
     <string name="error_updating_gravatar">Error updating your Gravatar</string>
     <string name="gravatar_camera_and_media_permission_required">Permissions required in order to select or capture a photo</string>
 


### PR DESCRIPTION
Fixes #4884 

To test: remove the image from your Gravatar account. Prior to this fix you'd see a toast saying "Error reloading your gravatar" every time you ran the app. The fix was to simply remove this message, since it's not really necessary.

cc: @hypest Mind reviewing this one, since this feature was your baby? I'm pretty sure we don't need that toast but wanted to run it by you.

