### PR TITLE
Fixing bug to allow WP.com users to enter their password

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -385,6 +385,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             if (mInhibitMagicLogin) {
                 showDotComSignInForm();
             } else {
+                mIsMagicLinksEnabled = true;
                 configureMagicLinkUI();
             }
         } else {
@@ -612,7 +613,6 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
 
     private void configureMagicLinkUI() {
         showDotComSignInForm();
-        mIsMagicLinksEnabled = true;
         mSelfHosted = false;
         mPasswordLayout.setVisibility(View.GONE);
         mForgotPassword.setVisibility(View.GONE);


### PR DESCRIPTION
Setting mIsMagicLinksEnabled in the correct place so that the user can enter their password when they press “Enter your password instead”

Fixes #4988 

To test:
Enter a WP.com email and click "next". When you get sent to the next screen, tap "Enter your password instead". You should be sent to the previous screen with the password field visible and focused.