### PR TITLE
issue/5759-photo-picker-icon-order

### DIFF
--- a/WordPress/src/main/res/layout/photo_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/photo_picker_fragment.xml
@@ -37,16 +37,6 @@
         android:orientation="horizontal">
 
         <ImageView
-            android:id="@+id/icon_camera"
-            android:layout_width="@dimen/photo_picker_icon"
-            android:layout_height="@dimen/photo_picker_icon"
-            android:layout_weight="1"
-            android:background="?android:selectableItemBackground"
-            android:padding="@dimen/margin_medium"
-            android:tint="@color/white"
-            app:srcCompat="@drawable/ic_camera_alt_48px" />
-
-        <ImageView
             android:id="@+id/icon_picker"
             android:layout_width="@dimen/photo_picker_icon"
             android:layout_height="@dimen/photo_picker_icon"
@@ -55,6 +45,16 @@
             android:padding="@dimen/margin_medium"
             android:tint="@color/white"
             app:srcCompat="@drawable/ic_collections_48px" />
+
+        <ImageView
+            android:id="@+id/icon_camera"
+            android:layout_width="@dimen/photo_picker_icon"
+            android:layout_height="@dimen/photo_picker_icon"
+            android:layout_weight="1"
+            android:background="?android:selectableItemBackground"
+            android:padding="@dimen/margin_medium"
+            android:tint="@color/white"
+            app:srcCompat="@drawable/ic_camera_alt_48px" />
 
         <ImageView
             android:id="@+id/icon_wpmedia"


### PR DESCRIPTION
Fixes #5759 - simple PR which moves the camera icon to the middle in the photo picker.

![screenshot_1493306206](https://cloud.githubusercontent.com/assets/3903757/25490621/5fe5af70-2b3b-11e7-9281-4c6ef0af0554.png)
