### PR TITLE
Issue/5611 aztec wordpress media

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -489,6 +489,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             mActionStartedAt = System.currentTimeMillis();
         } else {
             String localMediaId = String.valueOf(mediaFile.getId());
+
             if (mediaFile.isVideo()) {
                 // TODO: insert local video
                 ToastUtils.showToast(getActivity(), R.string.media_insert_unimplemented);
@@ -501,7 +502,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 // load a scaled version of the image to prevent OOM exception
                 int maxWidth = DisplayUtils.getDisplayPixelWidth(getActivity());
                 Bitmap bitmapToShow = ImageUtils.getWPImageSpanThumbnailFromFilePath(getActivity(), safeMediaUrl, maxWidth);
-               if (bitmapToShow != null) {
+
+                if (bitmapToShow != null) {
                     content.insertMedia(new BitmapDrawable(getResources(), bitmapToShow), attrs);
                 } else {
                     // Use a placeholder

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -506,11 +506,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 if (bitmapToShow != null) {
                     content.insertMedia(new BitmapDrawable(getResources(), bitmapToShow), attrs);
                 } else {
-                    // Use a placeholder
+                    // Failed to retrieve bitmap.  Show failed placeholder.
                     ToastUtils.showToast(getActivity(), R.string.error_media_load);
-                    Drawable d = getResources().getDrawable(R.drawable.ic_gridicons_image);
-                    d.setBounds(0, 0, maxWidth, maxWidth);
-                    content.insertMedia(d, attrs);
+                    Drawable drawable = getResources().getDrawable(R.drawable.ic_image_failed_grey_a_40_48dp);
+                    drawable.setBounds(0, 0, maxWidth, maxWidth);
+                    content.insertMedia(drawable, attrs);
                 }
 
                 // set intermediate shade overlay

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -83,7 +83,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     private static final String TEMP_IMAGE_ID = "data-temp-aztec-id";
 
-    private static final int MIN_BITMAP_WIDTH = 200;
+    private static final int MIN_BITMAP_DIMENSION_DP = 48;
 
     public static final int MAX_ACTION_TIME_MS = 2000;
 
@@ -478,7 +478,9 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                         AztecAttributes attrs = new AztecAttributes();
                         attrs.setValue("src", mediaUrl);
 
-                        if (downloadedBitmap.getWidth() < MIN_BITMAP_WIDTH) {
+                        int minimumDimension = DisplayUtils.dpToPx(getActivity(), MIN_BITMAP_DIMENSION_DP);
+
+                        if (downloadedBitmap.getHeight() < minimumDimension || downloadedBitmap.getWidth() < minimumDimension) {
                             // Bitmap is too small.  Show image placeholder.
                             ToastUtils.showToast(getActivity(), R.string.error_media_small);
                             Drawable drawable = getResources().getDrawable(R.drawable.ic_image_loading_grey_a_40_48dp);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1022,86 +1022,87 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         super.onActivityResult(requestCode, resultCode, data);
 
         if (requestCode == ImageSettingsDialogFragment.IMAGE_SETTINGS_DIALOG_REQUEST_CODE) {
-            if (data == null || data.getExtras() == null && tappedImagePredicate != null) {
-                return;
-            }
+            if (tappedImagePredicate != null) {
+                AztecAttributes attributes = content.getElementAttributes(tappedImagePredicate);
+                attributes.removeAttribute(TEMP_IMAGE_ID);
 
-            Bundle extras = data.getExtras();
-            JSONObject meta;
-            try {
-                meta = new JSONObject(StringUtils.notNullStr(extras.getString("imageMeta")));
-            } catch (JSONException e) {
-                // ignore errors
-                return;
-            }
+                content.updateElementAttributes(tappedImagePredicate, attributes);
 
-            AztecAttributes attributes = content.getElementAttributes(tappedImagePredicate);
+                if (data == null || data.getExtras() == null) {
+                    return;
+                }
 
-            // set image properties
-            attributes.setValue("src", JSONUtils.getString(meta, "src"));
+                Bundle extras = data.getExtras();
+                JSONObject meta;
 
-            if (!TextUtils.isEmpty(JSONUtils.getString(meta, "title"))) {
-                attributes.setValue("title", JSONUtils.getString(meta, "title"));
-            }
+                try {
+                    meta = new JSONObject(StringUtils.notNullStr(extras.getString("imageMeta")));
+                } catch (JSONException e) {
+                    // ignore errors
+                    return;
+                }
 
-            attributes.setValue("width", JSONUtils.getString(meta, "width"));
-            attributes.setValue("height", JSONUtils.getString(meta, "height"));
+                // set image properties
+                attributes.setValue("src", JSONUtils.getString(meta, "src"));
 
-            if (!TextUtils.isEmpty(JSONUtils.getString(meta, "alt"))) {
-                attributes.setValue("alt", JSONUtils.getString(meta, "alt"));
-            }
+                if (!TextUtils.isEmpty(JSONUtils.getString(meta, "title"))) {
+                    attributes.setValue("title", JSONUtils.getString(meta, "title"));
+                }
 
-            AttributesWithClass attributesWithClass = new AttributesWithClass(attributes);
+                attributes.setValue("width", JSONUtils.getString(meta, "width"));
+                attributes.setValue("height", JSONUtils.getString(meta, "height"));
 
-            // remove previously set properties
-            attributesWithClass.removeClassStartingWith("align-");
-            attributesWithClass.removeClassStartingWith("size-");
-            attributesWithClass.removeClassStartingWith("wp-image-");
+                if (!TextUtils.isEmpty(JSONUtils.getString(meta, "alt"))) {
+                    attributes.setValue("alt", JSONUtils.getString(meta, "alt"));
+                }
 
-            // only assign the align class to the image if we're not printing
-            // a caption, since the alignment is sent to the shortcode
-            if (!TextUtils.isEmpty(JSONUtils.getString(meta, "align")) &&
-                    TextUtils.isEmpty(JSONUtils.getString(meta, "caption"))) {
-                attributesWithClass.addClass("align-" + JSONUtils.getString(meta, "align"));
-            }
+                AttributesWithClass attributesWithClass = new AttributesWithClass(attributes);
 
-            if (!TextUtils.isEmpty(JSONUtils.getString(meta, "size"))) {
-                attributesWithClass.addClass("size-" + JSONUtils.getString(meta, "size"));
-            }
+                // remove previously set properties
+                attributesWithClass.removeClassStartingWith("align-");
+                attributesWithClass.removeClassStartingWith("size-");
+                attributesWithClass.removeClassStartingWith("wp-image-");
 
-            if (!TextUtils.isEmpty(JSONUtils.getString(meta, "attachment_id"))) {
-                attributesWithClass.addClass("wp-image-" + JSONUtils.getString(meta, "attachment_id"));
-            }
+                // only assign the align class to the image if we're not printing
+                // a caption, since the alignment is sent to the shortcode
+                if (!TextUtils.isEmpty(JSONUtils.getString(meta, "align")) &&
+                        TextUtils.isEmpty(JSONUtils.getString(meta, "caption"))) {
+                    attributesWithClass.addClass("align-" + JSONUtils.getString(meta, "align"));
+                }
 
-            AztecAttributes attrs = attributesWithClass.getAttributes();
-            attrs.removeAttribute(TEMP_IMAGE_ID);
+                if (!TextUtils.isEmpty(JSONUtils.getString(meta, "size"))) {
+                    attributesWithClass.addClass("size-" + JSONUtils.getString(meta, "size"));
+                }
 
-            content.updateElementAttributes(tappedImagePredicate, attrs);
+                if (!TextUtils.isEmpty(JSONUtils.getString(meta, "attachment_id"))) {
+                    attributesWithClass.addClass("wp-image-" + JSONUtils.getString(meta, "attachment_id"));
+                }
 
-            // captions required shortcode support
+                // captions required shortcode support
 //            String caption = JSONUtils.getString(meta, "caption");
 
-            // there is an issue with having an image inside a link
-            // https://github.com/wordpress-mobile/AztecEditor-Android/issues/196
+                // there is an issue with having an image inside a link
+                // https://github.com/wordpress-mobile/AztecEditor-Android/issues/196
 //            String link = JSONUtils.getString(meta, "linkUrl");
 
-            final int imageRemoteId = extras.getInt("imageRemoteId");
-            final boolean isFeaturedImage = extras.getBoolean("isFeatured");
+                final int imageRemoteId = extras.getInt("imageRemoteId");
+                final boolean isFeaturedImage = extras.getBoolean("isFeatured");
 
-            if (imageRemoteId != 0) {
-                if (isFeaturedImage) {
-                    mFeaturedImageId = imageRemoteId;
-                    mEditorFragmentListener.onFeaturedImageChanged(mFeaturedImageId);
-                } else {
-                    // If this image was unset as featured, clear the featured image id
-                    if (mFeaturedImageId == imageRemoteId) {
-                        mFeaturedImageId = 0;
+                if (imageRemoteId != 0) {
+                    if (isFeaturedImage) {
+                        mFeaturedImageId = imageRemoteId;
                         mEditorFragmentListener.onFeaturedImageChanged(mFeaturedImageId);
+                    } else {
+                        // If this image was unset as featured, clear the featured image id
+                        if (mFeaturedImageId == imageRemoteId) {
+                            mFeaturedImageId = 0;
+                            mEditorFragmentListener.onFeaturedImageChanged(mFeaturedImageId);
+                        }
                     }
                 }
-            }
 
-            tappedImagePredicate = null;
+                tappedImagePredicate = null;
+            }
         }
     }
 }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -480,7 +480,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
                         if (downloadedBitmap.getWidth() < MIN_BITMAP_WIDTH) {
                             // Bitmap is too small.  Show image placeholder.
-                            ToastUtils.showToast(getActivity(), R.string.error_media_load);
+                            ToastUtils.showToast(getActivity(), R.string.error_media_small);
                             Drawable drawable = getResources().getDrawable(R.drawable.ic_image_loading_grey_a_40_48dp);
                             content.insertMedia(drawable, attrs);
                             return;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -109,7 +109,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     private long mActionStartedAt = -1;
 
-    private ImagePredicate tappedImagePredicate;
+    private ImagePredicate mTappedImagePredicate;
 
     public static AztecEditorFragment newInstance(String title, String content) {
         AztecEditorFragment fragment = new AztecEditorFragment();
@@ -879,7 +879,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         }
 
         attrs.setValue(idName, id);
-        tappedImagePredicate = new ImagePredicate(id, idName);
+        mTappedImagePredicate = new ImagePredicate(id, idName);
 
         onMediaTapped(id, MediaType.IMAGE, meta, uploadStatus);
     }
@@ -902,7 +902,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
                             switch (mediaType) {
                                 case IMAGE:
-                                    content.removeMedia(tappedImagePredicate);
+                                    content.removeMedia(mTappedImagePredicate);
                                     break;
                                 case VIDEO:
                                     // TODO: remove video
@@ -933,19 +933,19 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 switch (mediaType) {
                     case IMAGE:
                         AttributesWithClass attributesWithClass = new AttributesWithClass(
-                                content.getElementAttributes(tappedImagePredicate));
+                                content.getElementAttributes(mTappedImagePredicate));
                         attributesWithClass.removeClass("failed");
 
                         // set intermediate shade overlay
-                        content.setOverlay(tappedImagePredicate, 0,
+                        content.setOverlay(mTappedImagePredicate, 0,
                                 new ColorDrawable(getResources().getColor(R.color.media_shade_overlay_color)), Gravity.FILL);
 
                         Drawable progressDrawable = getResources().getDrawable(android.R.drawable.progress_horizontal);
                         // set the height of the progress bar to 2 (it's in dp since the drawable will be adjusted by the span)
                         progressDrawable.setBounds(0, 0, 0, 4);
 
-                        content.setOverlay(tappedImagePredicate, 1, progressDrawable, Gravity.FILL_HORIZONTAL | Gravity.TOP);
-                        content.updateElementAttributes(tappedImagePredicate, attributesWithClass.getAttributes());
+                        content.setOverlay(mTappedImagePredicate, 1, progressDrawable, Gravity.FILL_HORIZONTAL | Gravity.TOP);
+                        content.updateElementAttributes(mTappedImagePredicate, attributesWithClass.getAttributes());
 
                         content.refreshText();
                         break;
@@ -1022,11 +1022,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         super.onActivityResult(requestCode, resultCode, data);
 
         if (requestCode == ImageSettingsDialogFragment.IMAGE_SETTINGS_DIALOG_REQUEST_CODE) {
-            if (tappedImagePredicate != null) {
-                AztecAttributes attributes = content.getElementAttributes(tappedImagePredicate);
+            if (mTappedImagePredicate != null) {
+                AztecAttributes attributes = content.getElementAttributes(mTappedImagePredicate);
                 attributes.removeAttribute(TEMP_IMAGE_ID);
 
-                content.updateElementAttributes(tappedImagePredicate, attributes);
+                content.updateElementAttributes(mTappedImagePredicate, attributes);
 
                 if (data == null || data.getExtras() == null) {
                     return;
@@ -1099,7 +1099,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                     }
                 }
 
-                tappedImagePredicate = null;
+                mTappedImagePredicate = null;
             }
         }
     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1038,11 +1038,9 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 try {
                     meta = new JSONObject(StringUtils.notNullStr(extras.getString("imageMeta")));
                 } catch (JSONException e) {
-                    // ignore errors
                     return;
                 }
 
-                // set image properties
                 attributes.setValue("src", JSONUtils.getString(meta, "src"));
 
                 if (!TextUtils.isEmpty(JSONUtils.getString(meta, "title"))) {
@@ -1058,13 +1056,12 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
                 AttributesWithClass attributesWithClass = new AttributesWithClass(attributes);
 
-                // remove previously set properties
+                // remove previously set class attributes to add updated values
                 attributesWithClass.removeClassStartingWith("align-");
                 attributesWithClass.removeClassStartingWith("size-");
                 attributesWithClass.removeClassStartingWith("wp-image-");
 
-                // only assign the align class to the image if we're not printing
-                // a caption, since the alignment is sent to the shortcode
+                // only add align attribute if there is no caption since alignment is sent with shortcode
                 if (!TextUtils.isEmpty(JSONUtils.getString(meta, "align")) &&
                         TextUtils.isEmpty(JSONUtils.getString(meta, "caption"))) {
                     attributesWithClass.addClass("align-" + JSONUtils.getString(meta, "align"));
@@ -1078,12 +1075,13 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                     attributesWithClass.addClass("wp-image-" + JSONUtils.getString(meta, "attachment_id"));
                 }
 
-                // captions required shortcode support
-//            String caption = JSONUtils.getString(meta, "caption");
+//                TODO: Add shortcode support to allow captions.
+//                https://github.com/wordpress-mobile/AztecEditor-Android/issues/17
+//                String caption = JSONUtils.getString(meta, "caption");
 
-                // there is an issue with having an image inside a link
-                // https://github.com/wordpress-mobile/AztecEditor-Android/issues/196
-//            String link = JSONUtils.getString(meta, "linkUrl");
+//                TODO: Fix issue with image inside link.
+//                https://github.com/wordpress-mobile/AztecEditor-Android/issues/196
+//                String link = JSONUtils.getString(meta, "linkUrl");
 
                 final int imageRemoteId = extras.getInt("imageRemoteId");
                 final boolean isFeaturedImage = extras.getBoolean("isFeatured");
@@ -1093,7 +1091,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                         mFeaturedImageId = imageRemoteId;
                         mEditorFragmentListener.onFeaturedImageChanged(mFeaturedImageId);
                     } else {
-                        // If this image was unset as featured, clear the featured image id
+                        // if this image was unset as featured, clear the featured image id
                         if (mFeaturedImageId == imageRemoteId) {
                             mFeaturedImageId = 0;
                             mEditorFragmentListener.onFeaturedImageChanged(mFeaturedImageId);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -458,6 +458,12 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 imageLoader.get(mediaUrl, new ImageLoader.ImageListener() {
                     @Override
                     public void onErrorResponse(VolleyError error) {
+                        // Show failed placeholder.
+                        ToastUtils.showToast(getActivity(), R.string.error_media_load);
+                        Drawable drawable = getResources().getDrawable(R.drawable.ic_image_failed_grey_a_40_48dp);
+                        AztecAttributes attributes = new AztecAttributes();
+                        attributes.setValue("src", mediaUrl);
+                        content.insertMedia(drawable, attributes);
                     }
 
                     @Override

--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -107,4 +107,6 @@
 
     <string name="media_insert_unimplemented">Apologies! Feature not implemented yet :(</string>
     <string name="error_media_load">Unable to load media</string>
+    <string name="error_media_small">Media too small to show</string>
+
 </resources>


### PR DESCRIPTION
### Fix
Allow WordPress media library images to be added to the Aztec editor as described in https://github.com/wordpress-mobile/WordPress-Android/issues/5611.

### Test
0. Enable and activate Aztec editor.
1. Go to ***Sites*** tab.
2. Tap ***Create*** floating button.
3. Tap content text field.
4. Tap ***Media*** format button.
5. Tap ***WordPress*** media picker button.
6. Tap image from library.
7. Tap ***HTML*** format button.
8. Notice image tag and attributes.
9. Tap ***HTML*** format button.
10. Tap image in content text field.
11. Tap ***X*** to close ***Image Settings***.
12. Tap ***HTML*** format button.
13. Notice image tag and attributes are unchanged.
14. Tap ***HTML*** format button.
15. Tap image in content text field.
16. Edit ***Title***, ***Alt Text***, or ***Width*** and tap ***Save*** button.
17. Tap ***HTML*** format button.
18. Notice image tag and attributes have changed.
