### PR TITLE
Null check notification data before canceling

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
@@ -78,7 +78,10 @@ public class PostUploadNotifier {
     }
 
     public void cancelNotification(PostModel post) {
-        mNotificationManager.cancel(mPostIdToNotificationData.get(post.getId()).notificationId);
+        NotificationData notificationData = mPostIdToNotificationData.get(post.getId());
+        if (notificationData != null) {
+            mNotificationManager.cancel(notificationData.notificationId);
+        }
     }
 
     public void updateNotificationSuccess(PostModel post, SiteModel site, boolean isFirstTimePublish) {


### PR DESCRIPTION
Fixes #5569 by null checking notification data before accessing its `notificationId` field.