### PR TITLE
Fixes #5571: retry upload issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -76,7 +76,6 @@ public class MediaUploadService extends Service {
         return null;
     }
 
-
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         if (intent == null || !intent.hasExtra(WordPress.SITE)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2122,15 +2122,10 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
     @Override
     public void onMediaRetryClicked(String mediaId) {
-        MediaModel media = null;
-
-        List<MediaModel> localMediaList = mMediaStore.getLocalSiteMedia(mSite);
-        for (MediaModel localMedia : localMediaList) {
-            if (String.valueOf(localMedia.getId()).equals(mediaId)) {
-                media = localMedia;
-                break;
-            }
-        }
+        MediaModel media = mMediaStore.getMediaWithLocalId(Integer.valueOf(mediaId));
+        // Note: we should actually check if this is a local media file (ie. not uploaded yet) that matches the
+        // given media id, because we don't want to retry a successful upload. In case this method is called
+        // and the media id is not a local media, we should update the post (replace the local uri by the remote uri).
 
         if (media != null) {
             media.setUploadState(UploadState.QUEUED.name());

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -94,9 +94,11 @@ import org.wordpress.android.ui.notifications.utils.PendingDraftsNotificationsUt
 import org.wordpress.android.ui.posts.photochooser.PhotoChooserFragment;
 import org.wordpress.android.ui.posts.photochooser.PhotoChooserFragment.PhotoChooserIcon;
 import org.wordpress.android.ui.posts.services.AztecImageLoader;
+import org.wordpress.android.ui.posts.services.PostEvents;
 import org.wordpress.android.ui.posts.services.PostUploadService;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
+import org.wordpress.android.ui.stats.StatsEvents;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
@@ -139,6 +141,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.inject.Inject;
+
+import de.greenrobot.event.EventBus;
 
 public class EditPostActivity extends AppCompatActivity implements EditorFragmentListener, EditorDragAndDropListener,
         ActivityCompat.OnRequestPermissionsResultCallback, EditorWebViewCompatibility.ReflectionFailureListener,
@@ -2139,10 +2143,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
     @Override
     public void onMediaUploadCancelClicked(String mediaId, boolean delete) {
-        MediaModel media = new MediaModel();
-        media.setMediaId(Long.valueOf(mediaId));
-        MediaPayload payload = new MediaPayload(mSite, media);
-        mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload));
+        EventBus.getDefault().post(new PostEvents.PostMediaCanceled());
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2143,7 +2143,13 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
     @Override
     public void onMediaUploadCancelClicked(String mediaId, boolean delete) {
-        EventBus.getDefault().post(new PostEvents.PostMediaCanceled());
+        if (!TextUtils.isEmpty(mediaId)) {
+            int localMediaId = Integer.valueOf(mediaId);
+            EventBus.getDefault().post(new PostEvents.PostMediaCanceled(localMediaId));
+        } else {
+            // Passed mediaId is incorrect: cancel all uploads
+            EventBus.getDefault().post(new PostEvents.PostMediaCanceled(true));
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2126,6 +2126,10 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
     @Override
     public void onMediaRetryClicked(String mediaId) {
+        if (TextUtils.isEmpty(mediaId)) {
+            AppLog.e(T.MEDIA, "Invalid media id passed to onMediaRetryClicked");
+            return;
+        }
         MediaModel media = mMediaStore.getMediaWithLocalId(Integer.valueOf(mediaId));
         if (media == null) {
             AppLog.e(T.MEDIA, "Can't find media with local id: " + mediaId);
@@ -2156,6 +2160,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             EventBus.getDefault().post(new PostEvents.PostMediaCanceled(localMediaId));
         } else {
             // Passed mediaId is incorrect: cancel all uploads
+            ToastUtils.showToast(this, getString(R.string.error_all_media_upload_canceled));
             EventBus.getDefault().post(new PostEvents.PostMediaCanceled(true));
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostEvents.java
@@ -27,4 +27,7 @@ public class PostEvents {
             return StringUtils.notNullStr(mMediaUrl);
         }
     }
+
+    public static class PostMediaCanceled {
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostEvents.java
@@ -29,5 +29,15 @@ public class PostEvents {
     }
 
     public static class PostMediaCanceled {
+        public int localMediaId;
+        public boolean all;
+
+        public PostMediaCanceled(int localMediaId) {
+            this.localMediaId = localMediaId;
+            this.all = false;
+        }
+        public PostMediaCanceled(boolean all) {
+            this.all = all;
+        }
     }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1645,5 +1645,6 @@
     <string name="editor_toast_failed_uploads">Some media uploads have failed. You can\'t save or publish
         your post in this state. Would you like to remove all failed media?</string>
     <string name="editor_remove_failed_uploads">Remove failed uploads</string>
+    <string name="error_all_media_upload_canceled">All media uploads have been cancelled due to an unknown error. Please retry uploading</string>
 
 </resources>


### PR DESCRIPTION
cc @mzorz 

Cancel All uploads when the hybrid editor fragment is detached.

This was the behavior previously, but it changed when we made we transformed the bound service to an independent service.