### PR TITLE
FluxC: Don't fetch account info again while migrating

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -415,8 +415,10 @@ public class WordPress extends MultiDexApplication {
 
         // Refresh account informations
         if (mAccountStore.hasAccessToken()) {
-            mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
-            mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
+            if (!sIsMigrationInProgress) {
+                mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
+                mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
+            }
             NotificationsUpdateService.startService(getContext());
         }
     }


### PR DESCRIPTION
Prevents `FETCH_ACCOUNT` and `FETCH_SETTINGS` from being called (again) when `WordPress.onActivityResumed()` is called during a migration.