### PR TITLE
NPE - Deleting media

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -670,7 +670,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             }
 
             if (WordPressMediaUtils.canDeleteMedia(mediaModel)) {
-                if (MediaUtils.isLocalFile(mediaModel.getUploadState().toLowerCase())) {
+                if (mediaModel.getUploadState() != null &&
+                        MediaUtils.isLocalFile(mediaModel.getUploadState().toLowerCase())) {
                     mDispatcher.dispatch(MediaActionBuilder.newRemoveMediaAction(mediaModel));
                     sanitizedIds.add(String.valueOf(currentId));
                     continue;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaItemFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaItemFragment.java
@@ -190,8 +190,7 @@ public class MediaItemFragment extends Fragment {
         }
 
         // check whether or not to show the edit button
-        String state = mediaModel.getUploadState();
-        mIsLocal = MediaUtils.isLocalFile(state);
+        mIsLocal = MediaUtils.isLocalFile(mediaModel.getUploadState());
         if (mIsLocal && getActivity() != null) {
             getActivity().invalidateOptionsMenu();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1964,7 +1964,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         if (mPendingUploads != null && !mPendingUploads.isEmpty()) {
             ArrayList<MediaModel> mediaList = new ArrayList<>();
             for (MediaModel media : mPendingUploads) {
-                if (media.getUploadState().equals(UploadState.QUEUED.name())) {
+                if (UploadState.QUEUED.name().equals(media.getUploadState())) {
                     mediaList.add(media);
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -496,7 +496,7 @@ public class PostUploadService extends Service {
 
             MediaModel finishedMedia = mMediaStore.getMediaWithLocalId(mediaFile.getId());
 
-            if (finishedMedia == null || !finishedMedia.getUploadState().equals(UploadState.UPLOADED.name())) {
+            if (finishedMedia == null || finishedMedia.getUploadState() == null || !finishedMedia.getUploadState().equals(UploadState.UPLOADED.name())) {
                 mIsMediaError = true;
                 return null;
             }
@@ -525,7 +525,7 @@ public class PostUploadService extends Service {
 
             MediaModel finishedMedia = mMediaStore.getMediaWithLocalId(mediaFile.getId());
 
-            if (finishedMedia == null || !finishedMedia.getUploadState().equals(UploadState.UPLOADED.name())) {
+            if (finishedMedia == null || finishedMedia.getUploadState() == null || !finishedMedia.getUploadState().equals(UploadState.UPLOADED.name())) {
                 mIsMediaError = true;
                 return null;
             }


### PR DESCRIPTION
Fixes #5540 by adding `null` checks on the `state` of the media file before accessing it.

Not sure if the checks I added are really necessary, since we may have changed the state to be not null in FluxC. In any case they don't hurt.
