### PR TITLE
readded null-check for extras and finishing activity if no URL found

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -227,7 +227,7 @@ public class WPWebViewActivity extends WebViewActivity {
 
         // Configure the allowed URLs if available
         ArrayList<String> allowedURL = null;
-        if (extras.getBoolean(DISABLE_LINKS_ON_PAGE, false)) {
+        if (extras != null && extras.getBoolean(DISABLE_LINKS_ON_PAGE, false)) {
             String addressToLoad = extras.getString(URL_TO_LOAD);
             String authURL = extras.getString(AUTHENTICATION_URL);
             allowedURL = new ArrayList<>();
@@ -254,6 +254,10 @@ public class WPWebViewActivity extends WebViewActivity {
             }
             webViewClient = new WPWebViewClient(site, mAccountStore.getAccessToken(), allowedURL);
         } else {
+            if (allowedURL == null || allowedURL.size() == 0) {
+                AppLog.e(AppLog.T.UTILS, "No valid urls passed to WPWebViewActivity");
+                finish();
+            }
             webViewClient = new URLFilteredWebViewClient(allowedURL);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -254,10 +254,6 @@ public class WPWebViewActivity extends WebViewActivity {
             }
             webViewClient = new WPWebViewClient(site, mAccountStore.getAccessToken(), allowedURL);
         } else {
-            if (allowedURL == null || allowedURL.size() == 0) {
-                AppLog.e(AppLog.T.UTILS, "No valid urls passed to WPWebViewActivity");
-                finish();
-            }
             webViewClient = new URLFilteredWebViewClient(allowedURL);
         }
 


### PR DESCRIPTION
Fixes #5799 

While I haven't been able to reproduce this issue, the null check seems worth adding here. I've checked elsewhere where WPWEbActivity is used and it seems to be prevented before getting to this point. Also, tried re-creating the activity (configuration change / rotation) and it works alright.

This change, if no URL found makes the activity be finished silently (only an entry in the log is written) following the [same behavior this component already had here](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java#L251-L254)

Placing this in consideration and judgment of @oguzkocer 🙇 