### PR TITLE
Improved sharing from WPWebViewActivity while viewing post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -197,10 +197,11 @@ public class ActivityLauncher {
 
         // always add the preview parameter to avoid bumping stats when viewing posts
         String url = UrlUtils.appendUrlParameter(post.getLink(), "preview", "true");
+        String sharableUrl = post.getLink();
         if (site.isWPCom()) {
-            WPWebViewActivity.openPostUrlByUsingGlobalWPCOMCredentials(context, url, post.getLink());
+            WPWebViewActivity.openPostUrlByUsingGlobalWPCOMCredentials(context, url, sharableUrl);
         } else if (site.isJetpackConnected()) {
-            WPWebViewActivity.openJetpackBlogPostPreview(context, url, site.getFrameNonce());
+            WPWebViewActivity.openJetpackBlogPostPreview(context, url, sharableUrl, site.getFrameNonce());
         } else {
             // Add the original post URL to the list of allowed URLs.
             // This is necessary because links are disabled in the webview, but WP removes "?preview=true"

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -198,7 +198,7 @@ public class ActivityLauncher {
         // always add the preview parameter to avoid bumping stats when viewing posts
         String url = UrlUtils.appendUrlParameter(post.getLink(), "preview", "true");
         if (site.isWPCom()) {
-            WPWebViewActivity.openUrlByUsingGlobalWPCOMCredentials(context, url);
+            WPWebViewActivity.openPostUrlByUsingGlobalWPCOMCredentials(context, url, post.getLink());
         } else if (site.isJetpackConnected()) {
             WPWebViewActivity.openJetpackBlogPostPreview(context, url, site.getFrameNonce());
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -197,12 +197,12 @@ public class ActivityLauncher {
 
         // always add the preview parameter to avoid bumping stats when viewing posts
         String url = UrlUtils.appendUrlParameter(post.getLink(), "preview", "true");
-        String sharableUrl = post.getLink();
+        String shareableUrl = post.getLink();
         String shareSubject = post.getTitle();
         if (site.isWPCom()) {
-            WPWebViewActivity.openPostUrlByUsingGlobalWPCOMCredentials(context, url, sharableUrl, shareSubject);
+            WPWebViewActivity.openPostUrlByUsingGlobalWPCOMCredentials(context, url, shareableUrl, shareSubject);
         } else if (site.isJetpackConnected()) {
-            WPWebViewActivity.openJetpackBlogPostPreview(context, url, sharableUrl, shareSubject, site.getFrameNonce());
+            WPWebViewActivity.openJetpackBlogPostPreview(context, url, shareableUrl, shareSubject, site.getFrameNonce());
         } else {
             // Add the original post URL to the list of allowed URLs.
             // This is necessary because links are disabled in the webview, but WP removes "?preview=true"

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -198,10 +198,11 @@ public class ActivityLauncher {
         // always add the preview parameter to avoid bumping stats when viewing posts
         String url = UrlUtils.appendUrlParameter(post.getLink(), "preview", "true");
         String sharableUrl = post.getLink();
+        String shareSubject = post.getTitle();
         if (site.isWPCom()) {
-            WPWebViewActivity.openPostUrlByUsingGlobalWPCOMCredentials(context, url, sharableUrl);
+            WPWebViewActivity.openPostUrlByUsingGlobalWPCOMCredentials(context, url, sharableUrl, shareSubject);
         } else if (site.isJetpackConnected()) {
-            WPWebViewActivity.openJetpackBlogPostPreview(context, url, sharableUrl, site.getFrameNonce());
+            WPWebViewActivity.openJetpackBlogPostPreview(context, url, sharableUrl, shareSubject, site.getFrameNonce());
         } else {
             // Add the original post URL to the list of allowed URLs.
             // This is necessary because links are disabled in the webview, but WP removes "?preview=true"

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -94,7 +94,11 @@ public class WPWebViewActivity extends WebViewActivity {
     }
 
     public static void openUrlByUsingGlobalWPCOMCredentials(Context context, String url) {
-        openWPCOMURL(context, url);
+        openWPCOMURL(context, url, null);
+    }
+
+    public static void openPostUrlByUsingGlobalWPCOMCredentials(Context context, String url, String sharableUrl) {
+        openWPCOMURL(context, url, sharableUrl);
     }
 
     // frameNonce is used to show drafts, without it "no page found" error would be thrown
@@ -183,7 +187,7 @@ public class WPWebViewActivity extends WebViewActivity {
         return true;
     }
 
-    private static void openWPCOMURL(Context context, String url) {
+    private static void openWPCOMURL(Context context, String url, String sharableUrl) {
         if (!checkContextAndUrl(context, url)) {
             return;
         }
@@ -192,6 +196,9 @@ public class WPWebViewActivity extends WebViewActivity {
         intent.putExtra(WPWebViewActivity.USE_GLOBAL_WPCOM_USER, true);
         intent.putExtra(WPWebViewActivity.URL_TO_LOAD, url);
         intent.putExtra(WPWebViewActivity.AUTHENTICATION_URL, WPCOM_LOGIN_URL);
+        if (!TextUtils.isEmpty(sharableUrl)) {
+            intent.putExtra(WPWebViewActivity.SHARABLE_URL, sharableUrl);
+        }
         context.startActivity(intent);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -392,7 +392,7 @@ public class WPWebViewActivity extends WebViewActivity {
             // Use the preferred sharable URL or the default webview URL
             Bundle extras = getIntent().getExtras();
             String sharableUrl = extras.getString(SHARABLE_URL, null);
-            if (sharableUrl == null) {
+            if (TextUtils.isEmpty(sharableUrl)) {
                 sharableUrl = mWebView.getUrl();
             }
             share.putExtra(Intent.EXTRA_TEXT, sharableUrl);

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -102,13 +102,16 @@ public class WPWebViewActivity extends WebViewActivity {
     }
 
     // frameNonce is used to show drafts, without it "no page found" error would be thrown
-    public static void openJetpackBlogPostPreview(Context context, String url, String frameNonce) {
+    public static void openJetpackBlogPostPreview(Context context, String url, String sharableUrl, String frameNonce) {
         if (!TextUtils.isEmpty(frameNonce)) {
             url += "&frame-nonce=" + frameNonce;
         }
         Intent intent = new Intent(context, WPWebViewActivity.class);
         intent.putExtra(WPWebViewActivity.URL_TO_LOAD, url);
         intent.putExtra(WPWebViewActivity.DISABLE_LINKS_ON_PAGE, false);
+        if (!TextUtils.isEmpty(sharableUrl)) {
+            intent.putExtra(WPWebViewActivity.SHARABLE_URL, sharableUrl);
+        }
         context.startActivity(intent);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -78,6 +78,7 @@ public class WPWebViewActivity extends WebViewActivity {
     public static final String WPCOM_LOGIN_URL = "https://wordpress.com/wp-login.php";
     public static final String LOCAL_BLOG_ID = "local_blog_id";
     public static final String SHARABLE_URL = "sharable_url";
+    public static final String SHARE_SUBJECT = "share_subject";
     public static final String REFERRER_URL = "referrer_url";
     public static final String DISABLE_LINKS_ON_PAGE = "DISABLE_LINKS_ON_PAGE";
     public static final String ALLOWED_URLS = "allowed_urls";
@@ -94,15 +95,17 @@ public class WPWebViewActivity extends WebViewActivity {
     }
 
     public static void openUrlByUsingGlobalWPCOMCredentials(Context context, String url) {
-        openWPCOMURL(context, url, null);
+        openWPCOMURL(context, url, null, null);
     }
 
-    public static void openPostUrlByUsingGlobalWPCOMCredentials(Context context, String url, String sharableUrl) {
-        openWPCOMURL(context, url, sharableUrl);
+    public static void openPostUrlByUsingGlobalWPCOMCredentials(Context context, String url, String sharableUrl,
+                                                                String shareSubject) {
+        openWPCOMURL(context, url, sharableUrl, shareSubject);
     }
 
     // frameNonce is used to show drafts, without it "no page found" error would be thrown
-    public static void openJetpackBlogPostPreview(Context context, String url, String sharableUrl, String frameNonce) {
+    public static void openJetpackBlogPostPreview(Context context, String url, String sharableUrl, String shareSubject,
+                                                  String frameNonce) {
         if (!TextUtils.isEmpty(frameNonce)) {
             url += "&frame-nonce=" + frameNonce;
         }
@@ -111,6 +114,9 @@ public class WPWebViewActivity extends WebViewActivity {
         intent.putExtra(WPWebViewActivity.DISABLE_LINKS_ON_PAGE, false);
         if (!TextUtils.isEmpty(sharableUrl)) {
             intent.putExtra(WPWebViewActivity.SHARABLE_URL, sharableUrl);
+        }
+        if (!TextUtils.isEmpty(shareSubject)) {
+            intent.putExtra(WPWebViewActivity.SHARE_SUBJECT, shareSubject);
         }
         context.startActivity(intent);
     }
@@ -190,7 +196,7 @@ public class WPWebViewActivity extends WebViewActivity {
         return true;
     }
 
-    private static void openWPCOMURL(Context context, String url, String sharableUrl) {
+    private static void openWPCOMURL(Context context, String url, String sharableUrl, String shareSubject) {
         if (!checkContextAndUrl(context, url)) {
             return;
         }
@@ -201,6 +207,9 @@ public class WPWebViewActivity extends WebViewActivity {
         intent.putExtra(WPWebViewActivity.AUTHENTICATION_URL, WPCOM_LOGIN_URL);
         if (!TextUtils.isEmpty(sharableUrl)) {
             intent.putExtra(WPWebViewActivity.SHARABLE_URL, sharableUrl);
+        }
+        if (!TextUtils.isEmpty(shareSubject)) {
+            intent.putExtra(WPWebViewActivity.SHARE_SUBJECT, shareSubject);
         }
         context.startActivity(intent);
     }
@@ -387,6 +396,10 @@ public class WPWebViewActivity extends WebViewActivity {
                 sharableUrl = mWebView.getUrl();
             }
             share.putExtra(Intent.EXTRA_TEXT, sharableUrl);
+            String shareSubject = extras.getString(SHARE_SUBJECT, null);
+            if (!TextUtils.isEmpty(shareSubject)) {
+                share.putExtra(Intent.EXTRA_SUBJECT, shareSubject);
+            }
             startActivity(Intent.createChooser(share, getText(R.string.share_link)));
             return true;
         } else if (itemID == R.id.menu_browser) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -76,7 +76,7 @@ public class WPWebViewActivity extends WebViewActivity {
     public static final String URL_TO_LOAD = "url_to_load";
     public static final String WPCOM_LOGIN_URL = "https://wordpress.com/wp-login.php";
     public static final String LOCAL_BLOG_ID = "local_blog_id";
-    public static final String SHARABLE_URL = "sharable_url";
+    public static final String SHAREABLE_URL = "shareable_url";
     public static final String SHARE_SUBJECT = "share_subject";
     public static final String REFERRER_URL = "referrer_url";
     public static final String DISABLE_LINKS_ON_PAGE = "DISABLE_LINKS_ON_PAGE";
@@ -97,13 +97,13 @@ public class WPWebViewActivity extends WebViewActivity {
         openWPCOMURL(context, url, null, null);
     }
 
-    public static void openPostUrlByUsingGlobalWPCOMCredentials(Context context, String url, String sharableUrl,
+    public static void openPostUrlByUsingGlobalWPCOMCredentials(Context context, String url, String shareableUrl,
                                                                 String shareSubject) {
-        openWPCOMURL(context, url, sharableUrl, shareSubject);
+        openWPCOMURL(context, url, shareableUrl, shareSubject);
     }
 
     // frameNonce is used to show drafts, without it "no page found" error would be thrown
-    public static void openJetpackBlogPostPreview(Context context, String url, String sharableUrl, String shareSubject,
+    public static void openJetpackBlogPostPreview(Context context, String url, String shareableUrl, String shareSubject,
                                                   String frameNonce) {
         if (!TextUtils.isEmpty(frameNonce)) {
             url += "&frame-nonce=" + frameNonce;
@@ -111,8 +111,8 @@ public class WPWebViewActivity extends WebViewActivity {
         Intent intent = new Intent(context, WPWebViewActivity.class);
         intent.putExtra(WPWebViewActivity.URL_TO_LOAD, url);
         intent.putExtra(WPWebViewActivity.DISABLE_LINKS_ON_PAGE, false);
-        if (!TextUtils.isEmpty(sharableUrl)) {
-            intent.putExtra(WPWebViewActivity.SHARABLE_URL, sharableUrl);
+        if (!TextUtils.isEmpty(shareableUrl)) {
+            intent.putExtra(WPWebViewActivity.SHAREABLE_URL, shareableUrl);
         }
         if (!TextUtils.isEmpty(shareSubject)) {
             intent.putExtra(WPWebViewActivity.SHARE_SUBJECT, shareSubject);
@@ -150,7 +150,7 @@ public class WPWebViewActivity extends WebViewActivity {
         intent.putExtra(WPWebViewActivity.DISABLE_LINKS_ON_PAGE, true);
             intent.putExtra(ALLOWED_URLS, listOfAllowedURLs);
         if (post != null) {
-            intent.putExtra(WPWebViewActivity.SHARABLE_URL, post.getLink());
+            intent.putExtra(WPWebViewActivity.SHAREABLE_URL, post.getLink());
             if (!TextUtils.isEmpty(post.getTitle())) {
                 intent.putExtra(WPWebViewActivity.SHARE_SUBJECT, post.getTitle());
             }
@@ -198,7 +198,7 @@ public class WPWebViewActivity extends WebViewActivity {
         return true;
     }
 
-    private static void openWPCOMURL(Context context, String url, String sharableUrl, String shareSubject) {
+    private static void openWPCOMURL(Context context, String url, String shareableUrl, String shareSubject) {
         if (!checkContextAndUrl(context, url)) {
             return;
         }
@@ -207,8 +207,8 @@ public class WPWebViewActivity extends WebViewActivity {
         intent.putExtra(WPWebViewActivity.USE_GLOBAL_WPCOM_USER, true);
         intent.putExtra(WPWebViewActivity.URL_TO_LOAD, url);
         intent.putExtra(WPWebViewActivity.AUTHENTICATION_URL, WPCOM_LOGIN_URL);
-        if (!TextUtils.isEmpty(sharableUrl)) {
-            intent.putExtra(WPWebViewActivity.SHARABLE_URL, sharableUrl);
+        if (!TextUtils.isEmpty(shareableUrl)) {
+            intent.putExtra(WPWebViewActivity.SHAREABLE_URL, shareableUrl);
         }
         if (!TextUtils.isEmpty(shareSubject)) {
             intent.putExtra(WPWebViewActivity.SHARE_SUBJECT, shareSubject);
@@ -391,13 +391,13 @@ public class WPWebViewActivity extends WebViewActivity {
         } else if (itemID == R.id.menu_share) {
             Intent share = new Intent(Intent.ACTION_SEND);
             share.setType("text/plain");
-            // Use the preferred sharable URL or the default webview URL
+            // Use the preferred shareable URL or the default webview URL
             Bundle extras = getIntent().getExtras();
-            String sharableUrl = extras.getString(SHARABLE_URL, null);
-            if (TextUtils.isEmpty(sharableUrl)) {
-                sharableUrl = mWebView.getUrl();
+            String shareableUrl = extras.getString(SHAREABLE_URL, null);
+            if (TextUtils.isEmpty(shareableUrl)) {
+                shareableUrl = mWebView.getUrl();
             }
-            share.putExtra(Intent.EXTRA_TEXT, sharableUrl);
+            share.putExtra(Intent.EXTRA_TEXT, shareableUrl);
             String shareSubject = extras.getString(SHARE_SUBJECT, null);
             if (!TextUtils.isEmpty(shareSubject)) {
                 share.putExtra(Intent.EXTRA_SUBJECT, shareSubject);

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -23,7 +23,6 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.URLFilteredWebViewClient;
 import org.wordpress.android.util.UrlUtils;
-import org.wordpress.android.util.WPMeShortlinks;
 import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.util.WPWebViewClient;
 import org.wordpress.android.util.helpers.WPWebChromeClient;
@@ -151,7 +150,10 @@ public class WPWebViewActivity extends WebViewActivity {
         intent.putExtra(WPWebViewActivity.DISABLE_LINKS_ON_PAGE, true);
             intent.putExtra(ALLOWED_URLS, listOfAllowedURLs);
         if (post != null) {
-            intent.putExtra(WPWebViewActivity.SHARABLE_URL, WPMeShortlinks.getPostShortlink(site, post));
+            intent.putExtra(WPWebViewActivity.SHARABLE_URL, post.getLink());
+            if (!TextUtils.isEmpty(post.getTitle())) {
+                intent.putExtra(WPWebViewActivity.SHARE_SUBJECT, post.getTitle());
+            }
         }
         context.startActivity(intent);
     }


### PR DESCRIPTION
Fixes #5536. This is a follow-up PR to #5532. This PR adds the title field to share intent as well as fixing the url that's getting shared. We were sharing the `preview` version of the url in most cases and the web url of the current page for self-hosted posts. I don't think we should be using the preview version to share, since the only reason we use it is to make sure stats are not counted.

If you are checking a remote draft and you're trying to share it, it'll most likely fail, but that's to be expected. The user will need access to the blog in order to see the drafts. I don't think there is anything we can do about that.

@nbradbury Do you want to check out this one as well, if you have the time, since you reviewed the original PR?

To test:
* Go into post list page for .com/jetpack/self-hosted sites
* Tap on the view button, from the navbar, tap on the share button and share your post somewhere (you can share with WordPress)
* Make sure the title and url are correct
