### PR TITLE
Fix rare image settings crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1299,6 +1299,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             switch (position) {
                 case 0:
                     mEditorFragment = (EditorFragmentAbstract) fragment;
+                    mEditorFragment.setImageLoader(mImageLoader);
+
                     if (mEditorFragment instanceof EditorMediaUploadListener) {
                         mEditorMediaUploadListener = (EditorMediaUploadListener) mEditorFragment;
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -936,6 +936,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 }
                 mEditorFragmentListener.onTrackableEvent(TrackableEvent.IMAGE_EDITED);
                 ImageSettingsDialogFragment imageSettingsDialogFragment = new ImageSettingsDialogFragment();
+                imageSettingsDialogFragment.setImageLoader(mImageLoader);
                 imageSettingsDialogFragment.setTargetFragment(this,
                         ImageSettingsDialogFragment.IMAGE_SETTINGS_DIALOG_REQUEST_CODE);
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -946,25 +946,17 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 dialogBundle.putBoolean("featuredImageSupported", mFeaturedImageSupported);
                 dialogBundle.putBoolean("isAztecEnabled", true);
 
-                // Request and add an authorization header for HTTPS images
-                // Use https:// when requesting the auth header, in case the image is incorrectly using http://.
-                // If an auth header is returned, force https:// for the actual HTTP request.
-                HashMap<String, String> headerMap = new HashMap<>();
-                if (mCustomHttpHeaders != null) {
-                    headerMap.putAll(mCustomHttpHeaders);
-                }
-
                 try {
+                    // Use https:// when requesting the auth header, in case the image is incorrectly using http://
+                    // If an auth header is returned, force https:// for the actual HTTP request
                     final String imageSrc = meta.getString("src");
                     String authHeader = mEditorFragmentListener.onAuthHeaderRequested(UrlUtils.makeHttps(imageSrc));
                     if (authHeader.length() > 0) {
                         meta.put("src", UrlUtils.makeHttps(imageSrc));
-                        headerMap.put("Authorization", authHeader);
                     }
                 } catch (JSONException e) {
                     AppLog.e(AppLog.T.EDITOR, "Could not retrieve image url from JSON metadata");
                 }
-                dialogBundle.putSerializable("headerMap", headerMap);
 
                 dialogBundle.putString("imageMeta", meta.toString());
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1404,6 +1404,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 }
                 mEditorFragmentListener.onTrackableEvent(TrackableEvent.IMAGE_EDITED);
                 ImageSettingsDialogFragment imageSettingsDialogFragment = new ImageSettingsDialogFragment();
+                imageSettingsDialogFragment.setImageLoader(mImageLoader);
                 imageSettingsDialogFragment.setTargetFragment(this,
                         ImageSettingsDialogFragment.IMAGE_SETTINGS_DIALOG_REQUEST_CODE);
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1413,25 +1413,17 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 dialogBundle.putString("maxWidth", mBlogSettingMaxImageWidth);
                 dialogBundle.putBoolean("featuredImageSupported", mFeaturedImageSupported);
 
-                // Request and add an authorization header for HTTPS images
-                // Use https:// when requesting the auth header, in case the image is incorrectly using http://.
-                // If an auth header is returned, force https:// for the actual HTTP request.
-                HashMap<String, String> headerMap = new HashMap<>();
-                if (mCustomHttpHeaders != null) {
-                    headerMap.putAll(mCustomHttpHeaders);
-                }
-
                 try {
+                    // Use https:// when requesting the auth header, in case the image is incorrectly using http://
+                    // If an auth header is returned, force https:// for the actual HTTP request
                     final String imageSrc = meta.getString("src");
                     String authHeader = mEditorFragmentListener.onAuthHeaderRequested(UrlUtils.makeHttps(imageSrc));
                     if (authHeader.length() > 0) {
                         meta.put("src", UrlUtils.makeHttps(imageSrc));
-                        headerMap.put("Authorization", authHeader);
                     }
                 } catch (JSONException e) {
                     AppLog.e(T.EDITOR, "Could not retrieve image url from JSON metadata");
                 }
-                dialogBundle.putSerializable("headerMap", headerMap);
 
                 dialogBundle.putString("imageMeta", meta.toString());
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -20,12 +20,12 @@ import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.CheckBox;
 import android.widget.EditText;
-import android.widget.ImageView;
 import android.widget.SeekBar;
 import android.widget.Spinner;
 import android.widget.TextView;
 
 import com.android.volley.toolbox.ImageLoader;
+import com.android.volley.toolbox.NetworkImageView;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -132,7 +132,7 @@ public class ImageSettingsDialogFragment extends DialogFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.dialog_image_options, container, false);
 
-        ImageView thumbnailImage = (ImageView) view.findViewById(R.id.image_thumbnail);
+        NetworkImageView thumbnailImage = (NetworkImageView) view.findViewById(R.id.image_thumbnail);
         TextView filenameLabel = (TextView) view.findViewById(R.id.image_filename);
         mTitleText = (EditText) view.findViewById(R.id.image_title);
         mCaptionText = (EditText) view.findViewById(R.id.image_caption);
@@ -342,27 +342,20 @@ public class ImageSettingsDialogFragment extends DialogFragment {
 
         return metaData;
     }
+    /**
+     * Loads the given network image URL into the {@link NetworkImageView}.
+     */
+    private void loadThumbnail(String imageUrl, NetworkImageView imageView) {
+        if (imageUrl != null) {
+            Uri uri = Uri.parse(imageUrl);
+            String filepath = uri.getLastPathSegment();
 
-    private void loadThumbnail(final String src, final ImageView thumbnailImage) {
-        Thread thread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                if (isAdded()) {
-                    final Uri localUri = Utils.downloadExternalMedia(getActivity(), Uri.parse(src), mHttpHeaders);
-
-                    if (getActivity() != null) {
-                        getActivity().runOnUiThread(new Runnable() {
-                            @Override
-                            public void run() {
-                                thumbnailImage.setImageURI(localUri);
-                            }
-                        });
-                    }
-                }
+            if (MediaUtils.isValidImage(filepath)) {
+                imageView.setImageUrl(imageUrl, mImageLoader);
             }
-        });
-
-        thread.start();
+        } else {
+            imageView.setImageResource(0);
+        }
     }
 
     /**

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -25,6 +25,8 @@ import android.widget.SeekBar;
 import android.widget.Spinner;
 import android.widget.TextView;
 
+import com.android.volley.toolbox.ImageLoader;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.util.AppLog;
@@ -46,6 +48,7 @@ public class ImageSettingsDialogFragment extends DialogFragment {
 
     private JSONObject mImageMeta;
     private int mMaxImageWidth;
+    private ImageLoader mImageLoader;
 
     private EditText mTitleText;
     private EditText mCaptionText;
@@ -273,6 +276,10 @@ public class ImageSettingsDialogFragment extends DialogFragment {
         getTargetFragment().onActivityResult(getTargetRequestCode(), getTargetRequestCode(), null);
         restorePreviousActionBar();
         getFragmentManager().popBackStack();
+    }
+
+    public void setImageLoader(ImageLoader imageLoader) {
+        mImageLoader = imageLoader;
     }
 
     private void restorePreviousActionBar() {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -34,7 +34,6 @@ import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.ToastUtils;
 
 import java.util.Arrays;
-import java.util.Map;
 
 /**
  * A full-screen DialogFragment with image settings.
@@ -60,8 +59,6 @@ public class ImageSettingsDialogFragment extends DialogFragment {
     private CheckBox mFeaturedCheckBox;
 
     private boolean mIsFeatured;
-
-    private Map<String, String> mHttpHeaders;
 
     private CharSequence mPreviousActionBarTitle;
     private boolean mPreviousHomeAsUpEnabled;
@@ -148,8 +145,6 @@ public class ImageSettingsDialogFragment extends DialogFragment {
         if (bundle != null) {
             try {
                 mImageMeta = new JSONObject(bundle.getString("imageMeta"));
-
-                mHttpHeaders = (Map) bundle.getSerializable("headerMap");
 
                 final String imageSrc = mImageMeta.getString("src");
                 final String imageFilename = imageSrc.substring(imageSrc.lastIndexOf("/") + 1);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/Utils.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/Utils.java
@@ -5,23 +5,17 @@ import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.res.AssetManager;
-import android.net.Uri;
 import android.util.Patterns;
 
 import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.HTTPUtils;
 
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
-import java.net.HttpURLConnection;
 import java.net.URLDecoder;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -168,67 +162,6 @@ public class Utils {
         }
 
         return changeMap;
-    }
-
-    public static Uri downloadExternalMedia(Context context, Uri imageUri, Map<String, String> headers) {
-        if(context != null && imageUri != null) {
-            File cacheDir = null;
-
-            if (context.getApplicationContext() != null) {
-                cacheDir = context.getCacheDir();
-            }
-
-            try {
-                InputStream inputStream;
-                if (imageUri.toString().startsWith("content://")) {
-                    inputStream = context.getContentResolver().openInputStream(imageUri);
-                    if (inputStream == null) {
-                        AppLog.e(AppLog.T.UTILS, "openInputStream returned null");
-                        return null;
-                    }
-                } else {
-                    if (headers == null) {
-                        headers = Collections.emptyMap();
-                    }
-
-                    HttpURLConnection conn = HTTPUtils.setupUrlConnection(imageUri.toString(), headers);
-
-                    // If the HTTP response is a redirect, follow it
-                    int responseCode = conn.getResponseCode();
-                    if (responseCode != HttpURLConnection.HTTP_OK) {
-                        if (responseCode == HttpURLConnection.HTTP_MOVED_PERM
-                                || responseCode == HttpURLConnection.HTTP_MOVED_TEMP
-                                || responseCode == HttpURLConnection.HTTP_SEE_OTHER) {
-                            conn = HTTPUtils.setupUrlConnection(conn.getHeaderField("Location"), headers);
-                        }
-                    }
-
-                    inputStream = conn.getInputStream();
-                }
-
-                String fileName = "thumb-" + System.currentTimeMillis();
-
-                File f = new File(cacheDir, fileName);
-                FileOutputStream output = new FileOutputStream(f);
-                byte[] data = new byte[1024];
-
-                int count;
-                while ((count = inputStream.read(data)) != -1) {
-                    output.write(data, 0, count);
-                }
-
-                output.flush();
-                output.close();
-                inputStream.close();
-                return Uri.fromFile(f);
-            } catch (IOException e) {
-                AppLog.e(AppLog.T.UTILS, e);
-            }
-
-            return null;
-        } else {
-            return null;
-        }
     }
 
     /**

--- a/libs/editor/WordPressEditor/src/main/res/layout/dialog_image_options.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/dialog_image_options.xml
@@ -19,7 +19,7 @@
             android:orientation="horizontal"
             android:layout_marginBottom="@dimen/image_settings_dialog_thumbnail_container_margin_bottom">
 
-            <ImageView
+            <com.android.volley.toolbox.NetworkImageView
                 android:id="@+id/image_thumbnail"
                 android:contentDescription="@string/image_thumbnail"
                 android:layout_width="@dimen/image_settings_dialog_thumbnail_size"


### PR DESCRIPTION
Fixes #5669. An over-ambitious cast was causing a (fairly rare) crash when opening the image settings screen on certain non-stock devices.

Also fixes #5676 by removing `downloadExternalMedia()`.

* Refactored the image settings screen to use an `ImageLoader` to show thumbnails
* Modified the visual editor `WebView` to use the safe `URLConnection` instead of `HTTPUtils`' implementation

### Notes:

1. I'll be disposing of the `HTTPUtils` class in a PR in the `WordPress-Utils-Android` repo - it's not used anywhere else. (https://github.com/wordpress-mobile/WordPress-Utils-Android/pull/13)

2. The Aztec editor uses its own `ImageGetter`, which wraps around an `ImageLoader` - so we're now calling two `setImageLoader`s for Aztec, one from the `EditorFragmentAbstract` and one from `AztecEditorFragment`. This is pretty messy, but I didn't want to make any big changes to Aztec. cc @0nko for your opinion

I thought this was worth adding this crash fix to `7.3`. If we don't make it in time I'll change the base branch.

### To test:
The crash seems to affect specific (non-stock) devices - I haven't been able to reproduce the crash even on a Samsung S3. However, we can confirm that everything is still working as it should in general:

1. In the (hybrid) visual editor and in Aztec, edit an image
2. Confirm that the image thumbnail loads in the image settings screen
3. Try the above for self-hosted, and for a private WP.com site
4. Try uploading images in the (hybrid) visual editor to test the `EditorWebViewAbstract` change