### PR TITLE
Feature/aztec feature flag

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -43,12 +43,15 @@ android {
 
         multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
+
+        buildConfigField "boolean", "AZTEC_EDITOR_AVAILABLE", "false"
     }
 
     productFlavors {
         vanilla {} // used for release and beta
 
         zalpha { // alpha version - enable experimental features
+            buildConfigField "boolean", "AZTEC_EDITOR_AVAILABLE", "true"
             applicationId "org.wordpress.android"
         }
 

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -434,6 +434,19 @@
             </intent-filter>
         </activity>
 
+        <activity android:name=".ui.AztecEditorOptionsReceiver">
+            <intent-filter>
+                <data android:host="aztec"
+                    android:scheme="wordpress" />
+
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+            </intent-filter>
+        </activity>
+
         <!-- Lib activities-->
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"

--- a/WordPress/src/main/java/org/wordpress/android/ui/AztecEditorOptionsReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AztecEditorOptionsReceiver.java
@@ -29,23 +29,28 @@ public class AztecEditorOptionsReceiver extends AppCompatActivity {
             if ("1".equals(available)) {
                 AppLog.i(T.EDITOR, "Aztec Editor is now Available");
                 AppPrefs.setAztecEditorAvailable(true);
-                ToastUtils.showToast(this, R.string.aztec_editor_enabled);
             }
 
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
 
             if ("1".equals(enabled)) {
                 AppLog.i(T.EDITOR, "Aztec Editor Enabled");
+                ToastUtils.showToast(this, R.string.aztec_editor_enabled);
+
                 AppPrefs.setAztecEditorEnabled(true);
                 AppPrefs.setVisualEditorEnabled(false);
 
                 prefs.edit().putString(getString(R.string.pref_key_editor_type), "2").apply();
             } else if ("0".equals(enabled)) {
                 AppLog.i(T.EDITOR, "Aztec Editor Disabled");
+                ToastUtils.showToast(this, R.string.aztec_editor_disabled);
+
                 AppPrefs.setAztecEditorEnabled(false);
                 AppPrefs.setVisualEditorEnabled(true);
 
-                prefs.edit().putString(getString(R.string.pref_key_editor_type), "0").apply();
+                prefs.edit().putString(getString(R.string.pref_key_editor_type), "1").apply();
+            } else {
+                ToastUtils.showToast(this, R.string.aztec_editor_available);
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/AztecEditorOptionsReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AztecEditorOptionsReceiver.java
@@ -1,0 +1,57 @@
+package org.wordpress.android.ui;
+
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.support.v7.app.AppCompatActivity;
+
+import org.wordpress.android.R;
+import org.wordpress.android.ui.prefs.AppPrefs;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.ToastUtils;
+
+public class AztecEditorOptionsReceiver extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        String action = getIntent().getAction();
+        Uri uri = getIntent().getData();
+
+        if (Intent.ACTION_VIEW.equals(action) && uri != null) {
+            String available = uri.getQueryParameter("available");
+            String enabled = uri.getQueryParameter("enabled");
+
+            // Note: doesn't allow to deactivate visual editor
+            if ("1".equals(available)) {
+                AppLog.i(T.EDITOR, "Aztec Editor is now Available");
+                AppPrefs.setAztecEditorAvailable(true);
+                ToastUtils.showToast(this, R.string.aztec_editor_enabled);
+            }
+
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+
+            if ("1".equals(enabled)) {
+                AppLog.i(T.EDITOR, "Aztec Editor Enabled");
+                AppPrefs.setAztecEditorEnabled(true);
+                AppPrefs.setVisualEditorEnabled(false);
+
+                prefs.edit().putString(getString(R.string.pref_key_editor_type), "2").apply();
+            } else if ("0".equals(enabled)) {
+                AppLog.i(T.EDITOR, "Aztec Editor Disabled");
+                AppPrefs.setAztecEditorEnabled(false);
+                AppPrefs.setVisualEditorEnabled(true);
+
+                prefs.edit().putString(getString(R.string.pref_key_editor_type), "0").apply();
+            }
+        }
+
+        Intent intent = new Intent(this, WPLaunchActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(intent);
+        finish();
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/VisualEditorOptionsReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/VisualEditorOptionsReceiver.java
@@ -26,15 +26,16 @@ public class VisualEditorOptionsReceiver extends AppCompatActivity {
             if ("1".equals(available)) {
                 AppLog.i(T.EDITOR, "Visual Editor is now Available");
                 AppPrefs.setVisualEditorAvailable(true);
-                ToastUtils.showToast(this, R.string.visual_editor_enabled);
             }
 
             if ("1".equals(enabled)) {
                 AppLog.i(T.EDITOR, "Visual Editor Enabled");
                 AppPrefs.setVisualEditorEnabled(true);
+                ToastUtils.showToast(this, R.string.visual_editor_enabled);
             } else if ("0".equals(enabled)) {
                 AppLog.i(T.EDITOR, "Visual Editor Disabled");
                 AppPrefs.setVisualEditorEnabled(false);
+                ToastUtils.showToast(this, R.string.visual_editor_disabled);
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -376,7 +376,7 @@ public class AppPrefs {
     }
 
     public static boolean isAztecEditorEnabled() {
-        return isAztecEditorAvailable() && getBoolean(DeletablePrefKey.AZTEC_EDITOR_ENABLED, false);
+        return isAztecEditorAvailable() && getBoolean(DeletablePrefKey.AZTEC_EDITOR_ENABLED, true);
     }
 
     public static void setAztecEditorAvailable(boolean aztecEditorAvailable) {
@@ -387,7 +387,7 @@ public class AppPrefs {
     }
 
     public static boolean isAztecEditorAvailable() {
-        return getBoolean(UndeletablePrefKey.AZTEC_EDITOR_AVAILABLE, BuildConfig.AZTEC_EDITOR_AVAILABLE);
+        return BuildConfig.AZTEC_EDITOR_AVAILABLE || getBoolean(UndeletablePrefKey.AZTEC_EDITOR_AVAILABLE, false);
     }
 
     // Visual Editor
@@ -404,11 +404,11 @@ public class AppPrefs {
     }
 
     public static boolean isVisualEditorAvailable() {
-        return getBoolean(UndeletablePrefKey.VISUAL_EDITOR_AVAILABLE, false);
+        return getBoolean(UndeletablePrefKey.VISUAL_EDITOR_AVAILABLE, true);
     }
 
     public static boolean isVisualEditorEnabled() {
-        return isVisualEditorAvailable() && getBoolean(DeletablePrefKey.VISUAL_EDITOR_ENABLED, true);
+        return isVisualEditorAvailable() && getBoolean(DeletablePrefKey.VISUAL_EDITOR_ENABLED, !isAztecEditorEnabled());
     }
 
     public static boolean isVisualEditorPromoRequired() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -4,6 +4,7 @@ import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.text.TextUtils;
 
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
@@ -115,6 +116,9 @@ public class AppPrefs {
 
         // Same as above but for the reader
         SWIPE_TO_NAVIGATE_READER,
+
+        // aztec editor available
+        AZTEC_EDITOR_AVAILABLE,
     }
 
     private static SharedPreferences prefs() {
@@ -372,7 +376,18 @@ public class AppPrefs {
     }
 
     public static boolean isAztecEditorEnabled() {
-        return getBoolean(DeletablePrefKey.AZTEC_EDITOR_ENABLED, true);
+        return isAztecEditorAvailable() && getBoolean(DeletablePrefKey.AZTEC_EDITOR_ENABLED, false);
+    }
+
+    public static void setAztecEditorAvailable(boolean aztecEditorAvailable) {
+        setBoolean(UndeletablePrefKey.AZTEC_EDITOR_AVAILABLE, aztecEditorAvailable);
+        if (aztecEditorAvailable) {
+            AnalyticsTracker.track(Stat.EDITOR_AZTEC_ENABLED);
+        }
+    }
+
+    public static boolean isAztecEditorAvailable() {
+        return getBoolean(UndeletablePrefKey.AZTEC_EDITOR_AVAILABLE, BuildConfig.AZTEC_EDITOR_AVAILABLE);
     }
 
     // Visual Editor

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -59,7 +59,7 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
 
         mSettings = PreferenceManager.getDefaultSharedPreferences(getActivity());
 
-        updateVisualEditorSettings();
+        updateEditorSettings();
     }
 
     @Override
@@ -104,7 +104,7 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
         return super.onOptionsItemSelected(item);
     }
 
-    private void updateVisualEditorSettings() {
+    private void updateEditorSettings() {
         if (!AppPrefs.isVisualEditorAvailable()) {
             PreferenceScreen preferenceScreen = (PreferenceScreen) findPreference(getActivity()
                     .getString(R.string.pref_key_account_settings_root));
@@ -115,6 +115,13 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
             }
         } else {
             final ListPreference editorTypePreference = (ListPreference) findPreference(getActivity().getString(R.string.pref_key_editor_type));
+
+            // if Aztec unavailable, only show the old list old of editors
+            if (!AppPrefs.isAztecEditorAvailable()) {
+                editorTypePreference.setEntries(R.array.editor_entries_without_aztec);
+                editorTypePreference.setEntryValues(R.array.editor_values_without_aztec);
+            }
+
             editorTypePreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 @Override
                 public boolean onPreferenceChange(final Preference preference, final Object value) {
@@ -125,12 +132,12 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
 
                         switch (index) {
                             case 0:
-                                AppPrefs.setAztecEditorEnabled(true);
-                                AppPrefs.setVisualEditorEnabled(false);
-                                break;
-                            case 1:
                                 AppPrefs.setAztecEditorEnabled(false);
                                 AppPrefs.setVisualEditorEnabled(true);
+                                break;
+                            case 2:
+                                AppPrefs.setAztecEditorEnabled(true);
+                                AppPrefs.setVisualEditorEnabled(false);
                                 break;
                             default:
                                 AppPrefs.setAztecEditorEnabled(false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -131,7 +131,7 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
                         editorTypePreference.setSummary(entries[index]);
 
                         switch (index) {
-                            case 0:
+                            case 1:
                                 AppPrefs.setAztecEditorEnabled(false);
                                 AppPrefs.setVisualEditorEnabled(true);
                                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -116,6 +116,12 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
         } else {
             final ListPreference editorTypePreference = (ListPreference) findPreference(getActivity().getString(R.string.pref_key_editor_type));
 
+            // If user has Aztec preference from previous installation and it's not available anymore, don't use it
+            if (!AppPrefs.isAztecEditorAvailable() && "2".equals(editorTypePreference.getValue())) {
+                editorTypePreference.setValue("0");
+            }
+
+
             // if Aztec unavailable, only show the old list old of editors
             if (!AppPrefs.isAztecEditorAvailable()) {
                 editorTypePreference.setEntries(R.array.editor_entries_without_aztec);

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -172,6 +172,11 @@
         <item>2</item>
     </string-array>
 
+    <string-array name="editor_values_without_aztec">
+        <item>0</item>
+        <item>1</item>
+    </string-array>
+
     <!-- Used as values to a preference in Site Settings -->
     <string-array name="language_codes" translatable="false">
         <item>en_US</item>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -646,14 +646,14 @@
     <string name="preference_editor_type">Set editor type</string>
 
     <string-array name="editor_entries">
-        <item>Visual</item>
         <item>Legacy</item>
+        <item>Visual</item>
         <item>Aztec</item>
     </string-array>
 
     <string-array name="editor_entries_without_aztec">
-        <item>Visual</item>
         <item>Legacy</item>
+        <item>Visual</item>
     </string-array>
 
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -646,10 +646,16 @@
     <string name="preference_editor_type">Set editor type</string>
 
     <string-array name="editor_entries">
+        <item>Visual</item>
+        <item>Legacy</item>
         <item>Aztec</item>
+    </string-array>
+
+    <string-array name="editor_entries_without_aztec">
         <item>Visual</item>
         <item>Legacy</item>
     </string-array>
+
 
     <!-- stats -->
     <string name="stats">Stats</string>
@@ -948,6 +954,7 @@
     <string name="editor_page_title_placeholder">Page Title</string>
     <string name="editor_content_placeholder">Share your story here…</string>
     <string name="visual_editor_enabled">Visual Editor enabled</string>
+    <string name="aztec_editor_enabled">Aztec Editor enabled</string>
     <string name="new_editor_promo_button_label">Great, thanks!</string>
     <string name="new_editor_promo_title">Brand new editor</string>
     <string name="new_editor_promo_desc">The WordPress app for Android now includes a beautiful new visual

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -645,15 +645,19 @@
     <string name="preference_editor">Editor</string>
     <string name="preference_editor_type">Set editor type</string>
 
-    <string-array name="editor_entries">
-        <item>Legacy</item>
-        <item>Visual</item>
-        <item>Aztec</item>
+    <string name="preference_editor_legacy">Legacy</string>
+    <string name="preference_editor_visual">Visual</string>
+    <string name="preference_editor_aztec" translatable="false">Aztec</string>
+
+    <string-array name="editor_entries" translatable="false">
+        <item>@string/preference_editor_legacy</item>
+        <item>@string/preference_editor_visual</item>
+        <item>@string/preference_editor_aztec</item>
     </string-array>
 
-    <string-array name="editor_entries_without_aztec">
-        <item>Legacy</item>
-        <item>Visual</item>
+    <string-array name="editor_entries_without_aztec" translatable="false">
+        <item>@string/preference_editor_legacy</item>
+        <item>@string/preference_editor_visual</item>
     </string-array>
 
 
@@ -954,7 +958,10 @@
     <string name="editor_page_title_placeholder">Page Title</string>
     <string name="editor_content_placeholder">Share your story here…</string>
     <string name="visual_editor_enabled">Visual Editor enabled</string>
-    <string name="aztec_editor_enabled">Aztec Editor enabled</string>
+    <string name="visual_editor_disabled">Visual Editor disabled</string>
+    <string name="aztec_editor_enabled" translatable="false">Aztec Editor enabled</string>
+    <string name="aztec_editor_disabled" translatable="false">Aztec Editor disabled</string>
+    <string name="aztec_editor_available" translatable="false">Aztec Editor available</string>
     <string name="new_editor_promo_button_label">Great, thanks!</string>
     <string name="new_editor_promo_title">Brand new editor</string>
     <string name="new_editor_promo_desc">The WordPress app for Android now includes a beautiful new visual

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -29,7 +29,7 @@
             android:key="@string/pref_key_editor_type"
             android:entries="@array/editor_entries"
             android:entryValues="@array/editor_values"
-            android:defaultValue="0"
+            android:defaultValue="1"
             android:layout="@layout/preference_layout"
             android:title="@string/preference_editor_type" />
 

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -29,7 +29,7 @@
             android:key="@string/pref_key_editor_type"
             android:entries="@array/editor_entries"
             android:entryValues="@array/editor_values"
-            android:defaultValue="1"
+            android:defaultValue="2"
             android:layout="@layout/preference_layout"
             android:title="@string/preference_editor_type" />
 

--- a/WordPress/src/main/res/xml/app_settings.xml
+++ b/WordPress/src/main/res/xml/app_settings.xml
@@ -29,6 +29,7 @@
             android:key="@string/pref_key_editor_type"
             android:entries="@array/editor_entries"
             android:entryValues="@array/editor_values"
+            android:defaultValue="0"
             android:layout="@layout/preference_layout"
             android:title="@string/preference_editor_type" />
 

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -100,6 +100,7 @@ public final class AnalyticsTracker {
         EDITOR_TAPPED_UNORDERED_LIST, // Visual editor only
         EDITOR_AZTEC_TOGGLED_OFF, // Aztec editor only
         EDITOR_AZTEC_TOGGLED_ON, // Aztec editor only
+        EDITOR_AZTEC_ENABLED, // Aztec editor only
         ME_ACCESSED,
         ME_GRAVATAR_TAPPED,
         ME_GRAVATAR_TOOLTIP_TAPPED,

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     compile 'com.android.support:support-v4:25.1.1'
     compile 'com.android.support:design:25.1.1'
     compile 'org.wordpress:utils:1.11.0'
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:develop-SNAPSHOT')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v0.5.0-alpha')
 }
 
 signing {


### PR DESCRIPTION
Addresses #5154. 

Adds Aztec editor feature flag (enabled by default for the alpha release). The following URLs enable it for the other builds:
```
wordpress://aztec?available=1&enabled=1 
wordpress://aztec?available=1&enabled=0
```