### PR TITLE
issue/5731-wpmedia-no-blog-on-rotate

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
@@ -158,6 +158,7 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
         outState.putIntArray(STATE_SELECTED_ITEMS, ListUtils.toIntArray(mGridAdapter.getSelectedItems()));
         outState.putLongArray(STATE_FILTERED_ITEMS, ListUtils.toLongArray(mFilteredItems));
         outState.putBoolean(STATE_IS_SELECT_ONE_ITEM, mIsSelectOneItem);
+        outState.putSerializable(WordPress.SITE, mSite);
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
Fixes #5731 - the WP media picker wasn't saving the site in `onSaveInstanceState()`, which was causing a "blog not found" toast when the device is rotated.
