### PR TITLE
Fix #5210: FluxC gallery support

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -305,7 +305,7 @@ public class ActivityLauncher {
         if (!mediaIds.isEmpty()) {
             intent.putExtra(MediaGalleryPickerActivity.PARAM_SELECTED_IDS, ListUtils.toLongArray(mediaIds));
         }
-        activity.startActivityForResult(intent, MediaGalleryActivity.REQUEST_CODE);
+        activity.startActivityForResult(intent, MediaGalleryPickerActivity.REQUEST_CODE);
     }
 
     public static void viewMediaGalleryForSiteAndGallery(Activity activity, @NonNull SiteModel site,

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryEditFragment.java
@@ -16,6 +16,7 @@ import android.widget.AdapterView;
 import com.mobeta.android.dslv.DragSortListView;
 import com.mobeta.android.dslv.DragSortListView.DropListener;
 import com.mobeta.android.dslv.DragSortListView.RemoveListener;
+import com.wellsql.generated.MediaModelTable;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -130,8 +131,7 @@ public class MediaGalleryEditFragment extends Fragment implements DropListener, 
         int size = mIds.size();
         for (int i = 0; i < size; i++) {
             while (cursor.moveToNext()) {
-                // TODO: Use MediaModel cursor here
-                long mediaId = cursor.getLong(cursor.getColumnIndex("mediaId"));
+                long mediaId = cursor.getLong(cursor.getColumnIndex(MediaModelTable.MEDIA_ID));
                 if (mediaId == mIds.get(i)) {
                     positions.put(i, cursor.getPosition());
                     cursor.moveToPosition(-1);
@@ -213,8 +213,7 @@ public class MediaGalleryEditFragment extends Fragment implements DropListener, 
             return;
         }
         cursor.moveToPosition(info.position);
-        // TODO: Use MediaModel cursor here
-        long mediaId = cursor.getLong(cursor.getColumnIndex("mediaId"));
+        long mediaId = cursor.getLong(cursor.getColumnIndex(MediaModelTable.MEDIA_ID));
 
         menu.add(ContextMenu.NONE, mIds.indexOf(mediaId), ContextMenu.NONE, R.string.delete);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
@@ -223,7 +223,7 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
     @Override
     public void onDestroyActionMode(ActionMode mode) {
         Intent intent = new Intent();
-        if (!com.helpshift.support.util.ListUtils.isEmpty(mGridAdapter.getSelectedItems())) {
+        if (!mGridAdapter.getSelectedItems().isEmpty()) {
             intent.putExtra(RESULT_IDS, ListUtils.toLongArray(mGridAdapter.getSelectedItems()));
         }
         setResult(RESULT_OK, intent);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -172,9 +172,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     private boolean mShowAztecEditor;
     private boolean mShowNewEditor;
 
-    // Each element is a list of media IDs being uploaded to a gallery, keyed by gallery ID
-    private Map<Long, List<Long>> mPendingGalleryUploads = new HashMap<>();
-
     private List<String> mPendingVideoPressInfoRequests;
 
     /**


### PR DESCRIPTION
Fixes #5210.

Doesn't reintroduce support for uploading galleries, as that is temporarily missing since we dropped the 'new picker' in the [original MediaStore integration PR](https://github.com/wordpress-mobile/WordPress-Android/pull/4616), and, as far as I can tell, that was the only way to create a gallery directly from local images. I've opened a new issue for that: https://github.com/wordpress-mobile/WordPress-Android/issues/5244.

This PR does fix a few issues that prevented adding a gallery of already uploaded images to a post.
