### PR TITLE
Fix #5123: People tweaks for Jetpack sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/Role.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Role.java
@@ -104,6 +104,11 @@ public enum Role {
         return new Role[] { ADMIN, EDITOR, AUTHOR, CONTRIBUTOR };
     }
 
+    public static Role[] inviteRoles(SiteModel site) {
+        if (site.isJetpackConnected()) {
+            return new Role[] { FOLLOWER };
+        }
+
         if (site.isPrivate()) {
             return new Role[] { VIEWER, ADMIN, EDITOR, AUTHOR, CONTRIBUTOR };
         }

--- a/WordPress/src/main/java/org/wordpress/android/models/Role.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Role.java
@@ -4,6 +4,7 @@ import android.support.annotation.StringRes;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.CrashlyticsUtils;
 
@@ -90,11 +91,16 @@ public enum Role {
             case VIEWER:
                 // the remote expects "follower" as the role parameter even if the role is "viewer"
                 return "follower";
+            case SUBSCRIBER:
+                return "subscriber";
         }
         throw new IllegalArgumentException("All roles must be handled");
     }
 
-    public static Role[] userRoles() {
+    public static Role[] userRoles(SiteModel site) {
+        if (site.isJetpackConnected()) {
+            return new Role[] { ADMIN, EDITOR, AUTHOR, CONTRIBUTOR, SUBSCRIBER };
+        }
         return new Role[] { ADMIN, EDITOR, AUTHOR, CONTRIBUTOR };
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/models/Role.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Role.java
@@ -17,6 +17,12 @@ public enum Role {
     VIEWER(R.string.role_viewer),
     SUBSCRIBER(R.string.role_subscriber); // Jetpack only
 
+    private static final Role[] USER_ROLES_WPCOM = { ADMIN, EDITOR, AUTHOR, CONTRIBUTOR };
+    private static final Role[] USER_ROLES_JETPACK = { ADMIN, EDITOR, AUTHOR, CONTRIBUTOR, SUBSCRIBER };
+    private static final Role[] INVITE_ROLES_WPCOM = { FOLLOWER, ADMIN, EDITOR, AUTHOR, CONTRIBUTOR };
+    private static final Role[] INVITE_ROLES_WPCOM_PRIVATE = { VIEWER, ADMIN, EDITOR, AUTHOR, CONTRIBUTOR };
+    private static final Role[] INVITE_ROLES_JETPACK = { FOLLOWER };
+
     private final int mLabelResId;
 
     Role(@StringRes int labelResId) {
@@ -99,19 +105,19 @@ public enum Role {
 
     public static Role[] userRoles(SiteModel site) {
         if (site.isJetpackConnected()) {
-            return new Role[] { ADMIN, EDITOR, AUTHOR, CONTRIBUTOR, SUBSCRIBER };
+            return USER_ROLES_JETPACK;
         }
-        return new Role[] { ADMIN, EDITOR, AUTHOR, CONTRIBUTOR };
+        return USER_ROLES_WPCOM;
     }
 
     public static Role[] inviteRoles(SiteModel site) {
         if (site.isJetpackConnected()) {
-            return new Role[] { FOLLOWER };
+            return INVITE_ROLES_JETPACK;
         }
 
         if (site.isPrivate()) {
-            return new Role[] { VIEWER, ADMIN, EDITOR, AUTHOR, CONTRIBUTOR };
+            return INVITE_ROLES_WPCOM_PRIVATE;
         }
-        return new Role[] { FOLLOWER, ADMIN, EDITOR, AUTHOR, CONTRIBUTOR };
+        return INVITE_ROLES_WPCOM;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/Role.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Role.java
@@ -13,7 +13,8 @@ public enum Role {
     AUTHOR(R.string.role_author),
     CONTRIBUTOR(R.string.role_contributor),
     FOLLOWER(R.string.role_follower),
-    VIEWER(R.string.role_viewer);
+    VIEWER(R.string.role_viewer),
+    SUBSCRIBER(R.string.role_subscriber);
 
     private final int mLabelResId;
 
@@ -39,6 +40,8 @@ public enum Role {
                 return FOLLOWER;
             case "viewer":
                 return VIEWER;
+            case "subscriber":
+                return SUBSCRIBER;
         }
         Exception e = new IllegalArgumentException("All roles must be handled: " + role);
         CrashlyticsUtils.logException(e, CrashlyticsUtils.ExceptionType.SPECIFIC, AppLog.T.PEOPLE);
@@ -63,6 +66,8 @@ public enum Role {
                 return "follower";
             case VIEWER:
                 return "viewer";
+            case SUBSCRIBER:
+                return "subscriber";
         }
         throw new IllegalArgumentException("All roles must be handled");
     }

--- a/WordPress/src/main/java/org/wordpress/android/models/Role.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Role.java
@@ -15,7 +15,7 @@ public enum Role {
     CONTRIBUTOR(R.string.role_contributor),
     FOLLOWER(R.string.role_follower),
     VIEWER(R.string.role_viewer),
-    SUBSCRIBER(R.string.role_subscriber);
+    SUBSCRIBER(R.string.role_subscriber); // Jetpack only
 
     private final int mLabelResId;
 

--- a/WordPress/src/main/java/org/wordpress/android/models/Role.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Role.java
@@ -104,8 +104,7 @@ public enum Role {
         return new Role[] { ADMIN, EDITOR, AUTHOR, CONTRIBUTOR };
     }
 
-    public static Role[] inviteRoles(boolean isPrivateSite) {
-        if (isPrivateSite) {
+        if (site.isPrivate()) {
             return new Role[] { VIEWER, ADMIN, EDITOR, AUTHOR, CONTRIBUTOR };
         }
         return new Role[] { FOLLOWER, ADMIN, EDITOR, AUTHOR, CONTRIBUTOR };

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -212,7 +212,7 @@ public class PeopleInviteFragment extends Fragment implements RoleSelectDialogFr
         view.findViewById(R.id.role_container).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                RoleSelectDialogFragment.show(PeopleInviteFragment.this, 0, mSite.isPrivate());
+                RoleSelectDialogFragment.show(PeopleInviteFragment.this, 0, mSite);
             }
         });
 
@@ -285,7 +285,7 @@ public class PeopleInviteFragment extends Fragment implements RoleSelectDialogFr
     }
 
     private Role getDefaultRole() {
-        Role[] inviteRoles = Role.inviteRoles(mSite.isPrivate());
+        Role[] inviteRoles = Role.inviteRoles(mSite);
         return inviteRoles[0];
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleInviteFragment.java
@@ -208,14 +208,6 @@ public class PeopleInviteFragment extends Fragment implements RoleSelectDialogFr
             populateUsernameButtons(usernames);
         }
 
-
-        view.findViewById(R.id.role_container).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                RoleSelectDialogFragment.show(PeopleInviteFragment.this, 0, mSite);
-            }
-        });
-
         mRoleTextView = (TextView) view.findViewById(R.id.role);
         setRole(role);
         ImageView imgRoleInfo = (ImageView) view.findViewById(R.id.imgRoleInfo);
@@ -225,6 +217,18 @@ public class PeopleInviteFragment extends Fragment implements RoleSelectDialogFr
                 ActivityLauncher.openUrlExternal(v.getContext(), URL_USER_ROLES_DOCUMENTATION);
             }
         });
+
+        if (Role.inviteRoles(mSite).length > 1) {
+            view.findViewById(R.id.role_container).setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    RoleSelectDialogFragment.show(PeopleInviteFragment.this, 0, mSite);
+                }
+            });
+        } else {
+            // Don't show drop-down arrow or role selector if there's only one role available
+            mRoleTextView.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
+        }
 
         final int MAX_CHARS = getResources().getInteger(R.integer.invite_message_char_limit);
         final TextView remainingCharsTextView = (TextView) view.findViewById(R.id.message_remaining);

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -9,7 +9,6 @@ import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
-import android.view.Menu;
 import android.view.MenuItem;
 
 import org.wordpress.android.R;
@@ -226,23 +225,6 @@ public class PeopleManagementActivity extends AppCompatActivity
         if (!navigateBackToPeopleListFragment()) {
             super.onBackPressed();
         }
-    }
-
-    @Override
-    public boolean onPrepareOptionsMenu(Menu menu) {
-        super.onPrepareOptionsMenu(menu);
-
-        MenuItem inviteItem = menu.findItem(R.id.invite);
-        if (inviteItem != null) {
-            if (mSite.isJetpackConnected()) {
-                // User invitations aren't currently supported for Jetpack sites
-                inviteItem.setVisible(false);
-            } else {
-                inviteItem.setVisible(true);
-            }
-        }
-
-        return true;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleManagementActivity.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.view.Menu;
 import android.view.MenuItem;
 
 import org.wordpress.android.R;
@@ -225,6 +226,23 @@ public class PeopleManagementActivity extends AppCompatActivity
         if (!navigateBackToPeopleListFragment()) {
             super.onBackPressed();
         }
+    }
+
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+
+        MenuItem inviteItem = menu.findItem(R.id.invite);
+        if (inviteItem != null) {
+            if (mSite.isJetpackConnected()) {
+                // User invitations aren't currently supported for Jetpack sites
+                inviteItem.setVisible(false);
+            } else {
+                inviteItem.setVisible(true);
+            }
+        }
+
+        return true;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PersonDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PersonDetailFragment.java
@@ -189,7 +189,7 @@ public class PersonDetailFragment extends Fragment {
         }
 
         RoleChangeDialogFragment dialog = RoleChangeDialogFragment.newInstance(person.getPersonID(),
-                person.getLocalTableBlogId(), person.getRole());
+                mSiteStore.getSiteByLocalId(mLocalTableBlogId), person.getRole());
         dialog.show(getFragmentManager(), null);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/RoleChangeDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/RoleChangeDialogFragment.java
@@ -13,13 +13,14 @@ import android.widget.RadioButton;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.models.Role;
 
 import de.greenrobot.event.EventBus;
 
 public class RoleChangeDialogFragment extends DialogFragment {
     private static final String PERSON_ID_TAG = "person_id";
-    private static final String PERSON_LOCAL_TABLE_BLOG_ID_TAG = "local_table_blog_id";
     private static final String ROLE_TAG = "role";
 
     private RoleListAdapter mRoleListAdapter;
@@ -31,15 +32,15 @@ public class RoleChangeDialogFragment extends DialogFragment {
         outState.putSerializable(ROLE_TAG, role);
     }
 
-    public static RoleChangeDialogFragment newInstance(long personID, int localTableBlogId, Role role) {
+    public static RoleChangeDialogFragment newInstance(long personID, SiteModel site, Role role) {
         RoleChangeDialogFragment roleChangeDialogFragment = new RoleChangeDialogFragment();
         Bundle args = new Bundle();
 
         args.putLong(PERSON_ID_TAG, personID);
-        args.putInt(PERSON_LOCAL_TABLE_BLOG_ID_TAG, localTableBlogId);
         if (role != null) {
             args.putSerializable(ROLE_TAG, role);
         }
+        args.putSerializable(WordPress.SITE, site);
 
         roleChangeDialogFragment.setArguments(args);
         return roleChangeDialogFragment;
@@ -47,6 +48,8 @@ public class RoleChangeDialogFragment extends DialogFragment {
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
+        final SiteModel site = (SiteModel) getArguments().getSerializable(WordPress.SITE);
+
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(), R.style.Calypso_AlertDialog);
         builder.setTitle(R.string.role);
         builder.setNegativeButton(R.string.cancel, null);
@@ -57,14 +60,15 @@ public class RoleChangeDialogFragment extends DialogFragment {
                 Bundle args = getArguments();
                 if (args != null) {
                     long personID = args.getLong(PERSON_ID_TAG);
-                    int localTableBlogId = args.getInt(PERSON_LOCAL_TABLE_BLOG_ID_TAG);
-                    EventBus.getDefault().post(new RoleChangeEvent(personID, localTableBlogId, role));
+                    if (site != null) {
+                        EventBus.getDefault().post(new RoleChangeEvent(personID, site.getId(), role));
+                    }
                 }
             }
         });
 
         if (mRoleListAdapter == null) {
-            final Role[] userRoles = Role.userRoles();
+            final Role[] userRoles = Role.userRoles(site);
             mRoleListAdapter = new RoleListAdapter(getActivity(), R.layout.role_list_row, userRoles);
         }
         if (savedInstanceState != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/RoleSelectDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/RoleSelectDialogFragment.java
@@ -9,20 +9,19 @@ import android.content.DialogInterface;
 import android.os.Bundle;
 
 import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.models.Role;
 
 public class RoleSelectDialogFragment extends DialogFragment {
-    private static final String IS_PRIVATE_TAG = "is_private";
-
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        boolean isPrivateSite = getArguments().getBoolean(IS_PRIVATE_TAG);
-        final Role[] roles = Role.inviteRoles(isPrivateSite);
+        SiteModel site = (SiteModel) getArguments().getSerializable(WordPress.SITE);
+        final Role[] roles = Role.inviteRoles(site);
         final String[] stringRoles = new String[roles.length];
         for (int i = 0; i < roles.length; i++) {
             stringRoles[i] = roles[i].toDisplayString();
         }
-
 
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(), R.style.Calypso_AlertDialog);
         builder.setTitle(R.string.role);
@@ -45,10 +44,10 @@ public class RoleSelectDialogFragment extends DialogFragment {
     }
 
     public static <T extends Fragment & OnRoleSelectListener> void show(T parentFragment, int requestCode,
-                                                                        boolean isPrivateSite) {
+                                                                        SiteModel site) {
         RoleSelectDialogFragment roleChangeDialogFragment = new RoleSelectDialogFragment();
         Bundle args = new Bundle();
-        args.putBoolean(IS_PRIVATE_TAG, isPrivateSite);
+        args.putSerializable(WordPress.SITE, site);
         roleChangeDialogFragment.setArguments(args);
         roleChangeDialogFragment.setTargetFragment(parentFragment, requestCode);
         roleChangeDialogFragment.show(parentFragment.getFragmentManager(), null);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1521,6 +1521,7 @@
     <string name="role_contributor">Contributor</string>
     <string name="role_follower">Follower</string>
     <string name="role_viewer">Viewer</string>
+    <string name="role_subscriber">Subscriber</string>
 
     <!--My profile-->
     <string name="my_profile">My Profile</string>


### PR DESCRIPTION
Addresses #5123, making a few fixes needed for a smooth Jetpack experience in the People activity.

1. Added the missing `Subscriber` role for Jetpack sites
2. Disabled inviting new users to Jetpack sites: it doesn't look like this flow is supported yet. Calypso sends the user to their self-hosted `wp-admin`. Relevant Calypso issue: https://github.com/Automattic/wp-calypso/issues/11107.

To test:
* Try changing user roles for Jetpack and WP.com sites - only Jetpack sites should offer the `Subscriber` role
* Check user invitation flow - it should only be available for WP.com sites