### PR TITLE
Fix #5525: Correct italics display in visual editor

### DIFF
--- a/libs/editor/WordPressEditor/src/main/assets/editor.css
+++ b/libs/editor/WordPressEditor/src/main/assets/editor.css
@@ -3,7 +3,6 @@
     -webkit-tap-highlight-color: rgba(0,0,0,0);
     -webkit-touch-callout: none;
     font-family: 'Noto Serif', serif;
-    font-style: normal;
 }
 
 html {


### PR DESCRIPTION
Fixes #5525.

It looks like the line I removed was unnecessary for the [original intended fix](https://github.com/wordpress-mobile/WordPress-Android/pull/5324#issuecomment-284496401) and was all that was needed to fix the missing italics issue. Here's some sample text with this patch:

![editor-text-examples-noto-italic-fix](https://cloud.githubusercontent.com/assets/9613966/24363132/dca8ea44-12dc-11e7-9e89-c8d586ba8005.png)

cc @maxme