### PR TITLE
FluxC: Handle Jetpack sites not matching current WP.com account

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1113,9 +1113,11 @@
     <string name="jetpack_info">Jetpack info</string>
     <string name="jetpack_message">The Jetpack plugin must be installed and activated. Do you want to install or activate Jetpack?</string>
     <string name="jetpack_message_not_admin">The Jetpack plugin is required. Contact the site administrator.</string>
+    <string name="jetpack_use_com_account">To add your Jetpack site, log in to the WordPress.com account you used to connect Jetpack.</string>
     <string name="jetpack_not_found">Jetpack plugin not found</string>
     <string name="jetpack_not_connected">Jetpack plugin not connected</string>
     <string name="jetpack_not_connected_message">The Jetpack plugin is installed, but not connected to WordPress.com. Do you want to connect Jetpack?</string>
+    <string name="jetpack_different_com_account">Jetpack sites belonging to different WordPress.com accounts are not supported</string>
     <string name="jetpack_stats_module_disabled_message">The Jetpack plugin is connected, but the Stats module is not active. Do you want to activate Stats?</string>
     <string name="jetpack_stats_module_disabled_message_not_admin">The Jetpack plugin is connected, but the Stats module is not active. Contact the site administrator.</string>
 


### PR DESCRIPTION
Fixes #4763, sort of. I opted for the 'first pass' approach described in https://github.com/wordpress-mobile/WordPress-Android/issues/4763#issuecomment-285191731, which will seem to the user to sign in to the site, but will show them a WordPress.com sign-in screen as soon as we realize their site is Jetpack-connected:

![add-jetpack-site-wpcom](https://cloud.githubusercontent.com/assets/9613966/23761367/940badb4-04c0-11e7-8667-2a85a0e6eadd.png)

To test:
* While not signed in to WP.com, add a self-hosted site that's Jetpack-connected. You should be shown the above screen prompting you to sign in to WP.com, and be unable to use that site otherwise. Everything should work once signed in to WP.com
* While signed in to WP.com, add a self-hosted site that's Jetpack-connected to a different WP.com account. It should get added, but switching to that site should send you back to the site list with the site removed and a 'not supported' toast should be shown
