### PR TITLE
Fix #5568: Workaround a String.format bug: force the use of the US locale

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderSiteHeaderView.java
@@ -18,6 +18,8 @@ import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
 
+import java.util.Locale;
+
 import javax.inject.Inject;
 
 /**
@@ -129,7 +131,13 @@ public class ReaderSiteHeaderView extends LinearLayout {
             txtDescription.setVisibility(View.GONE);
         }
 
-        txtFollowCount.setText(String.format(getContext().getString(R.string.reader_label_follow_count), blogInfo.numSubscribers));
+        try {
+            txtFollowCount.setText(String.format(getContext().getString(R.string.reader_label_follow_count), blogInfo.numSubscribers));
+        } catch (ArithmeticException exception) {
+            // See https://github.com/wordpress-mobile/WordPress-Android/issues/5568
+            // In case of a "ArithmeticException: divide by zero", force the use of "US" locale to format the string.
+            txtFollowCount.setText(String.format(Locale.US, getContext().getString(R.string.reader_label_follow_count), blogInfo.numSubscribers));
+        }
 
         if (!mAccountStore.hasAccessToken()) {
             mFollowButton.setVisibility(View.GONE);


### PR DESCRIPTION
Fix #5568: Workaround a String.format bug: force the use of the US locale in case of an ArithmeticException