### PR TITLE
7.2 - Odd StringIndexOutOfBoundsException getting content type on URLConnection

### DIFF
--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -311,7 +311,13 @@ public class MediaUtils {
                 }
                 URL urlForGuessingMime = new URL(filePathForGuessingMime);
                 URLConnection uc = urlForGuessingMime.openConnection();
-                String guessedContentType = uc.getContentType(); //internally calls guessContentTypeFromName(url.getFile()); and guessContentTypeFromStream(is);
+                String guessedContentType = null;
+                try {
+                    guessedContentType = uc.getContentType(); //internally calls guessContentTypeFromName(url.getFile()); and guessContentTypeFromStream(is);
+                } catch (StringIndexOutOfBoundsException e) {
+                    // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/5699
+                    AppLog.e(AppLog.T.MEDIA, "Error getting the content type for " + mediaFile.getPath() +" by using URLConnection.getContentType", e);
+                }
                 // check if returned "content/unknown"
                 if (!TextUtils.isEmpty(guessedContentType) && !guessedContentType.equals("content/unknown")) {
                     mimeType = guessedContentType;


### PR DESCRIPTION
Fixes #5699 catching the `StringIndexOutOfBoundsException` thrown by the method `URLConnection.getContentType`. 

It's a kind of rare crash, but better to fix it asap, since the "fix" is super easy, and we don't want the app crashing just for "media analytics" purposes.




