### PR TITLE
Issue/4909 action bar obstructs fragment view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -39,14 +39,19 @@ public class WPActivityUtils {
         }
 
         Toolbar toolbar;
-        if (dialog.findViewById(android.R.id.list) == null) {
+        if (dialog.findViewById(android.R.id.list) == null &&
+                dialog.findViewById(android.R.id.list_container) == null) {
             return;
         }
 
-        ViewGroup root;
+        ViewGroup root = null;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            root = (ViewGroup) dialog.findViewById(android.R.id.list_container).getParent();
-        } else {
+            ViewGroup listContainer = (ViewGroup) dialog.findViewById(android.R.id.list_container);
+            if (listContainer != null) {
+                root = (ViewGroup) listContainer.getParent();
+            }
+        }
+        if (root == null) {
             root = (ViewGroup) dialog.findViewById(android.R.id.list).getParent();
         }
         toolbar = (Toolbar) LayoutInflater.from(context.getActivity())

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.util;
 
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.app.Fragment;
 import android.content.ComponentName;
@@ -44,16 +45,13 @@ public class WPActivityUtils {
             return;
         }
 
-        ViewGroup root = null;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            ViewGroup listContainer = (ViewGroup) dialog.findViewById(android.R.id.list_container);
-            if (listContainer != null) {
-                root = (ViewGroup) listContainer.getParent();
-            }
+        @SuppressLint("InlinedApi") View child = dialog.findViewById(android.R.id.list_container);
+        if (child == null) {
+            child = dialog.findViewById(android.R.id.list);
+            if (child == null) return;
         }
-        if (root == null) {
-            root = (ViewGroup) dialog.findViewById(android.R.id.list).getParent();
-        }
+
+        ViewGroup root = (ViewGroup) child.getParent();
         toolbar = (Toolbar) LayoutInflater.from(context.getActivity())
                 .inflate(org.wordpress.android.R.layout.toolbar, root, false);
         root.addView(toolbar, 0);

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -43,7 +43,12 @@ public class WPActivityUtils {
             return;
         }
 
-        ViewGroup root = (ViewGroup) dialog.findViewById(android.R.id.list).getParent();
+        ViewGroup root;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            root = (ViewGroup) dialog.findViewById(android.R.id.list_container).getParent();
+        } else {
+            root = (ViewGroup) dialog.findViewById(android.R.id.list).getParent();
+        }
         toolbar = (Toolbar) LayoutInflater.from(context.getActivity())
                 .inflate(org.wordpress.android.R.layout.toolbar, root, false);
         root.addView(toolbar, 0);


### PR DESCRIPTION
Fixes #4909 

The issue is with how `WPActivityUtils.addToolbarToDialog` selected the root view for the toolbar. API 24 introduced a new `list_container` view that gives us the correct behavior.

To test:
`WPActivityUtils.addToolbarToDialog` is used in the following scenarios:
* `NotificationsSettingsFragment` - select a site to view its notification settings
* `SiteSettingsFragment` - select `More` from the first settings screen
* `SiteSettingsFragment` - select `Start Over` from the first settings screen
* `SiteSettingsFragment` - select `Blacklist` or `Hold for Moderation` from the `More` screen

Verify that the action bar does not cover screen content on API 24+ and API 23-.