### PR TITLE
made AlertDialog show within UI thread

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -835,23 +835,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         new SavePostOnlineAndFinishTask(isFirstTimePublish).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
-    private boolean hasFailedMedia() {
-        // Show an Alert Dialog asking the user if he wants to remove all failed media before upload
-        if (mEditorFragment.hasFailedMediaUploads()) {
-            AlertDialog.Builder builder = new AlertDialog.Builder(this);
-            builder.setMessage(R.string.editor_toast_failed_uploads)
-                    .setPositiveButton(R.string.editor_remove_failed_uploads, new DialogInterface.OnClickListener() {
-                        public void onClick(DialogInterface dialog, int id) {
-                            // Clear failed uploads
-                            mEditorFragment.removeAllFailedMediaUploads();
-                        }
-                    }).setNegativeButton(android.R.string.cancel, null);
-            builder.create().show();
-            return true;
-        }
-        return false;
-    }
-
     @Override
     public void openContextMenu(View view) {
         // if we're using the native photo picker, ignore the request - if we're not using
@@ -1200,7 +1183,15 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
                 if (isPublishable) {
                     if (NetworkUtils.isNetworkAvailable(getBaseContext())) {
-                        if (!hasFailedMedia()) {
+                        // Show an Alert Dialog asking the user if they want to remove all failed media before upload
+                        if (mEditorFragment.hasFailedMediaUploads()) {
+                            EditPostActivity.this.runOnUiThread(new Runnable() {
+                                @Override
+                                public void run() {
+                                    showRemoveFailedUploadsDialog();
+                                }
+                            });
+                        } else {
                             savePostOnlineAndFinishAsync(isFirstTimePublish);
                         }
                     } else {
@@ -1216,6 +1207,18 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 }
             }
         }).start();
+    }
+
+    private void showRemoveFailedUploadsDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setMessage(R.string.editor_toast_failed_uploads)
+                .setPositiveButton(R.string.editor_remove_failed_uploads, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        // Clear failed uploads
+                        mEditorFragment.removeAllFailedMediaUploads();
+                    }
+                }).setNegativeButton(android.R.string.cancel, null);
+        builder.create().show();
     }
 
     private void savePostAndFinish() {


### PR DESCRIPTION
Fixes #5785 

To test:
1. Write a new post including an image
2. while the image is uploading, set the device to airplane mode
3. wait a couple of seconds and hit BACK
4. the draft will be saved
5. go back into the editor
6. set the post settings from Draft to Publish
7. Tap publish: it should show the dialog and not crash.


