### PR TITLE
Fix #5432: background migration now ends correctly

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -545,7 +545,7 @@ public class WordPress extends MultiDexApplication {
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteChanged(OnSiteChanged event) {
-        if (!sIsMigrationInProgress || sMigrationListener == null) {
+        if (!sIsMigrationInProgress) {
             return;
         }
 


### PR DESCRIPTION
Fix #5432: background migration now ends correctly

We were ending the migration prematurely  in `onSiteChanged()` during background migrations.

cc @aforcier 