### PR TITLE
Issue/media browser state

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -574,14 +574,15 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             } else {
                 showMediaToastError(R.string.media_upload_error, event.error.message);
             }
+            updateViews();
         } else if (event.completed) {
             String title = "";
             if (event.media != null) {
                 title = event.media.getTitle();
             }
             AppLog.d(AppLog.T.MEDIA, "<" + title + "> upload complete");
+            updateViews();
         }
-        updateViews();
     }
 
     public void onSavedEdit(int localMediaId, boolean result) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -115,7 +115,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
     }
 
     @Override
-    public void onBindViewHolder(GridViewHolder holder, int position) {
+    public void onBindViewHolder(final GridViewHolder holder, int position) {
         if (!isValidPosition(position)) {
             return;
         }
@@ -170,18 +170,18 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         // show upload state unless it's already uploaded
         boolean showState = !TextUtils.isEmpty(state) && !state.equalsIgnoreCase(MediaUploadState.UPLOADED.name());
         if (showState) {
-            holder.stateTextView.setVisibility(View.VISIBLE);
+            holder.stateContainer.setVisibility(View.VISIBLE);
             holder.stateTextView.setText(state);
 
             // hide progressbar and add onclick to retry failed uploads
             if (state.equalsIgnoreCase(MediaUploadState.FAILED.name())) {
                 holder.progressUpload.setVisibility(View.GONE);
                 holder.stateTextView.setText(mContext.getString(R.string.retry));
-                holder.stateTextView.setOnClickListener(new OnClickListener() {
+                holder.stateContainer.setOnClickListener(new OnClickListener() {
                     @Override
                     public void onClick(View v) {
                         if (!isInMultiSelect()) {
-                            ((TextView) v).setText(R.string.upload_queued);
+                            holder.stateTextView.setText(R.string.upload_queued);
                             v.setOnClickListener(null);
                             if (mCallback != null) {
                                 mCallback.onAdapterRetryUpload(localMediaId);
@@ -191,12 +191,11 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                 });
             } else {
                 holder.progressUpload.setVisibility(View.VISIBLE);
-                holder.stateTextView.setOnClickListener(null);
+                holder.stateContainer.setOnClickListener(null);
             }
         } else {
-            holder.progressUpload.setVisibility(View.GONE);
-            holder.stateTextView.setVisibility(View.GONE);
-            holder.stateTextView.setOnClickListener(null);
+            holder.stateContainer.setVisibility(View.GONE);
+            holder.stateContainer.setOnClickListener(null);
         }
 
         // if we are near the end, make a call to fetch more
@@ -244,6 +243,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         private final TextView selectionCountTextView;
         private final TextView stateTextView;
         private final ProgressBar progressUpload;
+        private final ViewGroup stateContainer;
 
         public GridViewHolder(View view) {
             super(view);
@@ -251,10 +251,11 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             titleView = (TextView) view.findViewById(R.id.media_grid_item_name);
             imageView = (FadeInNetworkImageView) view.findViewById(R.id.media_grid_item_image);
             fileTypeView = (TextView) view.findViewById(R.id.media_grid_item_filetype);
-
             selectionCountTextView = (TextView) view.findViewById(R.id.text_selection_count);
-            stateTextView = (TextView) view.findViewById(R.id.media_grid_item_upload_state);
-            progressUpload = (ProgressBar) view.findViewById(R.id.media_grid_item_upload_progress);
+
+            stateContainer = (ViewGroup) view.findViewById(R.id.media_grid_item_upload_state_container);
+            stateTextView = (TextView) stateContainer.findViewById(R.id.media_grid_item_upload_state);
+            progressUpload = (ProgressBar) stateContainer.findViewById(R.id.media_grid_item_upload_progress);
 
             imageView.getLayoutParams().width = mThumbWidth;
             imageView.getLayoutParams().height = mThumbHeight;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -3,6 +3,8 @@ package org.wordpress.android.ui.media;
 import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Bitmap;
+import android.graphics.Color;
+import android.graphics.PorterDuff;
 import android.os.Handler;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
@@ -168,6 +170,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         }
 
         // show upload state unless it's already uploaded
+        state = MediaUploadState.UPLOADING.toString();
         if (!TextUtils.isEmpty(state) && !state.equalsIgnoreCase(MediaUploadState.UPLOADED.name())) {
             holder.stateContainer.setVisibility(View.VISIBLE);
             holder.stateTextView.setText(state);
@@ -257,6 +260,9 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             stateContainer = (ViewGroup) view.findViewById(R.id.media_grid_item_upload_state_container);
             stateTextView = (TextView) stateContainer.findViewById(R.id.media_grid_item_upload_state);
             progressUpload = (ProgressBar) stateContainer.findViewById(R.id.media_grid_item_upload_progress);
+
+            // make the progress bar white
+            progressUpload.getIndeterminateDrawable().setColorFilter(Color.WHITE, PorterDuff.Mode.MULTIPLY);
 
             imageView.getLayoutParams().width = mThumbWidth;
             imageView.getLayoutParams().height = mThumbHeight;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -168,8 +168,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         }
 
         // show upload state unless it's already uploaded
-        boolean showState = !TextUtils.isEmpty(state) && !state.equalsIgnoreCase(MediaUploadState.UPLOADED.name());
-        if (showState) {
+        if (!TextUtils.isEmpty(state) && !state.equalsIgnoreCase(MediaUploadState.UPLOADED.name())) {
             holder.stateContainer.setVisibility(View.VISIBLE);
             holder.stateTextView.setText(state);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -170,7 +170,6 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         }
 
         // show upload state unless it's already uploaded
-        state = MediaUploadState.UPLOADING.toString();
         if (!TextUtils.isEmpty(state) && !state.equalsIgnoreCase(MediaUploadState.UPLOADED.name())) {
             holder.stateContainer.setVisibility(View.VISIBLE);
             holder.stateTextView.setText(state);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -117,7 +117,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
     }
 
     @Override
-    public void onBindViewHolder(final GridViewHolder holder, int position) {
+    public void onBindViewHolder(GridViewHolder holder, int position) {
         if (!isValidPosition(position)) {
             return;
         }
@@ -173,12 +173,12 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                 holder.progressUpload.setVisibility(View.GONE);
                 holder.stateTextView.setText(mContext.getString(R.string.retry));
                 holder.stateTextView.setCompoundDrawablesWithIntrinsicBounds(0, R.drawable.media_retry_image, 0, 0);
-                holder.stateContainer.setOnClickListener(new OnClickListener() {
+                holder.stateTextView.setOnClickListener(new OnClickListener() {
                     @Override
                     public void onClick(View v) {
                         if (!isInMultiSelect()) {
-                            holder.stateTextView.setText(R.string.upload_queued);
-                            holder.stateTextView.setCompoundDrawables(null, null, null, null);
+                            ((TextView) v).setText(R.string.upload_queued);
+                            ((TextView) v).setCompoundDrawables(null, null, null, null);
                             v.setOnClickListener(null);
                             if (mCallback != null) {
                                 mCallback.onAdapterRetryUpload(localMediaId);
@@ -188,7 +188,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                 });
             } else {
                 holder.progressUpload.setVisibility(View.VISIBLE);
-                holder.stateContainer.setOnClickListener(null);
+                holder.stateTextView.setOnClickListener(null);
                 holder.stateTextView.setCompoundDrawables(null, null, null, null);
             }
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -167,27 +167,15 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             holder.imageView.setScaleY(scale);
         }
 
-        // show upload state
-        if (state != null && state.length() > 0) {
+        // show upload state unless it's already uploaded
+        boolean showState = !TextUtils.isEmpty(state) && !state.equalsIgnoreCase(MediaUploadState.UPLOADED.name());
+        if (showState) {
             holder.stateTextView.setVisibility(View.VISIBLE);
             holder.stateTextView.setText(state);
 
-            // hide the progressbar only if the state is Uploaded or failed
-            if (state.equalsIgnoreCase(MediaUploadState.UPLOADED.name()) ||
-                    state.equalsIgnoreCase(MediaUploadState.FAILED.name())) {
-                holder.progressUpload.setVisibility(View.GONE);
-            } else {
-                holder.progressUpload.setVisibility(View.VISIBLE);
-            }
-
-            // Hide the state text only if the it's Uploaded
-            if (state.equalsIgnoreCase(MediaUploadState.UPLOADED.name())) {
-                holder.stateTextView.setVisibility(View.GONE);
-            }
-
-            // add onclick to retry failed uploads
+            // hide progressbar and add onclick to retry failed uploads
             if (state.equalsIgnoreCase(MediaUploadState.FAILED.name())) {
-                holder.stateTextView.setVisibility(View.VISIBLE);
+                holder.progressUpload.setVisibility(View.GONE);
                 holder.stateTextView.setText(mContext.getString(R.string.retry));
                 holder.stateTextView.setOnClickListener(new OnClickListener() {
                     @Override
@@ -201,6 +189,8 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                         }
                     }
                 });
+            } else {
+                holder.progressUpload.setVisibility(View.VISIBLE);
             }
         } else {
             holder.progressUpload.setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -177,6 +177,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             if (state.equalsIgnoreCase(MediaUploadState.FAILED.name())) {
                 holder.progressUpload.setVisibility(View.GONE);
                 holder.stateTextView.setText(mContext.getString(R.string.retry));
+                holder.stateTextView.setCompoundDrawablesWithIntrinsicBounds(0, R.drawable.media_retry_image, 0, 0);
                 holder.stateContainer.setOnClickListener(new OnClickListener() {
                     @Override
                     public void onClick(View v) {
@@ -192,6 +193,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             } else {
                 holder.progressUpload.setVisibility(View.VISIBLE);
                 holder.stateContainer.setOnClickListener(null);
+                holder.stateTextView.setCompoundDrawables(null, null, null, null);
             }
         } else {
             holder.stateContainer.setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -130,27 +130,21 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         String fileName = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.FILE_NAME));
         String title = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.TITLE));
         String filePath = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.FILE_PATH));
-        String mimeType = StringUtils.notNullStr(
-                mCursor.getString(mCursor.getColumnIndex(MediaModelTable.MIME_TYPE))
-        );
+        String thumbUrl = WordPressMediaUtils.getNetworkThumbnailUrl(mCursor, mSite, mThumbWidth);
+        String mimeType = StringUtils.notNullStr(mCursor.getString(mCursor.getColumnIndex(MediaModelTable.MIME_TYPE)));
 
         boolean isLocalFile = MediaUtils.isLocalFile(state);
         boolean isSelected = isItemSelected(localMediaId);
-        boolean isImage = mimeType.contains("image");
 
         holder.titleView.setText(TextUtils.isEmpty(title) ? fileName : title);
 
         String fileExtension = MediaUtils.getExtensionForMimeType(mimeType);
         holder.fileTypeView.setText(fileExtension.toUpperCase());
 
-        // load image
-        if (isImage) {
-            if (isLocalFile) {
-                loadLocalImage(filePath, holder.imageView);
-            } else {
-                String thumbUrl = WordPressMediaUtils.getNetworkThumbnailUrl(mCursor, mSite, mThumbWidth);
-                WordPressMediaUtils.loadNetworkImage(thumbUrl, holder.imageView, mImageLoader);
-            }
+        if (isLocalFile) {
+            loadLocalImage(filePath, holder.imageView);
+        } else if (!TextUtils.isEmpty(thumbUrl)) {
+            WordPressMediaUtils.loadNetworkImage(thumbUrl, holder.imageView, mImageLoader);
         } else {
             holder.imageView.setImageDrawable(null);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -191,10 +191,12 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                 });
             } else {
                 holder.progressUpload.setVisibility(View.VISIBLE);
+                holder.stateTextView.setOnClickListener(null);
             }
         } else {
             holder.progressUpload.setVisibility(View.GONE);
             holder.stateTextView.setVisibility(View.GONE);
+            holder.stateTextView.setOnClickListener(null);
         }
 
         // if we are near the end, make a call to fetch more

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -184,6 +184,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                     public void onClick(View v) {
                         if (!isInMultiSelect()) {
                             holder.stateTextView.setText(R.string.upload_queued);
+                            holder.stateTextView.setCompoundDrawables(null, null, null, null);
                             v.setOnClickListener(null);
                             if (mCallback != null) {
                                 mCallback.onAdapterRetryUpload(localMediaId);

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -40,16 +40,15 @@
 
             <ProgressBar
                 android:id="@+id/media_grid_item_upload_progress"
-                style="?android:attr/progressBarStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_centerInParent="true" />
+                android:layout_width="@dimen/media_grid_progress_height"
+                android:layout_height="@dimen/media_grid_progress_height"
+                android:layout_above="@+id/media_grid_item_upload_state"
+                android:layout_centerHorizontal="true" />
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/media_grid_item_upload_state"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_below="@+id/media_grid_item_upload_progress"
                 android:layout_centerInParent="true"
                 android:shadowColor="@color/grey_dark"
                 android:shadowDx="2"
@@ -57,7 +56,7 @@
                 android:shadowRadius="2"
                 android:textAllCaps="true"
                 android:textColor="@color/white"
-                android:textSize="@dimen/text_sz_large"
+                android:textSize="@dimen/text_sz_medium"
                 android:textStyle="bold"
                 tools:text="@string/upload_failed" />
         </RelativeLayout>

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content" >
+    android:layout_height="wrap_content">
 
     <FrameLayout
         android:id="@+id/media_grid_frame_layout"
@@ -34,29 +33,33 @@
         <RelativeLayout
             android:id="@+id/media_grid_item_upload_state_container"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:background="@color/grey_lighten_10_translucent_50"
+            android:visibility="gone"
+            tools:visibility="visible">
 
             <ProgressBar
                 android:id="@+id/media_grid_item_upload_progress"
                 style="?android:attr/progressBarStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_centerInParent="true"
-                android:paddingLeft="@dimen/margin_small"
-                android:paddingRight="@dimen/margin_small" />
+                android:layout_centerInParent="true" />
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/media_grid_item_upload_state"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_below="@id/media_grid_item_upload_progress"
-                android:layout_centerHorizontal="true"
-                android:layout_centerVertical="true"
-                android:paddingLeft="@dimen/margin_small"
-                android:shadowColor="@color/primary_text_default_material_light"
+                android:layout_below="@+id/media_grid_item_upload_progress"
+                android:layout_centerInParent="true"
+                android:shadowColor="@color/grey_dark"
+                android:shadowDx="2"
+                android:shadowDy="2"
                 android:shadowRadius="2"
+                android:textAllCaps="true"
                 android:textColor="@color/white"
-                android:textSize="@dimen/text_sz_small" />
+                android:textSize="@dimen/text_sz_large"
+                android:textStyle="bold"
+                tools:text="@string/upload_failed" />
         </RelativeLayout>
 
         <CheckBox

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -56,7 +56,7 @@
                 android:shadowRadius="2"
                 android:textAllCaps="true"
                 android:textColor="@color/white"
-                android:textSize="@dimen/text_sz_medium"
+                android:textSize="@dimen/text_sz_large"
                 android:textStyle="bold"
                 tools:text="@string/upload_failed" />
         </RelativeLayout>

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -34,7 +34,7 @@
             android:id="@+id/media_grid_item_upload_state_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="@color/grey_lighten_10_translucent_50"
+            android:background="@color/grey_lighten_20_translucent_50"
             android:visibility="gone"
             tools:visibility="visible">
 

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -34,7 +34,7 @@
             android:id="@+id/media_grid_item_upload_state_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="@color/grey_lighten_20_translucent_50"
+            android:background="@color/grey_dark_translucent_50"
             android:visibility="gone"
             tools:visibility="visible">
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -23,7 +23,7 @@
     <dimen name="message_bar_elevation">2dp</dimen>
     <dimen name="tabs_elevation">4dp</dimen>
 
-    <dimen name="media_grid_progress_height">50dp</dimen>
+    <dimen name="media_grid_progress_height">24dp</dimen>
 
     <dimen name="theme_details_fragment_width">650dp</dimen>
     <dimen name="theme_details_fragment_height">450dp</dimen>

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -104,8 +104,10 @@ public class MediaUtils {
             return false;
         }
 
-        return  (state.equals("queued") || state.equals("uploading") || state.equals("retry")
-                || state.equals("failed"));
+        return state.equalsIgnoreCase("queued")
+                || state.equalsIgnoreCase("uploading")
+                || state.equalsIgnoreCase("retry")
+                || state.equalsIgnoreCase("failed");
     }
 
     public static Uri getLastRecordedVideoUri(Activity activity) {


### PR DESCRIPTION
Fixes #4603 - as referenced in #5337, simplifies and improves how upload state is displayed in the media browser, including using a translucent background so the upload state TextView is readable regardless of the colors in the image behind it.

This is how failed images used to appear:
![failed-before](https://cloud.githubusercontent.com/assets/3903757/23912864/865ebe90-08b7-11e7-95c8-e0aeed35f099.png)

This is how they appear in this PR:
![failed-after](https://cloud.githubusercontent.com/assets/3903757/23917752/d5c22a4e-08c6-11e7-987c-f653d9fad7fd.png)

