### PR TITLE
README: Fix typos in OAUTH section

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ but this isn't used for mobile apps. Just use "https://localhost".
 
 Once you've created your application in the [applications manager][5], you'll
 need to edit the `./WordPress/gradle.properties` file and change the
-`WP.OAUTH.APP.ID` and `WP.OAUTH.APP.SECRET` fields. Then you can compile and
+`WP.OAUTH.APP_ID` and `WP.OAUTH.APP_SECRET` fields. Then you can compile and
 run the app on a device or an emulator and try to login with a WordPress.com
 account.
 


### PR DESCRIPTION
Per the [example config](https://github.com/wordpress-mobile/WordPress-Android/blob/a68f9f434a628a1f1bfccf8bf3260a1dacd587bf/WordPress/gradle.properties-example#L1-L2) file & the [implementation](https://github.com/wordpress-mobile/WordPress-Android/blob/a68f9f434a628a1f1bfccf8bf3260a1dacd587bf/WordPress/src/main/java/org/wordpress/android/ui/accounts/helpers/LoginWPCom.java#L62-L63), it looks like:
`WP.OAUTH.APP.ID` should be `WP.OAUTH.APP_ID`
..and..
`WP.OAUTH.APP.SECRET` should be `WP.OAUTH.APP_SECRET`