### PR TITLE
Remove payloads as class members in NewUserFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SmartLockHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SmartLockHelper.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.IntentSender;
 import android.net.Uri;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentActivity;
 
 import com.google.android.gms.auth.api.Auth;
@@ -104,7 +105,7 @@ public class SmartLockHelper {
 
 
     public void saveCredentialsInSmartLock(@NonNull final String username, @NonNull final String password,
-                                           @NonNull final String displayName, @NonNull final Uri profilePicture) {
+                                           @NonNull final String displayName, @Nullable final Uri profilePicture) {
         Activity activity = getActivityAndCheckAvailability();
         if (activity == null || mCredentialsClient == null || !mCredentialsClient.isConnected()) {
             return;


### PR DESCRIPTION
Fixes #5665 and fixes #5658

Use the EditText directly so we don't we won't get an unknown state in the middle of a user creation.

Also found this https://github.com/wordpress-mobile/WordPress-Android/issues/5717 while testing.

To test:
* Before the patch, create a new user, rotate the screen just after the validation steps, wait and 💥
* After the patch, create a new user, rotate the screen just after the validation steps, wait and 🍺

I wish the user/site creation network call was atomic...

cc @mzorz (can be merged in 7.2 if you think it's not too late).