### PR TITLE
Fix #5153: Keep site ID during self-hosted site migration

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -111,7 +111,7 @@ public class WPLegacyMigrationUtils {
         List<SiteModel> siteList = new ArrayList<>();
         try {
             SQLiteDatabase db = context.getApplicationContext().openOrCreateDatabase(DEPRECATED_DATABASE_NAME, 0, null);
-            String[] fields = new String[]{"username", "password", "url", "blogId", "api_blogid"};
+            String[] fields = new String[]{"username", "password", "url", "homeURL", "blogId", "api_blogid"};
 
             // To exclude the jetpack sites we need to check for empty password
             String byString = String.format("dotcomFlag=0 AND NOT(dotcomFlag=0 AND password='%s')",
@@ -122,7 +122,7 @@ public class WPLegacyMigrationUtils {
             for (int i = 0; i < numRows; i++) {
                 // If the api_blogid field is set, that's probably a Jetpack site that is not connected to the main
                 // account, so we want to skip it.
-                if (!TextUtils.isEmpty(c.getString(4))) {
+                if (!TextUtils.isEmpty(c.getString(5))) {
                     continue;
                 }
                 SiteModel siteModel = new SiteModel();
@@ -130,10 +130,13 @@ public class WPLegacyMigrationUtils {
                 // Decrypt password before migrating since we no longer encrypt passwords in FluxC
                 String encryptedPwd = c.getString(1);
                 siteModel.setPassword(decryptPassword(encryptedPwd));
-                String url = c.getString(2);
+
+                String xmlrpcUrl = c.getString(2);
+                siteModel.setXmlRpcUrl(xmlrpcUrl);
+                String url = c.getString(3);
                 siteModel.setUrl(url);
-                siteModel.setXmlRpcUrl(url);
-                siteModel.setSelfHostedSiteId(c.getLong(3));
+
+                siteModel.setSelfHostedSiteId(c.getLong(4));
                 siteList.add(siteModel);
                 c.moveToNext();
             }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -111,7 +111,7 @@ public class WPLegacyMigrationUtils {
         List<SiteModel> siteList = new ArrayList<>();
         try {
             SQLiteDatabase db = context.getApplicationContext().openOrCreateDatabase(DEPRECATED_DATABASE_NAME, 0, null);
-            String[] fields = new String[]{"username", "password", "url", "api_blogid"};
+            String[] fields = new String[]{"username", "password", "url", "blogId", "api_blogid"};
 
             // To exclude the jetpack sites we need to check for empty password
             String byString = String.format("dotcomFlag=0 AND NOT(dotcomFlag=0 AND password='%s')",
@@ -122,7 +122,7 @@ public class WPLegacyMigrationUtils {
             for (int i = 0; i < numRows; i++) {
                 // If the api_blogid field is set, that's probably a Jetpack site that is not connected to the main
                 // account, so we want to skip it.
-                if (!TextUtils.isEmpty(c.getString(3))) {
+                if (!TextUtils.isEmpty(c.getString(4))) {
                     continue;
                 }
                 SiteModel siteModel = new SiteModel();
@@ -133,6 +133,7 @@ public class WPLegacyMigrationUtils {
                 String url = c.getString(2);
                 siteModel.setUrl(url);
                 siteModel.setXmlRpcUrl(url);
+                siteModel.setSelfHostedSiteId(c.getLong(3));
                 siteList.add(siteModel);
                 c.moveToNext();
             }


### PR DESCRIPTION
Fixes #5153, migrating multisites when switching to FluxC. Non-multisites can also have remote site ID `1`, which is being set to `0` after migration.

To test:
1. In `develop`, sign into a self-hosted (non-Jetpack) multisite
2. Switch to this branch to set off site migration
3. Check that all sites have been transferred, and they've preserved their remote site ID