### PR TITLE
Issue/5015 reader detail title

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderBlogTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderBlogTable.java
@@ -272,6 +272,20 @@ public class ReaderBlogTable {
         return SqlUtils.boolForQuery(ReaderDatabase.getReadableDb(), sql, args);
     }
 
+    public static String getBlogName(long blogId) {
+        String[] args = {Long.toString(blogId)};
+        return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(),
+                "SELECT name FROM tbl_blog_info WHERE blog_id=?",
+                args);
+    }
+
+    public static String getFeedName(long feedId) {
+        String[] args = {Long.toString(feedId)};
+        return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(),
+                "SELECT name FROM tbl_blog_info WHERE feed_id=?",
+                args);
+    }
+
     public static ReaderRecommendBlogList getRecommendedBlogs() {
         String sql = " SELECT * FROM tbl_recommended_blogs ORDER BY title";
         Cursor c = ReaderDatabase.getReadableDb().rawQuery(sql, null);

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -443,6 +443,11 @@ public class ReaderPostTable {
         return ReaderDatabase.getWritableDb().delete("tbl_posts", "blog_id = ?", args);
     }
 
+    public static void deletePost(long blogId, long postId) {
+        String[] args = new String[] {Long.toString(blogId), Long.toString(postId)};
+        ReaderDatabase.getWritableDb().delete("tbl_posts", "blog_id=? AND post_id=?", args);
+    }
+
     /*
      * ensure that posts in blogs that are no longer followed don't have their followed status
      * set to true

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -305,6 +305,13 @@ public class ReaderPostTable {
                 args);
     }
 
+    public static String getPostBlogName(long blogId, long postId) {
+        String[] args = {Long.toString(blogId), Long.toString(postId)};
+        return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(),
+                "SELECT blog_name FROM tbl_posts WHERE blog_id=? AND post_id=?",
+                args);
+    }
+
     public static String getPostText(long blogId, long postId) {
         String[] args = {Long.toString(blogId), Long.toString(postId)};
         return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -47,6 +47,7 @@ public class ReaderConstants {
     static final String KEY_WAS_PAUSED        = "was_paused";
     static final String KEY_ERROR_MESSAGE     = "error_message";
     static final String KEY_FIRST_LOAD        = "first_load";
+    static final String KEY_ACTIVITY_TITLE    = "activity_title";
 
     static final String KEY_ALREADY_TRACKED_GLOBAL_RELATED_POSTS = "already_tracked_global_related_posts";
     static final String KEY_ALREADY_TRACKED_LOCAL_RELATED_POSTS  = "already_tracked_local_related_posts";

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
@@ -34,6 +34,8 @@ public class ReaderEvents {
     public static class FollowedBlogsChanged {}
     public static class RecommendedBlogsChanged {}
 
+    public static class SinglePostDownloaded {};
+
     public static class UpdatePostsStarted {
         private final ReaderPostService.UpdateAction mAction;
         public UpdatePostsStarted(ReaderPostService.UpdateAction action) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -813,6 +813,7 @@ public class ReaderPostDetailFragment extends Fragment
                 if (isAdded()) {
                     progress.setVisibility(View.GONE);
                     showPost();
+                    EventBus.getDefault().post(new ReaderEvents.SinglePostDownloaded());
                 }
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -13,7 +13,6 @@ import android.view.View;
 
 import org.wordpress.android.R;
 import org.wordpress.android.datasets.ReaderBlogTable;
-import org.wordpress.android.datasets.ReaderPostTable;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 
@@ -74,6 +73,11 @@ public class ReaderPostListActivity extends AppCompatActivity {
                 }
             }
         }
+
+        // restore the activity title
+        if (savedInstanceState != null && savedInstanceState.containsKey(ReaderConstants.KEY_ACTIVITY_TITLE)) {
+            setTitle(savedInstanceState.getString(ReaderConstants.KEY_ACTIVITY_TITLE));
+        }
     }
 
     @Override
@@ -114,6 +118,12 @@ public class ReaderPostListActivity extends AppCompatActivity {
         if (outState.isEmpty()) {
             outState.putBoolean("bug_19917_fix", true);
         }
+
+        // store the title for blog/tag preview so we can restore it upon recreation
+        if (getPostListType() == ReaderPostListType.BLOG_PREVIEW || getPostListType() == ReaderPostListType.TAG_PREVIEW) {
+            outState.putString(ReaderConstants.KEY_ACTIVITY_TITLE, getTitle().toString());
+        }
+
         super.onSaveInstanceState(outState);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -12,6 +12,8 @@ import android.view.MenuItem;
 import android.view.View;
 
 import org.wordpress.android.R;
+import org.wordpress.android.datasets.ReaderBlogTable;
+import org.wordpress.android.datasets.ReaderPostTable;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.ui.reader.ReaderTypes.ReaderPostListType;
 
@@ -158,6 +160,12 @@ public class ReaderPostListActivity extends AppCompatActivity {
                 .beginTransaction()
                 .replace(R.id.fragment_container, fragment, getString(R.string.fragment_tag_reader_post_list))
                 .commit();
+
+        String title = ReaderBlogTable.getBlogName(blogId);
+        if (title.isEmpty()) {
+            title = getString(R.string.reader_title_blog_preview);
+        }
+        setTitle(title);
     }
 
     private void showListFragmentForFeed(long feedId) {
@@ -169,6 +177,12 @@ public class ReaderPostListActivity extends AppCompatActivity {
                 .beginTransaction()
                 .replace(R.id.fragment_container, fragment, getString(R.string.fragment_tag_reader_post_list))
                 .commit();
+
+        String title = ReaderBlogTable.getFeedName(feedId);
+        if (title.isEmpty()) {
+            title = getString(R.string.reader_title_blog_preview);
+        }
+        setTitle(title);
     }
 
     private ReaderPostListFragment getListFragment() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListActivity.java
@@ -156,6 +156,8 @@ public class ReaderPostListActivity extends AppCompatActivity {
                 .beginTransaction()
                 .replace(R.id.fragment_container, fragment, getString(R.string.fragment_tag_reader_post_list))
                 .commit();
+
+        setTitle(tag.getTagDisplayName());
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -216,6 +216,9 @@ public class ReaderPostPagerActivity extends AppCompatActivity
                 new WPViewPagerTransformer(WPViewPagerTransformer.TransformType.SLIDE_OVER));
     }
 
+    /*
+     * set the activity title based on the post at the passed position
+     */
     private void updateTitle(int position) {
         // for related posts, always show "Related Post" as the title
         if (mIsRelatedPostView) {
@@ -235,6 +238,16 @@ public class ReaderPostPagerActivity extends AppCompatActivity
 
         // default when post hasn't been retrieved yet
         setTitle(isDeepLinking() ? R.string.reader_title_post_detail_wpcom : R.string.reader_title_post_detail);
+    }
+
+    /*
+     * used by the detail fragment when a post was requested due to not existing locally
+     */
+    @SuppressWarnings("unused")
+    public void onEventMainThread(ReaderEvents.SinglePostDownloaded event) {
+        if (!isFinishing()) {
+            updateTitle(mViewPager.getCurrentItem());
+        }
     }
 
     private boolean isDeepLinking() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -216,10 +216,14 @@ public class ReaderPostPagerActivity extends AppCompatActivity
                 new WPViewPagerTransformer(WPViewPagerTransformer.TransformType.SLIDE_OVER));
     }
 
-    /*
-     * changes the title to the site name of the current post
-     */
     private void updateTitle(int position) {
+        // for related posts, always show "Related Post" as the title
+        if (mIsRelatedPostView) {
+            setTitle(R.string.reader_title_related_post_detail);
+            return;
+        }
+
+        // otherwise set the title to the site name
         ReaderBlogIdPostId ids = getAdapterBlogIdPostIdAtPosition(position);
         if (ids != null) {
             String title = ReaderPostTable.getPostBlogName(ids.getBlogId(), ids.getPostId());
@@ -229,8 +233,8 @@ public class ReaderPostPagerActivity extends AppCompatActivity
             }
         }
 
-        setTitle(mIsRelatedPostView ? R.string.reader_title_related_post_detail : (isDeepLinking() ? R.string
-                .reader_title_post_detail_wpcom : R.string.reader_title_post_detail));
+        // default when post hasn't been retrieved yet
+        setTitle(isDeepLinking() ? R.string.reader_title_post_detail_wpcom : R.string.reader_title_post_detail);
     }
 
     private boolean isDeepLinking() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -170,9 +170,6 @@ public class ReaderPostPagerActivity extends AppCompatActivity
             mPostListType = ReaderPostListType.TAG_FOLLOWED;
         }
 
-        setTitle(mIsRelatedPostView ? R.string.reader_title_related_post_detail : (isDeepLinking() ? R.string
-                .reader_title_post_detail_wpcom : R.string.reader_title_post_detail));
-
         // for related posts, show an X in the toolbar which closes the activity - using the
         // back button will navigate through related posts
         if (mIsRelatedPostView) {
@@ -211,11 +208,29 @@ public class ReaderPostPagerActivity extends AppCompatActivity
                 }
 
                 mLastSelectedPosition = position;
+                updateTitle(position);
             }
         });
 
         mViewPager.setPageTransformer(false,
                 new WPViewPagerTransformer(WPViewPagerTransformer.TransformType.SLIDE_OVER));
+    }
+
+    /*
+     * changes the title to the site name of the current post
+     */
+    private void updateTitle(int position) {
+        ReaderBlogIdPostId ids = getAdapterBlogIdPostIdAtPosition(position);
+        if (ids != null) {
+            String title = ReaderPostTable.getPostBlogName(ids.getBlogId(), ids.getPostId());
+            if (!title.isEmpty()) {
+                setTitle(title);
+                return;
+            }
+        }
+
+        setTitle(mIsRelatedPostView ? R.string.reader_title_related_post_detail : (isDeepLinking() ? R.string
+                .reader_title_post_detail_wpcom : R.string.reader_title_post_detail));
     }
 
     private boolean isDeepLinking() {
@@ -635,9 +650,11 @@ public class ReaderPostPagerActivity extends AppCompatActivity
                         if (adapter.isValidPosition(newPosition)) {
                             mViewPager.setCurrentItem(newPosition);
                             trackPostAtPositionIfNeeded(newPosition);
+                            updateTitle(newPosition);
                         } else if (adapter.isValidPosition(currentPosition)) {
                             mViewPager.setCurrentItem(currentPosition);
                             trackPostAtPositionIfNeeded(currentPosition);
+                            updateTitle(currentPosition);
                         }
 
                         // let the user know they can swipe between posts

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -226,10 +226,10 @@ public class ReaderPostPagerActivity extends AppCompatActivity
             return;
         }
 
-        // otherwise set the title to the site name
+        // otherwise set the title to the title of the post
         ReaderBlogIdPostId ids = getAdapterBlogIdPostIdAtPosition(position);
         if (ids != null) {
-            String title = ReaderPostTable.getPostBlogName(ids.getBlogId(), ids.getPostId());
+            String title = ReaderPostTable.getPostTitle(ids.getBlogId(), ids.getPostId());
             if (!title.isEmpty()) {
                 setTitle(title);
                 return;


### PR DESCRIPTION
Fixes #5015 - changes the reader detail screen so that it shows the site name as the title.

Related iOS issue [here](https://github.com/wordpress-mobile/WordPress-iOS/issues/6333)

cc: @kwonye 
