### PR TITLE
FluxC: Tag automated transfer sites in Helpshift

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
@@ -273,6 +273,9 @@ public class HelpshiftHelper {
             mMetadata.put("blog-name-" + counter, site.getName());
             mMetadata.put("blog-url-" + counter, site.getUrl());
             mMetadata.put("blog-plan-" + counter, site.getPlanId());
+            if (site.isAutomatedTransfer()) {
+                mMetadata.put("is-automated-transfer-" + counter, "true");
+            }
             counter += 1;
         }
 


### PR DESCRIPTION
Adds a tag in Helpshift for Automated Transfer sites:

<img width="671" alt="at-helpshift" src="https://cloud.githubusercontent.com/assets/9613966/23183872/7e1b55e4-f84b-11e6-94ba-daf17760b5e6.png">

(The tag won't be present at all for non-AT sites, to not clog up the metadata list.)

cc @rachelmcr @kwonye 