### PR TITLE
Issues/5138 login wpcom domain as username

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -1066,29 +1066,18 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                     return;
                 }
                 endProgress();
-                try {
-                    // If the error is that the username is taken we treat this as our success condition.
-                    String errorReason = response.getString(REASON_ERROR);
-                    if (errorReason != null && errorReason.equals(REASON_ERROR_TAKEN)) {
-                        // Update the username field and show the password field.
-                        mUsername = username;
-                        mUsernameEditText.setText(username);
-                        showPasswordFieldAndFocus();
 
-                    } else if (errorReason == null) {
-                        // The username does not exist.
-                        // Do not show the password field, just
-                        // prompt that the username is invalid.
-                        showUsernameError(R.string.username_invalid);
-                    } else {
-                        // Just prompt for the error.
-                        showUsernameError(R.string.username_invalid);
-                    }
-                } catch (JSONException error) {
-                    AppLog.e(AppLog.T.MAIN, error);
-                    // Fail silently since we're trying to do something clever
-                    // and just show the password field.
+                // If the error is that the username is taken we treat this as our success condition.
+                String errorReason = response.optString(REASON_ERROR);
+                if (errorReason != null && errorReason.equals(REASON_ERROR_TAKEN)) {
+                    // Update the username field and show the password field.
+                    mUsername = username;
+                    mUsernameEditText.setText(username);
                     showPasswordFieldAndFocus();
+
+                 } else {
+                    // Just prompt for the error.
+                    showUsernameError(R.string.username_invalid);
                 }
             }
         }, new RestRequest.ErrorListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -1056,10 +1056,9 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
      * Performs an API request to see if the specified username exists.
      * If a username does exist, the username field is updated and the password field is displayed.
      *
-     * @param name The username to check.
+     * @param username The username to check.
      */
-    private void requestWPComUsernameCheck(String name) {
-        final String username = name;
+    private void requestWPComUsernameCheck(final String username) {
         WordPress.getRestClientUtilsV0().isUsernameAvailable(UrlUtils.urlEncode(username), new RestRequest.Listener() {
             @Override
             public void onResponse(JSONObject response) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -1008,7 +1008,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                 requestWPComEmailCheck();
             } else if (isWPComDomain(mUsername)) {
                 // If a wpcom domain was entered, check if the subdomain matches an existing username.
-                String maybeUsername = extractWPComSubDomain(mUsername);
+                String maybeUsername = UrlUtils.extractSubDomain(mUsername);
                 if (maybeUsername.length() > 0) {
                     // See if the username exists.
                     startProgress(getActivity().getString(R.string.checking_username));
@@ -1033,23 +1033,6 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     private boolean isWPComDomain(String string) {
         Matcher matcher = WPCOM_DOMAIN.matcher(string);
         return matcher.find();
-    }
-
-    /**
-     * Extracts the subdomain from a wpcom domain string.
-     * @param domain A wpcom domain is expected.
-     * @return A wpcom subdomain or an empty string.
-     */
-    private String extractWPComSubDomain(String domain) {
-        String str = UrlUtils.addUrlSchemeIfNeeded(domain, false);
-        String host = UrlUtils.getHost(str);
-        if (host.length() > 0) {
-            String[] parts = host.split("\\.");
-            if (parts.length > 0) {
-                return parts[0];
-            }
-        }
-        return "";
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -1080,7 +1080,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                     } else if (errorReason == null) {
                         // The username does not exist.
                         // Do not show the password field, just
-                        // prompt that the username does't exist.
+                        // prompt that the username is invalid.
                         showUsernameError(R.string.username_invalid);
                     } else {
                         // Just prompt for the error.
@@ -1088,8 +1088,9 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                     }
                 } catch (JSONException error) {
                     AppLog.e(AppLog.T.MAIN, error);
-                    // Just prompt for the error.
-                    showUsernameError(R.string.username_invalid);
+                    // Fail silently since we're trying to do something clever
+                    // and just show the password field.
+                    showPasswordFieldAndFocus();
                 }
             }
         }, new RestRequest.ErrorListener() {
@@ -1098,9 +1099,9 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                 if (!isAdded()) {
                     return;
                 }
-                endProgress();
-                // Just prompt for the error.
-                showUsernameError(R.string.username_invalid);
+                // Fail silently since we're trying to do something clever
+                // and just show the password field.
+                showPasswordFieldAndFocus();
             }
         });
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -1069,7 +1069,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                 try {
                     // If the error is that the username is taken we treat this as our success condition.
                     String errorReason = response.getString(REASON_ERROR);
-                    if (errorReason != null && errorReason.equals(REASON_ERROR_TAKEN) && mListener != null) {
+                    if (errorReason != null && errorReason.equals(REASON_ERROR_TAKEN)) {
                         // Update the username field and show the password field.
                         mUsername = username;
                         mUsernameEditText.setText(username);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -77,7 +77,6 @@ import org.wordpress.android.widgets.WPTextView;
 import org.wordpress.emailchecker2.EmailChecker;
 import org.xmlrpc.android.ApiHelper;
 
-import java.net.URL;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1341,6 +1341,7 @@
     <string name="blog_name_invalid">Invalid site address</string>
     <string name="blog_title_invalid">Invalid site title</string>
     <string name="username_invalid">Invalid username</string>
+    <string name="checking_username">Checking username</string>
     <string name="limit_reached">Limit reached. You can try again in 1 minute. Trying again before that will only increase the time you have to wait before the ban is lifted. If you think this is in error, contact support.</string>
     <string name="username_or_password_incorrect">The username or password you entered is incorrect</string>
     <string name="nux_tap_continue">Continue</string>

--- a/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
+++ b/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
@@ -332,8 +332,13 @@ public class RestClientUtils {
         post("auth/send-login-email", params, null, listener, errorListener);
     }
 
-    public void isAvailable(String email, Listener listener, ErrorListener errorListener) {
+    public void isEmailAvailable(String email, Listener listener, ErrorListener errorListener) {
         String path = String.format(Locale.US, "is-available/email?q=%s", email);
+        get(path, listener, errorListener);
+    }
+
+    public void isUsernameAvailable(String username, Listener listener, ErrorListener errorListener) {
+        String path = String.format(Locale.US, "is-available/username?q=%s", username);
         get(path, listener, errorListener);
     }
 

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
@@ -254,4 +254,22 @@ public class UrlUtils {
         }
         return uriBuilder.build().toString();
     }
+
+    /**
+     * Extracts the subdomain from a domain string.
+     * @param domain A domain is expected. Protocol is optional
+     * @return The subdomain or an empty string. Note that if the domain does not specify a subdomain
+     * (e.g. "http://example.com" then the host is returned.
+     */
+    public static String extractSubDomain(String domain) {
+        String str = UrlUtils.addUrlSchemeIfNeeded(domain, false);
+        String host = UrlUtils.getHost(str);
+        if (host.length() > 0) {
+            String[] parts = host.split("\\.");
+            if (parts.length > 0) {
+                return parts[0];
+            }
+        }
+        return "";
+    }
 }


### PR DESCRIPTION
Closes #5138 

To test:
- Enter a wpcom domain in the username field. 
- Try with and without including the http:// protocol as part of the domain.
- Confirm that a subdomain for an existing wpcom username extracts the username and shows the password field.
- Confirm a subdomain for a non-existent username shows an error.

This is my first android patch in what feels like an age, so a very violent review would be appreciated!
