### PR TITLE
FluxC: Prevent UI from loading while migrating

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -72,7 +72,7 @@
         <activity
             android:name=".ui.WPLaunchActivity"
             android:noHistory="true"
-            android:theme="@android:style/Theme.NoDisplay">
+            android:theme="@style/NoDisplay">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -211,7 +211,7 @@ public class WordPress extends MultiDexApplication {
         sImageLoader = mImageLoader;
         sOAuthAuthenticator = mOAuthAuthenticator;
 
-        if (!mAccountStore.hasAccessToken() || !AppPrefs.isSelfHostedSitesMigratedToFluxC()) {
+        if (!AppPrefs.wasAccessTokenMigrated() || !AppPrefs.isSelfHostedSitesMigratedToFluxC()) {
             sIsMigrationInProgress = true;
             migrateAccessToken();
         }
@@ -271,7 +271,7 @@ public class WordPress extends MultiDexApplication {
 
     private void migrateAccessToken() {
         // Migrate access token AccountStore
-        if (!mAccountStore.hasAccessToken()) {
+        if (!AppPrefs.wasAccessTokenMigrated() && !mAccountStore.hasAccessToken()) {
             AppLog.i(T.DB, "No access token found in FluxC - attempting to migrate existing one");
             // It will take some time to update the access token in the AccountStore if it was migrated
             // so it will be set to the migrated token
@@ -285,6 +285,8 @@ public class WordPress extends MultiDexApplication {
                 mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
                 return;
             }
+            // Even if there was no token to migrate, turn this flag on so we don't attempt to migrate again
+            AppPrefs.setAccessTokenMigrated(true);
         }
 
         migrateSelfHostedSites();

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -213,7 +213,7 @@ public class WordPress extends MultiDexApplication {
 
         if (!mAccountStore.hasAccessToken() || !AppPrefs.isSelfHostedSitesMigratedToFluxC()) {
             sIsMigrationInProgress = true;
-            performFluxCMigration();
+            migrateAccessToken();
         }
 
         ProfilingUtils.start("App Startup");
@@ -269,7 +269,7 @@ public class WordPress extends MultiDexApplication {
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
     }
 
-    private void performFluxCMigration() {
+    private void migrateAccessToken() {
         // Migrate access token AccountStore
         if (!mAccountStore.hasAccessToken()) {
             AppLog.i(T.DB, "No access token found in FluxC - attempting to migrate existing one");

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
@@ -12,8 +12,6 @@ import org.wordpress.android.util.ProfilingUtils;
 import org.wordpress.android.util.ToastUtils;
 
 public class WPLaunchActivity extends AppCompatActivity {
-    private ProgressDialog mMigrationProgressDialog;
-
     /*
      * this the main (default) activity, which does nothing more than launch the
      * previously active activity on startup - note that it's defined in the
@@ -26,22 +24,24 @@ public class WPLaunchActivity extends AppCompatActivity {
 
         ProfilingUtils.split("WPLaunchActivity.onCreate");
 
-        mMigrationProgressDialog = new ProgressDialog(this);
-        mMigrationProgressDialog.setMessage(this.getResources().getString(R.string.migration_message));
-        mMigrationProgressDialog.setCancelable(false);
-        mMigrationProgressDialog.show();
-
-        WordPress.registerMigrationListener(new WordPress.MigrationListener() {
-            @Override
-            public void onCompletion() {
-                launchWPMainActivity();
-            }
-        });
+        if (WordPress.sIsMigrationInProgress) {
+            final ProgressDialog migrationProgressDialog = new ProgressDialog(this);
+            migrationProgressDialog.setMessage(this.getResources().getString(R.string.migration_message));
+            migrationProgressDialog.setCancelable(false);
+            migrationProgressDialog.show();
+            WordPress.registerMigrationListener(new WordPress.MigrationListener() {
+                @Override
+                public void onCompletion() {
+                    migrationProgressDialog.dismiss();
+                    launchWPMainActivity();
+                }
+            });
+        } else {
+            launchWPMainActivity();
+        }
     }
 
     private void launchWPMainActivity() {
-        mMigrationProgressDialog.dismiss();
-
         if (WordPress.wpDB == null) {
             ToastUtils.showToast(this, R.string.fatal_db_error, ToastUtils.Duration.LONG);
             finish();

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui;
 
+import android.app.ProgressDialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -11,6 +12,7 @@ import org.wordpress.android.util.ProfilingUtils;
 import org.wordpress.android.util.ToastUtils;
 
 public class WPLaunchActivity extends AppCompatActivity {
+    private ProgressDialog mMigrationProgressDialog;
 
     /*
      * this the main (default) activity, which does nothing more than launch the
@@ -23,6 +25,22 @@ public class WPLaunchActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
 
         ProfilingUtils.split("WPLaunchActivity.onCreate");
+
+        mMigrationProgressDialog = new ProgressDialog(this);
+        mMigrationProgressDialog.setMessage(this.getResources().getString(R.string.migration_message));
+        mMigrationProgressDialog.setCancelable(false);
+        mMigrationProgressDialog.show();
+
+        WordPress.registerMigrationListener(new WordPress.MigrationListener() {
+            @Override
+            public void onCompletion() {
+                launchWPMainActivity();
+            }
+        });
+    }
+
+    private void launchWPMainActivity() {
+        mMigrationProgressDialog.dismiss();
 
         if (WordPress.wpDB == null) {
             ToastUtils.showToast(this, R.string.fatal_db_error, ToastUtils.Duration.LONG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInActivity.java
@@ -27,7 +27,6 @@ import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.accounts.SmartLockHelper.Callback;
 import org.wordpress.android.ui.accounts.login.MagicLinkRequestFragment;
 import org.wordpress.android.ui.accounts.login.MagicLinkSentFragment;
-import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -82,9 +81,7 @@ public class SignInActivity extends AppCompatActivity implements ConnectionCallb
         }
 
         mSmartLockHelper = new SmartLockHelper(this);
-        if (!AppPrefs.wasAccessTokenMigrated()) {
-            mSmartLockHelper.initSmartLockForPasswords();
-        }
+        mSmartLockHelper.initSmartLockForPasswords();
 
         ActivityId.trackLastActivity(ActivityId.LOGIN);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -360,12 +360,6 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             mTwoStepEditText.setText(getAuthCodeFromClipboard());
         }
 
-        // show progress indicator while waiting for network response when migrating access token
-        if (AppPrefs.wasAccessTokenMigrated() && checkNetworkConnectivity()) {
-            startProgress(getString(R.string.access_token_migration_message));
-            return;
-        }
-
         if (!mToken.isEmpty() && !mInhibitMagicLogin) {
             mSmartLockEnabled = false;
             attemptLoginWithMagicLink();
@@ -1229,7 +1223,6 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         mAccountFetched |= event.causeOfChange == AccountAction.FETCH_ACCOUNT;
         // Finish activity if sites have been fetched
         if (mSitesFetched && mAccountSettingsFetched && mAccountFetched) {
-            updateMigrationStatusIfNeeded();
             finishCurrentActivity();
         }
     }
@@ -1241,7 +1234,6 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         if (event.isError()) {
             AnalyticsTracker.track(Stat.LOGIN_FAILED);
             showAuthError(event.error.type, event.error.message);
-            updateMigrationStatusIfNeeded();
             endProgress();
             return;
         }
@@ -1258,7 +1250,6 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         mSitesFetched = true;
         // Finish activity if account settings have been fetched or if it's a wporg site
         if (((mAccountSettingsFetched && mAccountFetched) || !isWPComLogin()) && !event.isError()) {
-            updateMigrationStatusIfNeeded();
             finishCurrentActivity();
         }
     }
@@ -1350,13 +1341,6 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             default:
                 showGenericErrorDialog(getResources().getString(R.string.nux_cannot_log_in));
                 break;
-        }
-    }
-
-    private void updateMigrationStatusIfNeeded() {
-        if (AppPrefs.wasAccessTokenMigrated()) {
-            AppPrefs.setAccessTokenMigrated(false);
-            endProgress();
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -215,8 +215,7 @@ public class WPMainActivity extends AppCompatActivity {
 
 
         if (savedInstanceState == null) {
-            if (!AppPrefs.wasAccessTokenMigrated()
-                && WPStoreUtils.isSignedInWPComOrHasWPOrgSite(mAccountStore, mSiteStore)) {
+            if (WPStoreUtils.isSignedInWPComOrHasWPOrgSite(mAccountStore, mSiteStore)) {
                 // open note detail if activity called from a push, otherwise return to the tab
                 // that was showing last time
                 boolean openedFromPush = (getIntent() != null && getIntent().getBooleanExtra(ARG_OPENED_FROM_PUSH,

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -79,9 +79,6 @@ public class AppPrefs {
         // selected site in the main activity
         SELECTED_SITE_LOCAL_ID,
 
-        // access token migrated to AccountStore, must wait for network calls to return before app access
-        ACCESS_TOKEN_MIGRATED,
-
         // wpcom ID of the last push notification received
         PUSH_NOTIFICATIONS_LAST_NOTE_ID,
 
@@ -126,6 +123,9 @@ public class AppPrefs {
 
         // Same as above but for the reader
         SWIPE_TO_NAVIGATE_READER,
+
+        // access token migrated to AccountStore, must wait for network calls to return before app access
+        ACCESS_TOKEN_MIGRATED,
 
         // Self-hosted sites migration to FluxC
         SELF_HOSTED_SITES_MIGRATED_TO_FLUXC,
@@ -486,14 +486,6 @@ public class AppPrefs {
         setInt(DeletablePrefKey.SELECTED_SITE_LOCAL_ID, selectedSite);
     }
 
-    public static boolean wasAccessTokenMigrated() {
-        return getBoolean(DeletablePrefKey.ACCESS_TOKEN_MIGRATED, false);
-    }
-
-    public static void setAccessTokenMigrated(boolean migrated) {
-        setBoolean(DeletablePrefKey.ACCESS_TOKEN_MIGRATED, migrated);
-    }
-
     public static String getLastPushNotificationWpcomNoteId() {
         return getString(DeletablePrefKey.PUSH_NOTIFICATIONS_LAST_NOTE_ID);
     }
@@ -578,6 +570,14 @@ public class AppPrefs {
         // store in prefs
         String idsAsString = TextUtils.join(",", currentIds);
         setString(DeletablePrefKey.RECENTLY_PICKED_SITE_IDS, idsAsString);
+    }
+
+    public static boolean wasAccessTokenMigrated() {
+        return getBoolean(UndeletablePrefKey.ACCESS_TOKEN_MIGRATED, false);
+    }
+
+    public static void setAccessTokenMigrated(boolean migrated) {
+        setBoolean(UndeletablePrefKey.ACCESS_TOKEN_MIGRATED, migrated);
     }
 
     public static boolean isSelfHostedSitesMigratedToFluxC() {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1373,6 +1373,8 @@
     <string name="checking_email">Checking email</string>
     <string name="not_on_wordpress_com">Not on WordPress.com?</string>
     <string name="migration_message">Migration in progress&#8230;</string>
+    <string name="migration_error_not_connected">Migration process failed: try launching the app when you have a
+        network connection.</string>
     <string name="already_logged_in_wpcom">You\'re already logged in a WordPress.com account, you can\'t add a WordPress.com site bound to another account.</string>
     <string name="already_logged_in_wpcom_same_username">You\'re already logged in your WordPress.com account. Your site should appear in the site picker, make sure it\'s not hidden.</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1373,6 +1373,7 @@
     <string name="checking_email">Checking email</string>
     <string name="not_on_wordpress_com">Not on WordPress.com?</string>
     <string name="access_token_migration_message">Updating…</string>
+    <string name="migration_message">Migration in progress&#8230;</string>
     <string name="already_logged_in_wpcom">You\'re already logged in a WordPress.com account, you can\'t add a WordPress.com site bound to another account.</string>
     <string name="already_logged_in_wpcom_same_username">You\'re already logged in your WordPress.com account. Your site should appear in the site picker, make sure it\'s not hidden.</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1372,7 +1372,6 @@
     <string name="launch_your_email_app">Launch your email app</string>
     <string name="checking_email">Checking email</string>
     <string name="not_on_wordpress_com">Not on WordPress.com?</string>
-    <string name="access_token_migration_message">Updating…</string>
     <string name="migration_message">Migration in progress&#8230;</string>
     <string name="already_logged_in_wpcom">You\'re already logged in a WordPress.com account, you can\'t add a WordPress.com site bound to another account.</string>
     <string name="already_logged_in_wpcom_same_username">You\'re already logged in your WordPress.com account. Your site should appear in the site picker, make sure it\'s not hidden.</string>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -49,6 +49,14 @@
         <item name="android:statusBarColor">@color/status_bar_tint</item>
     </style>
 
+    <style name="NoDisplay" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:colorBackgroundCacheHint">@null</item>
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowAnimationStyle">@android:style/Animation</item>
+    </style>
+
     <style name="TabBarStyle.WordPress" parent="@android:style/Widget.Holo.ActionBar.TabBar">
         <item name="android:showDividers">middle</item>
         <item name="android:divider">@drawable/tab_divider_wordpress</item>


### PR DESCRIPTION
Refactors access token and self-hosted site migration to happen in sequence, and to complete before `WPMainActivity` is launched. A progress dialog is displayed while this happens.

This is necessary on slower connections, and will also be needed for drafts migration, since any WP.com sites and all self-hosted sites need to be updated FluxC-side before the drafts can be assigned to the correct site ID in FluxC.

cc @maxme