### PR TITLE
7.3 - Fix SecurityException fetching external media

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -662,23 +662,14 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
     private void fetchMedia(Uri mediaUri, final String mimeType) {
         if (!MediaUtils.isInMediaStore(mediaUri)) {
-            // Create an AsyncTask to download the file
-            new AsyncTask<Uri, Integer, Uri>() {
-                @Override
-                protected Uri doInBackground(Uri... uris) {
-                    Uri imageUri = uris[0];
-                    return MediaUtils.downloadExternalMedia(MediaBrowserActivity.this, imageUri);
-                }
-
-                protected void onPostExecute(Uri uri) {
-                    if (uri != null) {
-                        queueFileForUpload(uri, mimeType);
-                    } else {
-                        Toast.makeText(MediaBrowserActivity.this, getString(R.string.error_downloading_image),
-                                Toast.LENGTH_SHORT).show();
-                    }
-                }
-            }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, mediaUri);
+            // Do not download the file in async task. See https://github.com/wordpress-mobile/WordPress-Android/issues/5818
+            Uri downloadedUri = MediaUtils.downloadExternalMedia(MediaBrowserActivity.this, mediaUri);
+            if (downloadedUri != null) {
+                queueFileForUpload(downloadedUri, mimeType);
+            } else {
+                Toast.makeText(MediaBrowserActivity.this, getString(R.string.error_downloading_image),
+                        Toast.LENGTH_SHORT).show();
+            }
         } else {
             queueFileForUpload(mediaUri, mimeType);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1881,23 +1881,14 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
     private void fetchMedia(Uri mediaUri) {
         if (!MediaUtils.isInMediaStore(mediaUri)) {
-            // Create an AsyncTask to download the file
-            new AsyncTask<Uri, Integer, Uri>() {
-                @Override
-                protected Uri doInBackground(Uri... uris) {
-                    Uri imageUri = uris[0];
-                    return MediaUtils.downloadExternalMedia(EditPostActivity.this, imageUri);
-                }
-
-                protected void onPostExecute(Uri uri) {
-                    if (uri != null) {
-                        addMedia(uri);
-                    } else {
-                        Toast.makeText(EditPostActivity.this, getString(R.string.error_downloading_image),
-                                Toast.LENGTH_SHORT).show();
-                    }
-                }
-            }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, mediaUri);
+            // Do not download the file in async task. See https://github.com/wordpress-mobile/WordPress-Android/issues/5818
+            Uri downloadedUri = MediaUtils.downloadExternalMedia(EditPostActivity.this, mediaUri);
+            if (downloadedUri != null) {
+                addMedia(downloadedUri);
+            } else {
+                Toast.makeText(EditPostActivity.this, getString(R.string.error_downloading_image),
+                        Toast.LENGTH_SHORT).show();
+            }
         } else {
             addMedia(mediaUri);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1884,7 +1884,15 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     private void fetchMedia(Uri mediaUri) {
         if (!MediaUtils.isInMediaStore(mediaUri)) {
             // Do not download the file in async task. See https://github.com/wordpress-mobile/WordPress-Android/issues/5818
-            Uri downloadedUri = MediaUtils.downloadExternalMedia(EditPostActivity.this, mediaUri);
+            Uri downloadedUri = null;
+            try {
+                downloadedUri = MediaUtils.downloadExternalMedia(EditPostActivity.this, mediaUri);
+            } catch (IllegalStateException e) {
+                // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/5823
+                AppLog.e(AppLog.T.UTILS, "Can't download the image at: " + mediaUri.toString(), e);
+                CrashlyticsUtils.logException(e, AppLog.T.MEDIA, "Can't download the image at: " + mediaUri.toString() +
+                        " See issue #5823");
+            }
             if (downloadedUri != null) {
                 addMedia(downloadedUri);
             } else {


### PR DESCRIPTION
Fixes #5818 and #5672 by downloading the selected media file "in-line" in `onActivityResult` method.

**Details**
It seems that we're are using AsyncTask to download the content of the file from external app/content provider. Unfortunately this could lead to security errors due to design constraints.
`For security reasons, the permissions are temporary, so once the client app's task stack is finished, the file is no longer accessible. You must get the file data when you receive the intent answer, in the onActivityResult method. Store a copy of the file data, because the file won't be available anymore when onActivityResult returns.`

See `Access the Requested File` section here https://developer.android.com/training/secure-file-sharing/request-file.html#OpenFile

Also http://stackoverflow.com/questions/30572261/using-data-from-context-providers-or-requesting-google-photos-read-permission

