### PR TITLE
Issue/5407 media library drop image filenames

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -138,13 +138,9 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         boolean isSelected = isItemSelected(localMediaId);
         boolean isImage = mimeType.contains("image");
 
-        holder.titleView.setText(TextUtils.isEmpty(title) ? fileName : title);
-
-        String fileExtension = MediaUtils.getExtensionForMimeType(mimeType);
-        holder.fileTypeView.setText(fileExtension.toUpperCase());
-
-        // load image
+        // if this is an image, load the thumbnail
         if (isImage) {
+            holder.fileContainer.setVisibility(View.GONE);
             if (isLocalFile) {
                 loadLocalImage(filePath, holder.imageView);
             } else {
@@ -152,7 +148,12 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                 WordPressMediaUtils.loadNetworkImage(thumbUrl, holder.imageView, mImageLoader);
             }
         } else {
+            // not an image, so show file name and file type
             holder.imageView.setImageDrawable(null);
+            holder.fileContainer.setVisibility(View.VISIBLE);
+            holder.titleView.setText(TextUtils.isEmpty(title) ? fileName : title);
+            String fileExtension = MediaUtils.getExtensionForMimeType(mimeType);
+            holder.fileTypeView.setText(fileExtension.toUpperCase());
         }
 
         // show selection count when selected
@@ -247,6 +248,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         private final TextView stateTextView;
         private final ProgressBar progressUpload;
         private final ViewGroup stateContainer;
+        private final ViewGroup fileContainer;
 
         public GridViewHolder(View view) {
             super(view);
@@ -259,6 +261,8 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             stateContainer = (ViewGroup) view.findViewById(R.id.media_grid_item_upload_state_container);
             stateTextView = (TextView) stateContainer.findViewById(R.id.media_grid_item_upload_state);
             progressUpload = (ProgressBar) stateContainer.findViewById(R.id.media_grid_item_upload_progress);
+
+            fileContainer = (ViewGroup) view.findViewById(R.id.media_grid_item_file_container);
 
             // make the progress bar white
             progressUpload.getIndeterminateDrawable().setColorFilter(Color.WHITE, PorterDuff.Mode.MULTIPLY);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -267,8 +267,13 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             // make the progress bar white
             progressUpload.getIndeterminateDrawable().setColorFilter(Color.WHITE, PorterDuff.Mode.MULTIPLY);
 
+            // set size of image and container views
             imageView.getLayoutParams().width = mThumbWidth;
             imageView.getLayoutParams().height = mThumbHeight;
+            stateContainer.getLayoutParams().width = mThumbWidth;
+            stateContainer.getLayoutParams().height = mThumbHeight;
+            fileContainer.getLayoutParams().width = mThumbWidth;
+            fileContainer.getLayoutParams().height = mThumbHeight;
 
             itemView.setOnClickListener(new OnClickListener() {
                 @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -130,9 +130,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         String fileName = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.FILE_NAME));
         String title = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.TITLE));
         String filePath = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.FILE_PATH));
-        String mimeType = StringUtils.notNullStr(
-                mCursor.getString(mCursor.getColumnIndex(MediaModelTable.MIME_TYPE))
-        );
+        String mimeType = StringUtils.notNullStr(mCursor.getString(mCursor.getColumnIndex(MediaModelTable.MIME_TYPE)));
 
         boolean isLocalFile = MediaUtils.isLocalFile(state);
         boolean isSelected = isItemSelected(localMediaId);
@@ -149,11 +147,12 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             }
         } else {
             // not an image, so show file name and file type
-            holder.imageView.setImageDrawable(null);
             holder.fileContainer.setVisibility(View.VISIBLE);
             holder.titleView.setText(TextUtils.isEmpty(title) ? fileName : title);
             String fileExtension = MediaUtils.getExtensionForMimeType(mimeType);
             holder.fileTypeView.setText(fileExtension.toUpperCase());
+            int placeholderResId = WordPressMediaUtils.getPlaceholder(fileName);
+            holder.fileTypeView.setCompoundDrawablesWithIntrinsicBounds(0, placeholderResId, 0, 0);
         }
 
         // show selection count when selected

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -127,8 +127,6 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         final int localMediaId = mCursor.getInt(mCursor.getColumnIndex(MediaModelTable.ID));
 
         String state = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.UPLOAD_STATE));
-        String fileName = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.FILE_NAME));
-        String title = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.TITLE));
         String filePath = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.FILE_PATH));
         String mimeType = StringUtils.notNullStr(mCursor.getString(mCursor.getColumnIndex(MediaModelTable.MIME_TYPE)));
 
@@ -136,7 +134,6 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         boolean isSelected = isItemSelected(localMediaId);
         boolean isImage = mimeType.contains("image");
 
-        // if this is an image, load the thumbnail
         if (isImage) {
             holder.fileContainer.setVisibility(View.GONE);
             if (isLocalFile) {
@@ -147,12 +144,14 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             }
         } else {
             // not an image, so show file name and file type
+            String fileName = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.FILE_NAME));
+            String title = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.TITLE));
+            String fileExtension = MediaUtils.getExtensionForMimeType(mimeType);
             holder.fileContainer.setVisibility(View.VISIBLE);
             holder.titleView.setText(TextUtils.isEmpty(title) ? fileName : title);
-            String fileExtension = MediaUtils.getExtensionForMimeType(mimeType);
             holder.fileTypeView.setText(fileExtension.toUpperCase());
             int placeholderResId = WordPressMediaUtils.getPlaceholder(fileName);
-            holder.fileTypeView.setCompoundDrawablesWithIntrinsicBounds(0, placeholderResId, 0, 0);
+            holder.fileTypeImageView.setImageResource(placeholderResId);
         }
 
         // show selection count when selected
@@ -243,6 +242,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         private final TextView titleView;
         private final FadeInNetworkImageView imageView;
         private final TextView fileTypeView;
+        private final ImageView fileTypeImageView;
         private final TextView selectionCountTextView;
         private final TextView stateTextView;
         private final ProgressBar progressUpload;
@@ -252,9 +252,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         public GridViewHolder(View view) {
             super(view);
 
-            titleView = (TextView) view.findViewById(R.id.media_grid_item_name);
             imageView = (FadeInNetworkImageView) view.findViewById(R.id.media_grid_item_image);
-            fileTypeView = (TextView) view.findViewById(R.id.media_grid_item_filetype);
             selectionCountTextView = (TextView) view.findViewById(R.id.text_selection_count);
 
             stateContainer = (ViewGroup) view.findViewById(R.id.media_grid_item_upload_state_container);
@@ -262,6 +260,9 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             progressUpload = (ProgressBar) stateContainer.findViewById(R.id.media_grid_item_upload_progress);
 
             fileContainer = (ViewGroup) view.findViewById(R.id.media_grid_item_file_container);
+            titleView = (TextView) fileContainer.findViewById(R.id.media_grid_item_name);
+            fileTypeView = (TextView) fileContainer.findViewById(R.id.media_grid_item_filetype);
+            fileTypeImageView = (ImageView) fileContainer.findViewById(R.id.media_grid_item_filetype_image);
 
             // make the progress bar white
             progressUpload.getIndeterminateDrawable().setColorFilter(Color.WHITE, PorterDuff.Mode.MULTIPLY);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -133,13 +133,17 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
 
         boolean isLocalFile = MediaUtils.isLocalFile(state);
         boolean isSelected = isItemSelected(localMediaId);
+        boolean isImage = mimeType.startsWith("image/");
 
-        if (isLocalFile) {
-            loadLocalImage(filePath, holder.imageView);
-        } else if (!TextUtils.isEmpty(thumbUrl)) {
-            WordPressMediaUtils.loadNetworkImage(thumbUrl, holder.imageView, mImageLoader);
+        if (isImage) {
+            if (isLocalFile) {
+                loadLocalImage(filePath, holder.imageView);
+            } else {
+                WordPressMediaUtils.loadNetworkImage(thumbUrl, holder.imageView, mImageLoader);
+            }
         } else {
             // not an image, so show file name and file type
+            holder.imageView.setImageDrawable(null);
             String fileName = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.FILE_NAME));
             String title = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.TITLE));
             String fileExtension = MediaUtils.getExtensionForMimeType(mimeType);

--- a/WordPress/src/main/res/drawable/media_grid_item_checkstate_selector.xml
+++ b/WordPress/src/main/res/drawable/media_grid_item_checkstate_selector.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item android:drawable="@drawable/tab_unselected_pressed_wordpress" android:state_checked="true"/>
-    <item android:drawable="@android:color/transparent"/>
-
-</selector> 

--- a/WordPress/src/main/res/drawable/media_item_background.xml
+++ b/WordPress/src/main/res/drawable/media_item_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/white" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/grey_lighten_30" />
+</shape>

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:padding="@dimen/margin_small">
+    android:padding="@dimen/margin_extra_small">
 
     <org.wordpress.android.ui.FadeInNetworkImageView
         android:id="@+id/media_grid_item_image"

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -16,7 +16,7 @@
         android:id="@+id/media_grid_item_file_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/grey_lighten_20"
+        android:background="@drawable/media_item_background"
         android:padding="@dimen/margin_medium"
         android:visibility="gone"
         tools:visibility="visible">

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -13,37 +13,6 @@
         android:scaleType="centerCrop" />
 
     <RelativeLayout
-        android:id="@+id/media_grid_item_upload_state_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/grey_dark_translucent_50"
-        android:visibility="gone"
-        tools:visibility="visible">
-
-        <ProgressBar
-            android:id="@+id/media_grid_item_upload_progress"
-            android:layout_width="@dimen/media_grid_progress_height"
-            android:layout_height="@dimen/media_grid_progress_height"
-            android:layout_above="@+id/media_grid_item_upload_state"
-            android:layout_centerHorizontal="true" />
-
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/media_grid_item_upload_state"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:shadowColor="@color/grey_dark"
-            android:shadowDx="2"
-            android:shadowDy="2"
-            android:shadowRadius="2"
-            android:textAllCaps="true"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_sz_large"
-            android:textStyle="bold"
-            tools:text="@string/upload_failed" />
-    </RelativeLayout>
-
-    <RelativeLayout
         android:id="@+id/media_grid_item_file_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -91,7 +60,37 @@
                 tools:text="filename" />
         </LinearLayout>
 
+    </RelativeLayout>
 
+    <RelativeLayout
+        android:id="@+id/media_grid_item_upload_state_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/grey_dark_translucent_50"
+        android:visibility="gone"
+        tools:visibility="visible">
+
+        <ProgressBar
+            android:id="@+id/media_grid_item_upload_progress"
+            android:layout_width="@dimen/media_grid_progress_height"
+            android:layout_height="@dimen/media_grid_progress_height"
+            android:layout_above="@+id/media_grid_item_upload_state"
+            android:layout_centerHorizontal="true" />
+
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/media_grid_item_upload_state"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:shadowColor="@color/grey_dark"
+            android:shadowDx="2"
+            android:shadowDy="2"
+            android:shadowRadius="2"
+            android:textAllCaps="true"
+            android:textColor="@color/white"
+            android:textSize="@dimen/text_sz_large"
+            android:textStyle="bold"
+            tools:text="@string/upload_failed" />
     </RelativeLayout>
 
     <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -49,6 +49,7 @@
         android:layout_height="match_parent"
         android:background="@color/grey_lighten_20"
         android:orientation="vertical"
+        android:padding="@dimen/margin_medium"
         android:visibility="gone"
         tools:visibility="visible">
 
@@ -57,9 +58,12 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
+            android:drawableTint="@color/grey_dark"
+            android:drawableTop="@drawable/media_document"
+            android:gravity="center_horizontal"
             android:textAllCaps="true"
             android:textColor="@color/grey_dark"
-            android:textSize="@dimen/text_sz_large"
+            android:textSize="@dimen/text_sz_medium"
             android:textStyle="bold"
             tools:text="PDF" />
 
@@ -70,6 +74,7 @@
             android:layout_below="@+id/media_grid_item_filetype"
             android:layout_centerHorizontal="true"
             android:ellipsize="end"
+            android:gravity="center_horizontal"
             android:singleLine="true"
             android:textColor="@color/grey_dark"
             android:textSize="@dimen/text_sz_small"

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -57,11 +57,10 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
-            android:ellipsize="end"
-            android:singleLine="true"
             android:textAllCaps="true"
             android:textColor="@color/grey_dark"
-            android:textSize="@dimen/text_sz_extra_large"
+            android:textSize="@dimen/text_sz_large"
+            android:textStyle="bold"
             tools:text="PDF" />
 
         <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -48,37 +48,50 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/grey_lighten_20"
-        android:orientation="vertical"
         android:padding="@dimen/margin_medium"
         android:visibility="gone"
         tools:visibility="visible">
 
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/media_grid_item_filetype"
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
-            android:drawableTint="@color/grey_dark"
-            android:drawableTop="@drawable/media_document"
-            android:gravity="center_horizontal"
-            android:textAllCaps="true"
-            android:textColor="@color/grey_dark"
-            android:textSize="@dimen/text_sz_medium"
-            android:textStyle="bold"
-            tools:text="PDF" />
+            android:orientation="vertical">
 
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/media_grid_item_name"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/media_grid_item_filetype"
-            android:layout_centerHorizontal="true"
-            android:ellipsize="end"
-            android:gravity="center_horizontal"
-            android:singleLine="true"
-            android:textColor="@color/grey_dark"
-            android:textSize="@dimen/text_sz_small"
-            tools:text="filename" />
+            <ImageView
+                android:id="@+id/media_grid_item_filetype_image"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:layout_gravity="center_horizontal"
+                android:tint="@color/grey_dark"
+                tools:src="@drawable/media_document" />
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/media_grid_item_filetype"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="@dimen/margin_medium"
+                android:textAllCaps="true"
+                android:textColor="@color/grey_dark"
+                android:textSize="@dimen/text_sz_medium"
+                android:textStyle="bold"
+                tools:text="PDF" />
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/media_grid_item_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:ellipsize="end"
+                android:gravity="center_horizontal"
+                android:singleLine="true"
+                android:textColor="@color/grey_dark"
+                android:textSize="@dimen/text_sz_small"
+                tools:text="filename" />
+        </LinearLayout>
+
+
     </RelativeLayout>
 
     <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -61,7 +61,7 @@
             android:singleLine="true"
             android:textAllCaps="true"
             android:textColor="@color/grey_dark"
-            android:textSize="@dimen/text_sz_double_extra_large"
+            android:textSize="@dimen/text_sz_extra_large"
             tools:text="PDF" />
 
         <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -16,7 +16,7 @@
         android:id="@+id/text_selection_count"
         android:layout_width="32dp"
         android:layout_height="32dp"
-        android:layout_gravity="center"
+        android:layout_centerInParent="true"
         android:background="@drawable/shape_oval_blue"
         android:gravity="center"
         android:textColor="@color/white"
@@ -60,28 +60,33 @@
         android:id="@+id/media_grid_item_file_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/grey"
         android:orientation="vertical"
         android:visibility="gone"
         tools:visibility="visible">
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/media_grid_item_filetype"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:ellipsize="end"
+            android:gravity="center"
             android:singleLine="true"
             android:textAllCaps="true"
             android:textColor="@color/grey_dark"
-            android:textSize="@dimen/text_sz_large" />
+            android:textSize="@dimen/text_sz_large"
+            tools:text="PDF" />
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/media_grid_item_name"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:ellipsize="end"
+            android:gravity="center"
             android:singleLine="true"
             android:textColor="@color/grey_dark"
-            android:textSize="@dimen/text_sz_small" />
+            android:textSize="@dimen/text_sz_small"
+            tools:text="filename" />
     </LinearLayout>
 
-</FrameLayout>
+</RelativeLayout>

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -70,27 +70,34 @@
         android:visibility="gone"
         tools:visibility="visible">
 
-        <ProgressBar
-            android:id="@+id/media_grid_item_upload_progress"
-            android:layout_width="@dimen/media_grid_progress_height"
-            android:layout_height="@dimen/media_grid_progress_height"
-            android:layout_above="@+id/media_grid_item_upload_state"
-            android:layout_centerHorizontal="true" />
-
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/media_grid_item_upload_state"
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
-            android:shadowColor="@color/grey_dark"
-            android:shadowDx="2"
-            android:shadowDy="2"
-            android:shadowRadius="2"
-            android:textAllCaps="true"
-            android:textColor="@color/white"
-            android:textSize="@dimen/text_sz_large"
-            android:textStyle="bold"
-            tools:text="@string/upload_failed" />
+            android:orientation="vertical">
+
+            <ProgressBar
+                android:id="@+id/media_grid_item_upload_progress"
+                android:layout_width="@dimen/media_grid_progress_height"
+                android:layout_height="@dimen/media_grid_progress_height"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginBottom="@dimen/margin_small" />
+
+            <org.wordpress.android.widgets.WPTextView
+                android:id="@+id/media_grid_item_upload_state"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:shadowColor="@color/grey_dark"
+                android:shadowDx="2"
+                android:shadowDy="2"
+                android:shadowRadius="2"
+                android:textAllCaps="true"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_sz_large"
+                android:textStyle="bold"
+                tools:text="@string/upload_failed" />
+        </LinearLayout>
     </RelativeLayout>
 
     <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -1,94 +1,88 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/media_grid_frame_layout"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:padding="@dimen/margin_small">
 
-    <FrameLayout
-        android:id="@+id/media_grid_frame_layout"
-        android:layout_width="wrap_content"
+    <org.wordpress.android.ui.FadeInNetworkImageView
+        android:id="@+id/media_grid_item_image"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="@dimen/margin_small">
+        android:scaleType="centerCrop" />
 
-        <org.wordpress.android.ui.FadeInNetworkImageView
-            android:id="@+id/media_grid_item_image"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:scaleType="centerCrop" />
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/text_selection_count"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_gravity="center"
+        android:background="@drawable/shape_oval_blue"
+        android:gravity="center"
+        android:textColor="@color/white"
+        android:textSize="@dimen/text_sz_large"
+        android:visibility="gone"
+        tools:text="5"
+        tools:visibility="visible" />
+
+    <RelativeLayout
+        android:id="@+id/media_grid_item_upload_state_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/grey_dark_translucent_50"
+        android:visibility="gone"
+        tools:visibility="visible">
+
+        <ProgressBar
+            android:id="@+id/media_grid_item_upload_progress"
+            android:layout_width="@dimen/media_grid_progress_height"
+            android:layout_height="@dimen/media_grid_progress_height"
+            android:layout_above="@+id/media_grid_item_upload_state"
+            android:layout_centerHorizontal="true" />
 
         <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/text_selection_count"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:layout_gravity="center"
-            android:background="@drawable/shape_oval_blue"
-            android:gravity="center"
+            android:id="@+id/media_grid_item_upload_state"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:shadowColor="@color/grey_dark"
+            android:shadowDx="2"
+            android:shadowDy="2"
+            android:shadowRadius="2"
+            android:textAllCaps="true"
             android:textColor="@color/white"
             android:textSize="@dimen/text_sz_large"
-            android:visibility="gone"
-            tools:text="5"
-            tools:visibility="visible" />
+            android:textStyle="bold"
+            tools:text="@string/upload_failed" />
+    </RelativeLayout>
 
-        <RelativeLayout
-            android:id="@+id/media_grid_item_upload_state_container"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="@color/grey_dark_translucent_50"
-            android:visibility="gone"
-            tools:visibility="visible">
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:background="@color/media_gallery_grid_label_bg"
+        android:padding="@dimen/margin_medium">
 
-            <ProgressBar
-                android:id="@+id/media_grid_item_upload_progress"
-                android:layout_width="@dimen/media_grid_progress_height"
-                android:layout_height="@dimen/media_grid_progress_height"
-                android:layout_above="@+id/media_grid_item_upload_state"
-                android:layout_centerHorizontal="true" />
-
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/media_grid_item_upload_state"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_centerInParent="true"
-                android:shadowColor="@color/grey_dark"
-                android:shadowDx="2"
-                android:shadowDy="2"
-                android:shadowRadius="2"
-                android:textAllCaps="true"
-                android:textColor="@color/white"
-                android:textSize="@dimen/text_sz_large"
-                android:textStyle="bold"
-                tools:text="@string/upload_failed" />
-        </RelativeLayout>
-
-        <RelativeLayout
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/media_grid_item_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="bottom"
-            android:background="@color/media_gallery_grid_label_bg"
-            android:padding="@dimen/margin_medium">
+            android:layout_toLeftOf="@+id/media_grid_item_filetype"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:textColor="@color/media_gallery_grid_label"
+            android:textSize="@dimen/text_sz_small" />
 
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/media_grid_item_name"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_toLeftOf="@+id/media_grid_item_filetype"
-                android:ellipsize="end"
-                android:singleLine="true"
-                android:textColor="@color/media_gallery_grid_label"
-                android:textSize="@dimen/text_sz_small" />
-
-            <org.wordpress.android.widgets.WPTextView
-                android:id="@+id/media_grid_item_filetype"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                android:layout_marginLeft="@dimen/margin_extra_small"
-                android:ellipsize="end"
-                android:singleLine="true"
-                android:textColor="@color/media_gallery_grid_label"
-                android:textSize="@dimen/text_sz_small" />
-        </RelativeLayout>
-    </FrameLayout>
-
-</LinearLayout>
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/media_grid_item_filetype"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentRight="true"
+            android:layout_marginLeft="@dimen/margin_extra_small"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:textColor="@color/media_gallery_grid_label"
+            android:textSize="@dimen/text_sz_small" />
+    </RelativeLayout>
+</FrameLayout>

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -2,7 +2,6 @@
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/media_grid_frame_layout"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:padding="@dimen/margin_small">
@@ -57,32 +56,32 @@
             tools:text="@string/upload_failed" />
     </RelativeLayout>
 
-    <RelativeLayout
+    <LinearLayout
+        android:id="@+id/media_grid_item_file_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom"
-        android:background="@color/media_gallery_grid_label_bg"
-        android:padding="@dimen/margin_medium">
-
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/media_grid_item_name"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_toLeftOf="@+id/media_grid_item_filetype"
-            android:ellipsize="end"
-            android:singleLine="true"
-            android:textColor="@color/media_gallery_grid_label"
-            android:textSize="@dimen/text_sz_small" />
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:visibility="gone"
+        tools:visibility="visible">
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/media_grid_item_filetype"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
-            android:layout_marginLeft="@dimen/margin_extra_small"
             android:ellipsize="end"
             android:singleLine="true"
-            android:textColor="@color/media_gallery_grid_label"
+            android:textAllCaps="true"
+            android:textColor="@color/grey_dark"
+            android:textSize="@dimen/text_sz_large" />
+
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/media_grid_item_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:textColor="@color/grey_dark"
             android:textSize="@dimen/text_sz_small" />
-    </RelativeLayout>
+    </LinearLayout>
+
 </FrameLayout>

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -12,19 +12,6 @@
         android:layout_height="wrap_content"
         android:scaleType="centerCrop" />
 
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/text_selection_count"
-        android:layout_width="32dp"
-        android:layout_height="32dp"
-        android:layout_centerInParent="true"
-        android:background="@drawable/shape_oval_blue"
-        android:gravity="center"
-        android:textColor="@color/white"
-        android:textSize="@dimen/text_sz_large"
-        android:visibility="gone"
-        tools:text="5"
-        tools:visibility="visible" />
-
     <RelativeLayout
         android:id="@+id/media_grid_item_upload_state_container"
         android:layout_width="match_parent"
@@ -56,37 +43,51 @@
             tools:text="@string/upload_failed" />
     </RelativeLayout>
 
-    <LinearLayout
+    <RelativeLayout
         android:id="@+id/media_grid_item_file_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/grey"
+        android:background="@color/grey_lighten_20"
         android:orientation="vertical"
         android:visibility="gone"
         tools:visibility="visible">
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/media_grid_item_filetype"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
             android:ellipsize="end"
-            android:gravity="center"
             android:singleLine="true"
             android:textAllCaps="true"
             android:textColor="@color/grey_dark"
-            android:textSize="@dimen/text_sz_large"
+            android:textSize="@dimen/text_sz_double_extra_large"
             tools:text="PDF" />
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/media_grid_item_name"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_below="@+id/media_grid_item_filetype"
+            android:layout_centerHorizontal="true"
             android:ellipsize="end"
-            android:gravity="center"
             android:singleLine="true"
             android:textColor="@color/grey_dark"
             android:textSize="@dimen/text_sz_small"
             tools:text="filename" />
-    </LinearLayout>
+    </RelativeLayout>
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/text_selection_count"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_centerInParent="true"
+        android:background="@drawable/shape_oval_blue"
+        android:gravity="center"
+        android:textColor="@color/white"
+        android:textSize="@dimen/text_sz_large"
+        android:visibility="gone"
+        tools:text="5"
+        tools:visibility="visible" />
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -61,16 +61,6 @@
                 tools:text="@string/upload_failed" />
         </RelativeLayout>
 
-        <CheckBox
-            android:id="@+id/media_grid_item_checkstate"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="@drawable/media_grid_item_checkstate_selector"
-            android:button="@android:color/transparent"
-            android:clickable="false"
-            android:duplicateParentState="true"
-            android:focusable="false" />
-
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -95,8 +95,6 @@
     <color name="action_mode_status_bar_tint">#ff517188</color>
 
     <!-- Media Gallery -->
-    <color name="media_gallery_grid_label_bg">@color/grey_dark_translucent_70</color>
-    <color name="media_gallery_grid_label">@color/white</color>
     <color name="media_gallery_bg">@color/grey_darken_30</color>
     <color name="media_gallery_option_selected">@color/grey_dark</color>
     <color name="media_gallery_option_default">@color/grey_lighten_30</color>


### PR DESCRIPTION
Fixes #5407 - drops file names and file types from images in the media browser, improves the display of non-images.

Before & after shots below.

![before](https://cloud.githubusercontent.com/assets/3903757/24050151/54cc3aca-0b04-11e7-89f5-94f8bb098ca5.png)

Note: as with other media browser PRs, you may notice duplication or wrong images in grid cells. This is being addressed separately - see #5434
