### PR TITLE
feature/fluxc-medialib-kill-gallery

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -171,13 +171,12 @@ public class ActivityLauncher {
         context.startActivity(intent);
     }
 
-    public static void newMediaPost(Activity context, SiteModel site, long mediaId) {
+    public static void newMediaPost(Activity context, SiteModel site, ArrayList<Long> mediaIds) {
         if (site == null) return;
-        // Create a new post object and assign default settings
         Intent intent = new Intent(context, EditPostActivity.class);
         intent.putExtra(WordPress.SITE, site);
         intent.setAction(EditPostActivity.NEW_MEDIA_POST);
-        intent.putExtra(EditPostActivity.NEW_MEDIA_POST_EXTRA, mediaId);
+        intent.putExtra(EditPostActivity.NEW_MEDIA_POST_EXTRA_IDS, ListUtils.toLongArray(mediaIds));
         context.startActivity(intent);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -659,14 +659,7 @@ public class MediaGridFragment extends Fragment
     }
 
     private void updateActionButtons(int selectCount) {
-        switch (selectCount) {
-            case 1:
-                mNewPostButton.setVisible(true);
-                break;
-            default:
-                mNewPostButton.setVisible(false);
-                break;
-        }
+        mNewPostButton.setVisible(selectCount == 1);
     }
 
     private void handleNewPost() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -116,7 +116,6 @@ public class MediaGridFragment extends Fragment
     private AlertDialog mDatePickerDialog;
 
     private MenuItem mNewPostButton;
-    private MenuItem mNewGalleryButton;
 
     private SiteModel mSite;
 
@@ -304,7 +303,6 @@ public class MediaGridFragment extends Fragment
         MenuInflater inflater = mode.getMenuInflater();
         inflater.inflate(R.menu.media_multiselect, menu);
         mNewPostButton = menu.findItem(R.id.media_multiselect_actionbar_post);
-        mNewGalleryButton = menu.findItem(R.id.media_multiselect_actionbar_gallery);
         setSwipeToRefreshEnabled(false);
         mIsMultiSelect = true;
         updateActionButtons(selectCount);
@@ -321,9 +319,6 @@ public class MediaGridFragment extends Fragment
         int i = item.getItemId();
         if (i == R.id.media_multiselect_actionbar_post) {
             handleNewPost();
-            return true;
-        } else if (i == R.id.media_multiselect_actionbar_gallery) {
-            handleMultiSelectPost();
             return true;
         } else if (i == R.id.media_multiselect_actionbar_trash) {
             handleMultiSelectDelete();
@@ -667,11 +662,9 @@ public class MediaGridFragment extends Fragment
         switch (selectCount) {
             case 1:
                 mNewPostButton.setVisible(true);
-                mNewGalleryButton.setVisible(false);
                 break;
             default:
                 mNewPostButton.setVisible(false);
-                mNewGalleryButton.setVisible(true);
                 break;
         }
     }
@@ -714,20 +707,6 @@ public class MediaGridFragment extends Fragment
                         }).setNegativeButton(R.string.cancel, null);
         AlertDialog dialog = builder.create();
         dialog.show();
-    }
-
-    private void handleMultiSelectPost() {
-        if (!isAdded()) {
-            return;
-        }
-
-        ArrayList<Long> remoteMediaIds = new ArrayList<>();
-        for (int localMediaId : mGridAdapter.getSelectedItems()) {
-            MediaModel mediaModel = mMediaStore.getMediaWithLocalId(localMediaId);
-            remoteMediaIds.add(mediaModel.getMediaId());
-        }
-
-        ActivityLauncher.newGalleryPost(getActivity(), mSite, remoteMediaIds);
     }
 
     private void restoreState(Bundle savedInstanceState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -659,16 +659,23 @@ public class MediaGridFragment extends Fragment
     }
 
     private void updateActionButtons(int selectCount) {
-        mNewPostButton.setVisible(selectCount == 1);
+        mNewPostButton.setVisible(selectCount > 0);
     }
 
     private void handleNewPost() {
         if (!isAdded()) {
             return;
         }
-        ArrayList<Integer> ids = mGridAdapter.getSelectedItems();
-        MediaModel mediaModel = mMediaStore.getMediaWithLocalId(ids.iterator().next());
-        ActivityLauncher.newMediaPost(getActivity(), mSite, mediaModel.getMediaId());
+
+        ArrayList<Integer> localIds = mGridAdapter.getSelectedItems();
+        ArrayList<Long> mediaIds = new ArrayList<>();
+        for (Integer localId : localIds) {
+            MediaModel mediaModel = mMediaStore.getMediaWithLocalId(localId);
+            if (mediaModel != null) {
+                mediaIds.add(mediaModel.getMediaId());
+            }
+        }
+        ActivityLauncher.newMediaPost(getActivity(), mSite, mediaIds);
     }
 
     private void handleMultiSelectDelete() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1093,7 +1093,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     public static final String NEW_MEDIA_GALLERY = "NEW_MEDIA_GALLERY";
     public static final String NEW_MEDIA_GALLERY_EXTRA_IDS = "NEW_MEDIA_GALLERY_EXTRA_IDS";
     public static final String NEW_MEDIA_POST = "NEW_MEDIA_POST";
-    public static final String NEW_MEDIA_POST_EXTRA = "NEW_MEDIA_POST_ID";
+    public static final String NEW_MEDIA_POST_EXTRA_IDS = "NEW_MEDIA_POST_EXTRA_IDS";
     private String mMediaCapturePath = "";
     private int mMaxThumbWidth = 0;
 
@@ -1305,8 +1305,11 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     }
 
     private void prepareMediaPost() {
-        long mediaId = getIntent().getLongExtra(NEW_MEDIA_POST_EXTRA, 0);
-        addExistingMediaToEditor(mediaId);
+        long[] idsArray = getIntent().getLongArrayExtra(NEW_MEDIA_POST_EXTRA_IDS);
+        ArrayList<Long> idsList = ListUtils.fromLongArray(idsArray);
+        for (Long id: idsList) {
+            addExistingMediaToEditor(id);
+        }
     }
 
     // TODO: Replace with contents of the updatePostContentNewEditor() method when legacy editor is dropped

--- a/WordPress/src/main/res/menu/media_multiselect.xml
+++ b/WordPress/src/main/res/menu/media_multiselect.xml
@@ -3,11 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/media_multiselect_actionbar_gallery"
-        android:icon="@drawable/tab_icon_create_gallery"
-        app:showAsAction="always"
-        android:title="@string/media_add_new_media_gallery"/>
-    <item
         android:id="@+id/media_multiselect_actionbar_post"
         android:icon="@drawable/ic_create_white_24dp"
         app:showAsAction="always"


### PR DESCRIPTION
As per #5337,  drops the ability to create a gallery from the media browser. This feature may be redesigned and reintroduced down the road, but for now it's not very friendly so we've decided to remove it.

Note: It would be best if #5348 was reviewed and merged before this one.