### PR TITLE
Fix #5262: Close site picker and select site after creation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewBlogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewBlogFragment.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.accounts;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -21,6 +22,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
+import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.NewSiteErrorType;
@@ -28,6 +30,7 @@ import org.wordpress.android.fluxc.store.SiteStore.NewSitePayload;
 import org.wordpress.android.fluxc.store.SiteStore.OnNewSiteCreated;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.SiteVisibility;
+import org.wordpress.android.ui.main.SitePickerActivity;
 import org.wordpress.android.util.AlertUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -47,6 +50,8 @@ public class NewBlogFragment extends AbstractFragment implements TextWatcher {
 
     private boolean mSignoutOnCancelMode;
     private boolean mAutoCompleteUrl;
+
+    private long mNewSiteRemoteId;
 
     @Inject Dispatcher mDispatcher;
     @Inject AccountStore mAccountStore;
@@ -325,6 +330,7 @@ public class NewBlogFragment extends AbstractFragment implements TextWatcher {
             return;
         }
         AnalyticsTracker.track(AnalyticsTracker.Stat.CREATED_SITE);
+        mNewSiteRemoteId = event.newSiteRemoteId;
         // Site created, update sites
         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
     }
@@ -338,7 +344,10 @@ public class NewBlogFragment extends AbstractFragment implements TextWatcher {
             return;
         }
         endProgress();
-        getActivity().setResult(Activity.RESULT_OK);
+        Intent intent = new Intent();
+        SiteModel site = mSiteStore.getSiteBySiteId(mNewSiteRemoteId);
+        intent.putExtra(SitePickerActivity.KEY_LOCAL_ID, site.getId());
+        getActivity().setResult(Activity.RESULT_OK, intent);
         getActivity().finish();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -281,10 +281,6 @@ public class MySiteFragment extends Fragment
                     showAlert(getView().findViewById(R.id.postsGlowBackground));
                 }
                 break;
-            case RequestCodes.CREATE_SITE:
-                // user created a new blog, select it
-                // TODO: FluxC: setSelectedSite(newly created site);
-                break;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -181,8 +181,10 @@ public class SitePickerActivity extends AppCompatActivity
         switch (requestCode) {
             case RequestCodes.ADD_ACCOUNT:
             case RequestCodes.CREATE_SITE:
-                if (resultCode != RESULT_CANCELED) {
+                if (resultCode == RESULT_OK) {
                     getAdapter().loadSites();
+                    setResult(resultCode, data);
+                    finish();
                 }
                 break;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -542,11 +542,9 @@ public class WPMainActivity extends AppCompatActivity {
         switch (requestCode) {
             case RequestCodes.EDIT_POST:
             case RequestCodes.CREATE_SITE:
-                if (resultCode == RESULT_OK) {
-                    MySiteFragment mySiteFragment = getMySiteFragment();
-                    if (mySiteFragment != null) {
-                        mySiteFragment.onActivityResult(requestCode, resultCode, data);
-                    }
+                MySiteFragment mySiteFragment = getMySiteFragment();
+                if (mySiteFragment != null) {
+                    mySiteFragment.onActivityResult(requestCode, resultCode, data);
                 }
                 break;
             case RequestCodes.ADD_ACCOUNT:


### PR DESCRIPTION
Fix #5262: Close site picker and select site after creation

Note: this doesn't fix the other problem: when self hosted sites are added, they're not auto selected, we need to update the onSiteChanged event to add the list of changed sites. Update #5262 title and content when this is merged.