### PR TITLE
Fix #4158: Use bottom controls in picture edit mode

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -547,7 +547,7 @@ public class MeFragment extends Fragment {
         options.setShowCropGrid(false);
         options.setStatusBarColor(ContextCompat.getColor(context, R.color.status_bar_tint));
         options.setToolbarColor(ContextCompat.getColor(context, R.color.color_primary));
-        options.setAllowedGestures(UCropActivity.ALL, UCropActivity.ALL, UCropActivity.ALL);
+        options.setAllowedGestures(UCropActivity.SCALE, UCropActivity.NONE, UCropActivity.NONE);
         options.setHideBottomControls(true);
 
         UCrop.of(uri, Uri.fromFile(new File(context.getCacheDir(), "cropped_for_gravatar.jpg")))


### PR DESCRIPTION
Fix #4158: Use bottom controls and only allow scaling gesture while in scaling mode and rotation gesture while in rotation mode

I reverted https://github.com/wordpress-mobile/WordPress-Android/pull/4132 -  I was thinking how we could fix it in Ucrop, but unless we add a new button to reset rotation or we use some sort of magnet to keep the picture straight, it's not really fixable.

I don't think the controls are complicated, and they are pretty standard.

cc @hypest / @nbradbury 