### PR TITLE
Exclude Newlines in Post Title

### DIFF
--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
@@ -29,7 +29,7 @@
                 android:id="@+id/title"
                 android:background="@null"
                 android:hint="@string/post_title"
-                android:inputType="textNoSuggestions|textMultiLine"
+                android:inputType="textNoSuggestions"
                 android:layout_height="wrap_content"
                 android:layout_width="match_parent"
                 android:padding="16dp"


### PR DESCRIPTION
### Fix
Exclude newlines in the editor post title by removing the multiline input method as described in https://github.com/wordpress-mobile/WordPress-Android/issues/5079.

### Test
1. Go to ***Sites*** tab.
2. Tap ***Create*** floating button.
3. Tap title text area.
4. Try entering newline.