### PR TITLE
FluxC: Save hidden state of site on remote

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -315,6 +315,7 @@ public class SitePickerActivity extends AppCompatActivity
     }
 
     private void updateVisibilityOfSitesOnRemote(List<SiteModel> siteList) {
+        // Example json format for the request: {"sites":{"100001":{"visible":false}}}
         JSONObject jsonObject = new JSONObject();
         try {
             JSONObject sites = new JSONObject();

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -50,6 +50,7 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.helpers.Debouncer;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -283,6 +284,7 @@ public class SitePickerActivity extends AppCompatActivity
         boolean skippedCurrentSite = false;
         String currentSiteName = null;
         SiteList hiddenSites = getAdapter().getHiddenSites();
+        List<SiteModel> siteList = new ArrayList<>();
         for (SiteRecord siteRecord : changeSet) {
             SiteModel siteModel = mSiteStore.getSiteByLocalId(siteRecord.localId);
             if (hiddenSites.contains(siteRecord)) {
@@ -299,7 +301,10 @@ public class SitePickerActivity extends AppCompatActivity
             }
             // Save the site
             mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(siteModel));
+            siteList.add(siteModel);
         }
+
+        updateVisibilityOfSitesOnRemote(siteList);
 
         // let user know the current site wasn't hidden
         if (skippedCurrentSite) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -340,17 +341,24 @@ public class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.Si
         return hiddenSites;
     }
 
-    void setVisibilityForSelectedSites(boolean makeVisible) {
+    Set<SiteRecord> setVisibilityForSelectedSites(boolean makeVisible) {
         SiteList sites = getSelectedSites();
+        Set<SiteRecord> siteRecordSet = new HashSet<>();
         if (sites != null && sites.size() > 0) {
             for (SiteRecord site: sites) {
                 int index = mAllSites.indexOfSite(site);
                 if (index > -1) {
-                    mAllSites.get(index).isHidden = !makeVisible;
+                    SiteRecord siteRecord = mAllSites.get(index);
+                    if (siteRecord.isHidden == makeVisible) {
+                        // add it to change set
+                        siteRecordSet.add(siteRecord);
+                    }
+                    siteRecord.isHidden = !makeVisible;
                 }
             }
         }
         notifyDataSetChanged();
+        return siteRecordSet;
     }
 
     void loadSites() {


### PR DESCRIPTION
Closes #5161. Although this PR is marked as FluxC, this is not actually a FluxC change. We're just making the change on the integration branch, so it's marked as is.

This PR adds the ability to save the hidden state of a site on remote. It also introduces a more efficient way of tracking changes and updating them in the DB. Both the changes on DB and the network request should be happening on the change set, rather than all sites unless the user changes the state back and forth.

To test:
* Go into site picker and change the visibility of a couple different sites. Preferably you should both hide and show different sites at the same time. 
* Easiest way to verify changes are made successfully would be sending a GET request to `me/sites` on console
* Also make sure selecting the currently selected site throws an error.

/cc @maxme 