### PR TITLE
removed line of code that would set the username field empty in onResume

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -645,7 +645,6 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
             mJetpackAuthLabel.setVisibility(View.VISIBLE);
             mAddSelfHostedButton.setVisibility(View.GONE);
             mCreateAccountButton.setVisibility(View.GONE);
-            mUsernameEditText.setText("");
         }
     }
 


### PR DESCRIPTION
Fixes #5606 

To test:
0. make sure you activate 2FA on your wordpress.com account
1. Login to the wp android app by adding a jetpack connected site
2. when the wp.com credentials are requested, and the field for entering the verification code is shown, switch to another app (i.e. to the Authenticator app to get the new code)
3. switch back to WPAndroid to see the username field  - it should still keep your username in it.

cc @maxme 