### PR TITLE
Issue/5331 enable disable actions

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -15,6 +15,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
@@ -50,6 +51,7 @@ import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 import org.wordpress.aztec.AztecText;
 import org.wordpress.aztec.AztecText.OnMediaTappedListener;
+import org.wordpress.aztec.HistoryListener;
 import org.wordpress.aztec.Html;
 import org.wordpress.aztec.source.SourceViewEditText;
 import org.wordpress.aztec.toolbar.AztecToolbar;
@@ -65,8 +67,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-public class AztecEditorFragment extends EditorFragmentAbstract implements OnImeBackListener, EditorMediaUploadListener,
-        OnMediaTappedListener, AztecToolbarClickListener {
+public class AztecEditorFragment extends EditorFragmentAbstract implements
+        OnImeBackListener,
+        EditorMediaUploadListener,
+        OnMediaTappedListener,
+        AztecToolbarClickListener,
+        HistoryListener {
 
     private static final String ARG_PARAM_TITLE = "param_title";
     private static final String ARG_PARAM_CONTENT = "param_content";
@@ -89,6 +95,9 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements OnIme
     private SourceViewEditText source;
     private AztecToolbar formattingToolbar;
     private Html.ImageGetter imageLoader;
+
+    private Handler invalidateOptionsHandler;
+    private Runnable invalidateOptionsRunnable;
 
     private Map<String, MediaType> mUploadingMedia;
     private Set<String> mFailedMediaIds;
@@ -142,6 +151,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements OnIme
         source.setHistory(content.getHistory());
         content.setImageGetter(imageLoader);
 
+        content.getHistory().setHistoryListener(this);
+
         content.setOnMediaTappedListener(this);
 
         mEditorFragmentListener.onEditorFragmentInitialized();
@@ -152,6 +163,14 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements OnIme
         setHasOptionsMenu(true);
 
         registerForContextMenu(formattingToolbar);
+
+        invalidateOptionsHandler = new Handler();
+        invalidateOptionsRunnable = new Runnable() {
+            @Override
+            public void run() {
+                getActivity().invalidateOptionsMenu();
+            }
+        };
 
         return view;
     }
@@ -244,6 +263,18 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements OnIme
         }
 
         return false;
+    }
+
+    @Override
+    public void onRedoEnabled() {
+        invalidateOptionsHandler.removeCallbacks(invalidateOptionsRunnable);
+        invalidateOptionsHandler.postDelayed(invalidateOptionsRunnable, getResources().getInteger(android.R.integer.config_mediumAnimTime) );
+    }
+
+    @Override
+    public void onUndoEnabled() {
+        invalidateOptionsHandler.removeCallbacks(invalidateOptionsRunnable);
+        invalidateOptionsHandler.postDelayed(invalidateOptionsRunnable, getResources().getInteger(android.R.integer.config_mediumAnimTime) );
     }
 
     private ActionBar getActionBar() {

--- a/libs/editor/WordPressEditor/src/main/res/drawable/ic_action_redo_selector.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/ic_action_redo_selector.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/ic_action_redo_white_30_24dp" android:state_enabled="false" />
+    <item android:drawable="@drawable/ic_action_redo_white_24dp" />
+
+</selector>

--- a/libs/editor/WordPressEditor/src/main/res/drawable/ic_action_redo_white_30_24dp.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/ic_action_redo_white_30_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="#4dffffff"
+        android:pathData="M18.4,10.6C16.55,8.99 14.15,8 11.5,8c-4.65,0 -8.58,3.03 -9.96,7.22L3.9,16c1.05,-3.19 4.05,-5.5 7.6,-5.5 1.95,0 3.73,0.72 5.12,1.88L13,16h9V7l-3.6,3.6z" >
+    </path>
+
+</vector>

--- a/libs/editor/WordPressEditor/src/main/res/drawable/ic_action_undo_selector.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/ic_action_undo_selector.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/ic_action_undo_white_30_24dp" android:state_enabled="false" />
+    <item android:drawable="@drawable/ic_action_undo_white_24dp" />
+
+</selector>

--- a/libs/editor/WordPressEditor/src/main/res/drawable/ic_action_undo_white_30_24dp.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/ic_action_undo_white_30_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="#4dffffff"
+        android:pathData="M12.5,8c-2.65,0 -5.05,0.99 -6.9,2.6L2,7v9h9l-3.62,-3.62c1.39,-1.16 3.16,-1.88 5.12,-1.88 3.54,0 6.55,2.31 7.6,5.5l2.37,-0.78C21.08,11.03 17.15,8 12.5,8z" >
+    </path>
+
+</vector>

--- a/libs/editor/WordPressEditor/src/main/res/menu/menu_aztec.xml
+++ b/libs/editor/WordPressEditor/src/main/res/menu/menu_aztec.xml
@@ -7,14 +7,14 @@
     <item
         android:id="@+id/undo"
         android:title="@string/menu_undo"
-        android:icon="@drawable/ic_action_undo_white_24dp"
+        android:icon="@drawable/ic_action_undo_selector"
         app:showAsAction="always" >
     </item>
 
     <item
         android:id="@+id/redo"
         android:title="@string/menu_redo"
-        android:icon="@drawable/ic_action_redo_white_24dp"
+        android:icon="@drawable/ic_action_redo_selector"
         app:showAsAction="always" >
     </item>
 


### PR DESCRIPTION
### Fix
Update the state of the redo and undo actions as described in https://github.com/wordpress-mobile/WordPress-Android/issues/5331.

### Test
0. Enable Aztec editor.
1. Go to ***Sites*** tab.
2. Tap ***Create*** floating button.
3. Tap content field.
4. Notice ***Redo*** is disabled and ***Undo*** are disabled.
5. Type one character.
6. Notice ***Redo*** is disabled and ***Undo*** is enabled.
7. Type nine or more characters.
8. Notice ***Redo*** is disabled and ***Undo*** is enabled.
9. Tap ***Undo*** action button one time.
10. Notice ***Redo*** is enabled and ***Undo*** is enabled.
11. Tap ***Undo*** action button nine times.
12. Notice ***Redo*** is enabled and ***Undo*** is disabled.
13. Tap ***Redo*** action button one time.
14. Notice ***Redo*** is enabled and ***Undo*** is enabled.
13. Tap ***Redo*** action button nine times.
14. Notice ***Redo*** is disabled and ***Undo*** is enabled.