### PR TITLE
issue/5601-media-friendly-date

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaItemFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaItemFragment.java
@@ -214,12 +214,8 @@ public class MediaItemFragment extends Fragment {
             mDescriptionView.setVisibility(View.VISIBLE);
         }
 
-        Date date = DateTimeUtils.dateFromIso8601(mediaModel.getUploadDate());
-        if (date != null) {
-            mDateView.setText(SimpleDateFormat.getDateInstance().format(date));
-        } else {
-            mDateView.setText(mediaModel.getUploadDate());
-        }
+        mDateView.setText(getDisplayDate(mediaModel.getUploadDate()));
+
         if (getView() != null) {
             TextView txtDateLabel = (TextView) getView().findViewById(R.id.media_listitem_details_date_label);
             txtDateLabel.setText(
@@ -327,6 +323,20 @@ public class MediaItemFragment extends Fragment {
                 }
             });
         }
+    }
+
+    /*
+     * returns the passed string formatted as a short date if it's valid ISO 8601 date,
+     * otherwise returns the passed string
+     */
+    private String getDisplayDate(String dateString) {
+        if (dateString != null) {
+            Date date = DateTimeUtils.dateFromIso8601(dateString);
+            if (date != null) {
+                return SimpleDateFormat.getDateInstance().format(date);
+            }
+        }
+        return dateString;
     }
 
     private synchronized void loadLocalImage(ImageView imageView, String filePath, int width, int height) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaItemFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaItemFragment.java
@@ -32,6 +32,7 @@ import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher.PhotoViewerOption;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.ImageUtils.BitmapWorkerCallback;
 import org.wordpress.android.util.ImageUtils.BitmapWorkerTask;
@@ -42,7 +43,9 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -211,7 +214,12 @@ public class MediaItemFragment extends Fragment {
             mDescriptionView.setVisibility(View.VISIBLE);
         }
 
-        mDateView.setText(mediaModel.getUploadDate());
+        Date date = DateTimeUtils.dateFromIso8601(mediaModel.getUploadDate());
+        if (date != null) {
+            mDateView.setText(SimpleDateFormat.getDateInstance().format(date));
+        } else {
+            mDateView.setText(mediaModel.getUploadDate());
+        }
         if (getView() != null) {
             TextView txtDateLabel = (TextView) getView().findViewById(R.id.media_listitem_details_date_label);
             txtDateLabel.setText(


### PR DESCRIPTION
Fixes #5601 - uses a friendlier date format for the media item fragment.

**Before**
![before](https://cloud.githubusercontent.com/assets/3903757/24833680/e40141bc-1c9e-11e7-8514-e98c5c5ade6e.png)

**After**
![after](https://cloud.githubusercontent.com/assets/3903757/24833686/0051b644-1c9f-11e7-957c-db3f224ab14f.png)
