### PR TITLE
Fix #5417: Images added from WP media cache are empty

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -25,7 +26,7 @@ import java.io.OutputStream;
 public class WordPressDB {
     private static final String COLUMN_NAME_ID = "_id";
 
-    private static final int DATABASE_VERSION = 53;
+    private static final int DATABASE_VERSION = 54;
 
     // Warning if you rename DATABASE_NAME, that could break previous App backups (see: xml/backup_scheme.xml)
     private static final String DATABASE_NAME = "wordpress";
@@ -199,6 +200,10 @@ public class WordPressDB {
                     // ignore "duplicate column" exception
                 }
                 currentVersion++;
+            case 53:
+                // Clean up empty cache files caused by #5417
+                clearEmptyCacheFiles(ctx);
+                currentVersion++;
         }
         db.setVersion(DATABASE_VERSION);
     }
@@ -364,6 +369,32 @@ public class WordPressDB {
             input.close();
         } catch (IOException e) {
             AppLog.e(T.DB, "failed to copy database", e);
+        }
+    }
+
+    private void clearEmptyCacheFiles(Context context) {
+        if (android.os.Environment.getExternalStorageState().equals(android.os.Environment.MEDIA_MOUNTED)) {
+            File imageCacheDir = new File(android.os.Environment.getExternalStorageDirectory() + "/WordPress/images");
+            File videoCacheDir = new File(android.os.Environment.getExternalStorageDirectory() + "/WordPress/video");
+
+            deleteEmptyFilesInDirectory(imageCacheDir);
+            deleteEmptyFilesInDirectory(videoCacheDir);
+        } else {
+            File cacheDir = context.getApplicationContext().getCacheDir();
+            deleteEmptyFilesInDirectory(cacheDir);
+        }
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    private void deleteEmptyFilesInDirectory(File directory) {
+        if (directory == null || !directory.exists() || directory.listFiles() == null) {
+            return;
+        }
+
+        for (File file : directory.listFiles()) {
+            if (file != null && file.length() == 0) {
+                file.delete();
+            }
         }
     }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -231,11 +231,10 @@ public class MediaUtils {
 
             String fileName = getFilenameFromURI(context, imageUri);
             if (TextUtils.isEmpty(fileName)) {
-                fileName = "wp-" + System.currentTimeMillis() + "."
-                    + MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
+                fileName = generateTimeStampedFileName(mimeType);
             }
 
-            File f = getUniqueCacheFileForName(fileName, cacheDir);
+            File f = getUniqueCacheFileForName(fileName, cacheDir, mimeType);
 
             OutputStream output = new FileOutputStream(f);
 
@@ -261,7 +260,7 @@ public class MediaUtils {
         return null;
     }
 
-    private static File getUniqueCacheFileForName(String fileName, File cacheDir) {
+    private static File getUniqueCacheFileForName(String fileName, File cacheDir, String mimeType) {
         File file = new File(cacheDir, fileName);
 
         while (file.exists()) {
@@ -277,10 +276,17 @@ public class MediaUtils {
                 } else {
                     fileName = baseFileName + "-" + (StringUtils.stringToInt(existingDuplicationNumber) + 1) + fileType;
                 }
+            } else {
+                // Shouldn't happen, but in case our match fails fall back to timestamped file name
+                fileName = generateTimeStampedFileName(mimeType);
             }
             file = new File(cacheDir, fileName);
         }
         return file;
+    }
+
+    private static String generateTimeStampedFileName(String mimeType) {
+        return "wp-" + System.currentTimeMillis() + "." + getExtensionForMimeType(mimeType);
     }
 
     public static String getMimeTypeOfInputStream(InputStream stream) {

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -228,7 +228,7 @@ public class MediaUtils {
 
             String fileName = getFilenameFromURI(context, imageUri);
             if (TextUtils.isEmpty(fileName)) {
-                fileName = "wp-" + System.currentTimeMillis()
+                fileName = "wp-" + System.currentTimeMillis() + "."
                     + MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
             }
 


### PR DESCRIPTION
Fixes #5417 by renaming media files saved to the cache directory if a file with that name already exists (`myphoto.png` will become `myphoto-1.png`).

This will prevent files from becoming empty as we read from and write to them at the same time; but a smarter fix would be to avoid saving a duplicate at all if we know it's the same file (or, at least, if we know the file is already in the cache directory). I'd like to open a separate issue for that, as figuring out the origin via `ContentProvider` is different depending on API level and probably won't be a trivial fix (and we'll still need this one anyway for external files with the same name as files in the cache directory).

One more thing that needs to be done is to delete already-affected images. Especially for devices with 'external' storage directories, the cache folder isn't actually cleared on cache/data clear, or on app uninstall, so those empty images will keep showing up in the picker until they're manually deleted.

To test:
1. Make sure you're able to reproduce the steps in #5417.
2. Choose a different file that is in the app's cache directory but isn't empty
3. Attempt to upload it
4. The upload should succeed, and you should have a new file named `{original-filename}-1.png` in the cache directory
5. Test with a few oddly-named files (`image-1.png`, `image`, `image-`, for example, should all correctly handled if they're uploaded a second time)

cc @maxme