### PR TITLE
Fix unauthenticated post view for custom domains

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -132,7 +132,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:a6147f4a3eb405497678d47124aeb922d1a8fe6e') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:37205a24a937b606e39f1a1e6f5d5b0c9b570cb9') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -205,6 +205,8 @@ public class ActivityLauncher {
 
         // always add the preview parameter to avoid bumping stats when viewing posts
         String url = UrlUtils.appendUrlParameter(post.getLink(), "preview", "true");
+        // Custom domains are not properly authenticated due to a server side(?) issue, so this gets around that
+        url = url.replace(site.getUrl(), site.getUnmappedUrl());
         String shareableUrl = post.getLink();
         String shareSubject = post.getTitle();
         if (site.isWPCom()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -205,11 +205,13 @@ public class ActivityLauncher {
 
         // always add the preview parameter to avoid bumping stats when viewing posts
         String url = UrlUtils.appendUrlParameter(post.getLink(), "preview", "true");
-        // Custom domains are not properly authenticated due to a server side(?) issue, so this gets around that
-        url = url.replace(site.getUrl(), site.getUnmappedUrl());
         String shareableUrl = post.getLink();
         String shareSubject = post.getTitle();
         if (site.isWPCom()) {
+            if (!TextUtils.isEmpty(site.getUnmappedUrl())) {
+                // Custom domains are not properly authenticated due to a server side(?) issue, so this gets around that
+                url = url.replace(site.getUrl(), site.getUnmappedUrl());
+            }
             WPWebViewActivity.openPostUrlByUsingGlobalWPCOMCredentials(context, url, shareableUrl, shareSubject);
         } else if (site.isJetpackConnected()) {
             WPWebViewActivity.openJetpackBlogPostPreview(context, url, shareableUrl, shareSubject, site.getFrameNonce());


### PR DESCRIPTION
Fixes #5326. This PR updates the Fluxc hash and adds a workaround for custom domains by replacing their url with the unmapped url so we can properly authenticate them in the webview. This is somewhat a hack, but a simple one and we have not yet been able to fix it in server side. /cc @astralbodies 

To test:
* Go into the post list for a site with custom domain
* Try to view a post before the change. You should see a login page. After the change the site should load properly and you should be authenticated.