### PR TITLE
FluxC spring cleaning - take 4

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -28,6 +28,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.ui.accounts.SignInActivity;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.util.GravatarUtils;
@@ -49,6 +50,7 @@ public class AddQuickPressShortcutActivity extends ListActivity {
     public List<String> accountNames = new ArrayList<>();
 
     @Inject SiteStore mSiteStore;
+    @Inject FluxCImageLoader mImageLoader;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -211,7 +213,7 @@ public class AddQuickPressShortcutActivity extends ListActivity {
             blogUsername.setText(
                     StringUtils.unescapeHTML(username));
             blavatar.setErrorImageResId(R.drawable.blavatar_placeholder);
-            blavatar.setImageUrl(blavatars[position], WordPress.sImageLoader);
+            blavatar.setImageUrl(blavatars[position], mImageLoader);
 
             return view;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -46,6 +46,7 @@ import org.wordpress.android.fluxc.store.CommentStore.RemoteCommentPayload;
 import org.wordpress.android.fluxc.store.CommentStore.RemoteCreateCommentPayload;
 import org.wordpress.android.fluxc.store.CommentStore.RemoteLikeCommentPayload;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.models.Note;
 import org.wordpress.android.models.Note.EnabledActions;
 import org.wordpress.android.models.Suggestion;
@@ -137,6 +138,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     @Inject AccountStore mAccountStore;
     @Inject CommentStore mCommentStore;
     @Inject SiteStore mSiteStore;
+    @Inject FluxCImageLoader mImageLoader;
 
     private boolean mIsSubmittingReply = false;
     private NotificationsDetailListFragment mNotificationsDetailListFragment;
@@ -626,7 +628,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
                 WordPress.getContext()));
 
         int maxImageSz = getResources().getDimensionPixelSize(R.dimen.reader_comment_max_image_size);
-        CommentUtils.displayHtmlComment(mTxtContent, mComment.getContent(), maxImageSz);
+        CommentUtils.displayHtmlComment(mTxtContent, mComment.getContent(), maxImageSz, mImageLoader);
 
         int avatarSz = getResources().getDimensionPixelSize(R.dimen.avatar_sz_large);
         if (mComment.getAuthorProfileImageUrl() != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentUtils.java
@@ -11,8 +11,9 @@ import android.text.style.LeadingMarginSpan;
 import android.text.util.Linkify;
 import android.widget.TextView;
 
+import com.android.volley.toolbox.ImageLoader;
+
 import org.wordpress.android.R;
-import org.wordpress.android.WordPress;
 import org.wordpress.android.util.EmoticonsUtils;
 import org.wordpress.android.util.HtmlUtils;
 import org.wordpress.android.util.helpers.WPImageGetter;
@@ -21,7 +22,8 @@ public class CommentUtils {
     /*
      * displays comment text as html, including retrieving images
      */
-    public static void displayHtmlComment(TextView textView, String content, int maxImageSize) {
+    public static void displayHtmlComment(TextView textView, String content, int maxImageSize,
+                                          ImageLoader imageLoader) {
         if (textView == null) {
             return;
         }
@@ -52,8 +54,7 @@ public class CommentUtils {
                     R.drawable.legacy_dashicon_format_image_big_grey);
             Drawable failed = ContextCompat.getDrawable(textView.getContext(),
                     R.drawable.noticon_warning_big_grey);
-            html = HtmlUtils.fromHtml(content, new WPImageGetter(textView, maxImageSize, WordPress.sImageLoader, loading,
-                    failed));
+            html = HtmlUtils.fromHtml(content, new WPImageGetter(textView, maxImageSize, imageLoader, loading, failed));
         } else {
             html = HtmlUtils.fromHtml(content);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -17,7 +17,6 @@ import android.widget.ImageView;
 import android.widget.ScrollView;
 import android.widget.Toast;
 
-import com.android.volley.toolbox.ImageLoader;
 import com.android.volley.toolbox.NetworkImageView;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -31,6 +30,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged;
+import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.ImageUtils.BitmapWorkerCallback;
 import org.wordpress.android.util.ImageUtils.BitmapWorkerTask;
@@ -49,8 +49,9 @@ public class MediaEditFragment extends Fragment {
     public static final String TAG = "MediaEditFragment";
     public static final int MISSING_MEDIA_ID = -1;
 
-    @Inject MediaStore mMediaStore;
     @Inject Dispatcher mDispatcher;
+    @Inject MediaStore mMediaStore;
+    @Inject FluxCImageLoader mImageLoader;
 
     private NetworkImageView mNetworkImageView;
     private ImageView mLocalImageView;
@@ -67,7 +68,6 @@ public class MediaEditFragment extends Fragment {
     private int mLocalMediaId = MISSING_MEDIA_ID;
     private ScrollView mScrollView;
     private View mLinearLayout;
-    private ImageLoader mImageLoader;
 
     private SiteModel mSite;
     private MediaModel mMediaModel;
@@ -109,8 +109,6 @@ public class MediaEditFragment extends Fragment {
         }
 
         setHasOptionsMenu(true);
-        // TODO: We want to inject the image loader in this class instead of using a static field.
-        mImageLoader = WordPress.sImageLoader;
 
         // retain this fragment across configuration changes
         setRetainInstance(true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryAdapter.java
@@ -13,7 +13,6 @@ import com.mobeta.android.dslv.ResourceDragSortCursorAdapter;
 import com.wellsql.generated.MediaModelTable;
 
 import org.wordpress.android.R;
-import org.wordpress.android.WordPress;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.StringUtils;
 
@@ -30,11 +29,7 @@ class MediaGalleryAdapter extends ResourceDragSortCursorAdapter {
     }
 
     void setImageLoader(ImageLoader imageLoader) {
-        if (imageLoader != null) {
-            mImageLoader = imageLoader;
-        } else {
-            mImageLoader = WordPress.sImageLoader;
-        }
+        mImageLoader = imageLoader;
     }
 
     private static class GridViewHolder {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryEditFragment.java
@@ -22,6 +22,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.MediaStore;
+import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.util.ListUtils;
 import org.wordpress.android.util.ToastUtils;
 
@@ -41,6 +42,7 @@ public class MediaGalleryEditFragment extends Fragment implements DropListener, 
     private SiteModel mSite;
 
     @Inject MediaStore mMediaStore;
+    @Inject FluxCImageLoader mImageLoader;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -58,9 +60,7 @@ public class MediaGalleryEditFragment extends Fragment implements DropListener, 
             mIds = ListUtils.fromLongArray(savedInstanceState.getLongArray(SAVED_MEDIA_IDS));
         }
 
-        // TODO: We want to inject the image loader in this class instead of using a static field.
-        mGridAdapter = new MediaGalleryAdapter(getActivity(), R.layout.media_gallery_item, null, true,
-                WordPress.sImageLoader);
+        mGridAdapter = new MediaGalleryAdapter(getActivity(), R.layout.media_gallery_item, null, true, mImageLoader);
 
         View view = inflater.inflate(R.layout.media_gallery_edit_fragment, container, false);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaListFetched;
+import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.util.ListUtils;
 import org.wordpress.android.util.ToastUtils;
 
@@ -62,6 +63,7 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
 
     @Inject Dispatcher mDispatcher;
     @Inject MediaStore mMediaStore;
+    @Inject FluxCImageLoader mImageLoader;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -100,8 +102,7 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
         mGridView = (GridView) findViewById(R.id.media_gallery_picker_gridview);
         mGridView.setMultiChoiceModeListener(this);
         mGridView.setOnItemClickListener(this);
-        // TODO: We want to inject the image loader in this class instead of using a static field.
-        mGridAdapter = new MediaGridAdapter(this, mSite, null, 0, WordPress.sImageLoader);
+        mGridAdapter = new MediaGridAdapter(this, mSite, null, 0, mImageLoader);
         mGridAdapter.setSelectedItems(selectedItems);
         mGridAdapter.setCallback(this);
         mGridView.setAdapter(mGridAdapter);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -86,11 +86,7 @@ public class MediaGridAdapter extends CursorAdapter {
     }
 
     void setImageLoader(ImageLoader imageLoader) {
-        if (imageLoader != null) {
-            mImageLoader = imageLoader;
-        } else {
-            mImageLoader = WordPress.sImageLoader;
-        }
+        mImageLoader = imageLoader;
     }
 
     public ArrayList<Integer> getSelectedItems() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -42,6 +42,7 @@ import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.FetchMediaListPayload;
 import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaListFetched;
+import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.models.MediaUploadState;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.CheckableFrameLayout;
@@ -87,6 +88,7 @@ public class MediaGridFragment extends Fragment
 
     @Inject Dispatcher mDispatcher;
     @Inject MediaStore mMediaStore;
+    @Inject FluxCImageLoader mImageLoader;
 
     private Filter mFilter = Filter.ALL;
     private String[] mFiltersText;
@@ -205,8 +207,7 @@ public class MediaGridFragment extends Fragment
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         super.onCreateView(inflater, container, savedInstanceState);
         mFiltersText = new String[Filter.values().length];
-        // TODO: We want to inject the image loader in this class instead of using a static field.
-        mGridAdapter = new MediaGridAdapter(getActivity(), mSite, null, 0, WordPress.sImageLoader);
+        mGridAdapter = new MediaGridAdapter(getActivity(), mSite, null, 0, mImageLoader);
         mGridAdapter.setCallback(this);
 
         View view = inflater.inflate(R.layout.media_grid_fragment, container);
@@ -278,7 +279,7 @@ public class MediaGridFragment extends Fragment
             String tag = (String) imageView.getTag();
             if (tag != null && tag.startsWith("http")) {
                 // need a listener to cancel request, even if the listener does nothing
-                ImageContainer container = WordPress.sImageLoader.get(tag, new ImageListener() {
+                ImageContainer container = mImageLoader.get(tag, new ImageListener() {
                     @Override
                     public void onErrorResponse(VolleyError error) { }
 
@@ -567,8 +568,7 @@ public class MediaGridFragment extends Fragment
         mGridView.setSelection(0);
         mGridView.requestFocusFromTouch();
         mGridView.setSelection(0);
-        // TODO: We want to inject the image loader in this class instead of using a static field.
-        mGridAdapter.setImageLoader(WordPress.sImageLoader);
+        mGridAdapter.setImageLoader(mImageLoader);
         mGridAdapter.changeCursor(null);
         resetSpinnerAdapter();
         mHasRetrievedAllMedia = false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
@@ -237,13 +237,6 @@ public class WordPressMediaUtils {
     }
 
     /**
-     * Loads the given network image URL into the {@link NetworkImageView}, using the default {@link ImageLoader}.
-     */
-    public static void loadNetworkImage(String imageUrl, NetworkImageView imageView) {
-        loadNetworkImage(imageUrl, imageView, WordPress.sImageLoader);
-    }
-
-    /**
      * Loads the given network image URL into the {@link NetworkImageView}.
      */
     public static void loadNetworkImage(String imageUrl, NetworkImageView imageView, ImageLoader imageLoader) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -84,6 +84,7 @@ import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
@@ -212,6 +213,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     @Inject SiteStore mSiteStore;
     @Inject PostStore mPostStore;
     @Inject MediaStore mMediaStore;
+    @Inject FluxCImageLoader mImageLoader;
 
     // Upload service
     private MediaUploadService.MediaUploadBinder mMediaUploadService;
@@ -327,7 +329,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         }
 
         if (mHasSetPostContent = mEditorFragment != null) {
-            mEditorFragment.setImageLoader(WordPress.sImageLoader);
+            mEditorFragment.setImageLoader(mImageLoader);
         }
 
         // Ensure we have a valid post
@@ -1109,7 +1111,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         if (media != null) {
             MediaFile mediaFile = FluxCUtils.mediaFileFromMediaModel(media);
             trackAddMediaFromWPLibraryEvents(mediaFile.isVideo(), media.getMediaId());
-            mEditorFragment.appendMediaFile(mediaFile, media.getUrl(), WordPress.sImageLoader);
+            mEditorFragment.appendMediaFile(mediaFile, media.getUrl(), mImageLoader);
         }
     }
 
@@ -1561,7 +1563,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         MediaFile mediaFile = FluxCUtils.mediaFileFromMediaModel(media);
         trackAddMediaFromDeviceEvents(isVideo, null, path);
         if (media != null) {
-            mEditorFragment.appendMediaFile(mediaFile, path, WordPress.sImageLoader);
+            mEditorFragment.appendMediaFile(mediaFile, path, mImageLoader);
         }
 
         return true;
@@ -1581,7 +1583,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mediaModel));
 
         MediaFile mediaFile = FluxCUtils.mediaFileFromMediaModel(mediaModel);
-        mEditorFragment.appendMediaFile(mediaFile, mediaFile.getFilePath(), WordPress.sImageLoader);
+        mEditorFragment.appendMediaFile(mediaFile, mediaFile.getFilePath(), mImageLoader);
         return true;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -59,6 +59,7 @@ import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.TaxonomyStore;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
+import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaGalleryPickerActivity;
@@ -132,6 +133,7 @@ public class EditPostSettingsFragment extends Fragment
     @Inject MediaStore mMediaStore;
     @Inject TaxonomyStore mTaxonomyStore;
     @Inject Dispatcher mDispatcher;
+    @Inject FluxCImageLoader mImageLoader;
 
     public static EditPostSettingsFragment newInstance(SiteModel site, PostModel post) {
         EditPostSettingsFragment fragment = new EditPostSettingsFragment();
@@ -438,7 +440,8 @@ public class EditPostSettingsFragment extends Fragment
                 int padding = DisplayUtils.dpToPx(getActivity(), 16);
                 int imageWidth = (maxWidth - padding);
 
-                WordPressMediaUtils.loadNetworkImage(media.getThumbnailUrl() + "?w=" + imageWidth, mFeaturedImageView);
+                WordPressMediaUtils.loadNetworkImage(media.getThumbnailUrl() + "?w=" + imageWidth, mFeaturedImageView,
+                        mImageLoader);
             } else {
                 mFeaturedImageView.setVisibility(View.GONE);
                 mFeaturedImageButton.setVisibility(View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -19,6 +19,7 @@ import org.wordpress.android.datasets.ReaderCommentTable;
 import org.wordpress.android.datasets.ReaderPostTable;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.models.ReaderComment;
 import org.wordpress.android.models.ReaderCommentList;
 import org.wordpress.android.models.ReaderPost;
@@ -71,6 +72,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
 
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
+    @Inject FluxCImageLoader mImageLoader;
 
     public interface RequestReplyListener {
         void onRequestReply(long commentId);
@@ -265,7 +267,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         }
 
         int maxImageWidth = mContentWidth - indentWidth;
-        CommentUtils.displayHtmlComment(commentHolder.txtText, comment.getText(), maxImageWidth);
+        CommentUtils.displayHtmlComment(commentHolder.txtText, comment.getText(), maxImageWidth, mImageLoader);
 
         // different background for highlighted comment, with optional progress bar
         if (mHighlightCommentId != 0 && mHighlightCommentId == comment.commentId) {


### PR DESCRIPTION
Replaces some instances of `WordPress.sImageLoader` with an injected `FluxCImageLoader`, cleaning up some media TODOs.

I focused on cases where already-connected, non-static classes could switch over to the `FluxCImageLoader`, which still leaves many other uses of `WordPress.sImageLoader`. Talked to @maxme about this, and we should leave them for now and work on a general refactor of this static usage in the future.

cc @maxme