### PR TITLE
Enable vertical scrollbar in Reader post detail ScrollView

### DIFF
--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -21,6 +21,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:clipToPadding="false"
+                android:scrollbars="vertical"
                 android:scrollbarStyle="insideOverlay">
 
                 <RelativeLayout


### PR DESCRIPTION
Fixes #5445

Simple fix for a user requested feature, info in Issue.

cc @nbradbury 

To test:
* Login, go to Reader tab
* Select a post to read
* Scroll up/down and make sure scrollbar is visible