### PR TITLE
Fixes #4967: null site in post list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
@@ -58,6 +58,10 @@ public class PostsListActivity extends AppCompatActivity {
      * upload error notification
      */
     private void showErrorDialogIfNeeded(Bundle extras) {
+        if (WordPress.getCurrentBlog() == null) {
+            ToastUtils.showToast(this, R.string.blog_not_found);
+            finish();
+        }
         if (extras == null || !extras.containsKey(EXTRA_ERROR_MSG) || isFinishing()) {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -7,6 +7,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -141,8 +142,8 @@ public class PostsListFragment extends Fragment
                 });
     }
 
-    public PostsListAdapter getPostListAdapter() {
-        if (mPostsListAdapter == null) {
+    private @Nullable PostsListAdapter getPostListAdapter() {
+        if (mPostsListAdapter == null && WordPress.getCurrentBlog() != null) {
             mPostsListAdapter = new PostsListAdapter(getActivity(), WordPress.getCurrentBlog(), mIsPage);
             mPostsListAdapter.setOnLoadMoreListener(this);
             mPostsListAdapter.setOnPostsLoadedListener(this);
@@ -158,7 +159,9 @@ public class PostsListFragment extends Fragment
     }
 
     private void loadPosts() {
-        getPostListAdapter().loadPosts();
+        if (getPostListAdapter() != null) {
+            getPostListAdapter().loadPosts();
+        }
     }
 
     @Override
@@ -187,7 +190,7 @@ public class PostsListFragment extends Fragment
     public void onResume() {
         super.onResume();
 
-        if (WordPress.getCurrentBlog() != null && mRecyclerView.getAdapter() == null) {
+        if (getPostListAdapter() != null && mRecyclerView.getAdapter() == null) {
             mRecyclerView.setAdapter(getPostListAdapter());
         }
 
@@ -228,7 +231,7 @@ public class PostsListFragment extends Fragment
             return;
         }
 
-        if (getPostListAdapter().getItemCount() == 0) {
+        if (getPostListAdapter() != null && getPostListAdapter().getItemCount() == 0) {
             updateEmptyView(EmptyViewMessageType.LOADING);
         }
 
@@ -257,7 +260,7 @@ public class PostsListFragment extends Fragment
      */
     @SuppressWarnings("unused")
     public void onEventMainThread(PostEvents.PostMediaInfoUpdated event) {
-        if (isAdded() && WordPress.getCurrentBlog() != null) {
+        if (isAdded() && getPostListAdapter() != null) {
             getPostListAdapter().mediaUpdated(event.getMediaId(), event.getMediaUrl());
         }
     }
@@ -473,7 +476,8 @@ public class PostsListFragment extends Fragment
     private void trashPost(final PostsListPost post) {
         //only check if network is available in case this is not a local draft - local drafts have not yet
         //been posted to the server so they can be trashed w/o further care
-        if (!isAdded() || (!post.isLocalDraft() && !NetworkUtils.checkConnection(getActivity()))) {
+        if (!isAdded() || (!post.isLocalDraft() && !NetworkUtils.checkConnection(getActivity()))
+            || getPostListAdapter() == null) {
             return;
         }
 


### PR DESCRIPTION
Fixes #4967:
* Close the PostList activity if current blog is null (can't do anything in there anyway, allows the app to recover and the user to eventually pick a site).
* Make sure the PostListAdapter can't be initialized with a null blog.


Note: this is handled better in the FluxC integration branch since we killed getCurrentBlog.
