### PR TITLE
Fix #5180: add missing analytics

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewBlogFragment.java
@@ -18,6 +18,7 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
@@ -322,6 +323,7 @@ public class NewBlogFragment extends AbstractFragment implements TextWatcher {
             showError(event.error.type, event.error.message);
             return;
         }
+        AnalyticsTracker.track(AnalyticsTracker.Stat.CREATED_SITE);
         // Site created, update sites
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -689,6 +689,7 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
             mDispatcher.dispatch(AccountActionBuilder.newCreateNewAccountAction(mNewAccountPayload));
             return;
         }
+        AnalyticsTracker.track(AnalyticsTracker.Stat.CREATED_SITE);
         // Site created, time to wrap up
         fetchSiteAndAccount();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -1304,6 +1304,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                 break;
             case INVALID_URL:
                 showUrlError(R.string.invalid_site_url_message);
+                AnalyticsTracker.track(Stat.LOGIN_INSERTED_INVALID_URL);
                 break;
             case MISSING_XMLRPC_METHOD:
                 showGenericErrorDialog(getResources().getString(R.string.xmlrpc_missing_method_error),

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -29,7 +29,6 @@ import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.network.MemorizingTrustManager;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
@@ -65,11 +64,11 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.AuthenticationDialogUtils;
 import org.wordpress.android.util.CoreEvents.MainViewPagerScrolled;
+import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ProfilingUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
-import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.widgets.WPViewPager;
 
 import java.util.List;
@@ -96,7 +95,6 @@ public class WPMainActivity extends AppCompatActivity {
     @Inject SiteStore mSiteStore;
     @Inject PostStore mPostStore;
     @Inject Dispatcher mDispatcher;
-    @Inject MemorizingTrustManager mMemorizingTrustManager;
 
     /*
      * tab fragments implement this if their contents can be scrolled, called when user

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
@@ -23,6 +23,7 @@ import android.webkit.WebViewClient;
 
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.util.ToastUtils;
 
 public class LearnMorePreference extends Preference
@@ -76,7 +77,7 @@ public class LearnMorePreference extends Preference
     @Override
     public void onClick(View v) {
         if (mDialog != null) return;
-        AnalyticsTracker.track(AnalyticsTracker.Stat.SITE_SETTINGS_LEARN_MORE_CLICKED);
+        AnalyticsTracker.track(Stat.SITE_SETTINGS_LEARN_MORE_CLICKED);
         showDialog();
     }
 
@@ -161,7 +162,7 @@ public class LearnMorePreference extends Preference
         public void onPageFinished(WebView webView, String url) {
             super.onPageFinished(webView, url);
             if (mDialog != null) {
-                AnalyticsTracker.track(AnalyticsTracker.Stat.SITE_SETTINGS_LEARN_MORE_CLICKED);
+                AnalyticsTracker.track(Stat.SITE_SETTINGS_LEARN_MORE_LOADED);
                 webView.loadUrl(SUPPORT_CONTENT_JS);
                 mDialog.setContentView(webView);
                 webView.scrollTo(0, 0);


### PR DESCRIPTION
Fix #5180: add missing analytics

- [x] CREATED_SITE
- [x] SITE_SETTINGS_LEARN_MORE_LOADED
- [x] ~LOGIN_FAILED_TO_GUESS_XMLRPC~ (ignored)
- [x] LOGIN_INSERTED_INVALID_URL
- [x] ~DEEP_LINK_NOT_DEFAULT_HANDER~ (was a typo HANDLER)