### PR TITLE
Differentiate wpcom, wporg, jetpack Helpshift origin

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInDialogFragment.java
@@ -156,7 +156,8 @@ public class SignInDialogFragment extends DialogFragment {
                         SignInFragment.ENTERED_URL_KEY));
                 HelpshiftHelper.getInstance().addMetaData(MetadataKey.USER_ENTERED_USERNAME, arguments.getString(
                         SignInFragment.ENTERED_USERNAME_KEY));
-                HelpshiftHelper.getInstance().showConversation(getActivity(), Tag.ORIGIN_LOGIN_SCREEN_ERROR);
+                Tag origin = (Tag) arguments.getSerializable(HelpshiftHelper.ORIGIN_KEY);
+                HelpshiftHelper.getInstance().showConversation(getActivity(), origin);
                 dismissAllowingStateLoss();
                 break;
             case ACTION_OPEN_APPLICATION_LOG:

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -1250,6 +1250,10 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     }
 
     protected void passHelpshiftErrorOriginTag(Bundle bundle) {
+        // Tag assignment:
+        //  ORIGIN_LOGIN_SCREEN_ERROR_WPCOM for when trying to log into a WPCOM site,
+        //  ORIGIN_LOGIN_SCREEN_ERROR_JETPACK when trying to view stats on a Jetpack site and need to login with WPCOM
+        //  ORIGIN_LOGIN_SCREEN_ERROR_SELFHOSTED when logging in a selfhosted site
         bundle.putSerializable(HelpshiftHelper.ORIGIN_KEY,
                 isWPComLogin() ? Tag.ORIGIN_LOGIN_SCREEN_ERROR_WPCOM
                         : (isJetpackAuth() ? Tag.ORIGIN_LOGIN_SCREEN_ERROR_JETPACK

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -1243,9 +1243,17 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         bundle.putString(SignInDialogFragment.ARG_OPEN_URL_PARAM, getForgotPasswordURL());
         bundle.putString(ENTERED_URL_KEY, EditTextUtils.getText(mUrlEditText));
         bundle.putString(ENTERED_USERNAME_KEY, EditTextUtils.getText(mUsernameEditText));
+        passHelpshiftErrorOriginTag(bundle);
         nuxAlert.setArguments(bundle);
         ft.add(nuxAlert, "alert");
         ft.commitAllowingStateLoss();
+    }
+
+    protected void passHelpshiftErrorOriginTag(Bundle bundle) {
+        bundle.putSerializable(HelpshiftHelper.ORIGIN_KEY,
+                isWPComLogin() ? Tag.ORIGIN_LOGIN_SCREEN_ERROR_WPCOM
+                        : (isJetpackAuth() ? Tag.ORIGIN_LOGIN_SCREEN_ERROR_JETPACK
+                                : Tag.ORIGIN_LOGIN_SCREEN_ERROR_SELFHOSTED));
     }
 
     protected void handleInvalidUsernameOrPassword(int messageId) {
@@ -1283,6 +1291,9 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                     getString(R.string.cancel), getString(R.string.contact_us), getString(R.string.reader_title_applog),
                     SignInDialogFragment.ACTION_OPEN_SUPPORT_CHAT,
                     SignInDialogFragment.ACTION_OPEN_APPLICATION_LOG);
+            Bundle bundle = nuxAlert.getArguments();
+            passHelpshiftErrorOriginTag(bundle);
+            nuxAlert.setArguments(bundle);
         }
         ft.add(nuxAlert, "alert");
         ft.commitAllowingStateLoss();

--- a/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
@@ -51,7 +51,9 @@ public class HelpshiftHelper {
     public enum Tag {
         ORIGIN_UNKNOWN("origin:unknown"),
         ORIGIN_LOGIN_SCREEN_HELP("origin:login-screen-help"),
-        ORIGIN_LOGIN_SCREEN_ERROR("origin:login-screen-error"),
+        ORIGIN_LOGIN_SCREEN_ERROR_WPCOM("origin:wpcom-login-screen-error"),
+        ORIGIN_LOGIN_SCREEN_ERROR_SELFHOSTED("origin:wporg-login-screen-error"),
+        ORIGIN_LOGIN_SCREEN_ERROR_JETPACK("origin:jetpack-login-screen-error"),
         ORIGIN_ME_SCREEN_HELP("origin:me-screen-help"),
         ORIGIN_START_OVER("origin:start-over"),
         ORIGIN_DELETE_SITE("origin:delete-site");


### PR DESCRIPTION
Fixes #4912 

Uses a specific Helpshift tag to differentiate between login origins (WordPress.com, Self-hosted, Jetpack) for the login failed dialog.