### PR TITLE
Prevent SignInActivity getting pushed on Stack twice

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -641,7 +641,9 @@ public class WPMainActivity extends AppCompatActivity {
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onAccountChanged(OnAccountChanged event) {
         // Sign-out is handled in `handleSiteRemoved`, no need to show the `SignInActivity` here
-        mTabLayout.showNoteBadge(mAccountStore.getAccount().getHasUnseenNotes());
+        if (mAccountStore.hasAccessToken()) {
+            mTabLayout.showNoteBadge(mAccountStore.getAccount().getHasUnseenNotes());
+        }
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -640,11 +640,7 @@ public class WPMainActivity extends AppCompatActivity {
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onAccountChanged(OnAccountChanged event) {
-        if (!FluxCUtils.isSignedInWPComOrHasWPOrgSite(mAccountStore, mSiteStore)) {
-            // User signed out
-            resetFragments();
-            ActivityLauncher.showSignInForResult(this);
-        }
+        // Sign-out is handled in `handleSiteRemoved`, no need to show the `SignInActivity` here
         mTabLayout.showNoteBadge(mAccountStore.getAccount().getHasUnseenNotes());
     }
 
@@ -677,6 +673,8 @@ public class WPMainActivity extends AppCompatActivity {
 
     private void handleSiteRemoved() {
         if (!FluxCUtils.isSignedInWPComOrHasWPOrgSite(mAccountStore, mSiteStore)) {
+            // User signed-out or removed the last self-hosted site, show `SignInActivity`
+            resetFragments();
             ActivityLauncher.showSignInForResult(this);
         } else {
             SiteModel site = getSelectedSite();


### PR DESCRIPTION
Fixes #5717. Since the `onSiteRemoved` should be called for both .com and self-hosted sites, I think it's better to handle the sign-out actions there. I've added some comments to explain this a bit in code.

I've also added a check for updating the note check. It's a really small change, so I didn't want to open a new PR for it.

To test:
* Put a breakpoint to `SignInActivity.onCreate` and make sure it's getting called only once when you logout/remove all sites.