### PR TITLE
Fix #5140: Don't migrate sites with an api_blogid set

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -111,7 +111,7 @@ public class WPLegacyMigrationUtils {
         List<SiteModel> siteList = new ArrayList<>();
         try {
             SQLiteDatabase db = context.getApplicationContext().openOrCreateDatabase(DEPRECATED_DATABASE_NAME, 0, null);
-            String[] fields = new String[]{"username", "password", "url"};
+            String[] fields = new String[]{"username", "password", "url", "api_blogid"};
 
             // To exclude the jetpack sites we need to check for empty password
             String byString = String.format("dotcomFlag=0 AND NOT(dotcomFlag=0 AND password='%s')",
@@ -120,6 +120,11 @@ public class WPLegacyMigrationUtils {
             int numRows = c.getCount();
             c.moveToFirst();
             for (int i = 0; i < numRows; i++) {
+                // If the api_blogid field is set, that's probably a Jetpack site that is not connected to the main
+                // account, so we want to skip it.
+                if (!TextUtils.isEmpty(c.getString(3))) {
+                    continue;
+                }
                 SiteModel siteModel = new SiteModel();
                 siteModel.setUsername(c.getString(0));
                 // Decrypt password before migrating since we no longer encrypt passwords in FluxC


### PR DESCRIPTION
Fix #5140: Don't migrate sites with an api_blogid set

Note: that might also skip self hosted sites that used to be jetpack sites (since this field won't be reset), but this should be limited to a very few users.