### PR TITLE
Remove "OK" string resource in favor of android.R.string.ok

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
@@ -244,7 +244,7 @@ public class EditCommentActivity extends AppCompatActivity {
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(EditCommentActivity.this);
         dialogBuilder.setTitle(getResources().getText(R.string.error));
         dialogBuilder.setMessage(R.string.error_edit_comment);
-        dialogBuilder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+        dialogBuilder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int whichButton) {
                 // just close the dialog
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
@@ -35,7 +35,7 @@ public class WordPressMediaUtils {
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(context);
         dialogBuilder.setTitle(context.getResources().getText(R.string.sdcard_title));
         dialogBuilder.setMessage(context.getResources().getText(R.string.sdcard_message));
-        dialogBuilder.setPositiveButton(context.getString(R.string.ok), new DialogInterface.OnClickListener() {
+        dialogBuilder.setPositiveButton(context.getString(android.R.string.ok), new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int whichButton) {
                 dialog.dismiss();
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/RoleChangeDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/RoleChangeDialogFragment.java
@@ -53,7 +53,7 @@ public class RoleChangeDialogFragment extends DialogFragment {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(), R.style.Calypso_AlertDialog);
         builder.setTitle(R.string.role);
         builder.setNegativeButton(R.string.cancel, null);
-        builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+        builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 Role role = mRoleListAdapter.getSelectedRole();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
@@ -99,7 +99,7 @@ public class PostsListActivity extends AppCompatActivity {
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
         builder.setTitle(getResources().getText(R.string.error))
                .setMessage(errorMessage)
-               .setPositiveButton(R.string.ok, null)
+               .setPositiveButton(android.R.string.ok, null)
                .setCancelable(true);
 
         builder.create().show();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DetailListPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DetailListPreference.java
@@ -85,7 +85,7 @@ public class DetailListPreference extends ListPreference
         AlertDialog.Builder builder = new AlertDialog.Builder(context, R.style.Calypso_AlertDialog);
 
         mWhichButtonClicked = DialogInterface.BUTTON_NEGATIVE;
-        builder.setPositiveButton(R.string.ok, this);
+        builder.setPositiveButton(android.R.string.ok, this);
         builder.setNegativeButton(res.getString(R.string.cancel).toUpperCase(), this);
 
         if (mDetails == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/NumberPickerDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/NumberPickerDialog.java
@@ -98,7 +98,7 @@ public class NumberPickerDialog extends DialogFragment
             mHeaderText.setVisibility(View.GONE);
         }
 
-        builder.setPositiveButton(R.string.ok, this);
+        builder.setPositiveButton(android.R.string.ok, this);
         builder.setNegativeButton(R.string.cancel, this);
         builder.setView(view);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ProfileInputDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ProfileInputDialogFragment.java
@@ -76,7 +76,7 @@ public class ProfileInputDialogFragment extends DialogFragment {
         }
 
         alertDialogBuilder.setCancelable(true)
-                .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         if (getTargetFragment() instanceof Callback) {
                             ((Callback) getTargetFragment()).onSuccessfulInput(editText.getText().toString(), callbackId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/RelatedPostsDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/RelatedPostsDialog.java
@@ -98,7 +98,7 @@ public class RelatedPostsDialog extends DialogFragment
         titleText.setText(R.string.site_settings_related_posts_title);
         titleText.setLayoutParams(new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT, RelativeLayout.LayoutParams.WRAP_CONTENT));
         builder.setCustomTitle(titleView);
-        builder.setPositiveButton(R.string.ok, this);
+        builder.setPositiveButton(android.R.string.ok, this);
         builder.setNegativeButton(R.string.cancel, this);
         builder.setView(v);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1231,7 +1231,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                 WPPrefUtils.layoutAsInput(input);
                 input.setWidth(getResources().getDimensionPixelSize(R.dimen.list_editor_input_max_width));
                 input.setHint(R.string.site_settings_list_editor_input_hint);
-                builder.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+                builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         String entry = input.getText().toString();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SummaryEditTextPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SummaryEditTextPreference.java
@@ -104,7 +104,7 @@ public class SummaryEditTextPreference extends EditTextPreference implements Pre
         View titleView = View.inflate(getContext(), R.layout.detail_list_preference_title, null);
         mWhichButtonClicked = DialogInterface.BUTTON_NEGATIVE;
 
-        builder.setPositiveButton(R.string.ok, this);
+        builder.setPositiveButton(android.R.string.ok, this);
         builder.setNegativeButton(res.getString(R.string.cancel).toUpperCase(), this);
         if (titleView != null) {
             TextView titleText = (TextView) titleView.findViewById(R.id.title);

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPAlertDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPAlertDialogFragment.java
@@ -121,7 +121,7 @@ public class WPAlertDialogFragment extends DialogFragment implements DialogInter
         switch (dialogType) {
             case ALERT:
                 builder.setIcon(android.R.drawable.ic_dialog_alert);
-                builder.setNeutralButton(R.string.ok, this);
+                builder.setNeutralButton(android.R.string.ok, this);
                 break;
 
             case CUSTOM:

--- a/WordPress/src/main/res/layout/add_category.xml
+++ b/WordPress/src/main/res/layout/add_category.xml
@@ -59,7 +59,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:text="@string/ok" />
+                android:text="@android:string/ok" />
 
         </LinearLayout>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1050,7 +1050,6 @@
     <!-- message on post preview explaining links are disabled -->
     <string name="preview_screen_links_disabled">Links are disabled on the preview screen</string>
 
-    <string name="ok">OK</string>
     <string name="image_settings">Image settings</string>
     <string name="add_account_blog_url">Blog address</string>
     <string name="wordpress_blog">WordPress blog</string>

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LinkDialogFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LinkDialogFragment.java
@@ -31,7 +31,7 @@ public class LinkDialogFragment extends DialogFragment {
         final EditText linkEditText = (EditText) view.findViewById(R.id.linkText);
 
         builder.setView(view)
-                .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int id) {
                         Intent intent = new Intent();

--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -4,7 +4,6 @@
     <string name="post_content">Content</string>
     <string name="post_title">Title</string>
 
-    <string name="ok">OK</string>
     <string name="cancel">Cancel</string>
     <string name="delete">Delete</string>
     <string name="save">Save</string>


### PR DESCRIPTION
Nothing major, just had these changes stashed after [some discussion](https://github.com/wordpress-mobile/WordPress-Android/pull/5553#discussion_r108898568) on using Android's auto-localized resource for the same string.

You may notice with a project-wide search that the editor module still has an `ok` string (used in `LinkDialogFragment`) still. Figured that should be patched in the editor repository.