### PR TITLE
Forward our logs in crashlytics

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -41,12 +41,14 @@ import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.module.AppContextModule;
+import org.wordpress.android.fluxc.persistence.SiteSqlUtils.DuplicateSiteException;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
+import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError;
 import org.wordpress.android.modules.AppComponent;
@@ -65,9 +67,9 @@ import org.wordpress.android.ui.stats.datasets.StatsDatabaseHelper;
 import org.wordpress.android.ui.stats.datasets.StatsTable;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.AppLog.AppLogListener;
 import org.wordpress.android.util.AppLog.LogLevel;
+import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.BitmapLruCache;
 import org.wordpress.android.util.CrashlyticsUtils;
 import org.wordpress.android.util.DateTimeUtils;
@@ -556,6 +558,10 @@ public class WordPress extends MultiDexApplication {
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteChanged(OnSiteChanged event) {
+        if (event.isError() && event.error.type == SiteErrorType.DUPLICATE_SITE) {
+            CrashlyticsUtils.logException(new DuplicateSiteException(), T.MAIN, "Duplicate site detected");
+        }
+
         if (!sIsMigrationInProgress) {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -66,6 +66,8 @@ import org.wordpress.android.ui.stats.datasets.StatsTable;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.AppLog.AppLogListener;
+import org.wordpress.android.util.AppLog.LogLevel;
 import org.wordpress.android.util.BitmapLruCache;
 import org.wordpress.android.util.CrashlyticsUtils;
 import org.wordpress.android.util.DateTimeUtils;
@@ -228,14 +230,23 @@ public class WordPress extends MultiDexApplication {
         sImageLoader = mImageLoader;
         sOAuthAuthenticator = mOAuthAuthenticator;
 
-        ProfilingUtils.start("App Startup");
-        // Enable log recording
-        AppLog.enableRecording(true);
-        AppLog.i(T.UTILS, "WordPress.onCreate");
-
         if (!PackageUtils.isDebugBuild()) {
             Fabric.with(this, new Crashlytics());
         }
+
+        ProfilingUtils.start("App Startup");
+        // Enable log recording
+        AppLog.enableRecording(true);
+        AppLog.addListener(new AppLogListener() {
+            @Override
+            public void onLog(T tag, LogLevel logLevel, String message) {
+                StringBuffer sb = new StringBuffer();
+                sb.append(logLevel.toString()).append("/").append(AppLog.TAG).append("-")
+                        .append(tag.toString()).append(": ").append(message);
+                CrashlyticsUtils.log(sb.toString());
+            }
+        });
+        AppLog.i(T.UTILS, "WordPress.onCreate");
 
         // If the migration was not done and if we have something to migrate
         runFluxCMigration();

--- a/WordPress/src/main/java/org/wordpress/android/util/CrashlyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/CrashlyticsUtils.java
@@ -29,6 +29,13 @@ public class CrashlyticsUtils {
         logException(tr, null, null);
     }
 
+    public static void log(String message) {
+        if (!Fabric.isInitialized() || message == null) {
+            return;
+        }
+        Crashlytics.log(message);
+    }
+
     // Utility functions to force us to use and reuse a limited set of keys
 
     public static void setInt(String key, int value) {


### PR DESCRIPTION
https://docs.fabric.io/android/crashlytics/enhanced-reports.html#custom-logging

Note: I remember we wanted to do this a while ago, but the only crashlytics method available was writing stuff using Log.x and thus we had duplicate entries. This is not the case anymore.