### PR TITLE
FluxC: Fix WP.com site creation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewBlogFragment.java
@@ -197,13 +197,13 @@ public class NewBlogFragment extends AbstractFragment implements TextWatcher {
 
 
         final String siteUrl = EditTextUtils.getText(mSiteUrlTextField).trim();
-        final String siteName = EditTextUtils.getText(mSiteTitleTextField).trim();
+        final String siteTitle = EditTextUtils.getText(mSiteTitleTextField).trim();
         final String language = LanguageUtils.getPatchedCurrentDeviceLanguage(getActivity());
 
-        NewSitePayload newSitePayload = new NewSitePayload(siteName, siteUrl, language, SiteVisibility.PUBLIC, false);
+        NewSitePayload newSitePayload = new NewSitePayload(siteUrl, siteTitle, language, SiteVisibility.PUBLIC, false);
         mDispatcher.dispatch(SiteActionBuilder.newCreateNewSiteAction(newSitePayload));
         updateProgress(getString(R.string.create_new_blog_wpcom));
-        AppLog.i(T.NUX, "User tries to create a new site, name: " + siteName + ", URL: " + siteUrl);
+        AppLog.i(T.NUX, "User tries to create a new site, title: " + siteTitle + ", URL: " + siteUrl);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewBlogFragment.java
@@ -198,6 +198,7 @@ public class NewBlogFragment extends AbstractFragment implements TextWatcher {
             return;
         }
 
+        startProgress(getString(R.string.validating_site_data));
 
         final String siteUrl = EditTextUtils.getText(mSiteUrlTextField).trim();
         final String siteTitle = EditTextUtils.getText(mSiteTitleTextField).trim();
@@ -205,7 +206,6 @@ public class NewBlogFragment extends AbstractFragment implements TextWatcher {
 
         mNewSitePayload = new NewSitePayload(siteUrl, siteTitle, language, SiteVisibility.PUBLIC, true);
         mDispatcher.dispatch(SiteActionBuilder.newCreateNewSiteAction(mNewSitePayload));
-        updateProgress(getString(R.string.create_new_blog_wpcom));
         AppLog.i(T.NUX, "User tries to create a new site, title: " + siteTitle + ", URL: " + siteUrl);
     }
 
@@ -329,6 +329,7 @@ public class NewBlogFragment extends AbstractFragment implements TextWatcher {
             // Site was validated - create it for real
             mNewSitePayload.dryRun = false;
             mDispatcher.dispatch(SiteActionBuilder.newCreateNewSiteAction(mNewSitePayload));
+            updateProgress(getString(R.string.creating_your_site));
             AppLog.i(T.NUX, "Site validated! Creating site with title: " + mNewSitePayload.siteTitle + ", URL: "
                     + mNewSitePayload.siteName);
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewBlogFragment.java
@@ -48,8 +48,6 @@ public class NewBlogFragment extends AbstractFragment implements TextWatcher {
     private boolean mSignoutOnCancelMode;
     private boolean mAutoCompleteUrl;
 
-    private NewSitePayload mNewSitePayload;
-
     @Inject Dispatcher mDispatcher;
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
@@ -199,14 +197,14 @@ public class NewBlogFragment extends AbstractFragment implements TextWatcher {
             return;
         }
 
-        startProgress(getString(R.string.validating_site_data));
+        startProgress(getString(R.string.creating_your_site));
 
         final String siteUrl = EditTextUtils.getText(mSiteUrlTextField).trim();
         final String siteTitle = EditTextUtils.getText(mSiteTitleTextField).trim();
         final String language = LanguageUtils.getPatchedCurrentDeviceLanguage(getActivity());
 
-        mNewSitePayload = new NewSitePayload(siteUrl, siteTitle, language, SiteVisibility.PUBLIC, true);
-        mDispatcher.dispatch(SiteActionBuilder.newCreateNewSiteAction(mNewSitePayload));
+        NewSitePayload newSitePayload = new NewSitePayload(siteUrl, siteTitle, language, SiteVisibility.PUBLIC, false);
+        mDispatcher.dispatch(SiteActionBuilder.newCreateNewSiteAction(newSitePayload));
         AppLog.i(T.NUX, "User tries to create a new site, title: " + siteTitle + ", URL: " + siteUrl);
     }
 
@@ -324,15 +322,6 @@ public class NewBlogFragment extends AbstractFragment implements TextWatcher {
         if (event.isError()) {
             endProgress();
             showError(event.error.type, event.error.message);
-            return;
-        }
-        if (event.dryRun) {
-            // Site was validated - create it for real
-            mNewSitePayload.dryRun = false;
-            mDispatcher.dispatch(SiteActionBuilder.newCreateNewSiteAction(mNewSitePayload));
-            updateProgress(getString(R.string.creating_your_site));
-            AppLog.i(T.NUX, "Site validated! Creating site with title: " + mNewSitePayload.siteTitle + ", URL: "
-                    + mNewSitePayload.siteName);
             return;
         }
         AnalyticsTracker.track(AnalyticsTracker.Stat.CREATED_SITE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -403,7 +403,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
         updateProgress(getString(R.string.validating_site_data));
 
         AppLog.i(T.NUX, "User tries to create a new account, username: " + mUsername + ", email: " + mEmail
-                + ", site name: " + siteTitle + ", site URL: " + siteUrl);
+                + ", site title: " + siteTitle + ", site URL: " + siteUrl);
     }
 
     private void finishCurrentActivity() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -393,17 +393,17 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
         mUsername = EditTextUtils.getText(mUsernameTextField).trim();
         mPassword = EditTextUtils.getText(mPasswordTextField).trim();
 
-        String siteName = siteUrlToSiteName(siteUrl);
+        String siteTitle = siteUrlToSiteName(siteUrl);
         String language = LanguageUtils.getPatchedCurrentDeviceLanguage(getActivity());
 
         mNewAccountPayload = new NewAccountPayload(mUsername, mPassword, mEmail, true);
-        mNewSitePayload = new NewSitePayload(siteName, siteUrl, language, SiteVisibility.PUBLIC, true);
+        mNewSitePayload = new NewSitePayload(siteUrl, siteTitle, language, SiteVisibility.PUBLIC, true);
 
         mDispatcher.dispatch(AccountActionBuilder.newCreateNewAccountAction(mNewAccountPayload));
         updateProgress(getString(R.string.validating_site_data));
 
         AppLog.i(T.NUX, "User tries to create a new account, username: " + mUsername + ", email: " + mEmail
-                + ", site name: " + siteName + ", site URL: " + siteUrl);
+                + ", site name: " + siteTitle + ", site URL: " + siteUrl);
     }
 
     private void finishCurrentActivity() {


### PR DESCRIPTION
Fixes a few issues with creating a new WP.com site (both standalone and as part of new user signup).

1. The order of the site name param (the *.wordpress.com part of its URL) and the site title was reversed when `NewSitePayload` was created (the naming is confusing - the endpoint calls these `blog_name` and `blog_title` respectively, and we've kept the same naming in FluxC).
2. `NewBlogFragment` should validate the new site before creating it
3. The progress indicator wasn't being displayed

Note: There's one more issue, which is that site creation can take longer than 30 seconds, which is our current default timeout in FluxC. I've increased it to 90 seconds for this endpoint in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/330 - using that branch for testing might be necessary.

cc @maxme