### PR TITLE
Fix #5303: Use emoji flags for Android 5.0+ users / default to the Gravatar option for other users

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.stats;
 
 import android.app.Activity;
 import android.net.http.SslError;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -250,16 +251,21 @@ public class StatsGeoviewsFragment extends StatsAbstractListFragment {
             // fill data
             String entry = currentRowData.getCountryFullName();
             String imageUrl = currentRowData.getFlatFlagIconURL();
-            int total = currentRowData.getViews();
+            holder.totalsTextView.setText(FormatUtils.formatDecimal(currentRowData.getViews()));
 
             holder.setEntryText(entry);
-            holder.totalsTextView.setText(FormatUtils.formatDecimal(total));
 
-            // image (country flag)
-            holder.networkImageView.setImageUrl(
-                    GravatarUtils.fixGravatarUrl(imageUrl, mResourceVars.headerAvatarSizePx),
-                    WPNetworkImageView.ImageType.BLAVATAR);
-            holder.networkImageView.setVisibility(View.VISIBLE);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                // On Android >= 5.0, ese the emoji flag
+                holder.alternativeImage.setText(currentRowData.getFlagEmoji());
+                holder.alternativeImage.setVisibility(View.VISIBLE);
+            } else {
+                // On other devices, use the Gravatar image
+                holder.networkImageView.setImageUrl(
+                        GravatarUtils.fixGravatarUrl(imageUrl, mResourceVars.headerAvatarSizePx),
+                        WPNetworkImageView.ImageType.BLAVATAR);
+                holder.networkImageView.setVisibility(View.VISIBLE);
+            }
 
             return rowView;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
@@ -256,11 +256,11 @@ public class StatsGeoviewsFragment extends StatsAbstractListFragment {
             holder.setEntryText(entry);
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                // On Android >= 5.0, ese the emoji flag
+                // On Android >= 5.0, use the emoji flag
                 holder.alternativeImage.setText(currentRowData.getFlagEmoji());
                 holder.alternativeImage.setVisibility(View.VISIBLE);
             } else {
-                // On other devices, use the Gravatar image
+                // On other Android versions, use the Gravatar image
                 holder.networkImageView.setImageUrl(
                         GravatarUtils.fixGravatarUrl(imageUrl, mResourceVars.headerAvatarSizePx),
                         WPNetworkImageView.ImageType.BLAVATAR);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
@@ -521,4 +521,10 @@ public class StatsUtils {
 
         return "";
     }
+
+    public static String countryCodeToEmoji(String countryCode) {
+        int char1 = Character.codePointAt(countryCode, 0) - 0x41 + 0x1F1E6;
+        int char2 = Character.codePointAt(countryCode, 1) - 0x41 + 0x1F1E6;
+        return new String(Character.toChars(char1)) + new String(Character.toChars(char2));
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsUtils.java
@@ -522,7 +522,22 @@ public class StatsUtils {
         return "";
     }
 
+    /**
+     * Transform a 2 characters country code into a 2 characters emoji flag.
+     * Emoji letter A starts at: 0x1F1E6 thus,
+     * 0x1F1E6 + 5  = 0x1F1EB represents the letter F
+     * 0x1F1E6 + 17 = 0x1F1F7 represents the letter R
+     *
+     * FR: 0x1F1EB 0x1F1F7 is the french flag: 🇫🇷
+     * More infos on https://apps.timwhitlock.info/emoji/tables/iso3166
+     *
+     * @param countryCode - iso3166 country code (2chars)
+     * @return emoji string representing the flag
+     */
     public static String countryCodeToEmoji(String countryCode) {
+        if (TextUtils.isEmpty(countryCode) || countryCode.length() != 2) {
+            return "";
+        }
         int char1 = Character.codePointAt(countryCode, 0) - 0x41 + 0x1F1E6;
         int char2 = Character.codePointAt(countryCode, 1) - 0x41 + 0x1F1E6;
         return new String(Character.toChars(char1)) + new String(Character.toChars(char2));

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewHolder.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewHolder.java
@@ -25,6 +25,7 @@ public class StatsViewHolder {
     public final TextView entryTextView;
     public final TextView totalsTextView;
     public final WPNetworkImageView networkImageView;
+    public final TextView alternativeImage;
     public final ImageView chevronImageView;
     public final ImageView linkImageView;
     public final ImageView imgMore;
@@ -37,7 +38,7 @@ public class StatsViewHolder {
         chevronImageView = (ImageView) view.findViewById(R.id.stats_list_cell_chevron);
         linkImageView = (ImageView) view.findViewById(R.id.stats_list_cell_link);
         networkImageView = (WPNetworkImageView) view.findViewById(R.id.stats_list_cell_image);
-
+        alternativeImage = (TextView) view.findViewById(R.id.stats_list_cell_image_alt);
         imgMore = (ImageView) view.findViewById(R.id.image_more);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/models/GeoviewModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/models/GeoviewModel.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.ui.stats.models;
 
+import org.wordpress.android.ui.stats.StatsUtils;
+
 import java.io.Serializable;
 
 /**
@@ -44,4 +46,7 @@ public class GeoviewModel implements Serializable {
         return mFlatFlagIconURL;
     }
 
+    public String getFlagEmoji() {
+        return StatsUtils.countryCodeToEmoji(mCountryShortName);
+    }
 }

--- a/WordPress/src/main/res/layout/stats_list_cell.xml
+++ b/WordPress/src/main/res/layout/stats_list_cell.xml
@@ -44,6 +44,17 @@
             android:layout_marginEnd="@dimen/margin_large"
             android:visibility="gone" />
 
+        <!-- Alternative to the Network image view above, can be used to display emojis (flags for instance) -->
+        <TextView
+            android:id="@+id/stats_list_cell_image_alt"
+            android:layout_width="@dimen/avatar_sz_small"
+            android:layout_height="@dimen/avatar_sz_small"
+            android:layout_marginRight="@dimen/margin_large"
+            android:layout_marginEnd="@dimen/margin_large"
+            android:textSize="@dimen/avatar_sz_extra_small"
+            android:textColor="@color/black"
+            android:visibility="gone" />
+
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/stats_list_cell_entry"
             android:layout_weight="1"


### PR DESCRIPTION
Pros:
* 257 countries supported
* no network requests
* no extra resources

Cons:
* waves
* only works in Android >= 5.0

![screenshot-2017-03-30_10 53 39 431](https://cloud.githubusercontent.com/assets/40213/24496206/de7de4f2-1537-11e7-83c6-2a033e229099.png)

Android < 5.0 usage is pretty low (~14%), I think it's fair to not fix it for them.

cc @daniloercoli 
