### PR TITLE
Fix #5514: Show a toast if the created site cannot be fetched

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1086,6 +1086,7 @@
     <string name="error_notif_q_action_like">Could not like comment. Please try again later.</string>
     <string name="error_notif_q_action_approve">Could not approve comment. Please try again later.</string>
     <string name="error_notif_q_action_reply">Could not reply to comment. Please try again later.</string>
+    <string name="error_fetch_site_after_creation">Site has been created, you might need to refresh your sites in the site picker.</string>
 
     <!-- Image Descriptions for Accessibility -->
     <string name="content_description_add_media">Add media</string>


### PR DESCRIPTION
Fix #5514: Show a toast if the created site cannot be fetched

I'm not a big fan of that patch, we would need an atomic new site/fetch site method. We should actually add all information about the new site in the end point response.

cc @aforcier 