### PR TITLE
Issue/5474 media delete retry

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -124,7 +124,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         String state = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.UPLOAD_STATE));
         String filePath = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.FILE_PATH));
         String mimeType = StringUtils.notNullStr(mCursor.getString(mCursor.getColumnIndex(MediaModelTable.MIME_TYPE)));
-
+state = MediaUploadState.FAILED.name();
         boolean isLocalFile = MediaUtils.isLocalFile(state) && !TextUtils.isEmpty(filePath);
         boolean isSelected = isItemSelected(localMediaId);
         boolean isImage = mimeType.startsWith("image/");
@@ -270,7 +270,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                 }
             });
 
-            itemView.setOnLongClickListener(new View.OnLongClickListener() {
+            View.OnLongClickListener longClickListener = new View.OnLongClickListener() {
                 @Override
                 public boolean onLongClick(View v) {
                     int position = getAdapterPosition();
@@ -282,7 +282,10 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                     }
                     return true;
                 }
-            });
+            };
+
+            itemView.setOnLongClickListener(longClickListener);
+            stateTextView.setOnLongClickListener(longClickListener);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -125,7 +125,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         String filePath = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.FILE_PATH));
         String mimeType = StringUtils.notNullStr(mCursor.getString(mCursor.getColumnIndex(MediaModelTable.MIME_TYPE)));
 
-        boolean isLocalFile = MediaUtils.isLocalFile(state);
+        boolean isLocalFile = MediaUtils.isLocalFile(state) && !TextUtils.isEmpty(filePath);
         boolean isSelected = isItemSelected(localMediaId);
         boolean isImage = mimeType.startsWith("image/");
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -283,8 +283,8 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                         mCursor.moveToPosition(position);
                         String state = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.UPLOAD_STATE));
                         if (state.equalsIgnoreCase(MediaUploadState.FAILED.name())) {
-                            ((TextView) v).setText(R.string.upload_queued);
-                            ((TextView) v).setCompoundDrawables(null, null, null, null);
+                            stateTextView.setText(R.string.upload_queued);
+                            stateTextView.setCompoundDrawables(null, null, null, null);
                             if (mCallback != null) {
                                 int localMediaId = mCursor.getInt(mCursor.getColumnIndex(MediaModelTable.ID));
                                 mCallback.onAdapterRetryUpload(localMediaId);


### PR DESCRIPTION
Fixes #5474 - prior to this PR, long-clicking on the "Retry" text in the media browser for failed uploads wouldn't enable multi-select, and clicking on it when multi-select is enabled wouldn't add it to the current selection.

cc: @daniloercoli 
