### PR TITLE
Fix #5265: FluxC media browser retries

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -630,7 +630,14 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             if (mediaModel == null) {
                 continue;
             }
+
             if (WordPressMediaUtils.canDeleteMedia(mediaModel)) {
+                if (MediaUtils.isLocalFile(mediaModel.getUploadState().toLowerCase())) {
+                    mDispatcher.dispatch(MediaActionBuilder.newRemoveMediaAction(mediaModel));
+                    updateViews();
+                    sanitizedIds.add(String.valueOf(currentId));
+                    continue;
+                }
                 mediaToDelete.add(mediaModel);
                 mediaModel.setUploadState(MediaUploadState.DELETE.name());
                 mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mediaModel));

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -57,7 +57,6 @@ import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.MediaStore;
-import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
 import org.wordpress.android.models.MediaUploadState;
 import org.wordpress.android.ui.ActivityId;
@@ -91,7 +90,7 @@ import javax.inject.Inject;
  */
 public class MediaBrowserActivity extends AppCompatActivity implements MediaGridListener,
         MediaItemFragmentCallback, OnQueryTextListener, OnActionExpandListener,
-        MediaEditFragmentCallback, WordPressMediaUtils.LaunchCameraCallback, MediaUploadService.MediaUploadListener {
+        MediaEditFragmentCallback, WordPressMediaUtils.LaunchCameraCallback {
     public static final int MEDIA_PERMISSION_REQUEST_CODE = 1;
 
     private static final String SAVED_QUERY = "SAVED_QUERY";
@@ -500,31 +499,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         addMediaToUploadService(media);
     }
 
-    @Override
-    public void onUploadBegin(MediaModel media) {
-        // TODO: indicate in UI
-    }
-
-    @Override
-    public void onUploadSuccess(MediaModel media) {
-        // TODO: update UI
-    }
-
-    @Override
-    public void onUploadCanceled(MediaModel media) {
-        // TODO
-    }
-
-    @Override
-    public void onUploadError(MediaModel media, MediaError error) {
-        // TODO: update UI
-    }
-
-    @Override
-    public void onUploadProgress(MediaModel media, float progress) {
-        // TODO
-    }
-
     private void showMediaToastError(@StringRes int message, @Nullable String messageDetail) {
         if (isFinishing()) {
             return;
@@ -707,7 +681,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         public void onServiceConnected(ComponentName className, IBinder service) {
             AppLog.i(T.MEDIA, "MediaUploadService connected");
             mUploadService = (MediaUploadService.MediaUploadBinder) service;
-            mUploadService.setListener(MediaBrowserActivity.this);
             if (!mPendingUploads.isEmpty()) {
                 for(MediaModel media : mPendingUploads) {
                     mUploadService.addMediaToQueue(media);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -878,6 +878,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         media.setLocalSiteId(mSite.getId());
         media.setFileExtension(fileExtension);
         media.setMimeType(mimeType);
+        media.setMediaId(System.currentTimeMillis());
         media.setUploadState(MediaUploadState.QUEUED.name());
         media.setUploadDate(DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000));
         mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -65,7 +65,7 @@ public class MediaEditFragment extends Fragment {
 
     private boolean mIsMediaUpdating = false;
 
-    private long mMediaId = MISSING_MEDIA_ID;
+    private int mLocalMediaId = MISSING_MEDIA_ID;
     private ScrollView mScrollView;
     private View mLinearLayout;
     private ImageLoader mImageLoader;
@@ -77,13 +77,13 @@ public class MediaEditFragment extends Fragment {
         void onResume(Fragment fragment);
         void setLookClosable();
         void onPause(Fragment fragment);
-        void onSavedEdit(long mediaId, boolean result);
+        void onSavedEdit(int localMediaId, boolean result);
     }
 
-    public static MediaEditFragment newInstance(SiteModel site, long mediaId) {
+    public static MediaEditFragment newInstance(SiteModel site, int localMediaId) {
         MediaEditFragment fragment = new MediaEditFragment();
         Bundle args = new Bundle();
-        args.putLong(ARGS_MEDIA_ID, mediaId);
+        args.putInt(ARGS_MEDIA_ID, localMediaId);
         args.putSerializable(WordPress.SITE, site);
         fragment.setArguments(args);
         return fragment;
@@ -169,12 +169,12 @@ public class MediaEditFragment extends Fragment {
         }
     }
 
-    public long getMediaId() {
-        if (mMediaId != MISSING_MEDIA_ID) {
-            return mMediaId;
+    public int getLocalMediaId() {
+        if (mLocalMediaId != MISSING_MEDIA_ID) {
+            return mLocalMediaId;
         } else if (getArguments() != null) {
-            mMediaId = getArguments().getLong(ARGS_MEDIA_ID);
-            return mMediaId;
+            mLocalMediaId = getArguments().getInt(ARGS_MEDIA_ID);
+            return mLocalMediaId;
         } else {
             return MISSING_MEDIA_ID;
         }
@@ -191,7 +191,7 @@ public class MediaEditFragment extends Fragment {
         mLocalImageView = (ImageView) mScrollView.findViewById(R.id.media_edit_fragment_image_local);
         mNetworkImageView = (NetworkImageView) mScrollView.findViewById(R.id.media_edit_fragment_image_network);
 
-        loadMedia(getMediaId());
+        loadMedia(getLocalMediaId());
 
         return mScrollView;
     }
@@ -202,10 +202,10 @@ public class MediaEditFragment extends Fragment {
         outState.putSerializable(WordPress.SITE, mSite);
     }
 
-    public void loadMedia(long mediaId) {
-        mMediaId = mediaId;
-        if (getActivity() != null && mMediaId != MISSING_MEDIA_ID) {
-            mMediaModel = mMediaStore.getSiteMediaWithId(mSite, mMediaId);
+    public void loadMedia(int localMediaId) {
+        mLocalMediaId = localMediaId;
+        if (getActivity() != null && mLocalMediaId != MISSING_MEDIA_ID) {
+            mMediaModel = mMediaStore.getMediaWithLocalId(mLocalMediaId);
             refreshViews(mMediaModel);
         } else {
             refreshViews(null);
@@ -344,7 +344,7 @@ public class MediaEditFragment extends Fragment {
     }
 
     public boolean isDirty() {
-        return mMediaId != MISSING_MEDIA_ID &&
+        return mLocalMediaId != MISSING_MEDIA_ID &&
                 (!StringUtils.equals(mTitleOriginal, mTitleView.getText().toString())
                 || !StringUtils.equals(mCaptionOriginal, mCaptionView.getText().toString())
                 || !StringUtils.equals(mDescriptionOriginal, mDescriptionView.getText().toString()));
@@ -362,7 +362,7 @@ public class MediaEditFragment extends Fragment {
                     Toast.LENGTH_LONG).show();
         }
         if (hasCallback()) {
-            mCallback.onSavedEdit(mMediaId, !event.isError());
+            mCallback.onSavedEdit(mLocalMediaId, !event.isError());
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
@@ -67,16 +67,16 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
         super.onCreate(savedInstanceState);
         ((WordPress) getApplication()).component().inject(this);
 
-        ArrayList<Long> selectedItems = new ArrayList<>();
+        ArrayList<Integer> selectedItems = new ArrayList<>();
         mIsSelectOneItem = getIntent().getBooleanExtra(PARAM_SELECT_ONE_ITEM, false);
 
-        ArrayList<Long> prevSelectedItems = ListUtils.fromLongArray(getIntent().getLongArrayExtra(PARAM_SELECTED_IDS));
+        ArrayList<Integer> prevSelectedItems = ListUtils.fromIntArray(getIntent().getIntArrayExtra(PARAM_SELECTED_IDS));
         if (prevSelectedItems != null) {
             selectedItems.addAll(prevSelectedItems);
         }
 
         if (savedInstanceState != null) {
-            ArrayList<Long> list = ListUtils.fromLongArray(savedInstanceState.getLongArray(STATE_SELECTED_ITEMS));
+            ArrayList<Integer> list = ListUtils.fromIntArray(savedInstanceState.getIntArray(STATE_SELECTED_ITEMS));
             selectedItems.addAll(list);
             mFilteredItems = ListUtils.fromLongArray(savedInstanceState.getLongArray(STATE_FILTERED_ITEMS));
             mIsSelectOneItem = savedInstanceState.getBoolean(STATE_IS_SELECT_ONE_ITEM, mIsSelectOneItem);
@@ -147,7 +147,7 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putLongArray(STATE_SELECTED_ITEMS, ListUtils.toLongArray(mGridAdapter.getSelectedItems()));
+        outState.putIntArray(STATE_SELECTED_ITEMS, ListUtils.toIntArray(mGridAdapter.getSelectedItems()));
         outState.putLongArray(STATE_FILTERED_ITEMS, ListUtils.toLongArray(mFilteredItems));
         outState.putBoolean(STATE_IS_SELECT_ONE_ITEM, mIsSelectOneItem);
     }
@@ -202,9 +202,9 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
         if (mIsSelectOneItem) {
             // Single select, just finish the activity once an item is selected
-            mGridAdapter.setItemSelected(position, true);
+            mGridAdapter.setItemSelectedByPosition(position, true);
             Intent intent = new Intent();
-            intent.putExtra(RESULT_IDS, ListUtils.toLongArray(mGridAdapter.getSelectedItems()));
+            intent.putExtra(RESULT_IDS, ListUtils.toIntArray(mGridAdapter.getSelectedItems()));
             setResult(RESULT_OK, intent);
             finish();
         } else {
@@ -216,14 +216,14 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
 
     @Override
     public void onItemCheckedStateChanged(ActionMode mode, int position, long id, boolean checked) {
-        mGridAdapter.setItemSelected(position, checked);
+        mGridAdapter.setItemSelectedByPosition(position, checked);
     }
 
     @Override
     public void onDestroyActionMode(ActionMode mode) {
         Intent intent = new Intent();
         if (!mGridAdapter.getSelectedItems().isEmpty()) {
-            intent.putExtra(RESULT_IDS, ListUtils.toLongArray(mGridAdapter.getSelectedItems()));
+            intent.putExtra(RESULT_IDS, ListUtils.toIntArray(mGridAdapter.getSelectedItems()));
         }
         setResult(RESULT_OK, intent);
         finish();
@@ -252,7 +252,7 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
     }
 
     @Override
-    public void onRetryUpload(long mediaId) {
+    public void onRetryUpload(int localMediaId) {
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -240,9 +240,8 @@ public class MediaGridAdapter extends CursorAdapter {
 
                 // add onclick to retry failed uploads
                 if (state.equalsIgnoreCase(MediaUploadState.FAILED.name())) {
-                    state = MediaUploadState.QUEUED.name();
                     holder.stateTextView.setVisibility(View.VISIBLE);
-                    holder.stateTextView.setText(state);
+                    holder.stateTextView.setText(context.getString(R.string.retry));
                     holder.stateTextView.setOnClickListener(new OnClickListener() {
                         @Override
                         public void onClick(View v) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -57,11 +57,11 @@ public class MediaGridAdapter extends CursorAdapter {
     private SiteModel mSite;
 
     // Must be an ArrayList (order is important for galleries)
-    private ArrayList<Long> mSelectedItems;
+    private ArrayList<Integer> mSelectedItems;
 
     public interface MediaGridAdapterCallback {
         void fetchMoreData();
-        void onRetryUpload(long mediaId);
+        void onRetryUpload(int localMediaId);
         boolean isInMultiSelect();
     }
 
@@ -93,7 +93,7 @@ public class MediaGridAdapter extends CursorAdapter {
         }
     }
 
-    public ArrayList<Long> getSelectedItems() {
+    public ArrayList<Integer> getSelectedItems() {
         return mSelectedItems;
     }
 
@@ -153,7 +153,7 @@ public class MediaGridAdapter extends CursorAdapter {
             view.setTag(holder);
         }
 
-        final long mediaId = cursor.getLong(cursor.getColumnIndex(MediaModelTable.MEDIA_ID));
+        final int localMediaId = cursor.getInt(cursor.getColumnIndex(MediaModelTable.ID));
 
         String state = cursor.getString(cursor.getColumnIndex(MediaModelTable.UPLOAD_STATE));
         boolean isLocalFile = MediaUtils.isLocalFile(state);
@@ -213,8 +213,8 @@ public class MediaGridAdapter extends CursorAdapter {
             }
         }
 
-        holder.frameLayout.setTag(mediaId);
-        holder.frameLayout.setChecked(mSelectedItems.contains(mediaId));
+        holder.frameLayout.setTag(localMediaId);
+        holder.frameLayout.setChecked(mSelectedItems.contains(localMediaId));
 
         // resizing layout to fit nicely into grid view
         updateGridWidth(context, holder.frameLayout);
@@ -248,7 +248,7 @@ public class MediaGridAdapter extends CursorAdapter {
                             if (!inMultiSelect()) {
                                 ((TextView) v).setText(R.string.upload_queued);
                                 v.setOnClickListener(null);
-                                mCallback.onRetryUpload(mediaId);
+                                mCallback.onRetryUpload(localMediaId);
                             }
                         }
                     });
@@ -474,46 +474,46 @@ public class MediaGridAdapter extends CursorAdapter {
         mSelectedItems.clear();
     }
 
-    public boolean isItemSelected(long mediaId) {
-        return mSelectedItems.contains(mediaId);
+    public boolean isItemSelected(int localMediaId) {
+        return mSelectedItems.contains(localMediaId);
     }
 
-    public void setItemSelected(int position, boolean selected) {
+    public void setItemSelectedByPosition(int position, boolean selected) {
         Cursor cursor = (Cursor) getItem(position);
         if (cursor == null) {
             return;
         }
-        int columnIndex = cursor.getColumnIndex(MediaModelTable.MEDIA_ID);
+        int columnIndex = cursor.getColumnIndex(MediaModelTable.ID);
         if (columnIndex != -1) {
-            long mediaId = cursor.getLong(columnIndex);
-            setItemSelected(mediaId, selected);
+            int localMediaId = cursor.getInt(columnIndex);
+            setItemSelectedByLocalId(localMediaId, selected);
         }
     }
 
-    public void setItemSelected(long mediaId, boolean selected) {
+    public void setItemSelectedByLocalId(int localMediaId, boolean selected) {
         if (selected) {
-            mSelectedItems.add(mediaId);
+            mSelectedItems.add(localMediaId);
         } else {
-            mSelectedItems.remove(mediaId);
+            mSelectedItems.remove(Integer.valueOf(localMediaId));
         }
         notifyDataSetChanged();
     }
 
     public void toggleItemSelected(int position) {
         Cursor cursor = (Cursor) getItem(position);
-        int columnIndex = cursor.getColumnIndex(MediaModelTable.MEDIA_ID);
+        int columnIndex = cursor.getColumnIndex(MediaModelTable.ID);
         if (columnIndex != -1) {
-            long mediaId = cursor.getLong(columnIndex);
-            if (mSelectedItems.contains(mediaId)) {
-                mSelectedItems.remove(mediaId);
+            int localMediaId = cursor.getInt(columnIndex);
+            if (mSelectedItems.contains(localMediaId)) {
+                mSelectedItems.remove(Integer.valueOf(localMediaId));
             } else {
-                mSelectedItems.add(mediaId);
+                mSelectedItems.add(localMediaId);
             }
             notifyDataSetChanged();
         }
     }
 
-    public void setSelectedItems(ArrayList<Long> selectedItems) {
+    public void setSelectedItems(ArrayList<Integer> selectedItems) {
         mSelectedItems = selectedItems;
         notifyDataSetChanged();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -121,8 +121,8 @@ public class MediaGridFragment extends Fragment
     private SiteModel mSite;
 
     public interface MediaGridListener {
-        void onMediaItemSelected(long mediaId);
-        void onRetryUpload(long mediaId);
+        void onMediaItemSelected(int localMediaId);
+        void onRetryUpload(int localMediaId);
     }
 
     public enum Filter {
@@ -343,7 +343,7 @@ public class MediaGridFragment extends Fragment
 
     @Override
     public void onItemCheckedStateChanged(ActionMode mode, int position, long id, boolean checked) {
-        mGridAdapter.setItemSelected(position, checked);
+        mGridAdapter.setItemSelectedByPosition(position, checked);
         int selectCount = mGridAdapter.getSelectedItems().size();
         setFilterSpinnerVisible(selectCount == 0);
         mode.setTitle(String.format(getString(R.string.cab_selected), selectCount));
@@ -358,13 +358,13 @@ public class MediaGridFragment extends Fragment
     @Override
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
         Cursor cursor = ((MediaGridAdapter) parent.getAdapter()).getCursor();
-        long mediaId = cursor.getLong(cursor.getColumnIndex(MediaModelTable.MEDIA_ID));
-        mListener.onMediaItemSelected(mediaId);
+        int localMediaId = cursor.getInt(cursor.getColumnIndex(MediaModelTable.ID));
+        mListener.onMediaItemSelected(localMediaId);
     }
 
     @Override
-    public void onRetryUpload(long mediaId) {
-        mListener.onRetryUpload(mediaId);
+    public void onRetryUpload(int localMediaId) {
+        mListener.onRetryUpload(localMediaId);
     }
 
     @SuppressWarnings("unused")
@@ -452,9 +452,9 @@ public class MediaGridFragment extends Fragment
         }
     }
 
-    public void removeFromMultiSelect(long mediaId) {
-        if (isInMultiSelect() && mGridAdapter.isItemSelected(mediaId)) {
-            mGridAdapter.setItemSelected(mediaId, false);
+    public void removeFromMultiSelect(int localMediaId) {
+        if (isInMultiSelect() && mGridAdapter.isItemSelected(localMediaId)) {
+            mGridAdapter.setItemSelectedByLocalId(localMediaId, false);
             setFilterSpinnerVisible(mGridAdapter.getSelectedItems().size() == 0);
         }
     }
@@ -620,7 +620,7 @@ public class MediaGridFragment extends Fragment
     }
 
     private void saveState(Bundle outState) {
-        outState.putLongArray(BUNDLE_SELECTED_STATES, ListUtils.toLongArray(mGridAdapter.getSelectedItems()));
+        outState.putIntArray(BUNDLE_SELECTED_STATES, ListUtils.toIntArray(mGridAdapter.getSelectedItems()));
         outState.putInt(BUNDLE_SCROLL_POSITION, mGridView.getFirstVisiblePosition());
         outState.putBoolean(BUNDLE_HAS_RETRIEVED_ALL_MEDIA, mHasRetrievedAllMedia);
         outState.putBoolean(BUNDLE_IN_MULTI_SELECT_MODE, isInMultiSelect());
@@ -680,7 +680,7 @@ public class MediaGridFragment extends Fragment
         if (!isAdded()) {
             return;
         }
-        ArrayList<Long> ids = mGridAdapter.getSelectedItems();
+        ArrayList<Integer> ids = mGridAdapter.getSelectedItems();
         ActivityLauncher.newMediaPost(getActivity(), mSite, ids.iterator().next());
     }
 
@@ -698,8 +698,8 @@ public class MediaGridFragment extends Fragment
                                             mGridAdapter.getSelectedItems());
                                 }
                                 // update upload state
-                                for (Long itemId : mGridAdapter.getSelectedItems()) {
-                                    MediaModel media = mMediaStore.getSiteMediaWithId(mSite, itemId);
+                                for (int itemId : mGridAdapter.getSelectedItems()) {
+                                    MediaModel media = mMediaStore.getMediaWithLocalId(itemId);
                                     media.setUploadState(MediaUploadState.DELETE.name());
                                     mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));
                                 }
@@ -719,7 +719,14 @@ public class MediaGridFragment extends Fragment
         if (!isAdded()) {
             return;
         }
-        ActivityLauncher.newGalleryPost(getActivity(), mSite, mGridAdapter.getSelectedItems());
+
+        ArrayList<Long> remoteMediaIds = new ArrayList<>();
+        for (int localMediaId : mGridAdapter.getSelectedItems()) {
+            MediaModel mediaModel = mMediaStore.getMediaWithLocalId(localMediaId);
+            remoteMediaIds.add(mediaModel.getMediaId());
+        }
+
+        ActivityLauncher.newGalleryPost(getActivity(), mSite, remoteMediaIds);
     }
 
     private void restoreState(Bundle savedInstanceState) {
@@ -729,7 +736,7 @@ public class MediaGridFragment extends Fragment
         boolean isInMultiSelectMode = savedInstanceState.getBoolean(BUNDLE_IN_MULTI_SELECT_MODE);
 
         if (savedInstanceState.containsKey(BUNDLE_SELECTED_STATES)) {
-            ArrayList<Long> selectedItems = ListUtils.fromLongArray(savedInstanceState.getLongArray(BUNDLE_SELECTED_STATES));
+            ArrayList<Integer> selectedItems = ListUtils.fromIntArray(savedInstanceState.getIntArray(BUNDLE_SELECTED_STATES));
             mGridAdapter.setSelectedItems(selectedItems);
             if (isInMultiSelectMode) {
                 setFilterSpinnerVisible(mGridAdapter.getSelectedItems().size() == 0);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaItemFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaItemFragment.java
@@ -361,6 +361,9 @@ public class MediaItemFragment extends Fragment {
 
         if (itemId == R.id.menu_delete) {
             MediaModel mediaModel = mMediaStore.getSiteMediaWithId(mSite, getMediaId());
+            if (mediaModel == null) {
+                return true;
+            }
             boolean canDeleteMedia = WordPressMediaUtils.canDeleteMedia(mediaModel);
             if (!canDeleteMedia) {
                 Toast.makeText(getActivity(), R.string.wait_until_upload_completes, Toast.LENGTH_LONG).show();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaItemFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaItemFragment.java
@@ -77,10 +77,10 @@ public class MediaItemFragment extends Fragment {
         void onPause(Fragment fragment);
     }
 
-    public static MediaItemFragment newInstance(SiteModel site, long mediaId) {
+    public static MediaItemFragment newInstance(SiteModel site, int localMediaId) {
         MediaItemFragment fragment = new MediaItemFragment();
         Bundle args = new Bundle();
-        args.putLong(ARGS_MEDIA_ID, mediaId);
+        args.putInt(ARGS_MEDIA_ID, localMediaId);
         args.putSerializable(WordPress.SITE, site);
         fragment.setArguments(args);
         return fragment;
@@ -129,7 +129,7 @@ public class MediaItemFragment extends Fragment {
     public void onResume() {
         super.onResume();
         mCallback.onResume(this);
-        loadMedia(getMediaId());
+        loadMedia(getLocalMediaId());
     }
 
     @Override
@@ -138,9 +138,9 @@ public class MediaItemFragment extends Fragment {
         mCallback.onPause(this);
     }
 
-    public long getMediaId() {
+    public int getLocalMediaId() {
         if (getArguments() != null) {
-            return getArguments().getLong(ARGS_MEDIA_ID);
+            return getArguments().getInt(ARGS_MEDIA_ID);
         } else {
             return MISSING_MEDIA_ID;
         }
@@ -165,13 +165,13 @@ public class MediaItemFragment extends Fragment {
         loadMedia(MISSING_MEDIA_ID);
     }
 
-    public void loadMedia(long mediaId) {
+    public void loadMedia(int localMediaId) {
         if (mSite == null)
             return;
 
         MediaModel mediaModel = null;
-        if (mediaId != MISSING_MEDIA_ID) {
-            mediaModel = mMediaStore.getSiteMediaWithId(mSite, mediaId);
+        if (localMediaId != MISSING_MEDIA_ID) {
+            mediaModel = mMediaStore.getMediaWithLocalId(localMediaId);
         }
 
         // if the id is null, get the first media item in the database
@@ -360,7 +360,7 @@ public class MediaItemFragment extends Fragment {
         int itemId = item.getItemId();
 
         if (itemId == R.id.menu_delete) {
-            MediaModel mediaModel = mMediaStore.getSiteMediaWithId(mSite, getMediaId());
+            MediaModel mediaModel = mMediaStore.getMediaWithLocalId(getLocalMediaId());
             if (mediaModel == null) {
                 return true;
             }
@@ -375,8 +375,8 @@ public class MediaItemFragment extends Fragment {
                             R.string.delete, new OnClickListener() {
                                 @Override
                                 public void onClick(DialogInterface dialog, int which) {
-                                    ArrayList<Long> ids = new ArrayList<>(1);
-                                    ids.add(getMediaId());
+                                    ArrayList<Integer> ids = new ArrayList<>(1);
+                                    ids.add(getLocalMediaId());
                                     if (getActivity() instanceof MediaBrowserActivity) {
                                         ((MediaBrowserActivity) getActivity()).deleteMedia(ids);
                                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -169,7 +169,9 @@ public class MediaUploadService extends Service {
 
     private void handleOnMediaUploadedError(@NonNull OnMediaUploaded event) {
         AppLog.w(T.MEDIA, "Error uploading media: " + event.error.message);
+        // TODO: Don't update the state here, it needs to be done in FluxC
         mCurrentUpload.setUploadState(UploadState.FAILED.name());
+        mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mCurrentUpload));
         completeCurrentUpload();
         if (mListener != null) {
             mListener.onUploadError(event.media, event.error);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -92,6 +92,7 @@
     <string name="send">Send</string>
     <string name="swipe_for_more">Swipe for more</string>
     <string name="no_default_app_available_to_open_link">Unable to open the link</string>
+    <string name="retry">Retry</string>
 
     <string name="button_skip">Skip</string>
     <string name="button_next">Next</string>

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ListUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ListUtils.java
@@ -26,4 +26,22 @@ public class ListUtils {
         Long[] array = list.toArray(new Long[list.size()]);
         return ArrayUtils.toPrimitive(array);
     }
+
+    @Nullable
+    public static ArrayList<Integer> fromIntArray(int[] array) {
+        if (array == null) {
+            return null;
+        }
+        Integer[] intObjects = ArrayUtils.toObject(array);
+        return new ArrayList<>(Arrays.asList(intObjects));
+    }
+
+    @Nullable
+    public static int[] toIntArray(List<Integer> list) {
+        if (list == null) {
+            return null;
+        }
+        Integer[] array = list.toArray(new Integer[list.size()]);
+        return ArrayUtils.toPrimitive(array);
+    }
 }


### PR DESCRIPTION
Partially fixes #5265.

1. Persists the `FAILED` media upload state in the FluxC DB (otherwise it's not correctly identified and stays `UPLOADING` in the UI forever)
2. Displays a 'Retry' message for failed media
3. Uses the local `REMOVE_MEDIA` action when attempting to delete failed uploads (this used to attempt a network delete and resulted in an error message)
4. Fixes a crash when deleting failed media

To get 1-3 working, I had to reinstate the hacky behaviour (that already exists in `develop`) of [setting a placeholder remote media ID](https://github.com/wordpress-mobile/WordPress-Android/commit/0f800d30265d77a955661a955a891e0de2e050bb) when uploading local media. Part of the issue was that the remote media ID is used throughout the media picker (which is `0` for local media).

A full refactor using local media IDs (or even better the `MediaModel`s themselves) to identify media is the ideal fix. I'm opening a separate PR for that against this one, since it's a fairly invasive change and we might decide to roll out this dirtier but 'safer' fix in the meantime.

Note about 1: We should make all upload state changes in FluxC instead of managing them in WPAndroid - that will be another refactor.