### PR TITLE
Issue/media library search disappearing icons

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -389,8 +389,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                 }
                 return true;
             case R.id.menu_search:
-                mSearchMenuItem = item;
-                mSearchView = (SearchView) item.getActionView();
                 mSearchView.setOnQueryTextListener(this);
                 MenuItemCompat.expandActionView(mSearchMenuItem);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -93,7 +93,7 @@ import javax.inject.Inject;
  * The main activity in which the user can browse their media.
  */
 public class MediaBrowserActivity extends AppCompatActivity implements MediaGridListener,
-        MediaItemFragmentCallback, OnQueryTextListener, MediaEditFragmentCallback,
+        MediaItemFragmentCallback, MediaEditFragmentCallback,
         WordPressMediaUtils.LaunchCameraCallback {
     private static final int MEDIA_PERMISSION_REQUEST_CODE = 1;
 
@@ -316,7 +316,24 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     @Override
     public boolean onPrepareOptionsMenu(final Menu menu) {
         mSearchView = (SearchView) menu.findItem(R.id.menu_search).getActionView();
-        mSearchView.setOnQueryTextListener(this);
+        mSearchView.setOnQueryTextListener(new OnQueryTextListener() {
+            @Override
+            public boolean onQueryTextSubmit(String query) {
+                if (mMediaGridFragment != null) {
+                    mMediaGridFragment.search(query);
+                }
+                mSearchView.clearFocus();
+                return true;
+            }
+
+            @Override
+            public boolean onQueryTextChange(String newText) {
+                if (mMediaGridFragment != null) {
+                    mMediaGridFragment.search(newText);
+                }
+                return true;
+            }
+        });
 
         mSearchMenuItem = menu.findItem(R.id.menu_search);
         MenuItemCompat.setOnActionExpandListener(mSearchMenuItem, new OnActionExpandListener() {
@@ -327,7 +344,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                     mMediaGridFragment.setFilterEnabled(false);
                     mMediaGridFragment.setFilter(Filter.ALL);
                 }
-                menu.findItem(R.id.menu_new_media).setEnabled(false);
+                menu.findItem(R.id.menu_new_media).setVisible(false);
                 return true;
             }
 
@@ -337,9 +354,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                     mMediaGridFragment.setFilterEnabled(true);
                     mMediaGridFragment.setFilter(Filter.ALL);
                 }
-
-                menu.findItem(R.id.menu_new_media).setEnabled(true);
-
+                menu.findItem(R.id.menu_new_media).setVisible(true);
                 return true;
             }
         });
@@ -360,7 +375,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                 }
                 return true;
             case R.id.menu_search:
-                mSearchView.setOnQueryTextListener(this);
                 MenuItemCompat.expandActionView(mSearchMenuItem);
                 return true;
             case R.id.menu_edit_media:
@@ -391,23 +405,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         }
 
         return super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    public boolean onQueryTextSubmit(String query) {
-        if (mMediaGridFragment != null) {
-            mMediaGridFragment.search(query);
-        }
-        mSearchView.clearFocus();
-        return true;
-    }
-
-    @Override
-    public boolean onQueryTextChange(String newText) {
-        if (mMediaGridFragment != null) {
-            mMediaGridFragment.search(newText);
-        }
-        return true;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -93,8 +93,8 @@ import javax.inject.Inject;
  * The main activity in which the user can browse their media.
  */
 public class MediaBrowserActivity extends AppCompatActivity implements MediaGridListener,
-        MediaItemFragmentCallback, OnQueryTextListener, OnActionExpandListener,
-        MediaEditFragmentCallback, WordPressMediaUtils.LaunchCameraCallback {
+        MediaItemFragmentCallback, OnQueryTextListener, MediaEditFragmentCallback,
+        WordPressMediaUtils.LaunchCameraCallback {
     private static final int MEDIA_PERMISSION_REQUEST_CODE = 1;
 
     private static final String SAVED_QUERY = "SAVED_QUERY";
@@ -114,7 +114,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     private Toolbar mToolbar;
     private SearchView mSearchView;
     private MenuItem mSearchMenuItem;
-    private Menu mMenu;
 
     // Services
     private MediaDeleteService.MediaDeleteBinder mDeleteService;
@@ -325,18 +324,46 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
-        mMenu = menu;
         getMenuInflater().inflate(R.menu.media_browser, menu);
         return true;
     }
 
     @Override
-    public boolean onPrepareOptionsMenu(Menu menu) {
+    public boolean onPrepareOptionsMenu(final Menu menu) {
         mSearchView = (SearchView) menu.findItem(R.id.menu_search).getActionView();
         mSearchView.setOnQueryTextListener(this);
 
         mSearchMenuItem = menu.findItem(R.id.menu_search);
-        MenuItemCompat.setOnActionExpandListener(mSearchMenuItem, this);
+        MenuItemCompat.setOnActionExpandListener(mSearchMenuItem, new OnActionExpandListener() {
+            @Override
+            public boolean onMenuItemActionExpand(MenuItem item) {
+                // currently we don't support searching from within a filter, so hide it
+                if (mMediaGridFragment != null) {
+                    mMediaGridFragment.setFilterEnabled(false);
+                    mMediaGridFragment.setFilter(Filter.ALL);
+                }
+
+                // load last search query
+                if (!TextUtils.isEmpty(mQuery)) {
+                    onQueryTextChange(mQuery);
+                }
+
+                menu.findItem(R.id.menu_new_media).setVisible(false);
+                return true;
+            }
+
+            @Override
+            public boolean onMenuItemActionCollapse(MenuItem item) {
+                if (mMediaGridFragment != null) {
+                    mMediaGridFragment.setFilterEnabled(true);
+                    mMediaGridFragment.setFilter(Filter.ALL);
+                }
+
+                menu.findItem(R.id.menu_new_media).setVisible(true);
+
+                return true;
+            }
+        });
 
         // open search bar if we were searching for something before
         if (!TextUtils.isEmpty(mQuery) && mMediaGridFragment != null && mMediaGridFragment.isVisible()) {
@@ -363,11 +390,9 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                 return true;
             case R.id.menu_search:
                 mSearchMenuItem = item;
-                MenuItemCompat.setOnActionExpandListener(mSearchMenuItem, this);
-                MenuItemCompat.expandActionView(mSearchMenuItem);
-
                 mSearchView = (SearchView) item.getActionView();
                 mSearchView.setOnQueryTextListener(this);
+                MenuItemCompat.expandActionView(mSearchMenuItem);
 
                 // load last saved query
                 if (!TextUtils.isEmpty(mQuery)) {
@@ -403,36 +428,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         }
 
         return super.onOptionsItemSelected(item);
-    }
-
-    @Override
-    public boolean onMenuItemActionExpand(MenuItem item) {
-        // currently we don't support searching from within a filter, so hide it
-        if (mMediaGridFragment != null) {
-            mMediaGridFragment.setFilterEnabled(false);
-            mMediaGridFragment.setFilter(Filter.ALL);
-        }
-
-        // load last search query
-        if (!TextUtils.isEmpty(mQuery)) {
-            onQueryTextChange(mQuery);
-        }
-
-        mMenu.findItem(R.id.menu_new_media).setVisible(false);
-
-        return true;
-    }
-
-    @Override
-    public boolean onMenuItemActionCollapse(MenuItem item) {
-        if (mMediaGridFragment != null) {
-            mMediaGridFragment.setFilterEnabled(true);
-            mMediaGridFragment.setFilter(Filter.ALL);
-        }
-
-        mMenu.findItem(R.id.menu_new_media).setVisible(true);
-
-        return true;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -355,6 +355,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                     mMediaGridFragment.setFilter(Filter.ALL);
                 }
                 menu.findItem(R.id.menu_new_media).setVisible(true);
+                invalidateOptionsMenu();
                 return true;
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -348,7 +348,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                     onQueryTextChange(mQuery);
                 }
 
-                menu.findItem(R.id.menu_new_media).setVisible(false);
+                menu.findItem(R.id.menu_new_media).setEnabled(false);
                 return true;
             }
 
@@ -359,19 +359,11 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                     mMediaGridFragment.setFilter(Filter.ALL);
                 }
 
-                menu.findItem(R.id.menu_new_media).setVisible(true);
+                menu.findItem(R.id.menu_new_media).setEnabled(true);
 
                 return true;
             }
         });
-
-        // open search bar if we were searching for something before
-        if (!TextUtils.isEmpty(mQuery) && mMediaGridFragment != null && mMediaGridFragment.isVisible()) {
-            String tempQuery = mQuery; //temporary hold onto query
-            MenuItemCompat.expandActionView(mSearchMenuItem); //this will reset mQuery
-            onQueryTextSubmit(tempQuery);
-            mSearchView.setQuery(mQuery, true);
-        }
 
         return super.onPrepareOptionsMenu(menu);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -97,7 +97,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         WordPressMediaUtils.LaunchCameraCallback {
     private static final int MEDIA_PERMISSION_REQUEST_CODE = 1;
 
-    private static final String SAVED_QUERY = "SAVED_QUERY";
     private static final String BUNDLE_MEDIA_CAPTURE_PATH = "mediaCapturePath";
 
     @Inject Dispatcher mDispatcher;
@@ -122,7 +121,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     private boolean mDeleteServiceBound;
     private boolean mUploadServiceBound;
 
-    private String mQuery;
     private String mMediaCapturePath;
 
     @Override
@@ -184,17 +182,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     }
 
     @Override
-    protected void onPause() {
-        super.onPause();
-
-        if (mSearchMenuItem != null) {
-            String tempQuery = mQuery;
-            MenuItemCompat.collapseActionView(mSearchMenuItem);
-            mQuery = tempQuery;
-        }
-    }
-
-    @Override
     public void onPause(Fragment fragment) {
         invalidateOptionsMenu();
     }
@@ -230,7 +217,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
 
-        outState.putString(SAVED_QUERY, mQuery);
         outState.putSerializable(WordPress.SITE, mSite);
         if (!TextUtils.isEmpty(mMediaCapturePath)) {
             outState.putString(BUNDLE_MEDIA_CAPTURE_PATH, mMediaCapturePath);
@@ -243,7 +229,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
         mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
         mMediaCapturePath = savedInstanceState.getString(BUNDLE_MEDIA_CAPTURE_PATH);
-        mQuery = savedInstanceState.getString(SAVED_QUERY);
     }
 
     @Override
@@ -342,12 +327,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                     mMediaGridFragment.setFilterEnabled(false);
                     mMediaGridFragment.setFilter(Filter.ALL);
                 }
-
-                // load last search query
-                if (!TextUtils.isEmpty(mQuery)) {
-                    onQueryTextChange(mQuery);
-                }
-
                 menu.findItem(R.id.menu_new_media).setEnabled(false);
                 return true;
             }
@@ -383,12 +362,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             case R.id.menu_search:
                 mSearchView.setOnQueryTextListener(this);
                 MenuItemCompat.expandActionView(mSearchMenuItem);
-
-                // load last saved query
-                if (!TextUtils.isEmpty(mQuery)) {
-                    onQueryTextSubmit(mQuery);
-                    mSearchView.setQuery(mQuery, true);
-                }
                 return true;
             case R.id.menu_edit_media:
                 int localMediaId = mMediaItemFragment.getLocalMediaId();
@@ -425,10 +398,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         if (mMediaGridFragment != null) {
             mMediaGridFragment.search(query);
         }
-
-        mQuery = query;
         mSearchView.clearFocus();
-
         return true;
     }
 
@@ -437,9 +407,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         if (mMediaGridFragment != null) {
             mMediaGridFragment.search(newText);
         }
-
-        mQuery = newText;
-
         return true;
     }
 
@@ -450,8 +417,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
     @Override
     public void onMediaItemSelected(int localMediaId) {
-        final String tempQuery = mQuery;
-
         if (mSearchView != null) {
             mSearchView.clearFocus();
         }
@@ -470,8 +435,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             ft.add(R.id.media_browser_container, mMediaItemFragment, MediaItemFragment.TAG);
             ft.addToBackStack(null);
             ft.commitAllowingStateLoss();
-
-            mQuery = tempQuery;
         }
     }
 


### PR DESCRIPTION
Fixes this problem identified in #5337:

> After you start a search then close the search view, the toolbar icons (search, add media) disappear and are replaced with a non-functioning options menu (the vertical three-dot icon)

To test:
* Open the media library
* Click the search icon
* Cancel the search

You should see the search & add media icons return to the toolbar (prior to this PR, those icons would disappear)

Note: Along with this fix, this PR also drops a lot of related code that either didn't work or was redundant.
