### PR TITLE
issue/5128-postlist-default-to-editor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -406,7 +406,7 @@ public class PostsListFragment extends Fragment
      */
     @Override
     public void onPostSelected(PostsListPost post) {
-        onPostButtonClicked(PostListButton.BUTTON_PREVIEW, post);
+        onPostButtonClicked(PostListButton.BUTTON_EDIT, post);
     }
 
     /*


### PR DESCRIPTION
Fixes #5128 - tapping a post in the post list now always opens it for editing, which is consistent with Calypso and iOS.
