### PR TITLE
Issue/media stuck uploading

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
@@ -17,7 +17,6 @@ import com.android.volley.toolbox.NetworkImageView;
 import com.wellsql.generated.MediaModelTable;
 
 import org.wordpress.android.R;
-import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.ui.RequestCodes;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -1,8 +1,9 @@
 package org.wordpress.android.ui.media.services;
 
+import android.app.IntentService;
 import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
-import android.os.Binder;
 import android.os.IBinder;
 import android.support.annotation.NonNull;
 
@@ -15,15 +16,12 @@ import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.MediaModel.UploadState;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.MediaStore;
-import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.models.MediaUploadState;
 import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.StringUtils;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,48 +31,9 @@ import javax.inject.Inject;
  * Started with explicit list of media to upload.
  */
 
-public class MediaUploadService extends Service {
-    public static final String SITE_KEY = "mediaSite";
-    public static final String LISTENER_KEY = "mediaUploadListener";
-    public static final String MEDIA_LIST_KEY = "mediaList";
+public class MediaUploadService extends IntentService {
+    private static final String MEDIA_LIST_KEY = "mediaList";
 
-    public interface MediaUploadListener extends Serializable {
-        void onUploadBegin(MediaModel media);
-        void onUploadSuccess(MediaModel media);
-        void onUploadCanceled(MediaModel media);
-        void onUploadError(MediaModel media, MediaError error);
-        void onUploadProgress(MediaModel media, float progress);
-    }
-
-    public class MediaUploadBinder extends Binder {
-        public MediaUploadService getService() {
-            return MediaUploadService.this;
-        }
-
-        public void addMediaToQueue(MediaModel media) {
-            addUniqueMediaToQueue(media);
-            uploadNextInQueue();
-        }
-
-        public void cancelUpload(boolean continueUploading) {
-            MediaUploadService.this.cancelUpload();
-            if (continueUploading) {
-                uploadNextInQueue();
-            }
-        }
-
-        public List<MediaModel> getCompletedItems() {
-            return MediaUploadService.this.getCompletedItems();
-        }
-
-        public void setListener(MediaUploadListener listener) {
-            MediaUploadService.this.mListener = listener;
-        }
-    }
-
-    private final IBinder mBinder = new MediaUploadBinder();
-
-    private MediaUploadListener mListener;
     private SiteModel mSite;
     private MediaModel mCurrentUpload;
 
@@ -84,10 +43,25 @@ public class MediaUploadService extends Service {
     @Inject Dispatcher mDispatcher;
     @Inject MediaStore mMediaStore;
 
+    public MediaUploadService() {
+        super("MediaUploadService");
+    }
+
+    public static void startService(Context context, SiteModel siteModel, ArrayList<MediaModel> mediaList) {
+        if (context == null) {
+            return;
+        }
+        Intent intent = new Intent(context, MediaUploadService.class);
+        intent.putExtra(WordPress.SITE, siteModel);
+        intent.putExtra(MediaUploadService.MEDIA_LIST_KEY, mediaList);
+        context.startService(intent);
+    }
+
     @Override
     public void onCreate() {
         super.onCreate();
         ((WordPress) getApplication()).component().inject(this);
+        AppLog.i(AppLog.T.MEDIA, "Media Upload Service > created");
         mDispatcher.register(this);
         mCurrentUpload = null;
     }
@@ -98,35 +72,23 @@ public class MediaUploadService extends Service {
             cancelUpload();
         }
         mDispatcher.unregister(this);
+        AppLog.i(AppLog.T.MEDIA, "Media Upload Service > destroyed");
         super.onDestroy();
     }
 
     @Override
     public IBinder onBind(Intent intent) {
-        if (intent != null) {
-            unpackIntent(intent);
-            uploadNextInQueue();
-        }
-        return mBinder;
+        return null;
     }
 
     @Override
-    public int onStartCommand(Intent intent, int flags, int startId) {
-        // stop service if no site is given
-        if (intent == null || !intent.hasExtra(SITE_KEY)) {
-            stopSelf();
-            return START_NOT_STICKY;
-        }
-
+    protected void onHandleIntent(Intent intent) {
         unpackIntent(intent);
         uploadNextInQueue();
-
-        return START_REDELIVER_INTENT;
     }
 
-
     @NonNull
-    public List<MediaModel> getUploadQueue() {
+    private List<MediaModel> getUploadQueue() {
         if (mQueue == null) {
             mQueue = new ArrayList<>();
         }
@@ -134,7 +96,7 @@ public class MediaUploadService extends Service {
     }
 
     @NonNull
-    public List<MediaModel> getCompletedItems() {
+    private List<MediaModel> getCompletedItems() {
         if (mCompletedItems == null) {
             mCompletedItems = new ArrayList<>();
         }
@@ -144,60 +106,52 @@ public class MediaUploadService extends Service {
     private void handleOnMediaUploadedSuccess(@NonNull OnMediaUploaded event) {
         if (event.canceled) {
             // Upload canceled
-            AppLog.i(T.MEDIA, "Upload successfully canceled.");
-            if (mListener != null) {
-                mListener.onUploadCanceled(event.media);
-            }
+            AppLog.i(AppLog.T.MEDIA, "Upload successfully canceled.");
             completeCurrentUpload();
             uploadNextInQueue();
         } else if (event.completed) {
             // Upload completed
-            AppLog.i(T.MEDIA, "Upload completed - localId=" + event.media.getId() + " title=" + event.media.getTitle());
-            if (mListener != null) {
-                mListener.onUploadSuccess(event.media);
-            }
+            AppLog.i(AppLog.T.MEDIA, "Upload completed - localId=" + event.media.getId() + " title=" + event.media.getTitle());
             mCurrentUpload.setMediaId(event.media.getMediaId());
             completeCurrentUpload();
             uploadNextInQueue();
         } else {
             // Upload Progress
-            if (mListener != null) {
-                mListener.onUploadProgress(event.media, event.progress);
-            }
+            // TODO check if we need to broadcast event.media, event.progress or we're just fine with
+            // listening to  event.media, event.progress
         }
     }
 
     private void handleOnMediaUploadedError(@NonNull OnMediaUploaded event) {
-        AppLog.w(T.MEDIA, "Error uploading media: " + event.error.message);
+        AppLog.w(AppLog.T.MEDIA, "Error uploading media: " + event.error.message);
         // TODO: Don't update the state here, it needs to be done in FluxC
         mCurrentUpload.setUploadState(UploadState.FAILED.name());
         mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mCurrentUpload));
         completeCurrentUpload();
-        if (mListener != null) {
-            mListener.onUploadError(event.media, event.error);
-        }
+        // TODO: check whether we need to broadcast the error or maybe it is enough to register for FluxC events
+        // event.media, event.error
         uploadNextInQueue();
     }
 
     private void uploadNextInQueue() {
         // waiting for response to current upload request
         if (mCurrentUpload != null) {
-            AppLog.i(T.MEDIA, "Ignoring request to uploadNextInQueue, only one media item can be uploaded at a time.");
+            AppLog.i(AppLog.T.MEDIA, "Ignoring request to uploadNextInQueue, only one media item can be uploaded at a time.");
             return;
         }
 
-        // somehow lost our reference to the site, stop service
+        // somehow lost our reference to the site, complete this action
         if (mSite == null) {
-            AppLog.i(T.MEDIA, "Unexpected state, site is null. Stopping MediaUploadService.");
-            stopSelf();
+            AppLog.i(AppLog.T.MEDIA, "Unexpected state, site is null. Skipping this request - MediaUploadService.");
+            stopServiceIfUploadsComplete();
             return;
         }
 
         mCurrentUpload = getNextMediaToUpload();
 
         if (mCurrentUpload == null) {
-            AppLog.v(T.MEDIA, "No more media items to upload. Stopping MediaUploadService.");
-            stopSelf();
+            AppLog.v(AppLog.T.MEDIA, "No more media items to upload. Skipping this request - MediaUploadService.");
+            stopServiceIfUploadsComplete();
             return;
         }
 
@@ -232,8 +186,7 @@ public class MediaUploadService extends Service {
     }
 
     private void unpackIntent(@NonNull Intent intent) {
-        mSite = (SiteModel) intent.getSerializableExtra(SITE_KEY);
-        mListener = (MediaUploadListener) intent.getSerializableExtra(LISTENER_KEY);
+        mSite = (SiteModel) intent.getSerializableExtra(WordPress.SITE);
 
         // add local queued media from store
         List<MediaModel> localMedia = mMediaStore.getLocalSiteMedia(mSite);
@@ -274,24 +227,28 @@ public class MediaUploadService extends Service {
     }
 
     private void dispatchUploadAction(@NonNull final MediaModel media) {
-        AppLog.i(T.MEDIA, "Dispatching upload action for media with local id: " + media.getId() +
+        AppLog.i(AppLog.T.MEDIA, "Dispatching upload action for media with local id: " + media.getId() +
                 " and path: " + media.getFilePath());
         media.setUploadState(UploadState.UPLOADING.name());
         mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));
 
         MediaPayload payload = new MediaPayload(mSite, media);
         mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
-
-        if (mListener != null) {
-            mListener.onUploadBegin(mCurrentUpload);
-        }
     }
 
     private void dispatchCancelAction(@NonNull final MediaModel media) {
-        AppLog.i(T.MEDIA, "Dispatching cancel upload action for media with local id: " + media.getId() +
+        AppLog.i(AppLog.T.MEDIA, "Dispatching cancel upload action for media with local id: " + media.getId() +
                 " and path: " + media.getFilePath());
         MediaPayload payload = new MediaPayload(mSite, mCurrentUpload);
         mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload));
+    }
+
+    private void stopServiceIfUploadsComplete(){
+        AppLog.i(AppLog.T.MEDIA, "Media Upload Service > completed");
+        if (getUploadQueue().size() == 0) {
+            AppLog.i(AppLog.T.MEDIA, "No more items pending in queue. Stopping MediaUploadService.");
+            stopSelf();
+        }
     }
 
     // FluxC events
@@ -301,7 +258,7 @@ public class MediaUploadService extends Service {
     public void onMediaUploaded(OnMediaUploaded event) {
         // event for unknown media, ignoring
         if (event.media == null || !matchesInProgressMedia(event.media)) {
-            AppLog.w(T.MEDIA, "Media event not recognized: " + event.media);
+            AppLog.w(AppLog.T.MEDIA, "Media event not recognized: " + event.media);
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.media.services;
 
-import android.app.IntentService;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -31,7 +31,7 @@ import javax.inject.Inject;
  * Started with explicit list of media to upload.
  */
 
-public class MediaUploadService extends IntentService {
+public class MediaUploadService extends Service {
     private static final String MEDIA_LIST_KEY = "mediaList";
 
     private SiteModel mSite;
@@ -42,10 +42,6 @@ public class MediaUploadService extends IntentService {
 
     @Inject Dispatcher mDispatcher;
     @Inject MediaStore mMediaStore;
-
-    public MediaUploadService() {
-        super("MediaUploadService");
-    }
 
     public static void startService(Context context, SiteModel siteModel, ArrayList<MediaModel> mediaList) {
         if (context == null) {
@@ -80,7 +76,8 @@ public class MediaUploadService extends IntentService {
     public IBinder onBind(Intent intent) {
         return null;
     }
-    
+
+
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         if (intent == null || !intent.hasExtra(WordPress.SITE)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -80,11 +80,19 @@ public class MediaUploadService extends IntentService {
     public IBinder onBind(Intent intent) {
         return null;
     }
-
+    
     @Override
-    protected void onHandleIntent(Intent intent) {
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent == null || !intent.hasExtra(WordPress.SITE)) {
+            AppLog.e(AppLog.T.MEDIA, "MediaUploadService was killed and restarted with a null intent.");
+            stopServiceIfUploadsComplete();
+            return START_NOT_STICKY;
+        }
+
         unpackIntent(intent);
         uploadNextInQueue();
+
+        return START_REDELIVER_INTENT;
     }
 
     @NonNull

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -6,12 +6,10 @@ import android.app.Activity;
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.content.BroadcastReceiver;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.ServiceConnection;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.database.Cursor;
@@ -23,7 +21,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
-import android.os.IBinder;
 import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.v13.app.FragmentPagerAdapter;
@@ -145,7 +142,7 @@ import javax.inject.Inject;
 
 public class EditPostActivity extends AppCompatActivity implements EditorFragmentListener, EditorDragAndDropListener,
         ActivityCompat.OnRequestPermissionsResultCallback, EditorWebViewCompatibility.ReflectionFailureListener,
-        MediaUploadService.MediaUploadListener, PhotoChooserFragment.PhotoChooserListener {
+        PhotoChooserFragment.PhotoChooserListener {
     public static final String EXTRA_POST = "postModel";
     public static final String EXTRA_IS_PAGE = "isPage";
     public static final String EXTRA_IS_QUICKPRESS = "isQuickPress";
@@ -226,10 +223,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     @Inject MediaStore mMediaStore;
     @Inject FluxCImageLoader mImageLoader;
 
-    // Upload service
-    private MediaUploadService.MediaUploadBinder mMediaUploadService;
-    private boolean mMediaUploadServiceBound;
-
     private SiteModel mSite;
 
     // for keeping the media uri while asking for permissions
@@ -277,27 +270,27 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         String action = getIntent().getAction();
         if (savedInstanceState == null) {
             if (!getIntent().hasExtra(EXTRA_POST)
-                    || Intent.ACTION_SEND.equals(action)
-                    || Intent.ACTION_SEND_MULTIPLE.equals(action)
+                    ||Intent.ACTION_SEND.equals(action) || Intent.ACTION_SEND_MULTIPLE.equals(action)
                     || NEW_MEDIA_POST.equals(action)
-                    || getIntent().hasExtra(EXTRA_IS_QUICKPRESS)) {
+                    || getIntent().hasExtra(EXTRA_IS_QUICKPRESS)
+                    || (extras != null && extras.getInt("quick-media", -1) > -1)) {
                 if (getIntent().hasExtra(EXTRA_QUICKPRESS_BLOG_ID)) {
                     // QuickPress might want to use a different blog than the current blog
                     int localSiteId = getIntent().getIntExtra(EXTRA_QUICKPRESS_BLOG_ID, -1);
-                    mSite = mSiteStore.getSiteByLocalId(localSiteId);
+                    SiteModel site = mSiteStore.getSiteByLocalId(localSiteId);
+                    if (site == null) {
+                        showErrorAndFinish(R.string.blog_not_found);
+                        return;
+                    }
+                    if (!site.isVisible()) {
+                        showErrorAndFinish(R.string.error_blog_hidden);
+                        return;
+                    }
+                    mSite = site;
                 }
 
                 mIsPage = extras.getBoolean(EXTRA_IS_PAGE);
                 mIsNewPost = true;
-
-                if (mSite == null) {
-                    showErrorAndFinish(R.string.blog_not_found);
-                    return;
-                }
-                if (!mSite.isVisible()) {
-                    showErrorAndFinish(R.string.error_blog_hidden);
-                    return;
-                }
 
                 // Create a new post
                 List<Long> categories = new ArrayList<>();
@@ -446,7 +439,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     protected void onDestroy() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.EDITOR_CLOSED);
         mDispatcher.unregister(this);
-        doUnbindUploadService();
         super.onDestroy();
     }
 
@@ -941,12 +933,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         }
     }
 
-    @Override
-    public void onUploadBegin(MediaModel media) {
-    }
-
-    @Override
-    public void onUploadSuccess(MediaModel media) {
+    private void onUploadSuccess(MediaModel media) {
         if (mEditorMediaUploadListener != null && media != null) {
             mEditorMediaUploadListener.onMediaUploadSucceeded(String.valueOf(media.getId()),
                     FluxCUtils.mediaFileFromMediaModel(media));
@@ -954,13 +941,11 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         removeMediaFromPendingList(media);
     }
 
-    @Override
-    public void onUploadCanceled(MediaModel media) {
+    private void onUploadCanceled(MediaModel media) {
         removeMediaFromPendingList(media);
     }
 
-    @Override
-    public void onUploadError(MediaModel media, MediaStore.MediaError error) {
+    private void onUploadError(MediaModel media, MediaStore.MediaError error) {
         String localMediaId = String.valueOf(media.getId());
 
         Map<String, Object> properties = null;
@@ -986,8 +971,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         removeMediaFromPendingList(media);
     }
 
-    @Override
-    public void onUploadProgress(MediaModel media, float progress) {
+    private void onUploadProgress(MediaModel media, float progress) {
         String localMediaId = String.valueOf(media.getId());
         mEditorMediaUploadListener.onMediaUploadProgress(localMediaId, progress);
     }
@@ -1040,6 +1024,10 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         if (intent != null && intent.hasExtra(EXTRA_IS_QUICKPRESS)) {
             // Quick press
             normalizedSourceName = "quick-press";
+        }
+        if (intent != null && intent.getIntExtra("quick-media", -1) > -1) {
+            // Quick photo or quick video
+            normalizedSourceName = "quick-media";
         }
         properties.put("created_post_source", normalizedSourceName);
         AnalyticsUtils.trackWithSiteDetails(
@@ -1676,7 +1664,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
     public boolean addMedia(Uri mediaUri) {
         if (mediaUri != null && !MediaUtils.isInMediaStore(mediaUri) && !mediaUri.toString().startsWith("/")
-            && !mediaUri.toString().startsWith("file://") ) {
+                && !mediaUri.toString().startsWith("file://") ) {
             mediaUri = MediaUtils.downloadExternalMedia(this, mediaUri);
         }
 
@@ -1720,7 +1708,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         }
 
         if (!isVideo && SiteSettingsInterface.getInterface(this, mSite, null).init(false).getOptimizedImage() &&
-               !NetworkUtils.isWiFiConnected(this)) {
+                !NetworkUtils.isWiFiConnected(this)) {
             // Not on WiFi and optimize image is set to ON
             // Max picture size will be 3000px wide. That's the maximum resolution you can set in the current picker.
             String optimizedPath = ImageUtils.optimizeImage(this, path, 3000, 85);
@@ -1975,54 +1963,18 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         }
     }
 
-    private ServiceConnection mMediaUploadConnection = new ServiceConnection() {
-        @Override
-        public void onServiceConnected(ComponentName name, IBinder service) {
-            mMediaUploadService = (MediaUploadService.MediaUploadBinder) service;
-            mMediaUploadService.setListener(EditPostActivity.this);
-            if (!mPendingUploads.isEmpty()) {
-                for (MediaModel media : mPendingUploads) {
-                    if (media.getUploadState().equals(UploadState.QUEUED.name())) {
-                        mMediaUploadService.addMediaToQueue(media);
-                    }
-                }
-            }
-        }
-
-        @Override
-        public void onServiceDisconnected(ComponentName name) {
-            mMediaUploadService = null;
-        }
-    };
-
-
-    private void doBindUploadService(Intent intent) {
-        mMediaUploadServiceBound = bindService(intent, mMediaUploadConnection,
-                Context.BIND_AUTO_CREATE | Context.BIND_ABOVE_CLIENT);
-    }
-
-    private void doUnbindUploadService() {
-        if (mMediaUploadServiceBound) {
-            unbindService(mMediaUploadConnection);
-            mMediaUploadServiceBound = false;
-        }
-    }
-
     /**
      * Starts the upload service to upload selected media.
      */
     private void startMediaUploadService() {
-        if (mMediaUploadService == null) {
-            Intent intent = new Intent(this, MediaUploadService.class);
-            intent.putExtra(MediaUploadService.SITE_KEY, mSite);
-            doBindUploadService(intent);
-            startService(intent);
-        } else if (mPendingUploads != null && !mPendingUploads.isEmpty()) {
+        if (mPendingUploads != null && !mPendingUploads.isEmpty()) {
+            ArrayList<MediaModel> mediaList = new ArrayList<>();
             for (MediaModel media : mPendingUploads) {
                 if (media.getUploadState().equals(UploadState.QUEUED.name())) {
-                    mMediaUploadService.addMediaToQueue(media);
+                    mediaList.add(media);
                 }
             }
+            MediaUploadService.startService(this, mSite, mediaList);
         }
     }
 
@@ -2180,13 +2132,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
     @Override
     public void onMediaUploadCancelClicked(String mediaId, boolean delete) {
-        int localMediaId = StringUtils.stringToInt(mediaId);
-        if (localMediaId == 0) {
-            return;
-        }
-
         MediaModel media = new MediaModel();
-        media.setId(localMediaId);
+        media.setMediaId(Long.valueOf(mediaId));
         MediaPayload payload = new MediaPayload(mSite, media);
         mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload));
     }
@@ -2245,7 +2192,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 @Override
                 public void onJavaScriptError(String sourceFile, int lineNumber, String message) {
                     CrashlyticsUtils.logException(new JavaScriptException(sourceFile, lineNumber, message),
-                            T.EDITOR, String.format(Locale.US, "%s:%d: %s", sourceFile, lineNumber, message));
+                            T.EDITOR,
+                            String.format(Locale.US, "%s:%d: %s", sourceFile, lineNumber, message));
                 }
 
                 @Override
@@ -2304,4 +2252,32 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 break;
         }
     }
+
+    // FluxC events
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onMediaUploaded(MediaStore.OnMediaUploaded event) {
+        // event for unknown media, ignoring
+        if (event.media == null) {
+            AppLog.w(AppLog.T.MEDIA, "Media event not recognized: " + event.media);
+            return;
+        }
+
+        if (event.isError()) {
+            onUploadError(event.media, event.error);
+        }
+        else
+        if (event.canceled) {
+            onUploadCanceled(event.media);
+        }
+        else
+        if (event.completed) {
+            onUploadSuccess(event.media);
+        }
+        else {
+            onUploadProgress(event.media, event.progress);
+        }
+    }
+
 }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1123,6 +1123,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
     @Override
     public void onMediaUploadSucceeded(final String localMediaId, final MediaFile mediaFile) {
+        if(!isAdded()) {
+            return;
+        }
+
         final String mimeType = mediaFile.getMimeType();
         if (TextUtils.isEmpty(mimeType)) {
             return;
@@ -1149,6 +1153,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
     @Override
     public void onMediaUploadProgress(final String mediaId, final float progress) {
+        if(!isAdded()) {
+            return;
+        }
+
         final MediaType mediaType = mUploadingMedia.get(mediaId);
         if (mediaType != null) {
             mWebView.post(new Runnable() {
@@ -1164,6 +1172,9 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
     @Override
     public void onMediaUploadFailed(final String mediaId, final String errorMessage) {
+        if(!isAdded()) {
+            return;
+        }
         mWebView.post(new Runnable() {
             @Override
             public void run() {
@@ -1187,6 +1198,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
     @Override
     public void onGalleryMediaUploadSucceeded(final long galleryId, long remoteMediaId, int remaining) {
+        if(!isAdded()) {
+            return;
+        }
+
         if (galleryId == mUploadingMediaGallery.getUniqueId()) {
             // TODO: media IDs are Long's; should we update to use ArrayList<Long>?
             ArrayList<String> mediaIds = mUploadingMediaGallery.getIds();


### PR DESCRIPTION
Fixes #5410 and #5409 in the sense this one at least shows the error to the user. The user can tap retry again to retry uploads, so they shouldn't be just hanging there anymore.
Please note the specific situation described by **#5389 is not resolved in this PR**, and will be tackled on another PR in the future as it's more deeply engrained in the network layer (FluxC / OkHttp).

The way we're fixing this for now in this PR is quick and dirty: just using an IntentService to make sure the intents to upload are enqueued and treated differently ( a different thread is created for each request, within which the full FluxC/OkHttp request is created internally, that's why it works without special code handling uploads).

To test: try to upload several images. If possible they'll be uploaded at the same time. If not, those that fail will show a `retry` button. You can tap on them to start uploading again.
Please note that going back / out from the Editor will make those pictures in your post be marked as "Failed" so you'll need to tap `retry` next time you open the post.

With this, we shouldn't lose the state now, and the user will be always informed about what's going on (either progressing, failed, or uploaded).

Please also note this is intended to fix the current RC but this mechanism will be superseded by the new media uploading scheme still in the works.

cc @daniloercoli 
