### PR TITLE
Revert drawableRightCompat/drawableLeftCompat - it's very error prone

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPTextView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPTextView.java
@@ -2,9 +2,6 @@ package org.wordpress.android.widgets;
 
 import android.content.Context;
 import android.content.res.TypedArray;
-import android.graphics.drawable.Drawable;
-import android.os.Build;
-import android.support.v7.content.res.AppCompatResources;
 import android.support.v7.widget.AppCompatTextView;
 import android.text.Spannable;
 import android.text.SpannableString;
@@ -63,35 +60,11 @@ public class WPTextView extends AppCompatTextView {
     private void readCustomAttrs(Context context, AttributeSet attrs) {
         TypedArray array = context.getTheme().obtainStyledAttributes(attrs, R.styleable.WPTextView, 0, 0);
         if (array != null) {
-            setFixWidowWord(array.getBoolean(R.styleable.WPTextView_fixWidowWords, false));
+            mFixWidowWordEnabled = array.getBoolean(R.styleable.WPTextView_fixWidowWords, false);
             if (mFixWidowWordEnabled) {
                 // Force text update
                 setText(getText());
             }
-
-            // support vector drawables for API < 5.0
-            Drawable drawableLeft = null;
-            Drawable drawableRight = null;
-            Drawable drawableBottom = null;
-            Drawable drawableTop = null;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                drawableLeft = array.getDrawable(R.styleable.WPTextView_drawableLeftCompat);
-                drawableRight = array.getDrawable(R.styleable.WPTextView_drawableRightCompat);
-                drawableBottom = array.getDrawable(R.styleable.WPTextView_drawableBottomCompat);
-                drawableTop = array.getDrawable(R.styleable.WPTextView_drawableTopCompat);
-            } else {
-                final int drawableLeftId = array.getResourceId(R.styleable.WPTextView_drawableLeftCompat, -1);
-                final int drawableRightId = array.getResourceId(R.styleable.WPTextView_drawableRightCompat, -1);
-                final int drawableBottomId = array.getResourceId(R.styleable.WPTextView_drawableBottomCompat, -1);
-                final int drawableTopId = array.getResourceId(R.styleable.WPTextView_drawableTopCompat, -1);
-
-                if (drawableLeftId != -1) drawableLeft = AppCompatResources.getDrawable(context, drawableLeftId);
-                if (drawableRightId != -1) drawableRight = AppCompatResources.getDrawable(context, drawableRightId);
-                if (drawableBottomId != -1) drawableBottom = AppCompatResources.getDrawable(context, drawableBottomId);
-                if (drawableTopId != -1) drawableTop = AppCompatResources.getDrawable(context, drawableTopId);
-            }
-            setCompoundDrawablesWithIntrinsicBounds(drawableLeft, drawableTop, drawableRight, drawableBottom);
-            array.recycle();
         }
     }
 

--- a/WordPress/src/main/res/layout/filter_spinner_item.xml
+++ b/WordPress/src/main/res/layout/filter_spinner_item.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <org.wordpress.android.widgets.WPTextView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/text"
     style="@style/FilteredRecyclerViewFilterTextView.WordPress"
     android:layout_width="wrap_content"
@@ -9,5 +8,5 @@
     android:textColor="@color/white"
     android:paddingRight="0dp"
     android:paddingLeft="0dp"
-    app:drawableRightCompat="@drawable/ic_dropdown_blue_light_24dp"
+    android:drawableRight="@drawable/ic_dropdown_blue_light_24dp"
     tools:text="spinner item"/>

--- a/WordPress/src/main/res/layout/people_invite_fragment.xml
+++ b/WordPress/src/main/res/layout/people_invite_fragment.xml
@@ -124,7 +124,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="1dp"
                 android:layout_marginTop="5dp"
-                app:drawableRightCompat="@drawable/ic_dropdown_blue_light_24dp"
+                android:drawableRight="@drawable/ic_dropdown_blue_light_24dp"
                 android:ellipsize="end"
                 android:gravity="center_vertical"
                 android:maxLines="1"

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -39,11 +39,6 @@
     -->
     <declare-styleable name="WPTextView">
         <attr name="fixWidowWords" format="boolean"/>
-        <!-- http://stackoverflow.com/questions/35761636/is-it-possible-to-use-vectordrawable-in-buttons-and-textviews-using-androiddraw -->
-        <attr name="drawableLeftCompat" format="reference"/>
-        <attr name="drawableRightCompat" format="reference"/>
-        <attr name="drawableTopCompat" format="reference"/>
-        <attr name="drawableBottomCompat" format="reference"/>
     </declare-styleable>
 
     <!--


### PR DESCRIPTION
Every other places where drawableLeft/drawableRight was used in WPTextView have to be checked, it's very error prone (we already missed a few cases). IMO, it's better to remove this and keep the use of PNG files for drawableLeft/Right.

To test:
* before the patch: open the "My site" tab, notice there is no arrow icon on the "Switch site" button
* after the patch: open the "My site" tab, notice the arrow icon on the "Switch site" button is back
