### PR TITLE
Only rebuild notifications if WPPin is enabled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -309,17 +309,17 @@ public class GCMMessageService extends GcmListenerService {
     }
 
     private boolean canAddActionsToNotifications() {
-        if (isWPPinLockEnabled()) {
+        if (isWPPinLockEnabled(this)) {
             return !isDeviceLocked();
         }
         return true;
     }
 
-    private boolean isWPPinLockEnabled() {
+    public static boolean isWPPinLockEnabled(Context context) {
         AppLockManager appLockManager = AppLockManager.getInstance();
         // Make sure PasscodeLock isn't already in place
         if (!appLockManager.isAppLockFeatureEnabled()) {
-            appLockManager.enableDefaultAppLockIfAvailable(this.getApplication());
+            appLockManager.enableDefaultAppLockIfAvailable((WordPress)context.getApplicationContext());
         }
 
         // Make sure the locker was correctly enabled, and it's active

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -39,6 +39,7 @@ import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DeviceUtils;
 import org.wordpress.android.util.HelpshiftHelper;
 import org.wordpress.android.util.ImageUtils;
@@ -839,6 +840,12 @@ public class GCMMessageService extends GcmListenerService {
                             shouldCircularizeNoteIcon(remainingNote.getString(PUSH_ARG_TYPE)));
 
                     builder = getNotificationBuilder(context, title, message);
+
+                    // set timestamp for note: first try notification timestamp, then try google's sent time if not available
+                    // finally just set the system's current time if everything else fails (not likely)
+                    long noteTimeStamp = DateTimeUtils.timestampFromIso8601(remainingNote.getString("note_timestamp"));
+                    noteTimeStamp = noteTimeStamp != 0 ? noteTimeStamp : remainingNote.getLong("google.sent_time", System.currentTimeMillis());
+                    builder.setWhen(noteTimeStamp);
 
                     noteType = StringUtils.notNullStr(remainingNote.getString(PUSH_ARG_TYPE));
                     wpcomNoteID = remainingNote.getString(PUSH_ARG_NOTE_ID, "");

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/ScreenLockUnlockBroadcastReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/ScreenLockUnlockBroadcastReceiver.java
@@ -14,8 +14,8 @@ public class ScreenLockUnlockBroadcastReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         final String action = intent.getAction();
         if (Intent.ACTION_SCREEN_OFF.equals(action) || Intent.ACTION_USER_PRESENT.equals(action)) {
-            // only rebuild notifications if WPpin not enabled, otherwise notifications are always
-            // updated and they always appear to have been just received (timestamp is always udpated)
+            // only rebuild notifications if WPpin not enabled, notifications don't need be updated
+            // if quick actions are to remain the same
             if (GCMMessageService.isWPPinLockEnabled(context)) {
                 GCMMessageService.rebuildAndUpdateNotifsOnSystemBarForRemainingNote(context);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/ScreenLockUnlockBroadcastReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/ScreenLockUnlockBroadcastReceiver.java
@@ -14,7 +14,11 @@ public class ScreenLockUnlockBroadcastReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         final String action = intent.getAction();
         if (Intent.ACTION_SCREEN_OFF.equals(action) || Intent.ACTION_USER_PRESENT.equals(action)) {
-            GCMMessageService.rebuildAndUpdateNotifsOnSystemBarForRemainingNote(context);
+            // only rebuild notifications if WPpin not enabled, otherwise notifications are always
+            // updated and they always appear to have been just received (timestamp is always udpated)
+            if (GCMMessageService.isWPPinLockEnabled(context)) {
+                GCMMessageService.rebuildAndUpdateNotifsOnSystemBarForRemainingNote(context);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #4886 

As per the description in [this comment](https://github.com/wordpress-mobile/WordPress-Android/issues/4886#issuecomment-266071385), this PR addresses that issue for users that don't have WPPin enabled, by bypassing the notification rebuild process if such feature is not enabled.

For those users who have WP Pin enabled, inevitably notifications need to be re-created each time on screen lock/unlock so we can make sure quick actions are not available to unidentified users.

To test:
1. Log in to the WP Android app 
2. Have another user make a comment on a blog you're an admin of
3. See the notification come in.
4. Without entering the app, just wait for a few minutes and observe whether locking/unlocking the screen changes the notification timestamp (it shouldn't).

5. Enable the PIN by going to 3rd tab (My Profile) -> App Settings -> Turn PIN lock on. Enter a pin (it'll ask twice), and check the notification (make another comment if notification has been dismissed already).
6. Try locking/unlocking the screen several times and verify each time the timestamp is re-generated (along with notifications quick actions being shown/hidden, respectively)

cc @nbradbury 
