### PR TITLE
NotificationHelper Refactor to make it be created upon app init.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -59,7 +59,7 @@ import static org.wordpress.android.ui.notifications.NotificationsListFragment.N
 
 public class GCMMessageService extends GcmListenerService {
     private static final ArrayMap<Integer, Bundle> sActiveNotificationsMap = new ArrayMap<>();
-    private static NotificationHelper sNotificationHelpers = new NotificationHelper();
+    private static final NotificationHelper sNotificationHelpers = new NotificationHelper();
 
     private static final String NOTIFICATION_GROUP_KEY = "notification_group_key";
     public static final int PUSH_NOTIFICATION_ID = 10000;
@@ -142,7 +142,7 @@ public class GCMMessageService extends GcmListenerService {
     }
 
     public static synchronized void rebuildAndUpdateNotificationsOnSystemBarForThisNote(Context context, String noteId){
-        if (sNotificationHelpers != null && sActiveNotificationsMap.size() > 0) {
+        if (sActiveNotificationsMap.size() > 0) {
             //get the corresponding bundle for this noteId
             for(Iterator<Map.Entry<Integer, Bundle>> it = sActiveNotificationsMap.entrySet().iterator(); it.hasNext(); ) {
                 Map.Entry<Integer, Bundle> row = it.next();
@@ -156,7 +156,7 @@ public class GCMMessageService extends GcmListenerService {
     }
 
     public static synchronized void rebuildAndUpdateNotifsOnSystemBarForRemainingNote(Context context){
-        if (sNotificationHelpers != null && sActiveNotificationsMap.size() > 0) {
+        if (sActiveNotificationsMap.size() > 0) {
             Bundle remainingNote = sActiveNotificationsMap.values().iterator().next();
             sNotificationHelpers.rebuildAndUpdateNotificationsOnSystemBar(context, remainingNote);
         }

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -59,7 +59,7 @@ import static org.wordpress.android.ui.notifications.NotificationsListFragment.N
 
 public class GCMMessageService extends GcmListenerService {
     private static final ArrayMap<Integer, Bundle> sActiveNotificationsMap = new ArrayMap<>();
-    private static NotificationHelper sNotificationHelpers;
+    private static NotificationHelper sNotificationHelpers = new NotificationHelper();
 
     private static final String NOTIFICATION_GROUP_KEY = "notification_group_key";
     public static final int PUSH_NOTIFICATION_ID = 10000;
@@ -101,15 +101,8 @@ public class GCMMessageService extends GcmListenerService {
     private void synchronizedHandleDefaultPush(@NonNull Bundle data) {
         // sActiveNotificationsMap being static, we can't just synchronize the method
         synchronized (GCMMessageService.class) {
-            getHelperInstace().handleDefaultPush(this, data);
+            sNotificationHelpers.handleDefaultPush(this, data);
         }
-    }
-
-    private NotificationHelper getHelperInstace() {
-        if (sNotificationHelpers == null) {
-            sNotificationHelpers = new NotificationHelper();
-        }
-        return sNotificationHelpers;
     }
 
     @Override
@@ -308,18 +301,18 @@ public class GCMMessageService extends GcmListenerService {
         }
     }
 
-    private boolean canAddActionsToNotifications() {
-        if (isWPPinLockEnabled()) {
-            return !isDeviceLocked();
+    private static boolean canAddActionsToNotifications(Context context) {
+        if (isWPPinLockEnabled(context)) {
+            return !isDeviceLocked(context);
         }
         return true;
     }
 
-    private boolean isWPPinLockEnabled() {
+    private static boolean isWPPinLockEnabled(Context context) {
         AppLockManager appLockManager = AppLockManager.getInstance();
         // Make sure PasscodeLock isn't already in place
         if (!appLockManager.isAppLockFeatureEnabled()) {
-            appLockManager.enableDefaultAppLockIfAvailable(this.getApplication());
+            appLockManager.enableDefaultAppLockIfAvailable((WordPress)context.getApplicationContext());
         }
 
         // Make sure the locker was correctly enabled, and it's active
@@ -329,8 +322,8 @@ public class GCMMessageService extends GcmListenerService {
         return Boolean.FALSE;
     }
 
-    private boolean isDeviceLocked() {
-        return DeviceUtils.getInstance().isDeviceLocked(this);
+    private static boolean isDeviceLocked(Context context) {
+        return DeviceUtils.getInstance().isDeviceLocked(context);
     }
 
 
@@ -338,12 +331,12 @@ public class GCMMessageService extends GcmListenerService {
         sActiveNotificationsMap.put(AUTH_PUSH_NOTIFICATION_ID, data);
     }
 
-    private class NotificationHelper {
+    private static class NotificationHelper {
 
         private void handleDefaultPush(Context context, @NonNull Bundle data) {
             // if a notification is received while the app has not yet been launched after last power on,
             // the screenlockwatchservice won't be running. Let's start it now.
-            startService(new Intent(context, NotificationsScreenLockWatchService.class));
+            context.startService(new Intent(context, NotificationsScreenLockWatchService.class));
 
             long wpcomUserId = AccountHelper.getDefaultAccount().getUserId();
             String pushUserId = data.getString(PUSH_ARG_USER);
@@ -396,7 +389,7 @@ public class GCMMessageService extends GcmListenerService {
 
             String title = StringEscapeUtils.unescapeHtml(data.getString(PUSH_ARG_TITLE));
             if (title == null) {
-                title = getString(R.string.app_name);
+                title = context.getString(R.string.app_name);
             }
             String message = StringEscapeUtils.unescapeHtml(data.getString(PUSH_ARG_MSG));
 
@@ -462,7 +455,7 @@ public class GCMMessageService extends GcmListenerService {
 
             // Build the new notification, add group to support wearable stacking
             NotificationCompat.Builder builder = getNotificationBuilder(context, title, message);
-            Bitmap largeIconBitmap = getLargeIconBitmap(data.getString("icon"), shouldCircularizeNoteIcon(noteType));
+            Bitmap largeIconBitmap = getLargeIconBitmap(context, data.getString("icon"), shouldCircularizeNoteIcon(noteType));
             if (largeIconBitmap != null) {
                 builder.setLargeIcon(largeIconBitmap);
             }
@@ -475,7 +468,7 @@ public class GCMMessageService extends GcmListenerService {
         }
 
         private void addActionsForCommentNotification(Context context, NotificationCompat.Builder builder, String noteId) {
-            if (!canAddActionsToNotifications()) {
+            if (!canAddActionsToNotifications(context)) {
                 return;
             }
 
@@ -514,7 +507,7 @@ public class GCMMessageService extends GcmListenerService {
         }
 
         private void addCommentReplyActionForCommentNotification(Context context, NotificationCompat.Builder builder, String noteId) {
-            if (!canAddActionsToNotifications()) {
+            if (!canAddActionsToNotifications(context)) {
                 return;
             }
 
@@ -534,13 +527,13 @@ public class GCMMessageService extends GcmListenerService {
             The following code adds the behavior for Direct reply, available on Android N (7.0) and on.
             Using backward compatibility with NotificationCompat.
              */
-            String replyLabel = getResources().getString(R.string.reply);
+            String replyLabel = context.getString(R.string.reply);
             RemoteInput remoteInput = new RemoteInput.Builder(EXTRA_VOICE_OR_INLINE_REPLY)
                     .setLabel(replyLabel)
                     .build();
             NotificationCompat.Action action =
                     new NotificationCompat.Action.Builder(R.drawable.ic_reply_white_24dp,
-                            getString(R.string.reply), commentReplyPendingIntent)
+                            context.getString(R.string.reply), commentReplyPendingIntent)
                             .addRemoteInput(remoteInput)
                             .build();
             // now add the action corresponding to direct-reply
@@ -548,7 +541,7 @@ public class GCMMessageService extends GcmListenerService {
         }
 
         private void addCommentLikeActionForCommentNotification(Context context, NotificationCompat.Builder builder, String noteId) {
-            if (!canAddActionsToNotifications()) {
+            if (!canAddActionsToNotifications(context)) {
                 return;
             }
 
@@ -562,12 +555,12 @@ public class GCMMessageService extends GcmListenerService {
             commentLikeIntent.putExtra(NotificationsProcessingService.ARG_NOTE_BUNDLE, getCurrentNoteBundleForNoteId(noteId));
 
             PendingIntent commentLikePendingIntent =  getCommentActionPendingIntenForService(context, commentLikeIntent);
-            builder.addAction(R.drawable.ic_action_like, getText(R.string.like),
+            builder.addAction(R.drawable.ic_action_like, context.getText(R.string.like),
                     commentLikePendingIntent);
         }
 
         private void addCommentApproveActionForCommentNotification(Context context, NotificationCompat.Builder builder, String noteId) {
-            if (!canAddActionsToNotifications()) {
+            if (!canAddActionsToNotifications(context)) {
                 return;
             }
 
@@ -581,7 +574,7 @@ public class GCMMessageService extends GcmListenerService {
             commentApproveIntent.putExtra(NotificationsProcessingService.ARG_NOTE_BUNDLE, getCurrentNoteBundleForNoteId(noteId));
 
             PendingIntent commentApprovePendingIntent =  getCommentActionPendingIntenForService(context, commentApproveIntent);
-            builder.addAction(R.drawable.ic_action_approve, getText(R.string.approve),
+            builder.addAction(R.drawable.ic_action_approve, context.getText(R.string.approve),
                     commentApprovePendingIntent);
         }
 
@@ -629,12 +622,12 @@ public class GCMMessageService extends GcmListenerService {
             return intent;
         }
 
-        private Bitmap getLargeIconBitmap(String iconUrl, boolean shouldCircularizeIcon){
+        private Bitmap getLargeIconBitmap(Context context, String iconUrl, boolean shouldCircularizeIcon){
             Bitmap largeIconBitmap = null;
             if (iconUrl != null) {
                 try {
                     iconUrl = URLDecoder.decode(iconUrl, "UTF-8");
-                    int largeIconSize = getResources().getDimensionPixelSize(
+                    int largeIconSize = context.getResources().getDimensionPixelSize(
                             android.R.dimen.notification_large_icon_height);
                     String resizedUrl = PhotonUtils.getPhotonImageUrl(iconUrl, largeIconSize, largeIconSize);
                     largeIconBitmap = ImageUtils.downloadBitmap(resizedUrl);
@@ -652,7 +645,7 @@ public class GCMMessageService extends GcmListenerService {
             // Build the new notification, add group to support wearable stacking
            return new NotificationCompat.Builder(context)
                     .setSmallIcon(R.drawable.notification_icon)
-                    .setColor(getResources().getColor(R.color.blue_wordpress))
+                    .setColor(context.getResources().getColor(R.color.blue_wordpress))
                     .setContentTitle(title)
                     .setContentText(message)
                     .setTicker(message)
@@ -696,19 +689,19 @@ public class GCMMessageService extends GcmListenerService {
                 }
 
                 if (sActiveNotificationsMap.size() > MAX_INBOX_ITEMS) {
-                    inboxStyle.setSummaryText(String.format(getString(R.string.more_notifications),
+                    inboxStyle.setSummaryText(String.format(context.getString(R.string.more_notifications),
                             sActiveNotificationsMap.size() - MAX_INBOX_ITEMS));
                 }
 
-                String subject = String.format(getString(R.string.new_notifications), sActiveNotificationsMap.size());
+                String subject = String.format(context.getString(R.string.new_notifications), sActiveNotificationsMap.size());
                 NotificationCompat.Builder groupBuilder = new NotificationCompat.Builder(context)
                         .setSmallIcon(R.drawable.notification_icon)
-                        .setColor(getResources().getColor(R.color.blue_wordpress))
+                        .setColor(context.getResources().getColor(R.color.blue_wordpress))
                         .setGroup(NOTIFICATION_GROUP_KEY)
                         .setGroupSummary(true)
                         .setAutoCancel(true)
                         .setTicker(message)
-                        .setContentTitle(getString(R.string.app_name))
+                        .setContentTitle(context.getString(R.string.app_name))
                         .setContentText(subject)
                         .setStyle(inboxStyle);
 
@@ -817,7 +810,7 @@ public class GCMMessageService extends GcmListenerService {
 
             Bitmap largeIconBitmap = null;
             // here notify the existing group notification by eliminating the line that is now gone
-            String title = getNotificationTitleOrAppNameFromBundle(data);
+            String title = getNotificationTitleOrAppNameFromBundle(context, data);
             String message = StringEscapeUtils.unescapeHtml(data.getString(PUSH_ARG_MSG));
 
             NotificationCompat.Builder builder = null;
@@ -835,7 +828,7 @@ public class GCMMessageService extends GcmListenerService {
                     if (!TextUtils.isEmpty(remainingNoteMessage)) {
                         message = remainingNoteMessage;
                     }
-                    largeIconBitmap = getLargeIconBitmap(remainingNote.getString("icon"),
+                    largeIconBitmap = getLargeIconBitmap(context, remainingNote.getString("icon"),
                             shouldCircularizeNoteIcon(remainingNote.getString(PUSH_ARG_TYPE)));
 
                     builder = getNotificationBuilder(context, title, message);
@@ -853,7 +846,7 @@ public class GCMMessageService extends GcmListenerService {
             }
 
             if (largeIconBitmap == null) {
-                largeIconBitmap = getLargeIconBitmap(data.getString("icon"), shouldCircularizeNoteIcon(PUSH_TYPE_BADGE_RESET));
+                largeIconBitmap = getLargeIconBitmap(context, data.getString("icon"), shouldCircularizeNoteIcon(PUSH_TYPE_BADGE_RESET));
             }
 
             if (wpcomNoteID == null) {
@@ -872,10 +865,10 @@ public class GCMMessageService extends GcmListenerService {
             }
         }
 
-        private String getNotificationTitleOrAppNameFromBundle(Bundle data){
+        private String getNotificationTitleOrAppNameFromBundle(Context context, Bundle data){
             String title = StringEscapeUtils.unescapeHtml(data.getString(PUSH_ARG_TITLE));
             if (title == null) {
-                title = getString(R.string.app_name);
+                title = context.getString(R.string.app_name);
             }
             return title;
         }
@@ -926,7 +919,7 @@ public class GCMMessageService extends GcmListenerService {
 
             NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
                     .setSmallIcon(R.drawable.notification_icon)
-                    .setColor(getResources().getColor(R.color.blue_wordpress))
+                    .setColor(context.getResources().getColor(R.color.blue_wordpress))
                     .setContentTitle(title)
                     .setContentText(message)
                     .setAutoCancel(true)
@@ -938,7 +931,7 @@ public class GCMMessageService extends GcmListenerService {
             builder.setContentIntent(pendingIntent);
 
 
-            if (canAddActionsToNotifications()) {
+            if (canAddActionsToNotifications(context)) {
                 // adding ignore / approve quick actions
                 Intent authApproveIntent = new Intent(context, WPMainActivity.class);
                 authApproveIntent.putExtra(WPMainActivity.ARG_OPENED_FROM_PUSH, true);
@@ -956,7 +949,7 @@ public class GCMMessageService extends GcmListenerService {
                 PendingIntent authApprovePendingIntent = PendingIntent.getActivity(context, AUTH_PUSH_REQUEST_CODE_APPROVE, authApproveIntent,
                         PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_UPDATE_CURRENT);
 
-                builder.addAction(R.drawable.ic_action_approve, getText(R.string.approve),
+                builder.addAction(R.drawable.ic_action_approve, context.getText(R.string.approve),
                         authApprovePendingIntent);
 
 
@@ -964,7 +957,7 @@ public class GCMMessageService extends GcmListenerService {
                 authIgnoreIntent.putExtra(NotificationsProcessingService.ARG_ACTION_TYPE, NotificationsProcessingService.ARG_ACTION_AUTH_IGNORE);
                 PendingIntent authIgnorePendingIntent =  PendingIntent.getService(context,
                         AUTH_PUSH_REQUEST_CODE_IGNORE, authIgnoreIntent, PendingIntent.FLAG_CANCEL_CURRENT);
-                builder.addAction(R.drawable.ic_close_white_24dp, getText(R.string.ignore),
+                builder.addAction(R.drawable.ic_close_white_24dp, context.getText(R.string.ignore),
                         authIgnorePendingIntent);
             }
 


### PR DESCRIPTION
Fixes #4895 

Found a weird bug, that only happened to me when debugging (?), but there's a potential for this to happen elsewhere (*): from time to time when I’m step-by-step debugging how we build a notification,  I lose connection to the debugger, but the notification remains there in the dashboard. I can re-launch the debugger and attach to the process but for some reason some vars are not initialised: specifically a NotificationHelper would not be constructed until a new notification was received, so when you re-started the app (lose debugger then launch again),  any remaining notification would show the quick actions and would never be re-built even when you had WPPin enabled. You’d have to wait until a new notification is received, then a notification helper static object is created, and from there on it would all work as expected.

This PR fixes this potential problem (*) by making NotificationHelper be initialised right at declaration of the GCMMessageService class, thus ensuring that if we have a GCMMessageService running we also always have a NotificationsHelper that can deal with anything notification-related (not only processing a received message but also re-building existing notifications when locking/unlocking the screen, etc).
