### PR TITLE
Site settings - .ORG - Remove site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -568,7 +568,7 @@ public class WPMainActivity extends AppCompatActivity {
                 break;
             case RequestCodes.SITE_SETTINGS:
                 if (resultCode == SiteSettingsFragment.RESULT_BLOG_REMOVED) {
-                    handleBlogRemoved();
+                    handleSiteRemoved();
                 }
                 break;
             case RequestCodes.APP_SETTINGS:
@@ -675,7 +675,7 @@ public class WPMainActivity extends AppCompatActivity {
         }
     }
 
-    private void handleBlogRemoved() {
+    private void handleSiteRemoved() {
         if (!FluxCUtils.isSignedInWPComOrHasWPOrgSite(mAccountStore, mSiteStore)) {
             ActivityLauncher.showSignInForResult(this);
         } else {
@@ -775,6 +775,6 @@ public class WPMainActivity extends AppCompatActivity {
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteRemoved(OnSiteRemoved event) {
-        handleBlogRemoved();
+        handleSiteRemoved();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
@@ -103,10 +103,7 @@ public class BlogPreferencesActivity extends AppCompatActivity {
 
     @SuppressWarnings("unused")
     public void onEventMainThread(ConnectionChangeReceiver.ConnectionChangeEvent event) {
-        FragmentManager fragmentManager = getFragmentManager();
-        SiteSettingsFragment siteSettingsFragment =
-                (SiteSettingsFragment) fragmentManager.findFragmentByTag(KEY_SETTINGS_FRAGMENT);
-
+        SiteSettingsFragment siteSettingsFragment = getSettingsFragment();
         if (siteSettingsFragment != null) {
             if (!event.isConnected()) {
                 ToastUtils.showToast(this, getString(R.string.site_settings_disconnected_toast));
@@ -123,17 +120,18 @@ public class BlogPreferencesActivity extends AppCompatActivity {
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteRemoved(OnSiteRemoved event) {
-        setResult(RESULT_BLOG_REMOVED);
-        finish();
+        SiteSettingsFragment siteSettingsFragment = getSettingsFragment();
+        if (siteSettingsFragment != null) {
+            siteSettingsFragment.handleSiteRemoved();
+            setResult(RESULT_BLOG_REMOVED);
+            finish();
+        }
     }
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteDeleted(OnSiteDeleted event) {
-        FragmentManager fragmentManager = getFragmentManager();
-        SiteSettingsFragment siteSettingsFragment =
-                (SiteSettingsFragment) fragmentManager.findFragmentByTag(KEY_SETTINGS_FRAGMENT);
-
+        SiteSettingsFragment siteSettingsFragment = getSettingsFragment();
         if (siteSettingsFragment != null) {
             if (event.isError()) {
                 siteSettingsFragment.handleDeleteSiteError(event.error);
@@ -144,5 +142,10 @@ public class BlogPreferencesActivity extends AppCompatActivity {
             setResult(RESULT_BLOG_REMOVED);
             finish();
         }
+    }
+
+    private SiteSettingsFragment getSettingsFragment() {
+        FragmentManager fragmentManager = getFragmentManager();
+        return (SiteSettingsFragment) fragmentManager.findFragmentByTag(KEY_SETTINGS_FRAGMENT);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
@@ -12,7 +12,6 @@ import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
-import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
@@ -1,16 +1,11 @@
 package org.wordpress.android.ui.prefs;
 
-import android.app.AlertDialog;
 import android.app.Fragment;
 import android.app.FragmentManager;
-import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
-import android.view.View;
-import android.widget.Button;
-import android.widget.EditText;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -39,11 +34,6 @@ public class BlogPreferencesActivity extends AppCompatActivity {
     public static final int RESULT_BLOG_REMOVED = RESULT_FIRST_USER;
 
     private static final String KEY_SETTINGS_FRAGMENT = "settings-fragment";
-
-    // The blog this activity is managing settings for.
-    private boolean mBlogDeleted;
-    private EditText mUsernameET;
-    private EditText mPasswordET;
 
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
@@ -155,23 +145,5 @@ public class BlogPreferencesActivity extends AppCompatActivity {
             setResult(RESULT_BLOG_REMOVED);
             finish();
         }
-    }
-
-    /**
-     * Remove the blog this activity is managing settings for.
-     */
-    private void removeBlogWithConfirmation() {
-        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(this);
-        dialogBuilder.setTitle(getResources().getText(R.string.remove_account));
-        dialogBuilder.setMessage(getResources().getText(R.string.sure_to_remove_account));
-        dialogBuilder.setPositiveButton(getResources().getText(R.string.yes), new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int whichButton) {
-                mDispatcher.dispatch(SiteActionBuilder.newRemoveSiteAction(mSite));
-                mBlogDeleted = true;
-            }
-        });
-        dialogBuilder.setNegativeButton(getResources().getText(R.string.no), null);
-        dialogBuilder.setCancelable(false);
-        dialogBuilder.create().show();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -246,7 +246,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     @Override
     public void onPause() {
         super.onPause();
-        // Locally save the site. mSite can be null after site deletion.
+        // Locally save the site. mSite can be null after site deletion or site removal (.org sites)
         if (mSite != null) {
             mDispatcher.dispatch(SiteActionBuilder.newUpdateSiteAction(mSite));
         }
@@ -444,6 +444,7 @@ public class SiteSettingsFragment extends PreferenceFragment
             dialogBuilder.setPositiveButton(getResources().getText(R.string.yes), new DialogInterface.OnClickListener() {
                 public void onClick(DialogInterface dialog, int whichButton) {
                     mDispatcher.dispatch(SiteActionBuilder.newRemoveSiteAction(mSite));
+                    mSite = null;
                 }
             });
             dialogBuilder.setNegativeButton(getResources().getText(R.string.no), null);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -188,6 +188,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     private Preference mStartOverPref;
     private Preference mExportSitePref;
     private Preference mDeleteSitePref;
+    private Preference mRemoveSitePref; // .ORG Only
 
     private boolean mEditingEnabled = true;
 
@@ -436,6 +437,18 @@ public class SiteSettingsFragment extends PreferenceFragment
         } else if (preference == mDeleteSitePref) {
             AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.SITE_SETTINGS_DELETE_SITE_ACCESSED, mSite);
             requestPurchasesForDeletionCheck();
+        } else if (preference == mRemoveSitePref) {
+            AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(getActivity());
+            dialogBuilder.setTitle(getResources().getText(R.string.remove_account));
+            dialogBuilder.setMessage(getResources().getText(R.string.sure_to_remove_account));
+            dialogBuilder.setPositiveButton(getResources().getText(R.string.yes), new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int whichButton) {
+                    mDispatcher.dispatch(SiteActionBuilder.newRemoveSiteAction(mSite));
+                }
+            });
+            dialogBuilder.setNegativeButton(getResources().getText(R.string.no), null);
+            dialogBuilder.setCancelable(false);
+            dialogBuilder.create().show();
         } else {
             return false;
         }
@@ -668,6 +681,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         mStartOverPref = getClickPref(R.string.pref_key_site_start_over);
         mExportSitePref = getClickPref(R.string.pref_key_site_export_site);
         mDeleteSitePref = getClickPref(R.string.pref_key_site_delete_site);
+        mRemoveSitePref = getClickPref(R.string.pref_key_site_remove_site);
 
         sortLanguages();
 
@@ -1269,7 +1283,9 @@ public class SiteSettingsFragment extends PreferenceFragment
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_general);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_writing);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_discussion);
-        WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_advanced);
+        WPPrefUtils.removePreference(this, R.string.pref_key_site_advanced, R.string.pref_key_site_start_over_screen);
+        WPPrefUtils.removePreference(this, R.string.pref_key_site_advanced, R.string.pref_key_site_export_site);
+        WPPrefUtils.removePreference(this, R.string.pref_key_site_advanced, R.string.pref_key_site_delete_site);
     }
 
     private void removeNonJetpackPreferences() {
@@ -1279,6 +1295,7 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void removeNonDotComPreferences() {
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_account);
+        WPPrefUtils.removePreference(this, R.string.pref_key_site_advanced, R.string.pref_key_site_remove_site);
     }
 
     private Preference getChangePref(int id) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -444,7 +444,6 @@ public class SiteSettingsFragment extends PreferenceFragment
             dialogBuilder.setPositiveButton(getResources().getText(R.string.yes), new DialogInterface.OnClickListener() {
                 public void onClick(DialogInterface dialog, int whichButton) {
                     mDispatcher.dispatch(SiteActionBuilder.newRemoveSiteAction(mSite));
-                    mSite = null;
                 }
             });
             dialogBuilder.setNegativeButton(getResources().getText(R.string.no), null);
@@ -1349,6 +1348,11 @@ public class SiteSettingsFragment extends PreferenceFragment
                 .SITE_SETTINGS_DELETE_SITE_RESPONSE_OK, mSite);
         dismissProgressDialog(mDeleteSiteProgressDialog);
         mDeleteSiteProgressDialog = null;
+        mSite = null;
+    }
+
+    // .org site removed from the app
+    public void handleSiteRemoved() {
         mSite = null;
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -58,7 +58,7 @@
     <string name="notification_vibrate">Vibrate</string>
     <string name="notification_pending_drafts">Notify me on pending drafts</string>
     <string name="notification_blink">Blink notification light</string>
-    <string name="sure_to_remove_account">Remove this site?</string>
+    <string name="sure_to_remove_account">Remove this site from the app?</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="error">Error</string>
@@ -1584,6 +1584,7 @@
     <string name="premium_upgrades_message">You have active premium upgrades on your site. Please cancel your upgrades prior to deleting your site.</string>
     <string name="show_purchases">Show purchases</string>
     <string name="checking_purchases">Checking purchases</string>
+    <string name="remove_site_hint">Remove this site from the app</string>
 
     <!--Account Settings-->
     <string name="account_settings">Account Settings</string>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -322,6 +322,12 @@
             android:title="@string/site_settings_delete_site_title"
             app:longClickHint="@string/delete_site_hint" />
 
+        <org.wordpress.android.ui.prefs.WPPreference
+            android:id="@+id/remove_account"
+            android:key="@string/pref_key_site_remove_site"
+            android:title="@string/remove_account"
+            app:longClickHint="@string/remove_site_hint" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
I forgot to put the `Remove site` option back into site settings for .org sites in https://github.com/wordpress-mobile/WordPress-Android/pull/5616
Sorry.

This PR re-adds it back with a slightly change on a string that I thought it could improve the feature. Let me know if the previous is better.


cc @nbradbury 