### PR TITLE
Bump Aztec version to v0.5.0-alpha.5

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile 'com.android.support:design:25.1.1'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.+'
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v0.5.0-alpha.4')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v0.5.0-alpha.5')
 }
 
 signing {


### PR DESCRIPTION
Fixes #5656

Bumps the Aztec version in use to v0.5.0-alpha.5

It should fix #5551 the least.
