### PR TITLE
Fix #5297: dismiss dialog on activity destroyed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPLaunchActivity.java
@@ -18,6 +18,8 @@ public class WPLaunchActivity extends AppCompatActivity {
      * manifest to have no UI
      */
 
+    private ProgressDialog mMigrationProgressDialog;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -25,14 +27,17 @@ public class WPLaunchActivity extends AppCompatActivity {
         ProfilingUtils.split("WPLaunchActivity.onCreate");
 
         if (WordPress.sIsMigrationInProgress) {
-            final ProgressDialog migrationProgressDialog = new ProgressDialog(this);
-            migrationProgressDialog.setMessage(this.getResources().getString(R.string.migration_message));
-            migrationProgressDialog.setCancelable(false);
-            migrationProgressDialog.show();
+            mMigrationProgressDialog = new ProgressDialog(this);
+            mMigrationProgressDialog.setMessage(this.getResources().getString(R.string.migration_message));
+            mMigrationProgressDialog.setCancelable(false);
+            mMigrationProgressDialog.show();
             WordPress.registerMigrationListener(new WordPress.MigrationListener() {
                 @Override
                 public void onCompletion() {
-                    migrationProgressDialog.dismiss();
+                    if (mMigrationProgressDialog != null) {
+                        mMigrationProgressDialog.dismiss();
+                        mMigrationProgressDialog = null;
+                    }
                     launchWPMainActivity();
                 }
             });
@@ -52,5 +57,14 @@ public class WPLaunchActivity extends AppCompatActivity {
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK | Intent.FLAG_ACTIVITY_NEW_TASK);
         startActivity(intent);
         finish();
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (mMigrationProgressDialog != null) {
+            mMigrationProgressDialog.dismiss();
+            mMigrationProgressDialog = null;
+        }
+        super.onDestroy();
     }
 }


### PR DESCRIPTION
Fix #5297: dismiss dialog on activity destroyed

App was crashing at the end of the migration process if the app was not in foreground.

To test:

Add the following code [here](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/5297-dismiss-dialog-on-destroy/WordPress/src/main/java/org/wordpress/android/WordPress.java#L247):
```
        sIsMigrationInProgress = true;
        final Handler handler = new Handler();
        handler.postDelayed(new Runnable() {
            @Override
            public void run() {
                endMigration();
            }
        }, 5000);
```

The migration dialog will always show during 5 secs even without migration in progress, that lets you test switching to another app.