### PR TITLE
IllegalStateException adding Media

### DIFF
--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -193,7 +193,11 @@ public class MediaUtils {
         try {
             String result = null;
             if (cursor != null && cursor.moveToFirst()) {
-                result = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME));
+                int columnIndexDisplayName = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+                if (columnIndexDisplayName == -1) {
+                    return null;
+                }
+                result = cursor.getString(columnIndexDisplayName);
             }
             return result;
         } finally {


### PR DESCRIPTION
Fixes #5662, making sure the column with the display_name is available in the cursor.
