### PR TITLE
Crash fix: NPE in CommentList

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/CommentList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/CommentList.java
@@ -102,4 +102,15 @@ public class CommentList extends ArrayList<CommentModel> {
 
         return true;
     }
+
+    private boolean isEqual(String first, String second) {
+        if (first == null && second == null) {
+            return true;
+        }
+        if (first != null) {
+            return first.equals(second);
+        }
+        // first is `null`, but second is not
+        return false;
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/CommentList.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/CommentList.java
@@ -83,19 +83,19 @@ public class CommentList extends ArrayList<CommentModel> {
                 return false;
             }
             final CommentModel thisComment = this.get(index);
-            if (!thisComment.getStatus().equals(comment.getStatus())) {
+            if (!isEqual(thisComment.getStatus(), comment.getStatus())) {
                 return false;
             }
-            if (!thisComment.getContent().equals(comment.getContent())) {
+            if (!isEqual(thisComment.getContent(), comment.getContent())) {
                 return false;
             }
-            if (!thisComment.getAuthorName().equals(comment.getAuthorName())) {
+            if (!isEqual(thisComment.getAuthorName(), comment.getAuthorName())) {
                 return false;
             }
-            if (!thisComment.getAuthorEmail().equals(comment.getAuthorEmail())) {
+            if (!isEqual(thisComment.getAuthorEmail(), comment.getAuthorEmail())) {
                 return false;
             }
-            if (!thisComment.getAuthorUrl().equals(comment.getAuthorUrl())) {
+            if (!isEqual(thisComment.getAuthorUrl(), comment.getAuthorUrl())) {
                 return false;
             }
         }


### PR DESCRIPTION
Fixes #5516. 

To test:
I could only reproduce this crash artificially. You can add the following in `CommentAdapter` after line `425`, go into the comments page, come back and go back in to reproduce the crash. (other changes could work as well)

```
for (CommentModel comment:comments) {
    comment.setAuthorName(null);
}
```

/cc @maxme 