### PR TITLE
Issue/4841 log timestamps

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AppLogViewerActivity.java
@@ -23,6 +23,9 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.ToastUtils;
 
 import java.util.ArrayList;
+import java.util.Locale;
+
+import static java.lang.String.format;
 
 /**
  * views the activity log (see utils/AppLog.java)
@@ -86,7 +89,7 @@ public class AppLogViewerActivity extends AppCompatActivity {
             // line numbers shown here won't match the line numbers when the log is shared
             int lineNum = position - AppLog.HEADER_LINE_COUNT + 1;
             if (lineNum > 0) {
-                holder.txtLineNumber.setText(String.format("%02d", lineNum));
+                holder.txtLineNumber.setText(format(Locale.US, "%02d", lineNum));
                 holder.txtLineNumber.setVisibility(View.VISIBLE);
             } else {
                 holder.txtLineNumber.setVisibility(View.GONE);

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -186,7 +186,7 @@ public class AppLog {
         }
 
         private String formatLogDate() {
-            return new SimpleDateFormat("MM-dd h:mma", Locale.US).format(mDate);
+            return new SimpleDateFormat("MM-dd h:mma", Locale.US).format(mDate).toLowerCase(Locale.US);
         }
 
         private String toHtml() {
@@ -200,8 +200,8 @@ public class AppLog {
             sb.append(mLogLevel.name());
             sb.append(": ");
             sb.append(TextUtils.htmlEncode(mLogText).replace("\n", "<br />"));
-            sb.append(" <font color=\"gray\">(").append(formatLogDate()).append("</font>)");
             sb.append("</font>");
+            sb.append(" <font color=\"gray\">(").append(formatLogDate()).append("</font>)");
             return sb.toString();
         }
     }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -198,10 +198,9 @@ public class AppLog {
             sb.append("\">");
             sb.append("[");
             sb.append(formatLogDate()).append(" ");
-            sb.append(mLogTag.name());
-            sb.append("] ");
+            sb.append(mLogTag.name()).append(" ");
             sb.append(mLogLevel.name());
-            sb.append(": ");
+            sb.append("] ");
             sb.append(TextUtils.htmlEncode(mLogText).replace("\n", "<br />"));
             sb.append("</font>");
             return sb.toString();

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -9,7 +9,6 @@ import android.util.Log;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -298,8 +297,10 @@ public class AppLog {
         Iterator<LogEntry> it = mLogEntries.iterator();
         int lineNum = 1;
         while (it.hasNext()) {
+            LogEntry entry = it.next();
             sb.append(String.format("%02d - ", lineNum))
-                    .append(it.next().mLogText)
+                    .append(entry.mLogText)
+                    .append(" (").append(entry.formatLogDate()).append(")")
                     .append("\n");
             lineNum++;
         }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -186,8 +186,11 @@ public class AppLog {
             mLogTag = logTag;
         }
 
+        private String formatLogDate() {
+            return new SimpleDateFormat("MM-dd h:mma", Locale.US).format(mDate);
+        }
+
         private String toHtml() {
-            DateFormat formatter = new SimpleDateFormat("MM-dd h:mma", Locale.US);
             StringBuilder sb = new StringBuilder();
             sb.append("<font color=\"");
             sb.append(mLogLevel.toHtmlColor());
@@ -198,7 +201,7 @@ public class AppLog {
             sb.append(mLogLevel.name());
             sb.append(": ");
             sb.append(TextUtils.htmlEncode(mLogText).replace("\n", "<br />"));
-            sb.append("<font color=\"gray\">").append(formatter.format(mDate)).append("</font>  ");
+            sb.append(" <font color=\"gray\">(").append(formatLogDate()).append("</font>)");
             sb.append("</font>");
             return sb.toString();
         }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -186,7 +186,8 @@ public class AppLog {
         }
 
         private String formatLogDate() {
-            return new SimpleDateFormat("MM-dd h:mma", Locale.US).format(mDate).toLowerCase(Locale.US);
+            // dec-13 08:00 UTILS i
+            return new SimpleDateFormat("MMM-dd kk:mm", Locale.US).format(mDate);
         }
 
         private String toHtml() {
@@ -195,12 +196,12 @@ public class AppLog {
             sb.append(mLogLevel.toHtmlColor());
             sb.append("\">");
             sb.append("[");
+            sb.append(formatLogDate()).append(" ");
             sb.append(mLogTag.name());
             sb.append("] ");
             sb.append(mLogLevel.name());
             sb.append(": ");
             sb.append(TextUtils.htmlEncode(mLogText).replace("\n", "<br />"));
-            sb.append(" (").append(formatLogDate()).append(")");
             sb.append("</font>");
             return sb.toString();
         }
@@ -299,9 +300,12 @@ public class AppLog {
         while (it.hasNext()) {
             LogEntry entry = it.next();
             sb.append(String.format("%02d - ", lineNum))
-                    .append(entry.mLogText)
-                    .append(" (").append(entry.formatLogDate()).append(")")
-                    .append("\n");
+                .append("[")
+                .append(entry.formatLogDate()).append(" ")
+                .append(entry.mLogTag.name())
+                .append("] ")
+                .append(entry.mLogText)
+                .append("\n");
             lineNum++;
         }
         return sb.toString();

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -9,8 +9,11 @@ import android.util.Log;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.NoSuchElementException;
 
 /**
@@ -184,6 +187,7 @@ public class AppLog {
         }
 
         private String toHtml() {
+            DateFormat formatter = new SimpleDateFormat("MM-dd h:mma", Locale.US);
             StringBuilder sb = new StringBuilder();
             sb.append("<font color=\"");
             sb.append(mLogLevel.toHtmlColor());
@@ -194,6 +198,7 @@ public class AppLog {
             sb.append(mLogLevel.name());
             sb.append(": ");
             sb.append(TextUtils.htmlEncode(mLogText).replace("\n", "<br />"));
+            sb.append("<font color=\"gray\">").append(formatter.format(mDate)).append("</font>  ");
             sb.append("</font>");
             return sb.toString();
         }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -167,10 +167,10 @@ public class AppLog {
     }
 
     private static class LogEntry {
-        LogLevel mLogLevel;
-        String mLogText;
-        java.util.Date mDate;
-        T mLogTag;
+        final LogLevel mLogLevel;
+        final String mLogText;
+        final java.util.Date mDate;
+        final T mLogTag;
 
         public LogEntry(LogLevel logLevel, String logText, T logTag) {
             mLogLevel = logLevel;

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -200,8 +200,8 @@ public class AppLog {
             sb.append(mLogLevel.name());
             sb.append(": ");
             sb.append(TextUtils.htmlEncode(mLogText).replace("\n", "<br />"));
+            sb.append(" (").append(formatLogDate()).append(")");
             sb.append("</font>");
-            sb.append(" <font color=\"gray\">(").append(formatLogDate()).append("</font>)");
             return sb.toString();
         }
     }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -169,13 +169,16 @@ public class AppLog {
     private static class LogEntry {
         LogLevel mLogLevel;
         String mLogText;
+        java.util.Date mDate;
         T mLogTag;
 
         public LogEntry(LogLevel logLevel, String logText, T logTag) {
             mLogLevel = logLevel;
-            mLogText = logText;
-            if (mLogText == null) {
+            mDate = DateTimeUtils.nowUTC();
+            if (logText == null) {
                 mLogText = "null";
+            } else {
+                mLogText = logText;
             }
             mLogTag = logTag;
         }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -15,6 +15,8 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.NoSuchElementException;
 
+import static java.lang.String.format;
+
 /**
  * simple wrapper for Android log calls, enables recording and displaying log
  */
@@ -186,7 +188,6 @@ public class AppLog {
         }
 
         private String formatLogDate() {
-            // dec-13 08:00 UTILS i
             return new SimpleDateFormat("MMM-dd kk:mm", Locale.US).format(mDate);
         }
 
@@ -299,7 +300,7 @@ public class AppLog {
         int lineNum = 1;
         while (it.hasNext()) {
             LogEntry entry = it.next();
-            sb.append(String.format("%02d - ", lineNum))
+            sb.append(format(Locale.US, "%02d - ", lineNum))
                 .append("[")
                 .append(entry.formatLogDate()).append(" ")
                 .append(entry.mLogTag.name())


### PR DESCRIPTION
Fixes #4841 - adds timestamp to the end of each AppLog entry. Note that the date is UTC and is formatted using `Locale.US`.

![screenshot_1481582678](https://cloud.githubusercontent.com/assets/3903757/21119932/d3b46806-c092-11e6-815e-cae7d423d026.png)

cc: @hypest 
