### PR TITLE
FluxC: Use local media IDs in media browser

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -878,7 +878,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         media.setLocalSiteId(mSite.getId());
         media.setFileExtension(fileExtension);
         media.setMimeType(mimeType);
-        media.setMediaId(System.currentTimeMillis());
         media.setUploadState(MediaUploadState.QUEUED.name());
         media.setUploadDate(DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000));
         mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -371,12 +371,12 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                 }
                 return true;
             case R.id.menu_edit_media:
-                long mediaId = mMediaItemFragment.getMediaId();
+                int localMediaId = mMediaItemFragment.getLocalMediaId();
 
                 if (mMediaEditFragment == null || !mMediaEditFragment.isInLayout()) {
                     // phone layout: hide item details, show and update edit fragment
                     FragmentManager fm = getFragmentManager();
-                    mMediaEditFragment = MediaEditFragment.newInstance(mSite, mediaId);
+                    mMediaEditFragment = MediaEditFragment.newInstance(mSite, localMediaId);
 
                     FragmentTransaction ft = fm.beginTransaction();
                     if (mMediaItemFragment.isVisible()) {
@@ -387,7 +387,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                     ft.commitAllowingStateLoss();
                 } else {
                     // tablet layout: update edit fragment
-                    mMediaEditFragment.loadMedia(mediaId);
+                    mMediaEditFragment.loadMedia(localMediaId);
                 }
 
                 if (mSearchView != null) {
@@ -459,7 +459,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     }
 
     @Override
-    public void onMediaItemSelected(long mediaId) {
+    public void onMediaItemSelected(int localMediaId) {
         final String tempQuery = mQuery;
 
         if (mSearchView != null) {
@@ -473,7 +473,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         FragmentManager fm = getFragmentManager();
         if (fm.getBackStackEntryCount() == 0) {
             mMediaGridFragment.clearSelectedItems();
-            mMediaItemFragment = MediaItemFragment.newInstance(mSite, mediaId);
+            mMediaItemFragment = MediaItemFragment.newInstance(mSite, localMediaId);
 
             FragmentTransaction ft = fm.beginTransaction();
             ft.hide(mMediaGridFragment);
@@ -491,8 +491,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     }
 
     @Override
-    public void onRetryUpload(long mediaId) {
-        MediaModel media = mMediaStore.getSiteMediaWithId(mSite, mediaId);
+    public void onRetryUpload(int localMediaId) {
+        MediaModel media = mMediaStore.getMediaWithLocalId(localMediaId);
         if (media == null) {
             return;
         }
@@ -531,11 +531,11 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                 // If the media was deleted, remove it from multi select (if it was selected) and hide it from the
                 // detail view (if it was the one displayed)
                 for (MediaModel mediaModel : event.mediaList) {
-                    long mediaId = mediaModel.getMediaId();
-                    mMediaGridFragment.removeFromMultiSelect(mediaId);
+                    int localMediaId = mediaModel.getId();
+                    mMediaGridFragment.removeFromMultiSelect(localMediaId);
                     if (mMediaEditFragment != null && mMediaEditFragment.isVisible()
-                            && mediaId == mMediaEditFragment.getMediaId()) {
-                        updateOnMediaChanged(String.valueOf(mediaModel.getLocalSiteId()), mediaId);
+                            && localMediaId == mMediaEditFragment.getLocalMediaId()) {
+                        updateOnMediaChanged(localMediaId);
                         if (mMediaEditFragment.isInLayout()) {
                             mMediaEditFragment.loadMedia(MediaEditFragment.MISSING_MEDIA_ID);
                         } else {
@@ -581,32 +581,30 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         updateViews();
     }
 
-    public void onSavedEdit(long mediaId, boolean result) {
+    public void onSavedEdit(int localMediaId, boolean result) {
         if (mMediaEditFragment != null && mMediaEditFragment.isVisible() && result) {
             doPopBackStack(getFragmentManager());
 
             // refresh media item details (phone-only)
             if (mMediaItemFragment != null)
-                mMediaItemFragment.loadMedia(mediaId);
+                mMediaItemFragment.loadMedia(localMediaId);
 
             // refresh grid
             mMediaGridFragment.refreshMediaFromDB();
         }
     }
 
-    public void updateOnMediaChanged(String blogId, long mediaId) {
-        if (mediaId == -1) {
+    public void updateOnMediaChanged(int localMediaId) {
+        if (localMediaId == -1) {
             return;
         }
 
-        // TODO: should we?
-        mSite.setSiteId(Long.valueOf(blogId));
         // If the media was deleted, remove it from multi select (if it was selected) and hide it from the the detail
         // view (if it was the one displayed)
-        if (!mMediaStore.hasSiteMediaWithId(mSite, mediaId)) {
-            mMediaGridFragment.removeFromMultiSelect(mediaId);
+        if (mMediaStore.getMediaWithLocalId(localMediaId) == null) {
+            mMediaGridFragment.removeFromMultiSelect(localMediaId);
             if (mMediaEditFragment != null && mMediaEditFragment.isVisible()
-                    && mediaId == mMediaEditFragment.getMediaId()) {
+                    && localMediaId == mMediaEditFragment.getLocalMediaId()) {
                 if (mMediaEditFragment.isInLayout()) {
                     mMediaEditFragment.loadMedia(MediaEditFragment.MISSING_MEDIA_ID);
                 } else {
@@ -617,7 +615,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         updateViews();
     }
 
-    public void deleteMedia(final ArrayList<Long> ids) {
+    public void deleteMedia(final ArrayList<Integer> ids) {
         Set<String> sanitizedIds = new HashSet<>(ids.size());
 
         // phone layout: pop the item fragment if it's visible
@@ -625,8 +623,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
         final ArrayList<MediaModel> mediaToDelete = new ArrayList<>();
         // Make sure there are no media in "uploading"
-        for (long currentId : ids) {
-            MediaModel mediaModel = mMediaStore.getSiteMediaWithId(mSite, currentId);
+        for (int currentId : ids) {
+            MediaModel mediaModel = mMediaStore.getMediaWithLocalId(currentId);
             if (mediaModel == null) {
                 continue;
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -65,7 +65,7 @@ public class MediaEditFragment extends Fragment {
 
     private boolean mIsMediaUpdating = false;
 
-    private long mMediaId = MISSING_MEDIA_ID;
+    private int mLocalMediaId = MISSING_MEDIA_ID;
     private ScrollView mScrollView;
     private View mLinearLayout;
     private ImageLoader mImageLoader;
@@ -77,13 +77,13 @@ public class MediaEditFragment extends Fragment {
         void onResume(Fragment fragment);
         void setLookClosable();
         void onPause(Fragment fragment);
-        void onSavedEdit(long mediaId, boolean result);
+        void onSavedEdit(int localMediaId, boolean result);
     }
 
-    public static MediaEditFragment newInstance(SiteModel site, long mediaId) {
+    public static MediaEditFragment newInstance(SiteModel site, int localMediaId) {
         MediaEditFragment fragment = new MediaEditFragment();
         Bundle args = new Bundle();
-        args.putLong(ARGS_MEDIA_ID, mediaId);
+        args.putInt(ARGS_MEDIA_ID, localMediaId);
         args.putSerializable(WordPress.SITE, site);
         fragment.setArguments(args);
         return fragment;
@@ -169,12 +169,12 @@ public class MediaEditFragment extends Fragment {
         }
     }
 
-    public long getMediaId() {
-        if (mMediaId != MISSING_MEDIA_ID) {
-            return mMediaId;
+    public int getLocalMediaId() {
+        if (mLocalMediaId != MISSING_MEDIA_ID) {
+            return mLocalMediaId;
         } else if (getArguments() != null) {
-            mMediaId = getArguments().getLong(ARGS_MEDIA_ID);
-            return mMediaId;
+            mLocalMediaId = getArguments().getInt(ARGS_MEDIA_ID);
+            return mLocalMediaId;
         } else {
             return MISSING_MEDIA_ID;
         }
@@ -191,7 +191,7 @@ public class MediaEditFragment extends Fragment {
         mLocalImageView = (ImageView) mScrollView.findViewById(R.id.media_edit_fragment_image_local);
         mNetworkImageView = (NetworkImageView) mScrollView.findViewById(R.id.media_edit_fragment_image_network);
 
-        loadMedia(getMediaId());
+        loadMedia(getLocalMediaId());
 
         return mScrollView;
     }
@@ -202,10 +202,10 @@ public class MediaEditFragment extends Fragment {
         outState.putSerializable(WordPress.SITE, mSite);
     }
 
-    public void loadMedia(long mediaId) {
-        mMediaId = mediaId;
-        if (getActivity() != null && mMediaId != MISSING_MEDIA_ID) {
-            mMediaModel = mMediaStore.getSiteMediaWithId(mSite, mMediaId);
+    public void loadMedia(int localMediaId) {
+        mLocalMediaId = localMediaId;
+        if (getActivity() != null && mLocalMediaId != MISSING_MEDIA_ID) {
+            mMediaModel = mMediaStore.getMediaWithLocalId(mLocalMediaId);
             refreshViews(mMediaModel);
         } else {
             refreshViews(null);
@@ -344,7 +344,7 @@ public class MediaEditFragment extends Fragment {
     }
 
     public boolean isDirty() {
-        return mMediaId != MISSING_MEDIA_ID &&
+        return mLocalMediaId != MISSING_MEDIA_ID &&
                 (!StringUtils.equals(mTitleOriginal, mTitleView.getText().toString())
                 || !StringUtils.equals(mCaptionOriginal, mCaptionView.getText().toString())
                 || !StringUtils.equals(mDescriptionOriginal, mDescriptionView.getText().toString()));
@@ -362,7 +362,7 @@ public class MediaEditFragment extends Fragment {
                     Toast.LENGTH_LONG).show();
         }
         if (hasCallback()) {
-            mCallback.onSavedEdit(mMediaId, !event.isError());
+            mCallback.onSavedEdit(mLocalMediaId, !event.isError());
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
@@ -67,16 +67,16 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
         super.onCreate(savedInstanceState);
         ((WordPress) getApplication()).component().inject(this);
 
-        ArrayList<Long> selectedItems = new ArrayList<>();
+        ArrayList<Integer> selectedItems = new ArrayList<>();
         mIsSelectOneItem = getIntent().getBooleanExtra(PARAM_SELECT_ONE_ITEM, false);
 
-        ArrayList<Long> prevSelectedItems = ListUtils.fromLongArray(getIntent().getLongArrayExtra(PARAM_SELECTED_IDS));
+        ArrayList<Integer> prevSelectedItems = ListUtils.fromIntArray(getIntent().getIntArrayExtra(PARAM_SELECTED_IDS));
         if (prevSelectedItems != null) {
             selectedItems.addAll(prevSelectedItems);
         }
 
         if (savedInstanceState != null) {
-            ArrayList<Long> list = ListUtils.fromLongArray(savedInstanceState.getLongArray(STATE_SELECTED_ITEMS));
+            ArrayList<Integer> list = ListUtils.fromIntArray(savedInstanceState.getIntArray(STATE_SELECTED_ITEMS));
             selectedItems.addAll(list);
             mFilteredItems = ListUtils.fromLongArray(savedInstanceState.getLongArray(STATE_FILTERED_ITEMS));
             mIsSelectOneItem = savedInstanceState.getBoolean(STATE_IS_SELECT_ONE_ITEM, mIsSelectOneItem);
@@ -147,7 +147,7 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putLongArray(STATE_SELECTED_ITEMS, ListUtils.toLongArray(mGridAdapter.getSelectedItems()));
+        outState.putIntArray(STATE_SELECTED_ITEMS, ListUtils.toIntArray(mGridAdapter.getSelectedItems()));
         outState.putLongArray(STATE_FILTERED_ITEMS, ListUtils.toLongArray(mFilteredItems));
         outState.putBoolean(STATE_IS_SELECT_ONE_ITEM, mIsSelectOneItem);
     }
@@ -202,9 +202,9 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
         if (mIsSelectOneItem) {
             // Single select, just finish the activity once an item is selected
-            mGridAdapter.setItemSelected(position, true);
+            mGridAdapter.setItemSelectedByPosition(position, true);
             Intent intent = new Intent();
-            intent.putExtra(RESULT_IDS, ListUtils.toLongArray(mGridAdapter.getSelectedItems()));
+            intent.putExtra(RESULT_IDS, ListUtils.toIntArray(mGridAdapter.getSelectedItems()));
             setResult(RESULT_OK, intent);
             finish();
         } else {
@@ -216,14 +216,14 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
 
     @Override
     public void onItemCheckedStateChanged(ActionMode mode, int position, long id, boolean checked) {
-        mGridAdapter.setItemSelected(position, checked);
+        mGridAdapter.setItemSelectedByPosition(position, checked);
     }
 
     @Override
     public void onDestroyActionMode(ActionMode mode) {
         Intent intent = new Intent();
         if (!mGridAdapter.getSelectedItems().isEmpty()) {
-            intent.putExtra(RESULT_IDS, ListUtils.toLongArray(mGridAdapter.getSelectedItems()));
+            intent.putExtra(RESULT_IDS, ListUtils.toIntArray(mGridAdapter.getSelectedItems()));
         }
         setResult(RESULT_OK, intent);
         finish();
@@ -252,7 +252,7 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
     }
 
     @Override
-    public void onRetryUpload(long mediaId) {
+    public void onRetryUpload(int localMediaId) {
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -57,11 +57,11 @@ public class MediaGridAdapter extends CursorAdapter {
     private SiteModel mSite;
 
     // Must be an ArrayList (order is important for galleries)
-    private ArrayList<Long> mSelectedItems;
+    private ArrayList<Integer> mSelectedItems;
 
     public interface MediaGridAdapterCallback {
         void fetchMoreData();
-        void onRetryUpload(long mediaId);
+        void onRetryUpload(int localMediaId);
         boolean isInMultiSelect();
     }
 
@@ -93,7 +93,7 @@ public class MediaGridAdapter extends CursorAdapter {
         }
     }
 
-    public ArrayList<Long> getSelectedItems() {
+    public ArrayList<Integer> getSelectedItems() {
         return mSelectedItems;
     }
 
@@ -153,7 +153,7 @@ public class MediaGridAdapter extends CursorAdapter {
             view.setTag(holder);
         }
 
-        final long mediaId = cursor.getLong(cursor.getColumnIndex(MediaModelTable.MEDIA_ID));
+        final int localMediaId = cursor.getInt(cursor.getColumnIndex(MediaModelTable.ID));
 
         String state = cursor.getString(cursor.getColumnIndex(MediaModelTable.UPLOAD_STATE));
         boolean isLocalFile = MediaUtils.isLocalFile(state);
@@ -213,8 +213,8 @@ public class MediaGridAdapter extends CursorAdapter {
             }
         }
 
-        holder.frameLayout.setTag(mediaId);
-        holder.frameLayout.setChecked(mSelectedItems.contains(mediaId));
+        holder.frameLayout.setTag(localMediaId);
+        holder.frameLayout.setChecked(mSelectedItems.contains(localMediaId));
 
         // resizing layout to fit nicely into grid view
         updateGridWidth(context, holder.frameLayout);
@@ -248,7 +248,7 @@ public class MediaGridAdapter extends CursorAdapter {
                             if (!inMultiSelect()) {
                                 ((TextView) v).setText(R.string.upload_queued);
                                 v.setOnClickListener(null);
-                                mCallback.onRetryUpload(mediaId);
+                                mCallback.onRetryUpload(localMediaId);
                             }
                         }
                     });
@@ -474,46 +474,46 @@ public class MediaGridAdapter extends CursorAdapter {
         mSelectedItems.clear();
     }
 
-    public boolean isItemSelected(long mediaId) {
-        return mSelectedItems.contains(mediaId);
+    public boolean isItemSelected(int localMediaId) {
+        return mSelectedItems.contains(localMediaId);
     }
 
-    public void setItemSelected(int position, boolean selected) {
+    public void setItemSelectedByPosition(int position, boolean selected) {
         Cursor cursor = (Cursor) getItem(position);
         if (cursor == null) {
             return;
         }
-        int columnIndex = cursor.getColumnIndex(MediaModelTable.MEDIA_ID);
+        int columnIndex = cursor.getColumnIndex(MediaModelTable.ID);
         if (columnIndex != -1) {
-            long mediaId = cursor.getLong(columnIndex);
-            setItemSelected(mediaId, selected);
+            int localMediaId = cursor.getInt(columnIndex);
+            setItemSelectedByLocalId(localMediaId, selected);
         }
     }
 
-    public void setItemSelected(long mediaId, boolean selected) {
+    public void setItemSelectedByLocalId(int localMediaId, boolean selected) {
         if (selected) {
-            mSelectedItems.add(mediaId);
+            mSelectedItems.add(localMediaId);
         } else {
-            mSelectedItems.remove(mediaId);
+            mSelectedItems.remove(Integer.valueOf(localMediaId));
         }
         notifyDataSetChanged();
     }
 
     public void toggleItemSelected(int position) {
         Cursor cursor = (Cursor) getItem(position);
-        int columnIndex = cursor.getColumnIndex(MediaModelTable.MEDIA_ID);
+        int columnIndex = cursor.getColumnIndex(MediaModelTable.ID);
         if (columnIndex != -1) {
-            long mediaId = cursor.getLong(columnIndex);
-            if (mSelectedItems.contains(mediaId)) {
-                mSelectedItems.remove(mediaId);
+            int localMediaId = cursor.getInt(columnIndex);
+            if (mSelectedItems.contains(localMediaId)) {
+                mSelectedItems.remove(Integer.valueOf(localMediaId));
             } else {
-                mSelectedItems.add(mediaId);
+                mSelectedItems.add(localMediaId);
             }
             notifyDataSetChanged();
         }
     }
 
-    public void setSelectedItems(ArrayList<Long> selectedItems) {
+    public void setSelectedItems(ArrayList<Integer> selectedItems) {
         mSelectedItems = selectedItems;
         notifyDataSetChanged();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -719,7 +719,14 @@ public class MediaGridFragment extends Fragment
         if (!isAdded()) {
             return;
         }
-        ActivityLauncher.newGalleryPost(getActivity(), mSite, mGridAdapter.getSelectedItems());
+
+        ArrayList<Long> remoteMediaIds = new ArrayList<>();
+        for (int localMediaId : mGridAdapter.getSelectedItems()) {
+            MediaModel mediaModel = mMediaStore.getMediaWithLocalId(localMediaId);
+            remoteMediaIds.add(mediaModel.getMediaId());
+        }
+
+        ActivityLauncher.newGalleryPost(getActivity(), mSite, remoteMediaIds);
     }
 
     private void restoreState(Bundle savedInstanceState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaItemFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaItemFragment.java
@@ -77,10 +77,10 @@ public class MediaItemFragment extends Fragment {
         void onPause(Fragment fragment);
     }
 
-    public static MediaItemFragment newInstance(SiteModel site, long mediaId) {
+    public static MediaItemFragment newInstance(SiteModel site, int localMediaId) {
         MediaItemFragment fragment = new MediaItemFragment();
         Bundle args = new Bundle();
-        args.putLong(ARGS_MEDIA_ID, mediaId);
+        args.putInt(ARGS_MEDIA_ID, localMediaId);
         args.putSerializable(WordPress.SITE, site);
         fragment.setArguments(args);
         return fragment;
@@ -129,7 +129,7 @@ public class MediaItemFragment extends Fragment {
     public void onResume() {
         super.onResume();
         mCallback.onResume(this);
-        loadMedia(getMediaId());
+        loadMedia(getLocalMediaId());
     }
 
     @Override
@@ -138,9 +138,9 @@ public class MediaItemFragment extends Fragment {
         mCallback.onPause(this);
     }
 
-    public long getMediaId() {
+    public int getLocalMediaId() {
         if (getArguments() != null) {
-            return getArguments().getLong(ARGS_MEDIA_ID);
+            return getArguments().getInt(ARGS_MEDIA_ID);
         } else {
             return MISSING_MEDIA_ID;
         }
@@ -165,13 +165,13 @@ public class MediaItemFragment extends Fragment {
         loadMedia(MISSING_MEDIA_ID);
     }
 
-    public void loadMedia(long mediaId) {
+    public void loadMedia(int localMediaId) {
         if (mSite == null)
             return;
 
         MediaModel mediaModel = null;
-        if (mediaId != MISSING_MEDIA_ID) {
-            mediaModel = mMediaStore.getSiteMediaWithId(mSite, mediaId);
+        if (localMediaId != MISSING_MEDIA_ID) {
+            mediaModel = mMediaStore.getMediaWithLocalId(localMediaId);
         }
 
         // if the id is null, get the first media item in the database
@@ -360,7 +360,7 @@ public class MediaItemFragment extends Fragment {
         int itemId = item.getItemId();
 
         if (itemId == R.id.menu_delete) {
-            MediaModel mediaModel = mMediaStore.getSiteMediaWithId(mSite, getMediaId());
+            MediaModel mediaModel = mMediaStore.getMediaWithLocalId(getLocalMediaId());
             if (mediaModel == null) {
                 return true;
             }
@@ -375,8 +375,8 @@ public class MediaItemFragment extends Fragment {
                             R.string.delete, new OnClickListener() {
                                 @Override
                                 public void onClick(DialogInterface dialog, int which) {
-                                    ArrayList<Long> ids = new ArrayList<>(1);
-                                    ids.add(getMediaId());
+                                    ArrayList<Integer> ids = new ArrayList<>(1);
+                                    ids.add(getLocalMediaId());
                                     if (getActivity() instanceof MediaBrowserActivity) {
                                         ((MediaBrowserActivity) getActivity()).deleteMedia(ids);
                                     }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ListUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ListUtils.java
@@ -26,4 +26,22 @@ public class ListUtils {
         Long[] array = list.toArray(new Long[list.size()]);
         return ArrayUtils.toPrimitive(array);
     }
+
+    @Nullable
+    public static ArrayList<Integer> fromIntArray(int[] array) {
+        if (array == null) {
+            return null;
+        }
+        Integer[] intObjects = ArrayUtils.toObject(array);
+        return new ArrayList<>(Arrays.asList(intObjects));
+    }
+
+    @Nullable
+    public static int[] toIntArray(List<Integer> list) {
+        if (list == null) {
+            return null;
+        }
+        Integer[] array = list.toArray(new Integer[list.size()]);
+        return ArrayUtils.toPrimitive(array);
+    }
 }


### PR DESCRIPTION
An extension of #5267, getting rid of the [placeholder remote media ID hack](https://github.com/wordpress-mobile/WordPress-Android/commit/0f800d30265d77a955661a955a891e0de2e050bb) and instead relying on the local media ID for uniqueness everywhere.

This relies on a method added in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/332, and that PR should be merged and this PR pointed back to FluxC `develop` before merging.