### PR TITLE
Issues/5138 login wpcom domain as username

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -1305,6 +1305,12 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         }
     }
 
+    /**
+     * Handler for an email availability event. If a user enters an email address for their
+     * username an API checks to see if it belongs to a wpcom account.  If it exists the magic links
+     * flow is followed. Otherwise the self-hosted sign in form is shown.
+     * @param event
+     */
     private void handleEmailAvailabilityEvent(OnAvailabilityChecked event) {
         if (event.type != IsAvailable.EMAIL) {
             return;
@@ -1320,20 +1326,28 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         }
     }
 
+    /**
+     * Handler for a username availability event. If a user enters a wpcom domain as their username
+     * an API call is made to check if the subdomain is a valid username. This method is handles
+     * the result of that API call, showing an error if the subdomain was not a valid username,
+     * or showing the password field if it was a valid username.
+     *
+     * @param event
+     */
     private void handleUsernameAvailabilityEvent(OnAvailabilityChecked event) {
         endProgress();
         if (event.type != IsAvailable.USERNAME ) {
             return;
         }
-        if (!event.isAvailable) {
-            // Username exists in WordPress.com
-            mUsername = event.value;
-            mUsernameEditText.setText(event.value);
-            showPasswordFieldAndFocus();
-        } else {
-            // Email address doesn't exist in WordPress.com, show the self hosted sign in form
+        if (event.isAvailable) {
+            // Username doesn't exist in WordPress.com, show just show an error.
             showUsernameError(R.string.username_invalid);
+            return;
         }
+        // Username exists in WordPress.com. Update the form and show the password field.
+        mUsername = event.value;
+        mUsernameEditText.setText(event.value);
+        showPasswordFieldAndFocus();
     }
 
     public void handleDiscoveryError(DiscoveryError error, final String failedEndpoint) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -1328,7 +1328,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
 
     /**
      * Handler for a username availability event. If a user enters a wpcom domain as their username
-     * an API call is made to check if the subdomain is a valid username. This method is handles
+     * an API call is made to check if the subdomain is a valid username. This method handles
      * the result of that API call, showing an error if the subdomain was not a valid username,
      * or showing the password field if it was a valid username.
      *

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -143,7 +143,6 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     protected String mHttpUsername;
     protected String mHttpPassword;
     protected SiteModel mJetpackSite;
-    protected String isAvailableUsername = "";
 
     protected WPTextView mSignInButton;
     protected WPTextView mCreateAccountButton;
@@ -911,16 +910,15 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                 mDispatcher.dispatch(AccountActionBuilder.newIsAvailableEmailAction(mUsername));
             } else if (isWPComDomain(mUsername)) {
                 // If a wpcom domain was entered, check if the subdomain matches an existing username.
-                isAvailableUsername = UrlUtils.extractSubDomain(mUsername);
-                if (isAvailableUsername.length() > 0) {
+                String maybeUsername = UrlUtils.extractSubDomain(mUsername);
+                if (maybeUsername.length() > 0) {
                     // See if the username exists.
                     startProgress(getActivity().getString(R.string.checking_username));
-                    mDispatcher.dispatch(AccountActionBuilder.newIsAvailableUsernameAction(isAvailableUsername));
+                    mDispatcher.dispatch(AccountActionBuilder.newIsAvailableUsernameAction(maybeUsername));
 
                 } else {
                     // The text that was entered was .wordpress.com or the like.
                     // Its invalid so just show an error.
-                    isAvailableUsername = "";
                     showUsernameError(R.string.username_invalid);
                 }
             } else {
@@ -1329,14 +1327,13 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         }
         if (!event.isAvailable) {
             // Username exists in WordPress.com
-            mUsername = isAvailableUsername;
-            mUsernameEditText.setText(isAvailableUsername);
+            mUsername = event.value;
+            mUsernameEditText.setText(event.value);
             showPasswordFieldAndFocus();
         } else {
             // Email address doesn't exist in WordPress.com, show the self hosted sign in form
             showUsernameError(R.string.username_invalid);
         }
-        isAvailableUsername = "";
     }
 
     public void handleDiscoveryError(DiscoveryError error, final String failedEndpoint) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -103,6 +103,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     private static final Pattern DOT_COM_RESERVED_NAMES =
             Pattern.compile("^(?:admin|administrator|invite|main|root|web|www|[^@]*wordpress[^@]*)$");
     private static final Pattern TWO_STEP_AUTH_CODE = Pattern.compile("^[0-9]{6}");
+    private static final Pattern WPCOM_DOMAIN = Pattern.compile("[a-z0-9]+\\.wordpress\\.com");
 
     public static final String ENTERED_URL_KEY = "ENTERED_URL_KEY";
     public static final String ENTERED_USERNAME_KEY = "ENTERED_USERNAME_KEY";
@@ -142,6 +143,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     protected String mHttpUsername;
     protected String mHttpPassword;
     protected SiteModel mJetpackSite;
+    protected String isAvailableUsername = "";
 
     protected WPTextView mSignInButton;
     protected WPTextView mCreateAccountButton;
@@ -887,7 +889,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
                 return;
             }
 
-            mUsername = EditTextUtils.getText(mUsernameEditText).trim();
+            mUsername = EditTextUtils.getText(mUsernameEditText).trim().toLowerCase();
             mPassword = EditTextUtils.getText(mPasswordEditText).trim();
             mTwoStepCode = EditTextUtils.getText(mTwoStepEditText).trim();
             if (isWPComLogin()) {
@@ -907,10 +909,35 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             if (isUsernameEmail()) {
                 startProgress(getActivity().getString(R.string.checking_email));
                 mDispatcher.dispatch(AccountActionBuilder.newIsAvailableEmailAction(mUsername));
+            } else if (isWPComDomain(mUsername)) {
+                // If a wpcom domain was entered, check if the subdomain matches an existing username.
+                isAvailableUsername = UrlUtils.extractSubDomain(mUsername);
+                if (isAvailableUsername.length() > 0) {
+                    // See if the username exists.
+                    startProgress(getActivity().getString(R.string.checking_username));
+                    mDispatcher.dispatch(AccountActionBuilder.newIsAvailableUsernameAction(isAvailableUsername));
+
+                } else {
+                    // The text that was entered was .wordpress.com or the like.
+                    // Its invalid so just show an error.
+                    isAvailableUsername = "";
+                    showUsernameError(R.string.username_invalid);
+                }
             } else {
                 showPasswordFieldAndFocus();
             }
         }
+    }
+
+    /**
+     * Tests the specified string to see if it contains a wpcom subdomain.
+     *
+     * @param string The string to check
+     * @return True if the string contains a wpcom subdomain, else false.
+     */
+    private boolean isWPComDomain(String string) {
+        Matcher matcher = WPCOM_DOMAIN.matcher(string);
+        return matcher.find();
     }
 
     private boolean isUsernameEmail() {
@@ -1267,7 +1294,24 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             AppLog.e(T.API, "OnAvailabilityChecked has error: " + event.error.type + " - " + event.error.message);
         }
 
-        if (event.type == IsAvailable.EMAIL && !event.isAvailable) {
+        switch(event.type) {
+            case EMAIL:
+                handleEmailAvailabilityEvent(event);
+                break;
+            case USERNAME:
+                handleUsernameAvailabilityEvent(event);
+                break;
+            default:
+                // Failsafe
+                showSelfHostedSignInForm();
+        }
+    }
+
+    private void handleEmailAvailabilityEvent(OnAvailabilityChecked event) {
+        if (event.type != IsAvailable.EMAIL) {
+            return;
+        }
+        if (!event.isAvailable) {
             // Email address exists in WordPress.com
             if (mListener != null) {
                 mListener.onMagicLinkRequestSuccess(mUsername);
@@ -1276,6 +1320,23 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             // Email address doesn't exist in WordPress.com, show the self hosted sign in form
             showSelfHostedSignInForm();
         }
+    }
+
+    private void handleUsernameAvailabilityEvent(OnAvailabilityChecked event) {
+        endProgress();
+        if (event.type != IsAvailable.USERNAME ) {
+            return;
+        }
+        if (!event.isAvailable) {
+            // Username exists in WordPress.com
+            mUsername = isAvailableUsername;
+            mUsernameEditText.setText(isAvailableUsername);
+            showPasswordFieldAndFocus();
+        } else {
+            // Email address doesn't exist in WordPress.com, show the self hosted sign in form
+            showUsernameError(R.string.username_invalid);
+        }
+        isAvailableUsername = "";
     }
 
     public void handleDiscoveryError(DiscoveryError error, final String failedEndpoint) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1329,6 +1329,7 @@
     <string name="blog_name_invalid">Invalid site address</string>
     <string name="blog_title_invalid">Invalid site title</string>
     <string name="username_invalid">Invalid username</string>
+    <string name="checking_username">Checking username</string>
     <string name="limit_reached">Limit reached. You can try again in 1 minute. Trying again before that will only increase the time you have to wait before the ban is lifted. If you think this is in error, contact support.</string>
     <string name="username_or_password_incorrect">The username or password you entered is incorrect</string>
     <string name="nux_tap_continue">Continue</string>

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/UrlUtils.java
@@ -254,4 +254,21 @@ public class UrlUtils {
         }
         return uriBuilder.build().toString();
     }
+
+    /**
+     * Extracts the subdomain from a domain string.
+     * @param domain A domain is expected. Protocol is optional
+     * @return The subdomain or an empty string.
+     */
+    public static String extractSubDomain(String domain) {
+        String str = UrlUtils.addUrlSchemeIfNeeded(domain, false);
+        String host = UrlUtils.getHost(str);
+        if (host.length() > 0) {
+            String[] parts = host.split("\\.");
+            if (parts.length > 1) { // There should be at least 2 dots for there to be a subdomain.
+                return parts[0];
+            }
+        }
+        return "";
+    }
 }


### PR DESCRIPTION
Closes #5138 

This is a second pass at a patch for #5138, and supersedes #5322.  It basically ports the previous code, but now with 100% more FluxC. :)

To test:

- Enter a wpcom domain in the username field.
- Try with and without including the http:// protocol as part of the domain.
- Confirm that a subdomain for an existing wpcom username extracts the username and shows the password field.
- Confirm a subdomain for a non-existent username shows an error.

@nbradbury care to take a look at this one also? 
