### PR TITLE
Fix #5320: FluxC: Restore featured images in post settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
@@ -204,10 +204,7 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
         if (mIsSelectOneItem) {
             // Single select, just finish the activity once an item is selected
             mGridAdapter.setItemSelectedByPosition(position, true);
-            Intent intent = new Intent();
-            intent.putExtra(RESULT_IDS, ListUtils.toIntArray(mGridAdapter.getSelectedItems()));
-            setResult(RESULT_OK, intent);
-            finish();
+            setResultIdsAndFinish();
         } else {
             mGridAdapter.toggleItemSelected(position);
             mActionMode.setTitle(String.format(getString(R.string.cab_selected),
@@ -222,12 +219,7 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
 
     @Override
     public void onDestroyActionMode(ActionMode mode) {
-        Intent intent = new Intent();
-        if (!mGridAdapter.getSelectedItems().isEmpty()) {
-            intent.putExtra(RESULT_IDS, ListUtils.toIntArray(mGridAdapter.getSelectedItems()));
-        }
-        setResult(RESULT_OK, intent);
-        finish();
+        setResultIdsAndFinish();
     }
 
     @Override
@@ -282,6 +274,19 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
             FetchMediaListPayload payload = new FetchMediaListPayload(mSite, loadMore);
             mDispatcher.dispatch(MediaActionBuilder.newFetchMediaListAction(payload));
         }
+    }
+
+    private void setResultIdsAndFinish() {
+        Intent intent = new Intent();
+        if (!mGridAdapter.getSelectedItems().isEmpty()) {
+            ArrayList<Long> remoteMediaIds = new ArrayList<>();
+            for (Integer localId : mGridAdapter.getSelectedItems()) {
+                remoteMediaIds.add(mMediaStore.getMediaWithLocalId(localId).getMediaId());
+            }
+            intent.putExtra(RESULT_IDS, ListUtils.toLongArray(remoteMediaIds));
+        }
+        setResult(RESULT_OK, intent);
+        finish();
     }
 
     private void noMediaFinish() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -681,7 +681,8 @@ public class MediaGridFragment extends Fragment
             return;
         }
         ArrayList<Integer> ids = mGridAdapter.getSelectedItems();
-        ActivityLauncher.newMediaPost(getActivity(), mSite, ids.iterator().next());
+        MediaModel mediaModel = mMediaStore.getMediaWithLocalId(ids.iterator().next());
+        ActivityLauncher.newMediaPost(getActivity(), mSite, mediaModel.getMediaId());
     }
 
     private void handleMultiSelectDelete() {


### PR DESCRIPTION
Fixes #5320.

The cause was the media refactor in #5268 - the `MediaGridAdapter` was refactored to use local instead of remote media internally, but `MediaGalleryPickerActivity` should have been updated to convert the local to remote IDs when returning a result. Without that change, `EditPostSettingsFragment` was receiving local instead of remote IDs for the featured image.

This had also broken adding media from the media gallery to a post (by using the ~seven~ six-headed monster menu).

I looked for other instances where we might be misusing `MediaGridAdapter.getSelectedItems()`, and I found one more case: creating a new post from the media picker activity (long-press, select the pencil in the action bar) is also broken, for the same reason.

To test:
* Set a featured image from post settings
* In the editor(s), insert media from the WP media library
* From the media browser activity, long-press a media item and press the pencil to create a new post with it
* Other local vs remote media cases