### PR TITLE
feature/media-preview-share

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -529,7 +529,7 @@ public class MediaPreviewActivity extends AppCompatActivity {
             intent.putExtra(Intent.EXTRA_SUBJECT, media.getDescription());
         }
         try {
-            startActivity(Intent.createChooser(intent, getString(R.string.reader_share_link)));
+            startActivity(Intent.createChooser(intent, getString(R.string.share_link)));
         } catch (android.content.ActivityNotFoundException ex) {
             ToastUtils.showToast(this, R.string.reader_toast_err_share_intent);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -263,19 +263,18 @@ public class MediaPreviewActivity extends AppCompatActivity {
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        // enable editing metadata if we have a valid site
-        if (mEnableMetadata && mSite != null) {
-            getMenuInflater().inflate(R.menu.media_edit, menu);
-        }
+        getMenuInflater().inflate(R.menu.media_preview, menu);
         return super.onCreateOptionsMenu(menu);
     }
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
         MenuItem mnuEdit = menu.findItem(R.id.menu_edit);
-        if (mnuEdit != null) {
-            mnuEdit.setVisible(mShowEditMenuItem);
-        }
+        mnuEdit.setVisible(mShowEditMenuItem);
+
+        MenuItem mnuShare = menu.findItem(R.id.menu_share);
+        mnuShare.setVisible(mMediaId != 0);
+
         return super.onPrepareOptionsMenu(menu);
     }
 
@@ -292,6 +291,8 @@ public class MediaPreviewActivity extends AppCompatActivity {
         } else if (item.getItemId() == R.id.menu_edit) {
             showEditFragment(mMediaId);
             return true;
+        } else if (item.getItemId() == R.id.menu_share) {
+            shareMedia();
         }
 
         return super.onOptionsItemSelected(item);
@@ -509,6 +510,28 @@ public class MediaPreviewActivity extends AppCompatActivity {
     private void setLookClosable(boolean lookClosable) {
         if (mToolbar != null) {
             mToolbar.setNavigationIcon(lookClosable ? R.drawable.ic_close_white_24dp : R.drawable.ic_arrow_left_white_24dp);
+        }
+    }
+
+    private void shareMedia() {
+        MediaModel media = mMediaStore.getMediaWithLocalId(mMediaId);
+        if (media == null) {
+            ToastUtils.showToast(this, R.string.error_media_not_found);
+            return;
+        }
+
+        Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.setType("text/plain");
+        intent.putExtra(Intent.EXTRA_TEXT, media.getUrl());
+        if (!TextUtils.isEmpty(media.getTitle())) {
+            intent.putExtra(Intent.EXTRA_SUBJECT, media.getTitle());
+        } else if (!TextUtils.isEmpty(media.getDescription())) {
+            intent.putExtra(Intent.EXTRA_SUBJECT, media.getDescription());
+        }
+        try {
+            startActivity(Intent.createChooser(intent, getString(R.string.reader_share_link)));
+        } catch (android.content.ActivityNotFoundException ex) {
+            ToastUtils.showToast(this, R.string.reader_toast_err_share_intent);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -457,7 +457,7 @@ public class ReaderPostDetailFragment extends Fragment
         intent.putExtra(Intent.EXTRA_TEXT, url);
         intent.putExtra(Intent.EXTRA_SUBJECT, mPost.getTitle());
         try {
-            startActivity(Intent.createChooser(intent, getString(R.string.reader_share_link)));
+            startActivity(Intent.createChooser(intent, getString(R.string.share_link)));
         } catch (android.content.ActivityNotFoundException ex) {
             ToastUtils.showToast(getActivity(), R.string.reader_toast_err_share_intent);
         }

--- a/WordPress/src/main/res/menu/media_preview.xml
+++ b/WordPress/src/main/res/menu/media_preview.xml
@@ -10,6 +10,6 @@
     <item
         android:id="@+id/menu_share"
         android:icon="@drawable/ic_share_24dp"
-        android:title="@string/edit"
+        android:title="@string/share_link"
         app:showAsAction="ifRoom" />
 </menu>

--- a/WordPress/src/main/res/menu/media_preview.xml
+++ b/WordPress/src/main/res/menu/media_preview.xml
@@ -6,4 +6,10 @@
         android:icon="@drawable/ab_icon_edit"
         android:title="@string/edit"
         app:showAsAction="always" />
+
+    <item
+        android:id="@+id/menu_share"
+        android:icon="@drawable/ic_share_24dp"
+        android:title="@string/edit"
+        app:showAsAction="ifRoom" />
 </menu>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1183,9 +1183,6 @@
     <string name="reader_followed_default_tag">Followed Sites</string>
     <string name="reader_liked_default_tag">Posts I Like</string>
 
-    <!-- share dialog title when sharing a reader url -->
-    <string name="reader_share_link">Share link</string>
-
     <!-- menu text -->
     <string name="reader_menu_tags">Edit tags and blogs</string>
     <string name="reader_menu_block_blog">Block this blog</string>


### PR DESCRIPTION
In #5640 we redid the media preview screen, which dropped the "Copy to clipboard" feature which enabled copying the media URL to the clipboard to share it elsewhere.

In #5337 we decided that feature should be replaced with a standard Share icon to share the URL. This PR adds that ability.

Note: In the future we may want to share the actual image, but for now we're only sharing the URL.