### PR TITLE
Fix #5181: Migrate drafts and local changes to FluxC

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -229,7 +229,8 @@ public class WordPress extends MultiDexApplication {
         if ((!AppPrefs.wasAccessTokenMigrated() || !AppPrefs.wereSelfHostedSitesMigratedToFluxC()
             || !AppPrefs.wereDraftsMigratedToFluxC())
             && (WPLegacyMigrationUtils.hasSelfHostedSiteToMigrate(this)
-                || WPLegacyMigrationUtils.getLatestDeprecatedAccessToken(this) != null)) {
+                || WPLegacyMigrationUtils.getLatestDeprecatedAccessToken(this) != null
+                || WPLegacyMigrationUtils.hasDraftsToMigrate(this))) {
             sIsMigrationInProgress = true;
 
             // No connection? Then exit and ask the user to come back.

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -44,6 +44,7 @@ import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
+import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
@@ -116,6 +117,7 @@ public class WordPress extends MultiDexApplication {
     @Inject Dispatcher mDispatcher;
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
+    @Inject PostStore mPostStore;
 
     @Inject @Named("custom-ssl") RequestQueue mRequestQueue;
     public static RequestQueue sRequestQueue;

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -326,6 +326,7 @@ public class WordPress extends MultiDexApplication {
             List<SiteModel> siteList = WPLegacyMigrationUtils.migrateSelfHostedSitesFromDeprecatedDB(this, mDispatcher);
             if (siteList != null && !siteList.isEmpty()) {
                 AppLog.i(T.DB, "Finished migrating " + siteList.size() + " self-hosted sites - fetching site info");
+                AppPrefs.setSelfHostedSitesMigratedToFluxC(true);
                 mRemainingSelfHostedSitesToFetch = siteList.size();
                 for (SiteModel siteModel : siteList) {
                     mDispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(siteModel));
@@ -333,8 +334,8 @@ public class WordPress extends MultiDexApplication {
                 return;
             } else {
                 AppLog.i(T.DB, "No self-hosted sites to migrate");
+                AppPrefs.setSelfHostedSitesMigratedToFluxC(true);
             }
-            AppPrefs.setSelfHostedSitesMigratedToFluxC(true);
         } else {
             AppLog.i(T.DB, "Self-hosted sites have already been migrated");
         }

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -224,7 +224,7 @@ public class WordPress extends MultiDexApplication {
         sOAuthAuthenticator = mOAuthAuthenticator;
 
         // If the migration was not done and if we have something to migrate
-        if ((!AppPrefs.wasAccessTokenMigrated() || !AppPrefs.isSelfHostedSitesMigratedToFluxC())
+        if ((!AppPrefs.wasAccessTokenMigrated() || !AppPrefs.wereSelfHostedSitesMigratedToFluxC())
             && (WPLegacyMigrationUtils.hasSelfHostedSiteToMigrate(this)
                 || WPLegacyMigrationUtils.getLatestDeprecatedAccessToken(this) != null)) {
             sIsMigrationInProgress = true;
@@ -318,7 +318,7 @@ public class WordPress extends MultiDexApplication {
     }
 
     private void migrateSelfHostedSites() {
-        if (!AppPrefs.isSelfHostedSitesMigratedToFluxC()) {
+        if (!AppPrefs.wereSelfHostedSitesMigratedToFluxC()) {
             List<SiteModel> siteList = WPLegacyMigrationUtils.migrateSelfHostedSitesFromDeprecatedDB(this, mDispatcher);
             if (siteList != null && !siteList.isEmpty()) {
                 AppLog.i(T.DB, "Finished migrating " + siteList.size() + " self-hosted sites - fetching site info");

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -583,12 +583,13 @@ public class AppPrefs {
         setBoolean(UndeletablePrefKey.ACCESS_TOKEN_MIGRATED, migrated);
     }
 
-    public static boolean isSelfHostedSitesMigratedToFluxC() {
+    public static boolean wereSelfHostedSitesMigratedToFluxC() {
         return getBoolean(UndeletablePrefKey.SELF_HOSTED_SITES_MIGRATED_TO_FLUXC, false);
     }
 
-    public static void setSelfHostedSitesMigratedToFluxC(boolean alreadyShown) {
-        setBoolean(UndeletablePrefKey.SELF_HOSTED_SITES_MIGRATED_TO_FLUXC, alreadyShown);
+    public static void setSelfHostedSitesMigratedToFluxC(boolean migrated) {
+        setBoolean(UndeletablePrefKey.SELF_HOSTED_SITES_MIGRATED_TO_FLUXC, migrated);
+    }
 
     public static boolean wereDraftsMigratedToFluxC() {
         return getBoolean(UndeletablePrefKey.DRAFTS_MIGRATED_TO_FLUXC, false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -130,6 +130,9 @@ public class AppPrefs {
         // Self-hosted sites migration to FluxC
         SELF_HOSTED_SITES_MIGRATED_TO_FLUXC,
 
+        // Draft migration to FluxC
+        DRAFTS_MIGRATED_TO_FLUXC,
+
         // aztec editor available
         AZTEC_EDITOR_AVAILABLE,
     }
@@ -586,5 +589,12 @@ public class AppPrefs {
 
     public static void setSelfHostedSitesMigratedToFluxC(boolean alreadyShown) {
         setBoolean(UndeletablePrefKey.SELF_HOSTED_SITES_MIGRATED_TO_FLUXC, alreadyShown);
+
+    public static boolean wereDraftsMigratedToFluxC() {
+        return getBoolean(UndeletablePrefKey.DRAFTS_MIGRATED_TO_FLUXC, false);
+    }
+
+    public static void setDraftsMigratedToFluxC(boolean migrated) {
+        setBoolean(UndeletablePrefKey.DRAFTS_MIGRATED_TO_FLUXC, migrated);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -41,7 +41,6 @@ public class WPLegacyMigrationUtils {
     /**
      * Moves an existing access token from a previous version of WPAndroid into FluxC's AccountStore.
      * The access token has historically existed in preferences and two DB tables.
-     * The existing access token is deleted if found.
      */
     public static String migrateAccessTokenToAccountStore(Context context, Dispatcher dispatcher) {
         String token = getLatestDeprecatedAccessToken(context);

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -185,6 +185,23 @@ public class WPLegacyMigrationUtils {
         return siteList;
     }
 
+    public static boolean hasDraftsToMigrate(Context context) {
+        try {
+            SQLiteDatabase db = context.getApplicationContext().openOrCreateDatabase(DEPRECATED_DATABASE_NAME, 0, null);
+
+            String byString = "localDraft=1 OR isLocalChange=1";
+            Cursor c = db.query(DEPRECATED_POSTS_TABLE, null, byString, null, null, null, null);
+            if (c.getCount() > 0) {
+                c.close();
+                return true;
+            }
+            c.close();
+            return false;
+        } catch (SQLException e) {
+            return false;
+        }
+    }
+
     private static List<PostModel> getDraftsFromDeprecatedDB(Context context, SiteStore siteStore) {
         List<PostModel> postList = new ArrayList<>();
         try {

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -12,9 +12,12 @@ import android.util.Base64;
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
+import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
+import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.util.AppLog.T;
 
 import java.util.ArrayList;
@@ -39,6 +42,7 @@ public class WPLegacyMigrationUtils {
     private static final String DEPRECATED_ACCESS_TOKEN_COLUMN = "access_token";
     private static final String DEPRECATED_ACCESS_TOKEN_PREFERENCE = "wp_pref_wpcom_access_token";
     private static final String DEPRECATED_BLOGS_TABLE = "accounts";
+    private static final String DEPRECATED_POSTS_TABLE = "posts";
 
     private static final String DEPRECATED_DB_PASSWORD_SECRET = BuildConfig.DB_SECRET;
 
@@ -64,6 +68,18 @@ public class WPLegacyMigrationUtils {
             }
         }
         return siteList;
+    }
+
+    public static void migrateDraftsFromDeprecatedDB(Context context, Dispatcher dispatcher, SiteStore siteStore) {
+        List<PostModel> postList = getDraftsFromDeprecatedDB(context, siteStore);
+        if (postList != null) {
+            AppLog.i(T.DB, "Starting migration of " + postList.size() + " drafts to FluxC");
+            for (PostModel postModel : postList) {
+                AppLog.i(T.DB, "Migrating draft with title: " + postModel.getTitle()
+                        + " and local site ID: " + postModel.getLocalSiteId());
+                dispatcher.dispatch(PostActionBuilder.newUpdatePostAction(postModel));
+            }
+        }
     }
 
     private static String getDeprecatedPreferencesAccessToken(Context context) {
@@ -160,6 +176,101 @@ public class WPLegacyMigrationUtils {
             // DB doesn't exist
         }
         return siteList;
+    }
+
+    private static List<PostModel> getDraftsFromDeprecatedDB(Context context, SiteStore siteStore) {
+        List<PostModel> postList = new ArrayList<>();
+        try {
+            SQLiteDatabase db = context.getApplicationContext().openOrCreateDatabase(DEPRECATED_DATABASE_NAME, 0, null);
+
+            String byString = "localDraft=1 OR isLocalChange=1";
+            Cursor c = db.query(DEPRECATED_POSTS_TABLE, null, byString, null, null, null, null);
+            int numRows = c.getCount();
+            c.moveToFirst();
+            for (int i = 0; i < numRows; i++) {
+                PostModel postModel = new PostModel();
+
+                Cursor siteCursor = db.query(DEPRECATED_BLOGS_TABLE, new String[]{"dotcomFlag","blogId","url"},
+                        String.format("id=%s", c.getInt(c.getColumnIndex("blogID"))), null, null, null, null);
+
+                if (siteCursor.getCount() > 0) {
+                    siteCursor.moveToFirst();
+
+                    boolean dotcomFlag = siteCursor.getInt(0) == 1;
+                    int blogId = siteCursor.getInt(1);
+                    String xmlrpcUrl = siteCursor.getString(2);
+
+                    int migratedSiteLocalId;
+                    if (dotcomFlag) {
+                        // WP.com site - identify it by WP.com site ID
+                        migratedSiteLocalId = siteStore.getLocalIdForRemoteSiteId(blogId);
+                    } else {
+                        // Self-hosted site - identify it by its self-hosted site ID and XML-RPC URL
+                        migratedSiteLocalId = siteStore.getLocalIdForSelfHostedSiteIdAndXmlRpcUrl(blogId,
+                                xmlrpcUrl);
+                    }
+                    postModel.setLocalSiteId(migratedSiteLocalId);
+                    siteCursor.close();
+                } else {
+                    AppLog.i(T.DB, "Couldn't find site corresponding to draft in deprecated DB! " +
+                            "Site local id " + c.getInt(c.getColumnIndex("blogId")) +
+                            " - Post title: " + c.getString(c.getColumnIndex("title")));
+                    siteCursor.close();
+                    continue;
+                }
+
+                postModel.setIsLocalDraft(SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("localDraft"))));
+                postModel.setIsLocallyChanged(SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("isLocalChange"))));
+
+                if (!c.getString(c.getColumnIndex("postid")).equals("")) {
+                    postModel.setRemotePostId(Long.valueOf(c.getString(c.getColumnIndex("postid"))));
+                }
+
+                postModel.setTitle(StringUtils.unescapeHTML(c.getString(c.getColumnIndex("title"))));
+
+                String descriptionText = c.getString(c.getColumnIndex("description"));
+                String moreText = c.getString(c.getColumnIndex("mt_text_more"));
+                if (TextUtils.isEmpty(moreText)) {
+                    postModel.setContent(descriptionText);
+                } else {
+                    postModel.setContent(descriptionText + "\n<!--more-->\n" + moreText);
+                }
+
+                long dateCreated = c.getLong(c.getColumnIndex("date_created_gmt"));
+                if (dateCreated > 0) {
+                    postModel.setDateCreated(DateTimeUtils.iso8601UTCFromTimestamp(dateCreated / 1000));
+                }
+
+                long dateLocallyChanged = c.getLong(c.getColumnIndex("dateLastUpdated"));
+                if (dateLocallyChanged > 0) {
+                    postModel.setDateLocallyChanged(DateTimeUtils.iso8601UTCFromTimestamp(dateLocallyChanged / 1000));
+                }
+
+                postModel.setExcerpt(c.getString(c.getColumnIndex("mt_excerpt")));
+                postModel.setFeaturedImageId(c.getLong(c.getColumnIndex("wp_post_thumbnail")));
+                postModel.setLink(c.getString(c.getColumnIndex("link")));
+                postModel.setTagNames(c.getString(c.getColumnIndex("mt_keywords")));
+                postModel.setStatus(c.getString(c.getColumnIndex("post_status")));
+                postModel.setPassword(c.getString(c.getColumnIndex("wp_password")));
+                postModel.setPostFormat(c.getString(c.getColumnIndex("wp_post_format")));
+                postModel.setIsPage(SqlUtils.sqlToBool(c.getInt(c.getColumnIndex("isPage"))));
+
+                int latColumnIndex = c.getColumnIndex("latitude");
+                int lngColumnIndex = c.getColumnIndex("longitude");
+                if (!c.isNull(latColumnIndex) && !c.isNull(lngColumnIndex)) {
+                    postModel.setLocation(c.getDouble(latColumnIndex), c.getDouble(lngColumnIndex));
+                }
+
+                postModel.setCustomFields(c.getString(c.getColumnIndex("custom_fields")));
+
+                postList.add(postModel);
+                c.moveToNext();
+            }
+            c.close();
+        } catch (SQLException e) {
+            // DB doesn't exist
+        }
+        return postList;
     }
 
     private static String encryptPassword(String clearText) {

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -28,15 +28,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.DESKeySpec;
 
-/**
- * {@link #migrateAccessTokenToAccountStore(Context, Dispatcher)} moves an existing access token from a previous version
- * of WPAndroid into {@link AccountStore}. The access token has historically existed in preferences and two DB tables.
- * The existing access token is deleted if found.
- */
 public class WPLegacyMigrationUtils {
-    //
-    // WPStores Access Token migration
-    //
     private static final String DEPRECATED_DATABASE_NAME = "wordpress";
     private static final String DEPRECATED_ACCOUNT_TABLE = "tbl_accounts";
     private static final String DEPRECATED_ACCESS_TOKEN_COLUMN = "access_token";
@@ -46,6 +38,11 @@ public class WPLegacyMigrationUtils {
 
     private static final String DEPRECATED_DB_PASSWORD_SECRET = BuildConfig.DB_SECRET;
 
+    /**
+     * Moves an existing access token from a previous version of WPAndroid into FluxC's AccountStore.
+     * The access token has historically existed in preferences and two DB tables.
+     * The existing access token is deleted if found.
+     */
     public static String migrateAccessTokenToAccountStore(Context context, Dispatcher dispatcher) {
         String token = getLatestDeprecatedAccessToken(context);
 
@@ -57,6 +54,12 @@ public class WPLegacyMigrationUtils {
         return token;
     }
 
+    /**
+     * Copies existing self-hosted sites from a previous version of WPAndroid into FluxC's SiteStore.
+     * Any Jetpack sites are ignored - those connected to the logged-in WP.com account will be pulled through the
+     * REST API after migration. Other Jetpack sites will not be migrated.
+     * Existing sites are retained in the deprecated accounts table after migration.
+     */
     public static List<SiteModel> migrateSelfHostedSitesFromDeprecatedDB(Context context, Dispatcher dispatcher) {
         List<SiteModel> siteList = getSelfHostedSitesFromDeprecatedDB(context);
         if (siteList != null) {
@@ -70,6 +73,10 @@ public class WPLegacyMigrationUtils {
         return siteList;
     }
 
+    /**
+     * Copies existing drafts and locally changed posts from a previous version of WPAndroid into FluxC's PostStore.
+     * Existing posts are retained in the deprecated posts table after migration.
+     */
     public static void migrateDraftsFromDeprecatedDB(Context context, Dispatcher dispatcher, SiteStore siteStore) {
         List<PostModel> postList = getDraftsFromDeprecatedDB(context, siteStore);
         if (postList != null) {

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -190,7 +190,8 @@ public class WPLegacyMigrationUtils {
             for (int i = 0; i < numRows; i++) {
                 PostModel postModel = new PostModel();
 
-                Cursor siteCursor = db.query(DEPRECATED_BLOGS_TABLE, new String[]{"dotcomFlag","blogId","url"},
+                Cursor siteCursor = db.query(DEPRECATED_BLOGS_TABLE,
+                        new String[]{"dotcomFlag","blogId","url","api_blogid"},
                         String.format("id=%s", c.getInt(c.getColumnIndex("blogID"))), null, null, null, null);
 
                 if (siteCursor.getCount() > 0) {
@@ -199,11 +200,15 @@ public class WPLegacyMigrationUtils {
                     boolean dotcomFlag = siteCursor.getInt(0) == 1;
                     int blogId = siteCursor.getInt(1);
                     String xmlrpcUrl = siteCursor.getString(2);
+                    String apiBlogId = siteCursor.getString(3);
 
                     int migratedSiteLocalId;
                     if (dotcomFlag) {
                         // WP.com site - identify it by WP.com site ID
                         migratedSiteLocalId = siteStore.getLocalIdForRemoteSiteId(blogId);
+                    } else if (!TextUtils.isEmpty(apiBlogId)) {
+                        // Jetpack site - identify it by WP.com site ID
+                        migratedSiteLocalId = siteStore.getLocalIdForRemoteSiteId(Long.valueOf(apiBlogId));
                     } else {
                         // Self-hosted site - identify it by its self-hosted site ID and XML-RPC URL
                         migratedSiteLocalId = siteStore.getLocalIdForSelfHostedSiteIdAndXmlRpcUrl(blogId,


### PR DESCRIPTION
Fixes #5181, migrating draft posts and local changes to FluxC.

A few caveats:
1. Any drafts for Jetpack sites connected to a different WP.com account than the current one are not migrated (since the sites themselves are not migrated)
2. Any changes to categories aren't migrated
3. The process of looking up the site from the `accounts` table given the id in the post is pretty inefficient - I didn't want to spend to much time on this given that this is a one-off and most people aren't going to have many drafts

This also fixes an existing issue with migration in 989610a - the `SELF_HOSTED_SITES_MIGRATED_TO_FLUXC` key wasn't being flipped on when self-hosted sites were migrated.