### PR TITLE
Updated FluxC integration with site getter renaming

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -132,7 +132,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:2fbd31a89315f826a6028af4285114bf4e09b126') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:feature~site-store-getters-renaming-SNAPSHOT') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -132,7 +132,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:feature~site-store-getters-renaming-SNAPSHOT') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:e46255029b6afa886b3e0ebb8ed96b4f57872e77') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -145,7 +145,7 @@ public class SitePickerActivity extends AppCompatActivity
             mMenuAdd.setVisible(false);
         } else {
             // don't allow editing visibility unless there are multiple wp.com and jetpack sites
-            mMenuEdit.setVisible(mSiteStore.getWPComAndJetpackSitesCount() > 1);
+            mMenuEdit.setVisible(mSiteStore.getSitesAccessedViaWPComRestCount() > 1);
             mMenuAdd.setVisible(true);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -489,21 +489,17 @@ public class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.Si
         private List<SiteModel> getBlogsForCurrentView() {
             if (mShowHiddenSites) {
                 if (mShowSelfHostedSites) {
-                    // all self-hosted sites and all wp.com sites
                     return mSiteStore.getSites();
                 } else {
-                    // only wp.com and jetpack sites
-                    return mSiteStore.getWPComAndJetpackSites();
+                    return mSiteStore.getSitesAccessedViaWPComRest();
                 }
             } else {
                 if (mShowSelfHostedSites) {
-                    // all self-hosted sites plus visible wp.com and jetpack sites
-                    List<SiteModel> out = mSiteStore.getVisibleWPComAndJetpackSites();
-                    out.addAll(mSiteStore.getSelfHostedSites());
+                    List<SiteModel> out = mSiteStore.getVisibleSitesAccessedViaWPCom();
+                    out.addAll(mSiteStore.getSitesAccessedViaXMLRPC());
                     return out;
                 } else {
-                    // only visible wp.com and jetpack blogs
-                    return mSiteStore.getVisibleWPComAndJetpackSites();
+                    return mSiteStore.getVisibleSitesAccessedViaWPCom();
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
@@ -287,7 +287,7 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
 
         @Override
         protected Void doInBackground(Void... params) {
-            List<SiteModel> sites = mSiteStore.getWPComAndJetpackSites();
+            List<SiteModel> sites = mSiteStore.getSitesAccessedViaWPComRest();
             mPrimarySitePreference.setEntries(getSiteNamesFromSites(sites));
             mPrimarySitePreference.setEntryValues(getSiteIdsFromSites(sites));
             mPrimarySitePreference.setDetails(getHomeURLOrHostNamesFromSites(sites));

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -307,9 +307,9 @@ public class NotificationsSettingsFragment extends PreferenceFragment implements
         String trimmedQuery = "";
         if (mSearchView != null && !TextUtils.isEmpty(mSearchView.getQuery())) {
             trimmedQuery = mSearchView.getQuery().toString().trim();
-            sites = mSiteStore.getWPComAndJetpackSitesByNameOrUrlMatching(trimmedQuery);
+            sites = mSiteStore.getSitesAccessedViaWPComRestByNameOrUrlMatching(trimmedQuery);
         } else {
-            sites = mSiteStore.getWPComAndJetpackSites();
+            sites = mSiteStore.getSitesAccessedViaWPComRest();
         }
         mSiteCount = sites.size();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
@@ -66,9 +66,9 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
         blogsListCreatorExecutor.submit(new Thread() {
             @Override
             public void run() {
-                // Read all the .com and jetpack sites and get the list of home URLs.
+                // Read all the WPComRest accessed sites and get the list of home URLs.
                 // This will be used later to check if the user is a member of followers blog marked as private.
-                List<SiteModel> sites = mSiteStore.getWPComAndJetpackSites();
+                List<SiteModel> sites = mSiteStore.getSitesAccessedViaWPComRest();
                 for (SiteModel site : sites) {
                     if (site.getUrl() != null && site.getSiteId() != 0) {
                         String normURL = normalizeAndRemoveScheme(site.getUrl());

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureAdapter.java
@@ -210,21 +210,17 @@ public class StatsWidgetConfigureAdapter extends RecyclerView.Adapter<StatsWidge
         private List<SiteModel> getBlogsForCurrentView() {
             if (mShowHiddenSites) {
                 if (mShowSelfHostedSites) {
-                    // all self-hosted sites and all wp.com sites
                     return mSiteStore.getSites();
                 } else {
-                    // only wp.com and jetpack sites
-                    return mSiteStore.getWPComAndJetpackSites();
+                    return mSiteStore.getSitesAccessedViaWPComRest();
                 }
             } else {
                 if (mShowSelfHostedSites) {
-                    // all self-hosted sites plus visible wp.com and jetpack sites
-                    List<SiteModel> out = mSiteStore.getVisibleWPComAndJetpackSites();
-                    out.addAll(mSiteStore.getSelfHostedSites());
+                    List<SiteModel> out = mSiteStore.getVisibleSitesAccessedViaWPCom();
+                    out.addAll(mSiteStore.getSitesAccessedViaXMLRPC());
                     return out;
                 } else {
-                    // only visible wp.com and jetpack sites
-                    return mSiteStore.getVisibleWPComAndJetpackSites();
+                    return mSiteStore.getVisibleSitesAccessedViaWPCom();
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
@@ -59,7 +59,7 @@ public class AnalyticsUtils {
         metadata.setSessionCount(preferences.getInt(AnalyticsTrackerMixpanel.SESSION_COUNT, 0));
         metadata.setUserConnected(FluxCUtils.isSignedInWPComOrHasWPOrgSite(accountStore, siteStore));
         metadata.setWordPressComUser(accountStore.hasAccessToken());
-        metadata.setJetpackUser(siteStore.hasJetpackSite());
+        metadata.setJetpackUser(siteStore.getSitesAccessedViaWPComRestCount() - siteStore.getWPComSitesCount() > 0);
         metadata.setNumBlogs(siteStore.getSitesCount());
         metadata.setUsername(accountStore.getAccount().getUserName());
         metadata.setEmail(accountStore.getAccount().getEmail());

--- a/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
@@ -59,12 +59,21 @@ public class AnalyticsUtils {
         metadata.setSessionCount(preferences.getInt(AnalyticsTrackerMixpanel.SESSION_COUNT, 0));
         metadata.setUserConnected(FluxCUtils.isSignedInWPComOrHasWPOrgSite(accountStore, siteStore));
         metadata.setWordPressComUser(accountStore.hasAccessToken());
-        metadata.setJetpackUser(siteStore.getSitesAccessedViaWPComRestCount() - siteStore.getWPComSitesCount() > 0);
+        metadata.setJetpackUser(isJetpackUser(siteStore));
         metadata.setNumBlogs(siteStore.getSitesCount());
         metadata.setUsername(accountStore.getAccount().getUserName());
         metadata.setEmail(accountStore.getAccount().getEmail());
 
         AnalyticsTracker.refreshMetadata(metadata);
+    }
+
+    /***
+     * @return true if the siteStore has sites accessed via the WPCom Rest API that are not WPCom sites. This only
+     * counts Jetpack sites connected via WPCom Rest API. If there are Jetpack sites in the site store and they're
+     * all accessed via XMLRPC, this method returns false.
+     */
+    private static boolean isJetpackUser(SiteStore siteStore) {
+        return siteStore.getSitesAccessedViaWPComRestCount() - siteStore.getWPComSitesCount() > 0;
     }
 
     public static void refreshMetadataNewUser(String username, String email) {

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -11,7 +11,7 @@ public class FluxCUtils {
      * @return true if the user is signed in a WordPress.com account or if he has a .org site.
      */
     public static boolean isSignedInWPComOrHasWPOrgSite(AccountStore accountStore, SiteStore siteStore) {
-        return accountStore.hasAccessToken() || siteStore.hasSelfHostedSite();
+        return accountStore.hasAccessToken() || siteStore.hasSiteAccessedViaXMLRPC();
     }
 
     public static MediaModel mediaModelFromMediaFile(MediaFile file) {


### PR DESCRIPTION
Updated FluxC integration with site getter renaming

Not ready for review yet, waiting for https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/430 to be merged.