### PR TITLE
FluxC: Fixes CommentDetailFragment isAccessibleViaWPComAPI NPE

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -377,7 +377,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     }
 
     private void setupSuggestionServiceAndAdapter() {
-        if (!isAdded() || !SiteUtils.isAccessibleViaWPComAPI(mSite)) {
+        if (!isAdded() || mSite == null || !SiteUtils.isAccessibleViaWPComAPI(mSite)) {
             return;
         }
         mSuggestionServiceConnectionManager = new SuggestionServiceConnectionManager(getActivity(), mSite.getSiteId());


### PR DESCRIPTION
Fixes #5288. @maxme as per our previous discussions, I didn't add a `null` check in `isAccessibleViaWPComAPI `, so we get these type of crashes and look into the root cause of them, instead of silently failing. I think in this case, having a `null` check before `` is called is enough. However, I wasn't really sure why we had the `Comment` and `SiteModel` `@Nullable` here: https://github.com/wordpress-mobile/WordPress-Android/blob/feature/fluxc-integration/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java#L406

Do you mind checking that out and let me know the decision behind it? I can maybe add a comment there explaining the decision as part of this PR?
