### PR TITLE
Fix #5449: replace a WPEditText by EditText+typeface=serif

### DIFF
--- a/WordPress/src/main/res/layout/comment_edit_activity.xml
+++ b/WordPress/src/main/res/layout/comment_edit_activity.xml
@@ -22,7 +22,7 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <org.wordpress.android.widgets.WPEditText
+            <EditText
                 android:id="@+id/edit_comment_content"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -30,6 +30,7 @@
                 android:hint="@string/hint_comment_content"
                 android:inputType="textCapSentences|textAutoCorrect|textMultiLine"
                 android:minLines="4"
+                android:typeface="serif"
                 android:textColorLink="@color/reader_hyperlink" />
 
         </LinearLayout>


### PR DESCRIPTION
Fix #5449: replace a WPEditText by EditText+typeface=serif

Bug was introduced by the Noto/FluxC merge.

To test:
* Checkout `release/7.0`: Comments -> edit a comment -> 💥 
* Checkout `issue/5449-wpedittext-in-comment_edit_activity`: Comments -> edit a comment -> 🍷 

