### PR TITLE
Fix #1777: better error messages on post upload failure

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1940,8 +1940,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                     errorMessage = getString(R.string.error_media_unauthorized);
                     break;
                 case PARSE_ERROR:
-                    String errorFormat = getString(R.string.error_media_parse_format);
-                    errorMessage = String.format(errorFormat, event.cause.toString());
+                    errorMessage = getString(R.string.error_media_parse_format);
                     break;
                 case MALFORMED_MEDIA_ARG:
                 case NULL_MEDIA_ARG:

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1940,7 +1940,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                     errorMessage = getString(R.string.error_media_unauthorized);
                     break;
                 case PARSE_ERROR:
-                    errorMessage = getString(R.string.error_media_parse_format);
+                    errorMessage = getString(R.string.error_media_parse_error);
                     break;
                 case MALFORMED_MEDIA_ARG:
                 case NULL_MEDIA_ARG:

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -569,7 +569,7 @@ public class PostUploadService extends Service {
             case AUTHORIZATION_REQUIRED:
                 return getString(R.string.error_media_unauthorized);
              case PARSE_ERROR:
-                 return getString(R.string.error_media_parse_format);
+                 return getString(R.string.error_media_parse_error);
             case REQUEST_TOO_LARGE:
                 return getString(R.string.error_media_request_too_large);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -11,6 +11,7 @@ import android.os.AsyncTask;
 import android.os.IBinder;
 import android.provider.MediaStore.Images;
 import android.provider.MediaStore.Video;
+import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.SparseArray;
 
@@ -28,6 +29,7 @@ import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.store.MediaStore;
+import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
@@ -544,12 +546,41 @@ public class PostUploadService extends Service {
     /**
      * Returns an error message string for a failed post upload.
      */
-    private String buildErrorMessage(PostModel post, PostError error) {
-        // TODO: We should interpret event.error.type and pass our own string rather than use event.error.message
-        String postType = mContext.getResources().getText(post.isPage() ? R.string.page : R.string.post).toString().toLowerCase();
-        String errorMessage = String.format(mContext.getResources().getText(R.string.error_upload).toString(), postType);
-        errorMessage += ": " + error.message;
-        return errorMessage;
+    private @NonNull String getErrorMessageFromPostError(PostModel post, PostError error) {
+        switch (error.type) {
+            case UNKNOWN_POST:
+                return getString(R.string.error_unknown_post);
+            case UNKNOWN_POST_TYPE:
+                return getString(R.string.error_unknown_post_type);
+            case UNAUTHORIZED:
+                return post.isPage() ? getString(R.string.error_refresh_unauthorized_pages) :
+                        getString(R.string.error_refresh_unauthorized_posts);
+        }
+        // In case of a generic or uncaught error, return the message from the API response or the error type
+        return TextUtils.isEmpty(error.message) ? error.type.toString() : error.message;
+    }
+
+    private @NonNull String getErrorMessageFromMediaError(MediaError error) {
+         switch (error.type) {
+            case FS_READ_PERMISSION_DENIED:
+                return getString(R.string.error_media_insufficient_fs_permissions);
+            case NOT_FOUND:
+                return getString(R.string.error_media_not_found);
+            case AUTHORIZATION_REQUIRED:
+                return getString(R.string.error_media_unauthorized);
+             case PARSE_ERROR:
+                 return getString(R.string.error_media_parse_format);
+            case REQUEST_TOO_LARGE:
+                return getString(R.string.error_media_request_too_large);
+        }
+        // In case of a generic or uncaught error, return the message from the API response or the error type
+        return TextUtils.isEmpty(error.message) ? error.type.toString() : error.message;
+    }
+
+    private @NonNull String getErrorMessage(PostModel post, String specificMessage) {
+        String postType = getString(post.isPage() ? R.string.page : R.string.post).toLowerCase();
+        return String.format(mContext.getResources().getText(R.string.error_upload).toString(), postType,
+                specificMessage);
     }
 
     @SuppressWarnings("unused")
@@ -558,9 +589,9 @@ public class PostUploadService extends Service {
         SiteModel site = mSiteStore.getSiteByLocalId(event.post.getLocalSiteId());
 
         if (event.isError()) {
-            AppLog.e(T.EDITOR, "Post upload failed. " + event.error.type + ": " + event.error.message);
-            mPostUploadNotifier.updateNotificationError(event.post, site, buildErrorMessage(event.post, event.error),
-                    false);
+            AppLog.e(T.POSTS, "Post upload failed. " + event.error.type + ": " + event.error.message);
+            String message = getErrorMessage(event.post, getErrorMessageFromPostError(event.post, event.error));
+            mPostUploadNotifier.updateNotificationError(event.post, site, message, false);
             mFirstPublishPosts.remove(event.post.getId());
         } else {
             mPostUploadNotifier.cancelNotification(event.post);
@@ -576,17 +607,15 @@ public class PostUploadService extends Service {
     public void onMediaUploaded(OnMediaUploaded event) {
         // Event for unknown media, ignoring
         if (event.media == null || mCurrentUploadingPost == null || mMediaLatchMap.get(event.media.getId()) == null) {
-            AppLog.w(T.POSTS, "Media event not recognized: " + event.media);
+            AppLog.w(T.MEDIA, "Media event not recognized: " + event.media);
             return;
         }
 
         if (event.isError()) {
+            AppLog.e(T.MEDIA, "Media upload failed. " + event.error.type + ": " + event.error.message);
             SiteModel site = mSiteStore.getSiteByLocalId(mCurrentUploadingPost.getLocalSiteId());
-
-            // TODO: We should interpret event.error.type and pass our own string rather than use error.message
-            String message = TextUtils.isEmpty(event.error.message) ? event.error.type.toString() : event.error.message;
+            String message = getErrorMessage(mCurrentUploadingPost, getErrorMessageFromMediaError(event.error));
             mPostUploadNotifier.updateNotificationError(mCurrentUploadingPost, site, message, true);
-
             mFirstPublishPosts.remove(mCurrentUploadingPost.getId());
             finishUpload();
             return;
@@ -598,7 +627,7 @@ public class PostUploadService extends Service {
         }
 
         if (event.completed) {
-            AppLog.i(T.POSTS, "Media upload completed for post. Media id: " + event.media.getId()
+            AppLog.i(T.MEDIA, "Media upload completed for post. Media id: " + event.media.getId()
                     + ", post id: " + mCurrentUploadingPost.getId());
             mMediaLatchMap.get(event.media.getId()).countDown();
             mMediaLatchMap.remove(event.media.getId());

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -579,7 +579,7 @@ public class PostUploadService extends Service {
 
     private @NonNull String getErrorMessage(PostModel post, String specificMessage) {
         String postType = getString(post.isPage() ? R.string.page : R.string.post).toLowerCase();
-        return String.format(mContext.getResources().getText(R.string.error_upload).toString(), postType,
+        return String.format(mContext.getResources().getText(R.string.error_upload_params).toString(), postType,
                 specificMessage);
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1062,15 +1062,16 @@
     <string name="error_edit_comment">An error occurred while editing the comment</string>
     <string name="error_publish_empty_post">Can\'t publish an empty post</string>
     <string name="error_publish_no_network">Can\'t publish while there is no connection. Saved as draft.</string>
-    <string name="error_upload">An error occurred while uploading the %s</string>
+    <string name="error_upload">Error while uploading the %1$s: %2$s</string>
     <string name="error_media_insufficient_fs_permissions">Read permission required on media file</string>
     <string name="error_media_not_found">Media could not be found</string>
     <string name="error_media_unauthorized">You don\'t have permission to view or edit media</string>
-    <string name="error_media_parse_format">Could not parse response to %s media</string>
+    <string name="error_media_parse_format">Could not parse response after media upload</string>
     <string name="error_media_upload">An error occurred while uploading media</string>
     <string name="error_media_upload_connection">A connection error occurred while uploading media</string>
     <string name="error_media_refresh_no_connection">Connection required to refresh library</string>
     <string name="error_media_load">Unable to load media</string>
+    <string name="error_media_request_too_large">Media too large, can\'t be uploaded</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>
     <string name="fatal_db_error">An error occurred while creating the app database. Try reinstalling the app.</string>
     <string name="error_copy_to_clipboard">An error occurred while copying text to clipboard</string>
@@ -1088,6 +1089,10 @@
     <string name="error_notif_q_action_like">Could not like comment. Please try again later.</string>
     <string name="error_notif_q_action_approve">Could not approve comment. Please try again later.</string>
     <string name="error_notif_q_action_reply">Could not reply to comment. Please try again later.</string>
+
+    <!-- Post Error -->
+    <string name="error_unknown_post">Unknown post, local copy of this post could be desynchronized with you server</string>
+    <string name="error_unknown_post_type">Unknown post format</string>
 
     <!-- Image Descriptions for Accessibility -->
     <string name="content_description_add_media">Add media</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1091,7 +1091,7 @@
     <string name="error_notif_q_action_reply">Could not reply to comment. Please try again later.</string>
 
     <!-- Post Error -->
-    <string name="error_unknown_post">Unknown post, local copy of this post could be desynchronized with you server</string>
+    <string name="error_unknown_post">Unknown post, local copy of this post may be out of sync with the server</string>
     <string name="error_unknown_post_type">Unknown post format</string>
 
     <!-- Image Descriptions for Accessibility -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1066,7 +1066,7 @@
     <string name="error_media_insufficient_fs_permissions">Read permission required on media file</string>
     <string name="error_media_not_found">Media could not be found</string>
     <string name="error_media_unauthorized">You don\'t have permission to view or edit media</string>
-    <string name="error_media_parse_format">Could not parse response after media upload</string>
+    <string name="error_media_parse_error">Could not parse response after media upload</string>
     <string name="error_media_upload">An error occurred while uploading media</string>
     <string name="error_media_upload_connection">A connection error occurred while uploading media</string>
     <string name="error_media_refresh_no_connection">Connection required to refresh library</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1062,7 +1062,7 @@
     <string name="error_edit_comment">An error occurred while editing the comment</string>
     <string name="error_publish_empty_post">Can\'t publish an empty post</string>
     <string name="error_publish_no_network">Can\'t publish while there is no connection. Saved as draft.</string>
-    <string name="error_upload">Error while uploading the %1$s: %2$s</string>
+    <string name="error_upload_params">Error while uploading the %1$s: %2$s</string>
     <string name="error_media_insufficient_fs_permissions">Read permission required on media file</string>
     <string name="error_media_not_found">Media could not be found</string>
     <string name="error_media_unauthorized">You don\'t have permission to view or edit media</string>


### PR DESCRIPTION
Fix #1777: better error messages on post upload failure

cc @tonyr59h 

Note: we can't do much better on self hosted sites (we can show the error provided by the API).