### PR TITLE
added extended timeout for PIN lock not to be shown when permissions requested

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -79,6 +79,7 @@ import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
+import org.wordpress.passcodelock.AppLockManager;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -768,6 +769,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 adapter.notifyDataSetChanged();
 
+                AppLockManager.getInstance().setExtendedTimeout();
                 if (position == 0) {
                     MediaBrowserActivity enclosingActivity = MediaBrowserActivity.this;
                     WordPressMediaUtils.launchCamera(enclosingActivity, BuildConfig.APPLICATION_ID, enclosingActivity);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -356,6 +356,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                 onBackPressed();
                 return true;
             case R.id.menu_new_media:
+                AppLockManager.getInstance().setExtendedTimeout();
                 if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(this, MEDIA_PERMISSION_REQUEST_CODE)) {
                     showNewMediaMenu();
                 }
@@ -769,7 +770,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 adapter.notifyDataSetChanged();
 
-                AppLockManager.getInstance().setExtendedTimeout();
                 if (position == 0) {
                     MediaBrowserActivity enclosingActivity = MediaBrowserActivity.this;
                     WordPressMediaUtils.launchCamera(enclosingActivity, BuildConfig.APPLICATION_ID, enclosingActivity);


### PR DESCRIPTION

Fixes #5327 

To test:
1. install the app for the first time (clean install)
2. log in and setup PIN lock (go to 3rd tab, then into App Settings, find PIN lock and turn it on)
3. enter your 4 digit pin, then re-enter it to save it.
4. now go to the media chooser (1st tab, Media option)
5. hit the + button on the top-right corner of the screen
6. the permission request dialog appears
7. Choose "not allow"
8. the media browser activity (where you were) is shown.

cc @aforcier 
