### PR TITLE
Default enable optimize images (with 3000px and .85 quality settings)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
@@ -111,7 +111,7 @@ public class SiteSettingsModel {
     public int languageId;
     public int privacy;
     public boolean location;
-    public boolean optimizedImage;
+    public boolean optimizedImage = true; // Default to true
     public int maxImageWidth;
     public int imageQualitySetting;
     public int defaultCategory;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -275,7 +275,7 @@ public abstract class SiteSettingsInterface {
 
     public int getMaxImageWidth() {
         int resizeWidth = mSettings.maxImageWidth;
-        return resizeWidth;
+        return resizeWidth == 0 ? WPMediaUtils.OPTIMIZE_IMAGE_MAX_WIDTH : resizeWidth;
     }
 
     public int getImageQuality() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -794,6 +794,7 @@ public abstract class SiteSettingsInterface {
             setUsername(mSite.getUsername());
             setPassword(mSite.getPassword());
             setTitle(mSite.getName());
+            setOptimizedImage(true); // Default to true
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -18,28 +18,21 @@ public class WPMediaUtils {
             return null;
         }
         SiteSettingsInterface siteSettings = SiteSettingsInterface.getInterface(activity, siteModel, null);
-        if (siteSettings == null) {
-            // Site Settings are NOT implemented for self hosted site.
-            // TODO implement site settings!!!
-            return null;
-            // optimizedPath = ImageUtils.optimizeImage(activity, path, OPTIMIZE_IMAGE_MAX_WIDTH, OPTIMIZE_IMAGE_ENCODER_QUALITY);
-        } else {
-            // Site Settings are implemented on .com/Jetpack sites only
-            if (siteSettings.init(false).getOptimizedImage()) {
-                int resizeWidth = siteSettings.getMaxImageWidth() > 0 ? siteSettings.getMaxImageWidth() : Integer.MAX_VALUE;
-                int quality = siteSettings.getImageQuality();
-                // do not optimize if original-size and 100% quality are set.
-                if (resizeWidth == Integer.MAX_VALUE && quality == 100) {
-                    return null;
-                }
-                String optimizedPath = ImageUtils.optimizeImage(activity, path, resizeWidth, quality);
-                if (optimizedPath == null) {
-                    AppLog.e(AppLog.T.EDITOR, "Optimized picture was null!");
-                    AnalyticsTracker.track(AnalyticsTracker.Stat.MEDIA_PHOTO_OPTIMIZE_ERROR);
-                } else {
-                    AnalyticsTracker.track(AnalyticsTracker.Stat.MEDIA_PHOTO_OPTIMIZED);
-                    return Uri.parse(optimizedPath);
-                }
+        // Site Settings are implemented on .com/Jetpack sites only
+        if (siteSettings != null && siteSettings.init(false).getOptimizedImage()) {
+            int resizeWidth = siteSettings.getMaxImageWidth() > 0 ? siteSettings.getMaxImageWidth() : Integer.MAX_VALUE;
+            int quality = siteSettings.getImageQuality();
+            // do not optimize if original-size and 100% quality are set.
+            if (resizeWidth == Integer.MAX_VALUE && quality == 100) {
+                return null;
+            }
+            String optimizedPath = ImageUtils.optimizeImage(activity, path, resizeWidth, quality);
+            if (optimizedPath == null) {
+                AppLog.e(AppLog.T.EDITOR, "Optimized picture was null!");
+                AnalyticsTracker.track(AnalyticsTracker.Stat.MEDIA_PHOTO_OPTIMIZE_ERROR);
+            } else {
+                AnalyticsTracker.track(AnalyticsTracker.Stat.MEDIA_PHOTO_OPTIMIZED);
+                return Uri.parse(optimizedPath);
             }
         }
         return null;

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -18,22 +18,28 @@ public class WPMediaUtils {
             return null;
         }
         SiteSettingsInterface siteSettings = SiteSettingsInterface.getInterface(activity, siteModel, null);
-        // Site Settings are implemented on .com/Jetpack sites only
-        if (siteSettings != null && siteSettings.init(false).getOptimizedImage()) {
-            int resizeWidth = siteSettings.getMaxImageWidth() > 0 ? siteSettings.getMaxImageWidth() : Integer.MAX_VALUE;
-            int quality = siteSettings.getImageQuality();
-            // do not optimize if original-size and 100% quality are set.
-            if (resizeWidth == Integer.MAX_VALUE && quality == 100) {
-                return null;
-            }
-
-            String optimizedPath = ImageUtils.optimizeImage(activity, path, resizeWidth, quality);
-            if (optimizedPath == null) {
-                AppLog.e(AppLog.T.EDITOR, "Optimized picture was null!");
-                AnalyticsTracker.track(AnalyticsTracker.Stat.MEDIA_PHOTO_OPTIMIZE_ERROR);
-            } else {
-                AnalyticsTracker.track(AnalyticsTracker.Stat.MEDIA_PHOTO_OPTIMIZED);
-                return Uri.parse(optimizedPath);
+        if (siteSettings == null) {
+            // Site Settings are NOT implemented for self hosted site.
+            // TODO implement site settings!!!
+            return null;
+            // optimizedPath = ImageUtils.optimizeImage(activity, path, OPTIMIZE_IMAGE_MAX_WIDTH, OPTIMIZE_IMAGE_ENCODER_QUALITY);
+        } else {
+            // Site Settings are implemented on .com/Jetpack sites only
+            if (siteSettings.init(false).getOptimizedImage()) {
+                int resizeWidth = siteSettings.getMaxImageWidth() > 0 ? siteSettings.getMaxImageWidth() : Integer.MAX_VALUE;
+                int quality = siteSettings.getImageQuality();
+                // do not optimize if original-size and 100% quality are set.
+                if (resizeWidth == Integer.MAX_VALUE && quality == 100) {
+                    return null;
+                }
+                String optimizedPath = ImageUtils.optimizeImage(activity, path, resizeWidth, quality);
+                if (optimizedPath == null) {
+                    AppLog.e(AppLog.T.EDITOR, "Optimized picture was null!");
+                    AnalyticsTracker.track(AnalyticsTracker.Stat.MEDIA_PHOTO_OPTIMIZE_ERROR);
+                } else {
+                    AnalyticsTracker.track(AnalyticsTracker.Stat.MEDIA_PHOTO_OPTIMIZED);
+                    return Uri.parse(optimizedPath);
+                }
             }
         }
         return null;

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -17,6 +17,7 @@ public class WPMediaUtils {
         if (isVideo) {
             return null;
         }
+        // TODO implement site settings for .org sites
         SiteSettingsInterface siteSettings = SiteSettingsInterface.getInterface(activity, siteModel, null);
         // Site Settings are implemented on .com/Jetpack sites only
         if (siteSettings != null && siteSettings.init(false).getOptimizedImage()) {
@@ -26,6 +27,7 @@ public class WPMediaUtils {
             if (resizeWidth == Integer.MAX_VALUE && quality == 100) {
                 return null;
             }
+
             String optimizedPath = ImageUtils.optimizeImage(activity, path, resizeWidth, quality);
             if (optimizedPath == null) {
                 AppLog.e(AppLog.T.EDITOR, "Optimized picture was null!");

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -248,7 +248,7 @@
         <item>2000</item>
         <item>2500</item>
         <item>3000</item>
-        <item>0</item>
+        <item>1</item>
     </string-array>
 
     <string-array name="site_settings_image_quality_entries" translatable="false">


### PR DESCRIPTION
@nbradbury This PR default enables `Optimize Images` setting for dotcom and Jetpack sites.
Default values are 3000px and .85 quality.

Unfortunately `Site Settings` are still missing for .org sites. What should we do for them?
- Force the optimize setting, and set it to ON? 
- Or just wait until site settings are there for .org sites? (I can do that but it would not make the 7.2 cut on Monday).