### PR TITLE
issue/5076-reader-unfollow-deleted-site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderBlogTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderBlogTable.java
@@ -279,6 +279,13 @@ public class ReaderBlogTable {
                 args);
     }
 
+    public static String getBlogUrl(long blogId) {
+        String[] args = {Long.toString(blogId)};
+        return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(),
+                "SELECT blog_url FROM tbl_blog_info WHERE blog_id=?",
+                args);
+    }
+
     public static String getFeedName(long feedId) {
         String[] args = {Long.toString(feedId)};
         return SqlUtils.stringForQuery(ReaderDatabase.getReadableDb(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -42,9 +42,7 @@ public class ReaderBlogActions {
                                          final boolean isAskingToFollow,
                                          final ActionListener actionListener) {
         if (blogId == 0) {
-            if (actionListener != null) {
-                actionListener.onActionResult(false);
-            }
+            ReaderActions.callActionListener(actionListener, false);
             return false;
         }
 
@@ -70,9 +68,7 @@ public class ReaderBlogActions {
                     AppLog.w(T.READER, "blog " + actionName + " failed - " + jsonToString(jsonObject) + " - " + path);
                     localRevertFollowBlogId(blogId, isAskingToFollow);
                 }
-                if (actionListener != null) {
-                    actionListener.onActionResult(success);
-                }
+                ReaderActions.callActionListener(actionListener, success);
             }
         };
         RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
@@ -88,9 +84,7 @@ public class ReaderBlogActions {
                     internalUnfollowBlogByUrl(blogId, actionListener);
                 } else {
                     localRevertFollowBlogId(blogId, isAskingToFollow);
-                    if (actionListener != null) {
-                        actionListener.onActionResult(false);
-                    }
+                    ReaderActions.callActionListener(actionListener, false);
                 }
             }
         };
@@ -143,8 +137,8 @@ public class ReaderBlogActions {
                             blogInfo.getFeedUrl(),
                             isAskingToFollow,
                             actionListener);
-                } else if (actionListener != null) {
-                    actionListener.onActionResult(false);
+                } else {
+                    ReaderActions.callActionListener(actionListener, false);
                 }
             }
         });
@@ -191,9 +185,7 @@ public class ReaderBlogActions {
     {
         // feedUrl is required
         if (TextUtils.isEmpty(feedUrl)) {
-            if (actionListener != null) {
-                actionListener.onActionResult(false);
-            }
+            ReaderActions.callActionListener(actionListener, false);
             return false;
         }
 
@@ -223,9 +215,7 @@ public class ReaderBlogActions {
                     AppLog.w(T.READER, "feed " + actionName + " failed - " + jsonToString(jsonObject) + " - " + path);
                     localRevertFollowFeedId(feedId, isAskingToFollow);
                 }
-                if (actionListener != null) {
-                    actionListener.onActionResult(success);
-                }
+                ReaderActions.callActionListener(actionListener, success);
             }
         };
         RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
@@ -234,9 +224,7 @@ public class ReaderBlogActions {
                 AppLog.w(T.READER, "feed " + actionName + " failed with error");
                 AppLog.e(T.READER, volleyError);
                 localRevertFollowFeedId(feedId, isAskingToFollow);
-                if (actionListener != null) {
-                    actionListener.onActionResult(false);
-                }
+                ReaderActions.callActionListener(actionListener, false);
             }
         };
         WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
@@ -252,9 +240,7 @@ public class ReaderBlogActions {
                                             ActionListener actionListener) {
         if (post == null) {
             AppLog.w(T.READER, "follow action performed with null post");
-            if (actionListener != null) {
-                actionListener.onActionResult(false);
-            }
+            ReaderActions.callActionListener(actionListener, false);
             return false;
         }
         if (post.feedId != 0) {
@@ -451,9 +437,7 @@ public class ReaderBlogActions {
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
             public void onResponse(JSONObject jsonObject) {
-               if (actionListener != null) {
-                    actionListener.onActionResult(true);
-                }
+                ReaderActions.callActionListener(actionListener, true);
             }
         };
         RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
@@ -464,9 +448,7 @@ public class ReaderBlogActions {
                 if (blockResult.wasFollowing) {
                     ReaderBlogTable.setIsFollowedBlogId(blogId, true);
                 }
-                if (actionListener != null) {
-                    actionListener.onActionResult(false);
-                }
+                ReaderActions.callActionListener(actionListener, false);
             }
         };
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -80,15 +80,50 @@ public class ReaderBlogActions {
             public void onErrorResponse(VolleyError volleyError) {
                 AppLog.w(T.READER, "blog " + actionName + " failed with error");
                 AppLog.e(T.READER, volleyError);
-                localRevertFollowBlogId(blogId, isAskingToFollow);
-                if (actionListener != null) {
-                    actionListener.onActionResult(false);
+                // check if we get a 403 when unfollowing - this will happen when we attempt
+                // to unfollow a blog that no longer exists - the workaround is to unfollow
+                // by url - note that the v1.2 endpoint will return a 404 in this situation
+                int status = VolleyUtils.statusCodeFromVolleyError(volleyError);
+                if (status == 403 && !isAskingToFollow) {
+                    internalUnfollowBlogByUrl(blogId, actionListener);
+                } else {
+                    localRevertFollowBlogId(blogId, isAskingToFollow);
+                    if (actionListener != null) {
+                        actionListener.onActionResult(false);
+                    }
                 }
             }
         };
         WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
 
         return true;
+    }
+
+    private static void internalUnfollowBlogByUrl(long blogId,
+                                                  final ActionListener actionListener) {
+        String blogUrl = ReaderBlogTable.getBlogUrl(blogId);
+        if (TextUtils.isEmpty(blogUrl)) {
+            AppLog.w(T.READER, "URL not found for blogId " + blogId);
+            ReaderActions.callActionListener(actionListener, false);
+            return;
+        }
+
+        com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
+            @Override
+            public void onResponse(JSONObject response) {
+                ReaderActions.callActionListener(actionListener, true);
+            }
+        };
+        RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
+            @Override
+            public void onErrorResponse(VolleyError error) {
+                AppLog.e(T.READER, error);
+                ReaderActions.callActionListener(actionListener, false);
+            }
+        };
+
+        String path = "/read/following/mine/delete?url=" + UrlUtils.urlEncode(blogUrl);
+        WordPress.getRestClientUtilsV1_1().post(path, listener, errorListener);
     }
 
     public static boolean followFeedById(final long feedId,


### PR DESCRIPTION
Fixes #5076 

To test: 
* Create a temporary blog
* Follow it in the reader
* Delete the blog
* Try to unfollow it from the mobile reader

Prior to this change, it would be impossible to unfollow a deleted blog.

Note: This was originally going to be resolved on the backend but that proved problematic. The solution is for the mobile apps to detect when unfollowing a blog by ID results in a 403 and then use the `/read/following/mine/delete?url=` endpoint to unfollow by URL (that endpoint isn't as reliable as unfollowing by ID, which is why we don't use it in the first place).

cc: @aerych 