### PR TITLE
Remove constraints on image width in post

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -304,7 +304,7 @@ public class ImageSettingsDialogFragment extends DialogFragment {
             }
             metaData.put("linkUrl", mLinkTo.getText().toString());
 
-            int newWidth = getEditTextIntegerClamped(mWidthText, 10, mMaxImageWidth);
+            int newWidth = getEditTextIntegerClamped(mWidthText, 1, Integer.MAX_VALUE);
             metaData.put("width", newWidth);
             metaData.put("height", getRelativeHeightFromWidth(newWidth));
         } catch (JSONException e) {


### PR DESCRIPTION
Fixes #4785 

`mMaxImageWidth` is no longer clamping the upper bound of the image width setting. However, it's still used to determine the max value for the slider.

To test:
* Create a post and add media to it
* Edit the media and change the image width to an arbitrary value in the range [1, INT_MAX]
* Save changes and verify on web