### PR TITLE
Possible fix to TransactionTooLarge crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -465,7 +465,11 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
         @Override
         public Parcelable saveState() {
             AppLog.d(AppLog.T.NOTIFS, "notifications pager > adapter saveState");
-            return super.saveState();
+            Bundle bundle = (Bundle) super.saveState();
+            // This is a possible solution to https://github.com/wordpress-mobile/WordPress-Android/issues/5456
+            // See https://issuetracker.google.com/issues/37103380#comment77 for more details
+            bundle.putParcelableArray("states", null);
+            return bundle;
         }
 
         boolean isValidPosition(int position) {


### PR DESCRIPTION
Fixes #5456. I have been unable to reproduce this crash no matter how many pages of notifications/reader posts I have browsed. I have tested on both emulator and my Pixel, the state seems to be saved without any issues. Since the report doesn't contain much info, this is just a possible fix. I was inclined to do the same for 
`ReaderPostPagerActivity` in case the issue is happening there, but this might be better to identify the issue. As @maxme mentioned, the issue started after `NotificationDetailFragmentAdapter`, so that should be the first place we test.

To test:
* No idea, since I can't reproduce the issue myself

/cc @maxme 