### PR TITLE
issue/5429-reader-track-blocked-site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -799,8 +799,7 @@ public class ReaderPostListFragment extends Fragment
         // perform call to block this blog - returns list of posts deleted by blocking so
         // they can be restored if the user undoes the block
         final BlockedBlogResult blockResult = ReaderBlogActions.blockBlogFromReader(post.blogId, actionListener);
-        // Only pass the blogID if available. Do not track feedID
-        AnalyticsUtils.trackWithSiteId(AnalyticsTracker.Stat.READER_BLOG_BLOCKED, mCurrentBlogId);
+        AnalyticsUtils.trackWithSiteId(AnalyticsTracker.Stat.READER_BLOG_BLOCKED, post.blogId);
 
         // remove posts in this blog from the adapter
         getPostAdapter().removePostsInBlog(post.blogId);


### PR DESCRIPTION
Fixes #5429 - when a site was blocked in the reader we were incorrectly tracking the ID of the current site rather than the ID of the site being blocked. This PR resolves the problem.
