### PR TITLE
Support user trust certificates in debug builds (API24+)

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -62,6 +62,7 @@
         android:icon="@mipmap/app_icon"
         android:label="@string/app_name"
         android:largeHeap="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/WordPress"
         tools:replace="allowBackup, icon">
         <activity

--- a/WordPress/src/main/res/xml/network_security_config.xml
+++ b/WordPress/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <debug-overrides>
+        <trust-anchors>
+            <!-- Trust user added certificate authorities while debuggable only -->
+            <certificates src="user" />
+        </trust-anchors>
+    </debug-overrides>
+</network-security-config>


### PR DESCRIPTION
As of Android Nougat, apps [no longer trust user-added certificate authorities](https://android-developers.googleblog.com/2016/07/changes-to-trusted-certificate.html) by default. This PR adds an override that disables this measure only when running a debug build of the app, allowing use of HTTP proxy tools like Charles Proxy for SSL requests.

To test:
1. Set up an API24+ device to proxy through an HTTP debugger like Charles Proxy or Fiddler
2. Enable SSL proxying and install the custom certificate for the HTTP debugger on the device (you can confirm this is working by visiting HTTPS sites in the device's Chrome browser - traffic should be appearing, decrypted, in the debugger)
3. Build a debug version of the app on the device and log in to WP.com - notice the traffic is appearing and decrypted
4. Build a release version of the app on the device and log in to WP.com - notice the traffic is not decrypted (login should either fail or the device should fall back to mobile data)

It's also worth verifying that everything works on a pre-API24 device.