### PR TITLE
Fix #5646: make sure the adapter is initialized

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -215,9 +215,9 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
     protected void onStart() {
         super.onStart();
         EventBus.getDefault().registerSticky(this);
-        //if the user hasn't used swipe yet, hint the user they can navigate through notifications detail
-        //using swipe on the ViewPager
-        if (!AppPrefs.isNotificationsSwipeToNavigateShown() && (mAdapter.getCount() > 1)) {
+        // If the user hasn't used swipe yet and if the adapter is initialised and have at least 2 notifications,
+        // show a hint to promote swipe usage on the ViewPager
+        if (!AppPrefs.isNotificationsSwipeToNavigateShown() && mAdapter != null && mAdapter.getCount() > 1) {
             WPSwipeSnackbar.show(mViewPager);
         }
     }


### PR DESCRIPTION
The adapter can be unitilaized if `mNoteId` is `null` (can't parse notification) or if the note [can't be found in the db](https://github.com/wordpress-mobile/WordPress-Android/blob/14e19a4db0f306efa3ab8d9ebb53cf90d0fd125c/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java#L135-L135). In those cases the activity will finish so we don't care if we show the hint or not.