### PR TITLE
Issue/5051 reader dup tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -39,6 +39,7 @@ public class ReaderConstants {
     static final String ARG_IS_RELATED_POST   = "is_related_post";
     static final String ARG_SEARCH_QUERY      = "search_query";
     static final String ARG_VIDEO_URL         = "video_url";
+    static final String ARG_TRACKED_POSITIONS = "tracked_positions";
 
     static final String KEY_POST_SLUGS_RESOLUTION_UNDERWAY = "post_slugs_resolution_underway";
     static final String KEY_ALREADY_UPDATED   = "already_updated";

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderConstants.java
@@ -39,7 +39,6 @@ public class ReaderConstants {
     static final String ARG_IS_RELATED_POST   = "is_related_post";
     static final String ARG_SEARCH_QUERY      = "search_query";
     static final String ARG_VIDEO_URL         = "video_url";
-    static final String ARG_TRACKED_POSITIONS = "tracked_positions";
 
     static final String KEY_POST_SLUGS_RESOLUTION_UNDERWAY = "post_slugs_resolution_underway";
     static final String KEY_ALREADY_UPDATED   = "already_updated";
@@ -49,6 +48,7 @@ public class ReaderConstants {
     static final String KEY_ERROR_MESSAGE     = "error_message";
     static final String KEY_FIRST_LOAD        = "first_load";
     static final String KEY_ACTIVITY_TITLE    = "activity_title";
+    static final String KEY_TRACKED_POSITIONS = "tracked_positions";
 
     static final String KEY_ALREADY_TRACKED_GLOBAL_RELATED_POSTS = "already_tracked_global_related_posts";
     static final String KEY_ALREADY_TRACKED_LOCAL_RELATED_POSTS  = "already_tracked_local_related_posts";

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -44,6 +44,7 @@ import org.wordpress.android.widgets.WPSwipeSnackbar;
 import org.wordpress.android.widgets.WPViewPager;
 import org.wordpress.android.widgets.WPViewPagerTransformer;
 
+import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.HashSet;
@@ -145,6 +146,12 @@ public class ReaderPostPagerActivity extends AppCompatActivity
                 mCurrentTag = (ReaderTag) savedInstanceState.getSerializable(ReaderConstants.ARG_TAG);
             }
             mPostSlugsResolutionUnderway = savedInstanceState.getBoolean(ReaderConstants.KEY_POST_SLUGS_RESOLUTION_UNDERWAY);
+            if (savedInstanceState.containsKey(ReaderConstants.KEY_TRACKED_POSITIONS)) {
+                Serializable positions = savedInstanceState.getSerializable(ReaderConstants.KEY_TRACKED_POSITIONS);
+                if (positions instanceof HashSet) {
+                    mTrackedPositions.addAll((HashSet<Integer>) positions);
+                }
+            }
         } else {
             mIsFeed = getIntent().getBooleanExtra(ReaderConstants.ARG_IS_FEED, false);
             mBlogId = getIntent().getLongExtra(ReaderConstants.ARG_BLOG_ID, 0);
@@ -559,6 +566,10 @@ public class ReaderPostPagerActivity extends AppCompatActivity
         }
 
         outState.putBoolean(ReaderConstants.KEY_POST_SLUGS_RESOLUTION_UNDERWAY, mPostSlugsResolutionUnderway);
+
+        if (mTrackedPositions.size() > 0) {
+            outState.putSerializable(ReaderConstants.KEY_TRACKED_POSITIONS, mTrackedPositions);
+        }
 
         super.onSaveInstanceState(outState);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -68,7 +68,6 @@ import de.greenrobot.event.EventBus;
  */
 public class ReaderPostPagerActivity extends AppCompatActivity
         implements ReaderInterfaces.AutoHideToolbarListener {
-    private static final String KEY_TRACKED_POST = "tracked_post";
 
     /**
      * Type of URL intercepted
@@ -111,7 +110,6 @@ public class ReaderPostPagerActivity extends AppCompatActivity
     private boolean mBackFromLogin;
 
     private final HashSet<Integer> mTrackedPositions = new HashSet<>();
-    private boolean mTrackedPost;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -146,7 +144,6 @@ public class ReaderPostPagerActivity extends AppCompatActivity
             if (savedInstanceState.containsKey(ReaderConstants.ARG_TAG)) {
                 mCurrentTag = (ReaderTag) savedInstanceState.getSerializable(ReaderConstants.ARG_TAG);
             }
-            mTrackedPost = savedInstanceState.getBoolean(KEY_TRACKED_POST);
             mPostSlugsResolutionUnderway = savedInstanceState.getBoolean(ReaderConstants.KEY_POST_SLUGS_RESOLUTION_UNDERWAY);
         } else {
             mIsFeed = getIntent().getBooleanExtra(ReaderConstants.ARG_IS_FEED, false);
@@ -560,8 +557,6 @@ public class ReaderPostPagerActivity extends AppCompatActivity
             outState.putLong(ReaderConstants.ARG_BLOG_ID, id.getBlogId());
             outState.putLong(ReaderConstants.ARG_POST_ID, id.getPostId());
         }
-
-        outState.putBoolean(KEY_TRACKED_POST, mTrackedPost);
 
         outState.putBoolean(ReaderConstants.KEY_POST_SLUGS_RESOLUTION_UNDERWAY, mPostSlugsResolutionUnderway);
 


### PR DESCRIPTION
Fixes #5051 - retains and restores `mTrackedPositions` when the device is rotated to avoid bumping the page view and tracking analytics for the same post(s).