### PR TITLE
Fix possible NPE in post uploaded notification

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
@@ -87,8 +87,6 @@ public class PostUploadNotifier {
     public void updateNotificationSuccess(PostModel post, SiteModel site, boolean isFirstTimePublish) {
         AppLog.d(AppLog.T.POSTS, "updateNotificationSuccess");
 
-        NotificationData notificationData = mPostIdToNotificationData.get(post.getId());
-
         // Get the shareableUrl
         String shareableUrl = WPMeShortlinks.getPostShortlink(site, post);
         if (shareableUrl == null && !TextUtils.isEmpty(post.getLink())) {
@@ -104,7 +102,9 @@ public class PostUploadNotifier {
                     .page_updated) : mContext.getResources().getText(R.string.post_updated));
         }
         notificationBuilder.setSmallIcon(android.R.drawable.stat_sys_upload_done);
-        if (notificationData.latestIcon == null) {
+
+        NotificationData notificationData = mPostIdToNotificationData.get(post.getId());
+        if (notificationData == null || notificationData.latestIcon == null) {
             notificationBuilder.setLargeIcon(BitmapFactory.decodeResource(mContext.getApplicationContext()
                     .getResources(),
                     R.mipmap.app_icon));


### PR DESCRIPTION
Fixes #5657.

As far as I can tell the `notificationData` should never be `null` as we set this before dispatching the upload post action. I am curious to if this is a state issue or not, I'd really like to understand how this case occurs. Nevertheless, this check is a good one and should be there in any case.

To test:
* I was able to manually reproduce this crash by setting the `notificationData` to `null` before the `notificationData.latestIcon == null` check. Make sure that doesn't result in a crash now.
