### PR TITLE
Fixes formatting issues in date & time pickers in Edit Post Settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -1,9 +1,9 @@
 package org.wordpress.android.ui.posts;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.app.DatePickerDialog;
 import android.app.Fragment;
+import android.app.TimePickerDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.location.Address;
@@ -551,9 +551,9 @@ public class EditPostSettingsFragment extends Fragment
 
     private void showPostDateSelectionDialog() {
         final DatePickerDialog datePickerDialog = new DatePickerDialog(getActivity(), null, mYear, mMonth, mDay);
-
         datePickerDialog.setTitle(R.string.select_date);
-        datePickerDialog.setButton(DialogInterface.BUTTON_POSITIVE, getResources().getText(android.R.string.ok), new DialogInterface.OnClickListener() {
+        datePickerDialog.setButton(DialogInterface.BUTTON_POSITIVE, getResources().getText(android.R.string.ok),
+                new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int id) {
                 mYear = datePickerDialog.getDatePicker().getYear();
                 mMonth = datePickerDialog.getDatePicker().getMonth();
@@ -561,14 +561,16 @@ public class EditPostSettingsFragment extends Fragment
                 showPostTimeSelectionDialog();
             }
         });
-        datePickerDialog.setButton(DialogInterface.BUTTON_NEUTRAL, getResources().getText(R.string.immediately), new DialogInterface.OnClickListener() {
+        datePickerDialog.setButton(DialogInterface.BUTTON_NEUTRAL, getResources().getText(R.string.immediately),
+                new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int id) {
                 mIsCustomPubDate = true;
                 mPubDateText.setText(R.string.immediately);
                 updatePostSettingsAndSaveButton();
             }
         });
-        datePickerDialog.setButton(DialogInterface.BUTTON_NEGATIVE, getResources().getText(android.R.string.cancel), new DialogInterface.OnClickListener() {
+        datePickerDialog.setButton(DialogInterface.BUTTON_NEGATIVE, getResources().getText(android.R.string.cancel),
+                new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int id) {
             }
         });
@@ -576,46 +578,34 @@ public class EditPostSettingsFragment extends Fragment
     }
 
     private void showPostTimeSelectionDialog() {
-        final TimePicker timePicker = new TimePicker(getActivity());
-        timePicker.setIs24HourView(DateFormat.is24HourFormat(getActivity()));
-        timePicker.setCurrentHour(mHour);
-        timePicker.setCurrentMinute(mMinute);
+        final TimePickerDialog timePickerDialog = new TimePickerDialog(getActivity(), new TimePickerDialog.OnTimeSetListener() {
+            @Override
+            public void onTimeSet(TimePicker timePicker, int selectedHour, int selectedMinute) {
+                mHour = selectedHour;
+                mMinute = selectedMinute;
 
-        new AlertDialog.Builder(getActivity())
-                .setTitle(R.string.select_time)
-                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        mHour = timePicker.getCurrentHour();
-                        mMinute = timePicker.getCurrentMinute();
+                Date javaDate = new Date(mYear - 1900, mMonth, mDay, mHour, mMinute);
+                long javaTimestamp = javaDate.getTime();
 
-                        Date javaDate = new Date(mYear - 1900, mMonth, mDay, mHour, mMinute);
-                        long javaTimestamp = javaDate.getTime();
+                try {
+                    int flags = 0;
+                    flags |= DateUtils.FORMAT_SHOW_DATE;
+                    flags |= DateUtils.FORMAT_ABBREV_MONTH;
+                    flags |= DateUtils.FORMAT_SHOW_YEAR;
+                    flags |= DateUtils.FORMAT_SHOW_TIME;
+                    String formattedDate = DateUtils.formatDateTime(getActivity(), javaTimestamp, flags);
+                    mCustomPubDate = DateTimeUtils.iso8601FromDate(javaDate);
+                    mPubDateText.setText(formattedDate);
+                    mIsCustomPubDate = true;
 
-                        try {
-                            int flags = 0;
-                            flags |= DateUtils.FORMAT_SHOW_DATE;
-                            flags |= DateUtils.FORMAT_ABBREV_MONTH;
-                            flags |= DateUtils.FORMAT_SHOW_YEAR;
-                            flags |= DateUtils.FORMAT_SHOW_TIME;
-                            String formattedDate = DateUtils.formatDateTime(getActivity(), javaTimestamp, flags);
-                            mCustomPubDate = DateTimeUtils.iso8601FromDate(javaDate);
-                            mPubDateText.setText(formattedDate);
-                            mIsCustomPubDate = true;
-
-                            updatePostSettingsAndSaveButton();
-                        } catch (RuntimeException e) {
-                            AppLog.e(T.POSTS, e);
-                        }
-                    }
-                })
-                .setNegativeButton(android.R.string.cancel,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog,
-                                                int which) {
-                            }
-                        }).setView(timePicker).show();
+                    updatePostSettingsAndSaveButton();
+                } catch (RuntimeException e) {
+                    AppLog.e(T.POSTS, e);
+                }
+            }
+        }, mHour, mMinute, DateFormat.is24HourFormat(getActivity()));
+        timePickerDialog.setTitle(R.string.select_time);
+        timePickerDialog.show();
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.posts;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.app.DatePickerDialog;
 import android.app.Fragment;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -31,7 +32,6 @@ import android.view.inputmethod.EditorInfo;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
-import android.widget.DatePicker;
 import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.TextView;
@@ -550,40 +550,29 @@ public class EditPostSettingsFragment extends Fragment
     }
 
     private void showPostDateSelectionDialog() {
-        final DatePicker datePicker = new DatePicker(getActivity());
-        datePicker.init(mYear, mMonth, mDay, null);
-        datePicker.setCalendarViewShown(false);
+        final DatePickerDialog datePickerDialog = new DatePickerDialog(getActivity(), null, mYear, mMonth, mDay);
 
-        new AlertDialog.Builder(getActivity())
-                .setTitle(R.string.select_date)
-                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        mYear = datePicker.getYear();
-                        mMonth = datePicker.getMonth();
-                        mDay = datePicker.getDayOfMonth();
-                        showPostTimeSelectionDialog();
-                    }
-                })
-                .setNeutralButton(getResources().getText(R.string.immediately),
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialogInterface,
-                                                int i) {
-                                mIsCustomPubDate = true;
-                                mPubDateText.setText(R.string.immediately);
-                                updatePostSettingsAndSaveButton();
-                            }
-                        })
-                .setNegativeButton(android.R.string.cancel,
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog,
-                                                int which) {
-                            }
-                        }
-                ).setView(datePicker).show();
-
+        datePickerDialog.setTitle(R.string.select_date);
+        datePickerDialog.setButton(DialogInterface.BUTTON_POSITIVE, getResources().getText(android.R.string.ok), new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int id) {
+                mYear = datePickerDialog.getDatePicker().getYear();
+                mMonth = datePickerDialog.getDatePicker().getMonth();
+                mDay = datePickerDialog.getDatePicker().getDayOfMonth();
+                showPostTimeSelectionDialog();
+            }
+        });
+        datePickerDialog.setButton(DialogInterface.BUTTON_NEUTRAL, getResources().getText(R.string.immediately), new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int id) {
+                mIsCustomPubDate = true;
+                mPubDateText.setText(R.string.immediately);
+                updatePostSettingsAndSaveButton();
+            }
+        });
+        datePickerDialog.setButton(DialogInterface.BUTTON_NEGATIVE, getResources().getText(android.R.string.cancel), new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int id) {
+            }
+        });
+        datePickerDialog.show();
     }
 
     private void showPostTimeSelectionDialog() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -578,7 +578,8 @@ public class EditPostSettingsFragment extends Fragment
     }
 
     private void showPostTimeSelectionDialog() {
-        final TimePickerDialog timePickerDialog = new TimePickerDialog(getActivity(), new TimePickerDialog.OnTimeSetListener() {
+        final TimePickerDialog timePickerDialog = new TimePickerDialog(getActivity(),
+                new TimePickerDialog.OnTimeSetListener() {
             @Override
             public void onTimeSet(TimePicker timePicker, int selectedHour, int selectedMinute) {
                 mHour = selectedHour;

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -22,6 +22,10 @@
 
         <item name="colorButtonNormal">@color/light_gray</item>
 
+        <item name="android:dialogTheme">@style/DialogTheme.WordPress</item>
+        <item name="android:datePickerStyle">@style/DatePicker.WordPress</item>
+        <item name="android:timePickerStyle">@style/TimePicker.WordPress</item>
+
         <!-- Light.DarkActionBar specific -->
         <item name="android:actionBarWidgetTheme">@style/Theme.WordPress.Widget</item>
 
@@ -96,6 +100,19 @@
         <item name="android:layout_marginLeft">@dimen/margin_extra_large</item>
         <item name="android:paddingRight">@dimen/margin_large</item>
         <item name="android:textSize">@dimen/text_sz_large</item>
+    </style>
+
+    <style name="DialogTheme.WordPress" parent="android:Theme.Material.Dialog">
+        <item name="android:datePickerStyle">@style/DatePicker.WordPress</item>
+        <item name="android:timePickerStyle">@style/TimePicker.WordPress</item>
+    </style>
+
+    <style name="DatePicker.WordPress" parent="android:Widget.Material.DatePicker">
+        <item name="android:datePickerMode">spinner</item>
+    </style>
+
+    <style name="TimePicker.WordPress" parent="android:Widget.Material.TimePicker">
+        <item name="android:timePickerMode">spinner</item>
     </style>
 
     <style name="FilteredRecyclerViewToolbar" parent="Widget.AppCompat.Toolbar">


### PR DESCRIPTION
Fixes #4965. This is an unfortunate change, because we have to remove the shiny material designed DatePicker and TimePicker. On landscape they don't fit and some part of the dialog would be cut. If this is ever fixed, this change is pretty easy to revert, so at least there is that!

I have converted the `DatePicker` to `DatePickerDialog` and `TimePicker` to `TimePickerDialog`, with just that change actually some of the issues got resolved, but it wasn't enough. I have also changed the style so both of them would use the spinner mode.

To test:
* Go to Post Settings
* Tap on Schedule and rotate the screen
* Set a date and when the time picker shows up, rotate again.
* Try different variations of this and make sure in all cases everything is visible.

Here are the after screenshots of this change:

![screenshot_1490626723](https://cloud.githubusercontent.com/assets/662023/24363002/2bbeed42-1317-11e7-8e72-89ba211f57fb.png)
![screenshot_1490626717](https://cloud.githubusercontent.com/assets/662023/24363001/2bbdc20a-1317-11e7-90d1-3a859c868c4f.png)
