### PR TITLE
issue/4868-reader-xpost-out-of-order

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -83,7 +83,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     private static final int VIEW_TYPE_TAG_HEADER  = 3;
     private static final int VIEW_TYPE_GAP_MARKER  = 4;
 
-    private static final long ITEM_ID_CUSTOM_VIEW = -1L;
+    private static final long ITEM_ID_HEADER     = -1L;
+    private static final long ITEM_ID_GAP_MARKER = -2L;
 
     /*
      * cross-post
@@ -716,10 +717,14 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
 
     @Override
     public long getItemId(int position) {
-        if (getItemViewType(position) == VIEW_TYPE_POST) {
-            return getItem(position).getStableId();
-        } else {
-            return ITEM_ID_CUSTOM_VIEW;
+        switch (getItemViewType(position)) {
+            case VIEW_TYPE_TAG_HEADER :
+            case VIEW_TYPE_SITE_HEADER :
+                return ITEM_ID_HEADER;
+            case VIEW_TYPE_GAP_MARKER :
+                return ITEM_ID_GAP_MARKER;
+            default:
+                return getItem(position).getStableId();
         }
     }
 


### PR DESCRIPTION
Fixes #4868 - problem was caused by a faulty `getItemId()` implementation in the adapter.

