### PR TITLE
Issue/5779 aztec media attributes

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -88,7 +88,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     public static final int MAX_ACTION_TIME_MS = 2000;
 
     private static final MediaFile DEFAULT_MEDIA = new MediaFile();
-    private static final String DEFAULT_MEDIA_TITLE = DEFAULT_MEDIA.getTitle();
     private static final int DEFAULT_MEDIA_HEIGHT = DEFAULT_MEDIA.getHeight();
     private static final int DEFAULT_MEDIA_WIDTH = DEFAULT_MEDIA.getWidth();
 
@@ -1120,7 +1119,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     protected void setAttributeValuesIfNotDefault(AztecAttributes attributes, MediaFile mediaFile) {
-        if (!mediaFile.getTitle().equalsIgnoreCase(DEFAULT_MEDIA_TITLE)) {
+        if (!TextUtils.isEmpty(StringUtils.notNullStr(mediaFile.getTitle()))) {
             attributes.setValue("title", mediaFile.getTitle());
         }
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1119,10 +1119,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     protected void setAttributeValuesIfNotDefault(AztecAttributes attributes, MediaFile mediaFile) {
-        if (!TextUtils.isEmpty(StringUtils.notNullStr(mediaFile.getTitle()))) {
-            attributes.setValue("title", mediaFile.getTitle());
-        }
-
         if (mediaFile.getWidth() != DEFAULT_MEDIA_WIDTH) {
             attributes.setValue("width", String.valueOf(mediaFile.getWidth()));
         }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -75,12 +75,12 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         AztecToolbarClickListener,
         HistoryListener {
 
-    private static final String ARG_PARAM_TITLE = "param_title";
-    private static final String ARG_PARAM_CONTENT = "param_content";
-
-    private static final String KEY_TITLE = "title";
-    private static final String KEY_CONTENT = "content";
-
+    private static final String ATTR_ALIGN_ = "align-";
+    private static final String ATTR_CLASS = "class";
+    private static final String ATTR_ID_WP = "data-wpid";
+    private static final String ATTR_IMAGE_WP = "wp-image-";
+    private static final String ATTR_SIZE = "size";
+    private static final String ATTR_SIZE_ = "size-";
     private static final String TEMP_IMAGE_ID = "data-temp-aztec-id";
 
     private static final int MIN_BITMAP_DIMENSION_DP = 48;
@@ -232,8 +232,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
-        outState.putCharSequence(KEY_TITLE, getTitle());
-        outState.putCharSequence(KEY_CONTENT, getContent());
+        outState.putCharSequence(ATTR_TITLE, getTitle());
+        outState.putCharSequence(ATTR_CONTENT, getContent());
     }
 
     @Override
@@ -403,14 +403,14 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             @Override
             public boolean matches(@NonNull Attributes attrs) {
                 AttributesWithClass attributesWithClass = new AttributesWithClass(attrs);
-                return attributesWithClass.hasClass("failed");
+                return attributesWithClass.hasClass(ATTR_STATUS_FAILED);
             }
         };
 
         mFailedMediaIds.clear();
 
         for (Attributes attrs : content.getAllElementAttributes(failedPredicate)) {
-            mFailedMediaIds.add(attrs.getValue("data-wpid"));
+            mFailedMediaIds.add(attrs.getValue(ATTR_ID_WP));
         }
     }
 
@@ -466,7 +466,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                         ToastUtils.showToast(getActivity(), R.string.error_media_load);
                         Drawable drawable = getResources().getDrawable(R.drawable.ic_image_failed_grey_a_40_48dp);
                         AztecAttributes attributes = new AztecAttributes();
-                        attributes.setValue("src", mediaUrl);
+                        attributes.setValue(ATTR_SRC, mediaUrl);
                         setAttributeValuesIfNotDefault(attributes, mediaFile);
                         content.insertMedia(drawable, attributes);
                     }
@@ -481,7 +481,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                         }
 
                         AztecAttributes attributes = new AztecAttributes();
-                        attributes.setValue("src", mediaUrl);
+                        attributes.setValue(ATTR_SRC, mediaUrl);
                         setAttributeValuesIfNotDefault(attributes, mediaFile);
 
                         int minimumDimension = DisplayUtils.dpToPx(getActivity(), MIN_BITMAP_DIMENSION_DP);
@@ -509,9 +509,9 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 ToastUtils.showToast(getActivity(), R.string.media_insert_unimplemented);
             } else {
                 AztecAttributes attrs = new AztecAttributes();
-                attrs.setValue("data-wpid", localMediaId);
-                attrs.setValue("src", safeMediaUrl);
-                attrs.setValue("class", "uploading");
+                attrs.setValue(ATTR_ID_WP, localMediaId);
+                attrs.setValue(ATTR_SRC, safeMediaUrl);
+                attrs.setValue(ATTR_CLASS, ATTR_STATUS_UPLOADING);
 
                 // load a scaled version of the image to prevent OOM exception
                 int maxWidth = DisplayUtils.getDisplayPixelWidth(getActivity());
@@ -573,7 +573,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         content.removeMedia(new AztecText.AttributePredicate() {
             @Override
             public boolean matches(@NotNull Attributes attrs) {
-                return new AttributesWithClass(attrs).hasClass("failed");
+                return new AttributesWithClass(attrs).hasClass(ATTR_STATUS_FAILED);
             }
         });
     }
@@ -602,7 +602,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             if (mediaType.equals(MediaType.IMAGE)) {
 
                 AztecAttributes attrs = new AztecAttributes();
-                attrs.setValue("src", remoteUrl);
+                attrs.setValue(ATTR_SRC, remoteUrl);
 
                 // clear overlay
                 ImagePredicate predicate = ImagePredicate.getLocalMediaIdPredicate(localMediaId);
@@ -622,7 +622,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         private final String mAttributeName;
 
         static ImagePredicate getLocalMediaIdPredicate(String id) {
-            return new ImagePredicate(id, "data-wpid");
+            return new ImagePredicate(id, ATTR_ID_WP);
         }
 
         ImagePredicate(String id, String attributeName) {
@@ -661,8 +661,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                     AttributesWithClass attributesWithClass = new AttributesWithClass(
                             content.getElementAttributes(ImagePredicate.getLocalMediaIdPredicate(localMediaId)));
 
-                    attributesWithClass.removeClass("uploading");
-                    attributesWithClass.addClass("failed");
+                    attributesWithClass.removeClass(ATTR_STATUS_UPLOADING);
+                    attributesWithClass.addClass(ATTR_STATUS_FAILED);
 
                     overlayFailedMedia(localMediaId, attributesWithClass.getAttributes());
                     content.refreshText();
@@ -874,19 +874,19 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         String idName;
         String uploadStatus = "";
         JSONObject meta = MetadataUtils.getMetadata(new AttributesWithClass(attrs), naturalWidth, naturalHeight);
-        if (classes.contains("uploading")) {
-            uploadStatus = "uploading";
-            idName = "data-wpid";
-        } else if (classes.contains("failed")) {
-            uploadStatus = "failed";
-            idName = "data-wpid";
+        if (classes.contains(ATTR_STATUS_UPLOADING)) {
+            uploadStatus = ATTR_STATUS_UPLOADING;
+            idName = ATTR_ID_WP;
+        } else if (classes.contains(ATTR_STATUS_FAILED)) {
+            uploadStatus = ATTR_STATUS_FAILED;
+            idName = ATTR_ID_WP;
         } else {
-            idName = "id";
+            idName = ATTR_ID;
         }
 
         String id = attrs.getValue(idName);
 
-        // generate the element ID if "id" or "data-wpid" are missing
+        // generate the element ID if ATTR_ID or ATTR_ID_WP are missing
         if (!attrs.hasAttribute(idName) || TextUtils.isEmpty(attrs.getValue(idName))) {
             idName = TEMP_IMAGE_ID;
             id = UUID.randomUUID().toString();
@@ -904,7 +904,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         }
 
         switch (uploadStatus) {
-            case "uploading":
+            case ATTR_STATUS_UPLOADING:
                 // Display 'cancel upload' dialog
                 AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
                 builder.setTitle(getString(R.string.stop_upload_dialog_title));
@@ -939,7 +939,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 AlertDialog dialog = builder.create();
                 dialog.show();
                 break;
-            case "failed":
+            case ATTR_STATUS_FAILED:
                 // Retry media upload
                 if (mFailedMediaIds.contains(localMediaId)) {
                     mEditorFragmentListener.onMediaRetryClicked(localMediaId);
@@ -948,7 +948,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                     case IMAGE:
                         AttributesWithClass attributesWithClass = new AttributesWithClass(
                                 content.getElementAttributes(mTappedImagePredicate));
-                        attributesWithClass.removeClass("failed");
+                        attributesWithClass.removeClass(ATTR_STATUS_FAILED);
 
                         // set intermediate shade overlay
                         content.setOverlay(mTappedImagePredicate, 0,
@@ -987,9 +987,9 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
                 Bundle dialogBundle = new Bundle();
 
-                dialogBundle.putString("maxWidth", mBlogSettingMaxImageWidth);
-                dialogBundle.putBoolean("featuredImageSupported", mFeaturedImageSupported);
-                dialogBundle.putBoolean("isAztecEnabled", true);
+                dialogBundle.putString(EXTRA_MAX_WIDTH, mBlogSettingMaxImageWidth);
+                dialogBundle.putBoolean(EXTRA_IMAGE_FEATURED, mFeaturedImageSupported);
+                dialogBundle.putBoolean(EXTRA_ENABLED_AZTEC, true);
 
                 // Request and add an authorization header for HTTPS images
                 // Use https:// when requesting the auth header, in case the image is incorrectly using http://.
@@ -1000,22 +1000,22 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 }
 
                 try {
-                    final String imageSrc = meta.getString("src");
+                    final String imageSrc = meta.getString(ATTR_SRC);
                     String authHeader = mEditorFragmentListener.onAuthHeaderRequested(UrlUtils.makeHttps(imageSrc));
                     if (authHeader.length() > 0) {
-                        meta.put("src", UrlUtils.makeHttps(imageSrc));
+                        meta.put(ATTR_SRC, UrlUtils.makeHttps(imageSrc));
                         headerMap.put("Authorization", authHeader);
                     }
                 } catch (JSONException e) {
                     AppLog.e(AppLog.T.EDITOR, "Could not retrieve image url from JSON metadata");
                 }
-                dialogBundle.putSerializable("headerMap", headerMap);
+                dialogBundle.putSerializable(EXTRA_HEADER, headerMap);
 
-                dialogBundle.putString("imageMeta", meta.toString());
+                dialogBundle.putString(EXTRA_IMAGE_META, meta.toString());
 
-                String imageId = JSONUtils.getString(meta, "attachment_id");
+                String imageId = JSONUtils.getString(meta, ATTR_ID_ATTACHMENT);
                 if (!imageId.isEmpty()) {
-                    dialogBundle.putBoolean("isFeatured", mFeaturedImageId == Integer.parseInt(imageId));
+                    dialogBundle.putBoolean(EXTRA_FEATURED, mFeaturedImageId == Integer.parseInt(imageId));
                 }
 
                 imageSettingsDialogFragment.setArguments(dialogBundle);
@@ -1050,55 +1050,55 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 JSONObject meta;
 
                 try {
-                    meta = new JSONObject(StringUtils.notNullStr(extras.getString("imageMeta")));
+                    meta = new JSONObject(StringUtils.notNullStr(extras.getString(EXTRA_IMAGE_META)));
                 } catch (JSONException e) {
                     return;
                 }
 
-                attributes.setValue("src", JSONUtils.getString(meta, "src"));
+                attributes.setValue(ATTR_SRC, JSONUtils.getString(meta, ATTR_SRC));
 
-                if (!TextUtils.isEmpty(JSONUtils.getString(meta, "title"))) {
-                    attributes.setValue("title", JSONUtils.getString(meta, "title"));
+                if (!TextUtils.isEmpty(JSONUtils.getString(meta, ATTR_TITLE))) {
+                    attributes.setValue(ATTR_TITLE, JSONUtils.getString(meta, ATTR_TITLE));
                 }
 
-                attributes.setValue("width", JSONUtils.getString(meta, "width"));
-                attributes.setValue("height", JSONUtils.getString(meta, "height"));
+                attributes.setValue(ATTR_DIMEN_WIDTH, JSONUtils.getString(meta, ATTR_DIMEN_WIDTH));
+                attributes.setValue(ATTR_DIMEN_HEIGHT, JSONUtils.getString(meta, ATTR_DIMEN_HEIGHT));
 
-                if (!TextUtils.isEmpty(JSONUtils.getString(meta, "alt"))) {
-                    attributes.setValue("alt", JSONUtils.getString(meta, "alt"));
+                if (!TextUtils.isEmpty(JSONUtils.getString(meta, ATTR_ALT))) {
+                    attributes.setValue(ATTR_ALT, JSONUtils.getString(meta, ATTR_ALT));
                 }
 
                 AttributesWithClass attributesWithClass = new AttributesWithClass(attributes);
 
                 // remove previously set class attributes to add updated values
-                attributesWithClass.removeClassStartingWith("align-");
-                attributesWithClass.removeClassStartingWith("size-");
-                attributesWithClass.removeClassStartingWith("wp-image-");
+                attributesWithClass.removeClassStartingWith(ATTR_ALIGN_);
+                attributesWithClass.removeClassStartingWith(ATTR_SIZE_);
+                attributesWithClass.removeClassStartingWith(ATTR_IMAGE_WP);
 
                 // only add align attribute if there is no caption since alignment is sent with shortcode
-                if (!TextUtils.isEmpty(JSONUtils.getString(meta, "align")) &&
-                        TextUtils.isEmpty(JSONUtils.getString(meta, "caption"))) {
-                    attributesWithClass.addClass("align-" + JSONUtils.getString(meta, "align"));
+                if (!TextUtils.isEmpty(JSONUtils.getString(meta, ATTR_ALIGN)) &&
+                        TextUtils.isEmpty(JSONUtils.getString(meta, ATTR_CAPTION))) {
+                    attributesWithClass.addClass(ATTR_ALIGN_ + JSONUtils.getString(meta, ATTR_ALIGN));
                 }
 
-                if (!TextUtils.isEmpty(JSONUtils.getString(meta, "size"))) {
-                    attributesWithClass.addClass("size-" + JSONUtils.getString(meta, "size"));
+                if (!TextUtils.isEmpty(JSONUtils.getString(meta, ATTR_SIZE))) {
+                    attributesWithClass.addClass(ATTR_SIZE_ + JSONUtils.getString(meta, ATTR_SIZE));
                 }
 
-                if (!TextUtils.isEmpty(JSONUtils.getString(meta, "attachment_id"))) {
-                    attributesWithClass.addClass("wp-image-" + JSONUtils.getString(meta, "attachment_id"));
+                if (!TextUtils.isEmpty(JSONUtils.getString(meta, ATTR_ID_ATTACHMENT))) {
+                    attributesWithClass.addClass(ATTR_IMAGE_WP + JSONUtils.getString(meta, ATTR_ID_ATTACHMENT));
                 }
 
 //                TODO: Add shortcode support to allow captions.
 //                https://github.com/wordpress-mobile/AztecEditor-Android/issues/17
-//                String caption = JSONUtils.getString(meta, "caption");
+//                String caption = JSONUtils.getString(meta, ATTR_CAPTION);
 
 //                TODO: Fix issue with image inside link.
 //                https://github.com/wordpress-mobile/AztecEditor-Android/issues/196
-//                String link = JSONUtils.getString(meta, "linkUrl");
+//                String link = JSONUtils.getString(meta, ATTR_URL_LINK);
 
-                final int imageRemoteId = extras.getInt("imageRemoteId");
-                final boolean isFeaturedImage = extras.getBoolean("isFeatured");
+                final int imageRemoteId = extras.getInt(ATTR_ID_IMAGE_REMOTE);
+                final boolean isFeaturedImage = extras.getBoolean(EXTRA_FEATURED);
 
                 if (imageRemoteId != 0) {
                     if (isFeaturedImage) {
@@ -1120,11 +1120,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     protected void setAttributeValuesIfNotDefault(AztecAttributes attributes, MediaFile mediaFile) {
         if (mediaFile.getWidth() != DEFAULT_MEDIA_WIDTH) {
-            attributes.setValue("width", String.valueOf(mediaFile.getWidth()));
+            attributes.setValue(ATTR_DIMEN_WIDTH, String.valueOf(mediaFile.getWidth()));
         }
 
         if (mediaFile.getHeight() != DEFAULT_MEDIA_HEIGHT) {
-            attributes.setValue("height", String.valueOf(mediaFile.getHeight()));
+            attributes.setValue(ATTR_DIMEN_HEIGHT, String.valueOf(mediaFile.getHeight()));
         }
     }
 }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -87,6 +87,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     public static final int MAX_ACTION_TIME_MS = 2000;
 
+    private static final MediaFile DEFAULT_MEDIA = new MediaFile();
+    private static final String DEFAULT_MEDIA_TITLE = DEFAULT_MEDIA.getTitle();
+    private static final int DEFAULT_MEDIA_HEIGHT = DEFAULT_MEDIA.getHeight();
+    private static final int DEFAULT_MEDIA_WIDTH = DEFAULT_MEDIA.getWidth();
+
     private static final List<String> DRAGNDROP_SUPPORTED_MIMETYPES_TEXT = Arrays.asList(ClipDescription
             .MIMETYPE_TEXT_PLAIN, ClipDescription.MIMETYPE_TEXT_HTML);
     private static final List<String> DRAGNDROP_SUPPORTED_MIMETYPES_IMAGE = Arrays.asList("image/jpeg", "image/png");
@@ -463,6 +468,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                         Drawable drawable = getResources().getDrawable(R.drawable.ic_image_failed_grey_a_40_48dp);
                         AztecAttributes attributes = new AztecAttributes();
                         attributes.setValue("src", mediaUrl);
+                        setAttributeValuesIfNotDefault(attributes, mediaFile);
                         content.insertMedia(drawable, attributes);
                     }
 
@@ -475,8 +481,9 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                             return;
                         }
 
-                        AztecAttributes attrs = new AztecAttributes();
-                        attrs.setValue("src", mediaUrl);
+                        AztecAttributes attributes = new AztecAttributes();
+                        attributes.setValue("src", mediaUrl);
+                        setAttributeValuesIfNotDefault(attributes, mediaFile);
 
                         int minimumDimension = DisplayUtils.dpToPx(getActivity(), MIN_BITMAP_DIMENSION_DP);
 
@@ -484,12 +491,12 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                             // Bitmap is too small.  Show image placeholder.
                             ToastUtils.showToast(getActivity(), R.string.error_media_small);
                             Drawable drawable = getResources().getDrawable(R.drawable.ic_image_loading_grey_a_40_48dp);
-                            content.insertMedia(drawable, attrs);
+                            content.insertMedia(drawable, attributes);
                             return;
                         }
 
                         Bitmap resizedBitmap = ImageUtils.getScaledBitmapAtLongestSide(downloadedBitmap, DisplayUtils.getDisplayPixelWidth(getActivity()));
-                        content.insertMedia(new BitmapDrawable(getResources(), resizedBitmap), attrs);
+                        content.insertMedia(new BitmapDrawable(getResources(), resizedBitmap), attributes);
                     }
                 }, 0, 0);
             }
@@ -1109,6 +1116,20 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
                 mTappedImagePredicate = null;
             }
+        }
+    }
+
+    protected void setAttributeValuesIfNotDefault(AztecAttributes attributes, MediaFile mediaFile) {
+        if (!mediaFile.getTitle().equalsIgnoreCase(DEFAULT_MEDIA_TITLE)) {
+            attributes.setValue("title", mediaFile.getTitle());
+        }
+
+        if (mediaFile.getWidth() != DEFAULT_MEDIA_WIDTH) {
+            attributes.setValue("width", String.valueOf(mediaFile.getWidth()));
+        }
+
+        if (mediaFile.getHeight() != DEFAULT_MEDIA_HEIGHT) {
+            attributes.setValue("height", String.valueOf(mediaFile.getHeight()));
         }
     }
 }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -75,12 +75,12 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         AztecToolbarClickListener,
         HistoryListener {
 
-    private static final String ATTR_ALIGN_ = "align-";
+    private static final String ATTR_ALIGN_DASH = "align-";
     private static final String ATTR_CLASS = "class";
     private static final String ATTR_ID_WP = "data-wpid";
     private static final String ATTR_IMAGE_WP = "wp-image-";
     private static final String ATTR_SIZE = "size";
-    private static final String ATTR_SIZE_ = "size-";
+    private static final String ATTR_SIZE_DASH = "size-";
     private static final String TEMP_IMAGE_ID = "data-temp-aztec-id";
 
     private static final int MIN_BITMAP_DIMENSION_DP = 48;
@@ -1071,18 +1071,18 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 AttributesWithClass attributesWithClass = new AttributesWithClass(attributes);
 
                 // remove previously set class attributes to add updated values
-                attributesWithClass.removeClassStartingWith(ATTR_ALIGN_);
-                attributesWithClass.removeClassStartingWith(ATTR_SIZE_);
+                attributesWithClass.removeClassStartingWith(ATTR_ALIGN_DASH);
+                attributesWithClass.removeClassStartingWith(ATTR_SIZE_DASH);
                 attributesWithClass.removeClassStartingWith(ATTR_IMAGE_WP);
 
                 // only add align attribute if there is no caption since alignment is sent with shortcode
                 if (!TextUtils.isEmpty(JSONUtils.getString(meta, ATTR_ALIGN)) &&
                         TextUtils.isEmpty(JSONUtils.getString(meta, ATTR_CAPTION))) {
-                    attributesWithClass.addClass(ATTR_ALIGN_ + JSONUtils.getString(meta, ATTR_ALIGN));
+                    attributesWithClass.addClass(ATTR_ALIGN_DASH + JSONUtils.getString(meta, ATTR_ALIGN));
                 }
 
                 if (!TextUtils.isEmpty(JSONUtils.getString(meta, ATTR_SIZE))) {
-                    attributesWithClass.addClass(ATTR_SIZE_ + JSONUtils.getString(meta, ATTR_SIZE));
+                    attributesWithClass.addClass(ATTR_SIZE_DASH + JSONUtils.getString(meta, ATTR_SIZE));
                 }
 
                 if (!TextUtils.isEmpty(JSONUtils.getString(meta, ATTR_ID_ATTACHMENT))) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -78,7 +78,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     private static final String ATTR_ALIGN_DASH = "align-";
     private static final String ATTR_CLASS = "class";
     private static final String ATTR_ID_WP = "data-wpid";
-    private static final String ATTR_IMAGE_WP = "wp-image-";
+    private static final String ATTR_IMAGE_WP_DASH = "wp-image-";
     private static final String ATTR_SIZE = "size";
     private static final String ATTR_SIZE_DASH = "size-";
     private static final String TEMP_IMAGE_ID = "data-temp-aztec-id";
@@ -1073,7 +1073,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 // remove previously set class attributes to add updated values
                 attributesWithClass.removeClassStartingWith(ATTR_ALIGN_DASH);
                 attributesWithClass.removeClassStartingWith(ATTR_SIZE_DASH);
-                attributesWithClass.removeClassStartingWith(ATTR_IMAGE_WP);
+                attributesWithClass.removeClassStartingWith(ATTR_IMAGE_WP_DASH);
 
                 // only add align attribute if there is no caption since alignment is sent with shortcode
                 if (!TextUtils.isEmpty(JSONUtils.getString(meta, ATTR_ALIGN)) &&
@@ -1086,7 +1086,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 }
 
                 if (!TextUtils.isEmpty(JSONUtils.getString(meta, ATTR_ID_ATTACHMENT))) {
-                    attributesWithClass.addClass(ATTR_IMAGE_WP + JSONUtils.getString(meta, ATTR_ID_ATTACHMENT));
+                    attributesWithClass.addClass(ATTR_IMAGE_WP_DASH + JSONUtils.getString(meta, ATTR_ID_ATTACHMENT));
                 }
 
 //                TODO: Add shortcode support to allow captions.

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -73,13 +73,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
     }
 
-    private static final String ARG_PARAM_TITLE = "param_title";
-    private static final String ARG_PARAM_CONTENT = "param_content";
-
     private static final String JS_CALLBACK_HANDLER = "nativeCallbackHandler";
-
-    private static final String KEY_TITLE = "title";
-    private static final String KEY_CONTENT = "content";
 
     private static final String TAG_FORMAT_BAR_BUTTON_MEDIA = "media";
     private static final String TAG_FORMAT_BAR_BUTTON_LINK = "link";
@@ -332,8 +326,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         initJsEditor();
 
         if (savedInstanceState != null) {
-            setTitle(savedInstanceState.getCharSequence(KEY_TITLE));
-            setContent(savedInstanceState.getCharSequence(KEY_CONTENT));
+            setTitle(savedInstanceState.getCharSequence(ATTR_TITLE));
+            setContent(savedInstanceState.getCharSequence(ATTR_CONTENT));
         }
 
         // -- HTML mode configuration
@@ -425,8 +419,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     @Override
     public void onSaveInstanceState(Bundle outState) {
         try {
-            outState.putCharSequence(KEY_TITLE, getTitle());
-            outState.putCharSequence(KEY_CONTENT, getContent());
+            outState.putCharSequence(ATTR_TITLE, getTitle());
+            outState.putCharSequence(ATTR_CONTENT, getContent());
         } catch (IllegalEditorStateException e) {
             AppLog.e(T.EDITOR, "onSaveInstanceState: unable to get title or content");
         }
@@ -884,9 +878,9 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 return;
             }
 
-            final String imageMeta = Utils.escapeQuotes(StringUtils.notNullStr(extras.getString("imageMeta")));
-            final int imageRemoteId = extras.getInt("imageRemoteId");
-            final boolean isFeaturedImage = extras.getBoolean("isFeatured");
+            final String imageMeta = Utils.escapeQuotes(StringUtils.notNullStr(extras.getString(EXTRA_IMAGE_META)));
+            final int imageRemoteId = extras.getInt(ATTR_ID_IMAGE_REMOTE);
+            final boolean isFeaturedImage = extras.getBoolean(EXTRA_FEATURED);
 
             mWebView.post(new Runnable() {
                 @Override
@@ -1336,7 +1330,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         }
 
         switch (uploadStatus) {
-            case "uploading":
+            case ATTR_STATUS_UPLOADING:
                 // Display 'cancel upload' dialog
                 AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
                 builder.setTitle(getString(R.string.stop_upload_dialog_title));
@@ -1370,7 +1364,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 AlertDialog dialog = builder.create();
                 dialog.show();
                 break;
-            case "failed":
+            case ATTR_STATUS_FAILED:
                 // Retry media upload
                 mEditorFragmentListener.onMediaRetryClicked(mediaId);
 
@@ -1409,8 +1403,8 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
                 Bundle dialogBundle = new Bundle();
 
-                dialogBundle.putString("maxWidth", mBlogSettingMaxImageWidth);
-                dialogBundle.putBoolean("featuredImageSupported", mFeaturedImageSupported);
+                dialogBundle.putString(EXTRA_MAX_WIDTH, mBlogSettingMaxImageWidth);
+                dialogBundle.putBoolean(EXTRA_IMAGE_FEATURED, mFeaturedImageSupported);
 
                 // Request and add an authorization header for HTTPS images
                 // Use https:// when requesting the auth header, in case the image is incorrectly using http://.
@@ -1421,22 +1415,22 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 }
 
                 try {
-                    final String imageSrc = meta.getString("src");
+                    final String imageSrc = meta.getString(ATTR_SRC);
                     String authHeader = mEditorFragmentListener.onAuthHeaderRequested(UrlUtils.makeHttps(imageSrc));
                     if (authHeader.length() > 0) {
-                        meta.put("src", UrlUtils.makeHttps(imageSrc));
+                        meta.put(ATTR_SRC, UrlUtils.makeHttps(imageSrc));
                         headerMap.put("Authorization", authHeader);
                     }
                 } catch (JSONException e) {
                     AppLog.e(T.EDITOR, "Could not retrieve image url from JSON metadata");
                 }
-                dialogBundle.putSerializable("headerMap", headerMap);
+                dialogBundle.putSerializable(EXTRA_HEADER, headerMap);
 
-                dialogBundle.putString("imageMeta", meta.toString());
+                dialogBundle.putString(EXTRA_IMAGE_META, meta.toString());
 
-                String imageId = JSONUtils.getString(meta, "attachment_id");
+                String imageId = JSONUtils.getString(meta, ATTR_ID_ATTACHMENT);
                 if (!imageId.isEmpty()) {
-                    dialogBundle.putBoolean("isFeatured", mFeaturedImageId == Integer.parseInt(imageId));
+                    dialogBundle.putBoolean(EXTRA_FEATURED, mFeaturedImageId == Integer.parseInt(imageId));
                 }
 
                 imageSettingsDialogFragment.setArguments(dialogBundle);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -49,6 +49,29 @@ public abstract class EditorFragmentAbstract extends Fragment {
         }
     }
 
+    protected static final String ARG_PARAM_TITLE = "param_title";
+    protected static final String ARG_PARAM_CONTENT = "param_content";
+    protected static final String ATTR_ALIGN = "align";
+    protected static final String ATTR_ALT = "alt";
+    protected static final String ATTR_CAPTION = "caption";
+    protected static final String ATTR_CONTENT = "content";
+    protected static final String ATTR_DIMEN_HEIGHT = "height";
+    protected static final String ATTR_DIMEN_WIDTH = "width";
+    protected static final String ATTR_ID = "id";
+    protected static final String ATTR_ID_ATTACHMENT = "attachment_id";
+    protected static final String ATTR_ID_IMAGE_REMOTE = "imageRemoteId";
+    protected static final String ATTR_SRC = "src";
+    protected static final String ATTR_STATUS_FAILED = "failed";
+    protected static final String ATTR_STATUS_UPLOADING = "uploading";
+    protected static final String ATTR_TITLE = "title";
+    protected static final String ATTR_URL_LINK = "linkUrl";
+    protected static final String EXTRA_ENABLED_AZTEC = "isAztecEnabled";
+    protected static final String EXTRA_FEATURED = "isFeatured";
+    protected static final String EXTRA_HEADER = "headerMap";
+    protected static final String EXTRA_IMAGE_FEATURED = "featuredImageSupported";
+    protected static final String EXTRA_IMAGE_META = "imageMeta";
+    protected static final String EXTRA_MAX_WIDTH = "maxWidth";
+
     private static final String FEATURED_IMAGE_SUPPORT_KEY = "featured-image-supported";
     private static final String FEATURED_IMAGE_WIDTH_KEY   = "featured-image-width";
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -34,6 +34,23 @@ import org.wordpress.android.util.ToastUtils;
 import java.util.Arrays;
 import java.util.Map;
 
+import static org.wordpress.android.editor.EditorFragmentAbstract.ATTR_ALIGN;
+import static org.wordpress.android.editor.EditorFragmentAbstract.ATTR_CAPTION;
+import static org.wordpress.android.editor.EditorFragmentAbstract.ATTR_ID_IMAGE_REMOTE;
+import static org.wordpress.android.editor.EditorFragmentAbstract.ATTR_URL_LINK;
+import static org.wordpress.android.editor.EditorFragmentAbstract.EXTRA_ENABLED_AZTEC;
+import static org.wordpress.android.editor.EditorFragmentAbstract.EXTRA_FEATURED;
+import static org.wordpress.android.editor.EditorFragmentAbstract.EXTRA_HEADER;
+import static org.wordpress.android.editor.EditorFragmentAbstract.EXTRA_IMAGE_FEATURED;
+import static org.wordpress.android.editor.EditorFragmentAbstract.EXTRA_IMAGE_META;
+import static org.wordpress.android.editor.EditorFragmentAbstract.EXTRA_MAX_WIDTH;
+import static org.wordpress.android.editor.EditorFragmentAbstract.ATTR_SRC;
+import static org.wordpress.android.editor.EditorFragmentAbstract.ATTR_ALT;
+import static org.wordpress.android.editor.EditorFragmentAbstract.ATTR_DIMEN_HEIGHT;
+import static org.wordpress.android.editor.EditorFragmentAbstract.ATTR_ID_ATTACHMENT;
+import static org.wordpress.android.editor.EditorFragmentAbstract.ATTR_TITLE;
+import static org.wordpress.android.editor.EditorFragmentAbstract.ATTR_DIMEN_WIDTH;
+
 /**
  * A full-screen DialogFragment with image settings.
  *
@@ -101,19 +118,19 @@ public class ImageSettingsDialogFragment extends DialogFragment {
 
                 String imageRemoteId = "";
                 try {
-                    imageRemoteId = mImageMeta.getString("attachment_id");
+                    imageRemoteId = mImageMeta.getString(ATTR_ID_ATTACHMENT);
                 } catch (JSONException e) {
                     AppLog.e(AppLog.T.EDITOR, "Unable to retrieve featured image id from meta data");
                 }
 
                 Intent intent = new Intent();
-                intent.putExtra("imageMeta", mImageMeta.toString());
+                intent.putExtra(EXTRA_IMAGE_META, mImageMeta.toString());
 
                 mIsFeatured = mFeaturedCheckBox.isChecked();
-                intent.putExtra("isFeatured", mIsFeatured);
+                intent.putExtra(EXTRA_FEATURED, mIsFeatured);
 
                 if (!imageRemoteId.isEmpty()) {
-                    intent.putExtra("imageRemoteId", Integer.parseInt(imageRemoteId));
+                    intent.putExtra(ATTR_ID_IMAGE_REMOTE, Integer.parseInt(imageRemoteId));
                 }
 
                 getTargetFragment().onActivityResult(getTargetRequestCode(), getTargetRequestCode(), intent);
@@ -144,36 +161,36 @@ public class ImageSettingsDialogFragment extends DialogFragment {
         Bundle bundle = getArguments();
         if (bundle != null) {
             try {
-                mImageMeta = new JSONObject(bundle.getString("imageMeta"));
+                mImageMeta = new JSONObject(bundle.getString(EXTRA_IMAGE_META));
 
-                mHttpHeaders = (Map) bundle.getSerializable("headerMap");
+                mHttpHeaders = (Map) bundle.getSerializable(EXTRA_HEADER);
 
-                final String imageSrc = mImageMeta.getString("src");
+                final String imageSrc = mImageMeta.getString(ATTR_SRC);
                 final String imageFilename = imageSrc.substring(imageSrc.lastIndexOf("/") + 1);
 
                 loadThumbnail(imageSrc, thumbnailImage);
                 filenameLabel.setText(imageFilename);
 
-                mTitleText.setText(mImageMeta.getString("title"));
-                mCaptionText.setText(mImageMeta.getString("caption"));
-                mAltText.setText(mImageMeta.getString("alt"));
+                mTitleText.setText(mImageMeta.getString(ATTR_TITLE));
+                mCaptionText.setText(mImageMeta.getString(ATTR_CAPTION));
+                mAltText.setText(mImageMeta.getString(ATTR_ALT));
 
-                String alignment = mImageMeta.getString("align");
+                String alignment = mImageMeta.getString(ATTR_ALIGN);
                 mAlignmentKeyArray = getResources().getStringArray(R.array.alignment_key_array);
                 int alignmentIndex = Arrays.asList(mAlignmentKeyArray).indexOf(alignment);
                 mAlignmentSpinner.setSelection(alignmentIndex == -1 ? 0 : alignmentIndex);
 
-                mLinkTo.setText(mImageMeta.getString("linkUrl"));
+                mLinkTo.setText(mImageMeta.getString(ATTR_URL_LINK));
 
                 mMaxImageWidth = MediaUtils.getMaximumImageWidth(mImageMeta.getInt("naturalWidth"),
-                        bundle.getString("maxWidth"));
+                        bundle.getString(EXTRA_MAX_WIDTH));
 
-                setupWidthSeekBar(widthSeekBar, mWidthText, mImageMeta.getInt("width"));
+                setupWidthSeekBar(widthSeekBar, mWidthText, mImageMeta.getInt(ATTR_DIMEN_WIDTH));
 
-                boolean featuredImageSupported = bundle.getBoolean("featuredImageSupported");
+                boolean featuredImageSupported = bundle.getBoolean(EXTRA_IMAGE_FEATURED);
                 if (featuredImageSupported) {
                     mFeaturedCheckBox.setVisibility(View.VISIBLE);
-                    mIsFeatured = bundle.getBoolean("isFeatured", false);
+                    mIsFeatured = bundle.getBoolean(EXTRA_FEATURED, false);
                     mFeaturedCheckBox.setChecked(mIsFeatured);
                 }
             } catch (JSONException e1) {
@@ -181,7 +198,7 @@ public class ImageSettingsDialogFragment extends DialogFragment {
             }
 
             // TODO: Unsupported in Aztec - remove once caption, alignment & link support added
-            if (bundle.getBoolean("isAztecEnabled")) {
+            if (bundle.getBoolean(EXTRA_ENABLED_AZTEC)) {
                 mCaptionText.setVisibility(View.GONE);
                 View label = view.findViewById(R.id.image_caption_label);
                 if (label != null) {
@@ -318,17 +335,17 @@ public class ImageSettingsDialogFragment extends DialogFragment {
      */
     private JSONObject extractMetaDataFromFields(JSONObject metaData) {
         try {
-            metaData.put("title", mTitleText.getText().toString());
-            metaData.put("caption", mCaptionText.getText().toString());
-            metaData.put("alt", mAltText.getText().toString());
+            metaData.put(ATTR_TITLE, mTitleText.getText().toString());
+            metaData.put(ATTR_CAPTION, mCaptionText.getText().toString());
+            metaData.put(ATTR_ALT, mAltText.getText().toString());
             if (mAlignmentSpinner.getSelectedItemPosition() < mAlignmentKeyArray.length) {
-                metaData.put("align", mAlignmentKeyArray[mAlignmentSpinner.getSelectedItemPosition()]);
+                metaData.put(ATTR_ALIGN, mAlignmentKeyArray[mAlignmentSpinner.getSelectedItemPosition()]);
             }
-            metaData.put("linkUrl", mLinkTo.getText().toString());
+            metaData.put(ATTR_URL_LINK, mLinkTo.getText().toString());
 
             int newWidth = getEditTextIntegerClamped(mWidthText, 1, Integer.MAX_VALUE);
-            metaData.put("width", newWidth);
-            metaData.put("height", getRelativeHeightFromWidth(newWidth));
+            metaData.put(ATTR_DIMEN_WIDTH, newWidth);
+            metaData.put(ATTR_DIMEN_HEIGHT, getRelativeHeightFromWidth(newWidth));
         } catch (JSONException e) {
             AppLog.d(AppLog.T.EDITOR, "Unable to build JSON object from new meta data");
         }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
@@ -81,7 +81,6 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
     private static final String KEY_IMAGE_SPANS = "image-spans";
     private static final String KEY_START = "start";
     private static final String KEY_END = "end";
-    private static final String KEY_CONTENT = "content";
     private static final String TAG_FORMAT_BAR_BUTTON_STRONG = "strong";
     private static final String TAG_FORMAT_BAR_BUTTON_EM = "em";
     private static final String TAG_FORMAT_BAR_BUTTON_UNDERLINE = "u";
@@ -230,7 +229,7 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
         if (savedInstanceState != null) {
             Parcelable[] spans = savedInstanceState.getParcelableArray(KEY_IMAGE_SPANS);
 
-            mContent = savedInstanceState.getString(KEY_CONTENT, "");
+            mContent = savedInstanceState.getString(ATTR_CONTENT, "");
             mContentEditText.setText(mContent);
             mContentEditText.setSelection(savedInstanceState.getInt(KEY_START, 0),
                                           savedInstanceState.getInt(KEY_END, 0));
@@ -1021,7 +1020,7 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
 
         outState.putInt(KEY_START, mContentEditText.getSelectionStart());
         outState.putInt(KEY_END, mContentEditText.getSelectionEnd());
-        outState.putString(KEY_CONTENT, mContentEditText.getText().toString());
+        outState.putString(ATTR_CONTENT, mContentEditText.getText().toString());
     }
 
     private class AddMediaFileTask extends AsyncTask<Void, Void, WPEditImageSpan> {


### PR DESCRIPTION
### Fix
When inserting an image from the WordPress media library, the image's HTML contains all custom attributes as described in https://github.com/wordpress-mobile/WordPress-Android/issues/5779.  The attributes included are `title`, `width`, and `height`.  The `alt text` attribute is not included since it doesn't exist in the [`MediaFile`](https://github.com/wordpress-mobile/WordPress-Utils-Android/blob/develop/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/MediaFile.java) object even though that value can be set for the media file on the web.  The `alt text` attribute shown on the ***Image Settings*** screen is taken from the HTML when the [media is tapped](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java#L870) and not from the media file stored on the device.

### Test
0. Add custom attributes to image.
1. Go to ***Sites*** tab.
2. Tap ***Create*** floating button.
3. Tap content text field.
4. Tap ***Media*** format button.
5. Tap ***WordPress*** media picker button.
6. Tap image from library.
7. Tap ***HTML*** format button.
8. Notice `img` tag with custom attributes.