### PR TITLE
Open the Customizer in the default Browser

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
@@ -16,6 +16,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Blog;
 import org.wordpress.android.models.Theme;
+import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ToastUtils;
@@ -48,7 +49,16 @@ public class ThemeWebActivity extends WPWebViewActivity {
         }
 
         String url = getUrl(currentTheme, type, currentTheme.isPremium());
-        openWPCOMURL(activity, url, currentTheme, WordPress.getCurrentBlog(), isCurrentTheme);
+
+        if (type == ThemeWebActivityType.PREVIEW) {
+            // Do not open the Customizer with the in-app browser.
+            // Customizer may need to access local files (mostly pictures) on the device storage,
+            // and our internal webview doesn't handle this feature yet.
+            // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/4934
+            ActivityLauncher.openUrlExternal(activity, url);
+        } else {
+            openWPCOMURL(activity, url, currentTheme, WordPress.getCurrentBlog(), isCurrentTheme);
+        }
     }
 
     /*


### PR DESCRIPTION
Fixes #4934 by opening the Customizer with the default device browser.

To test:
- In the app, open a site's Themes section
- Tap "Customize" to open the site's customizer
- Open the Site Logo section
- Tap the "Select logo" button
- Go to the Upload Files tab
- Tap the "Select Files" button to try to upload a file


cc @kwonye Since you've worked on Themes in the past.

*Note:* On my Nexus 5X the device runs in low memory mode when I opened the default browser and took a picture, resulting in the Android system restarting/killing foreground processes (wp-android got killed). Not a big deal, since there were not unsaved changes in the app, but just a thing to consider for the future.
