### PR TITLE
issue/5775-photo-picker-help-7.3

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -230,13 +230,15 @@
         <!-- Media Activities -->
         <activity
             android:name=".ui.media.MediaBrowserActivity"
-            android:theme="@style/Calypso.NoActionBar" />
+            android:theme="@style/Calypso.NoActionBar"
+            android:label="@string/wp_media_title" />
         <activity
             android:name=".ui.media.MediaPreviewActivity"
             android:windowSoftInputMode="adjustNothing"
             android:theme="@style/Theme.AppCompat.NoActionBar" />
         <activity android:name=".ui.media.MediaGalleryActivity" />
-        <activity android:name=".ui.media.MediaGalleryPickerActivity" />
+        <activity android:name=".ui.media.MediaGalleryPickerActivity"
+            android:label="@string/wp_media_title" />
 
         <!-- Theme Activities -->
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -31,6 +31,7 @@ import org.wordpress.android.ui.notifications.NotificationFragment;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.SmartToast;
 import org.wordpress.android.util.ToastUtils;
 
 import javax.inject.Inject;
@@ -102,6 +103,10 @@ public class CommentsActivity extends AppCompatActivity
             getIntent().putExtra(KEY_AUTO_REFRESHED, savedInstanceState.getBoolean(KEY_AUTO_REFRESHED));
             getIntent().putExtra(KEY_EMPTY_VIEW_MESSAGE, savedInstanceState.getString(KEY_EMPTY_VIEW_MESSAGE));
             mComment = (CommentModel) savedInstanceState.getSerializable(KEY_SELECTED_COMMENT);
+        }
+
+        if (savedInstanceState == null) {
+            SmartToast.show(this, SmartToast.SmartToastType.COMMENTS_LONG_PRESS);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -68,6 +68,7 @@ import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.PermissionUtils;
+import org.wordpress.android.util.SmartToast;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPMediaUtils;
@@ -140,7 +141,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         if (actionBar != null) {
             actionBar.setDisplayShowTitleEnabled(true);
             actionBar.setDisplayHomeAsUpEnabled(true);
-            actionBar.setTitle(R.string.media);
         }
 
         FragmentManager fm = getFragmentManager();
@@ -151,6 +151,10 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
         // if media was shared add it to the library
         handleSharedMedia();
+
+        if (savedInstanceState == null) {
+            SmartToast.show(this, SmartToast.SmartToastType.WP_MEDIA_BROWSER_LONG_PRESS);
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGalleryPickerActivity.java
@@ -101,7 +101,6 @@ public class MediaGalleryPickerActivity extends AppCompatActivity
         }
 
         setContentView(R.layout.media_gallery_picker_layout);
-        setTitle(R.string.select_from_media_library);
 
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -117,6 +117,7 @@ import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.SiteUtils;
+import org.wordpress.android.util.SmartToast;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
@@ -560,6 +561,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         // make sure we initialized the photo picker
         if (mPhotoPickerFragment == null) {
             initPhotoPicker();
+            SmartToast.show(this, SmartToast.SmartToastType.PHOTO_PICKER_LONG_PRESS);
         }
 
         // hide soft keyboard

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -90,6 +90,11 @@ public class AppPrefs {
 
         // list of last time a notification has been created for a draft
         PENDING_DRAFTS_NOTIFICATION_LAST_NOTIFICATION_DATES,
+
+        // smart toast counters
+        SMART_TOAST_PHOTO_PICKER_LONG_PRESS_COUNTER,
+        SMART_TOAST_WP_MEDIA_BROWSER_LONG_PRESS_COUNTER,
+        SMART_TOAST_COMMENTS_LONG_PRESS_COUNTER
     }
 
     /**
@@ -184,11 +189,11 @@ public class AppPrefs {
         }
     }
 
-    private static int getInt(PrefKey key) {
+    public static int getInt(PrefKey key) {
         return getInt(key, 0);
     }
 
-    private static void setInt(PrefKey key, int value) {
+    public static void setInt(PrefKey key, int value) {
         setString(key, Integer.toString(value));
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -90,11 +90,6 @@ public class AppPrefs {
 
         // list of last time a notification has been created for a draft
         PENDING_DRAFTS_NOTIFICATION_LAST_NOTIFICATION_DATES,
-
-        // smart toast counters
-        SMART_TOAST_PHOTO_PICKER_LONG_PRESS_COUNTER,
-        SMART_TOAST_WP_MEDIA_BROWSER_LONG_PRESS_COUNTER,
-        SMART_TOAST_COMMENTS_LONG_PRESS_COUNTER
     }
 
     /**
@@ -140,6 +135,11 @@ public class AppPrefs {
 
         // aztec editor available
         AZTEC_EDITOR_AVAILABLE,
+
+        // smart toast counters
+        SMART_TOAST_PHOTO_PICKER_LONG_PRESS_COUNTER,
+        SMART_TOAST_WP_MEDIA_BROWSER_LONG_PRESS_COUNTER,
+        SMART_TOAST_COMMENTS_LONG_PRESS_COUNTER
     }
 
     private static SharedPreferences prefs() {

--- a/WordPress/src/main/java/org/wordpress/android/util/SmartToast.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SmartToast.java
@@ -1,0 +1,59 @@
+package org.wordpress.android.util;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.view.Gravity;
+import android.widget.Toast;
+
+import org.wordpress.android.R;
+import org.wordpress.android.ui.prefs.AppPrefs;
+import org.wordpress.android.ui.prefs.AppPrefs.DeletablePrefKey;
+
+/**
+ * Simple wrapper for limiting the number of times to show a toast message - originally designed
+ * to let users know where they can long press to multi-select
+ */
+
+public class SmartToast {
+
+    public enum SmartToastType {
+        PHOTO_PICKER_LONG_PRESS,
+        WP_MEDIA_BROWSER_LONG_PRESS,
+        COMMENTS_LONG_PRESS
+    }
+
+    private static final int MAX_TIMES_TO_SHOW = 3;
+
+    public static void show(@NonNull Context context, @NonNull SmartToastType type) {
+        DeletablePrefKey keyCounter;
+        int stringResId;
+        switch (type) {
+            case PHOTO_PICKER_LONG_PRESS:
+                keyCounter = DeletablePrefKey.SMART_TOAST_PHOTO_PICKER_LONG_PRESS_COUNTER;
+                stringResId = R.string.smart_toast_photo_long_press;
+                break;
+            case WP_MEDIA_BROWSER_LONG_PRESS:
+                keyCounter = DeletablePrefKey.SMART_TOAST_WP_MEDIA_BROWSER_LONG_PRESS_COUNTER;
+                stringResId = R.string.smart_toast_photo_long_press;
+                break;
+            case COMMENTS_LONG_PRESS:
+                keyCounter = DeletablePrefKey.SMART_TOAST_COMMENTS_LONG_PRESS_COUNTER;
+                stringResId = R.string.smart_toast_comments_long_press;
+                break;
+            default:
+                return;
+        }
+        int numTimesShown = AppPrefs.getInt(keyCounter);
+        if (numTimesShown >= MAX_TIMES_TO_SHOW) {
+            return;
+        }
+
+        int yOffset = context.getResources().getDimensionPixelOffset(R.dimen.smart_toast_offset_y);
+        Toast toast = Toast.makeText(context, context.getString(stringResId), Toast.LENGTH_LONG);
+        toast.setGravity(Gravity.CENTER_HORIZONTAL | Gravity.BOTTOM, 0, yOffset);
+        toast.show();
+
+        numTimesShown++;
+        AppPrefs.setInt(keyCounter, numTimesShown);
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/SmartToast.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SmartToast.java
@@ -7,7 +7,7 @@ import android.widget.Toast;
 
 import org.wordpress.android.R;
 import org.wordpress.android.ui.prefs.AppPrefs;
-import org.wordpress.android.ui.prefs.AppPrefs.DeletablePrefKey;
+import org.wordpress.android.ui.prefs.AppPrefs.UndeletablePrefKey;
 
 /**
  * Simple wrapper for limiting the number of times to show a toast message - originally designed
@@ -25,19 +25,19 @@ public class SmartToast {
     private static final int MAX_TIMES_TO_SHOW = 3;
 
     public static void show(@NonNull Context context, @NonNull SmartToastType type) {
-        DeletablePrefKey keyCounter;
+        UndeletablePrefKey keyCounter;
         int stringResId;
         switch (type) {
             case PHOTO_PICKER_LONG_PRESS:
-                keyCounter = DeletablePrefKey.SMART_TOAST_PHOTO_PICKER_LONG_PRESS_COUNTER;
+                keyCounter = UndeletablePrefKey.SMART_TOAST_PHOTO_PICKER_LONG_PRESS_COUNTER;
                 stringResId = R.string.smart_toast_photo_long_press;
                 break;
             case WP_MEDIA_BROWSER_LONG_PRESS:
-                keyCounter = DeletablePrefKey.SMART_TOAST_WP_MEDIA_BROWSER_LONG_PRESS_COUNTER;
+                keyCounter = UndeletablePrefKey.SMART_TOAST_WP_MEDIA_BROWSER_LONG_PRESS_COUNTER;
                 stringResId = R.string.smart_toast_photo_long_press;
                 break;
             case COMMENTS_LONG_PRESS:
-                keyCounter = DeletablePrefKey.SMART_TOAST_COMMENTS_LONG_PRESS_COUNTER;
+                keyCounter = UndeletablePrefKey.SMART_TOAST_COMMENTS_LONG_PRESS_COUNTER;
                 stringResId = R.string.smart_toast_comments_long_press;
                 break;
             default:

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -295,4 +295,6 @@
     <dimen name="photo_picker_selected_item_padding">4dp</dimen>
     <dimen name="photo_picker_icon">48dp</dimen>
     <dimen name="photo_picker_video_overlay">36dp</dimen>
+
+    <dimen name="smart_toast_offset_y">48dp</dimen>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -136,6 +136,7 @@
     <string name="media_insert_title">Add multiple photos</string>
     <string name="media_insert_individually">Add individually</string>
     <string name="media_insert_as_gallery">Add as gallery</string>
+    <string name="wp_media_title">WordPress media</string>
     <string name="pick_photo">Select photo</string>
     <string name="pick_video">Select video</string>
     <string name="capture_or_pick_photo">Capture or select photo</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1679,8 +1679,8 @@
     <string name="error_all_media_upload_canceled">All media uploads have been cancelled due to an unknown error. Please retry uploading</string>
 
     <string name="photo_picker_title">Choose photo</string>
-    <string name="photo_picker_choose_photo">Choose photo</string>
-    <string name="photo_picker_choose_video">Choose video</string>
+    <string name="photo_picker_choose_photo">Choose photo from device</string>
+    <string name="photo_picker_choose_video">Choose video from device</string>
     <string name="photo_picker_capture_photo">Take photo</string>
     <string name="photo_picker_capture_video">Take video</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1693,4 +1693,7 @@
     <string name="editor_confirm_email_prompt_message_with_email">We sent an email to %s when you first signed up. Please open the message and click the blue button to enable publishing.</string>
     <string name="editor_confirm_email_prompt_negative">Resend Email</string>
 
+    <!-- smart toasts -->
+    <string name="smart_toast_photo_long_press">Tap and hold to select multiple photos</string>
+    <string name="smart_toast_comments_long_press">Tap and hold to select multiple comments</string>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -131,6 +131,7 @@
     <string name="media_gallery_type_circles">Circles</string>
     <string name="media_gallery_type_slideshow">Slideshow</string>
     <string name="media_gallery_edit">Edit gallery</string>
+    <string name="wp_media_title">WordPress media</string>
     <string name="pick_photo">Select photo</string>
     <string name="pick_video">Select video</string>
     <string name="capture_or_pick_photo">Capture or select photo</string>
@@ -399,7 +400,6 @@
     <!-- media selection -->
     <string name="select_photo">Select a photo from gallery</string>
     <string name="select_video">Select a video from gallery</string>
-    <string name="select_from_media_library">Select from media library</string>
 
     <!-- category management -->
     <string name="categories">Categories</string>
@@ -1673,8 +1673,8 @@
     <string name="error_all_media_upload_canceled">All media uploads have been cancelled due to an unknown error. Please retry uploading</string>
 
     <string name="photo_picker_title">Choose photo</string>
-    <string name="photo_picker_choose_photo">Choose photo</string>
-    <string name="photo_picker_choose_video">Choose video</string>
+    <string name="photo_picker_choose_photo">Choose photo from device</string>
+    <string name="photo_picker_choose_video">Choose video from device</string>
     <string name="photo_picker_capture_photo">Take photo</string>
     <string name="photo_picker_capture_video">Take video</string>
 
@@ -1687,4 +1687,7 @@
     <string name="editor_confirm_email_prompt_message_with_email">We sent an email to %s when you first signed up. Please open the message and click the blue button to enable publishing.</string>
     <string name="editor_confirm_email_prompt_negative">Resend Email</string>
 
+    <!-- smart toasts -->
+    <string name="smart_toast_photo_long_press">Tap and hold to select multiple photos</string>
+    <string name="smart_toast_comments_long_press">Tap and hold to select multiple comments</string>
 </resources>


### PR DESCRIPTION
Fixes #5775 - clarifies the photo picker by:
* Adding a toast letting the user know long-press is available the first three times the feature is accessed.
* Changing the WP media library title from "Select from media library" to "WordPress media."
* Changing the device icon menu to show "Choose photo from device" and "Choose video from device"

Note that the toast was also added to the Comments activity, since long press is available there. It was _not_ added to the WP media picker since that's called from the photo picker "W" icon and the user may have just seen the same toast there.

![screenshot_1493396829](https://cloud.githubusercontent.com/assets/3903757/25537978/ce925ad0-2c0e-11e7-92ac-a19cddf08a5e.png)
