### PR TITLE
Issue/5771 wpmedia gallery settings 7.3

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/InsertMediaDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/InsertMediaDialog.java
@@ -1,0 +1,305 @@
+package org.wordpress.android.ui.posts;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.annotation.DrawableRes;
+import android.support.annotation.IdRes;
+import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatDialogFragment;
+import android.view.ContextThemeWrapper;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
+import android.widget.SeekBar;
+import android.widget.TextView;
+
+import org.wordpress.android.R;
+import org.wordpress.android.util.AniUtils;
+
+/**
+ * Displayed after user selects multiple items from the WP media library to insert into
+ * a post - provides a choice between inserting them individually or as a gallery
+ */
+public class InsertMediaDialog extends AppCompatDialogFragment {
+
+    public enum InsertType {
+        INDIVIDUALLY,
+        GALLERY
+    }
+
+    public enum GalleryType {
+        DEFAULT,
+        TILED,
+        SQUARES,
+        CIRCLES,
+        SLIDESHOW;
+
+        // overridden to return the actual name used in the gallery shortcode
+        @Override
+        public String toString() {
+            switch (this) {
+                case CIRCLES:
+                    return "circle";
+                case SLIDESHOW:
+                    return "slideshow";
+                case SQUARES:
+                    return "square";
+                case TILED:
+                    return "rectangular";
+                default:
+                    return "";
+            }
+        }
+    }
+
+    public interface InsertMediaCallback {
+        void onCompleted(@NonNull InsertMediaDialog dialog);
+    }
+
+    private static final int DEFAULT_COLUMN_COUNT = 3;
+    private static final int MAX_COLUMN_COUNT = 9;
+
+    private static final String STATE_INSERT_TYPE = "STATE_INSERT_TYPE";
+    private static final String STATE_NUM_COLUMNS = "STATE_NUM_COLUMNS";
+    private static final String STATE_GALLERY_TYPE_ORD = "GALLERY_TYPE_ORD";
+
+    private RadioGroup mInsertRadioGroup;
+    private RadioGroup mGalleryRadioGroup;
+    private ViewGroup mNumColumnsContainer;
+    private SeekBar mNumColumnsSeekBar;
+
+    private InsertMediaCallback mCallback;
+    private GalleryType mGalleryType;
+    private InsertType mInsertType;
+    private int mNumColumns;
+
+
+    public static InsertMediaDialog newInstance(@NonNull InsertMediaCallback callback) {
+        InsertMediaDialog dialog = new InsertMediaDialog();
+        dialog.setStyle(AppCompatDialogFragment.STYLE_NORMAL, R.style.Theme_AppCompat_Light_Dialog);
+        dialog.setCallback(callback);
+        return dialog;
+    }
+
+    private void setCallback(@NonNull InsertMediaCallback callback) {
+        mCallback = callback;
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        getDialog().setTitle(R.string.media_insert_title);
+
+        Context themer = new ContextThemeWrapper(getActivity(), R.style.Calypso_SiteSettingsTheme);
+        LayoutInflater localInflater = inflater.cloneInContext(themer);
+        View view = localInflater.inflate(R.layout.insert_media_dialog, container, false);
+
+        mInsertRadioGroup = (RadioGroup) view.findViewById(R.id.radio_group_insert_type);
+        mInsertRadioGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(RadioGroup group, @IdRes int checkedId) {
+                if (checkedId == R.id.radio_insert_as_gallery) {
+                    setInsertType(InsertType.GALLERY);
+                } else {
+                    setInsertType(InsertType.INDIVIDUALLY);
+                }
+            }
+        });
+
+        mGalleryRadioGroup = (RadioGroup) view.findViewById(R.id.radio_group_gallery_type);
+        mGalleryRadioGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(RadioGroup group, @IdRes int checkedId) {
+                GalleryType galleryType;
+                switch (checkedId) {
+                    case R.id.radio_circles:
+                        galleryType = GalleryType.CIRCLES;
+                        break;
+                    case R.id.radio_slideshow:
+                        galleryType = GalleryType.SLIDESHOW;
+                        break;
+                    case R.id.radio_squares:
+                        galleryType = GalleryType.SQUARES;
+                        break;
+                    case R.id.radio_tiled:
+                        galleryType = GalleryType.TILED;
+                        break;
+                    default:
+                        galleryType = GalleryType.DEFAULT;
+                        break;
+                }
+                setGalleryType(galleryType);
+            }
+        });
+
+        mNumColumnsContainer = (ViewGroup) view.findViewById(R.id.num_columns_container);
+        mNumColumnsSeekBar = (SeekBar) mNumColumnsContainer.findViewById(R.id.seekbar_num_columns);
+        mNumColumnsSeekBar.setMax(MAX_COLUMN_COUNT - 1);
+        mNumColumnsSeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+                if (fromUser) {
+                    setNumColumns(progress, true);
+                }
+            }
+            @Override
+            public void onStartTrackingTouch(SeekBar seekBar) {
+                // noop
+            }
+            @Override
+            public void onStopTrackingTouch(SeekBar seekBar) {
+                // noop
+            }
+        });
+
+        Button btnCancel = (Button) view.findViewById(R.id.button_cancel);
+        btnCancel.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                getDialog().cancel();
+            }
+        });
+
+        Button btnOk = (Button) view.findViewById(R.id.button_ok);
+        btnOk.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mCallback.onCompleted(InsertMediaDialog.this);
+                getDialog().dismiss();
+            }
+        });
+
+        return view;
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putInt(STATE_INSERT_TYPE, mInsertType.ordinal());
+        outState.putInt(STATE_GALLERY_TYPE_ORD, mGalleryType.ordinal());
+        outState.putInt(STATE_NUM_COLUMNS, mNumColumns);
+    }
+
+    @Override
+    public void onActivityCreated(Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        if (savedInstanceState != null) {
+            int insertTypeOrdinal = savedInstanceState.getInt(STATE_INSERT_TYPE);
+            setInsertType(InsertType.values()[insertTypeOrdinal]);
+            int galleryTypeOrdinal = savedInstanceState.getInt(STATE_GALLERY_TYPE_ORD);
+            setGalleryType(GalleryType.values()[galleryTypeOrdinal]);
+            setNumColumns(savedInstanceState.getInt(STATE_NUM_COLUMNS), false);
+        } else {
+            setInsertType(InsertType.GALLERY);
+            setGalleryType(GalleryType.DEFAULT);
+            setNumColumns(DEFAULT_COLUMN_COUNT, false);
+        }
+    }
+
+    public InsertType getInsertType() {
+        return mInsertType;
+    }
+
+    private void setInsertType(@NonNull InsertType insertType) {
+        if (insertType == mInsertType) {
+            return;
+        }
+
+        mInsertType = insertType;
+
+        @IdRes int radioId = insertType == InsertType.GALLERY
+                ? R.id.radio_insert_as_gallery : R.id.radio_insert_individually;
+        RadioButton radio = (RadioButton) getView().findViewById(radioId);
+        if (!radio.isChecked()) {
+            radio.setChecked(true);
+        }
+
+        ViewGroup container = (ViewGroup) getView().findViewById(R.id.container_gallery_settings);
+        boolean enableGalleryTypes = insertType == InsertType.GALLERY;
+        if (enableGalleryTypes && container.getVisibility() != View.VISIBLE) {
+            AniUtils.fadeIn(container, AniUtils.Duration.SHORT);
+        } else if (!enableGalleryTypes && container.getVisibility() == View.VISIBLE) {
+            AniUtils.fadeOut(container, AniUtils.Duration.SHORT, View.INVISIBLE);
+        }
+    }
+
+    public GalleryType getGalleryType() {
+        return mGalleryType;
+    }
+
+    private void setGalleryType(@NonNull GalleryType galleryType) {
+        if (galleryType == mGalleryType) {
+            return;
+        }
+
+        mGalleryType = galleryType;
+
+        // column count applies only to thumbnail grid
+        boolean showNumColumns = (galleryType == GalleryType.DEFAULT);
+        if (showNumColumns && mNumColumnsContainer.getVisibility() != View.VISIBLE) {
+            AniUtils.fadeIn(mNumColumnsContainer, AniUtils.Duration.SHORT);
+        } else if (!showNumColumns && mNumColumnsContainer.getVisibility() == View.VISIBLE) {
+            AniUtils.fadeOut(mNumColumnsContainer, AniUtils.Duration.SHORT, View.INVISIBLE);
+        }
+
+        @IdRes final int resId;
+        @DrawableRes final int drawableId;
+        switch (galleryType) {
+            case CIRCLES:
+                resId = R.id.radio_circles;
+                drawableId = R.drawable.gallery_icon_circles;
+                break;
+            case SLIDESHOW:
+                resId = R.id.radio_slideshow;
+                drawableId = R.drawable.gallery_icon_slideshow;
+                break;
+            case SQUARES:
+                resId = R.id.radio_squares;
+                drawableId = R.drawable.gallery_icon_squares;
+                break;
+            case TILED:
+                resId = R.id.radio_tiled;
+                drawableId = R.drawable.gallery_icon_tiled;
+                break;
+            default:
+                resId = R.id.radio_thumbnail_grid;
+                drawableId = R.drawable.gallery_icon_thumbnailgrid;
+                break;
+        }
+
+        RadioButton radio = (RadioButton) mGalleryRadioGroup.findViewById(resId);
+        if (!radio.isChecked()) {
+            radio.setChecked(true);
+        }
+
+        // scale out the gallery type image, then set the new image and scale it back in
+        final ImageView imageView = (ImageView) getView().findViewById(R.id.image_gallery_type);
+        AniUtils.scaleOut(imageView, View.VISIBLE, AniUtils.Duration.SHORT, new AniUtils.AnimationEndListener() {
+            @Override
+            public void onAnimationEnd() {
+                imageView.setImageResource(drawableId);
+                AniUtils.scaleIn(imageView, AniUtils.Duration.SHORT);
+            }
+        });
+    }
+
+    public int getNumColumns() {
+        return mNumColumns;
+    }
+
+    private void setNumColumns(int numColumns, boolean fromSeekBar) {
+        // seekbar is zero-based, so increment the column count if this was called from it
+        if (fromSeekBar) {
+            mNumColumns = numColumns + 1;
+        } else {
+            mNumColumns = numColumns;
+            mNumColumnsSeekBar.setProgress(numColumns);
+        }
+
+        TextView textValue = (TextView) getView().findViewById(R.id.text_num_columns_label);
+        textValue.setText(String.format(getString(R.string.media_gallery_column_count), mNumColumns));
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/InsertMediaDialog.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/InsertMediaDialog.java
@@ -300,6 +300,10 @@ public class InsertMediaDialog extends AppCompatDialogFragment {
         }
 
         TextView textValue = (TextView) getView().findViewById(R.id.text_num_columns_label);
-        textValue.setText(String.format(getString(R.string.media_gallery_column_count), mNumColumns));
+        if (mNumColumns == 1) {
+            textValue.setText(getString(R.string.media_gallery_column_count_single));
+        } else {
+            textValue.setText(String.format(getString(R.string.media_gallery_column_count_multi), mNumColumns));
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/AniUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AniUtils.java
@@ -177,14 +177,14 @@ public class AniUtils {
         return fadeIn;
     }
 
-    private static ObjectAnimator getFadeOutAnim(final View target, Duration duration) {
+    private static ObjectAnimator getFadeOutAnim(final View target, Duration duration, final int endVisibility) {
         ObjectAnimator fadeOut = ObjectAnimator.ofFloat(target, View.ALPHA, 1.0f, 0.0f);
         fadeOut.setDuration(duration.toMillis(target.getContext()));
         fadeOut.setInterpolator(new LinearInterpolator());
         fadeOut.addListener(new AnimatorListenerAdapter() {
             @Override
             public void onAnimationEnd(Animator animation) {
-                target.setVisibility(View.GONE);
+                target.setVisibility(endVisibility);
             }
         });
         return fadeOut;
@@ -197,8 +197,12 @@ public class AniUtils {
     }
 
     public static void fadeOut(final View target, Duration duration) {
+        fadeOut(target, duration, View.GONE);
+    }
+
+    public static void fadeOut(final View target, Duration duration, int endVisibility) {
         if (target != null && duration != null) {
-            getFadeOutAnim(target, duration).start();
+            getFadeOutAnim(target, duration, endVisibility).start();
         }
     }
 

--- a/WordPress/src/main/res/layout/insert_media_dialog.xml
+++ b/WordPress/src/main/res/layout/insert_media_dialog.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/margin_large">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <RadioGroup
+            android:id="@+id/radio_group_insert_type"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/margin_small">
+
+            <RadioButton
+                android:id="@+id/radio_insert_individually"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/media_insert_individually"
+                android:textSize="@dimen/text_sz_large" />
+
+            <RadioButton
+                android:id="@+id/radio_insert_as_gallery"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/media_insert_as_gallery"
+                android:textSize="@dimen/text_sz_large" />
+        </RadioGroup>
+
+        <LinearLayout
+            android:id="@+id/container_gallery_settings"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/margin_extra_large"
+            android:layout_marginTop="@dimen/margin_medium"
+            android:orientation="vertical">
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <RadioGroup
+                    android:id="@+id/radio_group_gallery_type"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content">
+
+                    <RadioButton
+                        android:id="@+id/radio_thumbnail_grid"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/media_gallery_type_thumbnail_grid" />
+
+                    <RadioButton
+                        android:id="@+id/radio_tiled"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/media_gallery_type_tiled" />
+
+                    <RadioButton
+                        android:id="@+id/radio_squares"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/media_gallery_type_squares" />
+
+                    <RadioButton
+                        android:id="@+id/radio_circles"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/media_gallery_type_circles" />
+
+                    <RadioButton
+                        android:id="@+id/radio_slideshow"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/media_gallery_type_slideshow" />
+
+                </RadioGroup>
+
+                <ImageView
+                    android:id="@+id/image_gallery_type"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_vertical|right"
+                    android:layout_marginRight="@dimen/margin_extra_large"
+                    android:tint="@color/grey_darken_10"
+                    tools:src="@drawable/gallery_icon_thumbnailgrid" />
+            </FrameLayout>
+
+            <RelativeLayout
+                android:id="@+id/num_columns_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_large"
+                android:orientation="horizontal"
+                android:visibility="invisible"
+                tools:visibility="visible">
+
+                <TextView
+                    android:id="@+id/text_num_columns_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/media_gallery_column_count" />
+
+                <SeekBar
+                    android:id="@+id/seekbar_num_columns"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_below="@+id/text_num_columns_label"
+                    android:progress="3"
+                    android:theme="@style/Widget.AppCompat.SeekBar.Discrete" />
+
+            </RelativeLayout>
+        </LinearLayout>
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_extra_large">
+
+            <Button
+                android:id="@+id/button_cancel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_toLeftOf="@+id/button_ok"
+                android:text="@android:string/cancel" />
+
+            <Button
+                android:id="@+id/button_ok"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:text="@android:string/ok" />
+        </RelativeLayout>
+    </LinearLayout>
+</ScrollView>

--- a/WordPress/src/main/res/layout/insert_media_dialog.xml
+++ b/WordPress/src/main/res/layout/insert_media_dialog.xml
@@ -103,7 +103,7 @@
                     android:id="@+id/text_num_columns_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/media_gallery_column_count" />
+                    android:text="@string/media_gallery_column_count_single" />
 
                 <SeekBar
                     android:id="@+id/seekbar_num_columns"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -131,7 +131,8 @@
     <string name="media_gallery_type_circles">Circles</string>
     <string name="media_gallery_type_slideshow">Slideshow</string>
     <string name="media_gallery_edit">Edit gallery</string>
-    <string name="media_gallery_column_count">%d columns</string>
+    <string name="media_gallery_column_count_single">1 column</string>
+    <string name="media_gallery_column_count_multi">%d columns</string>
     <string name="media_insert_title">Add multiple photos</string>
     <string name="media_insert_individually">Add individually</string>
     <string name="media_insert_as_gallery">Add as gallery</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -131,6 +131,10 @@
     <string name="media_gallery_type_circles">Circles</string>
     <string name="media_gallery_type_slideshow">Slideshow</string>
     <string name="media_gallery_edit">Edit gallery</string>
+    <string name="media_gallery_column_count">%d columns</string>
+    <string name="media_insert_title">Add multiple photos</string>
+    <string name="media_insert_individually">Add individually</string>
+    <string name="media_insert_as_gallery">Add as gallery</string>
     <string name="pick_photo">Select photo</string>
     <string name="pick_video">Select video</string>
     <string name="capture_or_pick_photo">Capture or select photo</string>


### PR DESCRIPTION
Fixes #5771 - When the user selects multiple photos from the WP media library we now show a dialog enabling them to choose whether to insert them individually or as a gallery, and if as a gallery we enable choosing the gallery settings.

![wp-media-insert](https://cloud.githubusercontent.com/assets/3903757/25557084/ba475c78-2cd7-11e7-8c6d-685bb1a20557.gif)

**Note:** this should be tested with the Aztec editor _disabled_ because inserting `[gallery]` shortcodes isn't supported by Aztec yet.
