### PR TITLE
FluxC: Site Settings fixes & improvements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
@@ -97,21 +97,13 @@ public class BlogPreferencesActivity extends AppCompatActivity {
             mUsernameET = (EditText) findViewById(R.id.username);
             mPasswordET = (EditText) findViewById(R.id.password);
             Button removeBlogButton = (Button) findViewById(R.id.remove_account);
-
-            // remove blog & credentials apply only to dot org
-            if (SiteUtils.isAccessibleViaWPComAPI(mSite)) {
-                View credentialsRL = findViewById(R.id.sectionContent);
-                credentialsRL.setVisibility(View.GONE);
-                removeBlogButton.setVisibility(View.GONE);
-            } else {
-                removeBlogButton.setVisibility(View.VISIBLE);
-                removeBlogButton.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View view) {
-                        removeBlogWithConfirmation();
-                    }
-                });
-            }
+            removeBlogButton.setVisibility(View.VISIBLE);
+            removeBlogButton.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    removeBlogWithConfirmation();
+                }
+            });
 
             loadSettingsForBlog();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1213,6 +1213,7 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void removeNonJetpackPreferences() {
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_advanced);
+        WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_account);
     }
 
     private void removeNonDotComPreferences() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -657,10 +657,15 @@ public class SiteSettingsFragment extends PreferenceFragment
         boolean isAccessibleViaWPComAPI = SiteUtils.isAccessibleViaWPComAPI(mSite);
 
         // .com sites hide the Account category, self-hosted sites hide the Related Posts preference
-        if (isAccessibleViaWPComAPI) {
-            removeSelfHostedOnlyPreferences();
+        if (!isAccessibleViaWPComAPI) {
+            // self-hosted, non-jetpack site
+            removeNonSelfHostedPreferences();
+        } else if (mSite.isJetpackConnected()) {
+            // jetpack site
+            removeNonJetpackPreferences();
         } else {
-            removeDotComOnlyPreferences();
+            // wp.com site
+            removeNonDotComPreferences();
         }
 
         // hide Admin options depending of capabilities on this site
@@ -1200,12 +1205,16 @@ public class SiteSettingsFragment extends PreferenceFragment
         WPPrefUtils.removePreference(this, R.string.pref_key_site_writing, R.string.pref_key_site_related_posts);
     }
 
-    private void removeDotComOnlyPreferences() {
+    private void removeNonSelfHostedPreferences() {
         WPPrefUtils.removePreference(this, R.string.pref_key_site_general, R.string.pref_key_site_language);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_writing, R.string.pref_key_site_related_posts);
     }
 
-    private void removeSelfHostedOnlyPreferences() {
+    private void removeNonJetpackPreferences() {
+        WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_advanced);
+    }
+
+    private void removeNonDotComPreferences() {
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_account);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_delete_site_screen);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1217,7 +1217,6 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void removeNonDotComPreferences() {
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_account);
-        WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_delete_site_screen);
     }
 
     private Preference getChangePref(int id) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1208,6 +1208,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     private void removeNonSelfHostedPreferences() {
         WPPrefUtils.removePreference(this, R.string.pref_key_site_general, R.string.pref_key_site_language);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_writing, R.string.pref_key_site_related_posts);
+        WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_advanced);
     }
 
     private void removeNonJetpackPreferences() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -654,16 +654,18 @@ public class SiteSettingsFragment extends PreferenceFragment
 
         sortLanguages();
 
+        boolean isAccessibleViaWPComAPI = SiteUtils.isAccessibleViaWPComAPI(mSite);
+
         // .com sites hide the Account category, self-hosted sites hide the Related Posts preference
-        if (SiteUtils.isAccessibleViaWPComAPI(mSite)) {
+        if (isAccessibleViaWPComAPI) {
             removeSelfHostedOnlyPreferences();
         } else {
             removeDotComOnlyPreferences();
         }
 
         // hide Admin options depending of capabilities on this site
-        if ((!mSite.isWPCom() && !mSite.isSelfHostedAdmin())
-            || (mSite.isWPCom() && !mSite.getHasCapabilityManageOptions())) {
+        if ((!isAccessibleViaWPComAPI && !mSite.isSelfHostedAdmin())
+            || (isAccessibleViaWPComAPI && !mSite.getHasCapabilityManageOptions())) {
             hideAdminRequiredPreferences();
         }
     }

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -68,7 +68,6 @@
     <string name="pref_key_site_blacklist" translatable="false">wp_pref_site_blacklist</string>
     <string name="pref_key_site_danger" translatable="false">wp_pref_site_danger</string>
     <string name="pref_key_site_advanced" translatable="false">wp_pref_site_advanced</string>
-    <string name="pref_key_site_delete_site_screen" translatable="false">wp_pref_site_delete_site_screen</string>
     <string name="pref_key_site_start_over" translatable="false">wp_pref_site_start_over</string>
     <string name="pref_key_site_export_site" translatable="false">pref_key_site_export_site</string>
     <string name="pref_key_site_delete_site" translatable="false">wp_pref_site_delete_site</string>


### PR DESCRIPTION
Fixes #5278. This PR brings several fixes and improvements to the Site Settings screen in FluxC.

* In `BlogPreferencesActivity` we were double checking `isAccessibleViaWPComAPI`, so the unnecessary second check is removed
* Method names for removing Site Settings preferences has been improved, now that we need to handle Jetpack
* Removed Advanced section for self-hosted and Jetpack sites
* Removed a key that wasn't used anymore `pref_key_site_delete_site_screen`

/cc @maxme - @kwonye & @tonyr59h (as you guys worked on this before)