### PR TITLE
Media Async: Use correct methods for setting/getting media local post ID

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -146,7 +146,7 @@ public class MediaUploadService extends Service {
 
     private synchronized void updatePostWithMediaUrl(MediaModel media){
         if (media != null) {
-            PostModel post = mPostStore.getPostByLocalPostId(media.getPostId());
+            PostModel post = mPostStore.getPostByLocalPostId(media.getLocalPostId());
             if (post != null) {
                 // actually replace the media ID with the media uri
                 MediaUploadReadyListener processor = new MediaUploadReadyProcessor();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2128,9 +2128,9 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             return null;
         }
 
-        // we need to update media with the post Id
+        // we need to update media with the local post Id
         MediaModel media = buildMediaModel(uri, mimeType, startingState);
-        media.setPostId(mPost.getId());
+        media.setLocalPostId(mPost.getId());
         mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));
 
         // add this item to the queue - we keep it for visual aid atm


### PR DESCRIPTION
Updates the async branch to use the new local post ID field in `MediaModel`. This fixes async uploads to self-hosted sites.

See https://github.com/wordpress-mobile/WordPress-Android/pull/5745 and https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/426 for background.

cc @mzorz 