### PR TITLE
Add right and left margins to the Create New Account title

### DIFF
--- a/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
+++ b/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
@@ -43,6 +43,8 @@
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/create_account_label"
                 android:text="@string/create_account_wpcom"
+                android:layout_marginLeft="@dimen/margin_medium"
+                android:layout_marginRight="@dimen/margin_medium"
                 style="@style/WordPress.NUXTitle"
                 android:fontFamily="sans-serif-light"
                 app:fixWidowWords="true"/>


### PR DESCRIPTION
Add right and left margins to the Create New Account title

Discovered while testing Icelandic translation (h/t @egill)

Before:
![screenshot-2017-01-06_10 45 44 643](https://cloud.githubusercontent.com/assets/40213/21714283/760fe278-d3fe-11e6-8c33-07291e666c52.png)


After:
![screenshot-2017-01-06_10 52 25 519](https://cloud.githubusercontent.com/assets/40213/21714288/790fe8ec-d3fe-11e6-8c69-f670a285283c.png)

