### PR TITLE
Remove ZERO WIDTH SPACE character at the begining of the post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -233,7 +233,15 @@ public class PostUploadService extends Service {
                 mPost.setPostStatus(PostStatus.toString(PostStatus.PUBLISHED));
             }
 
-            String descriptionContent = processPostMedia(mPost.getDescription());
+            String descriptionContent = mPost.getDescription();
+            // Get rid of ZERO WIDTH SPACE character that the Visual editor can insert
+            // at the beginning of the content.
+            // http://www.fileformat.info/info/unicode/char/200b/index.htm
+            // See: https://github.com/wordpress-mobile/WordPress-Android/issues/5009
+            if (descriptionContent.length() > 0 && descriptionContent.charAt(0) == '\u200B') {
+                descriptionContent = descriptionContent.substring(1, descriptionContent.length());
+            }
+            descriptionContent = processPostMedia(descriptionContent);
 
             String moreContent = "";
             if (!TextUtils.isEmpty(mPost.getMoreText())) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1014,7 +1014,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         mContentHtml = StringUtils.notNullStr(mContentHtml);
         // Remove ZERO WIDTH SPACE character - http://www.fileformat.info/info/unicode/char/200b/index.htm
         // from the beginning of the content. See: https://github.com/wordpress-mobile/WordPress-Android/issues/5009
-        if (mContentHtml.charAt(0) == '\u200B') {
+        if (mContentHtml.length() > 0 && mContentHtml.charAt(0) == '\u200B') {
             mContentHtml = mContentHtml.substring(1, mContentHtml.length());
         }
         return mContentHtml;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1010,13 +1010,9 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             AppLog.e(T.EDITOR, e);
             Thread.currentThread().interrupt();
         }
-
+        
         mContentHtml = StringUtils.notNullStr(mContentHtml);
-        // Remove ZERO WIDTH SPACE character - http://www.fileformat.info/info/unicode/char/200b/index.htm
-        // from the beginning of the content. See: https://github.com/wordpress-mobile/WordPress-Android/issues/5009
-        if (mContentHtml.length() > 0 && mContentHtml.charAt(0) == '\u200B') {
-            mContentHtml = mContentHtml.substring(1, mContentHtml.length());
-        }
+
         return mContentHtml;
     }
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1010,10 +1010,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             AppLog.e(T.EDITOR, e);
             Thread.currentThread().interrupt();
         }
-        
-        mContentHtml = StringUtils.notNullStr(mContentHtml);
 
-        return mContentHtml;
+        return StringUtils.notNullStr(mContentHtml);
     }
 
     @Override

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1011,7 +1011,13 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
             Thread.currentThread().interrupt();
         }
 
-        return StringUtils.notNullStr(mContentHtml);
+        mContentHtml = StringUtils.notNullStr(mContentHtml);
+        // Remove ZERO WIDTH SPACE character - http://www.fileformat.info/info/unicode/char/200b/index.htm
+        // from the beginning of the content. See: https://github.com/wordpress-mobile/WordPress-Android/issues/5009
+        if (mContentHtml.charAt(0) == '\u200B') {
+            mContentHtml = mContentHtml.substring(1, mContentHtml.length());
+        }
+        return mContentHtml;
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/462 , #5007, #4910, and #5009 by removing the ZERO WIDTH SPACE character (http://www.fileformat.info/info/unicode/char/200b/index.htm) at the beginning of the post.
The Visual editor can magically insert it when pasting content into a fresh post. 
Once inserted, it is then sent to the server `<string>&#8203;http://www.youtube.com/watch?v=dQw4w9WgXcQ</string>` and breaks regular expressions that "unfold" oEmbeds.

*Developer note:* Java handles that character in strange way, since the underlaying characters object of the String could contain even other chars before the `ZERO WIDTH SPACE` character, but standard Java functions over Strings seem to ignore them. See attached screenshots.
![screen shot 2017-01-26 at 15 46 45](https://cloud.githubusercontent.com/assets/518232/22339874/cdb7f9dc-e3eb-11e6-8caa-eac12ba87ec8.png)

![screen shot 2017-01-26 at 15 47 10](https://cloud.githubusercontent.com/assets/518232/22339886/d5395070-e3eb-11e6-9642-884c32b352be.png)


To test:
- Start a new post.
- Add a title.
- (optional) Add some  text.
- Add the link copied earlier on a line by itself.
- Hit publish.
- From the Posts page in the app, click preview.
- Check to see if the embed is working there.

Some testing links:
- http://www.youtube.com/watch?v=dQw4w9WgXcQ 
- https://youtu.be/RbXchpAZR8c
- https://www.kickstarter.com/projects/1131502390/the-nomatic-travel-bag
