### PR TITLE
Start over changes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -15,6 +15,7 @@ import android.preference.EditTextPreference;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceScreen;
+import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
 import android.support.v7.widget.LinearLayoutManager;
@@ -1137,7 +1138,7 @@ public class SiteSettingsFragment extends PreferenceFragment
             return;
         }
         Intent intent = new Intent(Intent.ACTION_SEND);
-        intent.setType("text/plain");
+        intent.setType(ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE);
         intent.putExtra(Intent.EXTRA_EMAIL, new String[]{"help@wordpress.com"});
         intent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.start_over_email_subject,
                 SiteUtils.getHomeURLOrHostName(mSite)));

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -105,6 +105,11 @@ public class SiteSettingsFragment extends PreferenceFragment
     public static final String WORDPRESS_PURCHASES_URL = "https://wordpress.com/purchases";
 
     /**
+     * url for redirecting free users to empty their sites (start over)
+     */
+    private final String WORDRESS_EMPTY_SITE_SUPPORT_URL = "https://en.support.wordpress.com/empty-site/";
+
+    /**
      * Used to move the Uncategorized category to the beginning of the category list.
      */
     private static final int UNCATEGORIZED_CATEGORY_ID = 1;
@@ -392,13 +397,19 @@ public class SiteSettingsFragment extends PreferenceFragment
             return setupMorePreferenceScreen();
         } else if (preference == findPreference(getString(R.string.pref_key_site_start_over_screen))) {
             Dialog dialog = ((PreferenceScreen) preference).getDialog();
-            if (dialog == null) return false;
+            if (mSite == null || dialog == null) return false;
 
             AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.SITE_SETTINGS_START_OVER_ACCESSED, mSite);
 
-            setupPreferenceList((ListView) dialog.findViewById(android.R.id.list), getResources());
-            String title = getString(R.string.start_over);
-            WPActivityUtils.addToolbarToDialog(this, dialog, title);
+            if (mSite.getHasFreePlan()) {
+                // Don't show the start over detail screen for free users, instead show the support page
+                dialog.dismiss();
+                WPWebViewActivity.openUrlByUsingGlobalWPCOMCredentials(getActivity(), WORDRESS_EMPTY_SITE_SUPPORT_URL);
+            } else {
+                setupPreferenceList((ListView) dialog.findViewById(android.R.id.list), getResources());
+                String title = getString(R.string.start_over);
+                WPActivityUtils.addToolbarToDialog(this, dialog, title);
+            }
         }
 
         return false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -108,7 +108,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     /**
      * url for redirecting free users to empty their sites (start over)
      */
-    private final String WORDRESS_EMPTY_SITE_SUPPORT_URL = "https://en.support.wordpress.com/empty-site/";
+    public static final String WORDPRESS_EMPTY_SITE_SUPPORT_URL = "https://en.support.wordpress.com/empty-site/";
 
     /**
      * Used to move the Uncategorized category to the beginning of the category list.
@@ -405,7 +405,7 @@ public class SiteSettingsFragment extends PreferenceFragment
             if (mSite.getHasFreePlan()) {
                 // Don't show the start over detail screen for free users, instead show the support page
                 dialog.dismiss();
-                WPWebViewActivity.openUrlByUsingGlobalWPCOMCredentials(getActivity(), WORDRESS_EMPTY_SITE_SUPPORT_URL);
+                WPWebViewActivity.openUrlByUsingGlobalWPCOMCredentials(getActivity(), WORDPRESS_EMPTY_SITE_SUPPORT_URL);
             } else {
                 setupPreferenceList((ListView) dialog.findViewById(android.R.id.list), getResources());
                 String title = getString(R.string.start_over);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1121,13 +1121,23 @@ public class SiteSettingsFragment extends PreferenceFragment
     }
 
     private void handleStartOver() {
+        // Only paid plans should be handled here, free plans should be redirected to website from "Start Over" button
+        if (mSite == null || mSite.getHasFreePlan()) {
+            return;
+        }
+        Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.setType("text/plain");
+        intent.putExtra(Intent.EXTRA_EMAIL, new String[]{"help@wordpress.com"});
+        intent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.start_over_email_subject,
+                SiteUtils.getHomeURLOrHostName(mSite)));
+        intent.putExtra(Intent.EXTRA_TEXT, getString(R.string.start_over_email_body, mSite.getUrl()));
+        try {
+            startActivity(Intent.createChooser(intent, getString(R.string.contact_support)));
+        } catch (android.content.ActivityNotFoundException ex) {
+            ToastUtils.showToast(getActivity(), R.string.start_over_email_intent_error);
+        }
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.SITE_SETTINGS_START_OVER_CONTACT_SUPPORT_CLICKED,
                 mSite);
-        if (mSite == null || mSite.getHasFreePlan()) {
-            // free plan, redirect to website
-        } else {
-            // paid plan, send email
-        }
     }
 
     private void showListEditorDialog(int titleRes, int headerRes) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -419,10 +419,7 @@ public class SiteSettingsFragment extends PreferenceFragment
             showListEditorDialog(R.string.site_settings_blacklist_title,
                     R.string.site_settings_blacklist_description);
         } else if (preference == mStartOverPref) {
-            AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.SITE_SETTINGS_START_OVER_CONTACT_SUPPORT_CLICKED,
-                    mSite);
-            HelpshiftHelper.getInstance().showConversation(getActivity(), mSiteStore,
-                    HelpshiftHelper.Tag.ORIGIN_START_OVER, mAccountStore.getAccount().getUserName());
+            handleStartOver();
         } else if (preference == mCloseAfterPref) {
             showCloseAfterDialog();
         } else if (preference == mPagingPref) {
@@ -1121,6 +1118,16 @@ public class SiteSettingsFragment extends PreferenceFragment
         setDetailListPreferenceValue(mWhitelistPref,
                 String.valueOf(val),
                 getWhitelistSummary(val));
+    }
+
+    private void handleStartOver() {
+        AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.SITE_SETTINGS_START_OVER_CONTACT_SUPPORT_CLICKED,
+                mSite);
+        if (mSite == null || mSite.getHasFreePlan()) {
+            // free plan, redirect to website
+        } else {
+            // paid plan, send email
+        }
     }
 
     private void showListEditorDialog(int titleRes, int headerRes) {

--- a/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
@@ -57,7 +57,6 @@ public class HelpshiftHelper {
         ORIGIN_LOGIN_SCREEN_JETPACK("origin:jetpack-login-screen"),
         ORIGIN_SIGNUP_SCREEN("origin:signup-screen"),
         ORIGIN_ME_SCREEN_HELP("origin:me-screen-help"),
-        ORIGIN_START_OVER("origin:start-over"),
         ORIGIN_DELETE_SITE("origin:delete-site");
 
         private final String mStringValue;

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1560,6 +1560,9 @@
     <string name="about_me_hint">A few words about you…</string>
     <string name="start_over">Start Over</string>
     <string name="site_settings_start_over_hint">Start your site over</string>
+    <string name="start_over_email_subject">Start over with site %s</string>
+    <string name="start_over_email_body">I want to start over with the site %s</string>
+    <string name="start_over_email_intent_error">Unable to send an email</string>
     <string name="let_us_help">Let Us Help</string>
     <string name="start_over_text">If you want a site but don\'t want any of the posts and pages you have now, our support team can delete your posts, pages, media and comments for you.\n\nThis will keep your site and URL active, but give you a fresh start on your content creation. Just contact us to have your current content cleared out.</string>
     <string name="contact_support">Contact support</string>


### PR DESCRIPTION
Fixes #5013. The changes are documented within the issue. The only concern I have is that when we want to send an email, it doesn't force Android to use an email client so apps like WhatsApp show up, but I don't think we can do anything about that.

Also, the `dialog.dismiss()` feels like a hack, but I don't think there is any other way to achieve that either (without major changes at least).

To test:
* Try to start over for both free and paid sites. For free site, you should land on the support page for it, for paid users, you should be able to send an email.

@tonyr59h Do you mind taking a look at this one since you're the most familiar one with preferences?