### PR TITLE
Better sign in error handling

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -1228,6 +1228,10 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             updateMigrationStatusIfNeeded();
             finishCurrentActivity();
         }
+
+        if (event.isError()) {
+            endProgress();
+        }
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -1254,7 +1254,6 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     public void onAvailabilityChecked(OnAvailabilityChecked event) {
         if (event.isError()) {
             AppLog.e(T.API, "OnAvailabilityChecked has error: " + event.error.type + " - " + event.error.message);
-            return;
         }
 
         if (event.type == IsAvailable.EMAIL && !event.isAvailable) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -1178,6 +1178,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     public void onAccountChanged(OnAccountChanged event) {
         if (event.isError()) {
             AppLog.e(T.API, "onAccountChanged has error: " + event.error.type + " - " + event.error.message);
+            showAccountError(event.error.type, event.error.message);
             endProgress();
             return;
         }
@@ -1323,6 +1324,24 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             case GENERIC_ERROR:
             default:
                 showGenericErrorDialog(getResources().getString(R.string.nux_cannot_log_in));
+                break;
+        }
+    }
+
+    private void showAccountError(AccountStore.AccountErrorType error, String errorMessage) {
+        switch (error) {
+            case ACCOUNT_FETCH_ERROR:
+                showError(R.string.error_fetch_my_profile);
+                break;
+            case SETTINGS_FETCH_ERROR:
+                showError(R.string.error_fetch_account_settings);
+                break;
+            case SETTINGS_POST_ERROR:
+                showError(R.string.error_post_account_settings);
+                break;
+            case GENERIC_ERROR:
+            default:
+                showError(errorMessage);
                 break;
         }
     }


### PR DESCRIPTION
Fixes #4641

To test:
* You can force an error in each of the `On[Site/Account/Authentication]Changed` events and verify that progress is ended and the user can attempt to login again

Add the following to the top of the appropriate OnChange event:

`event.error = new AccountStore.AccountError(AccountStore.AccountErrorType.ACCOUNT_FETCH_ERROR, "");`

`event.error = new SiteStore.SiteError(SiteStore.SiteErrorType.INVALID_SITE);`

`event.error = new AccountStore.AuthenticationError(AuthenticationErrorType.AUTHORIZATION_REQUIRED, "");`