### PR TITLE
Issue/5085 reader recursive details

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -1042,6 +1042,9 @@ public class ReaderPostDetailFragment extends Fragment
             String timestamp = DateTimeUtils.javaDateToTimeSpan(mPost.getDisplayDate(), WordPress.getContext());
             txtDateline.setText(timestamp);
 
+            // only enable showing blog preview from the header if we're not already
+            // previewing a blog
+            headerView.setEnableBlogPreview(getPostListType() != ReaderPostListType.BLOG_PREVIEW);
 
             headerView.setPost(mPost);
             tagStrip.setPost(mPost);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -201,6 +201,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             if (getPostListType() == ReaderTypes.ReaderPostListType.BLOG_PREVIEW) {
                 int color = itemView.getContext().getResources().getColor(R.color.grey_dark);
                 txtAuthorAndBlogName.setTextColor(color);
+                // remove the ripple background
+                postHeaderView.setBackground(null);
             } else {
                 postHeaderView.setOnClickListener(new View.OnClickListener() {
                     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.reader.adapters;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.os.AsyncTask;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.RecyclerView;
@@ -196,17 +197,22 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             txtVisit.setOnClickListener(visitListener);
             imgVisit.setOnClickListener(visitListener);
 
-            // show blog preview when post header is tapped
-            postHeaderView.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    int position = getAdapterPosition();
-                    ReaderPost post = getItem(position);
-                    if (post != null) {
-                        ReaderActivityLauncher.showReaderBlogPreview(view.getContext(), post);
+            // show author/blog link as disabled if we're previewing a blog, otherwise show
+            // blog preview when the post header is clicked
+            if (getPostListType() == ReaderTypes.ReaderPostListType.BLOG_PREVIEW) {
+                txtAuthorAndBlogName.setTextColor(Color.DKGRAY);
+            } else {
+                postHeaderView.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        int position = getAdapterPosition();
+                        ReaderPost post = getItem(position);
+                        if (post != null) {
+                            ReaderActivityLauncher.showReaderBlogPreview(view.getContext(), post);
+                        }
                     }
-                }
-            });
+                });
+            }
 
             // play the featured video when the overlay image is tapped - note that the overlay
             // image only appears when there's a featured video

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.reader.adapters;
 
 import android.content.Context;
-import android.graphics.Color;
 import android.os.AsyncTask;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.RecyclerView;
@@ -200,7 +199,8 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             // show author/blog link as disabled if we're previewing a blog, otherwise show
             // blog preview when the post header is clicked
             if (getPostListType() == ReaderTypes.ReaderPostListType.BLOG_PREVIEW) {
-                txtAuthorAndBlogName.setTextColor(Color.DKGRAY);
+                int color = itemView.getContext().getResources().getColor(R.color.grey_dark);
+                txtAuthorAndBlogName.setTextColor(color);
             } else {
                 postHeaderView.setOnClickListener(new View.OnClickListener() {
                     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.java
@@ -30,6 +30,7 @@ public class ReaderPostDetailHeaderView extends LinearLayout {
 
     private ReaderPost mPost;
     private ReaderFollowButton mFollowButton;
+    private boolean mEnableBlogPreview = true;
 
     public ReaderPostDetailHeaderView(Context context) {
         super(context);
@@ -49,6 +50,10 @@ public class ReaderPostDetailHeaderView extends LinearLayout {
     private void initView(Context context) {
         View view = inflate(context, R.layout.reader_post_detail_header_view, this);
         mFollowButton = (ReaderFollowButton) view.findViewById(R.id.header_follow_button);
+    }
+
+    public void setEnableBlogPreview(boolean enable) {
+        mEnableBlogPreview = enable;
     }
 
     public void setPost(@NonNull ReaderPost post) {
@@ -80,9 +85,14 @@ public class ReaderPostDetailHeaderView extends LinearLayout {
             txtSubtitle.setVisibility(View.GONE);
         }
 
-        // show blog preview when these views are tapped
-        txtTitle.setOnClickListener(mClickListener);
-        txtSubtitle.setOnClickListener(mClickListener);
+        if (mEnableBlogPreview) {
+            txtTitle.setOnClickListener(mClickListener);
+            txtSubtitle.setOnClickListener(mClickListener);
+        } else {
+            int color = getContext().getResources().getColor(R.color.grey_dark);
+            txtTitle.setTextColor(color);
+            txtSubtitle.setTextColor(color);
+        }
 
         if (ReaderUtils.isLoggedOutReader()) {
             mFollowButton.setVisibility(View.GONE);
@@ -194,8 +204,10 @@ public class ReaderPostDetailHeaderView extends LinearLayout {
         // hide the frame if there's neither a blavatar nor an avatar
         avatarFrame.setVisibility(hasAvatar || hasBlavatar ? View.VISIBLE : View.GONE);
 
-        imgBlavatar.setOnClickListener(mClickListener);
-        imgAvatar.setOnClickListener(mClickListener);
+        if (mEnableBlogPreview) {
+            imgBlavatar.setOnClickListener(mClickListener);
+            imgAvatar.setOnClickListener(mClickListener);
+        }
     }
 
     /*


### PR DESCRIPTION
Fixes #5085 - tapping the post header no longer shows blog preview when the user is already previewing a blog

To test:
* View the reader list
* Tap the header above a post to show blog preview
* Tap the header above a post in blog preview - it should now open the detail view rather than show preview again
* Now tap the header on the detail view - it should do nothing now rather than show preview again
