### PR TITLE
Fix #5275: Media upload support for legacy editor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1540,20 +1540,18 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
     private boolean addMediaLegacyEditor(Uri mediaUri, boolean isVideo) {
         trackAddMediaFromDeviceEvents(isVideo, mediaUri, null);
-        String mediaTitle;
-        if (isVideo) {
-            mediaTitle = getResources().getString(R.string.video);
-        } else {
-            mediaTitle = ImageUtils.getTitleForWPImageSpan(this, mediaUri.getEncodedPath());
-        }
 
-        MediaFile mediaFile = new MediaFile();
-        mediaFile.setPostID(mPost.getId());
-        mediaFile.setTitle(mediaTitle);
-        mediaFile.setFilePath(mediaUri.toString());
-        if (mediaUri.getEncodedPath() != null) {
-            mediaFile.setVideo(isVideo);
+        MediaModel mediaModel = buildMediaModel(mediaUri, getContentResolver().getType(mediaUri), UploadState.QUEUED);
+        if (isVideo) {
+            mediaModel.setTitle(getResources().getString(R.string.video));
+        } else {
+            mediaModel.setTitle(ImageUtils.getTitleForWPImageSpan(this, mediaUri.getEncodedPath()));
         }
+        mediaModel.setPostId(mPost.getId());
+
+        mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mediaModel));
+
+        MediaFile mediaFile = FluxCUtils.fromMediaModel(mediaModel);
         mEditorFragment.appendMediaFile(mediaFile, mediaFile.getFilePath(), WordPress.sImageLoader);
         return true;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1858,6 +1858,17 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             return null;
         }
 
+        MediaModel media = buildMediaModel(uri, mimeType, startingState);
+        mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));
+        mPendingUploads.add(media);
+        startMediaUploadService();
+
+        return media;
+    }
+
+    private MediaModel buildMediaModel(Uri uri, String mimeType, UploadState startingState) {
+        String path = getRealPathFromURI(uri);
+
         MediaModel media = mMediaStore.instantiateMediaModel();
         AppLog.i(T.MEDIA, "New media instantiated localId=" + media.getId());
         String filename = org.wordpress.android.fluxc.utils.MediaUtils.getFileName(path);
@@ -1891,10 +1902,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         media.setMimeType(mimeType);
         media.setUploadState(startingState.name());
         media.setUploadDate(DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000));
-
-        mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));
-        mPendingUploads.add(media);
-        startMediaUploadService();
 
         return media;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1357,14 +1357,15 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             if (imageSpans.length != 0) {
                 for (WPImageSpan wpIS : imageSpans) {
                     MediaFile mediaFile = wpIS.getMediaFile();
-                    if (mediaFile == null)
+                    if (mediaFile == null) {
                         continue;
+                    }
+
                     if (mediaFile.getMediaId() != null) {
                         updateMediaFileOnServer(mediaFile);
                     } else {
                         mediaFile.setFileName(wpIS.getImageSource().toString());
                         mediaFile.setFilePath(wpIS.getImageSource().toString());
-                        updateMediaFileOnServer(mediaFile);
                     }
 
                     int tagStart = postContent.getSpanStart(wpIS);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -758,7 +758,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     public void onUploadSuccess(MediaModel media) {
         if (mEditorMediaUploadListener != null && media != null) {
             mEditorMediaUploadListener.onMediaUploadSucceeded(String.valueOf(media.getId()),
-                    FluxCUtils.fromMediaModel(media));
+                    FluxCUtils.mediaFileFromMediaModel(media));
         }
         removeMediaFromPendingList(media);
     }
@@ -1099,7 +1099,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     private void addExistingMediaToEditor(long mediaId) {
         MediaModel media = mMediaStore.getSiteMediaWithId(mSite, mediaId);
         if (media != null) {
-            MediaFile mediaFile = FluxCUtils.fromMediaModel(media);
+            MediaFile mediaFile = FluxCUtils.mediaFileFromMediaModel(media);
             trackAddMediaFromWPLibraryEvents(mediaFile.isVideo(), media.getMediaId());
             mEditorFragment.appendMediaFile(mediaFile, media.getUrl(), WordPress.sImageLoader);
         }
@@ -1155,7 +1155,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             while (matcher.find()) {
                 String stringUri = matcher.group(1);
                 Uri uri = Uri.parse(stringUri);
-                MediaFile mediaFile = FluxCUtils.fromMediaModel(queueFileForUpload(uri,
+                MediaFile mediaFile = FluxCUtils.mediaFileFromMediaModel(queueFileForUpload(uri,
                         getContentResolver().getType(uri), UploadState.FAILED));
                 if (mediaFile == null) {
                     continue;
@@ -1439,7 +1439,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             return;
         }
 
-        MediaPayload payload = new MediaPayload(mSite, FluxCUtils.fromMediaFile(mediaFile));
+        MediaPayload payload = new MediaPayload(mSite, FluxCUtils.mediaModelFromMediaFile(mediaFile));
         mDispatcher.dispatch(MediaActionBuilder.newPushMediaAction(payload));
     }
 
@@ -1530,7 +1530,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         }
 
         MediaModel media = queueFileForUpload(uri, getContentResolver().getType(uri));
-        MediaFile mediaFile = FluxCUtils.fromMediaModel(media);
+        MediaFile mediaFile = FluxCUtils.mediaFileFromMediaModel(media);
         trackAddMediaFromDeviceEvents(isVideo, null, path);
         if (media != null) {
             mEditorFragment.appendMediaFile(mediaFile, path, WordPress.sImageLoader);
@@ -1552,7 +1552,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
         mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mediaModel));
 
-        MediaFile mediaFile = FluxCUtils.fromMediaModel(mediaModel);
+        MediaFile mediaFile = FluxCUtils.mediaFileFromMediaModel(mediaModel);
         mEditorFragment.appendMediaFile(mediaFile, mediaFile.getFilePath(), WordPress.sImageLoader);
         return true;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
@@ -188,7 +188,7 @@ public class PostUploadNotifier {
 
         // Simple way to show progress of entire post upload
         // Would be better if we could get total bytes for all media items.
-        double currentChunkProgress = (notificationData.itemProgressSize * progress) / 100;
+        double currentChunkProgress = (notificationData.itemProgressSize * progress);
 
         if (notificationData.currentMediaItem > 1) {
             currentChunkProgress += notificationData.itemProgressSize * (notificationData.currentMediaItem - 1);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -581,8 +581,6 @@ public class PostUploadService extends Service {
                     false);
             mFirstPublishPosts.remove(event.post.getId());
         } else {
-            // TODO: MediaStore?
-            // WordPress.wpDB.deleteMediaFilesForPost(mPost);
             mPostUploadNotifier.cancelNotification(event.post);
             boolean isFirstTimePublish = mFirstPublishPosts.remove(event.post.getId());
             mPostUploadNotifier.updateNotificationSuccess(event.post, site, isFirstTimePublish);
@@ -606,7 +604,6 @@ public class PostUploadService extends Service {
             mMediaLatchMap.get(event.media.getId()).countDown();
             mMediaLatchMap.remove(event.media.getId());
         } else if (!event.canceled && !event.isError()) {
-            // TODO: Update media item progress in notification
             mPostUploadNotifier.updateNotificationProgress(mCurrentUploadingPost, event.progress);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -45,7 +45,6 @@ import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.SqlUtils;
-import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 
 import java.io.File;
@@ -64,8 +63,6 @@ import java.util.regex.Pattern;
 import javax.inject.Inject;
 
 import de.greenrobot.event.EventBus;
-
-import static com.android.volley.Request.Method.HEAD;
 
 public class PostUploadService extends Service {
     private static final ArrayList<PostModel> mPostsList = new ArrayList<>();
@@ -315,7 +312,7 @@ public class PostUploadService extends Service {
             Matcher matcher = pattern.matcher(postContent);
 
             int totalMediaItems = 0;
-            List<String> imageTags = new ArrayList<String>();
+            List<String> imageTags = new ArrayList<>();
             while (matcher.find()) {
                 imageTags.add(matcher.group());
                 totalMediaItems++;
@@ -523,14 +520,6 @@ public class PostUploadService extends Service {
                 mErrorMessage = mContext.getResources().getString(R.string.error_media_upload);
                 return null;
             }
-        }
-
-        private void setUploadPostErrorMessage(Exception e) {
-            mErrorMessage = String.format(mContext.getResources().getText(R.string.error_upload).toString(),
-                    mPost.isPage() ? mContext.getResources().getText(R.string.page).toString() :
-                            mContext.getResources().getText(R.string.post).toString()) + " - " + e.getMessage();
-            mIsMediaError = false;
-            AppLog.e(T.EDITOR, mErrorMessage, e);
         }
 
         private String uploadImageFile(MediaFile mediaFile, SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -592,12 +592,18 @@ public class PostUploadService extends Service {
             return;
         }
 
+        if (event.canceled) {
+            // Not implemented
+            return;
+        }
+
         if (event.completed) {
             AppLog.i(T.POSTS, "Media upload completed for post. Media id: " + event.media.getId()
                     + ", post id: " + mCurrentUploadingPost.getId());
             mMediaLatchMap.get(event.media.getId()).countDown();
             mMediaLatchMap.remove(event.media.getId());
-        } else if (!event.canceled && !event.isError()) {
+        } else {
+            // Progress update
             mPostUploadNotifier.updateNotificationProgress(mCurrentUploadingPost, event.progress);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -580,6 +580,18 @@ public class PostUploadService extends Service {
             return;
         }
 
+        if (event.isError()) {
+            SiteModel site = mSiteStore.getSiteByLocalId(mCurrentUploadingPost.getLocalSiteId());
+
+            // TODO: We should interpret event.error.type and pass our own string rather than use error.message
+            String message = TextUtils.isEmpty(event.error.message) ? event.error.type.toString() : event.error.message;
+            mPostUploadNotifier.updateNotificationError(mCurrentUploadingPost, site, message, true);
+
+            mFirstPublishPosts.remove(mCurrentUploadingPost.getId());
+            finishUpload();
+            return;
+        }
+
         if (event.completed) {
             AppLog.i(T.POSTS, "Media upload completed for post. Media id: " + event.media.getId()
                     + ", post id: " + mCurrentUploadingPost.getId());

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -575,7 +575,7 @@ public class PostUploadService extends Service {
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onMediaUploaded(OnMediaUploaded event) {
         // Event for unknown media, ignoring
-        if (event.media == null || mMediaLatchMap.get(event.media.getId()) == null) {
+        if (event.media == null || mCurrentUploadingPost == null || mMediaLatchMap.get(event.media.getId()) == null) {
             AppLog.w(T.POSTS, "Media event not recognized: " + event.media);
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -608,6 +608,7 @@ public class PostUploadService extends Service {
             mMediaLatchMap.remove(event.media.getId());
         } else if (!event.canceled && !event.isError()) {
             // TODO: Update media item progress in notification
+            mPostUploadNotifier.updateNotificationProgress(mCurrentUploadingPost, event.progress);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -206,6 +206,16 @@ public class PostUploadService extends Service {
         private boolean mHasImage, mHasVideo, mHasCategory;
 
         @Override
+        protected void onPostExecute(Boolean pushActionWasDispatched) {
+            if (!pushActionWasDispatched) {
+                // This block only runs if the PUSH_POST action was never dispatched - if it was dispatched, any error
+                // will be handled in OnPostChanged instead of here
+                mPostUploadNotifier.updateNotificationError(mPost, mSite, mErrorMessage, mIsMediaError);
+                finishUpload();
+            }
+        }
+
+        @Override
         protected Boolean doInBackground(PostModel... posts) {
             mPost = posts[0];
 

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -29,7 +29,7 @@ public class FluxCUtils {
         mediaModel.setTitle(file.getTitle());
         mediaModel.setDescription(file.getDescription());
         mediaModel.setCaption(file.getCaption());
-        mediaModel.setMediaId(Long.valueOf(file.getMediaId()));
+        mediaModel.setMediaId(file.getMediaId() != null ? Long.valueOf(file.getMediaId()) : 0);
         mediaModel.setId(file.getId());
         mediaModel.setUploadState(file.getUploadState());
         mediaModel.setLocalSiteId(Integer.valueOf(file.getBlogId()));
@@ -44,7 +44,7 @@ public class FluxCUtils {
 
         MediaFile mediaFile = new MediaFile();
         mediaFile.setBlogId(String.valueOf(media.getLocalSiteId()));
-        mediaFile.setMediaId(String.valueOf(media.getMediaId()));
+        mediaFile.setMediaId(media.getMediaId() > 0 ? String.valueOf(media.getMediaId()) : null);
         mediaFile.setId(media.getId());
         mediaFile.setFileName(media.getFileName());
         mediaFile.setFilePath(media.getFilePath());

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -14,7 +14,7 @@ public class FluxCUtils {
         return accountStore.hasAccessToken() || siteStore.hasSelfHostedSite();
     }
 
-    public static MediaModel fromMediaFile(MediaFile file) {
+    public static MediaModel mediaModelFromMediaFile(MediaFile file) {
         if (file == null) {
             return null;
         }
@@ -37,9 +37,9 @@ public class FluxCUtils {
         return mediaModel;
     }
 
-    public static MediaFile fromMediaModel(MediaModel media) {
+    public static MediaFile mediaFileFromMediaModel(MediaModel media) {
         if (media == null) {
-            return  null;
+            return null;
         }
 
         MediaFile mediaFile = new MediaFile();


### PR DESCRIPTION
Fixes #5275, re-enabling media uploads from the `PostUploadService` (only used by the legacy editor at the moment).

I consider this a 'first pass' - ideally `PostUploadService` won't dispatch media events itself, but rather rely on `MediaUploadService`, and we should be able to drop or refactor some of the processing code. I'm also not fond of the `CountDownLatch` approach, but I wanted to avoid making a lot of deep changes where I could - we should instead have a neater way of making the media upload in sequence.

Further refactoring will probably fall under the scope of the async upload/upload manager project: https://github.com/wordpress-mobile/WordPress-Android/issues/5252.