### PR TITLE
Fix npe in EditPostSettingsFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -408,7 +408,7 @@ public class EditPostSettingsFragment extends Fragment
         }
 
         String tags = TextUtils.join(",", mPost.getTagNameList());
-        if (!tags.equals("")) {
+        if (!tags.equals("") && mTagsEditText != null) {
             mTagsEditText.setText(tags);
         }
 


### PR DESCRIPTION
Fixes #5515. I am actually a little confused about this issue. `mTagsEditText` can be `null`, so this PR should go in no matter what. However, `mPost.getTagNameList()` should also be empty in that case (which is post being a page), so it should never go into that `if`. I am not sure how to reproduce it either, so in the spirit of moving fast and this being a necessary PR no matter what, I felt I'd just send it and move along :)

/cc @maxme 