### PR TITLE
Fix NPE launching camera

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
@@ -167,6 +167,10 @@ public class WordPressMediaUtils {
         } catch (IllegalArgumentException e) {
             AppLog.e(T.MEDIA, "Cannot access the file planned to store the new media", e);
             throw new IOException("Cannot access the file planned to store the new media");
+        } catch (NullPointerException e) {
+            AppLog.e(T.MEDIA, "Cannot access the file planned to store the new media - " +
+                    "FileProvider.getUriForFile cannot find a valid provider for the authority: " + applicationId + ".provider", e);
+            throw new IOException("Cannot access the file planned to store the new media");
         }
 
         Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);


### PR DESCRIPTION
Fixes #5700 by catching the null pointer exception thrown by `android.support.v4.content.FileProvider.getUriForFile`

It seems that the `parsePathStrategy` routine here https://android.googlesource.com/platform/frameworks/support/+/android-support-lib-19.1.0/v4/java/android/support/v4/content/FileProvider.java#559, internally used by `getUriForFile`, doesn't check wether the `ProviderInfo` object (containing information about the provider) is null or null. 

`resolveContentProvider(authority, PackageManager.GET_META_DATA);` can return `null` if a provider was not found. In any case this is weird, since we correctly declare the provider in the manifest of the app. 
