### PR TITLE
User raster image for the notification button

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
@@ -131,7 +131,7 @@ public class PostUploadNotifier {
             shareIntent.putExtra(Intent.EXTRA_SUBJECT, post.getTitle());
             PendingIntent pendingIntent = PendingIntent.getBroadcast(mContext, 0, shareIntent,
                     PendingIntent.FLAG_CANCEL_CURRENT);
-            notificationBuilder.addAction(R.drawable.ic_share_white_24dp, mContext.getString(R.string.share_action),
+            notificationBuilder.addAction(R.drawable.ic_share_24dp, mContext.getString(R.string.share_action),
                     pendingIntent);
         }
         doNotify(notificationId, notificationBuilder.build());


### PR DESCRIPTION
Fixes #5497

To test:

1. Run the app on API 16
2. Start a new post and publish it
3. The app doesn't crash and you can see the notification