### PR TITLE
Media Async: Load post from store when selected from post list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -464,6 +464,13 @@ public class PostsListFragment extends Fragment
     public void onPostButtonClicked(int buttonType, PostModel post) {
         if (!isAdded()) return;
 
+        // Get the latest version of the post, in case it's changed since the last time we refreshed the post list
+        post = mPostStore.getPostByLocalPostId(post.getId());
+        if (post == null) {
+            loadPosts(LoadMode.FORCED);
+            return;
+        }
+
         switch (buttonType) {
             case PostListButton.BUTTON_EDIT:
                 ActivityLauncher.editPostOrPageForResult(getActivity(), mSite, post);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -476,7 +476,12 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                         break;
                     default:
                         if (mOnPostButtonClickListener != null) {
-                            mOnPostButtonClickListener.onPostButtonClicked(buttonType, post);
+                            PostModel latestPost = mPostStore.getPostByLocalPostId(post.getId());
+                            if (latestPost == null) {
+                                loadPosts(LoadMode.FORCED);
+                                return;
+                            }
+                            mOnPostButtonClickListener.onPostButtonClicked(buttonType, latestPost);
                         }
                         break;
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -476,12 +476,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                         break;
                     default:
                         if (mOnPostButtonClickListener != null) {
-                            PostModel latestPost = mPostStore.getPostByLocalPostId(post.getId());
-                            if (latestPost == null) {
-                                loadPosts(LoadMode.FORCED);
-                                return;
-                            }
-                            mOnPostButtonClickListener.onPostButtonClicked(buttonType, latestPost);
+                            mOnPostButtonClickListener.onPostButtonClicked(buttonType, post);
                         }
                         break;
                 }


### PR DESCRIPTION
Makes sure any changes to the post since we the last update of the post list are reflected, and we don't open an outdated `PostModel` in the editor, for example.

cc @mzorz