### PR TITLE
Fix #4274: Add a new Unspam button and hide the Spam button when selected comments are all spams

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -587,7 +587,7 @@ public class CommentsListFragment extends Fragment {
 
         private void setItemEnabled(Menu menu, int menuId, boolean isEnabled, boolean isVisible) {
             final MenuItem item = menu.findItem(menuId);
-            if (item == null || item.isEnabled() == isEnabled)
+            if (item == null || (item.isEnabled() == isEnabled && item.isVisible() == isVisible))
                 return;
             item.setVisible(isVisible);
             item.setEnabled(isEnabled);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -585,10 +585,11 @@ public class CommentsListFragment extends Fragment {
             return true;
         }
 
-        private void setItemEnabled(Menu menu, int menuId, boolean isEnabled) {
+        private void setItemEnabled(Menu menu, int menuId, boolean isEnabled, boolean isVisible) {
             final MenuItem item = menu.findItem(menuId);
             if (item == null || item.isEnabled() == isEnabled)
                 return;
+            item.setVisible(isVisible);
             item.setEnabled(isEnabled);
             if (item.getIcon() != null) {
                 // must mutate the drawable to avoid affecting other instances of it
@@ -609,16 +610,16 @@ public class CommentsListFragment extends Fragment {
             boolean hasAnyNonSpam = hasSelection && selectedComments.hasAnyWithoutStatus(CommentStatus.SPAM);
             boolean hasTrash = hasSelection && selectedComments.hasAnyWithStatus(CommentStatus.TRASH);
 
-            setItemEnabled(menu, R.id.menu_approve, hasUnapproved || hasSpam || hasTrash);
-            setItemEnabled(menu, R.id.menu_unapprove, hasApproved);
-            setItemEnabled(menu, R.id.menu_spam, hasAnyNonSpam);
-            setItemEnabled(menu, R.id.menu_trash, hasSelection);
+            setItemEnabled(menu, R.id.menu_approve, hasUnapproved || hasSpam || hasTrash, true);
+            setItemEnabled(menu, R.id.menu_unapprove, hasApproved, true);
+            setItemEnabled(menu, R.id.menu_spam, hasAnyNonSpam, hasAnyNonSpam);
+            setItemEnabled(menu, R.id.menu_unspam, hasSpam && !hasAnyNonSpam, hasSpam && !hasAnyNonSpam);
+            setItemEnabled(menu, R.id.menu_trash, hasSelection, true);
 
             final MenuItem trashItem = menu.findItem(R.id.menu_trash);
             if (trashItem != null && mCommentStatusFilter == CommentStatusCriteria.TRASH) {
                 trashItem.setTitle(R.string.mnu_comment_delete_permanently);
             }
-
             return true;
         }
 
@@ -634,6 +635,9 @@ public class CommentsListFragment extends Fragment {
                 return true;
             } else if (i == R.id.menu_unapprove) {
                 moderateSelectedComments(CommentStatus.UNAPPROVED);
+                return true;
+            } else if (i == R.id.menu_unspam) {
+                moderateSelectedComments(CommentStatus.APPROVED);
                 return true;
             } else if (i == R.id.menu_spam) {
                 moderateSelectedComments(CommentStatus.SPAM);

--- a/WordPress/src/main/res/menu/menu_comments_cab.xml
+++ b/WordPress/src/main/res/menu/menu_comments_cab.xml
@@ -23,6 +23,11 @@
         app:showAsAction="ifRoom"
         android:title="@string/mnu_comment_spam" />
     <item
+        android:id="@+id/menu_unspam"
+        android:icon="@drawable/ic_spam_white_24dp"
+        app:showAsAction="ifRoom"
+        android:title="@string/mnu_comment_unspam" />
+    <item
         android:id="@+id/menu_trash"
         android:icon="@drawable/ic_trash_white_24dp"
         app:showAsAction="ifRoom"


### PR DESCRIPTION
Fix #4274: Add a new Unspam button and hide the Spam button when selected comments are all spams

Here is what it looks like in portrait and landscape modes:
https://cloudup.com/ij2OQe5ojc2

A new unspam icon would be nice for landscape mode, even if that kind of works with the current one.

Also note: the current unspam action in comment detail use the normal "spam" icon.

![screenshot-2017-04-11_11 43 18 559](https://cloud.githubusercontent.com/assets/40213/24902932/1722796c-1eac-11e7-829b-92207d85383c.png)
