### PR TITLE
Jetpack post preview implemented using frame-nonce

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -199,6 +199,8 @@ public class ActivityLauncher {
         String url = UrlUtils.appendUrlParameter(post.getLink(), "preview", "true");
         if (site.isWPCom()) {
             WPWebViewActivity.openUrlByUsingGlobalWPCOMCredentials(context, url);
+        } else if (site.isJetpackConnected()) {
+            WPWebViewActivity.openJetpackBlogPostPreview(context, url, site.getFrameNonce());
         } else {
             // Add the original post URL to the list of allowed URLs.
             // This is necessary because links are disabled in the webview, but WP removes "?preview=true"

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -97,6 +97,17 @@ public class WPWebViewActivity extends WebViewActivity {
         openWPCOMURL(context, url);
     }
 
+    // frameNonce is used to show drafts, without it "no page found" error would be thrown
+    public static void openJetpackBlogPostPreview(Context context, String url, String frameNonce) {
+        if (!TextUtils.isEmpty(frameNonce)) {
+            url += "&frame-nonce=" + frameNonce;
+        }
+        Intent intent = new Intent(context, WPWebViewActivity.class);
+        intent.putExtra(WPWebViewActivity.URL_TO_LOAD, url);
+        intent.putExtra(WPWebViewActivity.DISABLE_LINKS_ON_PAGE, false);
+        context.startActivity(intent);
+    }
+
     // Note: The webview has links disabled (excepted for urls in the whitelist: listOfAllowedURLs)
     public static void openUrlByUsingBlogCredentials(Context context, SiteModel site, PostModel post, String url,
                                                      String[] listOfAllowedURLs) {


### PR DESCRIPTION
As discussed here: https://github.com/wordpress-mobile/WordPress-Android/pull/5416#issuecomment-287361860, I am sending a PR against `release/7.0` for the same fix.
