### PR TITLE
Fixes notification unread mark

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -180,7 +180,7 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
             NotificationsActions.markNoteAsRead(note);
             note.setRead();
             NotificationsTable.saveNote(note);
-            EventBus.getDefault().post(new NotificationEvents.NotificationsChanged());
+            EventBus.getDefault().postSticky(new NotificationEvents.NotificationsChanged());
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -609,6 +609,7 @@ public class NotificationsListFragment extends Fragment
         }
         mRestoredScrollNoteID = getFirstVisibleItemID(); // Remember the ID of the first note visible on the screen
         getNotesAdapter().reloadNotesFromDBAsync();
+        EventBus.getDefault().removeStickyEvent(event);
         if (event.hasUnseenNotes) {
             showNewUnseenNotificationsUI();
         }


### PR DESCRIPTION
Makes `NotificationsChanged` event into a sticky event when a notification's detail is shown so the NotificationsListFragment is sure to process it and show the new list accordingly once you hit back.
The problem was when the app is not in the recent apps list, the NotificationsListFragment is not instantiated in memory, so the event was being broadcasted but not catched by the object responsible for refreshing the list.

You'll probably notice a unread/read change on the screen when the list is shown, but this is to be expected as the list is refreshed.

Fixes #5061 

To test:
1. have the app in the background (for instance, by deleting the app from the recent apps list)
2. have another user make a comment to a post you've made
3. the notification should appear in the system dashboard
4. open it
5. Tap the back arrow or back button.
6. Notice the notification is still unread (i.e. light blue background), and within a second it changes to read (i.e. white background).

cc @theck13 @daniloercoli 

