### PR TITLE
issue/4936-reader-tag-header

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -590,7 +590,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     }
 
     private boolean hasTagHeader() {
-        return mCurrentTag != null && mCurrentTag.isTagTopic();
+        return mCurrentTag != null && mCurrentTag.isTagTopic() && !isEmpty();
     }
 
     private boolean isDiscover() {


### PR DESCRIPTION
Fixes #4936 - hides the tag header when there aren't any posts. Before and after shots below.

![screenshot_1483464409](https://cloud.githubusercontent.com/assets/3903757/21616727/b2ca6012-d1b0-11e6-828b-e7275f2afd63.png)

