### PR TITLE
FluxC: fix a NPE when adding Stats widget on the homescreen.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetProvider.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetProvider.java
@@ -43,8 +43,8 @@ public class StatsWidgetProvider extends AppWidgetProvider {
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        super.onReceive(context, intent);
         ((WordPress) context.getApplicationContext()).component().inject(this);
+        super.onReceive(context, intent);
     }
 
     private static void showMessage(Context context, int[] allWidgets, String message, SiteStore siteStore) {


### PR DESCRIPTION
Inject stores before the super.onReceive call - This fixes a NPE when adding Stats widget on the homescreen.