### PR TITLE
Removing self-hosted site shows the Sign-in Screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -243,6 +243,10 @@ public class WPMainActivity extends AppCompatActivity {
 
         // monitor whether we're not the default app
         trackDefaultApp();
+
+        // We need to register the dispatcher here otherwise it won't trigger if for example Site Picker is present
+        mDispatcher.register(this);
+        EventBus.getDefault().register(this);
     }
 
     private void setTabLayoutElevation(float newElevation){
@@ -383,17 +387,10 @@ public class WPMainActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStop() {
+    protected void onDestroy() {
         EventBus.getDefault().unregister(this);
         mDispatcher.unregister(this);
-        super.onStop();
-    }
-
-    @Override
-    protected void onStart() {
-        super.onStart();
-        mDispatcher.register(this);
-        EventBus.getDefault().register(this);
+        super.onDestroy();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -701,7 +701,7 @@ public class WPMainActivity extends AppCompatActivity {
             return;
         }
 
-        // When we select a site, we want to update its informations or options
+        // When we select a site, we want to update its information or options
         mDispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(selectedSite));
 
         // Make selected site visible


### PR DESCRIPTION
Fixes #5829. The issue was due to `WPMainActivity.onSiteRemoved` not getting called when a self-hosted site was removed since we were unregistering the dispatcher in `onStop`. I think `WPMainActivity` is too important to unregister while it lives, so I've moved the register/unregister to `onCreate` & `onDestroy` instead.

Please note that while testing you might see a double push for the `SignInActivity`, it has been fixed in #5752.

To test:
* Add a self-hosted site and remove it from site picker, make sure you see the sign-in screen

P.S: I initially targeted this PR against `develop` and when I was jut about the create it I realized this probably happens in `7.3` too (which it does) and it's a somewhat important bug, so I am targeting the release branch instead. `7.2` should not be affected since we only moved the remove button to site picker recently.