### PR TITLE
Report extra infos from UnexpectedError to Crashlytics 

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -131,7 +131,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:c7d399bac1cd57e7aa1b0eafbbda469afde6ff2b') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:issue~add-extra-to-unexpected-error') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -131,7 +131,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:issue~add-extra-to-unexpected-error') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:issue~add-extra-to-unexpected-error-SNAPSHOT') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -68,7 +68,6 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.BitmapLruCache;
 import org.wordpress.android.util.CrashlyticsUtils;
-import org.wordpress.android.util.CrashlyticsUtils.ExceptionType;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.HelpshiftHelper;
@@ -566,7 +565,12 @@ public class WordPress extends MultiDexApplication {
     public void onParseError(OnUnexpectedError event) {
         AppLog.d(T.API, "Receiving OnUnexpectedError event, message: " + event.exception.getMessage());
         String description = "FluxC: " + event.description;
-        CrashlyticsUtils.logException(event.exception, ExceptionType.SPECIFIC, event.type, description);
+        if (event.extras != null) {
+            for (String key : event.extras.keySet()) {
+                CrashlyticsUtils.setString(key, event.extras.get(key));
+            }
+        }
+        CrashlyticsUtils.logException(event.exception, event.type, description);
     }
 
     public void removeWpComUserRelatedData(Context context) {

--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -946,7 +946,7 @@ public class ReaderPostTable {
                 } while (cursor.moveToNext());
             }
         } catch (IllegalStateException e) {
-            CrashlyticsUtils.logException(e, CrashlyticsUtils.ExceptionType.SPECIFIC);
+            CrashlyticsUtils.logException(e);
             AppLog.e(AppLog.T.READER, e);
         }
         return posts;

--- a/WordPress/src/main/java/org/wordpress/android/models/Role.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Role.java
@@ -51,7 +51,7 @@ public enum Role {
                 return SUBSCRIBER;
         }
         Exception e = new IllegalArgumentException("All roles must be handled: " + role);
-        CrashlyticsUtils.logException(e, CrashlyticsUtils.ExceptionType.SPECIFIC, AppLog.T.PEOPLE);
+        CrashlyticsUtils.logException(e, AppLog.T.PEOPLE);
 
         // All roles should have been handled, but in case an edge case occurs,
         // using "Contributor" role is the safest option

--- a/WordPress/src/main/java/org/wordpress/android/networking/GravatarApi.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/GravatarApi.java
@@ -107,8 +107,7 @@ public class GravatarApi {
                         properties.put("network_exception_class", e != null ? e.getClass().getCanonicalName() : "null");
                         properties.put("network_exception_message", e != null ? e.getMessage() : "null");
                         AnalyticsTracker.track(AnalyticsTracker.Stat.ME_GRAVATAR_UPLOAD_EXCEPTION, properties);
-                        CrashlyticsUtils.logException(e, CrashlyticsUtils.ExceptionType.SPECIFIC,
-                                AppLog.T.API, "Network call failure trying to upload Gravatar!");
+                        CrashlyticsUtils.logException(e, AppLog.T.API, "Network call failure trying to upload Gravatar!");
                         AppLog.w(AppLog.T.API, "Network call failure trying to upload Gravatar!" + (e != null ?
                                 e.getMessage() : "null"));
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -106,7 +106,6 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.AutolinkUtils;
 import org.wordpress.android.util.CrashlyticsUtils;
-import org.wordpress.android.util.CrashlyticsUtils.ExceptionType;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DeviceUtils;
 import org.wordpress.android.util.DisplayUtils;
@@ -1211,7 +1210,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
      */
     @Override
     public void onReflectionFailure(ReflectionException e) {
-        CrashlyticsUtils.logException(e, ExceptionType.SPECIFIC, T.EDITOR, "Reflection Failure on Visual Editor init");
+        CrashlyticsUtils.logException(e, T.EDITOR, "Reflection Failure on Visual Editor init");
         // Disable visual editor and show an error message
         AppPrefs.setVisualEditorEnabled(false);
         ToastUtils.showToast(this, R.string.new_editor_reflection_error, Duration.LONG);
@@ -2245,8 +2244,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 @Override
                 public void onJavaScriptError(String sourceFile, int lineNumber, String message) {
                     CrashlyticsUtils.logException(new JavaScriptException(sourceFile, lineNumber, message),
-                            ExceptionType.SPECIFIC, T.EDITOR,
-                            String.format(Locale.US, "%s:%d: %s", sourceFile, lineNumber, message));
+                            T.EDITOR, String.format(Locale.US, "%s:%d: %s", sourceFile, lineNumber, message));
                 }
 
                 @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
@@ -202,8 +202,7 @@ public class PostUploadNotifier {
         try {
             mNotificationManager.notify((int) id, notification);
         } catch (RuntimeException runtimeException) {
-            CrashlyticsUtils.logException(runtimeException, CrashlyticsUtils.ExceptionType.SPECIFIC,
-                    AppLog.T.UTILS, "See issue #2858 / #3966");
+            CrashlyticsUtils.logException(runtimeException, AppLog.T.UTILS, "See issue #2858 / #3966");
             AppLog.d(AppLog.T.POSTS, "See issue #2858 / #3966; notify failed with:" + runtimeException);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/CrashlyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/CrashlyticsUtils.java
@@ -5,13 +5,10 @@ import com.crashlytics.android.Crashlytics;
 import io.fabric.sdk.android.Fabric;
 
 public class CrashlyticsUtils {
-    final private static String EXCEPTION_KEY = "exception";
     final private static String TAG_KEY = "tag";
     final private static String MESSAGE_KEY = "message";
-    public enum ExceptionType {USUAL, SPECIFIC}
-    public enum ExtraKey {IMAGE_ANGLE, IMAGE_WIDTH, IMAGE_HEIGHT, IMAGE_RESIZE_SCALE, NOTE_HTMLDATA, ENTERED_URL}
 
-    public static void logException(Throwable tr, ExceptionType exceptionType, AppLog.T tag, String message) {
+    public static void logException(Throwable tr, AppLog.T tag, String message) {
         if (!Fabric.isInitialized()) {
             return;
         }
@@ -21,45 +18,44 @@ public class CrashlyticsUtils {
         if (message != null) {
             Crashlytics.setString(MESSAGE_KEY, message);
         }
-        Crashlytics.setString(EXCEPTION_KEY, exceptionType.name());
         Crashlytics.logException(tr);
     }
 
-    public static void logException(Throwable tr, ExceptionType exceptionType, AppLog.T tag) {
-        logException(tr, exceptionType, tag, null);
+    public static void logException(Throwable tr, AppLog.T tag) {
+        logException(tr, tag, null);
     }
 
-    public static void logException(Throwable tr, ExceptionType exceptionType) {
-        logException(tr, exceptionType, null, null);
+    public static void logException(Throwable tr) {
+        logException(tr, null, null);
     }
 
     // Utility functions to force us to use and reuse a limited set of keys
 
-    public static void setInt(ExtraKey key, int value) {
+    public static void setInt(String key, int value) {
         if (!Fabric.isInitialized()) {
             return;
         }
-        Crashlytics.setInt(key.name(), value);
+        Crashlytics.setInt(key, value);
     }
 
-    public static void setFloat(ExtraKey key, float value) {
+    public static void setFloat(String key, float value) {
         if (!Fabric.isInitialized()) {
             return;
         }
-        Crashlytics.setFloat(key.name(), value);
+        Crashlytics.setFloat(key, value);
     }
 
-    public static void setString(ExtraKey key, String value) {
+    public static void setString(String key, String value) {
         if (!Fabric.isInitialized()) {
             return;
         }
-        Crashlytics.setString(key.name(), value);
+        Crashlytics.setString(key, value);
     }
 
-    public static void setBool(ExtraKey key, boolean value) {
+    public static void setBool(String key, boolean value) {
         if (!Fabric.isInitialized()) {
             return;
         }
-        Crashlytics.setBool(key.name(), value);
+        Crashlytics.setBool(key, value);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/HtmlToSpannedConverter.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HtmlToSpannedConverter.java
@@ -349,7 +349,7 @@ public class HtmlToSpannedConverter implements ContentHandler {
                 }
             }
         } catch (OutOfMemoryError e) {
-            CrashlyticsUtils.logException(e, CrashlyticsUtils.ExceptionType.SPECIFIC, AppLog.T.UTILS);
+            CrashlyticsUtils.logException(e, AppLog.T.UTILS);
         }
 
         if (resizedBitmap != null) {


### PR DESCRIPTION
Related to https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/361

I also cleaned up `CrashlyticsUtils`, we're not using `ExceptionType` anymore (and naming was super confusing), I also dropped `ExtraKey` and gave users the ability to pick their own key names.