### PR TITLE
Disable Editor Format Toolbar Buttons in HTML Mode

### DIFF
--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_bold_selector.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_bold_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_bold_disabled"/>
     <item android:state_checked="true" android:drawable="@drawable/format_bar_button_bold_highlighted"/>
     <item android:state_pressed="true" android:drawable="@drawable/format_bar_button_bold_highlighted"/>
-    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_bold_disabled"/>
     <item android:drawable="@drawable/format_bar_button_bold"/>
 </selector>

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_html_selector.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_html_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_html_disabled"/>
     <item android:state_checked="true" android:drawable="@drawable/format_bar_button_html_highlighted"/>
     <item android:state_pressed="true" android:drawable="@drawable/format_bar_button_html_highlighted"/>
-    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_html_disabled"/>
     <item android:drawable="@drawable/format_bar_button_html"/>
 </selector>

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_italic_selector.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_italic_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_italic_disabled"/>
     <item android:state_checked="true" android:drawable="@drawable/format_bar_button_italic_highlighted"/>
     <item android:state_pressed="true" android:drawable="@drawable/format_bar_button_italic_highlighted"/>
-    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_italic_disabled"/>
     <item android:drawable="@drawable/format_bar_button_italic"/>
 </selector>

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_link_selector.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_link_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_link_disabled"/>
     <item android:state_checked="true" android:drawable="@drawable/format_bar_button_link_highlighted"/>
     <item android:state_pressed="true" android:drawable="@drawable/format_bar_button_link_highlighted"/>
-    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_link_disabled"/>
     <item android:drawable="@drawable/format_bar_button_link"/>
 </selector>

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_media_selector.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_media_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_media_disabled"/>
     <item android:state_checked="true" android:drawable="@drawable/format_bar_button_media_highlighted"/>
     <item android:state_pressed="true" android:drawable="@drawable/format_bar_button_media_highlighted"/>
-    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_media_disabled"/>
     <item android:drawable="@drawable/format_bar_button_media"/>
 </selector>

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ol_selector.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ol_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_ol_disabled"/>
     <item android:state_checked="true" android:drawable="@drawable/format_bar_button_ol_highlighted"/>
     <item android:state_pressed="true" android:drawable="@drawable/format_bar_button_ol_highlighted"/>
-    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_ol_disabled"/>
     <item android:drawable="@drawable/format_bar_button_ol"/>
 </selector>

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_quote_selector.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_quote_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_quote_disabled"/>
     <item android:state_checked="true" android:drawable="@drawable/format_bar_button_quote_highlighted"/>
     <item android:state_pressed="true" android:drawable="@drawable/format_bar_button_quote_highlighted"/>
-    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_quote_disabled"/>
     <item android:drawable="@drawable/format_bar_button_quote"/>
 </selector>

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_strikethrough_selector.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_strikethrough_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_strikethrough_disabled"/>
     <item android:state_checked="true" android:drawable="@drawable/format_bar_button_strikethrough_highlighted"/>
     <item android:state_pressed="true" android:drawable="@drawable/format_bar_button_strikethrough_highlighted"/>
-    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_strikethrough_disabled"/>
     <item android:drawable="@drawable/format_bar_button_strikethrough"/>
 </selector>

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ul_selector.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ul_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_ul_disabled"/>
     <item android:state_checked="true" android:drawable="@drawable/format_bar_button_ul_highlighted"/>
     <item android:state_pressed="true" android:drawable="@drawable/format_bar_button_ul_highlighted"/>
-    <item android:state_enabled="false" android:drawable="@drawable/format_bar_button_ul_disabled"/>
     <item android:drawable="@drawable/format_bar_button_ul"/>
 </selector>


### PR DESCRIPTION
### Fix
The editor format toolbar buttons become disabled when in HTML mode.

### Test
0. Enable visual editor under ***App Settings***.
1. Enter "Bold" in new blog post.
2. Highlight "Bold" and tap ***Bold*** format toolbar button.
3. Notice ***Bold*** format toolbar button is active.
4. Tap ***HTML*** format toolbar button.
5. Notice ***Bold*** format toolbar button is disabled.