### PR TITLE
issue/5119-reader-default-followed-sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -18,8 +18,8 @@ public class ReaderTag implements Serializable, FilterCriteria {
     // these are the default tags, which aren't localized in the /read/menu/ response
     private static final String TAG_TITLE_LIKED = "Posts I Like";
     private static final String TAG_TITLE_DISCOVER = "Discover";
-    public  static final String TAG_TITLE_DEFAULT = TAG_TITLE_DISCOVER;
     public  static final String TAG_TITLE_FOLLOWED_SITES = "Followed Sites";
+    public  static final String TAG_TITLE_DEFAULT = TAG_TITLE_FOLLOWED_SITES;
 
     public ReaderTag(String slug,
                      String displayName,


### PR DESCRIPTION
Fixes #5119 - changes the default topic from Discover to Followed Sites.