### PR TITLE
Show a toast message if the detected site is a duplicate and endProgress on error

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -61,10 +61,10 @@ import org.wordpress.android.fluxc.store.AccountStore.OnDiscoveryResponse;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.RefreshSitesXMLRPCPayload;
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.notifications.services.NotificationsUpdateService;
-import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -1244,6 +1244,17 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteChanged(OnSiteChanged event) {
         AppLog.i(T.NUX, event.toString());
+
+        if (event.isError()) {
+            endProgress();
+            if (!isAdded()) {
+                return;
+            }
+            if (event.error.type == SiteErrorType.DUPLICATE_SITE) {
+                ToastUtils.showToast(getContext(), R.string.cannot_add_duplicate_site);
+            }
+            return;
+        }
 
         // Login Successful
         trackAnalyticsSignIn();

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1357,6 +1357,7 @@
         network connection.</string>
     <string name="already_logged_in_wpcom">You\'re already logged in a WordPress.com account, you can\'t add a WordPress.com site bound to another account.</string>
     <string name="already_logged_in_wpcom_same_username">You\'re already logged in your WordPress.com account. Your site should appear in the site picker, make sure it\'s not hidden.</string>
+    <string name="cannot_add_duplicate_site">This site already exists in the app, you can\'t add it.</string>
 
     <!-- Help view -->
     <string name="help">Help</string>


### PR DESCRIPTION
Note: this doesn't fix #5201 which is a FluxC issue (we need to compare the XMLRPC url without the scheme part).

Opened an issue on FluxC: https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/317