### PR TITLE
Login: Show logotype only when showing wpcom password form.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -412,6 +412,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             mForgotPassword.setVisibility(View.VISIBLE);
             if (!mSelfHosted) {
                 mPasswordEditText.setImeOptions(EditorInfo.IME_ACTION_DONE);
+                showWPComLogoType(true);
             }
             mSignInButton.setText(R.string.sign_in);
         }
@@ -440,6 +441,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         mAddSelfHostedButton.setText(getString(R.string.nux_add_selfhosted_blog));
         switchToDotOrgIcon(false);
         switchBackgroundToDotOrg(false, false);
+        showWPComLogoType(false);
     }
 
     protected void showSelfHostedSignInForm(){
@@ -456,24 +458,18 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
         if (mIconSwitcher.getDisplayedChild() == 0) {
             if (showDotOrg) {
                 mIconSwitcher.showNext();
-                mWpcomLogotype.setVisibility(View.GONE);
             }
+            showWPComLogoType(false);
         } else {
             if (!showDotOrg) {
                 mIconSwitcher.showPrevious();
-
-                // reinstate the logotype into the layout so the switcher can compute sizes
-                mWpcomLogotype.setVisibility(View.INVISIBLE);
-
-                // delay the actual appearance of the logotype for smoother coordination with the rest of animations
-                new Handler().postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        mWpcomLogotype.setVisibility(View.VISIBLE);
-                    }
-                }, 300);
             }
         }
+    }
+
+    private void showWPComLogoType(boolean show) {
+        int visibility = show ? View.VISIBLE : View.GONE;
+        mWpcomLogotype.setVisibility(visibility);
     }
 
     private void switchBackgroundToDotOrg(boolean useDotOrg, boolean noFading) {


### PR DESCRIPTION
Fixes #4742 

To test:
Scenario 1:
- Completely sign out of the app.
- The first screen showing just the username/email field should show the W icon, but not the logotype. 
- Type a username and tap next. 
- When the wpcom password form appears the WordPress.com logotype should also appear. 
- Switch to the self-hosted form and confirm the logotype is hidden and there is not unnecessary space under the wporg icon.
- Tap to sign into wpcom. This currently takes the user back to the username/email form (no password). Ensure the logotype is still hidden.

Scenario 2: 
- Be signed into the app, and try adding a self-hosted site.
- Confirm the logotype is hidden and there is not unnecessary space below the wporg icon.


