### PR TITLE
Fix #5554: check for an eventual null username before aliasing

### DIFF
--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerMixpanel.java
@@ -191,7 +191,7 @@ public class AnalyticsTrackerMixpanel extends Tracker {
         if (metadata.isUserConnected() && metadata.isWordPressComUser()) {
             setWordPressComUserName(metadata.getUsername());
             // Re-unify the user
-            if (getAnonID() != null) {
+            if (getAnonID() != null && getWordPressComUserName() != null) {
                 mMixpanel.alias(getWordPressComUserName(), getAnonID());
                 clearAnonID();
             } else {


### PR DESCRIPTION
Fix #5554: check for an eventual null username before aliasing