### PR TITLE
issue/5674-is-valid-position

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -283,6 +283,9 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                 @Override
                 public void onClick(View v) {
                     int position = getAdapterPosition();
+                    if (!isValidPosition(position)) {
+                        return;
+                    }
                     if (isInMultiSelect()) {
                         if (canSelectPosition(position)) {
                             toggleItemSelected(GridViewHolder.this, position);


### PR DESCRIPTION
Fixes #5674 - adds an `isValidPosition()` check after the state TextView is tapped on a media item.