### PR TITLE
issue/4893-reader-pager-npe-6.3

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -346,7 +346,9 @@ public class ReaderPostPagerActivity extends AppCompatActivity
                                         EventBus.getDefault().post(slugsResolved);
 
                                         // post wasn't available locally earlier so, track it now
-                                        trackPost(post.blogId, post.postId);
+                                        if (post != null) {
+                                            trackPost(post.blogId, post.postId);
+                                        }
                                     }
 
                                     @Override


### PR DESCRIPTION
Fixes #4893 - NPE was caused by neglecting to null check a post object.