### PR TITLE
Issue/media progress spinner

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/MediaUploadState.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/MediaUploadState.java
@@ -7,4 +7,15 @@ public enum MediaUploadState {
     DELETED,
     FAILED,
     UPLOADED;
+
+    public static MediaUploadState fromString(String strState) {
+        if (strState != null) {
+            for (MediaUploadState state: MediaUploadState.values()) {
+                if (strState.equalsIgnoreCase(state.name())) {
+                    return state;
+                }
+            }
+        }
+        return UPLOADED;
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -179,13 +179,13 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             holder.stateContainer.setVisibility(View.VISIBLE);
             holder.stateTextView.setText(strState);
 
-            // hide progressbar and add onclick to retry failed uploads
+            boolean showProgress = state == MediaUploadState.UPLOADING || state == MediaUploadState.DELETE;
+            holder.progressUpload.setVisibility(showProgress ? View.VISIBLE : View.GONE);
+
             if (state == MediaUploadState.FAILED) {
-                holder.progressUpload.setVisibility(View.GONE);
                 holder.stateTextView.setText(mContext.getString(R.string.retry));
                 holder.stateTextView.setCompoundDrawablesWithIntrinsicBounds(0, R.drawable.media_retry_image, 0, 0);
             } else {
-                holder.progressUpload.setVisibility(View.VISIBLE);
                 holder.stateTextView.setCompoundDrawables(null, null, null, null);
             }
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -285,8 +285,9 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                     } else {
                         // retry uploading this media item if it previously failed
                         mCursor.moveToPosition(position);
-                        String state = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.UPLOAD_STATE));
-                        if (state.equalsIgnoreCase(MediaUploadState.FAILED.name())) {
+                        String strState = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.UPLOAD_STATE));
+                        MediaUploadState state = MediaUploadState.fromString(strState);
+                        if (state == MediaUploadState.FAILED) {
                             stateTextView.setText(R.string.upload_queued);
                             stateTextView.setCompoundDrawables(null, null, null, null);
                             if (mCallback != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -177,15 +177,17 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         // show upload state unless it's already uploaded
         if (state != MediaUploadState.UPLOADED) {
             holder.stateContainer.setVisibility(View.VISIBLE);
-            holder.stateTextView.setText(strState);
 
+            // only show progress for items currently being uploaded or deleted
             boolean showProgress = state == MediaUploadState.UPLOADING || state == MediaUploadState.DELETE;
             holder.progressUpload.setVisibility(showProgress ? View.VISIBLE : View.GONE);
 
+            // failed uploads can be retried
             if (state == MediaUploadState.FAILED) {
                 holder.stateTextView.setText(mContext.getString(R.string.retry));
                 holder.stateTextView.setCompoundDrawablesWithIntrinsicBounds(0, R.drawable.media_retry_image, 0, 0);
             } else {
+                holder.stateTextView.setText(strState);
                 holder.stateTextView.setCompoundDrawables(null, null, null, null);
             }
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -121,11 +121,13 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
 
         int localMediaId = mCursor.getInt(mCursor.getColumnIndex(MediaModelTable.ID));
 
-        String state = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.UPLOAD_STATE));
         String filePath = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.FILE_PATH));
         String mimeType = StringUtils.notNullStr(mCursor.getString(mCursor.getColumnIndex(MediaModelTable.MIME_TYPE)));
 
-        boolean isLocalFile = MediaUtils.isLocalFile(state) && !TextUtils.isEmpty(filePath);
+        String strState = mCursor.getString(mCursor.getColumnIndex(MediaModelTable.UPLOAD_STATE));
+        MediaUploadState state = MediaUploadState.fromString(strState);
+
+        boolean isLocalFile = MediaUtils.isLocalFile(strState) && !TextUtils.isEmpty(filePath);
         boolean isSelected = isItemSelected(localMediaId);
         boolean isImage = mimeType.startsWith("image/");
 
@@ -173,12 +175,12 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         }
 
         // show upload state unless it's already uploaded
-        if (!TextUtils.isEmpty(state) && !state.equalsIgnoreCase(MediaUploadState.UPLOADED.name())) {
+        if (state != MediaUploadState.UPLOADED) {
             holder.stateContainer.setVisibility(View.VISIBLE);
-            holder.stateTextView.setText(state);
+            holder.stateTextView.setText(strState);
 
             // hide progressbar and add onclick to retry failed uploads
-            if (state.equalsIgnoreCase(MediaUploadState.FAILED.name())) {
+            if (state == MediaUploadState.FAILED) {
                 holder.progressUpload.setVisibility(View.GONE);
                 holder.stateTextView.setText(mContext.getString(R.string.retry));
                 holder.stateTextView.setCompoundDrawablesWithIntrinsicBounds(0, R.drawable.media_retry_image, 0, 0);


### PR DESCRIPTION
This resolves part of #5483 by only showing the progress spinner in the media browser for items that are currently being uploaded or deleted. Previously it would show for queued and deleted items.