### PR TITLE
Fix: Missing featured images in Post List

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -6,6 +6,7 @@ import android.text.TextUtils;
 import android.text.format.DateUtils;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.model.PostModel;
@@ -19,6 +20,7 @@ import org.wordpress.android.util.HtmlUtils;
 import org.wordpress.android.widgets.WPAlertDialogFragment;
 
 import java.text.BreakIterator;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -266,15 +268,16 @@ public class PostUtils {
         return -1;
     }
 
-    public static int indexOfFeaturedMediaIdInList(final long mediaId, List<PostModel> posts) {
+    public static @NotNull List<Integer> indexesOfFeaturedMediaIdInList(final long mediaId, List<PostModel> posts) {
+        List<Integer> list = new ArrayList<>();
         if (mediaId == 0) {
-            return -1;
+            return list;
         }
         for (int i = 0; i < posts.size(); i++) {
             if (posts.get(i).getFeaturedImageId() == mediaId) {
-                return i;
+                list.add(i);
             }
         }
-        return -1;
+        return list;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -638,10 +638,10 @@ public class PostsListFragment extends Fragment
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onMediaChanged(MediaStore.OnMediaChanged event) {
-        if (isAdded() && !event.isError() && getPostListAdapter() != null) {
+        if (isAdded() && !event.isError() && mPostsListAdapter != null) {
             if (event.mediaList != null && event.mediaList.size() > 0) {
                 MediaModel mediaModel = event.mediaList.get(0);
-                getPostListAdapter().mediaChanged(mediaModel);
+                mPostsListAdapter.mediaChanged(mediaModel);
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -25,9 +25,11 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
+import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.post.PostStatus;
+import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload;
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged;
@@ -352,17 +354,6 @@ public class PostsListFragment extends Fragment
     }
 
     /*
-     * PostMediaService has downloaded the media info for a post's featured image, tell
-     * the adapter so it can show the featured image now that we have its URL
-     */
-    @SuppressWarnings("unused")
-    public void onEventMainThread(PostEvents.PostMediaInfoUpdated event) {
-        if (isAdded() && getPostListAdapter() != null) {
-            getPostListAdapter().mediaUpdated(event.getMediaId(), event.getMediaUrl());
-        }
-    }
-
-    /*
      * upload start, reload so correct status on uploading post appears
      */
     @SuppressWarnings("unused")
@@ -637,6 +628,17 @@ public class PostsListFragment extends Fragment
     public void onPostUploaded(OnPostUploaded event) {
         if (isAdded() && event.post.getLocalSiteId() == mSite.getId()) {
             loadPosts(LoadMode.FORCED);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onMediaChanged(MediaStore.OnMediaChanged event) {
+        if (isAdded() && !event.isError() && getPostListAdapter() != null) {
+            if (event.mediaList != null && event.mediaList.size() > 0) {
+                MediaModel mediaModel = event.mediaList.get(0);
+                getPostListAdapter().mediaUpdated(mediaModel);
+            }
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -637,7 +637,7 @@ public class PostsListFragment extends Fragment
         if (isAdded() && !event.isError() && getPostListAdapter() != null) {
             if (event.mediaList != null && event.mediaList.size() > 0) {
                 MediaModel mediaModel = event.mediaList.get(0);
-                getPostListAdapter().mediaUpdated(mediaModel);
+                getPostListAdapter().mediaChanged(mediaModel);
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -631,6 +631,10 @@ public class PostsListFragment extends Fragment
         }
     }
 
+    /*
+     * Media info for a post's featured image has been downloaded, tell
+     * the adapter so it can show the featured image now that we have its URL
+     */
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onMediaChanged(MediaStore.OnMediaChanged event) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -664,9 +664,9 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         // Multiple posts could have the same featured image
         List<Integer> indexList = PostUtils.indexesOfFeaturedMediaIdInList(mediaModel.getMediaId(), mPosts);
         for (int position : indexList) {
-            if (isValidPostPosition(position)) {
-                int postId = mPosts.get(position).getId();
-                mFeaturedImageUrls.put(postId, mediaModel.getUrl());
+            PostModel post = getItem(position);
+            if (post != null) {
+                mFeaturedImageUrls.put(post.getId(), mediaModel.getUrl());
                 notifyItemChanged(position);
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -660,7 +660,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
      * called after the media (featured image) for a post has been downloaded - locate the post
      * and set its featured image url to the passed url
      */
-    public void mediaUpdated(MediaModel mediaModel) {
+    public void mediaChanged(MediaModel mediaModel) {
         int position = PostUtils.indexOfFeaturedMediaIdInList(mediaModel.getMediaId(), mPosts);
         if (isValidPostPosition(position)) {
             int postId = mPosts.get(position).getId();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -660,11 +660,11 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
      * called after the media (featured image) for a post has been downloaded - locate the post
      * and set its featured image url to the passed url
      */
-    public void mediaUpdated(long mediaId, String mediaUrl) {
-        int position = PostUtils.indexOfFeaturedMediaIdInList(mediaId, mPosts);
+    public void mediaUpdated(MediaModel mediaModel) {
+        int position = PostUtils.indexOfFeaturedMediaIdInList(mediaModel.getMediaId(), mPosts);
         if (isValidPostPosition(position)) {
             int postId = mPosts.get(position).getId();
-            mFeaturedImageUrls.put(postId, mediaUrl);
+            mFeaturedImageUrls.put(postId, mediaModel.getUrl());
             notifyItemChanged(position);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -661,11 +661,14 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
      * and set its featured image url to the passed url
      */
     public void mediaChanged(MediaModel mediaModel) {
-        int position = PostUtils.indexOfFeaturedMediaIdInList(mediaModel.getMediaId(), mPosts);
-        if (isValidPostPosition(position)) {
-            int postId = mPosts.get(position).getId();
-            mFeaturedImageUrls.put(postId, mediaModel.getUrl());
-            notifyItemChanged(position);
+        // Multiple posts could have the same featured image
+        List<Integer> indexList = PostUtils.indexesOfFeaturedMediaIdInList(mediaModel.getMediaId(), mPosts);
+        for (int position : indexList) {
+            if (isValidPostPosition(position)) {
+                int postId = mPosts.get(position).getId();
+                mFeaturedImageUrls.put(postId, mediaModel.getUrl());
+                notifyItemChanged(position);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #5575. This PR fixes the missing featured images for when the relevant media is not yet in the DB. (fresh install, new post etc). It also makes sure multiple posts with the same featured image are updated once the media is downloaded as we were assuming only one post has a specific featured image.

To test:
* Setup some posts with featured images, make sure at least 2 posts have the same featured image (pick from media library, so the same id is used)
* Fresh install the app (to make things easier)
* Go into the blog posts page for that site, just scroll up and down and make sure the featured images show up. Pay special attention to the 2 posts you setup with the same featured image.