### PR TITLE
Restore state and null check to prevent crash returning to post preview

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -97,8 +97,7 @@ public class PostPreviewActivity extends AppCompatActivity {
         EventBus.getDefault().register(this);
         mDispatcher.register(this);
 
-        mPost = mPostStore.getPostByLocalPostId(mPost.getId());
-        if (mPost == null) {
+        if (mPost == null || (mPost = mPostStore.getPostByLocalPostId(mPost.getId())) == null) {
             finish();
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -25,6 +25,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.model.PostsModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.store.PostStore;
@@ -147,6 +148,17 @@ public class PostPreviewActivity extends AppCompatActivity {
                 fragment.setPost(mPost);
                 fragment.refreshPreview();
             }
+        }
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Bundle savedState) {
+        super.onRestoreInstanceState(savedState);
+        if (savedState.containsKey(WordPress.SITE)) {
+            mSite = (SiteModel) savedState.getSerializable(WordPress.SITE);
+        }
+        if (savedState.containsKey(EXTRA_POST)) {
+            mPost = (PostModel) savedState.getSerializable(EXTRA_POST);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -81,7 +81,7 @@ public class PostPreviewActivity extends AppCompatActivity {
         } else {
             mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
         }
-        if (mSite == null) {
+        if (mSite == null || mPost == null) {
             ToastUtils.showToast(this, R.string.blog_not_found, ToastUtils.Duration.SHORT);
             finish();
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -97,11 +97,11 @@ public class PostPreviewActivity extends AppCompatActivity {
         EventBus.getDefault().register(this);
         mDispatcher.register(this);
 
+        mPost = mPostStore.getPostByLocalPostId(mPost.getId());
         if (mPost == null) {
             finish();
             return;
         }
-        mPost = mPostStore.getPostByLocalPostId(mPost.getId());
         if (hasPreviewFragment()) {
             refreshPreview();
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -98,6 +98,10 @@ public class PostPreviewActivity extends AppCompatActivity {
         EventBus.getDefault().register(this);
         mDispatcher.register(this);
 
+        if (mPost == null) {
+            finish();
+            return;
+        }
         mPost = mPostStore.getPostByLocalPostId(mPost.getId());
         if (hasPreviewFragment()) {
             refreshPreview();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -25,7 +25,6 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.model.PostModel;
-import org.wordpress.android.fluxc.model.PostsModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.store.PostStore;
@@ -152,17 +151,6 @@ public class PostPreviewActivity extends AppCompatActivity {
                 fragment.setPost(mPost);
                 fragment.refreshPreview();
             }
-        }
-    }
-
-    @Override
-    protected void onRestoreInstanceState(Bundle savedState) {
-        super.onRestoreInstanceState(savedState);
-        if (savedState.containsKey(WordPress.SITE)) {
-            mSite = (SiteModel) savedState.getSerializable(WordPress.SITE);
-        }
-        if (savedState.containsKey(EXTRA_POST)) {
-            mPost = (PostModel) savedState.getSerializable(EXTRA_POST);
         }
     }
 


### PR DESCRIPTION
Fixes #5702 

`onRestoreInstanceState` wasn't implemented so the post and site were never restored. I've added that overload and included a null check at the crashing line just in case.

To test:
* Make a local draft
* Preview it
* Rotate, background, etc... and restore
* Verify no crashes