### PR TITLE
[Analytics] Track `post_id` on post events

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -106,25 +106,28 @@ public class PostUtils {
 
     public static void trackSavePostAnalytics(PostModel post, SiteModel site) {
         PostStatus status = PostStatus.fromPost(post);
+        Map<String, Object> properties = new HashMap<>();
         switch (status) {
             case PUBLISHED:
                 if (!post.isLocalDraft()) {
-                    AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.EDITOR_UPDATED_POST, site);
+                    properties.put("post_id", post.getRemotePostId());
+                    AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.EDITOR_UPDATED_POST, site, properties);
                 } else {
                     // Analytics for the event EDITOR_PUBLISHED_POST are tracked in PostUploadService
                 }
                 break;
             case SCHEDULED:
                 if (!post.isLocalDraft()) {
-                    AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.EDITOR_UPDATED_POST, site);
+                    properties.put("post_id", post.getRemotePostId());
+                    AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.EDITOR_UPDATED_POST, site, properties);
                 } else {
-                    Map<String, Object> properties = new HashMap<>();
                     properties.put("word_count", AnalyticsUtils.getWordCount(post.getContent()));
                     AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.EDITOR_SCHEDULED_POST, site,
                             properties);
                 }
                 break;
             case DRAFT:
+                properties.put("post_id", post.getRemotePostId());
                 AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.EDITOR_SAVED_DRAFT, site);
                 break;
             default:


### PR DESCRIPTION
This PR adds the `post_id` property to events about post:
- EDITOR_PUBLISHED_POST
- EDITOR_SAVED_DRAFT
- EDITOR_SCHEDULED_POST
- EDITOR_UPDATED_POST

Not the cleanest implementation on the world, but since `PostUploadService` is going to be revisited soon with multi-upload capabilities we can live with it in the meanwhile.

Things to keep in mind:
- When the `post_id` is not yet available the value `0` is stored in the property.
- `EDITOR_PUBLISHED_POST` is now bumped at the end of the uploading process. Before this PR it was bumped when the user tapped the "publish" button.  @charlescearl Are you OK with this new semantic? 
Consider that the event is NOT bumped when there are issues uploading the post. We may need to add a new event to track errors.


