### PR TITLE
Fix #5451: Verify that dateLastUpdated column exists

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -303,8 +303,11 @@ public class WPLegacyMigrationUtils {
                     postModel.setDateLocallyChanged(DateTimeUtils.iso8601UTCFromTimestamp(dateLocallyChanged / 1000));
                 }
 
+                int featuredImageIndex = c.getColumnIndex("wp_post_thumbnail");
+                long featuredImageId = featuredImageIndex > 0 ? c.getLong(featuredImageIndex) : 0;
+                postModel.setFeaturedImageId(featuredImageId);
+
                 postModel.setExcerpt(c.getString(c.getColumnIndex("mt_excerpt")));
-                postModel.setFeaturedImageId(c.getLong(c.getColumnIndex("wp_post_thumbnail")));
                 postModel.setLink(c.getString(c.getColumnIndex("link")));
                 postModel.setTagNames(c.getString(c.getColumnIndex("mt_keywords")));
                 postModel.setStatus(c.getString(c.getColumnIndex("post_status")));

--- a/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPLegacyMigrationUtils.java
@@ -295,7 +295,10 @@ public class WPLegacyMigrationUtils {
                     postModel.setDateCreated(DateTimeUtils.iso8601UTCFromTimestamp(dateCreated / 1000));
                 }
 
-                long dateLocallyChanged = c.getLong(c.getColumnIndex("dateLastUpdated"));
+                // Safety check as 'dateLastUpdated' was somewhat recently added and a user migrating from an old
+                // version of the app might not have it
+                int dateLastUpdatedIndex = c.getColumnIndex("dateLastUpdated");
+                long dateLocallyChanged = dateLastUpdatedIndex > 0 ? c.getLong(dateLastUpdatedIndex) : 0;
                 if (dateLocallyChanged > 0) {
                     postModel.setDateLocallyChanged(DateTimeUtils.iso8601UTCFromTimestamp(dateLocallyChanged / 1000));
                 }


### PR DESCRIPTION
Fixes #5451. If a user upgrades from version `6.3` (or earlier) of the app directly to `7.0-rc-2`, they'll be missing the `dateLastUpdated` column in `WordPressDB`.

I also added a safety check for `wp_post_thumbnail`, which was added just under two years ago.

We haven't made any other changes to tables that are relevant to migration in over four years (last one I spotted - I don't think we need to worry about those.