### PR TITLE
Fix #5645: Don't save posts with uploading media online

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -153,6 +153,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     public static final String EXTRA_IS_QUICKPRESS = "isQuickPress";
     public static final String EXTRA_QUICKPRESS_BLOG_ID = "quickPressBlogId";
     public static final String EXTRA_SAVED_AS_LOCAL_DRAFT = "savedAsLocalDraft";
+    public static final String EXTRA_HAS_UNFINISHED_MEDIA = "hasUnfinishedMedia";
     public static final String EXTRA_HAS_CHANGES = "hasChanges";
     public static final String STATE_KEY_CURRENT_POST = "stateKeyCurrentPost";
     public static final String STATE_KEY_ORIGINAL_POST = "stateKeyOriginalPost";
@@ -1169,6 +1170,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     private void saveResult(boolean saved, boolean savedLocally) {
         Intent i = getIntent();
         i.putExtra(EXTRA_SAVED_AS_LOCAL_DRAFT, savedLocally);
+        i.putExtra(EXTRA_HAS_UNFINISHED_MEDIA, hasUnfinishedMedia());
         i.putExtra(EXTRA_IS_PAGE, mIsPage);
         i.putExtra(EXTRA_HAS_CHANGES, saved);
         i.putExtra(EXTRA_POST, mPost);
@@ -1236,10 +1238,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 }
             }
 
-            boolean hasUploadingOrFailedMedia = mEditorFragment.isUploadingMedia() ||
-                    mEditorFragment.isActionInProgress() || mEditorFragment.hasFailedMediaUploads();
-
-            if (PostStatus.fromPost(mPost) == PostStatus.DRAFT && isPublishable && !hasUploadingOrFailedMedia
+            if (PostStatus.fromPost(mPost) == PostStatus.DRAFT && isPublishable && !hasUnfinishedMedia()
                     && NetworkUtils.isNetworkAvailable(this)) {
                 savePostOnlineAndFinishAsync(isFirstTimePublish);
             } else {
@@ -1257,6 +1256,11 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     private boolean isFirstTimePublish() {
         return PostStatus.fromPost(mPost) == PostStatus.PUBLISHED &&
                 (mPost.isLocalDraft() || PostStatus.fromPost(mOriginalPost) == PostStatus.DRAFT);
+    }
+
+    private boolean hasUnfinishedMedia() {
+        return mEditorFragment.isUploadingMedia() || mEditorFragment.isActionInProgress() ||
+                mEditorFragment.hasFailedMediaUploads();
     }
 
     private boolean updatePostObject() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1236,10 +1236,12 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 }
             }
 
-            if (PostStatus.fromPost(mPost) == PostStatus.DRAFT && isPublishable && NetworkUtils.isNetworkAvailable(this)) {
-                if (!hasFailedMedia()) {
-                    savePostOnlineAndFinishAsync(isFirstTimePublish);
-                }
+            boolean hasUploadingOrFailedMedia = mEditorFragment.isUploadingMedia() ||
+                    mEditorFragment.isActionInProgress() || mEditorFragment.hasFailedMediaUploads();
+
+            if (PostStatus.fromPost(mPost) == PostStatus.DRAFT && isPublishable && !hasUploadingOrFailedMedia
+                    && NetworkUtils.isNetworkAvailable(this)) {
+                savePostOnlineAndFinishAsync(isFirstTimePublish);
             } else {
                 savePostLocallyAndFinishAsync();
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -195,6 +195,7 @@ public class PostsListFragment extends Fragment
             final PostModel post = (PostModel)data.getSerializableExtra(EditPostActivity.EXTRA_POST);
             boolean isPublishable = post != null && PostUtils.isPublishable(post);
             boolean savedLocally = data.getBooleanExtra(EditPostActivity.EXTRA_SAVED_AS_LOCAL_DRAFT, false);
+            boolean hasUnfinishedMedia = data.getBooleanExtra(EditPostActivity.EXTRA_HAS_UNFINISHED_MEDIA, false);
 
             if (hasChanges) {
                 if (savedLocally && !NetworkUtils.isNetworkAvailable(getActivity())) {
@@ -202,7 +203,16 @@ public class PostsListFragment extends Fragment
                             ToastUtils.Duration.SHORT);
                 } else {
                     if (isPublishable) {
-                        if (savedLocally) {
+                        if (hasUnfinishedMedia) {
+                            Snackbar.make(getActivity().findViewById(R.id.coordinator),
+                                    R.string.editor_post_saved_locally_unfinished_media, Snackbar.LENGTH_LONG)
+                                    .setAction(R.string.button_edit, new View.OnClickListener() {
+                                        @Override
+                                        public void onClick(View v) {
+                                            ActivityLauncher.editPostOrPageForResult(getActivity(), mSite, post);
+                                        }
+                                    }).show();
+                        } else if (savedLocally) {
                             Snackbar.make(getActivity().findViewById(R.id.coordinator),
                                     R.string.editor_post_saved_locally_not_published, Snackbar.LENGTH_LONG)
                                     .setAction(R.string.button_publish, new View.OnClickListener() {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -960,6 +960,7 @@
     <string name="editor_post_saved_locally_not_published">Post saved locally only. Consider publishing it.</string>
     <string name="editor_post_saved_online">The post was saved online</string>
     <string name="editor_post_saved_online_not_published">The post was saved online as a draft. Consider publishing it.</string>
+    <string name="editor_post_saved_locally_unfinished_media">The post has unfinished media uploads and has been saved locally</string>
     <string name="visual_editor_enabled">Visual Editor enabled</string>
     <string name="visual_editor_disabled">Visual Editor disabled</string>
     <string name="aztec_editor_enabled" translatable="false">Aztec Editor enabled</string>


### PR DESCRIPTION
Fixes #5645, preventing posts with uploading media from being saved online when exiting the editor.

To test:
1. In either Aztec or the hybrid editor, add local media to a post (the fix should only apply to new posts and existing remote drafts, but other cases should also be checked)
2. Exit the editor while media are still uploading
3. The post should not be updated online - it should be saved as a local draft (or marked 'locally changed') instead

Note: This flow will be overhauled with the upcoming work on async media posting.