### PR TITLE
Null checking MIME type before invoking method

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -129,7 +129,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
 
         boolean isLocalFile = MediaUtils.isLocalFile(strState) && !TextUtils.isEmpty(media.getFilePath());
         boolean isSelected = isItemSelected(media.getId());
-        boolean isImage = media.getMimeType().startsWith("image/");
+        boolean isImage = media.getMimeType() != null && media.getMimeType().startsWith("image/");
 
         if (isImage) {
             holder.fileContainer.setVisibility(View.GONE);


### PR DESCRIPTION
Fixes #5712 

To test:
I explicitly set the MIME type to null before running since I couldn't get it to reproduce naturally.

* Go to media browser on a site with some media and make sure it doesn't crash