### PR TITLE
Magic Link: Error handling & Network check

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
@@ -23,6 +23,7 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.JetpackCallbacks;
 import org.wordpress.android.util.HelpshiftHelper;
+import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.widgets.WPTextView;
 
@@ -128,6 +129,10 @@ public class MagicLinkRequestFragment extends Fragment {
     }
 
     private void sendMagicLinkRequest() {
+        if (!NetworkUtils.isNetworkAvailable(getActivity())) {
+            ToastUtils.showToast(getActivity(), R.string.no_network_message, ToastUtils.Duration.LONG);
+            return;
+        }
         disableRequestEmailButtonAndShowProgressDialog();
 
         Map<String, String> params = new HashMap<>();

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
@@ -138,15 +138,16 @@ public class MagicLinkRequestFragment extends Fragment {
         WordPress.getRestClientUtilsV1_1().sendLoginEmail(params, new RestRequest.Listener() {
             @Override
             public void onResponse(JSONObject response) {
+                mProgressDialog.cancel();
+                AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_REQUESTED);
                 if (mListener != null) {
-                    mProgressDialog.cancel();
-                    AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_REQUESTED);
                     mListener.onMagicLinkSent();
                 }
             }
         }, new RestRequest.ErrorListener() {
             @Override
             public void onErrorResponse(VolleyError error) {
+                mProgressDialog.cancel();
                 HashMap<String, String> errorProperties = new HashMap<>();
                 errorProperties.put(ERROR_KEY, error.getMessage());
                 AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_FAILED, errorProperties);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -24,6 +23,7 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.JetpackCallbacks;
 import org.wordpress.android.util.HelpshiftHelper;
+import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.widgets.WPTextView;
 
 import java.util.HashMap;
@@ -147,13 +147,11 @@ public class MagicLinkRequestFragment extends Fragment {
         }, new RestRequest.ErrorListener() {
             @Override
             public void onErrorResponse(VolleyError error) {
-                mProgressDialog.cancel();
                 HashMap<String, String> errorProperties = new HashMap<>();
                 errorProperties.put(ERROR_KEY, error.getMessage());
                 AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_FAILED, errorProperties);
-                if (getView() != null) {
-                    Snackbar.make(getView(), R.string.magic_link_unavailable_error_message, Snackbar.LENGTH_SHORT);
-                }
+                mProgressDialog.cancel();
+                ToastUtils.showToast(getActivity(), R.string.magic_link_unavailable_error_message, ToastUtils.Duration.LONG);
                 if (mListener != null) {
                     mListener.onEnterPasswordRequested();
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
@@ -156,7 +156,9 @@ public class MagicLinkRequestFragment extends Fragment {
                 errorProperties.put(ERROR_KEY, error.getMessage());
                 AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_FAILED, errorProperties);
                 mProgressDialog.cancel();
-                ToastUtils.showToast(getActivity(), R.string.magic_link_unavailable_error_message, ToastUtils.Duration.LONG);
+                if (isAdded()) {
+                    ToastUtils.showToast(getActivity(), R.string.magic_link_unavailable_error_message, ToastUtils.Duration.LONG);
+                }
                 if (mListener != null) {
                     mListener.onEnterPasswordRequested();
                 }


### PR DESCRIPTION
Fixes #5393. This PR improves the error handling for magic link requests. We were never removing the dialog on error, which was getting the users stuck on that screen. This happens on any kind of error, not just the network one mentioned in the original issue. I also added a check for network reach-ability before the request as we do in many other places.

I had to remove the `Snackbar` and use the `Toast` instead. We don't have a `CoordinatorLayout` in the fragment or activity and even after adding it, the Snackbar never appears for me. I'd really appreciate it if there are any suggestions on how to make the Snackbar work instead.

To test:
* Disable the network
* Try to log in via magic link and make sure you get no network available error
* Comment out the following code and make sure there is an error shown and the dialog dismissed (although since it's too fast, you'll probably not see the dialog)

```
if (!NetworkUtils.isNetworkAvailable(getActivity())) {
    ToastUtils.showToast(getActivity(), R.string.no_network_message, ToastUtils.Duration.LONG);
    return;
}
```
