### PR TITLE
Use null safe helper method to check URL length

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -16,7 +16,7 @@ public class SiteUtils {
     public static String getHomeURLOrHostName(SiteModel site) {
         String homeURL = UrlUtils.removeScheme(site.getUrl());
         homeURL = StringUtils.removeTrailingSlash(homeURL);
-        if (homeURL.length() == 0) {
+        if (TextUtils.isEmpty(homeURL)) {
             return UrlUtils.getHost(site.getXmlRpcUrl());
         }
         return homeURL;


### PR DESCRIPTION
Fixes #5567 by using `TextUtils.isEmpty` which performs the null check for us.