### PR TITLE
Issue/5434 media browser image load

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -118,6 +118,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         }
 
         mCursor.moveToPosition(position);
+        holder.imageView.setTag(null);
 
         final int localMediaId = mCursor.getInt(mCursor.getColumnIndex(MediaModelTable.ID));
 
@@ -133,6 +134,8 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             } else {
                 String imageUrl = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.URL));
                 String thumbUrl;
+                // if this isn't a private site use Photon to request the image at the exact size,
+                // otherwise append the standard wp query params to request the desired size
                 if (SiteUtils.isPhotonCapable(mSite)) {
                     thumbUrl = PhotonUtils.getPhotonImageUrl(imageUrl, mThumbWidth, mThumbHeight);
                 } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -124,7 +124,6 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         String mimeType = StringUtils.notNullStr(mCursor.getString(mCursor.getColumnIndex(MediaModelTable.MIME_TYPE)));
         boolean isSelected = isItemSelected(localMediaId);
 
-        holder.imageView.setImageDrawable(null);
         if (mimeType.contains("image/")) {
             holder.fileContainer.setVisibility(View.GONE);
             if (MediaUtils.isLocalFile(state)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -31,7 +31,10 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.ImageUtils.BitmapWorkerCallback;
 import org.wordpress.android.util.ImageUtils.BitmapWorkerTask;
 import org.wordpress.android.util.MediaUtils;
+import org.wordpress.android.util.PhotonUtils;
+import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.UrlUtils;
 
 import java.util.ArrayList;
 
@@ -120,7 +123,6 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
 
         String state = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.UPLOAD_STATE));
         String filePath = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.FILE_PATH));
-        String thumbUrl = WordPressMediaUtils.getNetworkThumbnailUrl(mCursor, mSite, mThumbWidth);
         String mimeType = StringUtils.notNullStr(mCursor.getString(mCursor.getColumnIndex(MediaModelTable.MIME_TYPE)));
         boolean isSelected = isItemSelected(localMediaId);
 
@@ -128,7 +130,14 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             holder.fileContainer.setVisibility(View.GONE);
             if (MediaUtils.isLocalFile(state)) {
                 loadLocalImage(filePath, holder.imageView);
-            } else if (!TextUtils.isEmpty(thumbUrl)) {
+            } else {
+                String imageUrl = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.URL));
+                String thumbUrl;
+                if (SiteUtils.isPhotonCapable(mSite)) {
+                    thumbUrl = PhotonUtils.getPhotonImageUrl(imageUrl, mThumbWidth, mThumbHeight);
+                } else {
+                    thumbUrl = UrlUtils.removeQuery(imageUrl) + "?w=" + mThumbWidth + "&h=" + mThumbHeight;
+                }
                 WordPressMediaUtils.loadNetworkImage(thumbUrl, holder.imageView, mImageLoader);
             }
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -144,6 +144,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             }
         } else {
             // not an image, so show file name and file type
+            holder.imageView.setImageDrawable(null);
             String fileName = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.FILE_NAME));
             String title = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.TITLE));
             String fileExtension = MediaUtils.getExtensionForMimeType(mimeType);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -124,11 +124,14 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         String state = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.UPLOAD_STATE));
         String filePath = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.FILE_PATH));
         String mimeType = StringUtils.notNullStr(mCursor.getString(mCursor.getColumnIndex(MediaModelTable.MIME_TYPE)));
-        boolean isSelected = isItemSelected(localMediaId);
 
-        if (mimeType.contains("image/")) {
+        boolean isLocalFile = MediaUtils.isLocalFile(state);
+        boolean isSelected = isItemSelected(localMediaId);
+        boolean isImage = mimeType.startsWith("image/");
+
+        if (isImage) {
             holder.fileContainer.setVisibility(View.GONE);
-            if (MediaUtils.isLocalFile(state)) {
+            if (isLocalFile) {
                 loadLocalImage(filePath, holder.imageView);
             } else {
                 String imageUrl = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.URL));

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -122,14 +122,16 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         String filePath = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.FILE_PATH));
         String thumbUrl = WordPressMediaUtils.getNetworkThumbnailUrl(mCursor, mSite, mThumbWidth);
         String mimeType = StringUtils.notNullStr(mCursor.getString(mCursor.getColumnIndex(MediaModelTable.MIME_TYPE)));
-
-        boolean isLocalFile = MediaUtils.isLocalFile(state);
         boolean isSelected = isItemSelected(localMediaId);
 
-        if (isLocalFile) {
-            loadLocalImage(filePath, holder.imageView);
-        } else if (!TextUtils.isEmpty(thumbUrl)) {
-            WordPressMediaUtils.loadNetworkImage(thumbUrl, holder.imageView, mImageLoader);
+        holder.imageView.setImageDrawable(null);
+        if (mimeType.contains("image/")) {
+            holder.fileContainer.setVisibility(View.GONE);
+            if (MediaUtils.isLocalFile(state)) {
+                loadLocalImage(filePath, holder.imageView);
+            } else if (!TextUtils.isEmpty(thumbUrl)) {
+                WordPressMediaUtils.loadNetworkImage(thumbUrl, holder.imageView, mImageLoader);
+            }
         } else {
             // not an image, so show file name and file type
             String fileName = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.FILE_NAME));

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -17,7 +17,6 @@ import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import com.android.volley.VolleyError;
 import com.android.volley.toolbox.ImageLoader;
 import com.wellsql.generated.MediaModelTable;
 
@@ -207,28 +206,6 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                 && !mHasRetrievedAll
                 && mCallback != null) {
             mCallback.onAdapterFetchMoreData();
-        }
-    }
-
-    @Override
-    public void onViewRecycled(GridViewHolder holder) {
-        super.onViewRecycled(holder);
-
-        // cancel image fetch requests if the view has been moved to recycler.
-        if (holder.imageView != null) {
-            String tag = (String) holder.imageView.getTag();
-            if (tag != null && tag.startsWith("http")) {
-                // need a listener to cancel request, even if the listener does nothing
-                ImageLoader.ImageContainer container = mImageLoader.get(tag, new ImageLoader.ImageListener() {
-                    @Override
-                    public void onErrorResponse(VolleyError error) { }
-
-                    @Override
-                    public void onResponse(ImageLoader.ImageContainer response, boolean isImmediate) { }
-
-                });
-                container.cancelRequest();
-            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -311,7 +311,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         return INVALID_POSITION;
     }
 
-    private synchronized void loadLocalImage(final String filePath, ImageView imageView) {
+    private void loadLocalImage(final String filePath, ImageView imageView) {
         imageView.setTag(filePath);
 
         Bitmap bitmap = WordPress.getBitmapCache().get(filePath);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -39,7 +39,6 @@ import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaListFetched;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.models.MediaUploadState;
-import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.EmptyViewMessageType;
 import org.wordpress.android.ui.media.MediaGridAdapter.MediaGridAdapterCallback;
 import org.wordpress.android.util.AppLog;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
@@ -6,7 +6,6 @@ import android.app.Fragment;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.database.Cursor;
 import android.net.Uri;
 import android.os.Environment;
 import android.provider.MediaStore;
@@ -14,18 +13,14 @@ import android.support.v4.content.FileProvider;
 
 import com.android.volley.toolbox.ImageLoader;
 import com.android.volley.toolbox.NetworkImageView;
-import com.wellsql.generated.MediaModelTable;
 
 import org.wordpress.android.R;
 import org.wordpress.android.fluxc.model.MediaModel;
-import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DeviceUtils;
 import org.wordpress.android.util.MediaUtils;
-import org.wordpress.android.util.PhotonUtils;
-import org.wordpress.android.util.SiteUtils;
 import org.wordpress.passcodelock.AppLockManager;
 
 import java.io.File;
@@ -213,26 +208,6 @@ public class WordPressMediaUtils {
     public static boolean canDeleteMedia(MediaModel mediaModel) {
         String state = mediaModel.getUploadState();
         return state == null || (!state.equalsIgnoreCase("uploading") && !state.equalsIgnoreCase("deleted"));
-    }
-
-    /**
-     * Given a media file cursor, returns the thumbnail network URL. Will use photon if available, using the specified
-     * width.
-     * @param cursor the media file cursor
-     * @param width width to use for photon request (if applicable)
-     */
-    public static String getNetworkThumbnailUrl(Cursor cursor, SiteModel site, int width) {
-        String thumbnailURL = cursor.getString(cursor.getColumnIndex(MediaModelTable.THUMBNAIL_URL));
-
-        // Allow non-private wp.com and Jetpack blogs to use photon to get a higher res thumbnail
-        if (SiteUtils.isPhotonCapable(site)) {
-            String imageURL = cursor.getString(cursor.getColumnIndex(MediaModelTable.URL));
-            if (imageURL != null) {
-                thumbnailURL = PhotonUtils.getPhotonImageUrl(imageURL, width, 0);
-            }
-        }
-
-        return thumbnailURL;
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
@@ -246,8 +246,8 @@ public class WordPressMediaUtils {
             int placeholderResId = WordPressMediaUtils.getPlaceholder(filepath);
             imageView.setErrorImageResId(placeholderResId);
 
-            // no default image while downloading
-            imageView.setDefaultImageResId(0);
+            // default image while downloading
+            imageView.setDefaultImageResId(R.drawable.media_item_background);
 
             if (MediaUtils.isValidImage(filepath)) {
                 imageView.setTag(imageUrl);

--- a/WordPress/src/main/res/drawable/media_item_background.xml
+++ b/WordPress/src/main/res/drawable/media_item_background.xml
@@ -3,6 +3,6 @@
     android:shape="rectangle">
     <solid android:color="@color/grey_lighten_30" />
     <stroke
-        android:width="1dp"
+        android:width="1px"
         android:color="@color/grey_lighten_20" />
 </shape>

--- a/WordPress/src/main/res/drawable/media_item_background.xml
+++ b/WordPress/src/main/res/drawable/media_item_background.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/grey_lighten_30" />
+    <solid android:color="@color/grey_lighten_20" />
     <stroke
         android:width="1px"
-        android:color="@color/grey_lighten_20" />
+        android:color="@color/grey_lighten_10" />
 </shape>

--- a/WordPress/src/main/res/drawable/media_item_background.xml
+++ b/WordPress/src/main/res/drawable/media_item_background.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/white" />
+    <solid android:color="@color/grey_lighten_30" />
     <stroke
         android:width="1dp"
-        android:color="@color/grey_lighten_30" />
+        android:color="@color/grey_lighten_20" />
 </shape>


### PR DESCRIPTION
Fixes #5434 - This PR fixes a number of problems with the media browser.

* Local media fail to appear the first time they're requested, resulting in either missing or incorrect images
* No default image was being set while downloading remote images, also resulting in either missing or incorrect images
* Fetching local images was needlessly complicated
* Remote images in private sites were pixelated due to being requested at the wrong size
* In-flight image requests were being canceled when the view was recycled, which meant the next time the image was requested it would be re-downloaded since it wasn't being cached