### PR TITLE
Workaround: Authenticated wpcom url by using unmapped url

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -208,10 +208,6 @@ public class ActivityLauncher {
         String shareableUrl = post.getLink();
         String shareSubject = post.getTitle();
         if (site.isWPCom()) {
-            if (!TextUtils.isEmpty(site.getUnmappedUrl())) {
-                // Custom domains are not properly authenticated due to a server side(?) issue, so this gets around that
-                url = url.replace(site.getUrl(), site.getUnmappedUrl());
-            }
             WPWebViewActivity.openPostUrlByUsingGlobalWPCOMCredentials(context, url, shareableUrl, shareSubject);
         } else if (site.isJetpackConnected()) {
             WPWebViewActivity.openJetpackBlogPostPreview(context, url, shareableUrl, shareSubject, site.getFrameNonce());

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -18,7 +18,6 @@ import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
-import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
@@ -32,6 +31,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -289,10 +289,13 @@ public class WPWebViewActivity extends WebViewActivity {
             username = mAccountStore.getAccount().getUserName();
 
             // Custom domains are not properly authenticated due to a server side(?) issue, so this gets around that
-            int siteLocalId = AppPrefs.getSelectedSite();
-            SiteModel selectedSite = mSiteStore.getSiteByLocalId(siteLocalId);
-            if (selectedSite != null && selectedSite.isWPCom() && !TextUtils.isEmpty(selectedSite.getUnmappedUrl())) {
-                addressToLoad = addressToLoad.replace(selectedSite.getUrl(), selectedSite.getUnmappedUrl());
+            List<SiteModel> wpComSites = mSiteStore.getWPComSites();
+            for (SiteModel siteModel : wpComSites) {
+                // Only replace the url if we know the unmapped url and if it's a custom domain
+                if (!TextUtils.isEmpty(siteModel.getUnmappedUrl())
+                        && !siteModel.getUrl().contains("wordpress.com")) {
+                    addressToLoad = addressToLoad.replace(siteModel.getUrl(), siteModel.getUnmappedUrl());
+                }
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -289,12 +289,14 @@ public class WPWebViewActivity extends WebViewActivity {
             username = mAccountStore.getAccount().getUserName();
 
             // Custom domains are not properly authenticated due to a server side(?) issue, so this gets around that
-            List<SiteModel> wpComSites = mSiteStore.getWPComSites();
-            for (SiteModel siteModel : wpComSites) {
-                // Only replace the url if we know the unmapped url and if it's a custom domain
-                if (!TextUtils.isEmpty(siteModel.getUnmappedUrl())
-                        && !siteModel.getUrl().contains("wordpress.com")) {
-                    addressToLoad = addressToLoad.replace(siteModel.getUrl(), siteModel.getUnmappedUrl());
+            if (!addressToLoad.contains(".wordpress.com")) {
+                List<SiteModel> wpComSites = mSiteStore.getWPComSites();
+                for (SiteModel siteModel : wpComSites) {
+                    // Only replace the url if we know the unmapped url and if it's a custom domain
+                    if (!TextUtils.isEmpty(siteModel.getUnmappedUrl())
+                            && !siteModel.getUrl().contains(".wordpress.com")) {
+                        addressToLoad = addressToLoad.replace(siteModel.getUrl(), siteModel.getUnmappedUrl());
+                    }
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -26,7 +26,6 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.datasets.ReaderLikeTable;
 import org.wordpress.android.datasets.ReaderPostTable;
-import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.ReaderPost;
@@ -301,12 +300,7 @@ public class ReaderPostDetailFragment extends Fragment
         int i = item.getItemId();
         if (i == R.id.menu_browse) {
             if (hasPost()) {
-                String url = mPost.getUrl();
-                SiteModel siteModel = mSiteStore.getSiteBySiteId(mPost.blogId);
-                if (siteModel != null && siteModel.isWPCom() && !TextUtils.isEmpty(siteModel.getUnmappedUrl())) {
-                    url = url.replace(siteModel.getUrl(), siteModel.getUnmappedUrl());
-                }
-                ReaderActivityLauncher.openUrl(getActivity(), url, OpenUrlType.EXTERNAL);
+                ReaderActivityLauncher.openUrl(getActivity(), mPost.getUrl(), OpenUrlType.EXTERNAL);
             } else if (mInterceptedUri != null) {
                 AnalyticsUtils.trackWithInterceptedUri(AnalyticsTracker.Stat.DEEP_LINKED_FALLBACK, mInterceptedUri);
                 ReaderActivityLauncher.openUrl(getActivity(), mInterceptedUri, OpenUrlType.EXTERNAL);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -26,6 +26,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.datasets.ReaderLikeTable;
 import org.wordpress.android.datasets.ReaderPostTable;
+import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.ReaderPost;
@@ -300,7 +301,12 @@ public class ReaderPostDetailFragment extends Fragment
         int i = item.getItemId();
         if (i == R.id.menu_browse) {
             if (hasPost()) {
-                ReaderActivityLauncher.openUrl(getActivity(), mPost.getUrl(), OpenUrlType.EXTERNAL);
+                String url = mPost.getUrl();
+                SiteModel siteModel = mSiteStore.getSiteBySiteId(mPost.blogId);
+                if (siteModel != null && siteModel.isWPCom() && !TextUtils.isEmpty(siteModel.getUnmappedUrl())) {
+                    url = url.replace(siteModel.getUrl(), siteModel.getUnmappedUrl());
+                }
+                ReaderActivityLauncher.openUrl(getActivity(), url, OpenUrlType.EXTERNAL);
             } else if (mInterceptedUri != null) {
                 AnalyticsUtils.trackWithInterceptedUri(AnalyticsTracker.Stat.DEEP_LINKED_FALLBACK, mInterceptedUri);
                 ReaderActivityLauncher.openUrl(getActivity(), mInterceptedUri, OpenUrlType.EXTERNAL);


### PR DESCRIPTION
Fixes #5734. @aforcier This turned out to be both much trickier and easier than I expected. The problem is, the open url calls are all over the place and especially in reader, it's a little messy since there are a bunch of middle methods. However, the only way we can use the `unmapped_url` is if it's in the `SiteStore` which will be the case in most situations if the user is opening a url from their selected blog. Most other blogs won't be in the store, unless they are following their own blogs in their reader.

The following change seemed to make the most sense to me. It's changing the url to unmapped one just before loading it, if it's a url from the selected site. This actually eliminates the need for https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java#L211-L214 and I think we should remove it, but I wanted to ask your opinion first.

I also changed a reader method to try to use the unmapped url, but I think it's unlikely to actually work.

What do you think about this approach?
