### PR TITLE
Fix "No Activity found to handle VIEW" crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -158,7 +158,8 @@ public class ActivityLauncher {
         AnalyticsUtils.trackWithBlogDetails(AnalyticsTracker.Stat.OPENED_VIEW_ADMIN, blog);
 
         if (!WPActivityUtils.isDefaultViewAppAvailable(context, uri)) {
-            Toast.makeText(context, context.getText(R.string.no_default_app_available_to_load_uri), Toast.LENGTH_SHORT).show();
+            String toastErrorUrlIntent = context.getString(R.string.no_default_app_available_to_load_uri);
+            ToastUtils.showToast(context, String.format(toastErrorUrlIntent, adminUrl), ToastUtils.Duration.LONG);
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -43,7 +43,9 @@ import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.HelpshiftHelper;
 import org.wordpress.android.util.HelpshiftHelper.Tag;
+import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
+import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.passcodelock.AppLockManager;
 
 import java.io.IOException;
@@ -132,6 +134,12 @@ public class ActivityLauncher {
 
         AnalyticsUtils.trackWithCurrentBlogDetails(AnalyticsTracker.Stat.OPENED_VIEW_SITE);
 
+        if (!WPActivityUtils.isDefaultViewAppAvailable(context, uri)) {
+            String toastErrorUrlIntent = context.getString(R.string.no_default_app_available_to_load_uri);
+            ToastUtils.showToast(context, String.format(toastErrorUrlIntent, siteUrl), ToastUtils.Duration.LONG);
+            return;
+        }
+
         Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.setData(uri);
         context.startActivity(intent);
@@ -148,6 +156,11 @@ public class ActivityLauncher {
         Uri uri = Uri.parse(adminUrl);
 
         AnalyticsUtils.trackWithBlogDetails(AnalyticsTracker.Stat.OPENED_VIEW_ADMIN, blog);
+
+        if (!WPActivityUtils.isDefaultViewAppAvailable(context, uri)) {
+            Toast.makeText(context, context.getText(R.string.no_default_app_available_to_load_uri), Toast.LENGTH_SHORT).show();
+            return;
+        }
 
         Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.setData(uri);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -39,6 +39,7 @@ import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.UserEmailUtils;
+import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.widgets.WPTextView;
 import org.wordpress.emailchecker2.EmailChecker;
 import org.wordpress.persistentedittext.PersistentEditTextHelper;
@@ -437,6 +438,12 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
                                                       @Override
                                                       public void onClick(View v) {
                                                           Uri uri = Uri.parse(Constants.URL_TOS);
+                                                          if (!WPActivityUtils.isDefaultViewAppAvailable(getContext(), uri)) {
+                                                              String toastErrorUrlIntent = getContext().getString(R.string.no_default_app_available_to_load_uri);
+                                                              ToastUtils.showToast(getContext(), String.format(toastErrorUrlIntent, Constants.URL_TOS), ToastUtils.Duration.LONG);
+                                                              return;
+                                                          }
+
                                                           startActivity(new Intent(Intent.ACTION_VIEW, uri));
                                                       }
                                                   }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.accounts;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.Html;
@@ -23,6 +22,7 @@ import org.json.JSONObject;
 import org.wordpress.android.Constants;
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.accounts.helpers.CreateUserAndBlog;
 import org.wordpress.android.ui.accounts.helpers.FetchBlogListAbstract.Callback;
 import org.wordpress.android.ui.accounts.helpers.FetchBlogListWPCom;
@@ -39,7 +39,6 @@ import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.UserEmailUtils;
-import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.widgets.WPTextView;
 import org.wordpress.emailchecker2.EmailChecker;
 import org.wordpress.persistentedittext.PersistentEditTextHelper;
@@ -437,14 +436,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
         termsOfServiceTextView.setOnClickListener(new OnClickListener() {
                                                       @Override
                                                       public void onClick(View v) {
-                                                          Uri uri = Uri.parse(Constants.URL_TOS);
-                                                          if (!WPActivityUtils.isDefaultViewAppAvailable(getContext(), uri)) {
-                                                              String toastErrorUrlIntent = getContext().getString(R.string.no_default_app_available_to_load_uri);
-                                                              ToastUtils.showToast(getContext(), String.format(toastErrorUrlIntent, Constants.URL_TOS), ToastUtils.Duration.LONG);
-                                                              return;
-                                                          }
-
-                                                          startActivity(new Intent(Intent.ACTION_VIEW, uri));
+                                                          ActivityLauncher.openUrlExternal(getContext(), Constants.URL_TOS);
                                                       }
                                                   }
         );

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInDialogFragment.java
@@ -14,6 +14,8 @@ import org.wordpress.android.ui.AppLogViewerActivity;
 import org.wordpress.android.util.HelpshiftHelper;
 import org.wordpress.android.util.HelpshiftHelper.MetadataKey;
 import org.wordpress.android.util.HelpshiftHelper.Tag;
+import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.widgets.WPTextView;
 
 public class SignInDialogFragment extends DialogFragment {
@@ -144,7 +146,13 @@ public class SignInDialogFragment extends DialogFragment {
         }
         switch (action) {
             case ACTION_OPEN_URL:
-                Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(arguments.getString(ARG_OPEN_URL_PARAM)));
+                Uri addressToLoad = Uri.parse(arguments.getString(ARG_OPEN_URL_PARAM));
+                if (!WPActivityUtils.isDefaultViewAppAvailable(getContext(), addressToLoad)) {
+                    String toastErrorUrlIntent = getContext().getString(R.string.no_default_app_available_to_load_uri);
+                    ToastUtils.showToast(getContext(), String.format(toastErrorUrlIntent, arguments.getString(ARG_OPEN_URL_PARAM)), ToastUtils.Duration.LONG);
+                    return;
+                }
+                Intent intent = new Intent(Intent.ACTION_VIEW, addressToLoad);
                 startActivity(intent);
                 dismissAllowingStateLoss();
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInDialogFragment.java
@@ -1,21 +1,20 @@
 package org.wordpress.android.ui.accounts;
 
 import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 
 import org.wordpress.android.R;
+import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.AppLogViewerActivity;
 import org.wordpress.android.util.HelpshiftHelper;
 import org.wordpress.android.util.HelpshiftHelper.MetadataKey;
 import org.wordpress.android.util.HelpshiftHelper.Tag;
-import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.widgets.WPTextView;
 
 public class SignInDialogFragment extends DialogFragment {
@@ -146,14 +145,11 @@ public class SignInDialogFragment extends DialogFragment {
         }
         switch (action) {
             case ACTION_OPEN_URL:
-                Uri addressToLoad = Uri.parse(arguments.getString(ARG_OPEN_URL_PARAM));
-                if (!WPActivityUtils.isDefaultViewAppAvailable(getContext(), addressToLoad)) {
-                    String toastErrorUrlIntent = getContext().getString(R.string.no_default_app_available_to_load_uri);
-                    ToastUtils.showToast(getContext(), String.format(toastErrorUrlIntent, arguments.getString(ARG_OPEN_URL_PARAM)), ToastUtils.Duration.LONG);
+                String url = arguments.getString(ARG_OPEN_URL_PARAM);
+                if (TextUtils.isEmpty(url)) {
                     return;
                 }
-                Intent intent = new Intent(Intent.ACTION_VIEW, addressToLoad);
-                startActivity(intent);
+                ActivityLauncher.openUrlExternal(getContext(), url);
                 dismissAllowingStateLoss();
                 break;
             case ACTION_OPEN_SUPPORT_CHAT:

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -682,7 +682,13 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         public void onClick(View v) {
             String forgotPasswordUrl = getForgotPasswordURL();
             AppLog.i(T.NUX, "User tapped forgot password link: " + forgotPasswordUrl);
-            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(forgotPasswordUrl));
+            Uri addressToLoad = Uri.parse(forgotPasswordUrl);
+            if (!WPActivityUtils.isDefaultViewAppAvailable(getContext(), addressToLoad)) {
+                String toastErrorUrlIntent = getContext().getString(R.string.no_default_app_available_to_load_uri);
+                ToastUtils.showToast(getContext(), String.format(toastErrorUrlIntent, getForgotPasswordURL()), ToastUtils.Duration.LONG);
+                return;
+            }
+            Intent intent = new Intent(Intent.ACTION_VIEW, addressToLoad);
             startActivity(intent);
         }
     };

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -48,6 +48,7 @@ import org.wordpress.android.models.Account;
 import org.wordpress.android.models.AccountHelper;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.networking.SelfSignedSSLCertsManager;
+import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.accounts.helpers.FetchBlogListAbstract.Callback;
 import org.wordpress.android.ui.accounts.helpers.FetchBlogListWPCom;
 import org.wordpress.android.ui.accounts.helpers.FetchBlogListWPOrg;
@@ -682,14 +683,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         public void onClick(View v) {
             String forgotPasswordUrl = getForgotPasswordURL();
             AppLog.i(T.NUX, "User tapped forgot password link: " + forgotPasswordUrl);
-            Uri addressToLoad = Uri.parse(forgotPasswordUrl);
-            if (!WPActivityUtils.isDefaultViewAppAvailable(getContext(), addressToLoad)) {
-                String toastErrorUrlIntent = getContext().getString(R.string.no_default_app_available_to_load_uri);
-                ToastUtils.showToast(getContext(), String.format(toastErrorUrlIntent, getForgotPasswordURL()), ToastUtils.Duration.LONG);
-                return;
-            }
-            Intent intent = new Intent(Intent.ACTION_VIEW, addressToLoad);
-            startActivity(intent);
+            ActivityLauncher.openUrlExternal(getContext(), forgotPasswordUrl);
         }
     };
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -216,7 +216,6 @@ public class PeopleInviteFragment extends Fragment implements
                 if (!WPActivityUtils.isDefaultViewAppAvailable(v.getContext(), uri)) {
                     String toastErrorUrlIntent = v.getContext().getString(R.string.no_default_app_available_to_load_uri);
                     ToastUtils.showToast(v.getContext(), String.format(toastErrorUrlIntent, getString(R.string.role_info_url)), ToastUtils.Duration.LONG);
-
                     return;
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -32,6 +32,7 @@ import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.widgets.MultiUsernameEditText;
 import org.wordpress.passcodelock.AppLockManager;
 
@@ -212,6 +213,13 @@ public class PeopleInviteFragment extends Fragment implements
             @Override
             public void onClick(View v) {
                 Uri uri = Uri.parse(getString(R.string.role_info_url));
+                if (!WPActivityUtils.isDefaultViewAppAvailable(v.getContext(), uri)) {
+                    String toastErrorUrlIntent = v.getContext().getString(R.string.no_default_app_available_to_load_uri);
+                    ToastUtils.showToast(v.getContext(), String.format(toastErrorUrlIntent, getString(R.string.role_info_url)), ToastUtils.Duration.LONG);
+
+                    return;
+                }
+
                 AppLockManager.getInstance().setExtendedTimeout();
                 startActivity(new Intent(Intent.ACTION_VIEW, uri));
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -2,8 +2,6 @@ package org.wordpress.android.ui.people;
 
 
 import android.app.Fragment;
-import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
@@ -26,15 +24,14 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.models.Role;
+import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.people.utils.PeopleUtils;
 import org.wordpress.android.ui.people.utils.PeopleUtils.ValidateUsernameCallback.ValidationResult;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.widgets.MultiUsernameEditText;
-import org.wordpress.passcodelock.AppLockManager;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -212,15 +209,7 @@ public class PeopleInviteFragment extends Fragment implements
         imgRoleInfo.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Uri uri = Uri.parse(getString(R.string.role_info_url));
-                if (!WPActivityUtils.isDefaultViewAppAvailable(v.getContext(), uri)) {
-                    String toastErrorUrlIntent = v.getContext().getString(R.string.no_default_app_available_to_load_uri);
-                    ToastUtils.showToast(v.getContext(), String.format(toastErrorUrlIntent, getString(R.string.role_info_url)), ToastUtils.Duration.LONG);
-                    return;
-                }
-
-                AppLockManager.getInstance().setExtendedTimeout();
-                startActivity(new Intent(Intent.ACTION_VIEW, uri));
+                ActivityLauncher.openUrlExternal(v.getContext(), getString(R.string.role_info_url));
             }
         });
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -68,6 +68,7 @@ import org.wordpress.android.util.JSONUtils;
 import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.helpers.LocationHelper;
 import org.wordpress.android.widgets.SuggestionAutoCompleteText;
 import org.xmlrpc.android.ApiHelper;
@@ -921,8 +922,14 @@ public class EditPostSettingsFragment extends Fragment
 
     private void viewLocation() {
         if (mPostLocation != null && mPostLocation.isValid()) {
-            String uri = "geo:" + mPostLocation.getLatitude() + "," + mPostLocation.getLongitude();
-            startActivity(new Intent(android.content.Intent.ACTION_VIEW, Uri.parse(uri)));
+            String locationString = "geo:" + mPostLocation.getLatitude() + "," + mPostLocation.getLongitude();
+            Uri uri = Uri.parse(locationString);
+            if (!WPActivityUtils.isDefaultViewAppAvailable(getActivity(), uri)) {
+                String toastErrorUrlIntent = getActivity().getString(R.string.no_default_app_available_to_load_uri);
+                ToastUtils.showToast(getActivity(), String.format(toastErrorUrlIntent, uri), ToastUtils.Duration.LONG);
+                return;
+            }
+            startActivity(new Intent(android.content.Intent.ACTION_VIEW, uri));
         } else {
             showLocationNotAvailableError();
             showLocationAdd();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -8,7 +8,6 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.location.Address;
 import android.location.Location;
-import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -51,6 +50,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Post;
 import org.wordpress.android.models.PostLocation;
 import org.wordpress.android.models.PostStatus;
+import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaGalleryPickerActivity;
 import org.wordpress.android.ui.media.WordPressMediaUtils;
@@ -68,7 +68,6 @@ import org.wordpress.android.util.JSONUtils;
 import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.helpers.LocationHelper;
 import org.wordpress.android.widgets.SuggestionAutoCompleteText;
 import org.xmlrpc.android.ApiHelper;
@@ -923,13 +922,7 @@ public class EditPostSettingsFragment extends Fragment
     private void viewLocation() {
         if (mPostLocation != null && mPostLocation.isValid()) {
             String locationString = "geo:" + mPostLocation.getLatitude() + "," + mPostLocation.getLongitude();
-            Uri uri = Uri.parse(locationString);
-            if (!WPActivityUtils.isDefaultViewAppAvailable(getActivity(), uri)) {
-                String toastErrorUrlIntent = getActivity().getString(R.string.no_default_app_available_to_load_uri);
-                ToastUtils.showToast(getActivity(), String.format(toastErrorUrlIntent, uri), ToastUtils.Duration.LONG);
-                return;
-            }
-            startActivity(new Intent(android.content.Intent.ACTION_VIEW, uri));
+            ActivityLauncher.openUrlExternal(getActivity(), locationString);
         } else {
             showLocationNotAvailableError();
             showLocationAdd();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AboutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AboutActivity.java
@@ -10,6 +10,8 @@ import android.view.View.OnClickListener;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.widgets.WPTextView;
 import org.wordpress.passcodelock.AppLockManager;
 
@@ -57,6 +59,13 @@ public class AboutActivity extends AppCompatActivity implements OnClickListener 
         } else {
             return;
         }
+
+        if (!WPActivityUtils.isDefaultViewAppAvailable(this, uri)) {
+            String toastErrorUrlIntent = this.getString(R.string.no_default_app_available_to_load_uri);
+            ToastUtils.showToast(this, String.format(toastErrorUrlIntent, uri.toString()), ToastUtils.Duration.LONG);
+            return;
+        }
+
         AppLockManager.getInstance().setExtendedTimeout();
         startActivity(new Intent(Intent.ACTION_VIEW, uri));
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AboutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AboutActivity.java
@@ -1,7 +1,5 @@
 package org.wordpress.android.ui.prefs;
 
-import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
@@ -10,10 +8,8 @@ import android.view.View.OnClickListener;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
-import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.WPActivityUtils;
+import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.widgets.WPTextView;
-import org.wordpress.passcodelock.AppLockManager;
 
 import java.util.Calendar;
 
@@ -48,26 +44,19 @@ public class AboutActivity extends AppCompatActivity implements OnClickListener 
 
     @Override
     public void onClick(View v) {
-        Uri uri;
+        String url;
         int id = v.getId();
         if (id == R.id.about_url) {
-            uri = Uri.parse(URL_AUTOMATTIC);
+            url = URL_AUTOMATTIC;
         } else if (id == R.id.about_tos) {
-            uri = Uri.parse(URL_TOS);
+            url = URL_TOS;
         } else if (id == R.id.about_privacy) {
-            uri = Uri.parse(URL_AUTOMATTIC + URL_PRIVACY_POLICY);
+            url = URL_AUTOMATTIC + URL_PRIVACY_POLICY;
         } else {
             return;
         }
 
-        if (!WPActivityUtils.isDefaultViewAppAvailable(this, uri)) {
-            String toastErrorUrlIntent = this.getString(R.string.no_default_app_available_to_load_uri);
-            ToastUtils.showToast(this, String.format(toastErrorUrlIntent, uri.toString()), ToastUtils.Duration.LONG);
-            return;
-        }
-
-        AppLockManager.getInstance().setExtendedTimeout();
-        startActivity(new Intent(Intent.ACTION_VIEW, uri));
+        ActivityLauncher.openUrlExternal(this, url);
     }
 
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -15,6 +15,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderTag;
+import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.reader.ReaderPostPagerActivity.DirectOperation;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
@@ -268,7 +269,7 @@ public class ReaderActivityLauncher {
         if (openUrlType == OpenUrlType.INTERNAL) {
             openUrlInternal(context, url);
         } else {
-            openUrlExternal(context, url);
+            ActivityLauncher.openUrlExternal(context, url);
         }
     }
 
@@ -281,34 +282,6 @@ public class ReaderActivityLauncher {
             WPWebViewActivity.openUrlByUsingWPCOMCredentials(context, url);
         } else {
             WPWebViewActivity.openURL(context, url, ReaderConstants.HTTP_REFERER_URL);
-        }
-    }
-
-    /*
-     * open the passed url in the device's external browser
-     */
-    private static void openUrlExternal(Context context, @NonNull String url) {
-        try {
-            // disable deeplinking activity so to not catch WP URLs
-            WPActivityUtils.disableComponent(context, ReaderPostPagerActivity.class);
-
-            Uri uri = Uri.parse(url);
-            if (!WPActivityUtils.isDefaultViewAppAvailable(context, uri)) {
-                String toastErrorUrlIntent = context.getString(R.string.no_default_app_available_to_load_uri);
-                ToastUtils.showToast(context, String.format(toastErrorUrlIntent, url), ToastUtils.Duration.LONG);
-                return;
-            }
-
-            Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-            context.startActivity(intent);
-            AppLockManager.getInstance().setExtendedTimeout();
-
-        } catch (ActivityNotFoundException e) {
-            String readerToastErrorUrlIntent = context.getString(R.string.reader_toast_err_url_intent);
-            ToastUtils.showToast(context, String.format(readerToastErrorUrlIntent, url), ToastUtils.Duration.LONG);
-        } finally {
-            // re-enable deeplinking
-            WPActivityUtils.enableComponent(context, ReaderPostPagerActivity.class);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderActivityLauncher.java
@@ -292,7 +292,14 @@ public class ReaderActivityLauncher {
             // disable deeplinking activity so to not catch WP URLs
             WPActivityUtils.disableComponent(context, ReaderPostPagerActivity.class);
 
-            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+            Uri uri = Uri.parse(url);
+            if (!WPActivityUtils.isDefaultViewAppAvailable(context, uri)) {
+                String toastErrorUrlIntent = context.getString(R.string.no_default_app_available_to_load_uri);
+                ToastUtils.showToast(context, String.format(toastErrorUrlIntent, url), ToastUtils.Duration.LONG);
+                return;
+            }
+
+            Intent intent = new Intent(Intent.ACTION_VIEW, uri);
             context.startActivity(intent);
             AppLockManager.getInstance().setExtendedTimeout();
 

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -142,18 +142,6 @@ public class WPActivityUtils {
         return !emailApps.isEmpty();
     }
 
-    public static boolean isDefaultViewAppAvailable(Context context, Uri uri) {
-        if (context == null) {
-            return false;
-        }
-
-        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-        PackageManager packageManager = context.getPackageManager();
-        List<ResolveInfo> webBrowserApps = packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
-
-        return !webBrowserApps.isEmpty();
-    }
-
     public static void disableComponent(Context context, Class<?> klass) {
         PackageManager pm = context.getPackageManager();
         pm.setComponentEnabledSetting(new ComponentName(context, klass),

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -10,6 +10,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.net.Uri;
 import android.os.Build;
 import android.preference.PreferenceManager;
 import android.support.v7.app.ActionBar;
@@ -22,11 +23,9 @@ import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
-import org.wordpress.android.ui.DeepLinkingIntentReceiverActivity;
 import org.wordpress.android.ui.prefs.AppSettingsFragment;
 
 import java.util.List;
@@ -141,6 +140,18 @@ public class WPActivityUtils {
         List<ResolveInfo> emailApps = packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
 
         return !emailApps.isEmpty();
+    }
+
+    public static boolean isDefaultViewAppAvailable(Context context, Uri uri) {
+        if (context == null) {
+            return false;
+        }
+
+        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+        PackageManager packageManager = context.getPackageManager();
+        List<ResolveInfo> webBrowserApps = packageManager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+
+        return !webBrowserApps.isEmpty();
     }
 
     public static void disableComponent(Context context, Class<?> klass) {

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -10,7 +10,6 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.content.res.Configuration;
 import android.content.res.Resources;
-import android.net.Uri;
 import android.os.Build;
 import android.preference.PreferenceManager;
 import android.support.v7.app.ActionBar;

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPAlertDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPAlertDialogFragment.java
@@ -12,6 +12,8 @@ import android.text.TextUtils;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.WPActivityUtils;
 
 public class WPAlertDialogFragment extends DialogFragment implements DialogInterface.OnClickListener {
     private static enum WPAlertDialogType {ALERT,    // simple ok dialog with error message
@@ -123,8 +125,15 @@ public class WPAlertDialogFragment extends DialogFragment implements DialogInter
                 builder.setPositiveButton(infoTitle, new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
-                            if (!TextUtils.isEmpty(infoURL))
-                                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(infoURL)));
+                            if (!TextUtils.isEmpty(infoURL)) {
+                                Uri uri = Uri.parse(infoURL);
+                                if (!WPActivityUtils.isDefaultViewAppAvailable(getActivity(), uri)) {
+                                    String toastErrorUrlIntent = getActivity().getString(R.string.no_default_app_available_to_load_uri);
+                                    ToastUtils.showToast(getActivity(), String.format(toastErrorUrlIntent, infoURL), ToastUtils.Duration.LONG);
+                                    return;
+                                }
+                                startActivity(new Intent(Intent.ACTION_VIEW, uri));
+                            }
                         }
                 });
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPAlertDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPAlertDialogFragment.java
@@ -4,16 +4,13 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
 import android.content.DialogInterface;
-import android.content.Intent;
-import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.util.StringUtils;
-import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.WPActivityUtils;
 
 public class WPAlertDialogFragment extends DialogFragment implements DialogInterface.OnClickListener {
     private static enum WPAlertDialogType {ALERT,    // simple ok dialog with error message
@@ -126,13 +123,7 @@ public class WPAlertDialogFragment extends DialogFragment implements DialogInter
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
                             if (!TextUtils.isEmpty(infoURL)) {
-                                Uri uri = Uri.parse(infoURL);
-                                if (!WPActivityUtils.isDefaultViewAppAvailable(getActivity(), uri)) {
-                                    String toastErrorUrlIntent = getActivity().getString(R.string.no_default_app_available_to_load_uri);
-                                    ToastUtils.showToast(getActivity(), String.format(toastErrorUrlIntent, infoURL), ToastUtils.Duration.LONG);
-                                    return;
-                                }
-                                startActivity(new Intent(Intent.ACTION_VIEW, uri));
+                                ActivityLauncher.openUrlExternal(getActivity(), infoURL);
                             }
                         }
                 });

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1196,7 +1196,6 @@
     <string name="reader_toast_err_remove_tag">Unable to remove this tag</string>
     <string name="reader_toast_err_share_intent">Unable to share</string>
     <string name="reader_toast_err_view_image">Unable to view image</string>
-    <string name="reader_toast_err_url_intent">Unable to open %s</string>
     <string name="reader_toast_err_get_comment">Unable to retrieve this comment</string>
     <string name="reader_toast_err_get_blog_info">Unable to show this blog</string>
     <string name="reader_toast_err_already_follow_blog">You already follow this blog</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -83,6 +83,7 @@
     <string name="unknown">Unknown</string>
     <string name="off">Off</string>
     <string name="could_not_load_page">Could not load page</string>
+    <string name="no_default_app_available_to_load_uri">Unable to open %s</string>
     <string name="send">Send</string>
     <string name="swipe_for_more">Swipe for more</string>
 


### PR DESCRIPTION
Fixes #4899 by checking there is a default app installed on the device that is able to open the passed Uri.

To test on Emulator: 
- Open settings and disable the Browser.
- Start WP and tap on view site

A toast should be shown on the screen with the correct error message in it.


On device you need to disable any installed browsers, and maybe disable the system webview.
