### PR TITLE
issue/5117-reader-use-post-avatar-blavatar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderPostDetailHeaderView.java
@@ -9,8 +9,6 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
-import org.wordpress.android.datasets.ReaderBlogTable;
-import org.wordpress.android.models.ReaderBlog;
 import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
@@ -107,41 +105,7 @@ public class ReaderPostDetailHeaderView extends LinearLayout {
             });
         }
 
-        // get local blog info so we can set the follower count and blavatar
-        ReaderBlog blogInfo = mPost.isExternal ? ReaderBlogTable.getFeedInfo(mPost.feedId) : ReaderBlogTable.getBlogInfo(mPost.blogId);
-        if (blogInfo != null) {
-            showBlogInfo(blogInfo);
-        }
-
-        // update blog info if it's time or it doesn't exist
-        if (blogInfo == null || ReaderBlogTable.isTimeToUpdateBlogInfo(blogInfo)) {
-            updateBlogInfo();
-        }
-    }
-
-    /*
-     * get the latest info about this post's blog so we have an accurate follower count
-     */
-    private void updateBlogInfo() {
-        if (!NetworkUtils.isNetworkAvailable(getContext())) return;
-
-        ReaderActions.UpdateBlogInfoListener listener = new ReaderActions.UpdateBlogInfoListener() {
-            @Override
-            public void onResult(ReaderBlog blogInfo) {
-                showBlogInfo(blogInfo);
-            }
-        };
-        if (mPost.isExternal) {
-            ReaderBlogActions.updateFeedInfo(mPost.feedId, null, listener);
-        } else {
-            ReaderBlogActions.updateBlogInfo(mPost.blogId, null, listener);
-        }
-    }
-
-    private void showBlogInfo(ReaderBlog blogInfo) {
-        String blavatarUrl = blogInfo != null ? blogInfo.getImageUrl() : null;
-        String avatarUrl = mPost != null ? mPost.getPostAvatar() : null;
-        showBlavatarAndAvatar(blavatarUrl, avatarUrl);
+        showBlavatarAndAvatar(mPost.getBlogImageUrl(), mPost.getPostAvatar());
     }
 
     private void showBlavatarAndAvatar(String blavatarUrl, String avatarUrl) {
@@ -240,7 +204,6 @@ public class ReaderPostDetailHeaderView extends LinearLayout {
                     ToastUtils.showToast(getContext(), errResId);
                     mFollowButton.setIsFollowed(!isAskingToFollow);
                 }
-                updateBlogInfo();
             }
         };
 


### PR DESCRIPTION
Fixes #5117 - prior to this change the header in the reader full post view would make a separate request to get the avatar and blavatar for a post. 

The recent reader refresh made these URLs part of the post model, so it's unnecessary to request them. This PR simply relies on the URLs that are already included in the post model.