### PR TITLE
Issue/5078 post newlines removed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1219,7 +1219,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         if (post != null) {
             if (!TextUtils.isEmpty(post.getContent()) && !mHasSetPostContent) {
                 mHasSetPostContent = true;
-                if (post.isLocalDraft() && !mShowNewEditor) {
+                if (post.isLocalDraft() && !mShowNewEditor && !mShowAztecEditor) {
                     // TODO: Unnecessary for new editor, as all images are uploaded right away, even for local drafts
                     // Load local post content in the background, as it may take time to generate images
                     new LoadPostContentTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,


### PR DESCRIPTION
### Fix
Retain newlines and other formatted text when loading post content with Aztec as described in https://github.com/wordpress-mobile/WordPress-Android/issues/5078.

### Test
1. Go to ***Sites*** tab.
2. Tap ***Create*** floating button.
3. Enter text with newlines.
4. Tap back arrow in action bar.
5. Tap ***Edit*** button for post created in Step 3.
6. Notice newlines remain intact.