### PR TITLE
Issue/5460 media browser frequent refresh

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -401,10 +401,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
     @Override
     public boolean onMenuItemActionExpand(MenuItem item) {
-        // currently we don't support searching from within a filter, so hide it
         if (mMediaGridFragment != null) {
             mMediaGridFragment.setFilterEnabled(false);
-            mMediaGridFragment.setFilter(Filter.ALL);
         }
 
         // load last search query
@@ -421,7 +419,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     public boolean onMenuItemActionCollapse(MenuItem item) {
         if (mMediaGridFragment != null) {
             mMediaGridFragment.setFilterEnabled(true);
-            mMediaGridFragment.setFilter(Filter.ALL);
         }
 
         mMenu.findItem(R.id.menu_new_media).setVisible(true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -627,14 +627,12 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             if (WordPressMediaUtils.canDeleteMedia(mediaModel)) {
                 if (MediaUtils.isLocalFile(mediaModel.getUploadState().toLowerCase())) {
                     mDispatcher.dispatch(MediaActionBuilder.newRemoveMediaAction(mediaModel));
-                    updateViews();
                     sanitizedIds.add(String.valueOf(currentId));
                     continue;
                 }
                 mediaToDelete.add(mediaModel);
                 mediaModel.setUploadState(MediaUploadState.DELETE.name());
                 mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mediaModel));
-                updateViews();
                 sanitizedIds.add(String.valueOf(currentId));
             }
         }
@@ -654,7 +652,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         }
         if (mMediaGridFragment != null) {
             mMediaGridFragment.clearSelectedItems();
-            updateViews();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -278,7 +278,6 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
     public void refreshSpinnerAdapter() {
         updateFilterText();
         updateSpinnerAdapter();
-        setFilter(mFilter);
     }
 
     public void refreshMediaFromDB() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -281,10 +281,12 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
     }
 
     public void refreshMediaFromDB() {
+        if (!isAdded()) return;
+
         setFilter(mFilter);
         updateFilterText();
         updateSpinnerAdapter();
-        if (isAdded() && mGridAdapter.getItemCount() == 0) {
+        if (mGridAdapter.getItemCount() == 0) {
             if (NetworkUtils.isNetworkAvailable(getActivity())) {
                 if (!mHasRetrievedAllMedia) {
                     fetchMediaList(false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -470,8 +470,6 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
                                 if (mActionMode != null) {
                                     mActionMode.finish();
                                 }
-                                refreshMediaFromDB();
-                                refreshSpinnerAdapter();
                             }
                         }).setNegativeButton(R.string.cancel, null);
         AlertDialog dialog = builder.create();


### PR DESCRIPTION
Fixes #5460 -  Removes calls to `setFilter()` and `updateViews()`which resulted in the media grid being refreshed when it wasn't necessary.

Note: if this is reviewed prior to #5470 being merged, you'll likely see duplicated/incorrect images in the media grid. These issues can be ignored since #5470 resolves them.