### PR TITLE
Fix #2822: Show icons for Jetpack sites

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -131,7 +131,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:develop-SNAPSHOT') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:issue~jetpack-icons-SNAPSHOT') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -31,7 +31,6 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.ui.accounts.SignInActivity;
 import org.wordpress.android.ui.posts.EditPostActivity;
-import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.StringUtils;
 
@@ -93,7 +92,7 @@ public class AddQuickPressShortcutActivity extends ListActivity {
                 accountUsers[i] = site.getUsername();
                 siteIds[i] = site.getId();
                 if (site.getUrl() != null) {
-                    blavatars[i] = GravatarUtils.blavatarFromUrl(site.getUrl(), 60);
+                    blavatars[i] = SiteUtils.getSiteIconUrl(site, 60);
                 } else {
                     blavatars[i] = "";
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -36,7 +36,6 @@ import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.CoreEvents;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DisplayUtils;
-import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.ServiceUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
@@ -350,7 +349,7 @@ public class MySiteFragment extends Fragment
         int settingsVisibility = (isAdminOrSelfHosted || site.getHasCapabilityListUsers()) ? View.VISIBLE : View.GONE;
         mConfigurationHeader.setVisibility(settingsVisibility);
 
-        mBlavatarImageView.setImageUrl(GravatarUtils.blavatarFromUrl(site.getUrl(), mBlavatarSz), WPNetworkImageView
+        mBlavatarImageView.setImageUrl(SiteUtils.getSiteIconUrl(site, mBlavatarSz), WPNetworkImageView
                 .ImageType.BLAVATAR);
         String homeUrl = SiteUtils.getHomeURLOrHostName(site);
         String blogTitle = SiteUtils.getSiteNameOrHomeURL(site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -19,7 +19,6 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
@@ -508,7 +507,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.Si
             blogName = SiteUtils.getSiteNameOrHomeURL(siteModel);
             homeURL = SiteUtils.getHomeURLOrHostName(siteModel);
             url = siteModel.getUrl();
-            blavatarUrl = GravatarUtils.blavatarFromUrl(url, mBlavatarSz);
+            blavatarUrl = SiteUtils.getSiteIconUrl(siteModel, mBlavatarSz);
             isHidden = !siteModel.isVisible();
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureAdapter.java
@@ -17,7 +17,6 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
@@ -250,7 +249,7 @@ public class StatsWidgetConfigureAdapter extends RecyclerView.Adapter<StatsWidge
             blogName = SiteUtils.getSiteNameOrHomeURL(site);
             homeURL = SiteUtils.getHomeURLOrHostName(site);
             url = site.getUrl();
-            blavatarUrl = GravatarUtils.blavatarFromUrl(url, mBlavatarSz);
+            blavatarUrl = SiteUtils.getSiteIconUrl(site, mBlavatarSz);
             isDotComOrJetpack = SiteUtils.isAccessibleViaWPComAPI(site);
             isHidden = !site.isVisible();
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -39,7 +39,7 @@ public class SiteUtils {
 
     public static String getSiteIconUrl(SiteModel site, int size) {
         if (!TextUtils.isEmpty(site.getIconUrl())) {
-            return StringUtils.getPhotonUrl(site.getIconUrl(), size);
+            return PhotonUtils.getPhotonImageUrl(site.getIconUrl(), size, size, PhotonUtils.Quality.HIGH);
         } else {
             return GravatarUtils.blavatarFromUrl(site.getUrl(), size);
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.util;
 
+import android.text.TextUtils;
+
 import org.wordpress.android.fluxc.model.SiteModel;
 
 public class SiteUtils {
@@ -33,5 +35,13 @@ public class SiteUtils {
 
     public static boolean isAccessibleViaWPComAPI(SiteModel site) {
         return site.isWPCom() || site.isJetpackConnected();
+    }
+
+    public static String getSiteIconUrl(SiteModel site, int size) {
+        if (!TextUtils.isEmpty(site.getIconUrl())) {
+            return StringUtils.getPhotonUrl(site.getIconUrl(), size);
+        } else {
+            return GravatarUtils.blavatarFromUrl(site.getUrl(), size);
+        }
     }
 }


### PR DESCRIPTION
Fixes #2822, displaying Jetpack site icons in the site picker and My Site view.

https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/350 should be merged before this PR (and 0472a99 reverted).

![jetpack-site-icon](https://cloud.githubusercontent.com/assets/9613966/23773489/757f3a82-04ed-11e7-8b50-10326bbefb7e.png)

To test:
1. Sign into a WordPress.com account with a Jetpack site
2. Check that the site icon shows up in the site picker and My Site view
3. Check that normal WordPress.com site avatars are still showing up
4. Check that site icons are displayed for both sites when adding Quick Post and Stats widgets

Bonus round: Run this branch on top of an already logged-into app, to test the `SiteModel` migration from https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/350.