### PR TITLE
Use explicit flag to know when to show a pending draft notification

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsPendingDraftsService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsPendingDraftsService.java
@@ -144,11 +144,14 @@ public class NotificationsPendingDraftsService extends Service {
                         } else if (draftPostsOlderThan3Days.size() > 1) {
                             long longestLivingDraft = 0;
                             boolean onlyPagesFound = true;
+                            boolean doShowNotification = false;
                             for (Post post : draftPostsOlderThan3Days) {
 
                                 // update each post dateLastNotified field to now
                                 if ((now - post.getDateLastNotified()) > MINIMUM_ELAPSED_TIME_BEFORE_REPEATING_NOTIFICATION) {
-                                    if (post.getDateLastNotified() > longestLivingDraft) {
+
+                                    if (post.getDateLastNotified() >= longestLivingDraft) {
+                                        doShowNotification = true;
                                         longestLivingDraft = post.getDateLastNotified();
                                         if (!post.isPage()) {
                                             onlyPagesFound = false;
@@ -161,7 +164,7 @@ public class NotificationsPendingDraftsService extends Service {
 
                             // if there was at least one notification that exceeded the minimum elapsed time to repeat the notif,
                             // then show the notification again
-                            if (longestLivingDraft > 0) {
+                            if (doShowNotification) {
                                 buildPendingDraftsNotification(draftPostsOlderThan3Days, onlyPagesFound);
                             }
                         }


### PR DESCRIPTION
Fixes #4986 

The problem that this PR fixes is around this section of code https://github.com/wordpress-mobile/WordPress-Android/blob/issue/4978-multiple-pending-draft-error/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsPendingDraftsService.java#L164

It seems `longestLivingDraft` ends up being equal to zero when that check is performed, so the notification doesn’t happen.
Next time things are checked, they end up the same, unless `MINIMUM_ELAPSED_TIME_BEFORE_REPEATING_NOTIFICATION` is met, and that’s when it works again. So to simplify this means that the first time the notification could/should appear it doesn’t appear, but it only appears the next time that minimum value passes (like, 24 hours later and the app is run).

This PR makes the condition explicit for code readibility.

To test:
1. write a draft
2. write a second draft
3. set the device date beyond 3 days in the future
4. bring WordPress app to the foreground
5. “grouped” notification should appear, but it doesn’t

cc @daniloercoli 