### PR TITLE
Async Media: Fix duplication when uploading multiple media

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -132,7 +132,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:a6147f4a3eb405497678d47124aeb922d1a8fe6e') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:a26f1cf1ce153f29c6ef5e467bded0003d014953') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -310,7 +310,7 @@ public class MediaUploadService extends Service {
     public void onMediaUploaded(OnMediaUploaded event) {
         // event for unknown media, ignoring
         if (event.media == null) {
-            AppLog.w(AppLog.T.MEDIA, "Media event not recognized: " + event.media);
+            AppLog.w(AppLog.T.MEDIA, "Received media event for null media, ignoring");
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -43,7 +43,7 @@ import javax.inject.Inject;
 public class MediaUploadService extends Service {
     private static final String MEDIA_LIST_KEY = "mediaList";
 
-    private List<MediaModel> mQueue;
+    private List<MediaModel> mUploadQueue;
 
     @Inject Dispatcher mDispatcher;
     @Inject MediaStore mMediaStore;
@@ -71,8 +71,7 @@ public class MediaUploadService extends Service {
 
     @Override
     public void onDestroy() {
-        List<MediaModel> queue = getUploadQueue();
-        for (MediaModel oneUpload : queue) {
+        for (MediaModel oneUpload : mUploadQueue) {
             cancelUpload(oneUpload);
         }
         mDispatcher.unregister(this);
@@ -99,14 +98,6 @@ public class MediaUploadService extends Service {
         uploadNextInQueue();
 
         return START_REDELIVER_INTENT;
-    }
-
-    @NonNull
-    private List<MediaModel> getUploadQueue() {
-        if (mQueue == null) {
-            mQueue = new ArrayList<>();
-        }
-        return mQueue;
     }
 
     private void handleOnMediaUploadedSuccess(@NonNull OnMediaUploaded event) {
@@ -205,14 +196,13 @@ public class MediaUploadService extends Service {
     private void completeUploadWithId(int id) {
         MediaModel media = getMediaFromQueueById(id);
         if (media != null) {
-            getUploadQueue().remove(media);
+            mUploadQueue.remove(media);
             trackUploadMediaEvents(AnalyticsTracker.Stat.MEDIA_UPLOAD_STARTED, media, null);
         }
     }
 
     private MediaModel getMediaFromQueueById(int id) {
-        List<MediaModel> queue = getUploadQueue();
-        for (MediaModel media : queue) {
+        for (MediaModel media : mUploadQueue) {
             if (media.getId() == id)
                 return media;
         }
@@ -220,15 +210,15 @@ public class MediaUploadService extends Service {
     }
 
     private MediaModel getNextMediaToUpload() {
-        if (!getUploadQueue().isEmpty()) {
-            return getUploadQueue().get(0);
+        if (!mUploadQueue.isEmpty()) {
+            return mUploadQueue.get(0);
         }
         return null;
     }
 
     private void addUniqueMediaToQueue(MediaModel media) {
         if (media != null) {
-            for (MediaModel queuedMedia : getUploadQueue()) {
+            for (MediaModel queuedMedia : mUploadQueue) {
                 if (queuedMedia.getLocalSiteId() == media.getLocalSiteId() &&
                         StringUtils.equals(queuedMedia.getFilePath(), media.getFilePath())) {
                     return;
@@ -236,7 +226,7 @@ public class MediaUploadService extends Service {
             }
 
             // no match found in queue
-            getUploadQueue().add(media);
+            mUploadQueue.add(media);
         }
     }
 
@@ -309,7 +299,7 @@ public class MediaUploadService extends Service {
 
     private void stopServiceIfUploadsComplete(){
         AppLog.i(AppLog.T.MEDIA, "Media Upload Service > completed");
-        if (getUploadQueue().size() == 0) {
+        if (mUploadQueue.size() == 0) {
             AppLog.i(AppLog.T.MEDIA, "No more items pending in queue. Stopping MediaUploadService.");
             stopSelf();
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -43,7 +43,8 @@ import javax.inject.Inject;
 public class MediaUploadService extends Service {
     private static final String MEDIA_LIST_KEY = "mediaList";
 
-    private List<MediaModel> mUploadQueue;
+    private List<MediaModel> mPendingUploads = new ArrayList<>();
+    private List<MediaModel> mInProgressUploads = new ArrayList<>();
 
     @Inject Dispatcher mDispatcher;
     @Inject MediaStore mMediaStore;
@@ -71,7 +72,7 @@ public class MediaUploadService extends Service {
 
     @Override
     public void onDestroy() {
-        for (MediaModel oneUpload : mUploadQueue) {
+        for (MediaModel oneUpload : mInProgressUploads) {
             cancelUpload(oneUpload);
         }
         mDispatcher.unregister(this);
@@ -83,7 +84,6 @@ public class MediaUploadService extends Service {
     public IBinder onBind(Intent intent) {
         return null;
     }
-
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
@@ -196,13 +196,13 @@ public class MediaUploadService extends Service {
     private void completeUploadWithId(int id) {
         MediaModel media = getMediaFromQueueById(id);
         if (media != null) {
-            mUploadQueue.remove(media);
+            mInProgressUploads.remove(media);
             trackUploadMediaEvents(AnalyticsTracker.Stat.MEDIA_UPLOAD_STARTED, media, null);
         }
     }
 
     private MediaModel getMediaFromQueueById(int id) {
-        for (MediaModel media : mUploadQueue) {
+        for (MediaModel media : mInProgressUploads) {
             if (media.getId() == id)
                 return media;
         }
@@ -210,23 +210,20 @@ public class MediaUploadService extends Service {
     }
 
     private MediaModel getNextMediaToUpload() {
-        if (!mUploadQueue.isEmpty()) {
-            return mUploadQueue.get(0);
+        if (!mPendingUploads.isEmpty()) {
+            return mPendingUploads.remove(0);
         }
         return null;
     }
 
     private void addUniqueMediaToQueue(MediaModel media) {
         if (media != null) {
-            for (MediaModel queuedMedia : mUploadQueue) {
-                if (queuedMedia.getLocalSiteId() == media.getLocalSiteId() &&
-                        StringUtils.equals(queuedMedia.getFilePath(), media.getFilePath())) {
-                    return;
-                }
+            if (mediaAlreadyQueuedOrUploading(media)) {
+                return;
             }
 
             // no match found in queue
-            mUploadQueue.add(media);
+            mPendingUploads.add(media);
         }
     }
 
@@ -283,6 +280,7 @@ public class MediaUploadService extends Service {
     private void dispatchUploadAction(@NonNull final MediaModel media, @NonNull final SiteModel site) {
         AppLog.i(AppLog.T.MEDIA, "Dispatching upload action for media with local id: " + media.getId() +
                 " and path: " + media.getFilePath());
+        mInProgressUploads.add(media);
         media.setUploadState(UploadState.UPLOADING.name());
         mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));
 
@@ -299,7 +297,7 @@ public class MediaUploadService extends Service {
 
     private void stopServiceIfUploadsComplete(){
         AppLog.i(AppLog.T.MEDIA, "Media Upload Service > completed");
-        if (mUploadQueue.size() == 0) {
+        if (mPendingUploads.isEmpty() && mInProgressUploads.isEmpty()) {
             AppLog.i(AppLog.T.MEDIA, "No more items pending in queue. Stopping MediaUploadService.");
             stopSelf();
         }
@@ -338,5 +336,28 @@ public class MediaUploadService extends Service {
             mediaProperties.putAll(properties);
         }
         AnalyticsTracker.track(stat, mediaProperties);
+    }
+
+    private boolean mediaAlreadyQueuedOrUploading(MediaModel mediaModel) {
+        for (MediaModel queuedMedia : mInProgressUploads) {
+            AppLog.d(AppLog.T.TESTS, "Looking to add media with path " + mediaModel.getFilePath() + " and site id " +
+                    mediaModel.getLocalSiteId() + ". Comparing with " + queuedMedia.getFilePath() + ", " +
+                    queuedMedia.getLocalSiteId());
+            if (queuedMedia.getLocalSiteId() == mediaModel.getLocalSiteId() &&
+                    StringUtils.equals(queuedMedia.getFilePath(), mediaModel.getFilePath())) {
+                return true;
+            }
+        }
+
+        for (MediaModel queuedMedia : mPendingUploads) {
+            AppLog.d(AppLog.T.TESTS, "Looking to add media with path " + mediaModel.getFilePath() + " and site id " +
+                    mediaModel.getLocalSiteId() + ". Comparing with " + queuedMedia.getFilePath() + ", " +
+                    queuedMedia.getLocalSiteId());
+            if (queuedMedia.getLocalSiteId() == mediaModel.getLocalSiteId() &&
+                    StringUtils.equals(queuedMedia.getFilePath(), mediaModel.getFilePath())) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Fixes an issue where duplicate upload events would be dispatched when uploading multiple media.

The issue was caused by `onStartCommand()` triggering an upload for every item in its queue each time a new item was given to the `MediaUploadService`, even when those items were already in-progress.

This PR splits the previous 'queue' into two lists, one for in-progress uploads and one for media that has been sent to the `MediaUploadService` but no upload event has been dispatched for yet.

cc @mzorz