### PR TITLE
issue/5739-media-detail-small-pics

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -313,7 +313,7 @@ public class MediaPreviewActivity extends AppCompatActivity {
                 public void onResponse(ImageLoader.ImageContainer response, boolean isImmediate) {
                     if (!isFinishing() && response.getBitmap() != null) {
                         showProgress(false);
-                        mImageView.setImageBitmap(response.getBitmap());
+                        setBitmap(response.getBitmap());
                     }
                 }
                 @Override
@@ -334,14 +334,17 @@ public class MediaPreviewActivity extends AppCompatActivity {
 
             Bitmap bmp = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
             if (bmp != null) {
-                mImageView.setImageBitmap(bmp);
+                setBitmap(bmp);
             } else {
                 delayedFinish(true);
                 return;
             }
         }
+    }
 
-        // assign the photo attacher to enable pinch/zoom
+    private void setBitmap(@NonNull Bitmap bmp) {
+        // assign the photo attacher to enable pinch/zoom - must come before setImageBitmap
+        // for it to be correctly resized upon loading
         PhotoViewAttacher attacher = new PhotoViewAttacher(mImageView);
 
         // fade in metadata when tapped
@@ -355,6 +358,8 @@ public class MediaPreviewActivity extends AppCompatActivity {
                 }
             });
         }
+
+        mImageView.setImageBitmap(bmp);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -304,10 +304,11 @@ public class MediaPreviewActivity extends AppCompatActivity {
     private void loadImage(@NonNull String mediaUri) {
         int width = DisplayUtils.getDisplayPixelWidth(this);
         int height = DisplayUtils.getDisplayPixelHeight(this);
+        int size = Math.max(width, height);
 
         if (mediaUri.startsWith("http")) {
             showProgress(true);
-            String imageUrl = PhotonUtils.getPhotonImageUrl(mediaUri, width, height);
+            String imageUrl = PhotonUtils.getPhotonImageUrl(mediaUri, size, 0);
             mImageLoader.get(imageUrl, new ImageLoader.ImageListener() {
                 @Override
                 public void onResponse(ImageLoader.ImageContainer response, boolean isImmediate) {
@@ -324,9 +325,9 @@ public class MediaPreviewActivity extends AppCompatActivity {
                         delayedFinish(true);
                     }
                 }
-            }, width, height);
+            }, size, 0);
         } else {
-            byte[] bytes = ImageUtils.createThumbnailFromUri(this, Uri.parse(mediaUri), width, null, 0);
+            byte[] bytes = ImageUtils.createThumbnailFromUri(this, Uri.parse(mediaUri), size, null, 0);
             if (bytes == null) {
                 delayedFinish(true);
                 return;


### PR DESCRIPTION
Fixes #5739 and #5740 - problems were caused primarily by assigning the `PhotoViewAttacher` after the image was loaded.

To test, open the WP Media Browser and tap on a very small photo (one much smaller than the pixel width of the display). Prior to this fix, the photo would appear at the top left of the screen.

Next, tap on a landscape photo and ensure it's not cropped in the preview.

Before and after shots below:

![before](https://cloud.githubusercontent.com/assets/3903757/25398502/5a8cf1fa-29ba-11e7-8a1a-742a467cb81c.png)

