### PR TITLE
Issue/5187 add featured image

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -174,7 +174,7 @@ public class EditPostSettingsFragment extends Fragment
         mFeaturedImageView = (NetworkImageView) mRootView.findViewById(R.id.featuredImage);
         mFeaturedImageButton = (Button) mRootView.findViewById(R.id.addFeaturedImage);
 
-        if (AppPrefs.isVisualEditorEnabled()) {
+        if (AppPrefs.isVisualEditorEnabled() || AppPrefs.isAztecEditorEnabled()) {
             registerForContextMenu(mFeaturedImageView);
             mFeaturedImageView.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -370,7 +370,7 @@ public class EditPostSettingsFragment extends Fragment
             mTagsEditText.setText(tags);
         }
 
-        if (AppPrefs.isVisualEditorEnabled()) {
+        if (AppPrefs.isVisualEditorEnabled() || AppPrefs.isAztecEditorEnabled()) {
             updateFeaturedImage(mPost.getFeaturedImageId());
         }
     }
@@ -644,7 +644,7 @@ public class EditPostSettingsFragment extends Fragment
             mPost.setJSONCategories(new JSONArray(mCategories));
         }
 
-        if (AppPrefs.isVisualEditorEnabled()) {
+        if (AppPrefs.isVisualEditorEnabled() || AppPrefs.isAztecEditorEnabled()) {
             mPost.setFeaturedImageId(mFeaturedImageId);
         }
 


### PR DESCRIPTION
### Fix
Add featured image option to post settings when using Aztec as described in https://github.com/wordpress-mobile/WordPress-Android/issues/5187.

### Test
0. Enable Aztec editor in ***Me*** > ***App Settings*** > ***Set editor type*** > ***Aztec***.
1. Go to ***Sites*** tab.
2. Tap ***Create*** floating button.
3. Tap ***Settings*** (i.e. cog) action icon.
4. Notice ***SET FEATURED IMAGE*** button.