### PR TITLE
showing toast from within UI thread

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1207,7 +1207,12 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                         savePostLocallyAndFinishAsync();
                     }
                 } else {
-                    ToastUtils.showToast(EditPostActivity.this, R.string.error_publish_empty_post, Duration.SHORT);
+                    EditPostActivity.this.runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            ToastUtils.showToast(EditPostActivity.this, R.string.error_publish_empty_post, Duration.SHORT);
+                        }
+                    });
                 }
             }
         }).start();


### PR DESCRIPTION
Fixes #5773

To test:
1. Start a new post leave it empty (no title, no content)
2. tap Publish
3. should not crash, but show a "Can't publish an empty post" toast.

