### PR TITLE
Fix #4058: Fix some embeds by injecting a specific js resource when we load the webview

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderEmbedScanner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderEmbedScanner.java
@@ -1,0 +1,32 @@
+package org.wordpress.android.ui.reader.utils;
+
+import java.util.HashMap;
+import java.util.regex.Pattern;
+
+public class ReaderEmbedScanner {
+    private final String mContent;
+
+    private final HashMap<Pattern, String> mKnownEmbeds = new HashMap<>();
+
+    public ReaderEmbedScanner(String contentOfPost) {
+        mContent = contentOfPost;
+        mKnownEmbeds.put(Pattern.compile("<blockquote[^<>]class=\"instagram-", Pattern.CASE_INSENSITIVE),
+                "https://platform.instagram.com/en_US/embeds.js");
+        mKnownEmbeds.put(Pattern.compile("<fb:post", Pattern.CASE_INSENSITIVE),
+                "https://connect.facebook.net/en_US/sdk.js#xfbml=1&amp;version=v2.8");
+    }
+
+    public void beginScan(ReaderHtmlUtils.HtmlScannerListener listener) {
+        if (listener == null) {
+            throw new IllegalArgumentException("HtmlScannerListener is required");
+        }
+
+        for (Pattern pattern : mKnownEmbeds.keySet()) {
+            if (pattern.matcher(mContent).find()) {
+                // Use the onTagFound callback to pass a URL. Not super clean, but avoid clutter with more kind
+                // of listeners.
+                listener.onTagFound("", mKnownEmbeds.get(pattern));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fix #4058: Fix some embeds by injecting a specific js resource when we load the webview

Twitter and Tumblr don't need anything, they were already working in the Reader. Here are some screenshots from a [test post ](https://taliwutblog.wordpress.com/2017/04/04/instagram-embed/):

![screenshot_1491470499](https://cloud.githubusercontent.com/assets/40213/24747238/01a8a1ae-1abc-11e7-9619-623fdba63bae.png)
![screenshot_1491470502](https://cloud.githubusercontent.com/assets/40213/24747239/01a8989e-1abc-11e7-9330-090413adc13e.png)
![screenshot_1491470769](https://cloud.githubusercontent.com/assets/40213/24747237/01a84b5a-1abc-11e7-9ee9-c63e5384fcfc.png)
![screenshot_1491470777](https://cloud.githubusercontent.com/assets/40213/24747240/01acd300-1abc-11e7-9c23-00e8cc06334b.png)
