### PR TITLE
FluxC: Migrate self-hosted sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -214,6 +214,7 @@ public class WordPress extends MultiDexApplication {
         if (!AppPrefs.isSelfHostedSitesMigratedToFluxC()) {
             List<SiteModel> siteList = WPLegacyMigrationUtils.migrateSelfHostedSitesFromDeprecatedDB(this, mDispatcher);
             if (siteList != null) {
+                AppLog.i(T.DB, "Fetching the site info for migrated self-hosted sites");
                 for (SiteModel siteModel : siteList) {
                     mDispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(siteModel));
                 }

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -85,6 +85,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -210,7 +211,12 @@ public class WordPress extends MultiDexApplication {
         }
 
         // Migrate self-hosted sites to FluxC
-        WPLegacyMigrationUtils.migrateSelfHostedSitesFromDeprecatedDB(this, mDispatcher);
+        List<SiteModel> siteList = WPLegacyMigrationUtils.migrateSelfHostedSitesFromDeprecatedDB(this, mDispatcher);
+        if (siteList != null) {
+            for (SiteModel siteModel : siteList) {
+                mDispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(siteModel));
+            }
+        }
 
         ProfilingUtils.start("App Startup");
         // Enable log recording

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -43,6 +43,7 @@ import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 import org.wordpress.android.fluxc.store.AccountStore;
@@ -208,6 +209,9 @@ public class WordPress extends MultiDexApplication {
                 mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
             }
         }
+
+        // Migrate self-hosted sites to FluxC
+        WPLegacyMigrationUtils.migrateSelfHostedSitesFromDeprecatedDB(this, mDispatcher);
 
         ProfilingUtils.start("App Startup");
         // Enable log recording

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -43,7 +43,6 @@ import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 import org.wordpress.android.fluxc.store.AccountStore;

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -211,11 +211,14 @@ public class WordPress extends MultiDexApplication {
         }
 
         // Migrate self-hosted sites to FluxC
-        List<SiteModel> siteList = WPLegacyMigrationUtils.migrateSelfHostedSitesFromDeprecatedDB(this, mDispatcher);
-        if (siteList != null) {
-            for (SiteModel siteModel : siteList) {
-                mDispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(siteModel));
+        if (!AppPrefs.isSelfHostedSitesMigratedToFluxC()) {
+            List<SiteModel> siteList = WPLegacyMigrationUtils.migrateSelfHostedSitesFromDeprecatedDB(this, mDispatcher);
+            if (siteList != null) {
+                for (SiteModel siteModel : siteList) {
+                    mDispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(siteModel));
+                }
             }
+            AppPrefs.setSelfHostedSitesMigratedToFluxC(true);
         }
 
         ProfilingUtils.start("App Startup");

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -126,6 +126,9 @@ public class AppPrefs {
 
         // Same as above but for the reader
         SWIPE_TO_NAVIGATE_READER,
+
+        // Self-hosted sites migration to FluxC
+        SELF_HOSTED_SITES_MIGRATED_TO_FLUXC,
     }
 
     private static SharedPreferences prefs() {
@@ -643,5 +646,13 @@ public class AppPrefs {
         // store in prefs
         String idsAsString = TextUtils.join(",", currentIds);
         setString(DeletablePrefKey.RECENTLY_PICKED_SITE_IDS, idsAsString);
+    }
+
+    public static boolean isSelfHostedSitesMigratedToFluxC() {
+        return getBoolean(UndeletablePrefKey.SELF_HOSTED_SITES_MIGRATED_TO_FLUXC, false);
+    }
+
+    public static void setSelfHostedSitesMigratedToFluxC(boolean alreadyShown) {
+        setBoolean(UndeletablePrefKey.SELF_HOSTED_SITES_MIGRATED_TO_FLUXC, alreadyShown);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -12,7 +12,6 @@ import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 
 import java.util.ArrayList;
@@ -47,9 +46,10 @@ public class WPLegacyMigrationUtils {
 
     public static List<SiteModel> migrateSelfHostedSitesFromDeprecatedDB(Context context, Dispatcher dispatcher) {
         List<SiteModel> siteList = getSelfHostedSitesFromDeprecatedDB(context);
-        if (siteList != null && siteList.size() > 0) {
-            SitesModel sitesModel = new SitesModel(siteList);
-            dispatcher.dispatch(SiteActionBuilder.newUpdateSitesAction(sitesModel));
+        if (siteList != null) {
+            for (SiteModel siteModel : siteList) {
+                dispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(siteModel));
+            }
         }
         return siteList;
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -113,7 +113,9 @@ public class WPLegacyMigrationUtils {
                 SiteModel siteModel = new SiteModel();
                 siteModel.setUsername(c.getString(0));
                 siteModel.setPassword(c.getString(1));
-                siteModel.setXmlRpcUrl(c.getString(2));
+                String url = c.getString(2);
+                siteModel.setUrl(url);
+                siteModel.setXmlRpcUrl(url);
                 siteList.add(siteModel);
                 c.moveToNext();
             }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -11,6 +11,7 @@ import android.text.TextUtils;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 
 import java.util.ArrayList;
@@ -83,7 +84,7 @@ public class WPLegacyMigrationUtils {
         return token;
     }
 
-    private static List<SiteModel> getSelfHostedSitedFromDeprecatedDB(Context context) {
+    private static SitesModel getSelfHostedSitedFromDeprecatedDB(Context context) {
         List<SiteModel> siteList = new ArrayList<>();
         try {
             SQLiteDatabase db = context.getApplicationContext().openOrCreateDatabase(DEPRECATED_DATABASE_NAME, 0, null);
@@ -104,6 +105,6 @@ public class WPLegacyMigrationUtils {
         } catch (SQLException e) {
             // DB doesn't exist
         }
-        return siteList;
+        return siteList.size() > 0 ? new SitesModel(siteList) : null;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -9,6 +9,7 @@ import android.preference.PreferenceManager;
 import android.text.TextUtils;
 import android.util.Base64;
 
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -46,7 +46,7 @@ public class WPLegacyMigrationUtils {
     }
 
     public static SitesModel migrateSelfHostedSitesFromDeprecatedDB(Context context, Dispatcher dispatcher) {
-        SitesModel sitesModel = getSelfHostedSitedFromDeprecatedDB(context);
+        SitesModel sitesModel = getSelfHostedSitesFromDeprecatedDB(context);
         if (sitesModel != null) {
             dispatcher.dispatch(SiteActionBuilder.newUpdateSitesAction(sitesModel));
         }
@@ -93,7 +93,7 @@ public class WPLegacyMigrationUtils {
         return token;
     }
 
-    private static SitesModel getSelfHostedSitedFromDeprecatedDB(Context context) {
+    private static SitesModel getSelfHostedSitesFromDeprecatedDB(Context context) {
         List<SiteModel> siteList = new ArrayList<>();
         try {
             SQLiteDatabase db = context.getApplicationContext().openOrCreateDatabase(DEPRECATED_DATABASE_NAME, 0, null);

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -45,12 +45,13 @@ public class WPLegacyMigrationUtils {
         return token;
     }
 
-    public static SitesModel migrateSelfHostedSitesFromDeprecatedDB(Context context, Dispatcher dispatcher) {
-        SitesModel sitesModel = getSelfHostedSitesFromDeprecatedDB(context);
-        if (sitesModel != null) {
+    public static List<SiteModel> migrateSelfHostedSitesFromDeprecatedDB(Context context, Dispatcher dispatcher) {
+        List<SiteModel> siteList = getSelfHostedSitesFromDeprecatedDB(context);
+        if (siteList != null && siteList.size() > 0) {
+            SitesModel sitesModel = new SitesModel(siteList);
             dispatcher.dispatch(SiteActionBuilder.newUpdateSitesAction(sitesModel));
         }
-        return sitesModel;
+        return siteList;
     }
 
     private static String getDeprecatedPreferencesAccessTokenThenDelete(Context context) {
@@ -93,7 +94,7 @@ public class WPLegacyMigrationUtils {
         return token;
     }
 
-    private static SitesModel getSelfHostedSitesFromDeprecatedDB(Context context) {
+    private static List<SiteModel> getSelfHostedSitesFromDeprecatedDB(Context context) {
         List<SiteModel> siteList = new ArrayList<>();
         try {
             SQLiteDatabase db = context.getApplicationContext().openOrCreateDatabase(DEPRECATED_DATABASE_NAME, 0, null);
@@ -114,6 +115,6 @@ public class WPLegacyMigrationUtils {
         } catch (SQLException e) {
             // DB doesn't exist
         }
-        return siteList.size() > 0 ? new SitesModel(siteList) : null;
+        return siteList;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -33,6 +33,9 @@ public class WPLegacyMigrationUtils {
     private static final String DEPRECATED_ACCESS_TOKEN_PREFERENCE = "wp_pref_wpcom_access_token";
     private static final String DEPRECATED_BLOGS_TABLE = "accounts";
 
+    // Empty text encrypted with the previous DB secret
+    private static final String ENCRYPTED_EMPTY_PASSWORD = "AS3vw/BNTdI=";
+
     public static String migrateAccessTokenToAccountStore(Context context, Dispatcher dispatcher) {
         String token = getLatestDeprecatedAccessToken(context);
 
@@ -101,10 +104,8 @@ public class WPLegacyMigrationUtils {
             String[] fields = new String[]{"username", "password", "url"};
 
             // To exclude the jetpack sites we need to check for empty password
-            // Since it was an encrypted field in the previous DB, we need to compare with the encrypted empty text
-            String encryptedEmptyPassword = "AS3vw/BNTdl=";
             String byString = String.format("dotcomFlag=0 AND NOT(dotcomFlag=0 AND password='%s')",
-                    encryptedEmptyPassword);
+                    ENCRYPTED_EMPTY_PASSWORD);
             Cursor c = db.query(DEPRECATED_BLOGS_TABLE, fields, byString, null, null, null, null);
             int numRows = c.getCount();
             c.moveToFirst();

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -99,7 +99,7 @@ public class WPLegacyMigrationUtils {
         try {
             SQLiteDatabase db = context.getApplicationContext().openOrCreateDatabase(DEPRECATED_DATABASE_NAME, 0, null);
             String[] fields = new String[]{"username", "password", "url"};
-            String byString = "dotcomFlag=0";
+            String byString = "dotcomFlag=0 AND api_blogid = 0";
             Cursor c = db.query(DEPRECATED_BLOGS_TABLE, fields, byString, null, null, null, null);
             int numRows = c.getCount();
             c.moveToFirst();

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -15,6 +15,7 @@ import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.util.AppLog.T;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -56,7 +57,10 @@ public class WPLegacyMigrationUtils {
     public static List<SiteModel> migrateSelfHostedSitesFromDeprecatedDB(Context context, Dispatcher dispatcher) {
         List<SiteModel> siteList = getSelfHostedSitesFromDeprecatedDB(context);
         if (siteList != null) {
+            AppLog.i(T.DB, "Starting migration of " + siteList.size() + " self-hosted sites to FluxC");
             for (SiteModel siteModel : siteList) {
+                AppLog.i(T.DB, "Migrating self-hosted site with url: " + siteModel.getXmlRpcUrl()
+                        + " username: " + siteModel.getUsername());
                 dispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(siteModel));
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -10,6 +10,7 @@ import android.text.TextUtils;
 
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
+import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.store.AccountStore;
@@ -42,6 +43,14 @@ public class WPLegacyMigrationUtils {
             dispatcher.dispatch(AccountActionBuilder.newUpdateAccessTokenAction(payload));
         }
         return token;
+    }
+
+    public static SitesModel migrateSelfHostedSitesFromDeprecatedDB(Context context, Dispatcher dispatcher) {
+        SitesModel sitesModel = getSelfHostedSitedFromDeprecatedDB(context);
+        if (sitesModel != null) {
+            dispatcher.dispatch(SiteActionBuilder.newUpdateSitesAction(sitesModel));
+        }
+        return sitesModel;
     }
 
     private static String getDeprecatedPreferencesAccessTokenThenDelete(Context context) {

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -99,7 +99,12 @@ public class WPLegacyMigrationUtils {
         try {
             SQLiteDatabase db = context.getApplicationContext().openOrCreateDatabase(DEPRECATED_DATABASE_NAME, 0, null);
             String[] fields = new String[]{"username", "password", "url"};
-            String byString = "dotcomFlag=0 AND api_blogid = 0";
+
+            // To exclude the jetpack sites we need to check for empty password
+            // Since it was an encrypted field in the previous DB, we need to compare with the encrypted empty text
+            String encryptedEmptyPassword = "AS3vw/BNTdl=";
+            String byString = String.format("dotcomFlag=0 AND NOT(dotcomFlag=0 AND password='%s')",
+                    encryptedEmptyPassword);
             Cursor c = db.query(DEPRECATED_BLOGS_TABLE, fields, byString, null, null, null, null);
             int numRows = c.getCount();
             c.moveToFirst();

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -107,7 +107,7 @@ public class WPLegacyMigrationUtils {
                 SiteModel siteModel = new SiteModel();
                 siteModel.setUsername(c.getString(0));
                 siteModel.setPassword(c.getString(1));
-                siteModel.setUrl(c.getString(2));
+                siteModel.setXmlRpcUrl(c.getString(2));
                 siteList.add(siteModel);
                 c.moveToNext();
             }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -93,10 +93,11 @@ public class WPLegacyMigrationUtils {
             int numRows = c.getCount();
             c.moveToFirst();
             for (int i = 0; i < numRows; i++) {
-                // TODO: Create sites
-                String username = c.getString(0);
-                String password = c.getString(1);
-                String url = c.getString(2);
+                SiteModel siteModel = new SiteModel();
+                siteModel.setUsername(c.getString(0));
+                siteModel.setPassword(c.getString(1));
+                siteModel.setUrl(c.getString(2));
+                siteList.add(siteModel);
                 c.moveToNext();
             }
             c.close();


### PR DESCRIPTION
Fixes #5027. This PR migrates the self-hosted sites to FluxC DB. We only migrate `username`, `password` & `url` and then trigger a fetch so we can save the latest info.

I think we should drop all the sites after this migration, but I felt it's probably better to handle that in a separate PR.

To test:
* This is probably a bit difficult to test. The best method would be checking `develop` out and doing a fresh install and logging in with self-hosted, getting the db from device, switching branch and checking db after. However, Android Device Monitor didn't want to cooperate on that.
* Alternatively, do the same thing (without checking db) for `fluxc-integration` branch and this one, the integration branch will log you out and this one will not.
