### PR TITLE
Refresh preview page on revert and edit

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -27,6 +27,7 @@ import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.post.PostStatus;
+import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged;
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
 import org.wordpress.android.fluxc.store.PostStore.RemotePostPayload;
@@ -52,6 +53,7 @@ public class PostPreviewActivity extends AppCompatActivity {
     private SiteModel mSite;
 
     @Inject Dispatcher mDispatcher;
+    @Inject PostStore mPostStore;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -141,6 +143,7 @@ public class PostPreviewActivity extends AppCompatActivity {
         if (!isFinishing()) {
             PostPreviewFragment fragment = getPreviewFragment();
             if (fragment != null) {
+                fragment.setPost(mPost);
                 fragment.refreshPreview();
             }
         }
@@ -321,6 +324,7 @@ public class PostPreviewActivity extends AppCompatActivity {
                     // TODO: Report error to user
                     AppLog.e(AppLog.T.POSTS, "UPDATE_POST failed: " + event.error.type + " - " + event.error.message);
                 } else {
+                    mPost = mPostStore.getPostByLocalPostId(mPost.getId());
                     refreshPreview();
                 }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -97,6 +97,7 @@ public class PostPreviewActivity extends AppCompatActivity {
         EventBus.getDefault().register(this);
         mDispatcher.register(this);
 
+        mPost = mPostStore.getPostByLocalPostId(mPost.getId());
         if (hasPreviewFragment()) {
             refreshPreview();
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewFragment.java
@@ -78,6 +78,10 @@ public class PostPreviewFragment extends Fragment {
         refreshPreview();
     }
 
+    public void setPost(PostModel post) {
+        mPost = post;
+    }
+
     void refreshPreview() {
         if (!isAdded()) return;
 


### PR DESCRIPTION
Fixes #5136 & Fixes #5137. I don't know if it was on purpose but we were never updating the local post variables in preview activity and fragment. The current post related files don't really feel like fully integrated with FluxC. I feel like we should stop passing the post model around in the Bundle and instead just pass the id and have the proper post store injections going. What do you think @aforcier?
