### PR TITLE
Synch Jetpack modules info and use them to disable shortlinks

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/Blog.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Blog.java
@@ -45,6 +45,7 @@ public class Blog {
     private String httppassword = "";
     private String postFormats;
     private String blogOptions = "{}";
+    private String jetpackModulesInfo = "{}";
     private String capabilities;
     private boolean isAdmin;
     private boolean isHidden;
@@ -408,6 +409,39 @@ public class Blog {
         }
         setBlogOptions(blogOptions);
         return true;
+    }
+
+    public boolean bsetJetpackModulesInfo(String modulesInfo) {
+        if (StringUtils.equals(this.jetpackModulesInfo, modulesInfo)) {
+            return false;
+        }
+        setJetpackModulesInfo(modulesInfo);
+        return true;
+    }
+
+    public void setJetpackModulesInfo(String modulesInfo) {
+        this.jetpackModulesInfo = modulesInfo;
+        JSONObject options = getJetpackModulesInfoJSONObject();
+        if (options == null) {
+            this.jetpackModulesInfo = "{}";
+        }
+    }
+
+    public String getJetpackModulesInfo() {
+        return jetpackModulesInfo;
+    }
+
+    public JSONObject getJetpackModulesInfoJSONObject() {
+        String modulesInfoString = getJetpackModulesInfo();
+        if (TextUtils.isEmpty(modulesInfoString)) {
+            return null;
+        }
+        try {
+            return new JSONObject(modulesInfoString);
+        } catch (JSONException e) {
+            AppLog.e(T.UTILS, "invalid Jetpack Modules Info json", e);
+        }
+        return null;
     }
 
     public boolean isAdmin() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/UpdateJetpackStatusTask.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/UpdateJetpackStatusTask.java
@@ -1,0 +1,58 @@
+package org.wordpress.android.ui.accounts.helpers;
+
+import android.content.Context;
+import android.os.AsyncTask;
+
+import com.android.volley.VolleyError;
+import com.wordpress.rest.RestRequest;
+
+import org.json.JSONObject;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.models.Blog;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.VolleyUtils;
+
+import java.util.Locale;
+
+public class UpdateJetpackStatusTask extends AsyncTask<Void, Void, Void> {
+    protected Context mContext;
+    private Blog mBlog;
+
+    public UpdateJetpackStatusTask(Context context, Blog blog) {
+        if (blog == null || !mBlog.isJetpackPowered()) {
+            cancel(true);
+            return;
+        }
+        mBlog = blog;
+        mContext = context;
+    }
+
+    @Override
+    protected Void doInBackground(Void... args) {
+        String path = String.format(Locale.US, "sites/%s/jetpack/modules", mBlog.getDotComBlogId());
+        WordPress.getRestClientUtils().get(path, new RestRequest.Listener() {
+            @Override
+            public void onResponse(JSONObject response) {
+                boolean isModified;
+                if (response == null) {
+                    AppLog.e(AppLog.T.MAIN, "Response from the server was 200, but no data received, or received a malformed response.");
+                    mBlog.setJetpackModulesInfo("{}");
+                    isModified = true;
+                } else {
+                    isModified = mBlog.bsetJetpackModulesInfo(response.toString());
+                }
+
+                if (isModified) {
+                    WordPress.wpDB.saveBlog(mBlog);
+                }
+            }
+        }, new RestRequest.ErrorListener() {
+            @Override
+            public void onErrorResponse(VolleyError error) {
+                AppLog.e(AppLog.T.MAIN, VolleyUtils.errStringFromVolleyError(error));
+                AppLog.e(AppLog.T.MAIN, VolleyUtils.messageStringFromVolleyError(error));
+            }
+        });
+        return null;
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/UpdateJetpackStatusTask.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/UpdateJetpackStatusTask.java
@@ -19,7 +19,7 @@ public class UpdateJetpackStatusTask extends AsyncTask<Void, Void, Void> {
     private Blog mBlog;
 
     public UpdateJetpackStatusTask(Context context, Blog blog) {
-        if (blog == null || !mBlog.isJetpackPowered()) {
+        if (blog == null || !blog.isJetpackPowered()) {
             cancel(true);
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackUtils.java
@@ -5,8 +5,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.models.Blog;
 
-public class JetpackUtils {
-    public static boolean isShortlinksModuleEnabled(Blog blog) {
+class JetpackUtils {
+    static boolean isShortlinksModuleEnabled(Blog blog) {
         if (blog == null) {
             AppLog.e(AppLog.T.UTILS, "Blog object is null, really?");
             return false;
@@ -18,6 +18,7 @@ public class JetpackUtils {
 
         JSONObject jetpackModulesInfo = blog.getJetpackModulesInfoJSONObject();
         if (jetpackModulesInfo == null || !jetpackModulesInfo.has("modules")) {
+            AppLog.w(AppLog.T.UTILS, "This blog " + blog.getAlternativeHomeUrl() + "doesn't have any modules info synched.");
             return false;
         }
 
@@ -25,8 +26,7 @@ public class JetpackUtils {
             JSONArray modules = jetpackModulesInfo.getJSONArray("modules");
             for (int i = 0; i < modules.length(); i++) {
                 JSONObject module = modules.getJSONObject(i);
-                if (module.has("id") && module.optString("id", "").equals("shortlinks") &&
-                        module.has("active") && module.optBoolean("active", false) ) {
+                if (module.optString("id", "").equals("shortlinks") && module.optBoolean("active", false) ) {
                     return true;
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackUtils.java
@@ -1,8 +1,38 @@
 package org.wordpress.android.util;
 
-/**
- * Created by daniloercoli on 16/12/16.
- */
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.wordpress.android.models.Blog;
 
 public class JetpackUtils {
+    public static boolean isShortlinksModuleEnabled(Blog blog) {
+        if (blog == null) {
+            AppLog.e(AppLog.T.UTILS, "Blog object is null, really?");
+            return false;
+        }
+        if (!blog.isJetpackPowered()) {
+            AppLog.e(AppLog.T.UTILS, "This blog " + blog.getAlternativeHomeUrl() + " doesn't seem Jetpack superpowered!");
+            return false;
+        }
+
+        JSONObject jetpackModulesInfo = blog.getJetpackModulesInfoJSONObject();
+        if (jetpackModulesInfo == null || !jetpackModulesInfo.has("modules")) {
+            return false;
+        }
+
+        try {
+            JSONArray modules = jetpackModulesInfo.getJSONArray("modules");
+            for (int i = 0; i < modules.length(); i++) {
+                JSONObject module = modules.getJSONObject(i);
+                if (module.has("id") && module.optString("id", "").equals("shortlinks") &&
+                        module.has("active") && module.optBoolean("active", false) ) {
+                    return true;
+                }
+            }
+        } catch (JSONException e) {
+            AppLog.e(AppLog.T.UTILS, "invalid module info json", e);
+        }
+        return false;
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackUtils.java
@@ -1,0 +1,8 @@
+package org.wordpress.android.util;
+
+/**
+ * Created by daniloercoli on 16/12/16.
+ */
+
+public class JetpackUtils {
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/JetpackUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/JetpackUtils.java
@@ -26,7 +26,8 @@ class JetpackUtils {
             JSONArray modules = jetpackModulesInfo.getJSONArray("modules");
             for (int i = 0; i < modules.length(); i++) {
                 JSONObject module = modules.getJSONObject(i);
-                if (module.optString("id", "").equals("shortlinks") && module.optBoolean("active", false) ) {
+                if (module.optString("id", "").equals("shortlinks") &&
+                        module.has("active") && JSONUtils.getBool(module,"active")) {
                     return true;
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMeShortlinks.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMeShortlinks.java
@@ -68,6 +68,11 @@ public class WPMeShortlinks {
             return null;
         }
 
+        // Make sure the Jetpack blog has the shortlinks module enabled
+        if (blog.isJetpackPowered() && !JetpackUtils.isShortlinksModuleEnabled(blog)) {
+            return null;
+        }
+
         String postID = post.getRemotePostId();
         if (postID == null) {
             return null;


### PR DESCRIPTION
Fixes #2076 by retrieving modules info from the .com backend.

With this patch Shortlinks are enabled only on those Jetpack sites that have the module active.
If the modules info are missing, the `.me` shortlinks are not used in the app when sharing the post.

**To test this** just add a Jetpack blog to the app, and enable/disable the shortlinks module in wp-admin. 
Put a breakpoint in the task that synchs data with the remote server, so you will be sure latest modules data are already available to the client.


Note that now we've the ability to use modules info to adapt the app to the user'site. One example could be enable/disable Stats, or give a better error message to the user.