### PR TITLE
Fix NPE in onActivityResult in MediaBrowserActivity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -289,7 +289,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                 }
                 break;
             case RequestCodes.TAKE_PHOTO:
-                if (resultCode == Activity.RESULT_OK && data != null) {
+                if (resultCode == Activity.RESULT_OK) {
                     Uri uri = Uri.parse(mMediaCapturePath);
                     mMediaCapturePath = null;
                     queueFileForUpload(uri, getContentResolver().getType(uri));

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -282,21 +282,17 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         switch (requestCode) {
             case RequestCodes.PICTURE_LIBRARY:
             case RequestCodes.VIDEO_LIBRARY:
-                if (resultCode == Activity.RESULT_OK) {
-                    if (data != null) {
-                        Uri imageUri = data.getData();
-                        String mimeType = getContentResolver().getType(imageUri);
-                        fetchMedia(imageUri, mimeType);
-                    }
+                if (resultCode == Activity.RESULT_OK && data != null) {
+                    Uri imageUri = data.getData();
+                    String mimeType = getContentResolver().getType(imageUri);
+                    fetchMedia(imageUri, mimeType);
                 }
                 break;
             case RequestCodes.TAKE_PHOTO:
-                if (resultCode == Activity.RESULT_OK) {
-                    if (data != null) {
-                        Uri uri = Uri.parse(mMediaCapturePath);
-                        mMediaCapturePath = null;
-                        queueFileForUpload(uri, getContentResolver().getType(uri));
-                    }
+                if (resultCode == Activity.RESULT_OK && data != null) {
+                    Uri uri = Uri.parse(mMediaCapturePath);
+                    mMediaCapturePath = null;
+                    queueFileForUpload(uri, getContentResolver().getType(uri));
                 }
                 break;
             case RequestCodes.TAKE_VIDEO:

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -282,9 +282,13 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         switch (requestCode) {
             case RequestCodes.PICTURE_LIBRARY:
             case RequestCodes.VIDEO_LIBRARY:
-                Uri imageUri = data.getData();
-                String mimeType = getContentResolver().getType(imageUri);
-                fetchMedia(imageUri, mimeType);
+                if (resultCode == Activity.RESULT_OK) {
+                    if (data != null) {
+                        Uri imageUri = data.getData();
+                        String mimeType = getContentResolver().getType(imageUri);
+                        fetchMedia(imageUri, mimeType);
+                    }
+                }
                 break;
             case RequestCodes.TAKE_PHOTO:
                 if (resultCode == Activity.RESULT_OK) {


### PR DESCRIPTION
Fixes #5328 

To test:
1. Open the Media browser by going to the first tab -> Media
2. Hit the + button on the top-right corner, and choose "select from gallery"
3. the native picker is presented
4. Hit the device back button
5. instead of crashing, the media browser activity should be shown.

cc @aforcier
