### PR TITLE
Fix a crash when the user hits back from the site picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -538,8 +538,10 @@ public class WPMainActivity extends AppCompatActivity {
             case RequestCodes.SITE_PICKER:
                 if (getMySiteFragment() != null) {
                     getMySiteFragment().onActivityResult(requestCode, resultCode, data);
-                    int selectedSite = data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1);
-                    setSelectedSite(selectedSite);
+                    if (data != null) {
+                        int selectedSite = data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1);
+                        setSelectedSite(selectedSite);
+                    }
                 }
                 break;
             case RequestCodes.BLOG_SETTINGS:


### PR DESCRIPTION
Before the patch: go to the site picker, hit the back button 🐛 💥 😢 
After the patch: go to the site picker, hit the back button 🏖 👍 🥇 