### PR TITLE
Instantiate array/hashmaps holders right away for listener use

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -95,8 +95,6 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
 
     private boolean mSpinnerHasLaunched;
 
-    private MenuItem mNewPostButton;
-
     private SiteModel mSite;
 
     public interface MediaGridListener {
@@ -264,7 +262,6 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         }
 
         setFilterEnabled(count == 0);
-        updateActionButtons(count);
         updateActionModeTitle(count);
     }
 
@@ -443,29 +440,10 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         mFiltersText[2] = getResources().getString(R.string.unattached) + " (" + countUnattached + ")";
     }
 
-    private void updateActionButtons(int selectCount) {
-        mNewPostButton.setVisible(selectCount > 0);
-    }
-
     private void updateActionModeTitle(int selectCount) {
         if (mActionMode != null) {
             mActionMode.setTitle(String.format(getString(R.string.cab_selected), selectCount));
         }
-    }
-
-    private void handleNewPost() {
-        if (!isAdded()) {
-            return;
-        }
-        ArrayList<Integer> localIds = mGridAdapter.getSelectedItems();
-        ArrayList<Long> mediaIds = new ArrayList<>();
-        for (Integer localId : localIds) {
-            MediaModel mediaModel = mMediaStore.getMediaWithLocalId(localId);
-            if (mediaModel != null) {
-                mediaIds.add(mediaModel.getMediaId());
-            }
-        }
-        ActivityLauncher.newMediaPost(getActivity(), mSite, mediaIds);
     }
 
     private void handleMultiSelectDelete() {
@@ -610,10 +588,8 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
             int selectCount = mGridAdapter.getSelectedItemCount();
             MenuInflater inflater = mode.getMenuInflater();
             inflater.inflate(R.menu.media_multiselect, menu);
-            mNewPostButton = menu.findItem(R.id.media_multiselect_actionbar_post);
             setSwipeToRefreshEnabled(false);
             mGridAdapter.setInMultiSelect(true);
-            updateActionButtons(selectCount);
             updateActionModeTitle(selectCount);
             return true;
         }
@@ -626,10 +602,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         @Override
         public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
             int i = item.getItemId();
-            if (i == R.id.media_multiselect_actionbar_post) {
-                handleNewPost();
-                return true;
-            } else if (i == R.id.media_multiselect_actionbar_trash) {
+            if (i == R.id.media_multiselect_actionbar_trash) {
                 handleMultiSelectDelete();
                 return true;
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1298,7 +1298,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         if (media != null) {
             MediaFile mediaFile = FluxCUtils.mediaFileFromMediaModel(media);
             trackAddMediaFromWPLibraryEvents(mediaFile.isVideo(), media.getMediaId());
-            mEditorFragment.appendMediaFile(mediaFile, media.getUrl(), mImageLoader);
+            String urlToUse = TextUtils.isEmpty(media.getUrl()) ? media.getFilePath() : media.getUrl();
+            mEditorFragment.appendMediaFile(mediaFile, urlToUse, mImageLoader);
         }
     }
 

--- a/WordPress/src/main/res/menu/media_multiselect.xml
+++ b/WordPress/src/main/res/menu/media_multiselect.xml
@@ -3,11 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/media_multiselect_actionbar_post"
-        android:icon="@drawable/ic_create_white_24dp"
-        app:showAsAction="always"
-        android:title="@string/new_post"/>
-    <item
         android:id="@+id/media_multiselect_actionbar_trash"
         android:icon="@drawable/ic_delete_white_24dp"
         app:showAsAction="always"

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -115,10 +115,11 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     private boolean mHideActionBarOnSoftKeyboardUp = false;
     private boolean mIsFormatBarDisabled = false;
 
-    private ConcurrentHashMap<String, MediaFile> mWaitingMediaFiles;
-    private Set<MediaGallery> mWaitingGalleries;
-    private Map<String, MediaType> mUploadingMedia;
-    private Set<String> mFailedMediaIds;
+    private ConcurrentHashMap<String, MediaFile> mWaitingMediaFiles = new ConcurrentHashMap<>();
+    private Set<MediaGallery> mWaitingGalleries = Collections.newSetFromMap(new ConcurrentHashMap<MediaGallery, Boolean>());
+    private Map<String, MediaType> mUploadingMedia = new HashMap<>();
+    private Set<String> mFailedMediaIds = new HashSet<>();
+
     private MediaGallery mUploadingMediaGallery;
 
     private String mJavaScriptResult = "";
@@ -284,11 +285,6 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 && !getResources().getBoolean(R.bool.is_large_tablet_landscape)) {
             mHideActionBarOnSoftKeyboardUp = true;
         }
-
-        mWaitingMediaFiles = new ConcurrentHashMap<>();
-        mWaitingGalleries = Collections.newSetFromMap(new ConcurrentHashMap<MediaGallery, Boolean>());
-        mUploadingMedia = new HashMap<>();
-        mFailedMediaIds = new HashSet<>();
 
         // -- WebView configuration
 


### PR DESCRIPTION
Fixes #5408 

To test:
- Go to WP Media Library
- Select two or more pictures (Among of those selected pictures should be at least one in the "retry" state).
- Tap the pencil icon --> Crash.

cc @daniloercoli 