### PR TITLE
Media Filter

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -123,8 +123,9 @@ public class MediaGridFragment extends Fragment
     private final OnItemSelectedListener mFilterSelectedListener = new OnItemSelectedListener() {
         @Override
         public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-            // need this to stop the bug where onItemSelected is called during initialization, before user input
+            // onItemSelected will be called during initialization, so ignore first call
             if (!mSpinnerHasLaunched) {
+                mSpinnerHasLaunched = true;
                 return;
             }
             if (position == Filter.CUSTOM_DATE.ordinal()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -15,7 +15,6 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.AbsListView.RecyclerListener;
 import android.widget.AdapterView;
@@ -160,21 +159,10 @@ public class MediaGridFragment extends Fragment
 
         mResultView = (TextView) view.findViewById(R.id.media_filter_result_text);
 
+        mSpinnerContainer = view.findViewById(R.id.media_filter_spinner_container);
         mSpinner = (CustomSpinner) view.findViewById(R.id.media_filter_spinner);
         mSpinner.setOnItemSelectedListener(mFilterSelectedListener);
         mSpinner.setOnItemSelectedEvenIfUnchangedListener(mFilterSelectedListener);
-
-        mSpinnerContainer = view.findViewById(R.id.media_filter_spinner_container);
-        mSpinnerContainer.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (!isInMultiSelect()) {
-                    mSpinnerHasLaunched = true;
-                    mSpinner.performClick();
-                }
-            }
-
-        });
 
         // swipe to refresh setup
         mSwipeToRefreshHelper = new SwipeToRefreshHelper(getActivity(),


### PR DESCRIPTION
Fixes #5055. This PR fixes the media filter not working unless the user touches the very right part of the filter due to a poorly set flag. This flag is handled in a much simpler way now. The test steps are documented on the issue, thanks @mzorz!

P.S: I was going to fix this on the FluxC media integration branch, but it turns out this has nothing to do with FluxC, so I thought a fix on `develop` makes more sense since that'll be merged to integration branch anyway. /cc @maxme & @aforcier 
