### PR TITLE
Fix #5344: ignore location settings for self hosted sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -528,7 +528,9 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                     mEditPostSettingsFragment.showLocationSearch();
 
                     // After permission request was granted add GeoTag to the new post (if GeoTagging is enabled)
-                    if (SiteSettingsInterface.getInterface(this, mSite, null).init(false).getLocation() && isNewPost()) {
+                    SiteSettingsInterface siteSettingsInterface = SiteSettingsInterface.getInterface(this, mSite, null);
+                    if ((siteSettingsInterface != null && siteSettingsInterface.init(false).isLocationEnabled())
+                        && isNewPost()) {
                         mEditPostSettingsFragment.searchLocation();
                     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -528,11 +528,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                     mEditPostSettingsFragment.showLocationSearch();
 
                     // After permission request was granted add GeoTag to the new post (if GeoTagging is enabled)
-                    SiteSettingsInterface siteSettingsInterface = SiteSettingsInterface.getInterface(this, mSite, null);
-                    if ((siteSettingsInterface != null && siteSettingsInterface.init(false).isLocationEnabled())
-                        && isNewPost()) {
-                        mEditPostSettingsFragment.searchLocation();
-                    }
+                    mEditPostSettingsFragment.searchLocation();
 
                     return;
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -64,7 +64,6 @@ import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaGalleryPickerActivity;
 import org.wordpress.android.ui.media.WordPressMediaUtils;
 import org.wordpress.android.ui.prefs.AppPrefs;
-import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 import org.wordpress.android.ui.suggestion.adapters.TagSuggestionAdapter;
 import org.wordpress.android.ui.suggestion.util.SuggestionServiceConnectionManager;
 import org.wordpress.android.ui.suggestion.util.SuggestionUtils;
@@ -853,26 +852,13 @@ public class EditPostSettingsFragment extends Fragment
         updateLocation.setOnClickListener(this);
         removeLocation.setOnClickListener(this);
 
-        // this is where we ask for location permission when EditPostActivity is opened
-        SiteSettingsInterface siteSettingsInterface = SiteSettingsInterface.getInterface(getActivity(), mSite, null);
-        if ((siteSettingsInterface != null && siteSettingsInterface.init(false).isLocationEnabled())
-            && !checkForLocationPermission()) {
-            return;
-        }
-
         // if this post has location attached to it, look up the location address
         if (mPost.hasLocation()) {
             showLocationView();
             PostLocation location = mPost.getLocation();
             setLocation(location.getLatitude(), location.getLongitude());
         } else {
-            // Search for current location to geotag post if preferences allow
-            EditPostActivity activity = (EditPostActivity) getActivity();
-            if (SiteSettingsInterface.getInterface(getActivity(), mSite, null).init(false).isLocationEnabled() && activity.isNewPost()) {
-                searchLocation();
-            } else {
-                showLocationAdd();
-            }
+            showLocationAdd();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -853,8 +853,12 @@ public class EditPostSettingsFragment extends Fragment
         updateLocation.setOnClickListener(this);
         removeLocation.setOnClickListener(this);
 
-        // this is where we ask for location permission when EditPostActivity is oppened
-        if (SiteSettingsInterface.getInterface(getActivity(), mSite, null).init(false).getLocation() && !checkForLocationPermission()) return;
+        // this is where we ask for location permission when EditPostActivity is opened
+        SiteSettingsInterface siteSettingsInterface = SiteSettingsInterface.getInterface(getActivity(), mSite, null);
+        if ((siteSettingsInterface != null && siteSettingsInterface.init(false).isLocationEnabled())
+            && !checkForLocationPermission()) {
+            return;
+        }
 
         // if this post has location attached to it, look up the location address
         if (mPost.hasLocation()) {
@@ -864,7 +868,7 @@ public class EditPostSettingsFragment extends Fragment
         } else {
             // Search for current location to geotag post if preferences allow
             EditPostActivity activity = (EditPostActivity) getActivity();
-            if (SiteSettingsInterface.getInterface(getActivity(), mSite, null).init(false).getLocation() && activity.isNewPost()) {
+            if (SiteSettingsInterface.getInterface(getActivity(), mSite, null).init(false).isLocationEnabled() && activity.isNewPost()) {
                 searchLocation();
             } else {
                 showLocationAdd();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -152,7 +152,6 @@ public class SiteSettingsFragment extends PreferenceFragment
     private EditTextPreference mPasswordPref;
 
     // Writing settings
-    private WPSwitchPreference mLocationPref;
     private DetailListPreference mCategoryPref;
     private DetailListPreference mFormatPref;
     private Preference mRelatedPostsPref;
@@ -504,8 +503,6 @@ public class SiteSettingsFragment extends PreferenceFragment
         } else if (preference == mPasswordPref) {
             mSiteSettings.setPassword(newValue.toString());
             changeEditTextPreferenceValue(mPasswordPref, mSiteSettings.getPassword());
-        } else if (preference == mLocationPref) {
-            mSiteSettings.setLocationEnabled((Boolean) newValue);
         } else if (preference == mOptimizedImage) {
             mSiteSettings.setOptimizedImage((Boolean) newValue);
         } else if (preference == mCategoryPref) {
@@ -628,7 +625,6 @@ public class SiteSettingsFragment extends PreferenceFragment
         mLanguagePref = (DetailListPreference) getChangePref(R.string.pref_key_site_language);
         mUsernamePref = (EditTextPreference) getChangePref(R.string.pref_key_site_username);
         mPasswordPref = (EditTextPreference) getChangePref(R.string.pref_key_site_password);
-        mLocationPref = (WPSwitchPreference) getChangePref(R.string.pref_key_site_location);
         mCategoryPref = (DetailListPreference) getChangePref(R.string.pref_key_site_category);
         mFormatPref = (DetailListPreference) getChangePref(R.string.pref_key_site_format);
         mAllowCommentsPref = (WPSwitchPreference) getChangePref(R.string.pref_key_site_allow_comments);
@@ -677,7 +673,6 @@ public class SiteSettingsFragment extends PreferenceFragment
         }
 
         // Set Local settings
-        mLocationPref.setChecked(mSiteSettings.isLocationEnabled());
         mOptimizedImage.setChecked(mSiteSettings.getOptimizedImage());
     }
 
@@ -685,7 +680,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         // excludes mAddressPref, mMorePreference
         final Preference[] editablePreference = {
                 mTitlePref , mTaglinePref, mPrivacyPref, mLanguagePref, mUsernamePref,
-                mPasswordPref, mLocationPref, mCategoryPref, mFormatPref, mAllowCommentsPref,
+                mPasswordPref, mCategoryPref, mFormatPref, mAllowCommentsPref,
                 mAllowCommentsNested, mSendPingbacksPref, mSendPingbacksNested, mReceivePingbacksPref,
                 mReceivePingbacksNested, mIdentityRequiredPreference, mUserAccountRequiredPref,
                 mSortByPref, mWhitelistPref, mRelatedPostsPref, mCloseAfterPref, mPagingPref,
@@ -693,8 +688,8 @@ public class SiteSettingsFragment extends PreferenceFragment
                 mOptimizedImage, mDeleteSitePref
         };
 
-        for(Preference preference : editablePreference) {
-            if(preference!=null) preference.setEnabled(enabled);
+        for (Preference preference : editablePreference) {
+            if (preference != null) preference.setEnabled(enabled);
         }
 
         mEditingEnabled = enabled;
@@ -892,7 +887,6 @@ public class SiteSettingsFragment extends PreferenceFragment
     }
 
     private void setPreferencesFromSiteSettings() {
-        mLocationPref.setChecked(mSiteSettings.isLocationEnabled());
         mOptimizedImage.setChecked(mSiteSettings.getOptimizedImage());
         changeEditTextPreferenceValue(mTitlePref, mSiteSettings.getTitle());
         changeEditTextPreferenceValue(mTaglinePref, mSiteSettings.getTagline());

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -505,7 +505,7 @@ public class SiteSettingsFragment extends PreferenceFragment
             mSiteSettings.setPassword(newValue.toString());
             changeEditTextPreferenceValue(mPasswordPref, mSiteSettings.getPassword());
         } else if (preference == mLocationPref) {
-            mSiteSettings.setLocation((Boolean) newValue);
+            mSiteSettings.setLocationEnabled((Boolean) newValue);
         } else if (preference == mOptimizedImage) {
             mSiteSettings.setOptimizedImage((Boolean) newValue);
         } else if (preference == mCategoryPref) {
@@ -677,7 +677,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         }
 
         // Set Local settings
-        mLocationPref.setChecked(mSiteSettings.getLocation());
+        mLocationPref.setChecked(mSiteSettings.isLocationEnabled());
         mOptimizedImage.setChecked(mSiteSettings.getOptimizedImage());
     }
 
@@ -892,7 +892,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     }
 
     private void setPreferencesFromSiteSettings() {
-        mLocationPref.setChecked(mSiteSettings.getLocation());
+        mLocationPref.setChecked(mSiteSettings.isLocationEnabled());
         mOptimizedImage.setChecked(mSiteSettings.getOptimizedImage());
         changeEditTextPreferenceValue(mTitlePref, mSiteSettings.getTitle());
         changeEditTextPreferenceValue(mTaglinePref, mSiteSettings.getTagline());

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.Html;
 import android.text.TextUtils;
 
@@ -119,6 +120,7 @@ public abstract class SiteSettingsInterface {
     /**
      * Instantiates the appropriate (self-hosted or .com) SiteSettingsInterface.
      */
+    @Nullable
     public static SiteSettingsInterface getInterface(Activity host, SiteModel site, SiteSettingsListener listener) {
         if (host == null || site == null) return null;
 
@@ -134,13 +136,6 @@ public abstract class SiteSettingsInterface {
      */
     public static SharedPreferences siteSettingsPreferences(Context context) {
         return context.getSharedPreferences(SITE_SETTINGS_PREFS, Context.MODE_PRIVATE);
-    }
-
-    /**
-     * Gets the geo-tagging value
-     */
-    public boolean getGeotagging() {
-        return mSettings.location;
     }
 
     /**
@@ -273,7 +268,7 @@ public abstract class SiteSettingsInterface {
         return mSettings.password == null ? "" : mSettings.password;
     }
 
-    public boolean getLocation() {
+    public boolean isLocationEnabled() {
         return mSettings.location;
     }
 
@@ -556,7 +551,7 @@ public abstract class SiteSettingsInterface {
         mSettings.password = password;
     }
 
-    public void setLocation(boolean location) {
+    public void setLocationEnabled(boolean location) {
         mSettings.location = location;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -45,7 +45,6 @@ import javax.inject.Inject;
  * - Language
  * - Username (.org only)
  * - Password (.org only)
- * - Location (local device setting, not saved remotely)
  * - Optimized Image (local device setting, not saved remotely)
  * - Default Category
  * - Default Format
@@ -268,9 +267,6 @@ public abstract class SiteSettingsInterface {
         return mSettings.password == null ? "" : mSettings.password;
     }
 
-    public boolean isLocationEnabled() {
-        return mSettings.location;
-    }
 
     public boolean getOptimizedImage() {
         return mSettings.optimizedImage;
@@ -551,10 +547,6 @@ public abstract class SiteSettingsInterface {
         mSettings.password = password;
     }
 
-    public void setLocationEnabled(boolean location) {
-        mSettings.location = location;
-    }
-
     public void setOptimizedImage(boolean optimizeImage) {
         mSettings.optimizedImage = optimizeImage;
     }
@@ -773,7 +765,6 @@ public abstract class SiteSettingsInterface {
             }
             mRemoteSettings.language = mSettings.language;
             mRemoteSettings.languageId = mSettings.languageId;
-            mRemoteSettings.location = mSettings.location;
             mRemoteSettings.optimizedImage = mSettings.optimizedImage;
             localSettings.close();
             notifyUpdatedOnUiThread(null);

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -41,7 +41,6 @@
     <string name="pref_key_site_username" translatable="false">wp_pref_site_username</string>
     <string name="pref_key_site_password" translatable="false">wp_pref_site_password</string>
     <string name="pref_key_site_related_posts" translatable="false">wp_pref_site_related_posts</string>
-    <string name="pref_key_site_location" translatable="false">wp_pref_site_location</string>
     <string name="pref_key_site_category" translatable="false">wp_pref_site_default_category</string>
     <string name="pref_key_site_format" translatable="false">wp_pref_site_default_format</string>
     <string name="pref_key_site_this_device" translatable="false">wp_pref_site_default_this_device</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -462,7 +462,6 @@
     <string name="site_settings_language_title" translatable="false">@string/language</string>
     <string name="site_settings_username_title" translatable="false">@string/username</string>
     <string name="site_settings_password_title" translatable="false">@string/password</string>
-    <string name="site_settings_location_title">Enable Location</string>
     <string name="site_settings_default_category_title">Default Category</string>
     <string name="site_settings_default_format_title">Default Format</string>
     <string name="site_settings_image_original_size">Original Size</string>
@@ -548,7 +547,6 @@
     <string name="site_settings_language_hint">Language this blog is primarily written in</string>
     <string name="site_settings_username_hint">Current user account</string>
     <string name="site_settings_password_hint">Change your password</string>
-    <string name="site_settings_location_hint">Automatically add location data to your posts</string>
     <string name="site_settings_category_hint">Sets new post category</string>
     <string name="site_settings_format_hint">Sets new post format</string>
     <string name="site_settings_image_width_hint">Resizes images in posts to this width</string>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -258,12 +258,6 @@
         android:title="@string/site_settings_this_device_header">
 
         <org.wordpress.android.ui.prefs.WPSwitchPreference
-            android:id="@+id/pref_enable_location"
-            android:key="@string/pref_key_site_location"
-            android:title="@string/site_settings_location_title"
-            app:longClickHint="@string/site_settings_location_hint" />
-
-        <org.wordpress.android.ui.prefs.WPSwitchPreference
             android:id="@+id/pref_optimize_image"
             android:key="@string/pref_key_optimize_image"
             android:title="@string/site_settings_optimize_images"


### PR DESCRIPTION
Fix #5344: ignore location settings for self hosted sites

I'm not sure why we have a (local only) location settings in the site settings for wpcom sites. IIRC we dropped this settings completely a while ago to have enable/disable per post location.

cc @daniloercoli 

I can drop that setting if we agree on that.

Ref https://github.com/wordpress-mobile/WordPress-Android/pull/1468