### PR TITLE
Jetpack - Stats: Improve error messages when the plugin is not active, or when the Stats module disable

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -882,6 +882,22 @@ public class StatsActivity extends AppCompatActivity
     }
 
     @SuppressWarnings("unused")
+    public void onEventMainThread(StatsEvents.JetpackNotConnectedError event) {
+        if (isFinishing() || !mIsInFront) {
+            return;
+        }
+        showJetpackNonConnectedAlert();
+    }
+
+    @SuppressWarnings("unused")
+    public void onEventMainThread(StatsEvents.JetpackMissingError event) {
+        if (isFinishing() || !mIsInFront) {
+            return;
+        }
+        showJetpackMissingAlert();
+    }
+
+    @SuppressWarnings("unused")
     public void onEventMainThread(StatsEvents.SectionUpdateError event) {
         // There was an error loading Stats. Don't bump stats for promo widget.
         if (isFinishing() || !mIsInFront) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -890,7 +890,7 @@ public class StatsActivity extends AppCompatActivity
     }
 
     @SuppressWarnings("unused")
-    public void onEventMainThread(StatsEvents.JetpackMissingError event) {
+    public void onEventMainThread(StatsEvents.JetpackStatsModuleNotConnectedError event) {
         if (isFinishing() || !mIsInFront) {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -31,7 +31,6 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.models.AccountHelper;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.ui.ActivityId;
-import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.accounts.SignInActivity;
 import org.wordpress.android.ui.posts.PromoDialog;
@@ -607,6 +606,59 @@ public class StatsActivity extends AppCompatActivity
         }
     }
 
+    private void showJetpackStatsModuleAlert() {
+        if (isFinishing()) {
+            return;
+        }
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        final Blog currentBlog = WordPress.getBlog(mLocalBlogID);
+        if (currentBlog == null) {
+            AppLog.e(T.STATS, "The blog with local_blog_id " + mLocalBlogID + " cannot be loaded from the DB.");
+            Toast.makeText(this, R.string.stats_no_blog, Toast.LENGTH_LONG).show();
+            finish();
+            return;
+        }
+        if (currentBlog.isAdmin()) {
+            builder.setMessage(getString(R.string.jetpack_stats_module_disabled_message))
+                    .setTitle(getString(R.string.jetpack_info));
+            builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int id) {
+                    String stringToLoad = currentBlog.getAdminUrl();
+                    String jetpackConnectPageAdminPath = "admin.php?page=jetpack#/engagement";
+                    stringToLoad = stringToLoad.endsWith("/") ? stringToLoad + jetpackConnectPageAdminPath :
+                            stringToLoad + "/" + jetpackConnectPageAdminPath;
+                    String authURL = WPWebViewActivity.getBlogLoginUrl(currentBlog);
+                    Intent jetpackIntent = new Intent(StatsActivity.this, WPWebViewActivity.class);
+                    jetpackIntent.putExtra(WPWebViewActivity.AUTHENTICATION_USER, currentBlog.getUsername());
+                    jetpackIntent.putExtra(WPWebViewActivity.AUTHENTICATION_PASSWD, currentBlog.getPassword());
+                    jetpackIntent.putExtra(WPWebViewActivity.URL_TO_LOAD, stringToLoad);
+                    jetpackIntent.putExtra(WPWebViewActivity.AUTHENTICATION_URL, authURL);
+                    startActivityForResult(jetpackIntent, REQUEST_JETPACK);
+                }
+            });
+            builder.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int id) {
+                    // User cancelled the dialog. Hide Stats.
+                    finish();
+                }
+            });
+        } else {
+            builder.setMessage(getString(R.string.jetpack_stats_module_disabled_message_not_admin))
+                    .setTitle(getString(R.string.jetpack_info));
+            builder.setPositiveButton(R.string.yes, null);
+        }
+
+        AlertDialog dialog = builder.create();
+        dialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
+            @Override
+            public void onCancel(DialogInterface dialog) {
+                // User pressed the back key Hide Stats.
+                finish();
+            }
+        });
+        dialog.show();
+    }
+
     private void showJetpackNonConnectedAlert() {
         if (isFinishing()) {
             return;
@@ -660,6 +712,7 @@ public class StatsActivity extends AppCompatActivity
         });
         dialog.show();
     }
+
 
     private void showJetpackMissingAlert() {
         if (isFinishing()) {
@@ -882,11 +935,29 @@ public class StatsActivity extends AppCompatActivity
     }
 
     @SuppressWarnings("unused")
-    public void onEventMainThread(StatsEvents.JetpackNotConnectedError event) {
+    public void onEventMainThread(StatsEvents.JetpackNotConnectedOrDeactivatedError event) {
         if (isFinishing() || !mIsInFront) {
             return;
         }
-        showJetpackNonConnectedAlert();
+        final Blog currentBlog = WordPress.getBlog(mLocalBlogID);
+        if (currentBlog == null) {
+            AppLog.e(T.STATS, "The blog with local_blog_id " + mLocalBlogID + " cannot be loaded from the DB.");
+            Toast.makeText(this, R.string.stats_no_blog, Toast.LENGTH_LONG).show();
+            finish();
+            return;
+        }
+
+        // Re-launch a blog option synch for safety reason.
+        // Blog options could not be synched if the user has just deactivated/removed or disconnected the plugin
+        new ApiHelper.RefreshBlogContentTask(currentBlog, null).execute(false);
+
+        if (TextUtils.isEmpty(currentBlog.getJetpackVersion())) {
+            // jetpack_version option is available, but not the jetpack_client_id ----> Jetpack available but not connected.
+            showJetpackNonConnectedAlert();
+        } else {
+            // Blog has not returned jetpack_version/jetpack_client_id.
+            showJetpackMissingAlert();
+        }
     }
 
     @SuppressWarnings("unused")
@@ -894,7 +965,7 @@ public class StatsActivity extends AppCompatActivity
         if (isFinishing() || !mIsInFront) {
             return;
         }
-        showJetpackMissingAlert();
+        showJetpackStatsModuleAlert();
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -947,8 +947,8 @@ public class StatsActivity extends AppCompatActivity
             return;
         }
 
-        // Re-launch a blog option synch for safety reason.
-        // Blog options could not be synched if the user has just deactivated/removed or disconnected the plugin
+        // Re-launch a blog option synching here o be sure we will have Jetpack status update next time we will start Stats again.
+        // This is because blog options could not be synched if the user has just deactivated/removed or disconnected the plugin.
         new ApiHelper.RefreshBlogContentTask(currentBlog, null).execute(false);
 
         if (TextUtils.isEmpty(currentBlog.getJetpackVersion())) {
@@ -958,7 +958,7 @@ public class StatsActivity extends AppCompatActivity
             // Blog has not returned jetpack_version/jetpack_client_id.
             showJetpackMissingAlert();
         }
-    }
+    }   
 
     @SuppressWarnings("unused")
     public void onEventMainThread(StatsEvents.JetpackStatsModuleNotConnectedError event) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -713,7 +713,6 @@ public class StatsActivity extends AppCompatActivity
         dialog.show();
     }
 
-
     private void showJetpackMissingAlert() {
         if (isFinishing()) {
             return;
@@ -958,7 +957,7 @@ public class StatsActivity extends AppCompatActivity
             // Blog has not returned jetpack_version/jetpack_client_id.
             showJetpackMissingAlert();
         }
-    }   
+    }
 
     @SuppressWarnings("unused")
     public void onEventMainThread(StatsEvents.JetpackStatsModuleNotConnectedError event) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsEvents.java
@@ -273,4 +273,21 @@ public class StatsEvents {
             mLocalBlogId = blogId;
         }
     }
+
+    public static class JetpackNotConnectedError {
+        public final int mLocalBlogId; // This is the local blogID
+
+        public JetpackNotConnectedError(int blogId) {
+            mLocalBlogId = blogId;
+        }
+    }
+
+    public static class JetpackStatsModuleNotConnectedError {
+        public final int mLocalBlogId; // This is the local blogID
+
+        public JetpackStatsModuleNotConnectedError(int blogId) {
+            mLocalBlogId = blogId;
+        }
+    }
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsEvents.java
@@ -274,10 +274,10 @@ public class StatsEvents {
         }
     }
 
-    public static class JetpackNotConnectedError {
+    public static class JetpackNotConnectedOrDeactivatedError {
         public final int mLocalBlogId; // This is the local blogID
 
-        public JetpackNotConnectedError(int blogId) {
+        public JetpackNotConnectedOrDeactivatedError(int blogId) {
             mLocalBlogId = blogId;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
@@ -321,6 +321,34 @@ public class StatsUtils {
         }
     }
 
+    public static synchronized boolean isJetpackDisconnectedOrDeactivatedError(final Serializable error) {
+        if (error == null || !(error instanceof com.android.volley.ServerError)) {
+            return false;
+        }
+        com.android.volley.ServerError volleyError = (com.android.volley.ServerError) error;
+        if (volleyError.networkResponse != null && volleyError.networkResponse.data != null) {
+            String errorMessage = new String(volleyError.networkResponse.data).toLowerCase();
+            return errorMessage.contains("jetpack") && errorMessage.contains("connected");
+        } else {
+            AppLog.e(T.STATS, "Network response is null in Volley. Can't check if it is a Rest Disabled error.");
+            return false;
+        }
+    }
+
+    public static synchronized boolean isJetpackStatsModuleDisabledError(final Serializable error) {
+        if (error == null || !(error instanceof com.android.volley.ServerError)) {
+            return false;
+        }
+        com.android.volley.ServerError volleyError = (com.android.volley.ServerError) error;
+        if (volleyError.networkResponse != null && volleyError.networkResponse.data != null) {
+            String errorMessage = new String(volleyError.networkResponse.data).toLowerCase();
+            return errorMessage.contains("stats") && errorMessage.contains("module") && errorMessage.contains("enabled");
+        } else {
+            AppLog.e(T.STATS, "Network response is null in Volley. Can't check if it is a Rest Disabled error.");
+            return false;
+        }
+    }
+
     public static synchronized BaseStatsModel parseResponse(StatsService.StatsEndpointsEnum endpointName, String blogID, JSONObject response)
             throws JSONException {
         BaseStatsModel model = null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -584,11 +584,10 @@ public class StatsService extends Service {
 
                     if (!blog.isDotcomFlag()) {
                         if (volleyError instanceof com.android.volley.AuthFailureError) {
-                            if (StatsUtils.isRESTDisabledError(volleyError)) {
+                            if (!StatsUtils.isRESTDisabledError(volleyError)) {
                                 // It's a kind of edge case, but the Jetpack site could have REST Disabled
                                 // In that case (only used in insights for now) shows the error in the module that use the REST API
-                            } else {
-                                //TODO Auth error here
+                                EventBus.getDefault().post(new StatsEvents.JetpackAuthError(localId));
                             }
                         } else if (volleyError instanceof com.android.volley.ServerError && mStatsNetworkRequests.size() == 1) {
                             // only the last connection triggers the error

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -570,24 +570,39 @@ public class StatsService extends Service {
                     AppLog.e(T.STATS, "Error while loading Stats!");
                     StatsUtils.logVolleyErrorDetails(volleyError);
                     BaseStatsModel mResponseObjectModel = null;
+
                     // Check here if this is an authentication error
                     // .com authentication errors are handled automatically by the app
-                    if (volleyError instanceof com.android.volley.AuthFailureError) {
-                        int localId = WordPress.wpDB.getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(
-                                Integer.parseInt(mRequestBlogId)
-                        );
-                        Blog blog = WordPress.wpDB.instantiateBlogByLocalId(localId);
-                        if (blog != null && blog.isJetpackPowered() ) {
-                            if (StatsUtils.isRESTDisabledError(volleyError) || mEndpointName == StatsEndpointsEnum.INSIGHTS_LATEST_POST_SUMMARY ) {
+                    int localId = WordPress.wpDB.getLocalTableBlogIdForJetpackOrWpComRemoteSiteId(
+                            Integer.parseInt(mRequestBlogId)
+                    );
+                    Blog blog = WordPress.wpDB.instantiateBlogByLocalId(localId);
+                    if (blog == null) {
+                        stopService();
+                        return;
+                    }
+
+                    if (!blog.isDotcomFlag()) {
+                        if (volleyError instanceof com.android.volley.AuthFailureError) {
+                            if (StatsUtils.isRESTDisabledError(volleyError)) {
                                 // It's a kind of edge case, but the Jetpack site could have REST Disabled
                                 // In that case (only used in insights for now) shows the error in the module that use the REST API
                             } else {
-                                // Check here if the module is disabled or Jetpack disconnected
-                                EventBus.getDefault().post(new StatsEvents.JetpackAuthError(localId));
+                                //TODO Auth error here
+                            }
+                        } else if (volleyError instanceof com.android.volley.ServerError && mStatsNetworkRequests.size() == 1) {
+                            // only the last connection triggers the error
+                            if (StatsUtils.isJetpackDisconnectedOrDeactivatedError(volleyError)) {
+                                EventBus.getDefault().post(new StatsEvents.JetpackNotConnectedOrDeactivatedError(localId));
+                            } else if (StatsUtils.isJetpackStatsModuleDisabledError(volleyError)) {
+                                EventBus.getDefault().post(new StatsEvents.JetpackStatsModuleNotConnectedError(localId));
+                            } else {
+                                // show the generic error into the module UI
                             }
                         }
                     }
 
+                    // default - publish error into the module UI
                     EventBus.getDefault().post(new StatsEvents.SectionUpdateError(mEndpointName, mRequestBlogId, mTimeframe, mDate,
                             mMaxResultsRequested, mPageRequested, volleyError));
                     updateWidgetsUI(mRequestBlogId, mEndpointName, mTimeframe, mDate, mPageRequested, mResponseObjectModel);
@@ -605,8 +620,10 @@ public class StatsService extends Service {
         }*/
         EventBus.getDefault().post(new StatsEvents.UpdateStatusChanged(false));
         stopSelf(mServiceStartId);
+        synchronized (mStatsNetworkRequests) {
+            mStatsNetworkRequests.clear();
+        }
     }
-
 
     private void checkAllRequestsFinished(Request<JSONObject> req) {
         synchronized (mStatsNetworkRequests) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/service/StatsService.java
@@ -577,19 +577,19 @@ public class StatsService extends Service {
                                 Integer.parseInt(mRequestBlogId)
                         );
                         Blog blog = WordPress.wpDB.instantiateBlogByLocalId(localId);
-                        if (blog != null && blog.isJetpackPowered()) {
-                            // It's a kind of edge case, but the Jetpack site could have REST Disabled
-                            // In that case (only used in insights for now) shows the error in the module that use the REST API
-                            if (!StatsUtils.isRESTDisabledError(volleyError)) {
+                        if (blog != null && blog.isJetpackPowered() ) {
+                            if (StatsUtils.isRESTDisabledError(volleyError) || mEndpointName == StatsEndpointsEnum.INSIGHTS_LATEST_POST_SUMMARY ) {
+                                // It's a kind of edge case, but the Jetpack site could have REST Disabled
+                                // In that case (only used in insights for now) shows the error in the module that use the REST API
+                            } else {
+                                // Check here if the module is disabled or Jetpack disconnected
                                 EventBus.getDefault().post(new StatsEvents.JetpackAuthError(localId));
                             }
                         }
                     }
 
-
                     EventBus.getDefault().post(new StatsEvents.SectionUpdateError(mEndpointName, mRequestBlogId, mTimeframe, mDate,
                             mMaxResultsRequested, mPageRequested, volleyError));
-
                     updateWidgetsUI(mRequestBlogId, mEndpointName, mTimeframe, mDate, mPageRequested, mResponseObjectModel);
                     checkAllRequestsFinished(currentRequest);
                 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1098,11 +1098,14 @@
     <!--
       Jetpack strings
     -->
+    <string name="jetpack_info">Jetpack info</string>
     <string name="jetpack_message">The Jetpack plugin is required for stats. Do you want to install Jetpack?</string>
     <string name="jetpack_message_not_admin">The Jetpack plugin is required for stats. Contact the site administrator.</string>
     <string name="jetpack_not_found">Jetpack plugin not found</string>
     <string name="jetpack_not_connected">Jetpack plugin not connected</string>
     <string name="jetpack_not_connected_message">The Jetpack plugin is installed, but not connected to WordPress.com. Do you want to connect Jetpack?</string>
+    <string name="jetpack_stats_module_disabled_message">The Jetpack plugin is connected, but the Stats module is not active. Do you want to activate Stats?</string>
+    <string name="jetpack_stats_module_disabled_message_not_admin">The Jetpack plugin is connected, but the Stats module is not active. Contact the site administrator.</string>
 
     <!--
       reader strings


### PR DESCRIPTION
This is a partial fix for #3716 and #4953.

A full fix will be rolled out with FluxC.

<del>*Note: Server side changes are currently pending, so do not merge this PR until they deployed.*</del>

**Steps**
Case One:
- Add and select self-hosted blog from Site Picker that has Jetpack installed and connected.
- Disable the Stats module on Jetpack settings.
- Open Stats in the app.

Case Two:
- Disconnect Jetpack from WordPress.com.
- Open Stats in the app.