### PR TITLE
Issue/5667 iae sanitizeurl

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -132,7 +132,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:issue~434-handle-iae-sanitizeurl-SNAPSHOT') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:e914459b1a99febf2d40b06e3bada80c755f083b') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -132,7 +132,8 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:1c2cef7fdcbb90e120a513b2f5f2adb8572fb0a9') {
+//    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:1c2cef7fdcbb90e120a513b2f5f2adb8572fb0a9') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:issue~434-handle-iae-sanitizeurl-SNAPSHOT') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -132,7 +132,6 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-//    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:1c2cef7fdcbb90e120a513b2f5f2adb8572fb0a9') {
     compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:issue~434-handle-iae-sanitizeurl-SNAPSHOT') {
         exclude group: "com.android.volley";
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -836,6 +836,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     private void signInAndFetchBlogListWPOrg() {
         startProgress(getString(R.string.signing_in));
         String url = EditTextUtils.getText(mUrlEditText).trim();
+        url = url.replace("\n", "").replace("\r", "");
         // Self Hosted don't have any "Authentication" request, try to list sites with user/password
         mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(url));
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -836,7 +836,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     private void signInAndFetchBlogListWPOrg() {
         startProgress(getString(R.string.signing_in));
         String url = EditTextUtils.getText(mUrlEditText).trim();
-        url = url.replace("\n", "").replace("\r", "");
+        url = url.replace("\r|\n", "");
         // Self Hosted don't have any "Authentication" request, try to list sites with user/password
         mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(url));
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInFragment.java
@@ -836,7 +836,7 @@ public class SignInFragment extends AbstractFragment implements TextWatcher {
     private void signInAndFetchBlogListWPOrg() {
         startProgress(getString(R.string.signing_in));
         String url = EditTextUtils.getText(mUrlEditText).trim();
-        url = url.replace("\r|\n", "");
+        url = url.replaceAll("\r|\n", "");
         // Self Hosted don't have any "Authentication" request, try to list sites with user/password
         mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(url));
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -145,7 +145,7 @@ public class SitePickerActivity extends AppCompatActivity
             mMenuAdd.setVisible(false);
         } else {
             // don't allow editing visibility unless there are multiple wp.com and jetpack sites
-            mMenuEdit.setVisible(mSiteStore.getWPComAndJetpackSitesCount() > 1);
+            mMenuEdit.setVisible(mSiteStore.getSitesAccessedViaWPComRestCount() > 1);
             mMenuAdd.setVisible(true);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -489,21 +489,17 @@ public class SitePickerAdapter extends RecyclerView.Adapter<SitePickerAdapter.Si
         private List<SiteModel> getBlogsForCurrentView() {
             if (mShowHiddenSites) {
                 if (mShowSelfHostedSites) {
-                    // all self-hosted sites and all wp.com sites
                     return mSiteStore.getSites();
                 } else {
-                    // only wp.com and jetpack sites
-                    return mSiteStore.getWPComAndJetpackSites();
+                    return mSiteStore.getSitesAccessedViaWPComRest();
                 }
             } else {
                 if (mShowSelfHostedSites) {
-                    // all self-hosted sites plus visible wp.com and jetpack sites
-                    List<SiteModel> out = mSiteStore.getVisibleWPComAndJetpackSites();
-                    out.addAll(mSiteStore.getSelfHostedSites());
+                    List<SiteModel> out = mSiteStore.getVisibleSitesAccessedViaWPCom();
+                    out.addAll(mSiteStore.getSitesAccessedViaXMLRPC());
                     return out;
                 } else {
-                    // only visible wp.com and jetpack blogs
-                    return mSiteStore.getVisibleWPComAndJetpackSites();
+                    return mSiteStore.getVisibleSitesAccessedViaWPCom();
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
@@ -287,7 +287,7 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
 
         @Override
         protected Void doInBackground(Void... params) {
-            List<SiteModel> sites = mSiteStore.getWPComAndJetpackSites();
+            List<SiteModel> sites = mSiteStore.getSitesAccessedViaWPComRest();
             mPrimarySitePreference.setEntries(getSiteNamesFromSites(sites));
             mPrimarySitePreference.setEntryValues(getSiteIdsFromSites(sites));
             mPrimarySitePreference.setDetails(getHomeURLOrHostNamesFromSites(sites));

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -307,9 +307,9 @@ public class NotificationsSettingsFragment extends PreferenceFragment implements
         String trimmedQuery = "";
         if (mSearchView != null && !TextUtils.isEmpty(mSearchView.getQuery())) {
             trimmedQuery = mSearchView.getQuery().toString().trim();
-            sites = mSiteStore.getWPComAndJetpackSitesByNameOrUrlMatching(trimmedQuery);
+            sites = mSiteStore.getSitesAccessedViaWPComRestByNameOrUrlMatching(trimmedQuery);
         } else {
-            sites = mSiteStore.getWPComAndJetpackSites();
+            sites = mSiteStore.getSitesAccessedViaWPComRest();
         }
         mSiteCount = sites.size();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
@@ -66,9 +66,9 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
         blogsListCreatorExecutor.submit(new Thread() {
             @Override
             public void run() {
-                // Read all the .com and jetpack sites and get the list of home URLs.
+                // Read all the WPComRest accessed sites and get the list of home URLs.
                 // This will be used later to check if the user is a member of followers blog marked as private.
-                List<SiteModel> sites = mSiteStore.getWPComAndJetpackSites();
+                List<SiteModel> sites = mSiteStore.getSitesAccessedViaWPComRest();
                 for (SiteModel site : sites) {
                     if (site.getUrl() != null && site.getSiteId() != 0) {
                         String normURL = normalizeAndRemoveScheme(site.getUrl());

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureAdapter.java
@@ -210,21 +210,17 @@ public class StatsWidgetConfigureAdapter extends RecyclerView.Adapter<StatsWidge
         private List<SiteModel> getBlogsForCurrentView() {
             if (mShowHiddenSites) {
                 if (mShowSelfHostedSites) {
-                    // all self-hosted sites and all wp.com sites
                     return mSiteStore.getSites();
                 } else {
-                    // only wp.com and jetpack sites
-                    return mSiteStore.getWPComAndJetpackSites();
+                    return mSiteStore.getSitesAccessedViaWPComRest();
                 }
             } else {
                 if (mShowSelfHostedSites) {
-                    // all self-hosted sites plus visible wp.com and jetpack sites
-                    List<SiteModel> out = mSiteStore.getVisibleWPComAndJetpackSites();
-                    out.addAll(mSiteStore.getSelfHostedSites());
+                    List<SiteModel> out = mSiteStore.getVisibleSitesAccessedViaWPCom();
+                    out.addAll(mSiteStore.getSitesAccessedViaXMLRPC());
                     return out;
                 } else {
-                    // only visible wp.com and jetpack sites
-                    return mSiteStore.getVisibleWPComAndJetpackSites();
+                    return mSiteStore.getVisibleSitesAccessedViaWPCom();
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
@@ -59,12 +59,21 @@ public class AnalyticsUtils {
         metadata.setSessionCount(preferences.getInt(AnalyticsTrackerMixpanel.SESSION_COUNT, 0));
         metadata.setUserConnected(FluxCUtils.isSignedInWPComOrHasWPOrgSite(accountStore, siteStore));
         metadata.setWordPressComUser(accountStore.hasAccessToken());
-        metadata.setJetpackUser(siteStore.hasJetpackSite());
+        metadata.setJetpackUser(isJetpackUser(siteStore));
         metadata.setNumBlogs(siteStore.getSitesCount());
         metadata.setUsername(accountStore.getAccount().getUserName());
         metadata.setEmail(accountStore.getAccount().getEmail());
 
         AnalyticsTracker.refreshMetadata(metadata);
+    }
+
+    /***
+     * @return true if the siteStore has sites accessed via the WPCom Rest API that are not WPCom sites. This only
+     * counts Jetpack sites connected via WPCom Rest API. If there are Jetpack sites in the site store and they're
+     * all accessed via XMLRPC, this method returns false.
+     */
+    private static boolean isJetpackUser(SiteStore siteStore) {
+        return siteStore.getSitesAccessedViaWPComRestCount() - siteStore.getWPComSitesCount() > 0;
     }
 
     public static void refreshMetadataNewUser(String username, String email) {

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -11,7 +11,7 @@ public class FluxCUtils {
      * @return true if the user is signed in a WordPress.com account or if he has a .org site.
      */
     public static boolean isSignedInWPComOrHasWPOrgSite(AccountStore accountStore, SiteStore siteStore) {
-        return accountStore.hasAccessToken() || siteStore.hasSelfHostedSite();
+        return accountStore.hasAccessToken() || siteStore.hasSiteAccessedViaXMLRPC();
     }
 
     public static MediaModel mediaModelFromMediaFile(MediaFile file) {


### PR DESCRIPTION
**DEPENDS ON:** https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/437

Fixes #5667 and #5832, and also fixes a rare native crash that I managed to get (and I believe would never get to be reported) when the url contains newlines , with an android library call (`java.net.IDN.toASCII()`) on 4.2.2 and 5.0.1:

```
05-04 12:13:23.540 19758-20904/org.wordpress.android.beta A/libc: Fatal signal 11 (SIGSEGV), code 1, fault addr 0x6e0068 in tid 20904 (Thread-317)
05-04 12:13:23.645 85-85/? I/DEBUG: *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
05-04 12:13:23.645 85-85/? I/DEBUG: Build fingerprint: 'generic/vbox86p/vbox86p:5.1/LMY47D/buildbot06092001:userdebug/test-keys'
05-04 12:13:23.645 85-85/? I/DEBUG: Revision: '0'
05-04 12:13:23.645 85-85/? I/DEBUG: ABI: 'x86'
05-04 12:13:23.645 85-85/? I/DEBUG: pid: 19758, tid: 20904, name: Thread-317  >>> org.wordpress.android.beta <<<
05-04 12:13:23.646 85-85/? I/DEBUG: signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x6e0068
05-04 12:13:23.653 85-85/? I/DEBUG:     eax 00000000  ebx 006f0069  ecx 9affeac0  edx 00000000
05-04 12:13:23.653 85-85/? I/DEBUG:     esi 0073006a  edi 00340062
05-04 12:13:23.653 85-85/? I/DEBUG:     xcs 00000073  xds 0000007b  xes 0000007b  xfs 000001e7  xss 0000007b
05-04 12:13:23.653 85-85/? I/DEBUG:     eip 006e0068  ebp 00370036  esp 9affed10  flags 00210286
05-04 12:13:23.653 85-85/? I/DEBUG: backtrace:
05-04 12:13:23.654 85-85/? I/DEBUG:     #00 pc 006e0068  <unknown>
05-04 12:13:23.934 85-85/? I/DEBUG: Tombstone written to: /data/tombstones/tombstone_05

```

This PR cherry-picks commits in this other PR #5820 
And applies a small change in FluxC to catch and transform the `IllegalArgumentException` in `sanitizeUrl()` into a `DiscoveryException`, which is more meaningful and is correctly handled by WPAndroid's logic.

Test string used:

```
あー、原因わかりました！
ログインURLが違いますね。

www.somedomain.com/word

でログインしてください。
アプリの仕様が変わったのか、元からそうだったのかわかりませんが、WordPressのシステムをインストールしたディレクトリを指定しないといけないようです。


不正アクセス防止の為わざとわかりにくい下層ディレクトリにしてありますので覚えておいてください。

ちなみにパソコンからはブックマークしていると思いますが↓です
www.somedomain.com/word/wp-login.php
```


To test:

1. in the login screen, tap  on "add self hosted", entering some user name and some password, and enter the test string (copy & paste)
2. instead of crashing, it should highlight the URL field and show the error sign `"Check that the site URL entered is valid".`

Note: this depends on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/437

cc @tonyr59h 