### PR TITLE
Processing screen lock/unlock within a new thread to allow icon downloading

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/ScreenLockUnlockBroadcastReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/ScreenLockUnlockBroadcastReceiver.java
@@ -14,7 +14,7 @@ public class ScreenLockUnlockBroadcastReceiver extends BroadcastReceiver {
     public void onReceive(final Context context, Intent intent) {
         final String action = intent.getAction();
         if (Intent.ACTION_SCREEN_OFF.equals(action) || Intent.ACTION_USER_PRESENT.equals(action)) {
-            // only rebuild notifications if WPpin not enabled, notifications don't need be updated
+            // only rebuild notifications if Pin lock is enabled, as notifications don't need be updated
             // if quick actions are to remain the same
             if (GCMMessageService.isWPPinLockEnabled(context)) {
                 new Thread(new Runnable() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/ScreenLockUnlockBroadcastReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/ScreenLockUnlockBroadcastReceiver.java
@@ -11,10 +11,15 @@ import org.wordpress.android.push.GCMMessageService;
  */
 public class ScreenLockUnlockBroadcastReceiver extends BroadcastReceiver {
     @Override
-    public void onReceive(Context context, Intent intent) {
+    public void onReceive(final Context context, Intent intent) {
         final String action = intent.getAction();
         if (Intent.ACTION_SCREEN_OFF.equals(action) || Intent.ACTION_USER_PRESENT.equals(action)) {
-            GCMMessageService.rebuildAndUpdateNotifsOnSystemBarForRemainingNote(context);
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    GCMMessageService.rebuildAndUpdateNotifsOnSystemBarForRemainingNote(context);
+                }
+             }).start();
         }
     }
 }


### PR DESCRIPTION
Fixes #4897 

To test:
1. Having WPPin enabled, receive a notification from a user that has an avatar configured.
2. Observe the avatar is shown in the notification in the system's dashboard
3. lock the screen and unlock
4. observe the avatar is not lost and is shown in the notification

