### PR TITLE
Fix #5199: FluxC - Persist post settings changes for local drafts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -150,6 +150,7 @@ public class PostUtils {
                 && StringUtils.equals(oldPost.getPassword(), newPost.getPassword())
                 && StringUtils.equals(oldPost.getPostFormat(), newPost.getPostFormat())
                 && StringUtils.equals(oldPost.getDateCreated(), newPost.getDateCreated())
+                && oldPost.getFeaturedImageId() == newPost.getFeaturedImageId()
                 && oldPost.getTagNameList().containsAll(newPost.getTagNameList())
                 && newPost.getTagNameList().containsAll(oldPost.getTagNameList())
                 && oldPost.getCategoryIdList().containsAll(newPost.getCategoryIdList())

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -23,8 +23,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.wordpress.android.util.StringUtils.notNullStr;
-
 public class PostUtils {
     private static final int MAX_EXCERPT_LEN = 150;
 
@@ -231,15 +229,7 @@ public class PostUtils {
             PostModel newPost = rhs.get(i);
             PostModel currentPost = lhs.get(i);
 
-            boolean postsAreEqual = newPost.getRemotePostId() == currentPost.getRemotePostId()
-                    && newPost.isLocalDraft() == currentPost.isLocalDraft()
-                    && newPost.isLocallyChanged() == currentPost.isLocallyChanged()
-                    && notNullStr(newPost.getTitle()).equals(notNullStr(currentPost.getTitle()))
-                    && notNullStr(newPost.getContent()).equals(notNullStr(currentPost.getContent()))
-                    && notNullStr(newPost.getDateCreated()).equals(notNullStr(currentPost.getDateCreated()))
-                    && notNullStr(newPost.getStatus()).equals(notNullStr(currentPost.getStatus()));
-
-            if (!postsAreEqual) {
+            if (!newPost.equals(currentPost)) {
                 return false;
             }
         }


### PR DESCRIPTION
Fixes #5199.

To test:
1. Open an existing draft, or a post with local changes, in the editor
2. Open post settings and change something (and nothing else)
3. Exit the editor
4. Re-open the same post and open post settings again
5. All changes should be persisted
