### PR TITLE
Fixes #4960: Make sure the user is not logged in when adding a new wpcom site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -76,6 +76,7 @@ import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SelfSignedSSLUtils;
 import org.wordpress.android.util.SelfSignedSSLUtils.Callback;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPUrlUtils;
@@ -84,7 +85,6 @@ import org.wordpress.android.widgets.WPTextView;
 import org.wordpress.emailchecker2.EmailChecker;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -874,6 +874,23 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         return true;
     }
 
+    private boolean isUserAlreadyLoggedIn() {
+        if (mAccountStore.hasAccessToken()) {
+            String currentUsername = mAccountStore.getAccount().getUserName();
+            AppLog.e(T.NUX, "User is already logged in WordPress.com: " + currentUsername
+                            + " - but tries to sign in again: " + mUsername);
+            if (getActivity() != null) {
+                if (currentUsername.equals(mUsername)) {
+                    ToastUtils.showToast(getActivity(), R.string.already_logged_in_wpcom_same_username, Duration.LONG);
+                } else {
+                    ToastUtils.showToast(getActivity(), R.string.already_logged_in_wpcom, Duration.LONG);
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
     protected void signIn() {
         if (mSelfHosted || isEnterPasswordMode()) {
             if (!isUserDataValid()) {
@@ -888,6 +905,9 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             mPassword = EditTextUtils.getText(mPasswordEditText).trim();
             mTwoStepCode = EditTextUtils.getText(mTwoStepEditText).trim();
             if (isWPComLogin()) {
+                if (isUserAlreadyLoggedIn()) {
+                    return;
+                }
                 AppLog.i(T.NUX, "User tries to sign in on WordPress.com with username: " + mUsername);
                 signInAndFetchBlogListWPCom();
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -874,7 +874,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         return true;
     }
 
-    private boolean isUserAlreadyLoggedIn() {
+    private boolean checkIfUserIsAlreadyLoggedIn() {
         if (mAccountStore.hasAccessToken()) {
             String currentUsername = mAccountStore.getAccount().getUserName();
             AppLog.e(T.NUX, "User is already logged in WordPress.com: " + currentUsername
@@ -905,7 +905,8 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             mPassword = EditTextUtils.getText(mPasswordEditText).trim();
             mTwoStepCode = EditTextUtils.getText(mTwoStepEditText).trim();
             if (isWPComLogin()) {
-                if (isUserAlreadyLoggedIn()) {
+                // If the user is already logged in a wordpress.com account, bail out
+                if (checkIfUserIsAlreadyLoggedIn()) {
                     return;
                 }
                 AppLog.i(T.NUX, "User tries to sign in on WordPress.com with username: " + mUsername);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1336,6 +1336,8 @@
     <string name="checking_email">Checking email</string>
     <string name="not_on_wordpress_com">Not on WordPress.com?</string>
     <string name="access_token_migration_message">Updating…</string>
+    <string name="already_logged_in_wpcom">You\'re already logged in a WordPress.com account, you can\'t add a WordPress.com site bound to another account.</string>
+    <string name="already_logged_in_wpcom_same_username">You\'re already logged in your WordPress.com account. Your site should appear in the site picker, make sure it\'s not hidden.</string>
 
     <!-- Help view -->
     <string name="help">Help</string>


### PR DESCRIPTION
Fixes #4960 Make sure the user is not logged in when adding a new wpcom site

