### PR TITLE
Remove extra and unecessary check when trying to upload post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -152,7 +152,7 @@ public class MediaUploadService extends Service {
             uploadNextInQueue();
         } else if (event.completed) {
             // Upload completed
-            AppLog.i(T.MEDIA, event.media.getTitle() + " uploaded!");
+            AppLog.i(T.MEDIA, "Upload completed - localId=" + event.media.getId() + " title=" + event.media.getTitle());
             if (mListener != null) {
                 mListener.onUploadSuccess(event.media);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -629,8 +629,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         }
 
         // Disable format bar buttons while a media upload is in progress
-        if (!mMediaStore.getLocalSiteMedia(mSite).isEmpty() || mEditorFragment.isUploadingMedia() ||
-                mEditorFragment.isActionInProgress()) {
+        if (mEditorFragment.isUploadingMedia() || mEditorFragment.isActionInProgress()) {
             ToastUtils.showToast(this, R.string.editor_toast_uploading_please_wait, Duration.SHORT);
             return false;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1807,6 +1807,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         }
 
         MediaModel media = mMediaStore.instantiateMediaModel();
+        AppLog.i(T.MEDIA, "New media instantiated localId=" + media.getId());
         String filename = org.wordpress.android.fluxc.utils.MediaUtils.getFileName(path);
         String fileExtension = org.wordpress.android.fluxc.utils.MediaUtils.getExtension(path);
 


### PR DESCRIPTION
Remove a test preventing post uploads when upload error occured in another post from the same site.

Also add some AppLog calls I found useful when debugging uploads.