### PR TITLE
Issue/4996 reader tag decode

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -16,6 +16,7 @@ import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.HtmlUtils;
 import org.wordpress.android.util.JSONUtils;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.UrlUtils;
 
 import java.text.BreakIterator;
 import java.util.Iterator;
@@ -307,7 +308,7 @@ public class ReaderPost {
 
         while (it.hasNext()) {
             JSONObject jsonThisTag = jsonTags.optJSONObject(it.next());
-            String thisTagName = JSONUtils.getStringDecoded(jsonThisTag, "slug");
+            String thisTagName = UrlUtils.urlDecode(JSONUtils.getString(jsonThisTag, "slug"));
 
             // if the number of posts on this blog that use this tag is higher than previous,
             // set this as the most popular tag, and set the second most popular tag to

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -735,28 +735,6 @@ public class ReaderPost {
     }
 
     /*
-     * determine which tag to display for this post
-     *  - no tag if this is a private blog or there is no primary tag for this post
-     *  - primary tag, unless it's the same as the currently selected tag
-     *  - secondary tag if primary tag is the same as the currently selected tag
-     */
-    private transient String tagForDisplay;
-    public String getTagForDisplay(final String currentTagName) {
-        if (tagForDisplay == null) {
-            if (!isPrivate && hasPrimaryTag()) {
-                if (getPrimaryTag().equalsIgnoreCase(currentTagName)) {
-                    tagForDisplay = getSecondaryTag();
-                } else {
-                    tagForDisplay = getPrimaryTag();
-                }
-            } else {
-                tagForDisplay = "";
-            }
-        }
-        return tagForDisplay;
-    }
-
-    /*
      * used when a unique numeric id is required by an adapter (when hasStableIds() = true)
      */
     private transient long stableId;


### PR DESCRIPTION
Fixes #4996

To test: Follow a blog such as [this one](https://thesstips.wordpress.com/) which uses Unicode tag names, then open the reader full post view for any of its posts. Prior to this fix the tag would be unencoded.

Before and after pics below.

![before-and-after](https://cloud.githubusercontent.com/assets/3903757/21724578/f2f2a3b2-d402-11e6-87c7-863f3f975a13.png)
