### PR TITLE
Issue/5367 media picker click not working

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -521,8 +521,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         // size the chooser before creating the fragment to avoid having it load media now
         resizePhotoChooser();
 
-        mPhotoChooserFragment = PhotoChooserFragment.newInstance();
-        mPhotoChooserFragment.setPhotoChooserListener(this);
+        mPhotoChooserFragment = PhotoChooserFragment.newInstance(this);
 
         getFragmentManager()
                 .beginTransaction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -522,6 +522,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         resizePhotoChooser();
 
         mPhotoChooserFragment = PhotoChooserFragment.newInstance();
+        mPhotoChooserFragment.setPhotoChooserListener(this);
 
         getFragmentManager()
                 .beginTransaction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/photochooser/PhotoChooserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/photochooser/PhotoChooserFragment.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.posts.photochooser;
 
 import android.app.Fragment;
-import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -99,15 +98,8 @@ public class PhotoChooserFragment extends Fragment {
         return view;
     }
 
-    @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-        try {
-            mListener = (PhotoChooserListener) context;
-        } catch (ClassCastException e) {
-            AppLog.e(AppLog.T.POSTS, e);
-            throw new ClassCastException(context.toString() + " must implement PhotoChooserListener");
-        }
+    public void setPhotoChooserListener(PhotoChooserListener listener) {
+        mListener = listener;
     }
 
     private void showBottomBar() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/photochooser/PhotoChooserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/photochooser/PhotoChooserFragment.java
@@ -53,9 +53,10 @@ public class PhotoChooserFragment extends Fragment {
     private Parcelable mRestoreState;
     private PhotoChooserListener mListener;
 
-    public static PhotoChooserFragment newInstance() {
+    public static PhotoChooserFragment newInstance(@NonNull PhotoChooserListener listener) {
         Bundle args = new Bundle();
         PhotoChooserFragment fragment = new PhotoChooserFragment();
+        fragment.setPhotoChooserListener(listener);
         fragment.setArguments(args);
         return fragment;
     }
@@ -98,7 +99,7 @@ public class PhotoChooserFragment extends Fragment {
         return view;
     }
 
-    public void setPhotoChooserListener(PhotoChooserListener listener) {
+    private void setPhotoChooserListener(PhotoChooserListener listener) {
         mListener = listener;
     }
 


### PR DESCRIPTION
Fixes #5367 - Problem was due to relying on `onAttach` to set the photo chooser listener, which was never called on Android 5. Details [here](http://stackoverflow.com/questions/32083053/android-fragment-onattach-deprecated).

Rather than rely on the solution recommended at that SO link, I decided it was better to simply pass the listener to the fragment's `newInstance()`.
