### PR TITLE
Enable Robolectric tests in WordPress module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ install:
   - cp WordPress/gradle.properties-example WordPress/gradle.properties
 
 script:
-  - ./gradlew -PdisablePreDex assembleVanillaRelease lint || (grep -A20 -B2 'severity="Error"' WordPress/build/**/*.xml; exit 1)
+  - ./gradlew -PdisablePreDex assembleVanillaRelease lint test || (grep -A20 -B2 'severity="Error"' WordPress/build/**/*.xml; exit 1)

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -116,6 +116,10 @@ dependencies {
     }
     compile 'com.github.xizzhu:simple-tool-tip:0.5.0'
 
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.robolectric:robolectric:3.3.2'
+    testCompile 'org.robolectric:shadows-multidex:3.3.2'
+
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.0'
     androidTestCompile 'org.objenesis:objenesis:2.1'
     androidTestCompile 'org.mockito:mockito-core:1.10.19'

--- a/WordPress/src/test/java/org/wordpress/android/RobolectricSetupTest.java
+++ b/WordPress/src/test/java/org/wordpress/android/RobolectricSetupTest.java
@@ -1,0 +1,40 @@
+package org.wordpress.android;
+
+import android.os.Build;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, manifest = "src/main/AndroidManifest.xml", sdk = Build.VERSION_CODES.JELLY_BEAN)
+public class RobolectricSetupTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Before
+    public void init() {
+        // nothing special to initialise
+    }
+
+    @After
+    public void teardown() {
+        // nothing special to clean up
+    }
+
+    @Test
+    public void appNameTest() {
+        // this test does nothing fancy but it helps make sure the Robolectric setup is working OK.
+        // If running this via AndroidStudio, make sure the run configuration's working directory is set to $MODULE_DIR$
+        //  and the VM options to `-ea`
+        Assert.assertEquals("WordPress for Android", RuntimeEnvironment.application.getString(R.string.app_title));
+    }
+}


### PR DESCRIPTION
Adds basic support for Robolectric (JVM) tests.

It also sets up Travis to automatically run these tests.

To test:
* In AndroidStudio, open the RobolectricSetupTest.java file, right-click on the class name and select `Run 'RobolectricSetupTest'`. Make sure the run configuration's working directory is set to $MODULE_DIR$ and the VM options to `-ea`
* The test (`appNameTest`) should run and succeed