### PR TITLE
NPE sharing media to WP Media Library

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -544,8 +544,13 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     }
 
     private void uploadList(List<Uri> uriList) {
+        if (uriList == null || uriList.size() == 0) {
+            return;
+        }
         for (Uri uri : uriList) {
-            fetchMedia(uri, getContentResolver().getType(uri));
+            if (uri != null) {
+                fetchMedia(uri, getContentResolver().getType(uri));
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #5666 by checking that both the list, and the items into it, are not null before adding (retrieving) them.