### PR TITLE
Issue/5313 update placeholder images

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
@@ -20,6 +20,7 @@ public class AztecImageLoader implements Html.ImageGetter {
     public AztecImageLoader(Context context) {
         this.context = context;
     }
+
     @Override
     public void loadImage(String url, final Callbacks callbacks, int maxWidth) {
         // TODO: if a local file then load it directly. This is a quick fix though.
@@ -36,10 +37,9 @@ public class AztecImageLoader implements Html.ImageGetter {
                 Bitmap bitmap = response.getBitmap();
 
                 if (bitmap == null) {
-                    // the loader tries to let us know to just use the default image for now
-                    callbacks.onUseDefaultImage();
+                    callbacks.onImageLoading(null);
                 } else {
-                    BitmapDrawable bitmapDrawable = new BitmapDrawable(context.getResources(), response.getBitmap());
+                    BitmapDrawable bitmapDrawable = new BitmapDrawable(context.getResources(), bitmap);
                     callbacks.onImageLoaded(bitmapDrawable);
                 }
             }

--- a/libs/editor/WordPressEditor/src/main/res/drawable/ic_image_failed_grey_a_40_48dp.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/ic_image_failed_grey_a_40_48dp.xml
@@ -1,0 +1,18 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="48dp"
+    android:width="48dp"
+    android:viewportHeight="48.0"
+    android:viewportWidth="48.0" >
+
+    <path
+        android:fillColor="#66888888"
+        android:pathData="M0,0h48v48H0V0z" >
+    </path>
+
+    <path
+        android:fillColor="#66aaaaaa"
+        android:pathData="M24,8c8.8,0,16,7.2,16,16s-7.2,16-16,16S8,32.8,8,24S15.2,8,24,8 M24,4C13,4,4,13,4,24s9,20,20,20s20-9,20-20 S35,4,24,4z M26,30h-4v4h4V30z M22,26h4l1-12h-6L22,26z" >
+    </path>
+
+</vector>

--- a/libs/editor/WordPressEditor/src/main/res/drawable/ic_image_loading_grey_a_40_48dp.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/ic_image_loading_grey_a_40_48dp.xml
@@ -1,0 +1,18 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="48dp"
+    android:width="48dp"
+    android:viewportHeight="48.0"
+    android:viewportWidth="48.0" >
+
+    <path
+        android:fillColor="#66888888"
+        android:pathData="M0,0h48v48H0V0z" >
+    </path>
+
+    <path
+        android:fillColor="#66aaaaaa"
+        android:pathData="M26.2,18.4c0-1.8,1.6-3.4,3.4-3.4s3.4,1.6,3.4,3.4s-1.6,3.4-3.4,3.4S26.2,20.2,26.2,18.4z M37.6,6H10.4 C8,6,6,8,6,10.4v27C6,40,8,42,10.4,42h27c2.4,0,4.4-2,4.4-4.4V10.4C42,8,40,6,37.6,6z M37.6,29l-1.2-1.2c-1.8-2-5-2-6.6,0l-1.4,1.6 L17.2,17.2l-6.8,7.4V10.4h27V29H37.6z" >
+    </path>
+
+</vector>

--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
@@ -72,6 +72,8 @@
                     aztec:bulletWidth="@dimen/bullet_width"
                     aztec:codeBackground="@color/code_background"
                     aztec:codeColor="@color/code"
+                    aztec:drawableFailed="@drawable/ic_image_failed_grey_a_40_48dp"
+                    aztec:drawableLoading="@drawable/ic_image_loading_grey_a_40_48dp"
                     aztec:historyEnable="true"
                     aztec:historySize="10"
                     aztec:linkColor="@color/link"


### PR DESCRIPTION
### Fix
Add WordPress placeholder images and attributes to `AztecText` to override the default library images as described in https://github.com/wordpress-mobile/WordPress-Android/issues/5313.

### Test
1. Go to ***Sites*** tab.
2. Tap ***Blog Posts*** item.
3. Tap ***Create*** floating button.
4. Tap ***HTML*** format button.
5. Enter `<img src="https://goo.gl/">`.
6. Tap ***HTML*** format button.
7. Notice WordPress loading and failed placeholder images.