### PR TITLE
Issue/5104 html discards changes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -190,6 +190,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     private Post mPost;
     private Post mOriginalPost;
 
+    private AztecEditorFragment mAztecEditorFragment;
     private EditorFragmentAbstract mEditorFragment;
     private EditPostSettingsFragment mEditPostSettingsFragment;
     private EditPostPreviewFragment mEditPostPreviewFragment;
@@ -919,6 +920,10 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     }
 
     private void saveAndFinish() {
+        if (mShowAztecEditor && mAztecEditorFragment != null) {
+            mAztecEditorFragment.saveContentFromSource();
+        }
+
         new SaveAndFinishTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
@@ -957,9 +962,9 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 case 0:
                     // TODO: Remove editor options after testing.
                     if (mShowAztecEditor) {
-                        AztecEditorFragment editor = AztecEditorFragment.newInstance("", "");
-                        editor.setImageLoader(new AztecImageLoader(getBaseContext()));
-                        return editor;
+                        mAztecEditorFragment = AztecEditorFragment.newInstance("", "");
+                        mAztecEditorFragment.setImageLoader(new AztecImageLoader(getBaseContext()));
+                        return mAztecEditorFragment;
                     } else if (mShowNewEditor) {
                         EditorWebViewCompatibility.setReflectionFailureListener(EditPostActivity.this);
                         return new EditorFragment();

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -449,4 +449,12 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements OnIme
         }
     };
 
+    /**
+     * Save post content from source HTML.
+     */
+    public void saveContentFromSource() {
+        if (content != null && source != null && source.getVisibility() == View.VISIBLE) {
+            content.fromHtml(source.getPureHtml(false));
+        }
+    }
 }


### PR DESCRIPTION
### Fix
Save post content from source HTML to avoid discarding changes as described in https://github.com/wordpress-mobile/WordPress-Android/issues/5104.

### Test
1. Go to ***Sites*** tab.
2. Tap ***Blog Posts*** item.
3. Tap ***Create*** floating button.
4. Tap ***HTML*** format button.
5. Enter text.
6. Tap back arrow or back button to exit editing.
7. Tap ***Edit*** button on post.
8. Notice content is saved.