### PR TITLE
New Aztec beta release

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile 'com.android.support:design:25.1.1'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.+'
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:develop-SNAPSHOT')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.0-beta')
 }
 
 signing {


### PR DESCRIPTION
Updated Aztec library version to [v1.0-beta](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.0-beta).