### PR TITLE
FluxC: Disable wpcom login while adding self hosted

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -132,6 +132,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     protected LinearLayout mTwoStepFooter;
 
     protected boolean mSelfHosted;
+    protected boolean mIsSelfHostedForced;
     protected boolean mEmailAutoCorrected;
     protected boolean mShouldSendTwoStepSMS;
     protected int mErroneousLogInCount;
@@ -383,6 +384,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             mUrlEditText.setText(prefillUrl);
         }
         mSelfHosted = true;
+        mIsSelfHostedForced = true;
     }
 
     private void showPasswordFieldAndFocus() {
@@ -965,6 +967,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     protected boolean isUserDataValid() {
         final String username = EditTextUtils.getText(mUsernameEditText).trim();
         final String password = EditTextUtils.getText(mPasswordEditText).trim();
+        final String url = EditTextUtils.getText(mUrlEditText).trim();
         boolean retValue = true;
 
         if (password.equals("")) {
@@ -976,6 +979,12 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         if (username.equals("")) {
             mUsernameEditText.setError(getString(R.string.required_field));
             mUsernameEditText.requestFocus();
+            retValue = false;
+        }
+
+        if (mIsSelfHostedForced && url.equals("")) {
+            mUrlEditText.setError(getString(R.string.required_field));
+            mUrlEditText.requestFocus();
             retValue = false;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -970,19 +970,19 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         final String url = EditTextUtils.getText(mUrlEditText).trim();
         boolean retValue = true;
 
-        if (password.equals("")) {
+        if (TextUtils.isEmpty(password)) {
             mPasswordEditText.setError(getString(R.string.required_field));
             mPasswordEditText.requestFocus();
             retValue = false;
         }
 
-        if (username.equals("")) {
+        if (TextUtils.isEmpty(username)) {
             mUsernameEditText.setError(getString(R.string.required_field));
             mUsernameEditText.requestFocus();
             retValue = false;
         }
 
-        if (mIsSelfHostedForced && url.equals("")) {
+        if (mIsSelfHostedForced && TextUtils.isEmpty(url)) {
             mUrlEditText.setError(getString(R.string.required_field));
             mUrlEditText.requestFocus();
             retValue = false;


### PR DESCRIPTION
Fixes #5256. This PR disables the .com login flow if the user selected "Add self-hosted site" from site picker.

To test:
* Select "Add self-hosted site" from site-picker
* Try adding a site without url
* You should get an error saying this field is required

/cc @maxme 