### PR TITLE
Fix: Duplicate featured images

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -728,6 +728,9 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                     MediaModel media = mMediaStore.getSiteMediaWithId(mSite, post.getFeaturedImageId());
                     if (media != null) {
                         imageUrl = media.getUrl();
+                    } else {
+                        // Reset the current `imageUrl` so it doesn't contain the previous post's image
+                        imageUrl = null;
                     }
                     // If the imageUrl isn't found it means the featured image info hasn't been added to
                     // the local media library yet, so add to the list of media IDs to request info for


### PR DESCRIPTION
Fixes #5442. The reason we had the duplicated featured images was a missing reset for the `imageUrl`. When the `MediaModel` is not in the DB, we do a fetch for it, but don't reset the `imageUrl` which results the previous post's image (or better put, the image for the post that's iterated after the last reset) being added to the `mFeaturedImageUrls`. This can lead to many duplicates, depending on the order of the posts.

There is still another issue, which is the fetched media doesn't show up at all until after the page is refreshed which will be taken care of in another issue.

To test:
* This is a little hard to reproduce, but basically you'll need a fresh install (so the media is not in your DB) and open a blog's post list which contains multiple posts with featured images preferably one after another.

P.S: Please note that I am targeting `7.1` for this as it could be a frustrating bug for our users, so the earlier the better.