### PR TITLE
Issue/5069 update hint text

### DIFF
--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -96,8 +96,8 @@
     <string name="editor_dropped_unsupported_files">Warning: not all dropped items are supported!</string>
 
     <!-- AZTEC -->
-    <string name="edit_hint">Tenochtitlan is the hint</string>
-    <string name="source_hint">Codex is the source</string>
+    <string name="edit_hint">Share your story here&#8230;</string>
+    <string name="source_hint">&lt;p&gt;Share your story here&#8230;&lt;/p&gt;</string>
 
     <string name="dialog_title">Insert link</string>
     <string name="dialog_edit_hint">http(s)://</string>


### PR DESCRIPTION
### Fix
Update hint text for visual and HTML views as described in https://github.com/wordpress-mobile/WordPress-Android/issues/5069.

### Test
1. Go to ***Sites*** tab.
2. Tap ***Create*** floating action button.
3. Notice `Share your story here...` is the content hint.
4. Tap ***HTML*** format button.
5. Notice `<p>Share your story here...</p>` is the content hint.