### PR TITLE
Only allow drafts to be auto-saved

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1236,7 +1236,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 }
             }
 
-            if (PostStatus.fromPost(mPost) != PostStatus.PUBLISHED && isPublishable && NetworkUtils.isNetworkAvailable(this)) {
+            if (PostStatus.fromPost(mPost) == PostStatus.DRAFT && isPublishable && NetworkUtils.isNetworkAvailable(this)) {
                 if (!hasFailedMedia()) {
                     savePostOnlineAndFinishAsync(isFirstTimePublish);
                 }


### PR DESCRIPTION
Fixes #5599.

To test:

1. Open any post that's not a draft (published, scheduled, etc.)
2. Exit the editor without saving
3. Notice the changes are saved only locally