### PR TITLE
issue/5492-reader-following-source

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderBlogActions.java
@@ -56,7 +56,7 @@ public class ReaderBlogActions {
         }
 
         final String actionName = (isAskingToFollow ? "follow" : "unfollow");
-        final String path = "sites/" + blogId + "/follows/" + (isAskingToFollow ? "new" : "mine/delete");
+        final String path = "sites/" + blogId + "/follows/" + (isAskingToFollow ? "new?source=android" : "mine/delete");
 
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override
@@ -202,8 +202,8 @@ public class ReaderBlogActions {
 
         final String actionName = (isAskingToFollow ? "follow" : "unfollow");
         final String path = "read/following/mine/"
-                + (isAskingToFollow ? "new" : "delete")
-                + "?url=" + UrlUtils.urlEncode(feedUrl);
+                + (isAskingToFollow ? "new?source=android&url=" : "delete?url=")
+                + UrlUtils.urlEncode(feedUrl);
 
         com.wordpress.rest.RestRequest.Listener listener = new RestRequest.Listener() {
             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/FollowHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/FollowHelper.java
@@ -56,7 +56,7 @@ class FollowHelper {
                 final RestClientUtils restClientUtils = WordPress.getRestClientUtils();
                 final String restPath;
                 if (!followData.isFollowing()) {
-                    restPath = String.format(Locale.US, "/sites/%s/follows/new", followData.getSiteID());
+                    restPath = String.format(Locale.US, "/sites/%s/follows/new?source=android", followData.getSiteID());
                 } else {
                     restPath = String.format(Locale.US, "/sites/%s/follows/mine/delete", followData.getSiteID());
                 }


### PR DESCRIPTION
Fixes #5492 - adds `?source=android` when following a site in the reader.