### PR TITLE
Update helpshift and the support library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ android:
     - extra-android-support
     - platform-tools
     - tools
-    - build-tools-25.0.1
+    - build-tools-25.0.2
     - android-25
 
 env:

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -30,7 +30,7 @@ android {
     }
 
     compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "org.wordpress.android"
@@ -84,16 +84,16 @@ dependencies {
     compile 'com.google.code.gson:gson:2.6.+'
     compile 'org.ccil.cowan.tagsoup:tagsoup:1.2.1'
 
-    compile 'com.android.support:support-compat:25.0.1'
-    compile 'com.android.support:support-core-ui:25.0.1'
-    compile 'com.android.support:support-fragment:25.0.1'
+    compile 'com.android.support:support-compat:25.1.1'
+    compile 'com.android.support:support-core-ui:25.1.1'
+    compile 'com.android.support:support-fragment:25.1.1'
 
     compile 'com.android.support:multidex:1.0.1'
-    compile 'com.android.support:appcompat-v7:25.0.1'
-    compile 'com.android.support:cardview-v7:25.0.1'
-    compile 'com.android.support:recyclerview-v7:25.0.1'
-    compile 'com.android.support:design:25.0.1'
-    compile 'com.android.support:percent:25.0.1'
+    compile 'com.android.support:appcompat-v7:25.1.1'
+    compile 'com.android.support:cardview-v7:25.1.1'
+    compile 'com.android.support:recyclerview-v7:25.1.1'
+    compile 'com.android.support:design:25.1.1'
+    compile 'com.android.support:percent:25.1.1'
 
     compile 'com.google.android.gms:play-services-gcm:9.0.2'
     compile 'com.google.android.gms:play-services-auth:9.0.2'

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -98,7 +98,7 @@ dependencies {
     compile 'com.google.android.gms:play-services-gcm:9.0.2'
     compile 'com.google.android.gms:play-services-auth:9.0.2'
     compile 'com.github.chrisbanes.photoview:library:1.2.4'
-    compile 'com.helpshift:android-helpshift-aar:4.7.0'
+    compile 'com.helpshift:android-helpshift-aar:4.8.1'
     compile 'de.greenrobot:eventbus:2.4.0'
     compile 'com.automattic:rest:1.0.7'
     compile 'org.wordpress:graphview:3.4.0'

--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -25,7 +25,7 @@ android {
     publishNonDefault true
 
     compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         versionName "1.2.0"

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -19,7 +19,7 @@ android {
     publishNonDefault true
 
     compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         versionCode 13
@@ -45,9 +45,9 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.0.1'
-    compile 'com.android.support:support-v4:25.0.1'
-    compile 'com.android.support:design:25.0.1'
+    compile 'com.android.support:appcompat-v7:25.1.1'
+    compile 'com.android.support:support-v4:25.1.1'
+    compile 'com.android.support:design:25.1.1'
     compile 'org.wordpress:utils:1.11.0'
 }
 

--- a/libs/networking/WordPressNetworking/build.gradle
+++ b/libs/networking/WordPressNetworking/build.gradle
@@ -19,7 +19,7 @@ android {
     publishNonDefault true
 
     compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         minSdkVersion 14

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -20,7 +20,7 @@ dependencies {
         exclude group: 'commons-logging'
     }
     compile 'com.mcxiaoke.volley:library:1.0.18'
-    compile 'com.android.support:support-v13:25.0.1'
+    compile 'com.android.support:support-v13:25.1.1'
 }
 
 android {
@@ -29,7 +29,7 @@ android {
     publishNonDefault true
 
     compileSdkVersion 25
-    buildToolsVersion "25.0.1"
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         versionName "1.14.0"


### PR DESCRIPTION
```
Issue #1: Incompatibility with Android Support Library 25.1.0
Google recently released an update to their ‘Android Support Library’, causing a change in behavior around fragments. This change will cause Helpshift to crash if you target this new Library during Helpshift integration.
 Impact: Your users will encounter this crash if your developer has integrated Helpshift and is currently using version 25.1.0 of the Android Support Library. If you use this version, the crash will occur on all Android operating systems and devices.
 Trigger: This cause occurs while searching through Helpshift FAQs.
 Workaround: Targeting any version below 25.1.0 will prevent this from occurring. Please see below for the workaround in code-snippet form:
```

This was the issue encountered with support library 25.1.0. They fixed that crash in Helpshift 4.8.1, along with Google releasing 25.1.1. Us updating these together guarantees we won't even mix 4.8.1 with 25.1.0.