### PR TITLE
Default post's dateLastUpdated to zero if the dateLocallyChanged field is not set

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/PendingDraftsNotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/PendingDraftsNotificationsUtils.java
@@ -4,6 +4,7 @@ import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.text.TextUtils;
 
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.push.GCMMessageService;
@@ -45,7 +46,10 @@ public class PendingDraftsNotificationsUtils {
         long one_week_ago = now - NotificationsPendingDraftsReceiver.ONE_WEEK;
         long one_month_ago = now - NotificationsPendingDraftsReceiver.ONE_MONTH;
 
-        long dateLastUpdated = DateTimeUtils.timestampFromIso8601(post.getDateLocallyChanged());
+        long dateLastUpdated = 0;
+        if (!TextUtils.isEmpty(post.getDateLocallyChanged())) {
+            dateLastUpdated = DateTimeUtils.timestampFromIso8601(post.getDateLocallyChanged());
+        }
 
         // set alarms for one day + one week + one month if just over a day but less than a week,
         // set alarms for a week and another for a month, if over a week but less than a month

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/PendingDraftsNotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/PendingDraftsNotificationsUtils.java
@@ -4,7 +4,6 @@ import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.text.TextUtils;
 
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.push.GCMMessageService;
@@ -46,10 +45,7 @@ public class PendingDraftsNotificationsUtils {
         long one_week_ago = now - NotificationsPendingDraftsReceiver.ONE_WEEK;
         long one_month_ago = now - NotificationsPendingDraftsReceiver.ONE_MONTH;
 
-        long dateLastUpdated = 0;
-        if (!TextUtils.isEmpty(post.getDateLocallyChanged())) {
-            dateLastUpdated = DateTimeUtils.timestampFromIso8601(post.getDateLocallyChanged());
-        }
+        long dateLastUpdated = DateTimeUtils.timestampFromIso8601(post.getDateLocallyChanged());
 
         // set alarms for one day + one week + one month if just over a day but less than a week,
         // set alarms for a week and another for a month, if over a week but less than a month

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/DateTimeUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/DateTimeUtils.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.util;
 
 import android.content.Context;
+import android.text.TextUtils;
 import android.text.format.DateUtils;
 
 import java.text.DateFormat;
@@ -201,18 +202,23 @@ public class DateTimeUtils {
      * Given an ISO 8601-formatted date as a String, returns the corresponding UNIX timestamp.
      */
     public static long timestampFromIso8601(final String strDate) {
-        return (timestampFromIso8601Millis(strDate) / 1000);
+        return timestampFromIso8601Millis(strDate) / 1000;
     }
 
     /**
      * Given an ISO 8601-formatted date as a String, returns the corresponding timestamp in milliseconds.
+     *
+     * @return 0 if the parameter is null, empty or not a date.
      */
     public static long timestampFromIso8601Millis(final String strDate) {
+        if (TextUtils.isEmpty(strDate)) {
+            return 0;
+        }
         Date date = dateFromIso8601(strDate);
         if (date == null) {
             return 0;
         }
-        return (date.getTime());
+        return date.getTime();
     }
 
     /**


### PR DESCRIPTION
Fix the following crash:

```
02-21 06:52:11.297  2301  2301 E AndroidRuntime: java.lang.RuntimeException: Unable to start receiver org.wordpress.android.ui.notifications.receivers.NotificationsPendingDraftsReceiver: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.length()' on a null object reference
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at android.app.ActivityThread.handleReceiver(ActivityThread.java:3018)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at android.app.ActivityThread.-wrap18(ActivityThread.java)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1544)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:102)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:154)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:6077)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:865)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:755)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.length()' on a null object reference
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at java.text.SimpleDateFormat.parseInternal(SimpleDateFormat.java:1436)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at java.text.SimpleDateFormat.parse(SimpleDateFormat.java:1424)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at java.text.DateFormat.parse(DateFormat.java:356)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at org.wordpress.android.util.DateTimeUtils.dateFromIso8601(DateTimeUtils.java:78)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at org.wordpress.android.util.DateTimeUtils.timestampFromIso8601Millis(DateTimeUtils.java:211)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at org.wordpress.android.util.DateTimeUtils.timestampFromIso8601(DateTimeUtils.java:204)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at org.wordpress.android.ui.notifications.utils.PendingDraftsNotificationsUtils.scheduleNextNotifications(PendingDraftsNotificationsUtils.java:48)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at org.wordpress.android.ui.notifications.receivers.NotificationsPendingDraftsReceiver.onReceive(NotificationsPendingDraftsReceiver.java:61)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	at android.app.ActivityThread.handleReceiver(ActivityThread.java:3011)
02-21 06:52:11.297  2301  2301 E AndroidRuntime: 	... 8 more
````