### PR TITLE
Issue/4873 view post not working self hosted

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -184,8 +184,13 @@ public class ActivityLauncher {
         if (blog == null || post == null || TextUtils.isEmpty(post.getPermaLink())) return;
 
         // always add the preview parameter to avoid bumping stats when viewing posts
-        String url = UrlUtils.appendUrlParameter(post.getPermaLink(), "preview", "true");
-        WPWebViewActivity.openPostOrPage(context, blog, post, url);
+        String urlToLoad = UrlUtils.appendUrlParameter(post.getPermaLink(), "preview", "true");
+
+        // Add the original post URL to the list of allowed URLs.
+        // This is necessary because links are disabled in the webview, but WP removes "?preview=true" from the passed URL,
+        // and internally redirects to it. EX:Published posts on a site with Plain permalink structure settings.
+        // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/4873
+        WPWebViewActivity.openPostOrPage(context, blog, post, urlToLoad, new String[] {post.getPermaLink()});
     }
 
     public static void addMedia(Activity activity) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -191,6 +191,15 @@ public class WPWebViewActivity extends WebViewActivity {
             if (!TextUtils.isEmpty(authURL)) {
                 allowedURL.add(authURL);
             }
+
+            // In this case Links are disabled, but WP removes "?preview=true" from the passed URL, and internally redirects to it.
+            // EX:  Published posts on a site with Plain permalink structure settings.
+            // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/4873
+            if (!TextUtils.isEmpty(addressToLoad) && addressToLoad.endsWith("preview=true")) {
+                int indexOf = addressToLoad.lastIndexOf("preview=true");
+                //allowedURL.add(addressToLoad.substring(0, indexOf-1));
+                allowedURL.add(addressToLoad.substring(0, addressToLoad.length() - 13));
+            }
         }
 
         if (getIntent().hasExtra(LOCAL_BLOG_ID)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -196,8 +196,7 @@ public class WPWebViewActivity extends WebViewActivity {
             // EX:  Published posts on a site with Plain permalink structure settings.
             // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/4873
             if (!TextUtils.isEmpty(addressToLoad) && addressToLoad.endsWith("preview=true")) {
-                int indexOf = addressToLoad.lastIndexOf("preview=true");
-                //allowedURL.add(addressToLoad.substring(0, indexOf-1));
+                // Remove "(?|&)preview=true" string
                 allowedURL.add(addressToLoad.substring(0, addressToLoad.length() - 13));
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -80,6 +80,7 @@ public class WPWebViewActivity extends WebViewActivity {
     public static final String SHARABLE_URL = "sharable_url";
     public static final String REFERRER_URL = "referrer_url";
     public static final String DISABLE_LINKS_ON_PAGE = "DISABLE_LINKS_ON_PAGE";
+    public static final String ALLOWED_URLS = "allowed_urls";
     public static final String USE_GLOBAL_WPCOM_USER = "USE_GLOBAL_WPCOM_USER";
 
     private static final String ENCODING_UTF8 = "UTF-8";
@@ -89,7 +90,7 @@ public class WPWebViewActivity extends WebViewActivity {
     }
 
     // Note: The webview has links disabled!!
-    public static void openPostOrPage(Context context, Blog blog, Post post, String url) {
+    public static void openPostOrPage(Context context, Blog blog, Post post, String url, String[] listOfAllowedURLs) {
         if (context == null) {
             AppLog.e(AppLog.T.UTILS, "Context is null");
             return;
@@ -116,6 +117,7 @@ public class WPWebViewActivity extends WebViewActivity {
             intent.putExtra(AUTHENTICATION_PASSWD, blog.getPassword());
         }
         intent.putExtra(URL_TO_LOAD, url);
+        intent.putExtra(ALLOWED_URLS, listOfAllowedURLs);
         intent.putExtra(AUTHENTICATION_URL, authURL);
         intent.putExtra(LOCAL_BLOG_ID, blog.getLocalTableBlogId());
         intent.putExtra(DISABLE_LINKS_ON_PAGE, true);
@@ -192,12 +194,11 @@ public class WPWebViewActivity extends WebViewActivity {
                 allowedURL.add(authURL);
             }
 
-            // In this case Links are disabled, but WP removes "?preview=true" from the passed URL, and internally redirects to it.
-            // EX:  Published posts on a site with Plain permalink structure settings.
-            // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/4873
-            if (!TextUtils.isEmpty(addressToLoad) && addressToLoad.endsWith("preview=true")) {
-                // Remove "(?|&)preview=true" string
-                allowedURL.add(addressToLoad.substring(0, addressToLoad.length() - 13));
+            if(extras.getStringArray(ALLOWED_URLS) != null) {
+                String[] urls = extras.getStringArray(ALLOWED_URLS);
+                for (String currentURL: urls) {
+                    allowedURL.add(currentURL);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #4873 by adding the original post URL to the list of allowed URLs.

To test:
- On a self-hosted WordPress site, go to Settings > Permalinks in the WP Admin dashboard.
- Select "Plain" for the permalink structure.
- In the WordPress app, add that site (or select it from the site picker if it already exists).
- Open the Blog Posts and make sure the list of posts is synced.
- Find or create a published post and select "View".

