### PR TITLE
Fix #5179: fix video upload in the editor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1851,8 +1851,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             filename += "." + fileExtension;
         }
 
-        boolean isVideo = mimeType.startsWith("video");
-        if (isVideo) {
+        if (org.wordpress.android.fluxc.utils.MediaUtils.isVideoMimeType(mimeType)) {
             media.setThumbnailUrl(getVideoThumbnail(path));
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1784,7 +1784,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     }
 
     private String getVideoThumbnail(String videoPath) {
-        String thumbnailPath = "drawable://" + R.drawable.media_image_placeholder;
+        String thumbnailPath = null;
         try {
             File outputFile = File.createTempFile("thumb", ".png", getCacheDir());
             FileOutputStream outputStream = new FileOutputStream(outputFile);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1795,7 +1795,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 thumbnailPath = outputFile.getAbsolutePath();
             }
         } catch (IOException e) {
-            // no op
+            AppLog.i(T.MEDIA, "Can't create thumbnail for video: " + videoPath);
         }
         return thumbnailPath;
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -54,6 +54,7 @@ public class FluxCUtils {
         mediaFile.setDescription(media.getDescription());
         mediaFile.setCaption(media.getCaption());
         mediaFile.setUploadState(media.getUploadState());
+        mediaFile.setVideo(media.getMimeType().startsWith("video"));
         return mediaFile;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -33,6 +33,7 @@ public class FluxCUtils {
         mediaModel.setId(file.getId());
         mediaModel.setUploadState(file.getUploadState());
         mediaModel.setLocalSiteId(Integer.valueOf(file.getBlogId()));
+        mediaModel.setVideoPressGuid(ShortcodeUtils.getVideoPressIdFromShortCode(file.getVideoPressShortCode()));
         return mediaModel;
     }
 
@@ -55,6 +56,7 @@ public class FluxCUtils {
         mediaFile.setCaption(media.getCaption());
         mediaFile.setUploadState(media.getUploadState());
         mediaFile.setVideo(media.getMimeType().startsWith("video"));
+        mediaFile.setVideoPressShortCode(ShortcodeUtils.getVideoPressShortcodeFromId(media.getVideoPressGuid()));
         return mediaFile;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -55,7 +55,7 @@ public class FluxCUtils {
         mediaFile.setDescription(media.getDescription());
         mediaFile.setCaption(media.getCaption());
         mediaFile.setUploadState(media.getUploadState());
-        mediaFile.setVideo(media.getMimeType().startsWith("video"));
+        mediaFile.setVideo(org.wordpress.android.fluxc.utils.MediaUtils.isVideoMimeType(media.getMimeType()));
         mediaFile.setVideoPressShortCode(ShortcodeUtils.getVideoPressShortcodeFromId(media.getVideoPressGuid()));
         return mediaFile;
     }


### PR DESCRIPTION
Fix #5179: fix video upload in the editor

Set the correct Thumbnail (or make sure the editor set its own placeholder). Also make sure the `fromMediaModel` and `fromMediaFile` utils convert the required fields for video handling.