### PR TITLE
feature/fluxc-missing-reader-toolbuttons

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -516,7 +516,7 @@ public class ReaderPostListFragment extends Fragment
                 getResources().getDimensionPixelSize(R.dimen.margin_extra_large) + spacingHorizontal);
 
         // add a menu to the filtered recycler's toolbar
-        if (!mAccountStore.hasAccessToken() && (getPostListType() == ReaderPostListType.TAG_FOLLOWED ||
+        if (mAccountStore.hasAccessToken() && (getPostListType() == ReaderPostListType.TAG_FOLLOWED ||
                 getPostListType() == ReaderPostListType.SEARCH_RESULTS)) {
             setupRecyclerToolbar();
         }


### PR DESCRIPTION
Fixes a simple logic error that prevented the reader toolbar from appearing. The buttons should appear as they do on the left, but in `fluxc-integration` they were missing.

![missing toolbuttons](https://cloud.githubusercontent.com/assets/3903757/23172444/c5482186-f823-11e6-83c5-8c6c7a18eff1.png)
