### PR TITLE
Fix #5558: Keep listening to onChanged events even if the fragment is stopped

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -50,8 +50,8 @@ import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.EditTextUtils;
-import org.wordpress.android.util.LanguageUtils;
 import org.wordpress.android.util.HelpshiftHelper;
+import org.wordpress.android.util.LanguageUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.UserEmailUtils;
@@ -458,8 +458,8 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
     }
 
     private void initInfoButton(View rootView) {
-        ImageView infoBUtton = (ImageView) rootView.findViewById(R.id.info_button);
-        infoBUtton.setOnClickListener(new OnClickListener() {
+        ImageView infoButton = (ImageView) rootView.findViewById(R.id.info_button);
+        infoButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
                 Intent newAccountIntent = new Intent(getActivity(), HelpActivity.class);
@@ -470,21 +470,16 @@ public class NewUserFragment extends AbstractFragment implements TextWatcher {
     }
 
     @Override
-    public void onStart() {
-        super.onStart();
-        mDispatcher.register(this);
-    }
-
-    @Override
-    public void onStop() {
+    public void onDestroy() {
         mDispatcher.unregister(this);
-        super.onStop();
+        super.onDestroy();
     }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
+        mDispatcher.register(this);
     }
 
     @Override


### PR DESCRIPTION
Fix #5558: Keep listening to onChanged events even if the fragment is stopped

Note: there is still an issue with state loss when the fragment is destroyed.
This issue existed in previous version of the app, we should eventually move this
to a service.

