### PR TITLE
Localize media upload states

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/MediaUploadState.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/MediaUploadState.java
@@ -23,7 +23,7 @@ public enum MediaUploadState {
         return UPLOADED;
     }
 
-    public static String getUIString(Context context, MediaUploadState state) {
+    public static String getLabel(Context context, MediaUploadState state) {
         switch (state) {
             case QUEUED:
                 return context.getString(R.string.media_upload_state_queued);

--- a/WordPress/src/main/java/org/wordpress/android/models/MediaUploadState.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/MediaUploadState.java
@@ -7,7 +7,7 @@ import org.wordpress.android.R;
 public enum MediaUploadState {
     QUEUED,
     UPLOADING,
-    DELETE,
+    DELETING,
     DELETED,
     FAILED,
     UPLOADED;
@@ -29,7 +29,7 @@ public enum MediaUploadState {
                 return context.getString(R.string.media_upload_state_queued);
             case UPLOADING:
                 return context.getString(R.string.media_upload_state_uploading);
-            case DELETE:
+            case DELETING:
                 return context.getString(R.string.media_upload_state_deleting);
             case DELETED:
                 return context.getString(R.string.media_upload_state_deleted);

--- a/WordPress/src/main/java/org/wordpress/android/models/MediaUploadState.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/MediaUploadState.java
@@ -1,5 +1,9 @@
 package org.wordpress.android.models;
 
+import android.content.Context;
+
+import org.wordpress.android.R;
+
 public enum MediaUploadState {
     QUEUED,
     UPLOADING,
@@ -17,5 +21,23 @@ public enum MediaUploadState {
             }
         }
         return UPLOADED;
+    }
+
+    public static String getUIString(Context context, MediaUploadState state) {
+        switch (state) {
+            case QUEUED:
+                return context.getString(R.string.media_upload_state_queued);
+            case UPLOADING:
+                return context.getString(R.string.media_upload_state_uploading);
+            case DELETE:
+                return context.getString(R.string.media_upload_state_deleting);
+            case DELETED:
+                return context.getString(R.string.media_upload_state_deleted);
+            case FAILED:
+                return context.getString(R.string.media_upload_state_failed);
+            case UPLOADED:
+                return context.getString(R.string.media_upload_state_uploaded);
+        }
+        return "";
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -668,7 +668,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                     continue;
                 }
                 mediaToDelete.add(mediaModel);
-                mediaModel.setUploadState(MediaUploadState.DELETE.name());
+                mediaModel.setUploadState(MediaUploadState.DELETING.name());
                 mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mediaModel));
                 sanitizedIds.add(String.valueOf(currentId));
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -178,7 +178,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             holder.stateContainer.setVisibility(View.VISIBLE);
 
             // only show progress for items currently being uploaded or deleted
-            boolean showProgress = state == MediaUploadState.UPLOADING || state == MediaUploadState.DELETE;
+            boolean showProgress = state == MediaUploadState.UPLOADING || state == MediaUploadState.DELETING;
             holder.progressUpload.setVisibility(showProgress ? View.VISIBLE : View.GONE);
 
             // failed uploads can be retried
@@ -341,7 +341,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             return false;
         }
         MediaUploadState state = MediaUploadState.fromString(mMediaList.get(position).getUploadState());
-        return state != MediaUploadState.DELETE && state != MediaUploadState.DELETED;
+        return state != MediaUploadState.DELETING && state != MediaUploadState.DELETED;
     }
 
     private void loadLocalImage(final String filePath, ImageView imageView) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -292,7 +292,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                         MediaModel media = mMediaList.get(position);
                         MediaUploadState state = MediaUploadState.fromString(media.getUploadState());
                         if (state == MediaUploadState.FAILED) {
-                            stateTextView.setText(R.string.upload_queued);
+                            stateTextView.setText(R.string.media_upload_state_queued);
                             stateTextView.setCompoundDrawables(null, null, null, null);
                             if (mCallback != null) {
                                 mCallback.onAdapterRetryUpload(media.getId());

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -186,7 +186,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                 holder.stateTextView.setText(mContext.getString(R.string.retry));
                 holder.stateTextView.setCompoundDrawablesWithIntrinsicBounds(0, R.drawable.media_retry_image, 0, 0);
             } else {
-                holder.stateTextView.setText(MediaUploadState.getUIString(mContext, state));
+                holder.stateTextView.setText(MediaUploadState.getLabel(mContext, state));
                 holder.stateTextView.setCompoundDrawables(null, null, null, null);
             }
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -186,7 +186,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                 holder.stateTextView.setText(mContext.getString(R.string.retry));
                 holder.stateTextView.setCompoundDrawablesWithIntrinsicBounds(0, R.drawable.media_retry_image, 0, 0);
             } else {
-                holder.stateTextView.setText(strState);
+                holder.stateTextView.setText(MediaUploadState.getUIString(mContext, state));
                 holder.stateTextView.setCompoundDrawables(null, null, null, null);
             }
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -453,7 +453,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
                                 // update upload state
                                 for (int itemId : mGridAdapter.getSelectedItems()) {
                                     MediaModel media = mMediaStore.getMediaWithLocalId(itemId);
-                                    media.setUploadState(MediaUploadState.DELETE.name());
+                                    media.setUploadState(MediaUploadState.DELETING.name());
                                     mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));
                                 }
                                 mGridAdapter.clearSelection();

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -140,7 +140,6 @@
     <string name="access_media_permission_required">Permissions required in order to access media</string>
     <string name="add_media_permission_required">Permissions required in order to add media</string>
     <string name="media_fetching">Fetching media…</string>
-    <string name="upload_queued">Queued</string>
     <string name="media_file_type">File type: %s</string>
     <string name="media_file_name">File name: %s</string>
     <string name="media_uploaded_on">Uploaded on: %s</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -147,12 +147,12 @@
     <string name="media_upload_error">Media upload error occurred</string>
     <string name="media_generic_error">Media error occurred</string>
 
-    <string name="media_upload_state_queued">Queued</string>
-    <string name="media_upload_state_uploading">Uploading</string>
-    <string name="media_upload_state_deleting">Deleting</string>
-    <string name="media_upload_state_deleted">Deleted</string>
-    <string name="media_upload_state_failed">Failed</string>
-    <string name="media_upload_state_uploaded">Uploaded</string>
+    <string name="media_upload_state_queued">QUEUED</string>
+    <string name="media_upload_state_uploading">UPLOADING</string>
+    <string name="media_upload_state_deleting">DELETING</string>
+    <string name="media_upload_state_deleted">DELETED</string>
+    <string name="media_upload_state_failed">FAILED</string>
+    <string name="media_upload_state_uploaded">UPLOADED</string>
 
     <!-- Upload Media -->
     <string name="image_added">Image added</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -148,6 +148,13 @@
     <string name="media_upload_error">Media upload error occurred</string>
     <string name="media_generic_error">Media error occurred</string>
 
+    <string name="media_upload_state_queued">Queued</string>
+    <string name="media_upload_state_uploading">Uploading</string>
+    <string name="media_upload_state_deleting">Deleting</string>
+    <string name="media_upload_state_deleted">Deleted</string>
+    <string name="media_upload_state_failed">Failed</string>
+    <string name="media_upload_state_uploaded">Uploaded</string>
+
     <!-- Upload Media -->
     <string name="image_added">Image added</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -147,12 +147,12 @@
     <string name="media_upload_error">Media upload error occurred</string>
     <string name="media_generic_error">Media error occurred</string>
 
-    <string name="media_upload_state_queued">QUEUED</string>
-    <string name="media_upload_state_uploading">UPLOADING</string>
-    <string name="media_upload_state_deleting">DELETING</string>
-    <string name="media_upload_state_deleted">DELETED</string>
-    <string name="media_upload_state_failed">FAILED</string>
-    <string name="media_upload_state_uploaded">UPLOADED</string>
+    <string name="media_upload_state_queued">Queued</string>
+    <string name="media_upload_state_uploading">Uploading</string>
+    <string name="media_upload_state_deleting">Deleting</string>
+    <string name="media_upload_state_deleted">Deleted</string>
+    <string name="media_upload_state_failed">Failed</string>
+    <string name="media_upload_state_uploaded">Uploaded</string>
 
     <!-- Upload Media -->
     <string name="image_added">Image added</string>


### PR DESCRIPTION
Fixes #5490. Before this change we were showing media upload states in English regardless of the user's language selection.

I've refactored `MediaUploadState.DELETE` as `MediaUploadState.DELETING` so it's clearer for us developers. I was a bit hesitant about this change since we save these states in DB as string, but I don't think you can update your app while the app is deleting a media, it'll just fail and change state. @maxme can you confirm that?

Also, should this point to release branch instead?