### PR TITLE
Add hint text to post title field for Aztec editor

### DIFF
--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
@@ -28,6 +28,7 @@
             <org.wordpress.aztec.AztecText
                 android:id="@+id/title"
                 android:background="@null"
+                android:hint="@string/post_title"
                 android:inputType="textNoSuggestions|textMultiLine"
                 android:layout_height="wrap_content"
                 android:layout_width="match_parent"


### PR DESCRIPTION
### Fix
The post title text box for the Aztec editor has hint text when empty as described in https://github.com/wordpress-mobile/WordPress-Android/issues/5039.

### Test
1. Go to ***Sites*** tab.
2. Tap ***Create*** floating action button.
3. Notice post title hint text.
