### PR TITLE
Issue/5101 update action menu

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -439,7 +439,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
         MenuInflater inflater = getMenuInflater();
-        if (mShowNewEditor) {
+        if (mShowNewEditor || mShowAztecEditor) {
             inflater.inflate(R.menu.edit_post, menu);
         } else {
             inflater.inflate(R.menu.edit_post_legacy, menu);


### PR DESCRIPTION
### Fix
Add Aztec editor condition when creating options menu to allow Aztec editor to use the same actions as the visual editor with the addition of redo and undo as described in https://github.com/wordpress-mobile/WordPress-Android/issues/5101.

### Test
***Visual***
1. Go to ***Me*** tab.
2. Tap ***App Settings*** item.
3. Tap ***Set editor type*** setting.
4. Select ***Visual*** option.
5. Go to ***Sites*** tab.
6. Tap ***Create*** floating button.
7. Notice ***Settings*** and ***Publish*** actions.

***Aztec***
1. Go to ***Me*** tab.
2. Tap ***App Settings*** item.
3. Tap ***Set editor type*** setting.
4. Select ***Aztec*** option.
5. Go to ***Sites*** tab.
6. Tap ***Create*** floating button.
7. Notice ***Settings***, ***Publish***, ***Undo***, and ***Redo*** actions.