### PR TITLE
Issue/4887 comments intercept bypass passcode

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -396,6 +396,7 @@
         <activity
             android:name="org.wordpress.passcodelock.PasscodeUnlockActivity"
             android:theme="@style/CalypsoTheme"
+            android:launchMode="singleInstance"
             android:windowSoftInputMode="stateHidden" />
         <activity
             android:name="org.wordpress.passcodelock.PasscodeManagePasswordActivity"

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -163,8 +163,6 @@ public class ReaderCommentListActivity extends AppCompatActivity {
             setReplyToCommentId(savedInstanceState.getLong(KEY_REPLY_TO_COMMENT_ID), false);
         }
 
-        refreshComments();
-
         mSuggestionServiceConnectionManager = new SuggestionServiceConnectionManager(this, (int) mBlogId);
         mSuggestionAdapter = SuggestionUtils.setupSuggestions((int) mBlogId, this, mSuggestionServiceConnectionManager,
                 mPost.isWP());
@@ -220,6 +218,8 @@ public class ReaderCommentListActivity extends AppCompatActivity {
             // clear up the back-from-login flag anyway
             mBackFromLogin = false;
         }
+
+        refreshComments();
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -64,6 +64,7 @@ import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 import org.wordpress.android.widgets.WPScrollView;
 import org.wordpress.android.widgets.WPScrollView.ScrollDirectionListener;
 import org.wordpress.android.widgets.WPTextView;
+import org.wordpress.passcodelock.AppLockManager;
 
 import java.util.EnumSet;
 
@@ -988,6 +989,12 @@ public class ReaderPostDetailFragment extends Fragment
                     case COMMENT_JUMP:
                     case COMMENT_REPLY:
                     case COMMENT_LIKE:
+                        if (AppLockManager.getInstance().isAppLockFeatureEnabled()) {
+                            // passcode screen was launched already (when ReaderPostPagerActivity got resumed) so reset
+                            // the timeout to let the passcode screen come up for the ReaderCommentListActivity.
+                            // See https://github.com/wordpress-mobile/WordPress-Android/issues/4887
+                            AppLockManager.getInstance().getAppLock().forcePasswordLock();
+                        }
                         ReaderActivityLauncher.showReaderComments(getActivity(), mPost.blogId, mPost.postId,
                                 mDirectOperation, mCommentId, mInterceptedUri);
                         getActivity().finish();


### PR DESCRIPTION
Fixes #4887 

Part of the fix is to always open the passcode screen in `singleInstance` mode so there is no residual launches in the activity/task history.

To test:
* Enable PIN lock in wpandroid and exit the app (press "Back" a few times)
* Using adb, open a comments link (like https://stefanosuser.wordpress.com/2016/09/28/wood/#comments. See https://github.com/wordpress-mobile/WordPress-Android/pull/4669's description on how to use adb to perform this)
* wpandroid should start and display the passcode (pin) screen. Enter your pin to unlock the app.
* Post's comments should appear
