### PR TITLE
Fix rare API16 visual editor crash

### DIFF
--- a/libs/editor/WordPressEditor/src/main/assets/ZSSRichTextEditor.js
+++ b/libs/editor/WordPressEditor/src/main/assets/ZSSRichTextEditor.js
@@ -3784,21 +3784,21 @@ ZSSField.prototype.getHTML = function() {
 ZSSField.prototype.getHTMLForCallback = function() {
     var functionArgument = "function=getHTMLForCallback";
     var idArgument = "id=" + this.getNodeId();
-    var contentsArgument;
 
+    var contents;
     if (this.hasNoStyle) {
-        contentsArgument = "contents=" + this.strippedHTML();
+        contents = this.strippedHTML();
     } else {
-        var html;
-        if (nativeState.androidApiLevel < 17) {
-            // URI Encode HTML on API < 17 because of the use of WebViewClient.shouldOverrideUrlLoading. Data must
-            // be decoded in shouldOverrideUrlLoading.
-            html = encodeURIComponent(this.getHTML());
-        } else {
-            html = this.getHTML();
-        }
-        contentsArgument = "contents=" + html;
+        contents = this.getHTML();
     }
+
+    if (nativeState.androidApiLevel < 17) {
+        // URI Encode HTML on API < 17 because of the use of WebViewClient.shouldOverrideUrlLoading. Data must
+        // be decoded in shouldOverrideUrlLoading.
+        contents = encodeURIComponent(contents);
+    }
+
+    var contentsArgument = "contents=" + contents;
     var joinedArguments = functionArgument + defaultCallbackSeparator + idArgument + defaultCallbackSeparator +
         contentsArgument;
     ZSSEditor.callback('callback-response-string', joinedArguments);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebViewAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebViewAbstract.java
@@ -59,7 +59,11 @@ public abstract class EditorWebViewAbstract extends WebView {
 
         this.setWebViewClient(new WebViewClient() {
             @Override
+            @SuppressWarnings("deprecation")
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                // Only used on API16, because of security issues with addJavascriptInterface below API 17.
+                // Instead of a JS interface, we use an iframe in the editor JavaScript to make callbacks as URL
+                // requests, which are intercepted here.
                 if (url != null && url.startsWith("callback") && mJsCallbackReceiver != null) {
                     String data = URLDecoder.decode(url);
                     String[] split = data.split(":", 2);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebViewAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorWebViewAbstract.java
@@ -27,6 +27,7 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URLDecoder;
 import java.util.HashMap;
@@ -65,7 +66,14 @@ public abstract class EditorWebViewAbstract extends WebView {
                 // Instead of a JS interface, we use an iframe in the editor JavaScript to make callbacks as URL
                 // requests, which are intercepted here.
                 if (url != null && url.startsWith("callback") && mJsCallbackReceiver != null) {
-                    String data = URLDecoder.decode(url);
+                    String data;
+                    try {
+                        data = URLDecoder.decode(url, "UTF-8");
+                    } catch (UnsupportedEncodingException e) {
+                        // Pretty much impossible
+                        AppLog.e(T.EDITOR, "UTF-8 is unsupported on this device, falling back to default");
+                        data = URLDecoder.decode(url);
+                    }
                     String[] split = data.split(":", 2);
                     String callbackId = split[0];
                     String params = (split.length > 1 ? split[1] : "");


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Editor-Android/issues/465.

The cause was the iframe callback used for API16 - the URL containing the callback string is decoded. In the crash instances, the title contained a `%`, which the decoder attempted to treat as encoded HTML and crashed.

The fix is to encode the title field just as we do for the content field before sending out the callback.

To test:
1. On API16, draft a post with a % in the title
2. Exit the editor (or switch to HTML mode and back, or publish)
3. There should be no crash, and the title text should be preserved correctly