### PR TITLE
Do not enable optimize pictures for all users

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
@@ -111,7 +111,7 @@ public class SiteSettingsModel {
     public int languageId;
     public int privacy;
     public boolean location;
-    public boolean optimizedImage = true; // Default to true
+    public boolean optimizedImage;
     public int maxImageWidth;
     public int imageQualitySetting;
     public int defaultCategory;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -794,7 +794,6 @@ public abstract class SiteSettingsInterface {
             setUsername(mSite.getUsername());
             setPassword(mSite.getPassword());
             setTitle(mSite.getName());
-            setOptimizedImage(true); // Default to true
         }
     }
 


### PR DESCRIPTION
This PR brings the "optimize images" feature default value back to off. 

We've set it on, for all users that didn't explicitly turn the setting OFF, in https://github.com/wordpress-mobile/WordPress-Android/pull/5596 but probably this could lead to unexpected behavior.

We should probably enable it by default  to new users / new logins only.

cc @mzorz 
  


