### PR TITLE
Add Analytics to MediaUploadService 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -9,6 +9,7 @@ import android.support.annotation.NonNull;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
@@ -18,11 +19,15 @@ import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.models.MediaUploadState;
+import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -38,6 +43,8 @@ public class MediaUploadService extends Service {
 
     private List<MediaModel> mQueue;
     private List<MediaModel> mCompletedItems;
+
+    private Set<AnalyticsTracker.Stat> availableAnalitycs;
 
     @Inject Dispatcher mDispatcher;
     @Inject MediaStore mMediaStore;
@@ -59,6 +66,12 @@ public class MediaUploadService extends Service {
         AppLog.i(AppLog.T.MEDIA, "Media Upload Service > created");
         mDispatcher.register(this);
         mCurrentUpload = null;
+
+        availableAnalitycs = EnumSet.noneOf(AnalyticsTracker.Stat.class);
+        availableAnalitycs.add(AnalyticsTracker.Stat.MEDIA_UPLOAD_STARTED);
+        availableAnalitycs.add(AnalyticsTracker.Stat.MEDIA_UPLOAD_ERROR);
+        availableAnalitycs.add(AnalyticsTracker.Stat.MEDIA_UPLOAD_SUCCESS);
+        availableAnalitycs.add(AnalyticsTracker.Stat.MEDIA_UPLOAD_CANCELED);
     }
 
     @Override
@@ -111,11 +124,13 @@ public class MediaUploadService extends Service {
         if (event.canceled) {
             // Upload canceled
             AppLog.i(AppLog.T.MEDIA, "Upload successfully canceled.");
+            trackUploadMediaEvents(AnalyticsTracker.Stat.MEDIA_UPLOAD_CANCELED, mCurrentUpload);
             completeCurrentUpload();
             uploadNextInQueue();
         } else if (event.completed) {
             // Upload completed
             AppLog.i(AppLog.T.MEDIA, "Upload completed - localId=" + event.media.getId() + " title=" + event.media.getTitle());
+            trackUploadMediaEvents(AnalyticsTracker.Stat.MEDIA_UPLOAD_SUCCESS, mCurrentUpload);
             mCurrentUpload.setMediaId(event.media.getMediaId());
             completeCurrentUpload();
             uploadNextInQueue();
@@ -134,6 +149,7 @@ public class MediaUploadService extends Service {
         completeCurrentUpload();
         // TODO: check whether we need to broadcast the error or maybe it is enough to register for FluxC events
         // event.media, event.error
+        trackUploadMediaEvents(AnalyticsTracker.Stat.MEDIA_UPLOAD_ERROR, mCurrentUpload);
         uploadNextInQueue();
     }
 
@@ -160,6 +176,7 @@ public class MediaUploadService extends Service {
         }
 
         dispatchUploadAction(mCurrentUpload);
+        trackUploadMediaEvents(AnalyticsTracker.Stat.MEDIA_UPLOAD_STARTED, mCurrentUpload);
     }
 
     private void completeCurrentUpload() {
@@ -270,6 +287,26 @@ public class MediaUploadService extends Service {
             handleOnMediaUploadedError(event);
         } else {
             handleOnMediaUploadedSuccess(event);
+        }
+    }
+
+    /**
+     * Analytics about media being uploaded
+     *
+     * @param media The media being uploaded
+     */
+    private void trackUploadMediaEvents(AnalyticsTracker.Stat stat, MediaModel media) {
+        if (media == null) {
+            AppLog.e(AppLog.T.MEDIA, "Cannot track media upload service events if the original media is null!!");
+            return;
+        }
+
+        if (availableAnalitycs != null && availableAnalitycs.contains(stat)) {
+            Map<String, Object> properties = AnalyticsUtils.getMediaProperties(this, media.isVideo(), null, media.getFilePath());
+            AnalyticsTracker.track(stat, properties);
+        } else {
+            AppLog.w(AppLog.T.MEDIA, "Tried to track the following analytic: " + stat.name() + " but either the allowable analytics are null, " +
+                    "or the current is not included in the set");
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -24,10 +24,9 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 
 import java.util.ArrayList;
-import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -116,13 +115,13 @@ public class MediaUploadService extends Service {
         if (event.canceled) {
             // Upload canceled
             AppLog.i(AppLog.T.MEDIA, "Upload successfully canceled.");
-            trackUploadMediaEvents(AnalyticsTracker.Stat.MEDIA_UPLOAD_CANCELED, mCurrentUpload);
+            trackUploadMediaEvents(AnalyticsTracker.Stat.MEDIA_UPLOAD_CANCELED, mCurrentUpload, null);
             completeCurrentUpload();
             uploadNextInQueue();
         } else if (event.completed) {
             // Upload completed
             AppLog.i(AppLog.T.MEDIA, "Upload completed - localId=" + event.media.getId() + " title=" + event.media.getTitle());
-            trackUploadMediaEvents(AnalyticsTracker.Stat.MEDIA_UPLOAD_SUCCESS, mCurrentUpload);
+            trackUploadMediaEvents(AnalyticsTracker.Stat.MEDIA_UPLOAD_SUCCESS, mCurrentUpload, null);
             mCurrentUpload.setMediaId(event.media.getMediaId());
             completeCurrentUpload();
             uploadNextInQueue();
@@ -141,7 +140,9 @@ public class MediaUploadService extends Service {
         completeCurrentUpload();
         // TODO: check whether we need to broadcast the error or maybe it is enough to register for FluxC events
         // event.media, event.error
-        trackUploadMediaEvents(AnalyticsTracker.Stat.MEDIA_UPLOAD_ERROR, mCurrentUpload);
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("error_type", event.error.type.name());
+        trackUploadMediaEvents(AnalyticsTracker.Stat.MEDIA_UPLOAD_ERROR, mCurrentUpload, properties);
         uploadNextInQueue();
     }
 
@@ -168,7 +169,7 @@ public class MediaUploadService extends Service {
         }
 
         dispatchUploadAction(mCurrentUpload);
-        trackUploadMediaEvents(AnalyticsTracker.Stat.MEDIA_UPLOAD_STARTED, mCurrentUpload);
+        trackUploadMediaEvents(AnalyticsTracker.Stat.MEDIA_UPLOAD_STARTED, mCurrentUpload, null);
     }
 
     private void completeCurrentUpload() {
@@ -287,13 +288,15 @@ public class MediaUploadService extends Service {
      *
      * @param media The media being uploaded
      */
-    private void trackUploadMediaEvents(AnalyticsTracker.Stat stat, MediaModel media) {
+    private void trackUploadMediaEvents(AnalyticsTracker.Stat stat, MediaModel media, Map<String, Object> properties) {
         if (media == null) {
             AppLog.e(AppLog.T.MEDIA, "Cannot track media upload service events if the original media is null!!");
             return;
         }
-
-        Map<String, Object> properties = AnalyticsUtils.getMediaProperties(this, media.isVideo(), null, media.getFilePath());
-        AnalyticsTracker.track(stat, properties);
+        Map<String, Object> mediaProperties = AnalyticsUtils.getMediaProperties(this, media.isVideo(), null, media.getFilePath());
+        if (properties != null) {
+            mediaProperties.putAll(properties);
+        }
+        AnalyticsTracker.track(stat, mediaProperties);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -44,8 +44,6 @@ public class MediaUploadService extends Service {
     private List<MediaModel> mQueue;
     private List<MediaModel> mCompletedItems;
 
-    private Set<AnalyticsTracker.Stat> availableAnalitycs;
-
     @Inject Dispatcher mDispatcher;
     @Inject MediaStore mMediaStore;
 
@@ -66,12 +64,6 @@ public class MediaUploadService extends Service {
         AppLog.i(AppLog.T.MEDIA, "Media Upload Service > created");
         mDispatcher.register(this);
         mCurrentUpload = null;
-
-        availableAnalitycs = EnumSet.noneOf(AnalyticsTracker.Stat.class);
-        availableAnalitycs.add(AnalyticsTracker.Stat.MEDIA_UPLOAD_STARTED);
-        availableAnalitycs.add(AnalyticsTracker.Stat.MEDIA_UPLOAD_ERROR);
-        availableAnalitycs.add(AnalyticsTracker.Stat.MEDIA_UPLOAD_SUCCESS);
-        availableAnalitycs.add(AnalyticsTracker.Stat.MEDIA_UPLOAD_CANCELED);
     }
 
     @Override
@@ -301,12 +293,7 @@ public class MediaUploadService extends Service {
             return;
         }
 
-        if (availableAnalitycs != null && availableAnalitycs.contains(stat)) {
-            Map<String, Object> properties = AnalyticsUtils.getMediaProperties(this, media.isVideo(), null, media.getFilePath());
-            AnalyticsTracker.track(stat, properties);
-        } else {
-            AppLog.w(AppLog.T.MEDIA, "Tried to track the following analytic: " + stat.name() + " but either the allowable analytics are null, " +
-                    "or the current is not included in the set");
-        }
+        Map<String, Object> properties = AnalyticsUtils.getMediaProperties(this, media.isVideo(), null, media.getFilePath());
+        AnalyticsTracker.track(stat, properties);
     }
 }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -229,6 +229,10 @@ public final class AnalyticsTracker {
         DEEP_LINKED,
         DEEP_LINKED_FALLBACK,
         DEEP_LINK_NOT_DEFAULT_HANDLER,
+        MEDIA_UPLOAD_STARTED,
+        MEDIA_UPLOAD_ERROR,
+        MEDIA_UPLOAD_SUCCESS,
+        MEDIA_UPLOAD_CANCELED,
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
@@ -1280,7 +1280,7 @@ public class AnalyticsTrackerMixpanel extends Tracker {
                 break;
             case MEDIA_UPLOAD_ERROR:
                 instructions = AnalyticsTrackerMixpanelInstructionsForStat.
-                        mixpanelInstructionsForEventName("Media Service - Response Error");
+                        mixpanelInstructionsForEventName("Media Service - Upload Error");
                 break;
             case MEDIA_UPLOAD_SUCCESS:
                 instructions = AnalyticsTrackerMixpanelInstructionsForStat.

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
@@ -1274,6 +1274,22 @@ public class AnalyticsTrackerMixpanel extends Tracker {
                 instructions = AnalyticsTrackerMixpanelInstructionsForStat.
                         mixpanelInstructionsForEventName("Media Library - Added Video");
                 break;
+            case MEDIA_UPLOAD_STARTED:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Media Service - Upload Started");
+                break;
+            case MEDIA_UPLOAD_ERROR:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Media Service - Response Error");
+                break;
+            case MEDIA_UPLOAD_SUCCESS:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Media Service - Response OK");
+                break;
+            case MEDIA_UPLOAD_CANCELED:
+                instructions = AnalyticsTrackerMixpanelInstructionsForStat.
+                        mixpanelInstructionsForEventName("Media Service - Upload Canceled");
+                break;
             default:
                 instructions = null;
                 break;

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -660,6 +660,14 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "media_library_photo_added";
             case MEDIA_LIBRARY_ADDED_VIDEO:
                 return "media_library_video_added";
+            case MEDIA_UPLOAD_STARTED:
+                return "media_service_upload_started";
+            case MEDIA_UPLOAD_ERROR:
+                return "media_service_upload_response_error";
+            case MEDIA_UPLOAD_SUCCESS:
+                return "media_service_upload_response_ok";
+            case MEDIA_UPLOAD_CANCELED:
+                return "media_service_upload_canceled";
             default:
                 return null;
         }


### PR DESCRIPTION
We need to track how many uploads fail/succeed, how many are canceled by the user, and the % over the total.