### PR TITLE
Only unbindService during the onDestroy call

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -430,14 +430,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     }
 
     @Override
-    public void onStop() {
-        if (mUploadService != null) {
-            unbindService(mUploadConnection);
-        }
-        super.onStop();
-    }
-
-    @Override
     protected void onPause() {
         super.onPause();
 


### PR DESCRIPTION
I forgot to remove the `unbindService()` call in previous patch