### PR TITLE
Sitepicker, back from "show/hide sites" should reset the view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -237,9 +237,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.Si
         mIsMultiSelectEnabled = enable;
         mSelectedPositions.clear();
 
-        if (enable) {
-            loadSites();
-        }
+        loadSites();
     }
 
     int getNumSelected() {


### PR DESCRIPTION
Fixes #5314. The issue was caused by a very simple change in fddbba16d8bfbb1649dce9cc82b758945cdde0c7. I am guessing that was just a simple mistake, but @maxme if you can review this one just in case there was a reason for that change, that'd be great!
