### PR TITLE
FluxC - Reinstate category tracking in post uploads

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -232,6 +232,10 @@ public class PostUploadService extends Service {
                 return false;
             }
 
+            if (mPost.getCategoryIdList().size() > 0) {
+                mHasCategory = true;
+            }
+
             // Support for legacy editor - images are identified as featured as they're being uploaded with the post
             if (mUseLegacyMode && featuredImageID != -1) {
                 mPost.setFeaturedImageId(featuredImageID);


### PR DESCRIPTION
Replaces accidentally dropped tracking for posts containing categories.