### PR TITLE
Clear the ZWJs from Aztec's title string

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -326,7 +326,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             return "";
         }
 
-        return StringUtils.notNullStr(title.getText().toString().replaceAll("&nbsp;$", ""));
+        // TODO: Aztec returns a ZeroWidthJoiner when empty so, strip it. Aztec needs fixing to return empty string.
+        return StringUtils.notNullStr(title.getText().toString().replaceAll("&nbsp;$", "").replaceAll("\u200B", ""));
     }
 
     @Override


### PR DESCRIPTION
Fixes #5625 

Currently when using `getText()`, Aztec returns a ZWJ (Zero Width Joiner) character when no other text is present in the string. We need to strip the ZWJ in order to check whether the post title field is really empty or not.

Note: the content field doesn't have that problem because Aztec automatically strips the ZWJ to return the _html_ content. 

To test:
* While having proper connectivity, create a new post but don't write anything in the title or content field
* Exit the editor back to the posts list
* Notice that the post gets discarded (silently) and nothing gets uploaded as draft
