### PR TITLE
issue/5054-reader-unattached-featured-image

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderPost.java
@@ -194,7 +194,7 @@ public class ReaderPost {
         // if the post still doesn't have a featured image but we have attachment data, check whether
         // we can find a suitable featured image from the attachments
         if (!post.hasFeaturedImage() && post.hasAttachments()) {
-            post.featuredImage = new ImageSizeMap(post.attachmentsJson)
+            post.featuredImage = new ImageSizeMap(post.getText(), post.attachmentsJson)
                     .getLargestImageUrl(ReaderConstants.MIN_FEATURED_IMAGE_WIDTH);
         }
         // if we *still* don't have a featured image but the text contains an IMG tag, check whether

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostRenderer.java
@@ -538,7 +538,7 @@ class ReaderPostRenderer {
 
     private ImageSize getImageSizeFromAttachments(final String imageUrl) {
         if (mAttachmentSizes == null) {
-            mAttachmentSizes = new ImageSizeMap(mPost.getAttachmentsJson());
+            mAttachmentSizes = new ImageSizeMap(mPost.getText(), mPost.getAttachmentsJson());
         }
         return mAttachmentSizes.getImageSize(imageUrl);
     }


### PR DESCRIPTION
Fixes #5054 - It's possible for an image to appear in a post's attachment list but not be in the post's content (this can happen if you upload a post with an image then remove the image). As a result, it then becomes possible for the reader to choose a featured image that isn't in the post's content.

This PR addresses this by ensuring attachments appear in the content before considering them.
