### PR TITLE
feature/fluxc-medialib-remove-gallery

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -171,13 +171,13 @@ public class ActivityLauncher {
         context.startActivity(intent);
     }
 
-    public static void newMediaPost(Activity context, SiteModel site, long mediaId) {
-        if (site == null) return;
+    public static void newMediaPost(Activity context, SiteModel site, ArrayList<Long> mediaIds) {
+        if (site == null || mediaIds == null) return;
         // Create a new post object and assign default settings
         Intent intent = new Intent(context, EditPostActivity.class);
         intent.putExtra(WordPress.SITE, site);
         intent.setAction(EditPostActivity.NEW_MEDIA_POST);
-        intent.putExtra(EditPostActivity.NEW_MEDIA_POST_EXTRA, mediaId);
+        intent.putExtra(EditPostActivity.NEW_MEDIA_POST_EXTRA_IDS, ListUtils.toLongArray(mediaIds));
         context.startActivity(intent);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1093,7 +1093,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     public static final String NEW_MEDIA_GALLERY = "NEW_MEDIA_GALLERY";
     public static final String NEW_MEDIA_GALLERY_EXTRA_IDS = "NEW_MEDIA_GALLERY_EXTRA_IDS";
     public static final String NEW_MEDIA_POST = "NEW_MEDIA_POST";
-    public static final String NEW_MEDIA_POST_EXTRA = "NEW_MEDIA_POST_ID";
+    public static final String NEW_MEDIA_POST_EXTRA_IDS = "NEW_MEDIA_POST_EXTRA_IDS";
     private String mMediaCapturePath = "";
     private int mMaxThumbWidth = 0;
 
@@ -1305,8 +1305,11 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     }
 
     private void prepareMediaPost() {
-        long mediaId = getIntent().getLongExtra(NEW_MEDIA_POST_EXTRA, 0);
-        addExistingMediaToEditor(mediaId);
+        long[] idsArray = getIntent().getLongArrayExtra(NEW_MEDIA_POST_EXTRA_IDS);
+        ArrayList<Long> idsList = ListUtils.fromLongArray(idsArray);
+        for (Long id: idsList) {
+            addExistingMediaToEditor(id);
+        }
     }
 
     // TODO: Replace with contents of the updatePostContentNewEditor() method when legacy editor is dropped

--- a/WordPress/src/main/res/menu/media_multiselect.xml
+++ b/WordPress/src/main/res/menu/media_multiselect.xml
@@ -3,11 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/media_multiselect_actionbar_gallery"
-        android:icon="@drawable/tab_icon_create_gallery"
-        app:showAsAction="always"
-        android:title="@string/media_add_new_media_gallery"/>
-    <item
         android:id="@+id/media_multiselect_actionbar_post"
         android:icon="@drawable/ic_create_white_24dp"
         app:showAsAction="always"


### PR DESCRIPTION
As per #5337, drops the ability to create a gallery from the media browser. This feature may be redesigned and reintroduced down the road, but for now it's not very friendly so we've decided to remove it.