### PR TITLE
Setting extended timeout for pin lock when requesting permissions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -57,6 +57,7 @@ import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
+import org.wordpress.passcodelock.AppLockManager;
 
 import java.io.DataInputStream;
 import java.io.File;
@@ -201,6 +202,8 @@ public class MeFragment extends Fragment {
                 if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(MeFragment.this,
                         CAMERA_AND_MEDIA_PERMISSION_REQUEST_CODE)) {
                     askForCameraOrGallery();
+                } else {
+                    AppLockManager.getInstance().setExtendedTimeout();
                 }
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -49,6 +49,7 @@ import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
+import org.wordpress.passcodelock.AppLockManager;
 import org.xmlrpc.android.ApiHelper;
 import org.xmlrpc.android.ApiHelper.GetFeatures.Callback;
 
@@ -347,6 +348,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         } else if (i == R.id.menu_new_media) {
             if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(this, MEDIA_PERMISSION_REQUEST_CODE)) {
                 showNewMediaMenu();
+            } else {
+                AppLockManager.getInstance().setExtendedTimeout();
             }
             return true;
         } else if (i == R.id.menu_search) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -678,6 +678,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(this, MEDIA_PERMISSION_REQUEST_CODE)) {
             super.openContextMenu(view);
         } else {
+            AppLockManager.getInstance().setExtendedTimeout();
             mMenuView = view;
         }
     }
@@ -2154,6 +2155,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                         refreshBlogMedia();
                     }
                 });
+            } else {
+                AppLockManager.getInstance().setExtendedTimeout();
             }
         }
 


### PR DESCRIPTION
Fixes #4916

To test:
* Disable permissions (if necessary)
* Enable PIN lock
* Go to the Me tab and select the avatar
* Deny permissions and verify PIN lock is hidden
* Repeat in the media browser (with Add Media button)
* Repeat in post editor (with Add Media button)
* Share an image with WordPress via the Gallery
* Accept permissions and verify that PIN lock is still shown