### PR TITLE
Fix NPE in ImageUtils

### DIFF
--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -495,7 +495,7 @@ public class ImageUtils {
         }
 
         Bitmap.CompressFormat fmt;
-        if (fileExtension.equalsIgnoreCase("png")) {
+        if (fileExtension != null && fileExtension.equalsIgnoreCase("png")) {
             fmt = Bitmap.CompressFormat.PNG;
         } else {
             fmt = Bitmap.CompressFormat.JPEG;


### PR DESCRIPTION
Fixes #5273, replacing a null check that prevents a crash when the legacy editor calls `ImageUtils.getWPImageSpanThumbnailFromFilePath()`.

To test:
1. Enable legacy editor
2. Insert a local image into the post