### PR TITLE
Persist selected app language across app sessions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -134,8 +134,8 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
 
         Resources res = getResources();
         Configuration conf = res.getConfiguration();
-        Locale currentLocale = conf.locale != null ?
-                conf.locale : LanguageUtils.getCurrentDeviceLanguage(WordPress.getContext());
+        // will return conf.locale if conf is non-null, or Locale.getDefault()
+        Locale currentLocale = LanguageUtils.getCurrentDeviceLanguage(WordPress.getContext());
 
         if (currentLocale.getLanguage().equals(new Locale(languageCode).getLanguage())) {
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -145,12 +145,7 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
         conf.locale = newLocale;
         res.updateConfiguration(conf, res.getDisplayMetrics());
 
-        if (LanguageUtils.getCurrentDeviceLanguage(WordPress.getContext()).equals(newLocale)) {
-            // remove custom locale key when original device locale is selected
-            mSettings.edit().remove(LANGUAGE_PREF_KEY).apply();
-        } else {
-            mSettings.edit().putString(LANGUAGE_PREF_KEY, newLocale.toString()).apply();
-        }
+        mSettings.edit().putString(LANGUAGE_PREF_KEY, newLocale.toString()).apply();
 
         // Track language change on Mixpanel because we have both the device language and app selected language
         // data in Tracks metadata.

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -138,19 +138,19 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
 
         if (currentLocale.toString().equals(languageCode)) return;
 
-        updateLanguagePreference(languageCode);
 
-        // update configuration
         Locale newLocale = WPPrefUtils.languageLocale(languageCode);
-        conf.locale = newLocale;
-        res.updateConfiguration(conf, res.getDisplayMetrics());
-
-        if (LanguageUtils.getCurrentDeviceLanguage(WordPress.getContext()).equals(newLocale)) {
+        if (currentLocale.getLanguage().equals(newLocale.getLanguage())) {
             // remove custom locale key when original device locale is selected
             mSettings.edit().remove(LANGUAGE_PREF_KEY).apply();
         } else {
             mSettings.edit().putString(LANGUAGE_PREF_KEY, newLocale.toString()).apply();
         }
+        updateLanguagePreference(languageCode);
+
+        // update configuration
+        conf.locale = newLocale;
+        res.updateConfiguration(conf, res.getDisplayMetrics());
 
         // Track language change on Mixpanel because we have both the device language and app selected language
         // data in Tracks metadata.

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -145,7 +145,12 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
         conf.locale = newLocale;
         res.updateConfiguration(conf, res.getDisplayMetrics());
 
-        mSettings.edit().putString(LANGUAGE_PREF_KEY, newLocale.toString()).apply();
+        if (LanguageUtils.getCurrentDeviceLanguage(WordPress.getContext()).equals(newLocale)) {
+            // remove custom locale key when original device locale is selected
+            mSettings.edit().remove(LANGUAGE_PREF_KEY).apply();
+        } else {
+            mSettings.edit().putString(LANGUAGE_PREF_KEY, newLocale.toString()).apply();
+        }
 
         // Track language change on Mixpanel because we have both the device language and app selected language
         // data in Tracks metadata.

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -136,13 +136,13 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
         Configuration conf = res.getConfiguration();
         // will return conf.locale if conf is non-null, or Locale.getDefault()
         Locale currentLocale = LanguageUtils.getCurrentDeviceLanguage(WordPress.getContext());
+        Locale newLocale = WPPrefUtils.languageLocale(languageCode);
 
-        if (currentLocale.getLanguage().equals(new Locale(languageCode).getLanguage())) {
+        if (currentLocale.toString().equals(newLocale.getDisplayLanguage())) {
             return;
         }
 
-        Locale newLocale = WPPrefUtils.languageLocale(languageCode);
-        if (currentLocale.getLanguage().equals(newLocale.getLanguage())) {
+        if (Locale.getDefault().toString().equals(newLocale.toString())) {
             // remove custom locale key when original device locale is selected
             mSettings.edit().remove(LANGUAGE_PREF_KEY).apply();
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -134,10 +134,12 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
 
         Resources res = getResources();
         Configuration conf = res.getConfiguration();
-        Locale currentLocale = conf.locale != null ? conf.locale : LanguageUtils.getCurrentDeviceLanguage(WordPress.getContext());
+        Locale currentLocale = conf.locale != null ?
+                conf.locale : LanguageUtils.getCurrentDeviceLanguage(WordPress.getContext());
 
-        if (currentLocale.toString().equals(languageCode)) return;
-
+        if (currentLocale.getLanguage().equals(new Locale(languageCode).getLanguage())) {
+            return;
+        }
 
         Locale newLocale = WPPrefUtils.languageLocale(languageCode);
         if (currentLocale.getLanguage().equals(newLocale.getLanguage())) {

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -106,7 +106,7 @@ public class WPActivityUtils {
             String locale = sharedPreferences.getString(AppSettingsFragment.LANGUAGE_PREF_KEY, "");
 
             if (!TextUtils.isEmpty(contextCountry)) {
-                contextLanguage += "-" + contextCountry;
+                contextLanguage += "_" + contextCountry;
             }
 
             if (!locale.equals(contextLanguage)) {


### PR DESCRIPTION
Fixes #4932 

To test:
* Go to Me -> App Settings and change your language
* Force close the app
* Restart the app and verify the language change persisted
* Change your language to device default
* Force close the app
* Restart the app and verify the language change persisted