### PR TITLE
Fix: Reader detail layout becoming left aligned for liked posts

### DIFF
--- a/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
@@ -4,7 +4,6 @@
     included by ReaderPostDetailFragment
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/layout_post_detail_content"
     android:layout_width="wrap_content"

--- a/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
@@ -28,7 +28,7 @@
 
     <View
         android:id="@+id/layout_liking_users_divider"
-        android:layout_width="match_parent"
+        android:layout_width="@dimen/reader_webview_width"
         android:layout_height="1dp"
         android:layout_below="@id/reader_webview"
         android:layout_marginTop="@dimen/margin_medium"
@@ -54,7 +54,7 @@
     <!-- liking avatars are inserted into this view at runtime -->
     <org.wordpress.android.ui.reader.views.ReaderLikingUsersView
         android:id="@+id/layout_liking_users_view"
-        android:layout_width="match_parent"
+        android:layout_width="@dimen/reader_webview_width"
         android:layout_height="@dimen/avatar_sz_small"
         android:layout_below="@id/text_liking_users_label"
         android:layout_marginBottom="@dimen/margin_medium"

--- a/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
@@ -4,7 +4,6 @@
     included by ReaderPostDetailFragment
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:wp="http://schemas.android.com/apk/res-auto"
     android:id="@+id/layout_post_detail_footer"
     android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #5444. This was such an interesting (read: `frustrating`) bug to track down. I am still not completely sure why `match_parent` was causing the whole layout to slide left when the post was liked, however this change seems to have resolved it.

To test:
* Create a Nexus 9 emulator (I used API 24, but shouldn't really matter)
* Before the change (on `develop`) run the app and like a post and get frustrated that it's sliding left
* Switch branches and relieve that it's staying still now

@nbradbury Do you want to take a look at this one as the original author of everything Reader? :)