### PR TITLE
Multiline tag field

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -657,6 +657,8 @@ public class EditPostSettingsFragment extends Fragment
         String tags = "", postFormat = "";
         if (!post.isPage()) {
             tags = EditTextUtils.getText(mTagsEditText);
+            // since mTagsEditText is a `textMultiLine` field, we should replace "\n" with space
+            tags = tags.replace("\n", " ");
 
             // post format
             if (mPostFormatKeys != null && mPostFormatSpinner != null &&

--- a/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
+++ b/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
@@ -92,7 +92,7 @@
                 android:layout_height="wrap_content"
                 android:textSize="@dimen/text_sz_large"
                 android:hint="@string/tags_separate_with_commas"
-                android:inputType="textAutoCorrect" />
+                android:inputType="textMultiLine" />
         </LinearLayout>
 
         <EditText


### PR DESCRIPTION
Fixes #4618.

To test:
* Go into post settings and change the tags, make sure you at least have 1 tag with a return character to make sure it becomes a space