### PR TITLE
Reader - translate default tag strings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -16,10 +16,10 @@ public class ReaderTag implements Serializable, FilterCriteria {
     public final ReaderTagType tagType;
 
     // these are the default tags, which aren't localized in the /read/menu/ response
-    public static final String TAG_TITLE_LIKED = "Posts I Like";
-    public static final String TAG_TITLE_DISCOVER = "Discover";
-    public static final String TAG_TITLE_FOLLOWED_SITES = "Followed Sites";
-    public static final String TAG_TITLE_DEFAULT = TAG_TITLE_FOLLOWED_SITES;
+    private static final String TAG_TITLE_LIKED = "Posts I Like";
+    private static final String TAG_TITLE_DISCOVER = "Discover";
+    public  static final String TAG_TITLE_FOLLOWED_SITES = "Followed Sites";
+    public  static final String TAG_TITLE_DEFAULT = TAG_TITLE_FOLLOWED_SITES;
 
     public ReaderTag(String slug,
                      String displayName,
@@ -54,8 +54,7 @@ public class ReaderTag implements Serializable, FilterCriteria {
     public String getTagTitle() {
         return StringUtils.notNullStr(tagTitle);
     }
-    // needed
-    public void setTagTitle(String title) {
+    private void setTagTitle(String title) {
         this.tagTitle = StringUtils.notNullStr(title);
     }
     private boolean hasTagTitle() {

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -2,6 +2,8 @@ package org.wordpress.android.models;
 
 import android.text.TextUtils;
 
+import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.StringUtils;
 
@@ -174,7 +176,17 @@ public class ReaderTag implements Serializable, FilterCriteria {
     @Override
     public String getLabel() {
         if (tagType == ReaderTagType.DEFAULT) {
-            return getTagTitle();
+            // translate default tags
+            // ref: https://github.com/wordpress-mobile/WordPress-Android/issues/5240
+            if (isDiscover()) {
+                return WordPress.getContext().getString(R.string.reader_discover_default_tag);
+            } else if (isFollowedSites()) {
+                return WordPress.getContext().getString(R.string.reader_followed_default_tag);
+            } else if (isPostsILike()) {
+                return WordPress.getContext().getString(R.string.reader_liked_default_tag);
+            } else {
+                return getTagTitle();
+            }
         } else if (isTagDisplayNameAlphaNumeric()) {
             return getTagDisplayName().toLowerCase();
         } else if (hasTagTitle()) {

--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderTag.java
@@ -16,10 +16,10 @@ public class ReaderTag implements Serializable, FilterCriteria {
     public final ReaderTagType tagType;
 
     // these are the default tags, which aren't localized in the /read/menu/ response
-    private static final String TAG_TITLE_LIKED = "Posts I Like";
-    private static final String TAG_TITLE_DISCOVER = "Discover";
-    public  static final String TAG_TITLE_FOLLOWED_SITES = "Followed Sites";
-    public  static final String TAG_TITLE_DEFAULT = TAG_TITLE_FOLLOWED_SITES;
+    public static final String TAG_TITLE_LIKED = "Posts I Like";
+    public static final String TAG_TITLE_DISCOVER = "Discover";
+    public static final String TAG_TITLE_FOLLOWED_SITES = "Followed Sites";
+    public static final String TAG_TITLE_DEFAULT = TAG_TITLE_FOLLOWED_SITES;
 
     public ReaderTag(String slug,
                      String displayName,
@@ -54,7 +54,8 @@ public class ReaderTag implements Serializable, FilterCriteria {
     public String getTagTitle() {
         return StringUtils.notNullStr(tagTitle);
     }
-    private void setTagTitle(String title) {
+    // needed
+    public void setTagTitle(String title) {
         this.tagTitle = StringUtils.notNullStr(title);
     }
     private boolean hasTagTitle() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1572,20 +1572,6 @@ public class ReaderPostListFragment extends Fragment
         @Override
         protected ReaderTagList doInBackground(Void... voids) {
             ReaderTagList tagList = ReaderTagTable.getDefaultTags();
-
-            // translate default tags
-            // ref: https://github.com/wordpress-mobile/WordPress-Android/issues/5240
-            Context context = getContext();
-            for (ReaderTag tag : tagList) {
-                if (tag.isDiscover()) {
-                    tag.setTagTitle(context.getString(R.string.reader_discover_default_tag));
-                } else if (tag.isFollowedSites()) {
-                    tag.setTagTitle(context.getString(R.string.reader_followed_default_tag));
-                } else if (tag.isPostsILike()) {
-                    tag.setTagTitle(context.getString(R.string.reader_liked_default_tag));
-                }
-            }
-
             tagList.addAll(ReaderTagTable.getCustomListTags());
             tagList.addAll(ReaderTagTable.getFollowedTags());
             return tagList;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -1572,6 +1572,20 @@ public class ReaderPostListFragment extends Fragment
         @Override
         protected ReaderTagList doInBackground(Void... voids) {
             ReaderTagList tagList = ReaderTagTable.getDefaultTags();
+
+            // translate default tags
+            // ref: https://github.com/wordpress-mobile/WordPress-Android/issues/5240
+            Context context = getContext();
+            for (ReaderTag tag : tagList) {
+                if (tag.isDiscover()) {
+                    tag.setTagTitle(context.getString(R.string.reader_discover_default_tag));
+                } else if (tag.isFollowedSites()) {
+                    tag.setTagTitle(context.getString(R.string.reader_followed_default_tag));
+                } else if (tag.isPostsILike()) {
+                    tag.setTagTitle(context.getString(R.string.reader_liked_default_tag));
+                }
+            }
+
             tagList.addAll(ReaderTagTable.getCustomListTags());
             tagList.addAll(ReaderTagTable.getFollowedTags());
             return tagList;

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -29,6 +29,9 @@ Language: es
 	<string name="reader_toast_err_cannot_like_post">Error al marcar como me gusta la publicación</string>
 	<string name="reader_title_post_detail_wpcom">Entrada de WordPress.com</string>
 	<string name="reader_title_deeplink">Lector de WordPress</string>
+	<string name="reader_discover_default_tag">Descubrir</string>
+	<string name="reader_followed_default_tag">Sitios que sigues</string>
+	<string name="reader_liked_default_tag">Entradas que me gustan</string>
 	<string name="error_notif_q_action_reply">No se pudo responder al comentario. Por favor inténtalo de nuevo más tarde.</string>
 	<string name="error_notif_q_action_approve">No se pudo aprobar el comentario. Por favor, inténtalo de nuevo más tarde.</string>
 	<string name="error_notif_q_action_like">No se puede marcar como me gusta el comentario. Por favor inténtalo de nuevo más tarde.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1159,6 +1159,11 @@
     <string name="reader_page_followed_blogs">Followed sites</string>
     <string name="reader_page_recommended_blogs">Sites you may like</string>
 
+    <!-- Default tags -->
+    <string name="reader_discover_default_tag">Discover</string>
+    <string name="reader_followed_default_tag">Followed Sites</string>
+    <string name="reader_liked_default_tag">Posts I Like</string>
+
     <!-- share dialog title when sharing a reader url -->
     <string name="reader_share_link">Share link</string>
 


### PR DESCRIPTION
Fixes #5240 

~The fix requires making `setTagTitle` public but that seems harmless.~ I've included Spanish translations (that someone should check! cc @mzorz) to help test.

To test:
* Go to App Setting and change language to/away Spanish
* Verify tags are translated on Reader tab
* Go to App Settings and change language back
* Verify tags again