### PR TITLE
Fixed pending drafts not working if no drafts first time run

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsPendingDraftsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsPendingDraftsService.java
@@ -167,8 +167,8 @@ public class NotificationsPendingDraftsService extends Service {
                         }
                     }
 
-                    completed();
                 }
+                completed();
             }
         }).start();
     }


### PR DESCRIPTION
Fixes #4941

The problem was that when you had no drafts in your blog post list, the service would not be stopped and the `running` flag would always be marked `true`, making further calls to the service not do anything.

To test:
- open blog post list
- make sure you delete all the drafts you have if any
- force stop the app
- launch the app again and go to blog posts
- write a draft
- change the device date to something beyond 3 days in the future
- get back to the app
- it should show the pending drafts notification

cc @rachelmcr @daniloercoli 
