### PR TITLE
Exclude the sharing intent from recent activities

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -363,6 +363,7 @@
 
         <activity
             android:name=".ui.ShareIntentReceiverActivity"
+            android:excludeFromRecents="true"
             android:theme="@style/Calypso.FloatingActivity">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />


### PR DESCRIPTION
Fixes #4412 by not including the Sharing Receiver in recent activities stack.

This could seem like a workaround, but we're already excluding other receivers from the stack, and can't find a valid reason to keep it since it makes the app crashing. 
This is also a kind of hard to debug, since you can't have WP already running on the device. If the app is already in memory, no crash happens.

To test:
- Share an image to WordPress and select the Media Library
- Once the image has uploaded, press the Back button to return to the previous app / home
- Attempt to task switch back to WordPress
- There should not be any WP instance in the list(*)

(*) If you see WP list there, this is because the app was already running. No crashes in this case.