### PR TITLE
New Aztec release

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
@@ -46,7 +46,7 @@ public class AztecImageLoader implements Html.ImageGetter {
 
             @Override
             public void onErrorResponse(VolleyError error) {
-                callbacks.onImageLoadingFailed();
+                callbacks.onImageFailed();
             }
         }, maxWidth, 0);
     }

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile 'com.android.support:design:25.1.1'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.+'
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v0.5.0-alpha.3')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v0.5.0-alpha.4')
 }
 
 signing {


### PR DESCRIPTION
Updated Aztec to version _v0.5.0-alpha.4_.

[Release notes](https://github.com/wordpress-mobile/WordPress-Aztec-Android/releases/tag/v0.5.0-alpha.4)