### PR TITLE
Helpshift origin tag work around signup and login flows

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/JetpackCallbacks.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/JetpackCallbacks.java
@@ -1,0 +1,8 @@
+package org.wordpress.android.ui.accounts;
+
+import org.wordpress.android.models.Blog;
+
+public interface JetpackCallbacks {
+    boolean isJetpackAuth();
+    Blog getJetpackBlog();
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -36,6 +36,7 @@ import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.EditTextUtils;
+import org.wordpress.android.util.HelpshiftHelper;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.UserEmailUtils;
@@ -429,6 +430,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
             @Override
             public void onClick(View v) {
                 Intent newAccountIntent = new Intent(getActivity(), HelpActivity.class);
+                newAccountIntent.putExtra(HelpshiftHelper.ORIGIN_KEY, HelpshiftHelper.Tag.ORIGIN_SIGNUP_SCREEN);
                 startActivity(newAccountIntent);
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInActivity.java
@@ -31,8 +31,9 @@ import org.wordpress.android.ui.accounts.login.MagicLinkSentFragment;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
-public class SignInActivity extends AppCompatActivity implements ConnectionCallbacks, OnConnectionFailedListener, MagicLinkRequestFragment.OnMagicLinkFragmentInteraction,
-        SignInFragment.OnMagicLinkRequestInteraction, MagicLinkSentFragment.OnMagicLinkSentInteraction {
+public class SignInActivity extends AppCompatActivity implements ConnectionCallbacks, OnConnectionFailedListener,
+        MagicLinkRequestFragment.OnMagicLinkFragmentInteraction, SignInFragment.OnMagicLinkRequestInteraction,
+        MagicLinkSentFragment.OnMagicLinkSentInteraction, JetpackCallbacks {
     public static final int SIGN_IN_REQUEST = 1;
     public static final int REQUEST_CODE = 5000;
     public static final int ADD_SELF_HOSTED_BLOG = 2;
@@ -51,6 +52,7 @@ public class SignInActivity extends AppCompatActivity implements ConnectionCallb
 
     private SmartLockHelper mSmartLockHelper;
     private ProgressDialog mProgressDialog;
+    private Blog mJetpackBlog;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -157,10 +159,10 @@ public class SignInActivity extends AppCompatActivity implements ConnectionCallb
         if (extras != null) {
             actionMode = extras.getInt(EXTRA_START_FRAGMENT, -1);
             if (extras.containsKey(EXTRA_JETPACK_SITE_AUTH)) {
-                Blog jetpackBlog = WordPress.getBlog(extras.getInt(EXTRA_JETPACK_SITE_AUTH));
-                if (jetpackBlog != null) {
+                mJetpackBlog = WordPress.getBlog(extras.getInt(EXTRA_JETPACK_SITE_AUTH));
+                if (mJetpackBlog != null) {
                     String customMessage = extras.getString(EXTRA_JETPACK_MESSAGE_AUTH, null);
-                    getSignInFragment().setBlogAndCustomMessageForJetpackAuth(jetpackBlog, customMessage);
+                    getSignInFragment().setCustomMessageForJetpackAuth(customMessage);
                 }
             } else if (extras.containsKey(EXTRA_IS_AUTH_ERROR)) {
                 getSignInFragment().showAuthErrorMessage();
@@ -278,5 +280,15 @@ public class SignInActivity extends AppCompatActivity implements ConnectionCallb
 
         MagicLinkRequestFragment magicLinkRequestFragment = MagicLinkRequestFragment.newInstance(email);
         slideInFragment(magicLinkRequestFragment);
+    }
+
+    @Override
+    public boolean isJetpackAuth() {
+        return mJetpackBlog != null;
+    }
+
+    @Override
+    public Blog getJetpackBlog() {
+        return mJetpackBlog;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -65,7 +65,6 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.GenericCallback;
 import org.wordpress.android.util.HelpshiftHelper;
-import org.wordpress.android.util.HelpshiftHelper.Tag;
 import org.wordpress.android.util.JSONUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.StringUtils;
@@ -128,7 +127,6 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     protected String mTwoStepCode;
     protected String mHttpUsername;
     protected String mHttpPassword;
-    protected Blog mJetpackBlog;
 
     protected WPTextView mSignInButton;
     protected WPTextView mCreateAccountButton;
@@ -147,6 +145,8 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     private boolean mSmartLockEnabled = true;
     private boolean mInhibitMagicLogin; // Prevent showing magic links as that is only applicable for initial sign in
     private boolean mIsMagicLinksEnabled = true;
+
+    private JetpackCallbacks mJetpackCallbacks;
 
     public interface OnMagicLinkRequestInteraction {
         void onMagicLinkRequestSuccess(String email);
@@ -303,6 +303,11 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             mListener = (SignInFragment.OnMagicLinkRequestInteraction) context;
         } else {
             throw new RuntimeException(context.toString() + " must implement OnMagicLinkRequestInteraction");
+        }
+        if (context instanceof JetpackCallbacks) {
+            mJetpackCallbacks = (JetpackCallbacks) context;
+        } else {
+            throw new RuntimeException(context.toString() + " must implement JetpackCallbacks");
         }
     }
 
@@ -496,7 +501,8 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                 // Used to pass data to an eventual support service
                 intent.putExtra(ENTERED_URL_KEY, EditTextUtils.getText(mUrlEditText));
                 intent.putExtra(ENTERED_USERNAME_KEY, EditTextUtils.getText(mUsernameEditText));
-                intent.putExtra(HelpshiftHelper.ORIGIN_KEY, chooseHelpshiftLoginTag());
+                intent.putExtra(HelpshiftHelper.ORIGIN_KEY, HelpshiftHelper.chooseHelpshiftLoginTag
+                        (mJetpackCallbacks.isJetpackAuth(), isWPComLogin() && !mSelfHosted));
                 startActivity(intent);
             }
         };
@@ -621,13 +627,8 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         mSignInButton.setText(getString(R.string.button_next));
     }
 
-    private boolean isJetpackAuth() {
-        return mJetpackBlog != null;
-    }
-
     // Set blog for Jetpack auth
-    public void setBlogAndCustomMessageForJetpackAuth(Blog blog, String customAuthMessage) {
-        mJetpackBlog = blog;
+    public void setCustomMessageForJetpackAuth(String customAuthMessage) {
         if(customAuthMessage != null && mJetpackAuthLabel != null) {
             mJetpackAuthLabel.setText(customAuthMessage);
         }
@@ -910,7 +911,8 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     }
 
     private void signInAndFetchBlogListWPCom() {
-        LoginWPCom login = new LoginWPCom(mUsername, mPassword, mTwoStepCode, mShouldSendTwoStepSMS, mJetpackBlog);
+        LoginWPCom login = new LoginWPCom(mUsername, mPassword, mTwoStepCode, mShouldSendTwoStepSMS,
+                mJetpackCallbacks.getJetpackBlog());
         login.execute(new LoginAbstract.Callback() {
             @Override
             public void onSuccess() {
@@ -942,7 +944,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         mShouldSendTwoStepSMS = false;
 
         // Finish this activity if we've authenticated to a Jetpack site
-        if (isJetpackAuth() && getActivity() != null) {
+        if (mJetpackCallbacks.isJetpackAuth() && getActivity() != null) {
             getActivity().setResult(Activity.RESULT_OK);
             getActivity().finish();
             return;
@@ -1243,19 +1245,11 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         bundle.putString(SignInDialogFragment.ARG_OPEN_URL_PARAM, getForgotPasswordURL());
         bundle.putString(ENTERED_URL_KEY, EditTextUtils.getText(mUrlEditText));
         bundle.putString(ENTERED_USERNAME_KEY, EditTextUtils.getText(mUsernameEditText));
-        bundle.putSerializable(HelpshiftHelper.ORIGIN_KEY, chooseHelpshiftLoginTag());
+        bundle.putSerializable(HelpshiftHelper.ORIGIN_KEY, HelpshiftHelper.chooseHelpshiftLoginTag
+                (mJetpackCallbacks.isJetpackAuth(), isWPComLogin() && !mSelfHosted));
         nuxAlert.setArguments(bundle);
         ft.add(nuxAlert, "alert");
         ft.commitAllowingStateLoss();
-    }
-
-    protected Tag chooseHelpshiftLoginTag() {
-        // Tag assignment:
-        //  ORIGIN_LOGIN_SCREEN_JETPACK when trying to view stats on a Jetpack site and need to login with WPCOM
-        //  ORIGIN_LOGIN_SCREEN_WPCOM for when trying to log into a WPCOM site and UI not in forced self-hosted mode
-        //  ORIGIN_LOGIN_SCREEN_SELFHOSTED when logging in a selfhosted site
-        return isJetpackAuth() ? Tag.ORIGIN_LOGIN_SCREEN_JETPACK :
-                ((isWPComLogin() && !mSelfHosted) ? Tag.ORIGIN_LOGIN_SCREEN_WPCOM : Tag.ORIGIN_LOGIN_SCREEN_SELFHOSTED);
     }
 
     protected void handleInvalidUsernameOrPassword(int messageId) {
@@ -1294,7 +1288,8 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                     SignInDialogFragment.ACTION_OPEN_SUPPORT_CHAT,
                     SignInDialogFragment.ACTION_OPEN_APPLICATION_LOG);
             Bundle bundle = nuxAlert.getArguments();
-            bundle.putSerializable(HelpshiftHelper.ORIGIN_KEY, chooseHelpshiftLoginTag());
+            bundle.putSerializable(HelpshiftHelper.ORIGIN_KEY, HelpshiftHelper.chooseHelpshiftLoginTag
+                    (mJetpackCallbacks.isJetpackAuth(), isWPComLogin() && !mSelfHosted));
             nuxAlert.setArguments(bundle);
         }
         ft.add(nuxAlert, "alert");

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -496,7 +496,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                 // Used to pass data to an eventual support service
                 intent.putExtra(ENTERED_URL_KEY, EditTextUtils.getText(mUrlEditText));
                 intent.putExtra(ENTERED_USERNAME_KEY, EditTextUtils.getText(mUsernameEditText));
-                intent.putExtra(HelpshiftHelper.ORIGIN_KEY, Tag.ORIGIN_LOGIN_SCREEN_HELP);
+                intent.putExtra(HelpshiftHelper.ORIGIN_KEY, chooseHelpshiftLoginTag());
                 startActivity(intent);
             }
         };
@@ -1243,19 +1243,19 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         bundle.putString(SignInDialogFragment.ARG_OPEN_URL_PARAM, getForgotPasswordURL());
         bundle.putString(ENTERED_URL_KEY, EditTextUtils.getText(mUrlEditText));
         bundle.putString(ENTERED_USERNAME_KEY, EditTextUtils.getText(mUsernameEditText));
-        passHelpshiftErrorOriginTag(bundle);
+        bundle.putSerializable(HelpshiftHelper.ORIGIN_KEY, chooseHelpshiftLoginTag());
         nuxAlert.setArguments(bundle);
         ft.add(nuxAlert, "alert");
         ft.commitAllowingStateLoss();
     }
 
-    protected void passHelpshiftErrorOriginTag(Bundle bundle) {
+    protected Tag chooseHelpshiftLoginTag() {
         // Tag assignment:
-        //  ORIGIN_LOGIN_SCREEN_WPCOM for when trying to log into a WPCOM site,
         //  ORIGIN_LOGIN_SCREEN_JETPACK when trying to view stats on a Jetpack site and need to login with WPCOM
+        //  ORIGIN_LOGIN_SCREEN_WPCOM for when trying to log into a WPCOM site and UI not in forced self-hosted mode
         //  ORIGIN_LOGIN_SCREEN_SELFHOSTED when logging in a selfhosted site
-        bundle.putSerializable(HelpshiftHelper.ORIGIN_KEY, isWPComLogin() ? Tag.ORIGIN_LOGIN_SCREEN_WPCOM
-                        : (isJetpackAuth() ? Tag.ORIGIN_LOGIN_SCREEN_JETPACK : Tag.ORIGIN_LOGIN_SCREEN_SELFHOSTED));
+        return isJetpackAuth() ? Tag.ORIGIN_LOGIN_SCREEN_JETPACK :
+                ((isWPComLogin() && !mSelfHosted) ? Tag.ORIGIN_LOGIN_SCREEN_WPCOM : Tag.ORIGIN_LOGIN_SCREEN_SELFHOSTED);
     }
 
     protected void handleInvalidUsernameOrPassword(int messageId) {
@@ -1294,7 +1294,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                     SignInDialogFragment.ACTION_OPEN_SUPPORT_CHAT,
                     SignInDialogFragment.ACTION_OPEN_APPLICATION_LOG);
             Bundle bundle = nuxAlert.getArguments();
-            passHelpshiftErrorOriginTag(bundle);
+            bundle.putSerializable(HelpshiftHelper.ORIGIN_KEY, chooseHelpshiftLoginTag());
             nuxAlert.setArguments(bundle);
         }
         ft.add(nuxAlert, "alert");

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -1251,13 +1251,11 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
 
     protected void passHelpshiftErrorOriginTag(Bundle bundle) {
         // Tag assignment:
-        //  ORIGIN_LOGIN_SCREEN_ERROR_WPCOM for when trying to log into a WPCOM site,
-        //  ORIGIN_LOGIN_SCREEN_ERROR_JETPACK when trying to view stats on a Jetpack site and need to login with WPCOM
-        //  ORIGIN_LOGIN_SCREEN_ERROR_SELFHOSTED when logging in a selfhosted site
-        bundle.putSerializable(HelpshiftHelper.ORIGIN_KEY,
-                isWPComLogin() ? Tag.ORIGIN_LOGIN_SCREEN_ERROR_WPCOM
-                        : (isJetpackAuth() ? Tag.ORIGIN_LOGIN_SCREEN_ERROR_JETPACK
-                                : Tag.ORIGIN_LOGIN_SCREEN_ERROR_SELFHOSTED));
+        //  ORIGIN_LOGIN_SCREEN_WPCOM for when trying to log into a WPCOM site,
+        //  ORIGIN_LOGIN_SCREEN_JETPACK when trying to view stats on a Jetpack site and need to login with WPCOM
+        //  ORIGIN_LOGIN_SCREEN_SELFHOSTED when logging in a selfhosted site
+        bundle.putSerializable(HelpshiftHelper.ORIGIN_KEY, isWPComLogin() ? Tag.ORIGIN_LOGIN_SCREEN_WPCOM
+                        : (isJetpackAuth() ? Tag.ORIGIN_LOGIN_SCREEN_JETPACK : Tag.ORIGIN_LOGIN_SCREEN_SELFHOSTED));
     }
 
     protected void handleInvalidUsernameOrPassword(int messageId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
@@ -110,7 +110,7 @@ public class MagicLinkRequestFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 Intent intent = new Intent(getActivity(), HelpActivity.class);
-                intent.putExtra(HelpshiftHelper.ORIGIN_KEY, HelpshiftHelper.Tag.ORIGIN_LOGIN_SCREEN_HELP);
+                intent.putExtra(HelpshiftHelper.ORIGIN_KEY, HelpshiftHelper.Tag.ORIGIN_LOGIN_SCREEN_WPCOM);
                 startActivity(intent);
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
@@ -22,6 +22,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.ui.accounts.HelpActivity;
+import org.wordpress.android.ui.accounts.JetpackCallbacks;
 import org.wordpress.android.util.HelpshiftHelper;
 import org.wordpress.android.widgets.WPTextView;
 
@@ -45,6 +46,8 @@ public class MagicLinkRequestFragment extends Fragment {
     private OnMagicLinkFragmentInteraction mListener;
     private ProgressDialog mProgressDialog;
     private TextView mRequestEmailView;
+
+    private JetpackCallbacks mJetpackCallbacks;
 
     public static MagicLinkRequestFragment newInstance(String email) {
         MagicLinkRequestFragment fragment = new MagicLinkRequestFragment();
@@ -97,6 +100,11 @@ public class MagicLinkRequestFragment extends Fragment {
         } else {
             throw new RuntimeException(context.toString() + " must implement OnFragmentInteractionListener");
         }
+        if (context instanceof JetpackCallbacks) {
+            mJetpackCallbacks = (JetpackCallbacks) context;
+        } else {
+            throw new RuntimeException(context.toString() + " must implement JetpackCallbacks");
+        }
     }
 
     @Override
@@ -110,7 +118,8 @@ public class MagicLinkRequestFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 Intent intent = new Intent(getActivity(), HelpActivity.class);
-                intent.putExtra(HelpshiftHelper.ORIGIN_KEY, HelpshiftHelper.Tag.ORIGIN_LOGIN_SCREEN_WPCOM);
+                intent.putExtra(HelpshiftHelper.ORIGIN_KEY, HelpshiftHelper.chooseHelpshiftLoginTag
+                        (mJetpackCallbacks.isJetpackAuth(), true));
                 startActivity(intent);
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkSentFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkSentFragment.java
@@ -12,6 +12,7 @@ import android.widget.TextView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.ui.accounts.HelpActivity;
+import org.wordpress.android.ui.accounts.JetpackCallbacks;
 import org.wordpress.android.util.HelpshiftHelper;
 
 public class MagicLinkSentFragment extends Fragment {
@@ -20,6 +21,7 @@ public class MagicLinkSentFragment extends Fragment {
     }
 
     private OnMagicLinkSentInteraction mListener;
+    private JetpackCallbacks mJetpackCallbacks;
 
     public MagicLinkSentFragment() {
     }
@@ -31,6 +33,11 @@ public class MagicLinkSentFragment extends Fragment {
             mListener = (OnMagicLinkSentInteraction) context;
         } else {
             throw new RuntimeException(context.toString() + " must implement OnMagicLinkSentInteraction");
+        }
+        if (context instanceof JetpackCallbacks) {
+            mJetpackCallbacks = (JetpackCallbacks) context;
+        } else {
+            throw new RuntimeException(context.toString() + " must implement JetpackCallbacks");
         }
     }
 
@@ -66,7 +73,8 @@ public class MagicLinkSentFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 Intent intent = new Intent(getActivity(), HelpActivity.class);
-                intent.putExtra(HelpshiftHelper.ORIGIN_KEY, HelpshiftHelper.Tag.ORIGIN_LOGIN_SCREEN_WPCOM);
+                intent.putExtra(HelpshiftHelper.ORIGIN_KEY, HelpshiftHelper.chooseHelpshiftLoginTag
+                        (mJetpackCallbacks.isJetpackAuth(), true));
                 startActivity(intent);
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkSentFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkSentFragment.java
@@ -66,7 +66,7 @@ public class MagicLinkSentFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 Intent intent = new Intent(getActivity(), HelpActivity.class);
-                intent.putExtra(HelpshiftHelper.ORIGIN_KEY, HelpshiftHelper.Tag.ORIGIN_LOGIN_SCREEN_HELP);
+                intent.putExtra(HelpshiftHelper.ORIGIN_KEY, HelpshiftHelper.Tag.ORIGIN_LOGIN_SCREEN_WPCOM);
                 startActivity(intent);
             }
         };

--- a/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
@@ -50,7 +50,6 @@ public class HelpshiftHelper {
 
     public enum Tag {
         ORIGIN_UNKNOWN("origin:unknown"),
-        ORIGIN_LOGIN_SCREEN_HELP("origin:login-screen-help"),
         ORIGIN_LOGIN_SCREEN_WPCOM("origin:wpcom-login-screen"),
         ORIGIN_LOGIN_SCREEN_SELFHOSTED("origin:wporg-login-screen"),
         ORIGIN_LOGIN_SCREEN_JETPACK("origin:jetpack-login-screen"),

--- a/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
@@ -51,9 +51,9 @@ public class HelpshiftHelper {
     public enum Tag {
         ORIGIN_UNKNOWN("origin:unknown"),
         ORIGIN_LOGIN_SCREEN_HELP("origin:login-screen-help"),
-        ORIGIN_LOGIN_SCREEN_ERROR_WPCOM("origin:wpcom-login-screen-error"),
-        ORIGIN_LOGIN_SCREEN_ERROR_SELFHOSTED("origin:wporg-login-screen-error"),
-        ORIGIN_LOGIN_SCREEN_ERROR_JETPACK("origin:jetpack-login-screen-error"),
+        ORIGIN_LOGIN_SCREEN_WPCOM("origin:wpcom-login-screen"),
+        ORIGIN_LOGIN_SCREEN_SELFHOSTED("origin:wporg-login-screen"),
+        ORIGIN_LOGIN_SCREEN_JETPACK("origin:jetpack-login-screen"),
         ORIGIN_SIGNUP_SCREEN("origin:signup-screen"),
         ORIGIN_ME_SCREEN_HELP("origin:me-screen-help"),
         ORIGIN_START_OVER("origin:start-over"),

--- a/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
@@ -281,4 +281,13 @@ public class HelpshiftHelper {
         config.put("showSearchOnNewConversation", true);
         return config;
     }
+
+    public static Tag chooseHelpshiftLoginTag(boolean isJetpackAuth, boolean isWPComMode) {
+        // Tag assignment:
+        //  ORIGIN_LOGIN_SCREEN_JETPACK when trying to view stats on a Jetpack site and need to login with WPCOM
+        //  ORIGIN_LOGIN_SCREEN_WPCOM for when trying to log into a WPCOM site and UI not in forced self-hosted mode
+        //  ORIGIN_LOGIN_SCREEN_SELFHOSTED when logging in a selfhosted site
+        return isJetpackAuth ? Tag.ORIGIN_LOGIN_SCREEN_JETPACK :
+                (isWPComMode ? Tag.ORIGIN_LOGIN_SCREEN_WPCOM : Tag.ORIGIN_LOGIN_SCREEN_SELFHOSTED);
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
@@ -54,6 +54,7 @@ public class HelpshiftHelper {
         ORIGIN_LOGIN_SCREEN_ERROR_WPCOM("origin:wpcom-login-screen-error"),
         ORIGIN_LOGIN_SCREEN_ERROR_SELFHOSTED("origin:wporg-login-screen-error"),
         ORIGIN_LOGIN_SCREEN_ERROR_JETPACK("origin:jetpack-login-screen-error"),
+        ORIGIN_SIGNUP_SCREEN("origin:signup-screen"),
         ORIGIN_ME_SCREEN_HELP("origin:me-screen-help"),
         ORIGIN_START_OVER("origin:start-over"),
         ORIGIN_DELETE_SITE("origin:delete-site");


### PR DESCRIPTION
Fixes #4911 by adding the `origin:signup-screen` tag to the Helpshift conversation when tapping at the "?" button on the signup screen.

Also fixes #5048 and #5049.