### PR TITLE
Make sure media services were bound and state reset on unbind

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -706,12 +706,14 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     private void doUnbindDeleteService() {
         if (mDeleteServiceBound) {
             unbindService(mDeleteConnection);
+            mDeleteServiceBound = false;
         }
     }
 
     private void doUnbindUploadService() {
         if (mUploadServiceBound) {
             unbindService(mUploadConnection);
+            mUploadServiceBound = false;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -694,13 +694,13 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     };
 
     private void doBindDeleteService(Intent intent) {
-        bindService(intent, mDeleteConnection, Context.BIND_AUTO_CREATE | Context.BIND_ABOVE_CLIENT);
-        mDeleteServiceBound = true;
+        mDeleteServiceBound = bindService(intent, mDeleteConnection,
+                Context.BIND_AUTO_CREATE | Context.BIND_ABOVE_CLIENT);
     }
 
     private void doBindUploadService(Intent intent) {
-        bindService(intent, mUploadConnection, Context.BIND_AUTO_CREATE | Context.BIND_ABOVE_CLIENT);
-        mUploadServiceBound = true;
+        mUploadServiceBound = bindService(intent, mUploadConnection,
+                Context.BIND_AUTO_CREATE | Context.BIND_ABOVE_CLIENT);
     }
 
     private void doUnbindDeleteService() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1860,6 +1860,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     private void doUnbindUploadService() {
         if (mUploadServiceBound) {
             unbindService(mUploadConnection);
+            mUploadServiceBound = false;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1853,8 +1853,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
 
     private void doBindUploadService(Intent intent) {
-        bindService(intent, mUploadConnection, Context.BIND_AUTO_CREATE | Context.BIND_ABOVE_CLIENT);
-        mUploadServiceBound = true;
+        mUploadServiceBound = bindService(intent, mUploadConnection,
+                Context.BIND_AUTO_CREATE | Context.BIND_ABOVE_CLIENT);
     }
 
     private void doUnbindUploadService() {


### PR DESCRIPTION
Note this is a bit different from the doc https://developer.android.com/reference/android/app/Service.html#LocalServiceSample  (we use the return value from `bindService()` call).
