### PR TITLE
 	Fix #5222: use Photon only for Photon compatible sites (public and accessed via WPCom REST API)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -50,6 +50,7 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.PhotonUtils;
+import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 
 import java.text.SimpleDateFormat;
@@ -311,7 +312,10 @@ public class MediaPreviewActivity extends AppCompatActivity {
 
         if (mediaUri.startsWith("http")) {
             showProgress(true);
-            String imageUrl = PhotonUtils.getPhotonImageUrl(mediaUri, size, 0);
+            String imageUrl = mediaUri;
+            if (SiteUtils.isPhotonCapable(mSite)) {
+                imageUrl = PhotonUtils.getPhotonImageUrl(mediaUri, size, 0);
+            }
             mImageLoader.get(imageUrl, new ImageLoader.ImageListener() {
                 @Override
                 public void onResponse(ImageLoader.ImageContainer response, boolean isImmediate) {
@@ -412,7 +416,7 @@ public class MediaPreviewActivity extends AppCompatActivity {
         mVideoView.setVideoURI(Uri.parse(mediaUri));
         mVideoView.requestFocus();
     }
-    
+
     private void loadMetaData(@NonNull final MediaModel media) {
         boolean isLocal = MediaUtils.isLocalFile(media.getUploadState());
 

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -34,7 +34,7 @@ public class SiteUtils {
     }
 
     public static boolean isAccessibleViaWPComAPI(SiteModel site) {
-        return site.isWPCom() || site.isJetpackConnected();
+        return site.getOrigin() == SiteModel.ORIGIN_WPCOM_REST;
     }
 
     public static String getSiteIconUrl(SiteModel site, int size) {


### PR DESCRIPTION
Fix #5222: use Photon only for Photon compatible sites (public and accessed via WPCom REST API)