### PR TITLE
Show network error message for adding category

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
@@ -174,6 +174,10 @@ public class SelectCategoriesActivity extends AppCompatActivity {
             switch (requestCode) {
                 case ACTIVITY_REQUEST_CODE_ADD_CATEGORY:
                     if (resultCode == RESULT_OK) {
+                        if (!NetworkUtils.checkConnection(this)) {
+                            mEmptyView.setText(R.string.no_network_title);
+                            break;
+                        }
                         TermModel newCategory = (TermModel) extras.getSerializable(AddCategoryActivity.KEY_CATEGORY);
 
                         // Save selected categories


### PR DESCRIPTION
Fixes #4410. 

> If you already have the Add Category dialog open, and then you lose your connection, the message "Adding category failed" still appears.

As discussed in the issue, the above problem is the only known offline related issue remaining. Instead of showing "Adding category failed" message, we should tell the user that their connection is down.

Please note that the user has to open the add category dialog while having a connection and lose the connection before trying to add the category, so this is kind of an edge case.

To test:
* Go into post settings and try to add a category
* Once you open the dialog, disable your connection and add the category
* You should see a connection related message instead of a generic "Adding category failed" one
