### PR TITLE
Update note read state with the "badge reset" push notification

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -888,7 +888,18 @@ public class GCMMessageService extends GcmListenerService {
                 return;
             }
 
-            removeNotificationWithNoteIdFromSystemBar(context, data.getString(PUSH_ARG_NOTE_ID, ""));
+            String noteID = data.getString(PUSH_ARG_NOTE_ID, "");
+            if (!TextUtils.isEmpty(noteID)) {
+                Note note = NotificationsTable.getNoteById(noteID);
+                // mark the note as read if it's unread and update the DB silently
+                if (note != null && note.isUnread()) {
+                    NotificationsActions.markNoteAsRead(note);
+                    note.setRead();
+                    NotificationsTable.saveNote(note);
+                }
+            }
+
+            removeNotificationWithNoteIdFromSystemBar(context, noteID);
             //now that we cleared the specific notif, we can check and make any visual updates
             if (sActiveNotificationsMap.size() > 0) {
                 rebuildAndUpdateNotificationsOnSystemBar(context, data);

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -893,7 +893,6 @@ public class GCMMessageService extends GcmListenerService {
                 Note note = NotificationsTable.getNoteById(noteID);
                 // mark the note as read if it's unread and update the DB silently
                 if (note != null && note.isUnread()) {
-                    NotificationsActions.markNoteAsRead(note);
                     note.setRead();
                     NotificationsTable.saveNote(note);
                 }


### PR DESCRIPTION
Update the notification obj in the DB, by marking it as `read`, when the badge reset push notification reach the device, and has the `note_id` field of the note read on another device.

cc @mzorz - This should improve the experience a little bit, since you will see notes already marked as read when the app starts without waiting for the full refresh (already started in BG).
