### PR TITLE
Fix NPE 7.3-rc1 previewing picture

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -162,7 +162,7 @@ public class MediaPreviewActivity extends AppCompatActivity {
         boolean hasEditFragment = hasEditFragment();
         setLookClosable(hasEditFragment);
 
-        String mediaUri;
+        String mediaUri = null;
         if (!TextUtils.isEmpty(mContentUri)) {
             mediaUri = mContentUri;
         } else if (mMediaId != 0) {
@@ -178,7 +178,9 @@ public class MediaPreviewActivity extends AppCompatActivity {
             if (!hasEditFragment) {
                 fadeInMetadata();
             }
-        } else {
+        }
+
+        if (TextUtils.isEmpty(mediaUri)) {
             delayedFinish(true);
             return;
         }


### PR DESCRIPTION
Fixes #5746 making sure the URL of the picture is available when opening the preview screen.

Note sure how to test this, since URL is always there on my tests. Maybe a self hosted site that returns empty URLs for pictures available in the WP Media Library?
