### PR TITLE
Fix #5188: FluxC: Fix featured image in post settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -461,7 +461,10 @@ public class EditPostSettingsFragment extends Fragment
     }
 
     private void launchMediaGalleryActivity() {
-        ActivityLauncher.viewMediaGalleryPickerForSite(getActivity(), mSite);
+        Intent intent = new Intent(getActivity(), MediaGalleryPickerActivity.class);
+        intent.putExtra(WordPress.SITE, mSite);
+        intent.putExtra(MediaGalleryPickerActivity.PARAM_SELECT_ONE_ITEM, true);
+        startActivityForResult(intent, MediaGalleryPickerActivity.REQUEST_CODE);
     }
 
     private PostStatus getPostStatusForSpinnerPosition(int position) {


### PR DESCRIPTION
Fixes #5188. An earlier refactor was causing the settings fragment to launch the `MediaGalleryPickerActivity` attached to the host `EditPostActivity` instead of the fragment itself. This caused the resulting `onActivityResult()` callback to fire in the wrong place.

Note: This can't be tested if the Aztec editor is enabled until the changes in https://github.com/wordpress-mobile/WordPress-Android/pull/5189 are merged into the FluxC branch.

To test:
1. Open a post
2. Visit the post settings page
3. Insert a featured image
4. Notice it appears in the post settings screen instead of being added to the post content
