### PR TITLE
Media - Handle HTTP Error 413

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -131,7 +131,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:72ccb534d10bce79c4733c9d7c54cb0ae8b3df8f') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:c1b157979c0f44ba1e3f58876287686493ceb9c6') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -563,10 +563,15 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         if (event.isError()) {
             AppLog.d(AppLog.T.MEDIA, "Received onMediaUploaded error:" + event.error.type
                     + " - " + event.error.message);
-            if (event.error.type == MediaErrorType.AUTHORIZATION_REQUIRED) {
-                showMediaToastError(R.string.media_error_no_permission, null);
-            } else {
-                showMediaToastError(R.string.media_upload_error, event.error.message);
+            switch (event.error.type) {
+                case AUTHORIZATION_REQUIRED:
+                    showMediaToastError(R.string.media_error_no_permission, null);
+                    break;
+                case REQUEST_TOO_LARGE:
+                    showMediaToastError(R.string.media_error_too_large_upload, null);
+                    break;
+                default:
+                    showMediaToastError(R.string.media_upload_error, event.error.message);
             }
             updateViews();
         } else if (event.completed) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -970,6 +970,9 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             case AUTHORIZATION_REQUIRED:
                 errorMessage = getString(R.string.media_error_no_permission_upload);
                 break;
+            case REQUEST_TOO_LARGE:
+                errorMessage = getString(R.string.media_error_too_large_upload);
+                break;
             case GENERIC_ERROR:
             default:
                 errorMessage = TextUtils.isEmpty(error.message) ? getString(R.string.tap_to_try_again) : error.message;

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -136,6 +136,7 @@
     <string name="reader_toast_err_get_post">Unable to retrieve this post</string>
     <string name="media_error_no_permission">You don\'t have permission to view the media library</string>
     <string name="media_error_no_permission_upload">You don\'t have permission to upload media to the site</string>
+    <string name="media_error_too_large_upload">The file is too big. Please contact the web hosting provider to fix this issue</string>
     <string name="access_media_permission_required">Permissions required in order to access media</string>
     <string name="add_media_permission_required">Permissions required in order to add media</string>
     <string name="media_fetching">Fetching media…</string>


### PR DESCRIPTION
This PR adds the ability to correctly reporting the HTTP 413 error up to the user.

Please, double check the error message wording :)

HTTP 413 is thrown by web servers when the uploaded media is too large. Usually when the max_post_size is reached.

To test this fix try to upload a media file to a web server configured to accept small files only.
I've a self-hosted installation already configured for that on altervista.org. Ping me if you want the credentials.

cc @oguzkocer 