### PR TITLE
Fix #4074: autocomplete sign in email

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -26,6 +26,8 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.ArrayAdapter;
+import android.widget.AutoCompleteTextView;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -71,6 +73,7 @@ import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
+import org.wordpress.android.util.UserEmailUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.widgets.ContextMenuEditText;
@@ -104,7 +107,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     public static final String ENTERED_URL_KEY = "ENTERED_URL_KEY";
     public static final String ENTERED_USERNAME_KEY = "ENTERED_USERNAME_KEY";
 
-    protected EditText mUsernameEditText;
+    protected AutoCompleteTextView mUsernameEditText;
     protected EditText mPasswordEditText;
     protected EditText mUrlEditText;
     protected ContextMenuEditText mTwoStepEditText;
@@ -178,10 +181,11 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         mUsernameLayout.setOnClickListener(mOnLoginFormClickListener);
         mPasswordLayout = (RelativeLayout) rootView.findViewById(R.id.nux_password_layout);
         mPasswordLayout.setOnClickListener(mOnLoginFormClickListener);
-
-        mUsernameEditText = (EditText) rootView.findViewById(R.id.nux_username);
+        mUsernameEditText = (AutoCompleteTextView) rootView.findViewById(R.id.nux_username);
         mUsernameEditText.addTextChangedListener(this);
         mUsernameEditText.setOnClickListener(mOnLoginFormClickListener);
+        mUsernameEditText.setAdapter(new ArrayAdapter<String>(container.getContext(),
+                android.R.layout.simple_spinner_dropdown_item, UserEmailUtils.getAccountEmails(container.getContext())));
         mPasswordEditText = (EditText) rootView.findViewById(R.id.nux_password);
         mPasswordEditText.addTextChangedListener(this);
         mPasswordEditText.setOnClickListener(mOnLoginFormClickListener);

--- a/WordPress/src/main/res/layout/signin_fragment.xml
+++ b/WordPress/src/main/res/layout/signin_fragment.xml
@@ -126,7 +126,7 @@
                 android:background="@color/white"
                 android:clickable="true">
 
-                <org.wordpress.android.widgets.WPEditText
+                <AutoCompleteTextView
                     android:id="@+id/nux_username"
                     style="@style/WordPress.NUXEditText"
                     android:layout_width="fill_parent"

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UserEmailUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UserEmailUtils.java
@@ -3,10 +3,14 @@ package org.wordpress.android.util;
 import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Patterns;
 
 import org.wordpress.android.util.AppLog.T;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Pattern;
 
 public class UserEmailUtils {
@@ -18,12 +22,13 @@ public class UserEmailUtils {
     public static String getPrimaryEmail(Context context) {
         try {
             AccountManager accountManager = AccountManager.get(context);
-            if (accountManager == null)
+            if (accountManager == null) {
                 return "";
+            }
             Account[] accounts = accountManager.getAccounts();
             Pattern emailPattern = Patterns.EMAIL_ADDRESS;
             for (Account account : accounts) {
-                // make sure account.name is an email address before adding to the list
+                // make sure account.name is an email address before returning it.
                 if (emailPattern.matcher(account.name).matches()) {
                     return account.name;
                 }
@@ -34,5 +39,35 @@ public class UserEmailUtils {
             AppLog.e(T.UTILS, "SecurityException - missing GET_ACCOUNTS permission");
             return "";
         }
+    }
+
+    /**
+     * Get list of account names matching an email address pattern.
+     *
+     * @return a list of emails or the empty list if none is found.
+     */
+    public static @NonNull List<String> getAccountEmails(@Nullable Context context) {
+        ArrayList<String> emails = new ArrayList<>();
+        if (context == null) {
+            return emails;
+        }
+        try {
+            AccountManager accountManager = AccountManager.get(context);
+            if (accountManager == null) {
+                return emails;
+            }
+            Account[] accounts = accountManager.getAccounts();
+            Pattern emailPattern = Patterns.EMAIL_ADDRESS;
+            for (Account account : accounts) {
+                // make sure account.name is an email address before adding to the list
+                if (emailPattern.matcher(account.name).matches()) {
+                    emails.add(account.name);
+                }
+            }
+        } catch (SecurityException e) {
+            // exception will occur if app doesn't have GET_ACCOUNTS permission
+            AppLog.e(T.UTILS, "SecurityException - missing GET_ACCOUNTS permission");
+        }
+        return emails;
     }
 }


### PR DESCRIPTION
Fix #4074: autocomplete sign in email

I'm actually not sure that's a good idea, I think this could confuse even more some users who don't use the same email address for their Google account and their WordPress.com account.