### PR TITLE
Issue/5548 reuse photo picker

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -392,6 +392,11 @@
             android:label="@string/site_picker_title"
             android:theme="@style/CalypsoTheme" />
 
+        <activity
+            android:name=".ui.photopicker.PhotoPickerActivity"
+            android:label="@string/photo_picker_title"
+            android:theme="@style/Calypso.NoActionBar" />
+
         <!-- Notifications activities -->
         <activity
             android:name=".ui.notifications.NotificationsDetailActivity"

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.media.MediaGalleryActivity;
 import org.wordpress.android.ui.media.MediaGalleryPickerActivity;
 import org.wordpress.android.ui.media.WordPressMediaUtils;
 import org.wordpress.android.ui.people.PeopleManagementActivity;
+import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
 import org.wordpress.android.ui.plans.PlansActivity;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.PostPreviewActivity;
@@ -66,6 +67,15 @@ public class ActivityLauncher {
                 R.anim.activity_slide_in_from_left,
                 R.anim.do_nothing);
         ActivityCompat.startActivityForResult(activity, intent, RequestCodes.SITE_PICKER, options.toBundle());
+    }
+
+    public static void showPhotoPickerForResult(Activity activity) {
+        Intent intent = new Intent(activity, PhotoPickerActivity.class);
+        ActivityOptionsCompat options = ActivityOptionsCompat.makeCustomAnimation(
+                activity,
+                R.anim.activity_slide_in_from_left,
+                R.anim.do_nothing);
+        ActivityCompat.startActivityForResult(activity, intent, RequestCodes.PHOTO_PICKER, options.toBundle());
     }
 
     public static void viewBlogStats(Context context, SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -71,11 +71,7 @@ public class ActivityLauncher {
 
     public static void showPhotoPickerForResult(Activity activity) {
         Intent intent = new Intent(activity, PhotoPickerActivity.class);
-        ActivityOptionsCompat options = ActivityOptionsCompat.makeCustomAnimation(
-                activity,
-                R.anim.activity_slide_in_from_left,
-                R.anim.do_nothing);
-        ActivityCompat.startActivityForResult(activity, intent, RequestCodes.PHOTO_PICKER, options.toBundle());
+        activity.startActivityForResult(intent, RequestCodes.PHOTO_PICKER);
     }
 
     public static void viewBlogStats(Context context, SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
@@ -14,6 +14,7 @@ public class RequestCodes {
     public static final int CREATE_SITE = 900;
     public static final int SITE_SETTINGS = 1000;
     public static final int DO_LOGIN = 1100;
+    public static final int PHOTO_PICKER = 1200;
 
     // Media
     public static final int PICTURE_LIBRARY = 2000;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -52,6 +52,7 @@ import org.wordpress.android.networking.GravatarApi;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.WordPressMediaUtils;
+import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.FluxCUtils;
@@ -213,7 +214,8 @@ public class MeFragment extends Fragment {
 
                 if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(MeFragment.this,
                         CAMERA_AND_MEDIA_PERMISSION_REQUEST_CODE)) {
-                    askForCameraOrGallery();
+                    //askForCameraOrGallery();
+                    showPhotoPickerForGravatar();
                 } else {
                     AppLockManager.getInstance().setExtendedTimeout();
                 }
@@ -470,7 +472,8 @@ public class MeFragment extends Fragment {
 
                     if (denied.size() == 0) {
                         AnalyticsTracker.track(AnalyticsTracker.Stat.ME_GRAVATAR_PERMISSIONS_ACCEPTED);
-                        askForCameraOrGallery();
+                        //askForCameraOrGallery();
+                        showPhotoPickerForGravatar();
                     } else {
                         ToastUtils.showToast(this.getActivity(), getString(R.string
                                 .gravatar_camera_and_media_permission_required), ToastUtils.Duration.LONG);
@@ -510,6 +513,15 @@ public class MeFragment extends Fragment {
                     }
                 }
                 break;
+            case RequestCodes.PHOTO_PICKER:
+                if (resultCode == Activity.RESULT_OK && data != null) {
+                    String strMediaUri = data.getStringExtra(PhotoPickerActivity.EXTRA_MEDIA_URI);
+                    if (strMediaUri != null) {
+                        Uri uri = Uri.parse(strMediaUri);
+                        startCropActivity(uri);
+                    }
+                }
+                break;
             case UCrop.REQUEST_CROP:
                 AnalyticsTracker.track(AnalyticsTracker.Stat.ME_GRAVATAR_CROPPED);
 
@@ -523,6 +535,10 @@ public class MeFragment extends Fragment {
                 }
                 break;
         }
+    }
+
+    private void showPhotoPickerForGravatar() {
+        ActivityLauncher.showPhotoPickerForResult(getActivity());
     }
 
     private void askForCameraOrGallery() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -214,6 +214,7 @@ public class MeFragment extends Fragment {
 
                 if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(MeFragment.this,
                         CAMERA_AND_MEDIA_PERMISSION_REQUEST_CODE)) {
+                    // TODO
                     //askForCameraOrGallery();
                     showPhotoPickerForGravatar();
                 } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -39,7 +39,6 @@ import com.yalantis.ucrop.UCropActivity;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -51,8 +50,8 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.networking.GravatarApi;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
-import org.wordpress.android.ui.media.WordPressMediaUtils;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
+import org.wordpress.android.ui.photopicker.PhotoPickerActivity.PhotoPickerMediaSource;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.FluxCUtils;
@@ -85,7 +84,6 @@ import de.greenrobot.event.EventBus;
 public class MeFragment extends Fragment {
     private static final String IS_DISCONNECTING = "IS_DISCONNECTING";
     private static final String IS_UPDATING_GRAVATAR = "IS_UPDATING_GRAVATAR";
-    private static final String MEDIA_CAPTURE_PATH = "MEDIA_CAPTURE_PATH";
 
     private static final int CAMERA_AND_MEDIA_PERMISSION_REQUEST_CODE = 1;
 
@@ -103,7 +101,6 @@ public class MeFragment extends Fragment {
     private View mNotificationsView;
     private View mNotificationsDividerView;
     private ProgressDialog mDisconnectProgressDialog;
-    private String mMediaCapturePath;
 
     // setUserVisibleHint is not available so we need to manually handle the UserVisibleHint state
     private boolean mIsUserVisible;
@@ -124,7 +121,6 @@ public class MeFragment extends Fragment {
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
         if (savedInstanceState != null) {
-            mMediaCapturePath = savedInstanceState.getString(MEDIA_CAPTURE_PATH);
             mIsUpdatingGravatar = savedInstanceState.getBoolean(IS_UPDATING_GRAVATAR);
         }
     }
@@ -214,8 +210,6 @@ public class MeFragment extends Fragment {
 
                 if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(MeFragment.this,
                         CAMERA_AND_MEDIA_PERMISSION_REQUEST_CODE)) {
-                    // TODO
-                    //askForCameraOrGallery();
                     showPhotoPickerForGravatar();
                 } else {
                     AppLockManager.getInstance().setExtendedTimeout();
@@ -286,11 +280,6 @@ public class MeFragment extends Fragment {
         if (mDisconnectProgressDialog != null) {
             outState.putBoolean(IS_DISCONNECTING, true);
         }
-
-        if (mMediaCapturePath != null) {
-            outState.putString(MEDIA_CAPTURE_PATH, mMediaCapturePath);
-        }
-
         outState.putBoolean(IS_UPDATING_GRAVATAR, mIsUpdatingGravatar);
 
         super.onSaveInstanceState(outState);
@@ -473,7 +462,6 @@ public class MeFragment extends Fragment {
 
                     if (denied.size() == 0) {
                         AnalyticsTracker.track(AnalyticsTracker.Stat.ME_GRAVATAR_PERMISSIONS_ACCEPTED);
-                        //askForCameraOrGallery();
                         showPhotoPickerForGravatar();
                     } else {
                         ToastUtils.showToast(this.getActivity(), getString(R.string
@@ -494,33 +482,22 @@ public class MeFragment extends Fragment {
         super.onActivityResult(requestCode, resultCode, data);
 
         switch (requestCode) {
-            case RequestCodes.PICTURE_LIBRARY_OR_CAPTURE:
-                if (resultCode == Activity.RESULT_OK) {
-                    Uri imageUri;
-
-                    if (data == null || data.getData() == null) {
-                        // image is from a capture
-                        imageUri = Uri.fromFile(new File(mMediaCapturePath));
-                        AnalyticsTracker.track(AnalyticsTracker.Stat.ME_GRAVATAR_SHOT_NEW);
-                    } else {
-                        imageUri = data.getData();
-                        AnalyticsTracker.track(AnalyticsTracker.Stat.ME_GRAVATAR_GALLERY_PICKED);
-                    }
-
-                    if (imageUri != null) {
-                        startCropActivity(imageUri);
-                    } else {
-                        AppLog.e(AppLog.T.UTILS, "Can't resolve picked or captured image");
-                    }
-                }
-                break;
             case RequestCodes.PHOTO_PICKER:
                 if (resultCode == Activity.RESULT_OK && data != null) {
                     String strMediaUri = data.getStringExtra(PhotoPickerActivity.EXTRA_MEDIA_URI);
-                    if (strMediaUri != null) {
-                        Uri uri = Uri.parse(strMediaUri);
-                        startCropActivity(uri);
+                    if (strMediaUri == null) {
+                        AppLog.e(AppLog.T.UTILS, "Can't resolve picked or captured image");
+                        return;
                     }
+                    PhotoPickerMediaSource source = PhotoPickerMediaSource.fromString(
+                            data.getStringExtra(PhotoPickerActivity.EXTRA_MEDIA_SOURCE));
+                    AnalyticsTracker.Stat stat =
+                            source == PhotoPickerMediaSource.ANDROID_CAMERA
+                                    ? AnalyticsTracker.Stat.ME_GRAVATAR_SHOT_NEW
+                                    : AnalyticsTracker.Stat.ME_GRAVATAR_GALLERY_PICKED;
+                    AnalyticsTracker.track(stat);
+                    Uri imageUri = Uri.parse(strMediaUri);
+                    startCropActivity(imageUri);
                 }
                 break;
             case UCrop.REQUEST_CROP:
@@ -540,17 +517,6 @@ public class MeFragment extends Fragment {
 
     private void showPhotoPickerForGravatar() {
         ActivityLauncher.showPhotoPickerForResult(getActivity());
-    }
-
-    private void askForCameraOrGallery() {
-        WordPressMediaUtils
-                .launchPictureLibraryOrCapture(MeFragment.this, BuildConfig.APPLICATION_ID,
-                        new WordPressMediaUtils.LaunchCameraCallback() {
-                            @Override
-                            public void onMediaCapturePathReady(String mediaCapturePath) {
-                                mMediaCapturePath = mediaCapturePath;
-                            }
-                        });
     }
 
     private void startCropActivity(Uri uri) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -243,6 +243,9 @@ public class WPMainActivity extends AppCompatActivity {
 
         // monitor whether we're not the default app
         trackDefaultApp();
+
+        // TODO: remove this, only here for testing
+        ActivityLauncher.showPhotoPickerForResult(this);
     }
 
     private void setTabLayoutElevation(float newElevation){

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -243,9 +243,6 @@ public class WPMainActivity extends AppCompatActivity {
 
         // monitor whether we're not the default app
         trackDefaultApp();
-
-        // TODO: remove this, only here for testing
-        ActivityLauncher.showPhotoPickerForResult(this);
     }
 
     private void setTabLayoutElevation(float newElevation){
@@ -583,6 +580,12 @@ public class WPMainActivity extends AppCompatActivity {
                 if (getNotificationsListFragment() != null) {
                     getNotificationsListFragment().onActivityResult(requestCode, resultCode, data);
                 }
+                break;
+            case RequestCodes.PHOTO_PICKER:
+                if (getMeFragment() != null) {
+                    getMeFragment().onActivityResult(requestCode, resultCode, data);
+                }
+                break;
         }
     }
 
@@ -598,6 +601,17 @@ public class WPMainActivity extends AppCompatActivity {
         Fragment fragment = mTabAdapter.getFragment(WPMainTabAdapter.TAB_MY_SITE);
         if (fragment instanceof MySiteFragment) {
             return (MySiteFragment) fragment;
+        }
+        return null;
+    }
+
+    /*
+     * returns the "me" fragment from the sites tab
+     */
+    private MeFragment getMeFragment() {
+        Fragment fragment = mTabAdapter.getFragment(WPMainTabAdapter.TAB_ME);
+        if (fragment instanceof MeFragment) {
+            return (MeFragment) fragment;
         }
         return null;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -31,9 +31,26 @@ public class PhotoPickerActivity extends AppCompatActivity
 
     private static final String PICKER_FRAGMENT_TAG = "picker_fragment_tag";
     private static final String KEY_MEDIA_CAPTURE_PATH = "media_capture_path";
+
     public static final String EXTRA_MEDIA_URI = "picker_media_uri";
+    public static final String EXTRA_MEDIA_SOURCE = "media_source";
 
     private String mMediaCapturePath;
+
+    public enum PhotoPickerMediaSource {
+        ANDROID_CAMERA,
+        ANDROID_PICKER,
+        APP_PICKER;
+
+        public static PhotoPickerMediaSource fromString(String strSource) {
+            for (PhotoPickerMediaSource source: PhotoPickerMediaSource.values()) {
+                if (source.name().equalsIgnoreCase(strSource)) {
+                    return source;
+                }
+            }
+            return null;
+        }
+    }
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -102,14 +119,14 @@ public class PhotoPickerActivity extends AppCompatActivity
             case RequestCodes.PICTURE_LIBRARY:
                 if (data != null) {
                     Uri imageUri = data.getData();
-                    pictureSelected(imageUri);
+                    pictureSelected(imageUri, PhotoPickerMediaSource.ANDROID_PICKER);
                 }
                 break;
             case RequestCodes.TAKE_PHOTO:
                 try {
                     File f = new File(mMediaCapturePath);
                     Uri capturedImageUri = Uri.fromFile(f);
-                    pictureSelected(capturedImageUri);
+                    pictureSelected(capturedImageUri, PhotoPickerMediaSource.ANDROID_CAMERA);
                 } catch (RuntimeException e) {
                     AppLog.e(AppLog.T.MEDIA, e);
                 }
@@ -141,15 +158,18 @@ public class PhotoPickerActivity extends AppCompatActivity
         AppLockManager.getInstance().setExtendedTimeout();
     }
 
-    private void pictureSelected(@NonNull Uri mediaUri) {
-        setResult(RESULT_OK, new Intent().putExtra(EXTRA_MEDIA_URI, mediaUri.toString()));
+    private void pictureSelected(@NonNull Uri mediaUri, @NonNull PhotoPickerMediaSource source) {
+        Intent intent = new Intent()
+                .putExtra(EXTRA_MEDIA_URI, mediaUri.toString())
+                .putExtra(EXTRA_MEDIA_SOURCE, source.name());
+        setResult(RESULT_OK, intent);
         finish();
     }
 
     @Override
     public void onPhotoPickerMediaChosen(@NonNull List<Uri> uriList) {
         if (uriList.size() > 0) {
-            pictureSelected(uriList.get(0));
+            pictureSelected(uriList.get(0), PhotoPickerMediaSource.APP_PICKER);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -43,9 +43,11 @@ public class PhotoPickerActivity extends AppCompatActivity
         APP_PICKER;
 
         public static PhotoPickerMediaSource fromString(String strSource) {
-            for (PhotoPickerMediaSource source: PhotoPickerMediaSource.values()) {
-                if (source.name().equalsIgnoreCase(strSource)) {
-                    return source;
+            if (strSource != null) {
+                for (PhotoPickerMediaSource source : PhotoPickerMediaSource.values()) {
+                    if (source.name().equalsIgnoreCase(strSource)) {
+                        return source;
+                    }
                 }
             }
             return null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -38,7 +38,8 @@ public class PhotoPickerActivity extends AppCompatActivity
         }
 
         if (!hasPhotoPickerFragment()) {
-            EnumSet<PhotoPickerOption> options = EnumSet.of(PhotoPickerOption.PHOTOS_ONLY);
+            EnumSet<PhotoPickerOption> options =
+                    EnumSet.of(PhotoPickerOption.PHOTOS_ONLY);
 
             Fragment fragment = PhotoPickerFragment.newInstance(this, options);
             getFragmentManager().beginTransaction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.photopicker;
 
 import android.app.Fragment;
 import android.app.FragmentTransaction;
+import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
@@ -20,6 +21,7 @@ public class PhotoPickerActivity extends AppCompatActivity
         implements PhotoPickerFragment.PhotoPickerListener {
 
     private static final String PICKER_FRAGMENT_TAG = "picker_fragment_tag";
+    public static final String EXTRA_MEDIA_URI = "picker_media_uri";
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -59,11 +61,15 @@ public class PhotoPickerActivity extends AppCompatActivity
 
     @Override
     public void onPhotoPickerMediaChosen(@NonNull List<Uri> uriList) {
-
+        if (uriList.size() > 0) {
+            Uri mediaUri = uriList.get(0);
+            setResult(RESULT_OK, new Intent().putExtra(EXTRA_MEDIA_URI, mediaUri.toString()));
+            finish();
+        }
     }
 
     @Override
     public void onPhotoPickerIconClicked(@NonNull PhotoPickerFragment.PhotoPickerIcon icon) {
-
+        // TODO
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -49,9 +49,10 @@ public class PhotoPickerActivity extends AppCompatActivity
             actionBar.setDisplayShowTitleEnabled(true);
         }
 
+        // only show photos (no videos) and only from device (no wp media)
         EnumSet<PhotoPickerOption> options = EnumSet.of(
                 PhotoPickerOption.PHOTOS_ONLY,
-                PhotoPickerOption.SHOW_ICONS);
+                PhotoPickerOption.DEVICE_ONLY);
         PhotoPickerFragment fragment = getPickerFragment();
         if (fragment == null) {
             fragment = PhotoPickerFragment.newInstance(this, options);
@@ -140,10 +141,6 @@ public class PhotoPickerActivity extends AppCompatActivity
         AppLockManager.getInstance().setExtendedTimeout();
     }
 
-    private void launchMediaGallery() {
-        // TODO
-    }
-
     private void pictureSelected(@NonNull Uri mediaUri) {
         setResult(RESULT_OK, new Intent().putExtra(EXTRA_MEDIA_URI, mediaUri.toString()));
         finish();
@@ -164,9 +161,6 @@ public class PhotoPickerActivity extends AppCompatActivity
                 break;
             case ANDROID_PICKER:
                 launchPictureLibrary();
-                break;
-            case WP_MEDIA:
-                launchMediaGallery();
                 break;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -1,0 +1,69 @@
+package org.wordpress.android.ui.photopicker;
+
+import android.app.Fragment;
+import android.app.FragmentTransaction;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+
+import org.wordpress.android.R;
+import org.wordpress.android.ui.photopicker.PhotoPickerFragment.PhotoPickerOption;
+
+import java.util.EnumSet;
+import java.util.List;
+
+public class PhotoPickerActivity extends AppCompatActivity
+        implements PhotoPickerFragment.PhotoPickerListener {
+
+    private static final String PICKER_FRAGMENT_TAG = "picker_fragment_tag";
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.photo_picker_activity);
+
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setDisplayShowTitleEnabled(true);
+        }
+
+        if (!hasPhotoPickerFragment()) {
+            EnumSet<PhotoPickerOption> options = EnumSet.noneOf(PhotoPickerOption.class);
+
+            Fragment fragment = PhotoPickerFragment.newInstance(this, options);
+            getFragmentManager().beginTransaction()
+                    .replace(R.id.fragment_container, fragment, PICKER_FRAGMENT_TAG)
+                    .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
+                    .commitAllowingStateLoss();
+        }
+    }
+
+    private PhotoPickerFragment getPickerFragment() {
+        Fragment fragment = getFragmentManager().findFragmentByTag(PICKER_FRAGMENT_TAG);
+        if (fragment != null) {
+            return (PhotoPickerFragment) fragment;
+        }
+        return null;
+    }
+
+    private boolean hasPhotoPickerFragment() {
+        return getPickerFragment() != null;
+    }
+
+    @Override
+    public void onPhotoPickerMediaChosen(@NonNull List<Uri> uriList) {
+
+    }
+
+    @Override
+    public void onPhotoPickerIconClicked(@NonNull PhotoPickerFragment.PhotoPickerIcon icon) {
+
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -30,6 +30,7 @@ public class PhotoPickerActivity extends AppCompatActivity
         setContentView(R.layout.photo_picker_activity);
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        toolbar.setNavigationIcon(R.drawable.ic_close_white_24dp);
         setSupportActionBar(toolbar);
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.photopicker;
 
+import android.app.Activity;
 import android.app.Fragment;
 import android.app.FragmentTransaction;
 import android.content.Intent;
@@ -10,11 +11,18 @@ import android.support.annotation.Nullable;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.text.TextUtils;
 import android.view.MenuItem;
 
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
+import org.wordpress.android.ui.RequestCodes;
+import org.wordpress.android.ui.media.WordPressMediaUtils;
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment.PhotoPickerOption;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.passcodelock.AppLockManager;
 
+import java.io.File;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -22,7 +30,10 @@ public class PhotoPickerActivity extends AppCompatActivity
         implements PhotoPickerFragment.PhotoPickerListener {
 
     private static final String PICKER_FRAGMENT_TAG = "picker_fragment_tag";
+    private static final String KEY_MEDIA_CAPTURE_PATH = "media_capture_path";
     public static final String EXTRA_MEDIA_URI = "picker_media_uri";
+
+    private String mMediaCapturePath;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -38,7 +49,9 @@ public class PhotoPickerActivity extends AppCompatActivity
             actionBar.setDisplayShowTitleEnabled(true);
         }
 
-        EnumSet<PhotoPickerOption> options = EnumSet.of(PhotoPickerOption.PHOTOS_ONLY);
+        EnumSet<PhotoPickerOption> options = EnumSet.of(
+                PhotoPickerOption.PHOTOS_ONLY,
+                PhotoPickerOption.SHOW_ICONS);
         PhotoPickerFragment fragment = getPickerFragment();
         if (fragment == null) {
             fragment = PhotoPickerFragment.newInstance(this, options);
@@ -53,6 +66,20 @@ public class PhotoPickerActivity extends AppCompatActivity
     }
 
     @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        if (!TextUtils.isEmpty(mMediaCapturePath)) {
+            outState.putString(KEY_MEDIA_CAPTURE_PATH, mMediaCapturePath);
+        }
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+        mMediaCapturePath = savedInstanceState.getString(KEY_MEDIA_CAPTURE_PATH);
+    }
+
+    @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             setResult(RESULT_CANCELED);
@@ -60,6 +87,33 @@ public class PhotoPickerActivity extends AppCompatActivity
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (resultCode != Activity.RESULT_OK) {
+            return;
+        }
+
+        switch (requestCode) {
+            case RequestCodes.PICTURE_LIBRARY:
+                if (data != null) {
+                    Uri imageUri = data.getData();
+                    pictureSelected(imageUri);
+                }
+                break;
+            case RequestCodes.TAKE_PHOTO:
+                try {
+                    File f = new File(mMediaCapturePath);
+                    Uri capturedImageUri = Uri.fromFile(f);
+                    pictureSelected(capturedImageUri);
+                } catch (RuntimeException e) {
+                    AppLog.e(AppLog.T.MEDIA, e);
+                }
+                break;
+        }
     }
 
     private PhotoPickerFragment getPickerFragment() {
@@ -70,17 +124,52 @@ public class PhotoPickerActivity extends AppCompatActivity
         return null;
     }
 
+    private void launchCamera() {
+        WordPressMediaUtils.launchCamera(this, BuildConfig.APPLICATION_ID,
+                new WordPressMediaUtils.LaunchCameraCallback() {
+                    @Override
+                    public void onMediaCapturePathReady(String mediaCapturePath) {
+                        mMediaCapturePath = mediaCapturePath;
+                        AppLockManager.getInstance().setExtendedTimeout();
+                    }
+                });
+    }
+
+    private void launchPictureLibrary() {
+        WordPressMediaUtils.launchPictureLibrary(this);
+        AppLockManager.getInstance().setExtendedTimeout();
+    }
+
+    private void launchMediaGallery() {
+        // TODO
+    }
+
+    private void pictureSelected(@NonNull Uri mediaUri) {
+        setResult(RESULT_OK, new Intent().putExtra(EXTRA_MEDIA_URI, mediaUri.toString()));
+        finish();
+    }
+
     @Override
     public void onPhotoPickerMediaChosen(@NonNull List<Uri> uriList) {
         if (uriList.size() > 0) {
-            Uri mediaUri = uriList.get(0);
-            setResult(RESULT_OK, new Intent().putExtra(EXTRA_MEDIA_URI, mediaUri.toString()));
-            finish();
+            pictureSelected(uriList.get(0));
         }
     }
 
     @Override
     public void onPhotoPickerIconClicked(@NonNull PhotoPickerFragment.PhotoPickerIcon icon) {
-        // noop
+        switch (icon) {
+            case ANDROID_CAMERA:
+                launchCamera();
+                break;
+            case ANDROID_PICKER:
+                launchPictureLibrary();
+                break;
+            case WP_MEDIA:
+                launchMediaGallery();
+                break;
+        }
     }
+
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -37,15 +37,17 @@ public class PhotoPickerActivity extends AppCompatActivity
             actionBar.setDisplayShowTitleEnabled(true);
         }
 
-        if (!hasPhotoPickerFragment()) {
-            EnumSet<PhotoPickerOption> options =
-                    EnumSet.of(PhotoPickerOption.PHOTOS_ONLY);
-
-            Fragment fragment = PhotoPickerFragment.newInstance(this, options);
+        EnumSet<PhotoPickerOption> options = EnumSet.of(PhotoPickerOption.PHOTOS_ONLY);
+        PhotoPickerFragment fragment = getPickerFragment();
+        if (fragment == null) {
+            fragment = PhotoPickerFragment.newInstance(this, options);
             getFragmentManager().beginTransaction()
                     .replace(R.id.fragment_container, fragment, PICKER_FRAGMENT_TAG)
                     .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
                     .commitAllowingStateLoss();
+        } else {
+            fragment.setOptions(options);
+            fragment.setPhotoPickerListener(this);
         }
     }
 
@@ -67,10 +69,6 @@ public class PhotoPickerActivity extends AppCompatActivity
         return null;
     }
 
-    private boolean hasPhotoPickerFragment() {
-        return getPickerFragment() != null;
-    }
-
     @Override
     public void onPhotoPickerMediaChosen(@NonNull List<Uri> uriList) {
         if (uriList.size() > 0) {
@@ -82,6 +80,6 @@ public class PhotoPickerActivity extends AppCompatActivity
 
     @Override
     public void onPhotoPickerIconClicked(@NonNull PhotoPickerFragment.PhotoPickerIcon icon) {
-        // TODO
+        // noop
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -38,7 +38,7 @@ public class PhotoPickerActivity extends AppCompatActivity
         }
 
         if (!hasPhotoPickerFragment()) {
-            EnumSet<PhotoPickerOption> options = EnumSet.noneOf(PhotoPickerOption.class);
+            EnumSet<PhotoPickerOption> options = EnumSet.of(PhotoPickerOption.PHOTOS_ONLY);
 
             Fragment fragment = PhotoPickerFragment.newInstance(this, options);
             getFragmentManager().beginTransaction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -10,6 +10,7 @@ import android.support.annotation.Nullable;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.view.MenuItem;
 
 import org.wordpress.android.R;
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment.PhotoPickerOption;
@@ -45,6 +46,16 @@ public class PhotoPickerActivity extends AppCompatActivity
                     .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
                     .commitAllowingStateLoss();
         }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(final MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            setResult(RESULT_CANCELED);
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     private PhotoPickerFragment getPickerFragment() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -32,7 +32,10 @@ public class PhotoPickerActivity extends AppCompatActivity
     private static final String PICKER_FRAGMENT_TAG = "picker_fragment_tag";
     private static final String KEY_MEDIA_CAPTURE_PATH = "media_capture_path";
 
+    // the uri of the selected image will be returned as a string in EXTRA_MEDIA_URI
     public static final String EXTRA_MEDIA_URI = "picker_media_uri";
+
+    // the enum name of the source will be returned as a string in EXTRA_MEDIA_SOURCE
     public static final String EXTRA_MEDIA_SOURCE = "media_source";
 
     private String mMediaCapturePath;
@@ -85,6 +88,14 @@ public class PhotoPickerActivity extends AppCompatActivity
         }
     }
 
+    private PhotoPickerFragment getPickerFragment() {
+        Fragment fragment = getFragmentManager().findFragmentByTag(PICKER_FRAGMENT_TAG);
+        if (fragment != null) {
+            return (PhotoPickerFragment) fragment;
+        }
+        return null;
+    }
+
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
@@ -118,12 +129,14 @@ public class PhotoPickerActivity extends AppCompatActivity
         }
 
         switch (requestCode) {
+            // user chose a photo from the device library
             case RequestCodes.PICTURE_LIBRARY:
                 if (data != null) {
                     Uri imageUri = data.getData();
                     pictureSelected(imageUri, PhotoPickerMediaSource.ANDROID_PICKER);
                 }
                 break;
+            // user took a photo with the device camera
             case RequestCodes.TAKE_PHOTO:
                 try {
                     File f = new File(mMediaCapturePath);
@@ -134,14 +147,6 @@ public class PhotoPickerActivity extends AppCompatActivity
                 }
                 break;
         }
-    }
-
-    private PhotoPickerFragment getPickerFragment() {
-        Fragment fragment = getFragmentManager().findFragmentByTag(PICKER_FRAGMENT_TAG);
-        if (fragment != null) {
-            return (PhotoPickerFragment) fragment;
-        }
-        return null;
     }
 
     private void launchCamera() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
@@ -69,6 +69,7 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
 
     private boolean mAllowMultiSelect;
     private boolean mIsMultiSelectEnabled;
+    private boolean mPhotosOnly;
 
     private final ThumbnailLoader mThumbnailLoader;
     private final PhotoPickerAdapterListener mListener;
@@ -175,6 +176,10 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
 
     void setAllowMultiSelect(boolean allow) {
         mAllowMultiSelect = allow;
+    }
+
+    void setShowPhotosOnly(boolean value) {
+        mPhotosOnly = value;
     }
 
     void setMultiSelectEnabled(boolean enabled) {
@@ -345,7 +350,9 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
             addMedia(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, false);
 
             // videos
-            addMedia(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, true);
+            if (!mPhotosOnly) {
+                addMedia(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, true);
+            }
 
             // sort by id in reverse (newest first)
             Collections.sort(tmpList, new Comparator<PhotoPickerItem>() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
@@ -67,6 +67,7 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
     private int mThumbWidth;
     private int mThumbHeight;
 
+    private boolean mAllowMultiSelect;
     private boolean mIsMultiSelectEnabled;
 
     private final ThumbnailLoader mThumbnailLoader;
@@ -170,6 +171,10 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
     boolean isVideoUri(Uri uri) {
         int index = indexOfUri(uri);
         return index > -1 && getItemAtPosition(index).isVideo;
+    }
+
+    void setAllowMultiSelect(boolean allow) {
+        mAllowMultiSelect = allow;
     }
 
     void setMultiSelectEnabled(boolean enabled) {
@@ -302,7 +307,7 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
                 @Override
                 public void onLongPress(MotionEvent e) {
                     int position = getAdapterPosition();
-                    if (isValidPosition(position)) {
+                    if (isValidPosition(position) && mAllowMultiSelect) {
                         if (!mIsMultiSelectEnabled) {
                             setMultiSelectEnabled(true);
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -65,9 +65,9 @@ public class PhotoPickerFragment extends Fragment {
     private boolean mShowIcons;
     private boolean mPhotosOnly;
 
-    private static String ARG_ALLOW_MULTI_SELECT = "allow_multi_select";
-    private static String ARG_SHOW_ICONS = "show_icons";
-    private static String ARG_PHOTOS_ONLY = "photos_only";
+    private static final String ARG_ALLOW_MULTI_SELECT = "allow_multi_select";
+    private static final String ARG_SHOW_ICONS = "show_icons";
+    private static final String ARG_PHOTOS_ONLY = "photos_only";
 
     public static PhotoPickerFragment newInstance(@NonNull PhotoPickerListener listener,
                                                   EnumSet<PhotoPickerOption> options) {
@@ -106,6 +106,21 @@ public class PhotoPickerFragment extends Fragment {
         outState.putBoolean(ARG_SHOW_ICONS, mShowIcons);
         outState.putBoolean(ARG_PHOTOS_ONLY, mPhotosOnly);
         super.onSaveInstanceState(outState);
+    }
+
+    public void setOptions(EnumSet<PhotoPickerOption> options) {
+        mAllowMultiSelect = options != null && options.contains(PhotoPickerOption.ALLOW_MULTI_SELECT);
+        mShowIcons = options != null && options.contains(PhotoPickerOption.SHOW_ICONS);
+        mPhotosOnly = options != null && options.contains(PhotoPickerOption.PHOTOS_ONLY);
+
+        if (hasAdapter()) {
+            getAdapter().setAllowMultiSelect(mAllowMultiSelect);
+            getAdapter().setShowPhotosOnly(mPhotosOnly);
+        }
+
+        if (mBottomBar != null) {
+            mBottomBar.setVisibility(mShowIcons ? View.VISIBLE : View.GONE);
+        }
     }
 
     @Override
@@ -150,7 +165,7 @@ public class PhotoPickerFragment extends Fragment {
         return view;
     }
 
-    private void setPhotoPickerListener(PhotoPickerListener listener) {
+    void setPhotoPickerListener(PhotoPickerListener listener) {
         mListener = listener;
     }
 
@@ -239,6 +254,10 @@ public class PhotoPickerFragment extends Fragment {
                 startWidth,
                 startHeight);
         ActivityCompat.startActivity(getActivity(), intent, options.toBundle());
+    }
+
+    private boolean hasAdapter() {
+        return mAdapter != null;
     }
 
     private PhotoPickerAdapter getAdapter() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -40,7 +40,8 @@ public class PhotoPickerFragment extends Fragment {
     }
 
     public enum PhotoPickerOption {
-        ALLOW_MULTI_SELECT
+        ALLOW_MULTI_SELECT,
+        SHOW_ICONS
     }
 
     /*
@@ -58,9 +59,12 @@ public class PhotoPickerFragment extends Fragment {
     private GridLayoutManager mGridManager;
     private Parcelable mRestoreState;
     private PhotoPickerListener mListener;
+
     private boolean mAllowMultiSelect;
+    private boolean mShowIcons;
 
     private static String ARG_ALLOW_MULTI_SELECT = "allow_multi_select";
+    private static String ARG_SHOW_ICONS = "show_icons";
 
     public static PhotoPickerFragment newInstance(@NonNull PhotoPickerListener listener,
                                                   EnumSet<PhotoPickerOption> options) {
@@ -69,6 +73,9 @@ public class PhotoPickerFragment extends Fragment {
         fragment.setPhotoPickerListener(listener);
         if (options != null && options.contains(PhotoPickerOption.ALLOW_MULTI_SELECT)) {
             args.putBoolean(ARG_ALLOW_MULTI_SELECT, true);
+        }
+        if (options != null && options.contains(PhotoPickerOption.SHOW_ICONS)) {
+            args.putBoolean(ARG_SHOW_ICONS, true);
         }
         fragment.setArguments(args);
         return fragment;
@@ -79,6 +86,7 @@ public class PhotoPickerFragment extends Fragment {
         super.onCreate(savedInstanceState);
         if (savedInstanceState != null) {
             mAllowMultiSelect = savedInstanceState.getBoolean(ARG_ALLOW_MULTI_SELECT, false);
+            mShowIcons = savedInstanceState.getBoolean(ARG_SHOW_ICONS, false);
         }
     }
 
@@ -86,11 +94,13 @@ public class PhotoPickerFragment extends Fragment {
     public void setArguments(Bundle args) {
         super.setArguments(args);
         mAllowMultiSelect = args != null && args.getBoolean(ARG_ALLOW_MULTI_SELECT);
+        mShowIcons = args != null && args.getBoolean(ARG_SHOW_ICONS);
     }
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
         outState.putBoolean(ARG_ALLOW_MULTI_SELECT, mAllowMultiSelect);
+        outState.getBoolean(ARG_SHOW_ICONS, mShowIcons);
         super.onSaveInstanceState(outState);
     }
 
@@ -102,30 +112,34 @@ public class PhotoPickerFragment extends Fragment {
         mRecycler.setHasFixedSize(true);
 
         mBottomBar = view.findViewById(R.id.bottom_bar);
-        mBottomBar.findViewById(R.id.icon_camera).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (mListener != null) {
-                    mListener.onPhotoPickerIconClicked(PhotoPickerIcon.ANDROID_CAMERA);
+        if (mShowIcons) {
+            mBottomBar.findViewById(R.id.icon_camera).setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (mListener != null) {
+                        mListener.onPhotoPickerIconClicked(PhotoPickerIcon.ANDROID_CAMERA);
+                    }
                 }
-            }
-        });
-        mBottomBar.findViewById(R.id.icon_picker).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (mListener != null) {
-                    mListener.onPhotoPickerIconClicked(PhotoPickerIcon.ANDROID_PICKER);
+            });
+            mBottomBar.findViewById(R.id.icon_picker).setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (mListener != null) {
+                        mListener.onPhotoPickerIconClicked(PhotoPickerIcon.ANDROID_PICKER);
+                    }
                 }
-            }
-        });
-        mBottomBar.findViewById(R.id.icon_wpmedia).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                if (mListener != null) {
-                    mListener.onPhotoPickerIconClicked(PhotoPickerIcon.WP_MEDIA);
+            });
+            mBottomBar.findViewById(R.id.icon_wpmedia).setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (mListener != null) {
+                        mListener.onPhotoPickerIconClicked(PhotoPickerIcon.WP_MEDIA);
+                    }
                 }
-            }
-        });
+            });
+        } else {
+            mBottomBar.setVisibility(View.GONE);
+        }
 
         reload();
 
@@ -137,13 +151,13 @@ public class PhotoPickerFragment extends Fragment {
     }
 
     private void showBottomBar() {
-        if (!isBottomBarShowing()) {
+        if (!isBottomBarShowing() && mShowIcons) {
             AniUtils.animateBottomBar(mBottomBar, true);
         }
     }
 
     private void hideBottomBar() {
-        if (isBottomBarShowing()) {
+        if (isBottomBarShowing() && mShowIcons) {
             AniUtils.animateBottomBar(mBottomBar, false);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -40,9 +40,9 @@ public class PhotoPickerFragment extends Fragment {
     }
 
     public enum PhotoPickerOption {
-        ALLOW_MULTI_SELECT,
-        PHOTOS_ONLY,
-        SHOW_ICONS
+        ALLOW_MULTI_SELECT,     // allow selecting more than one item
+        PHOTOS_ONLY,            // show only photos (no videos)
+        SHOW_ICONS              // show icons enabling selection from camera, native picker & wp library
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -41,6 +41,7 @@ public class PhotoPickerFragment extends Fragment {
 
     public enum PhotoPickerOption {
         ALLOW_MULTI_SELECT,
+        PHOTOS_ONLY,
         SHOW_ICONS
     }
 
@@ -62,20 +63,21 @@ public class PhotoPickerFragment extends Fragment {
 
     private boolean mAllowMultiSelect;
     private boolean mShowIcons;
+    private boolean mPhotosOnly;
 
     private static String ARG_ALLOW_MULTI_SELECT = "allow_multi_select";
     private static String ARG_SHOW_ICONS = "show_icons";
+    private static String ARG_PHOTOS_ONLY = "photos_only";
 
     public static PhotoPickerFragment newInstance(@NonNull PhotoPickerListener listener,
                                                   EnumSet<PhotoPickerOption> options) {
         Bundle args = new Bundle();
         PhotoPickerFragment fragment = new PhotoPickerFragment();
         fragment.setPhotoPickerListener(listener);
-        if (options != null && options.contains(PhotoPickerOption.ALLOW_MULTI_SELECT)) {
-            args.putBoolean(ARG_ALLOW_MULTI_SELECT, true);
-        }
-        if (options != null && options.contains(PhotoPickerOption.SHOW_ICONS)) {
-            args.putBoolean(ARG_SHOW_ICONS, true);
+        if (options != null) {
+            args.putBoolean(ARG_ALLOW_MULTI_SELECT, options.contains(PhotoPickerOption.ALLOW_MULTI_SELECT));
+            args.putBoolean(ARG_SHOW_ICONS, options.contains(PhotoPickerOption.SHOW_ICONS));
+            args.putBoolean(ARG_PHOTOS_ONLY, options.contains(PhotoPickerOption.PHOTOS_ONLY));
         }
         fragment.setArguments(args);
         return fragment;
@@ -95,12 +97,14 @@ public class PhotoPickerFragment extends Fragment {
         super.setArguments(args);
         mAllowMultiSelect = args != null && args.getBoolean(ARG_ALLOW_MULTI_SELECT);
         mShowIcons = args != null && args.getBoolean(ARG_SHOW_ICONS);
+        mPhotosOnly = args != null && args.getBoolean(ARG_PHOTOS_ONLY);
     }
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
         outState.putBoolean(ARG_ALLOW_MULTI_SELECT, mAllowMultiSelect);
-        outState.getBoolean(ARG_SHOW_ICONS, mShowIcons);
+        outState.putBoolean(ARG_SHOW_ICONS, mShowIcons);
+        outState.putBoolean(ARG_PHOTOS_ONLY, mPhotosOnly);
         super.onSaveInstanceState(outState);
     }
 
@@ -241,6 +245,7 @@ public class PhotoPickerFragment extends Fragment {
         if (mAdapter == null) {
             mAdapter = new PhotoPickerAdapter(getActivity(), mAdapterListener);
             mAdapter.setAllowMultiSelect(mAllowMultiSelect);
+            mAdapter.setShowPhotosOnly(mPhotosOnly);
         }
         return mAdapter;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -6,6 +6,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v7.app.AppCompatActivity;
@@ -71,6 +72,26 @@ public class PhotoPickerFragment extends Fragment {
         }
         fragment.setArguments(args);
         return fragment;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (savedInstanceState != null) {
+            mAllowMultiSelect = savedInstanceState.getBoolean(ARG_ALLOW_MULTI_SELECT, false);
+        }
+    }
+
+    @Override
+    public void setArguments(Bundle args) {
+        super.setArguments(args);
+        mAllowMultiSelect = args != null && args.getBoolean(ARG_ALLOW_MULTI_SELECT);
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        outState.putBoolean(ARG_ALLOW_MULTI_SELECT, mAllowMultiSelect);
+        super.onSaveInstanceState(outState);
     }
 
     @Override
@@ -205,6 +226,7 @@ public class PhotoPickerFragment extends Fragment {
     private PhotoPickerAdapter getAdapter() {
         if (mAdapter == null) {
             mAdapter = new PhotoPickerAdapter(getActivity(), mAdapterListener);
+            mAdapter.setAllowMultiSelect(mAllowMultiSelect);
         }
         return mAdapter;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -42,7 +42,9 @@ public class PhotoPickerFragment extends Fragment {
     public enum PhotoPickerOption {
         ALLOW_MULTI_SELECT,     // allow selecting more than one item
         PHOTOS_ONLY,            // show only photos (no videos)
-        SHOW_ICONS              // show icons enabling selection from camera, native picker & wp library
+        SHOW_ICONS              // show icons enabling selection from camera, native
+                                // picker & wp library - requires activity to implement
+                                // each of these features
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -25,6 +25,7 @@ import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 
 public class PhotoPickerFragment extends Fragment {
@@ -35,6 +36,10 @@ public class PhotoPickerFragment extends Fragment {
         ANDROID_CAMERA,
         ANDROID_PICKER,
         WP_MEDIA
+    }
+
+    public enum PhotoPickerOption {
+        ALLOW_MULTI_SELECT
     }
 
     /*
@@ -52,11 +57,18 @@ public class PhotoPickerFragment extends Fragment {
     private GridLayoutManager mGridManager;
     private Parcelable mRestoreState;
     private PhotoPickerListener mListener;
+    private boolean mAllowMultiSelect;
 
-    public static PhotoPickerFragment newInstance(@NonNull PhotoPickerListener listener) {
+    private static String ARG_ALLOW_MULTI_SELECT = "allow_multi_select";
+
+    public static PhotoPickerFragment newInstance(@NonNull PhotoPickerListener listener,
+                                                  EnumSet<PhotoPickerOption> options) {
         Bundle args = new Bundle();
         PhotoPickerFragment fragment = new PhotoPickerFragment();
         fragment.setPhotoPickerListener(listener);
+        if (options != null && options.contains(PhotoPickerOption.ALLOW_MULTI_SELECT)) {
+            args.putBoolean(ARG_ALLOW_MULTI_SELECT, true);
+        }
         fragment.setArguments(args);
         return fragment;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -93,6 +93,7 @@ import org.wordpress.android.ui.media.services.MediaUploadService;
 import org.wordpress.android.ui.notifications.utils.PendingDraftsNotificationsUtils;
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment;
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment.PhotoPickerIcon;
+import org.wordpress.android.ui.photopicker.PhotoPickerFragment.PhotoPickerOption;
 import org.wordpress.android.ui.posts.services.AztecImageLoader;
 import org.wordpress.android.ui.posts.services.PostUploadService;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -131,6 +132,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -544,7 +546,9 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         // size the picker before creating the fragment to avoid having it load media now
         resizePhotoPicker();
 
-        mPhotoPickerFragment = PhotoPickerFragment.newInstance(this);
+        EnumSet<PhotoPickerOption> options = EnumSet.noneOf(PhotoPickerOption.class);
+        options.add(PhotoPickerOption.ALLOW_MULTI_SELECT);
+        mPhotoPickerFragment = PhotoPickerFragment.newInstance(this, options);
 
         getFragmentManager()
                 .beginTransaction()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -546,8 +546,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         // size the picker before creating the fragment to avoid having it load media now
         resizePhotoPicker();
 
-        EnumSet<PhotoPickerOption> options = EnumSet.noneOf(PhotoPickerOption.class);
-        options.add(PhotoPickerOption.ALLOW_MULTI_SELECT);
+        EnumSet<PhotoPickerOption> options =
+                EnumSet.of(PhotoPickerOption.ALLOW_MULTI_SELECT, PhotoPickerOption.SHOW_ICONS);
         mPhotoPickerFragment = PhotoPickerFragment.newInstance(this, options);
 
         getFragmentManager()

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -548,7 +548,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         resizePhotoPicker();
 
         EnumSet<PhotoPickerOption> options =
-                EnumSet.of(PhotoPickerOption.ALLOW_MULTI_SELECT, PhotoPickerOption.SHOW_ICONS);
+                EnumSet.of(PhotoPickerOption.ALLOW_MULTI_SELECT);
         mPhotoPickerFragment = PhotoPickerFragment.newInstance(this, options);
 
         getFragmentManager()

--- a/WordPress/src/main/res/layout/photo_picker_activity.xml
+++ b/WordPress/src/main/res/layout/photo_picker_activity.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include layout="@layout/toolbar" />
+
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_above="@+id/message_container"
+        android:layout_below="@+id/toolbar" />
+
+</RelativeLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1656,4 +1656,6 @@
         your post in this state. Would you like to remove all failed media?</string>
     <string name="editor_remove_failed_uploads">Remove failed uploads</string>
 
+    <string name="photo_picker_title">Choose photo</string>
+
 </resources>


### PR DESCRIPTION
Fixes #5548 - expands the photo picker so it can be used anywhere to enable choosing a device photo. In this PR, it's used to choose a gravatar profile photo from the "Me" fragment.