### PR TITLE
Fixes NPE and makes sure the pending drafts note is deleted

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
@@ -44,8 +44,10 @@ public class NativeNotificationsUtils {
     }
 
     public static void dismissNotification(int pushId, Context context) {
-        final NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
-        notificationManager.cancel(pushId);
+        if (context != null) {
+            final NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+            notificationManager.cancel(pushId);
+        }
     }
 
     public static void hideStatusBar(Context context) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -67,6 +67,7 @@ public class PostsListFragment extends Fragment
     private boolean mCanLoadMorePosts = true;
     private boolean mIsPage;
     private boolean mIsFetchingPosts;
+    private boolean mShouldCancelPendingDraftNotification = false;
 
     private final PostsListPostList mTrashedPosts = new PostsListPostList();
 
@@ -355,9 +356,19 @@ public class PostsListFragment extends Fragment
         super.onStop();
     }
 
+    @Override
+    public void onDetach() {
+        if (mShouldCancelPendingDraftNotification) {
+            // delete the pending draft notification if available
+            NativeNotificationsUtils.dismissNotification(PENDING_DRAFTS_NOTIFICATION_ID, getActivity());
+            mShouldCancelPendingDraftNotification = false;
+        }
+        super.onDetach();
+    }
+
     /*
-     * called by the adapter after posts have been loaded
-     */
+         * called by the adapter after posts have been loaded
+         */
     @Override
     public void onPostsLoaded(int postCount) {
         if (!isAdded()) {
@@ -540,6 +551,7 @@ public class PostsListFragment extends Fragment
             }
         });
 
+        mShouldCancelPendingDraftNotification = true;
         snackbar.show();
     }
 }


### PR DESCRIPTION

Fixes #4939 

To test:
1. add a new draft post (just tap the edit icon in the post list, write some title and tap back)
2. tap "delete" button on that draft post item in the post list
3. immediately hit BACK button without waiting for the UNDO snackbar to disappear

It should delete the post, delete the pending draft notification if existing, and not crash.


