### PR TITLE
Better handling of upload error in the editor and the media browser

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -526,11 +526,12 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     }
 
     private void showMediaToastError(@StringRes int message, @Nullable String messageDetail) {
-        if (isFinishing())
+        if (isFinishing()) {
             return;
+        }
         String errorMessage = getString(message);
         if (!TextUtils.isEmpty(messageDetail)) {
-            errorMessage += ", " + messageDetail;
+            errorMessage += ". " + messageDetail;
         }
         ToastUtils.showToast(this, errorMessage, ToastUtils.Duration.LONG);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -23,6 +23,8 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 import android.support.v4.content.CursorLoader;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v4.view.MenuItemCompat.OnActionExpandListener;
@@ -56,6 +58,7 @@ import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.MediaError;
+import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
 import org.wordpress.android.models.MediaUploadState;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.RequestCodes;
@@ -522,13 +525,23 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         // TODO
     }
 
+    private void showMediaToastError(@StringRes int message, @Nullable String messageDetail) {
+        if (isFinishing())
+            return;
+        String errorMessage = getString(message);
+        if (!TextUtils.isEmpty(messageDetail)) {
+            errorMessage += ", " + messageDetail;
+        }
+        ToastUtils.showToast(this, errorMessage, ToastUtils.Duration.LONG);
+    }
+
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onMediaChanged(MediaStore.OnMediaChanged event) {
         if (event.isError()) {
             AppLog.w(AppLog.T.MEDIA, "Received onMediaChanged error: " + event.error.type
                                      + " - " + event.error.message);
-            ToastUtils.showToast(this, "Media error occurred: " + event.error.message, ToastUtils.Duration.LONG);
+            showMediaToastError(R.string.media_generic_error, event.error.message);
             return;
         }
 
@@ -568,14 +581,19 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         if (event.isError()) {
             AppLog.d(AppLog.T.MEDIA, "Received onMediaUploaded error:" + event.error.type
                                      + " - " + event.error.message);
+            if (event.error.type == MediaErrorType.AUTHORIZATION_REQUIRED) {
+                showMediaToastError(R.string.media_error_no_permission, null);
+            } else {
+                showMediaToastError(R.string.media_upload_error, event.error.message);
+            }
         } else if (event.completed) {
             String title = "";
             if (event.media != null) {
                 title = event.media.getTitle();
             }
             AppLog.d(AppLog.T.MEDIA, "<" + title + "> upload complete");
-            updateViews();
         }
+        updateViews();
     }
 
     public void onSavedEdit(long mediaId, boolean result) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -847,7 +847,7 @@ public class MediaGridFragment extends Fragment
 
     private void handleFetchAllMediaError(MediaErrorType errorType) {
         AppLog.e(AppLog.T.MEDIA, "Media error occurred: " + errorType);
-        final boolean isPermissionError = (errorType == MediaErrorType.UNAUTHORIZED);
+        final boolean isPermissionError = (errorType == MediaErrorType.AUTHORIZATION_REQUIRED);
         if (getActivity() != null) {
             if (!isPermissionError) {
                 ToastUtils.showToast(getActivity(), getString(R.string.error_refresh_media),

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaDeleteService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaDeleteService.java
@@ -153,8 +153,8 @@ public class MediaDeleteService extends Service {
         MediaModel media = event.mediaList.get(0);
 
         switch (event.error.type) {
-            case UNAUTHORIZED:
-                AppLog.v(T.MEDIA, "Unauthorized site access. Stopping MediaDeleteService.");
+            case AUTHORIZATION_REQUIRED:
+                AppLog.v(T.MEDIA, "Authorization required. Stopping MediaDeleteService.");
                 // stop delete service until authorized to perform actions on site
                 stopSelf();
                 break;
@@ -163,7 +163,7 @@ public class MediaDeleteService extends Service {
                 AppLog.d(T.MEDIA, "Null media argument supplied, skipping current delete.");
                 completeCurrentDelete();
                 break;
-            case MEDIA_NOT_FOUND:
+            case NOT_FOUND:
                 if (media == null) {
                     break;
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -295,7 +295,6 @@ public class MediaUploadService extends Service {
 
     // FluxC events
 
-
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onMediaUploaded(OnMediaUploaded event) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -776,7 +776,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         // Display custom error depending on error type
         String errorMessage;
         switch (error.type) {
-            case UNAUTHORIZED:
+            case AUTHORIZATION_REQUIRED:
                 errorMessage = getString(R.string.media_error_no_permission_upload);
                 break;
             case GENERIC_ERROR:
@@ -1697,10 +1697,10 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 case FS_READ_PERMISSION_DENIED:
                     errorMessage = getString(R.string.error_media_insufficient_fs_permissions);
                     break;
-                case MEDIA_NOT_FOUND:
+                case NOT_FOUND:
                     errorMessage = getString(R.string.error_media_not_found);
                     break;
-                case UNAUTHORIZED:
+                case AUTHORIZATION_REQUIRED:
                     errorMessage = getString(R.string.error_media_unauthorized);
                     break;
                 case PARSE_ERROR:

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -143,7 +143,7 @@
     <string name="media_file_name">File name: %s</string>
     <string name="media_uploaded_on">Uploaded on: %s</string>
     <string name="media_dimensions">Dimensions: %s</string>
-    <string name="media_upload_error">Media upload occurred</string>
+    <string name="media_upload_error">Media upload error occurred</string>
     <string name="media_generic_error">Media error occurred</string>
 
     <!-- Upload Media -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -143,6 +143,8 @@
     <string name="media_file_name">File name: %s</string>
     <string name="media_uploaded_on">Uploaded on: %s</string>
     <string name="media_dimensions">Dimensions: %s</string>
+    <string name="media_upload_error">Media upload occurred</string>
+    <string name="media_generic_error">Media error occurred</string>
 
     <!-- Upload Media -->
     <string name="image_added">Image added</string>


### PR DESCRIPTION
Better handling of upload error in the editor and the media browser.

This should be merged after https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/325