### PR TITLE
Enable Aztec for debug builds (wasabi) as well

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -45,14 +45,15 @@ android {
         multiDexEnabled true
         vectorDrawables.useSupportLibrary = true
 
-        buildConfigField "boolean", "AZTEC_EDITOR_AVAILABLE", "false"
+        buildConfigField "boolean", "AZTEC_EDITOR_AVAILABLE", "true"
     }
 
     productFlavors {
-        vanilla {} // used for release and beta
+        vanilla { // used for release and beta
+            buildConfigField "boolean", "AZTEC_EDITOR_AVAILABLE", "false"
+        }
 
         zalpha { // alpha version - enable experimental features
-            buildConfigField "boolean", "AZTEC_EDITOR_AVAILABLE", "true"
             applicationId "org.wordpress.android"
         }
 


### PR DESCRIPTION
Instead of turning on aztec for both alpha/wasabi, I "enabled" it by default and turned it off on vanilla.

If you think this is too dangerous, I'm totally ok with reverting it back to off by default and enabling it in both alpha/wasabi.