### PR TITLE
Fix #5493: fix a crash when getCurrentFocus() returns null

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/AbstractFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/AbstractFragment.java
@@ -52,8 +52,9 @@ public abstract class AbstractFragment extends Fragment {
             }
 
             // hide keyboard before calling the done action
-            View view = getActivity().getCurrentFocus();
-            if (view != null) WPActivityUtils.hideKeyboard(view);
+            if (getActivity() != null) {
+                WPActivityUtils.hideKeyboard(getActivity().getCurrentFocus());
+            }
 
             // call child action
             onDoneAction();

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -13,6 +13,7 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
 import android.preference.PreferenceManager;
+import android.support.annotation.Nullable;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -98,8 +99,10 @@ public class WPActivityUtils {
         }
     }
 
-    public static void hideKeyboard(final View view) {
-        InputMethodManager inputMethodManager = (InputMethodManager) view.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+    public static void hideKeyboard(@Nullable final View view) {
+        if (view == null) return;
+        InputMethodManager inputMethodManager = (InputMethodManager) view.getContext()
+                .getSystemService(Context.INPUT_METHOD_SERVICE);
         inputMethodManager.hideSoftInputFromWindow(view.getWindowToken(), 0);
     }
 


### PR DESCRIPTION
Fix #5493: fix a crash when getCurrentFocus() returns null