### PR TITLE
Return the html editor's content if in html mode

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -433,7 +433,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             return "";
         }
 
-        return content.toHtml(false);
+        if (content.getVisibility() == View.VISIBLE) {
+            return content.toHtml(false);
+        } else {
+            return source.getPureHtml(false);
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #5685 

When in html mode, need to return the html editor's content rather than the visual editor's

To test:
1. Type something in the visual mode
2. Switch to HTML mode
3. Change the text
4. Tap back to exit the editor (without switching to the visual mode)
5. Open the post again
6. Notice the changes made in HTML mode are preserved
