### PR TITLE
Fix #5377: check mSite null value on event received

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -514,7 +514,8 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     @SuppressWarnings("unused")
     public void onEventMainThread(SuggestionEvents.SuggestionNameListUpdated event) {
         // check if the updated suggestions are for the current blog and update the suggestions
-        if (event.mRemoteBlogId != 0 && event.mRemoteBlogId == mSite.getSiteId() && mSuggestionAdapter != null) {
+        if (event.mRemoteBlogId != 0 && mSite != null
+            && event.mRemoteBlogId == mSite.getSiteId() && mSuggestionAdapter != null) {
             List<Suggestion> suggestions = SuggestionTable.getSuggestionsForSite(event.mRemoteBlogId);
             mSuggestionAdapter.setSuggestionList(suggestions);
         }


### PR DESCRIPTION
Fix #5377: check mSite null value on event received