### PR TITLE
bumping fluxC commit hash to point to latest

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -131,7 +131,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:cdc724bfc8e14166f0b79441a4924c96ca0fb1d3') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:1c2cef7fdcbb90e120a513b2f5f2adb8572fb0a9') {
         exclude group: "com.android.volley";
     }
 


### PR DESCRIPTION
Fixes #5755 

as indicated here https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/427
