### PR TITLE
Rename AccessibleViaWPComAPI to AccessedViaWPComRest to match the changes in FluxC

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -379,7 +379,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     }
 
     private void setupSuggestionServiceAndAdapter() {
-        if (!isAdded() || mSite == null || !SiteUtils.isAccessibleViaWPComAPI(mSite)) {
+        if (!isAdded() || mSite == null || !SiteUtils.isAccessedViaWPComRest(mSite)) {
             return;
         }
         mSuggestionServiceConnectionManager = new SuggestionServiceConnectionManager(getActivity(), mSite.getSiteId());
@@ -730,7 +730,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
 
         // the post this comment is on can only be requested if this is a .com blog or a
         // jetpack-enabled self-hosted blog, and we have valid .com credentials
-        boolean canRequestPost = SiteUtils.isAccessibleViaWPComAPI(site) && mAccountStore.hasAccessToken();
+        boolean canRequestPost = SiteUtils.isAccessedViaWPComRest(site) && mAccountStore.hasAccessToken();
 
         final String title;
         final boolean hasTitle;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -348,7 +348,7 @@ public class MySiteFragment extends Fragment
         mThemesContainer.setVisibility(themesVisibility);
 
         // show settings for all self-hosted to expose Delete Site
-        boolean isAdminOrSelfHosted = site.getHasCapabilityManageOptions() || !SiteUtils.isAccessibleViaWPComAPI(site);
+        boolean isAdminOrSelfHosted = site.getHasCapabilityManageOptions() || !SiteUtils.isAccessedViaWPComRest(site);
         mSettingsView.setVisibility(isAdminOrSelfHosted ? View.VISIBLE : View.GONE);
         mPeopleView.setVisibility(site.getHasCapabilityListUsers() ? View.VISIBLE : View.GONE);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -106,7 +106,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         mLayoutInflater = LayoutInflater.from(context);
 
         mSite = site;
-        mIsStatsSupported = SiteUtils.isAccessibleViaWPComAPI(site) && site.getHasCapabilityViewStats();
+        mIsStatsSupported = SiteUtils.isAccessedViaWPComRest(site) && site.getHasCapabilityViewStats();
 
         int displayWidth = DisplayUtils.getDisplayPixelWidth(context);
         int contentSpacing = context.getResources().getDimensionPixelSize(R.dimen.content_margin);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -681,10 +681,10 @@ public class SiteSettingsFragment extends PreferenceFragment
 
         sortLanguages();
 
-        boolean isAccessibleViaWPComAPI = SiteUtils.isAccessibleViaWPComAPI(mSite);
+        boolean isAccessedViaWPComRest = SiteUtils.isAccessedViaWPComRest(mSite);
 
         // .com sites hide the Account category, self-hosted sites hide the Related Posts preference
-        if (!isAccessibleViaWPComAPI) {
+        if (!isAccessedViaWPComRest) {
             // self-hosted, non-jetpack site
             removeNonSelfHostedPreferences();
         } else if (mSite.isJetpackConnected()) {
@@ -696,8 +696,8 @@ public class SiteSettingsFragment extends PreferenceFragment
         }
 
         // hide Admin options depending of capabilities on this site
-        if ((!isAccessibleViaWPComAPI && !mSite.isSelfHostedAdmin())
-            || (isAccessibleViaWPComAPI && !mSite.getHasCapabilityManageOptions())) {
+        if ((!isAccessedViaWPComRest && !mSite.isSelfHostedAdmin())
+            || (isAccessedViaWPComRest && !mSite.getHasCapabilityManageOptions())) {
             hideAdminRequiredPreferences();
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -124,7 +124,7 @@ public abstract class SiteSettingsInterface {
     public static SiteSettingsInterface getInterface(Activity host, SiteModel site, SiteSettingsListener listener) {
         if (host == null || site == null) return null;
 
-        if (SiteUtils.isAccessibleViaWPComAPI(site)) {
+        if (SiteUtils.isAccessedViaWPComRest(site)) {
             return new DotComSiteSettings(host, site, listener);
         }
 
@@ -798,7 +798,7 @@ public abstract class SiteSettingsInterface {
         }
 
         // Self hosted always read account data from the main table
-        if (!SiteUtils.isAccessibleViaWPComAPI(mSite)) {
+        if (!SiteUtils.isAccessedViaWPComRest(mSite)) {
             setUsername(mSite.getUsername());
             setPassword(mSite.getPassword());
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
@@ -93,7 +93,7 @@ public abstract class StatsAbstractFragment extends Fragment {
         }
 
         // Check credentials for jetpack blogs first
-        if (!SiteUtils.isAccessibleViaWPComAPI(site) && !mAccountStore.hasAccessToken()) {
+        if (!SiteUtils.isAccessedViaWPComRest(site) && !mAccountStore.hasAccessToken()) {
             AppLog.w(AppLog.T.STATS, "Current blog is accessible via .com API without valid .com credentials");
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -280,7 +280,7 @@ public class StatsActivity extends AppCompatActivity
 
     private boolean checkIfSiteHasAccessibleStats(SiteModel site) {
         // If the site is not accessible via wpcom (Jetpack included), then show a dialog to the user.
-        if (!SiteUtils.isAccessibleViaWPComAPI(mSite)) {
+        if (!SiteUtils.isAccessedViaWPComRest(mSite)) {
             if (!site.isJetpackInstalled()) {
                 JetpackUtils.showInstallJetpackAlert(this, site);
                 return false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
@@ -809,7 +809,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         if (mListener!= null) {
             // Should never be null
             SiteModel site = mSiteStore.getSiteByLocalId(getLocalTableBlogID());
-            if (site != null && SiteUtils.isAccessibleViaWPComAPI(site)) {
+            if (site != null && SiteUtils.isAccessedViaWPComRest(site)) {
                 mListener.onDateChanged(site.getSiteId(), getTimeframe(), calculatedDate);
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureActivity.java
@@ -144,7 +144,7 @@ public class StatsWidgetConfigureActivity extends AppCompatActivity
             return;
         }
 
-        if (!SiteUtils.isAccessibleViaWPComAPI(site)) {
+        if (!SiteUtils.isAccessedViaWPComRest(site)) {
             // The blog could be a self-hosted blog with NO Jetpack installed on it
             // Or a Jetpack blog whose options are not yet synched in the app
             // In both of these cases show a generic message that encourages the user to refresh

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureAdapter.java
@@ -246,7 +246,7 @@ public class StatsWidgetConfigureAdapter extends RecyclerView.Adapter<StatsWidge
             homeURL = SiteUtils.getHomeURLOrHostName(site);
             url = site.getUrl();
             blavatarUrl = SiteUtils.getSiteIconUrl(site, mBlavatarSz);
-            isDotComOrJetpack = SiteUtils.isAccessibleViaWPComAPI(site);
+            isDotComOrJetpack = SiteUtils.isAccessedViaWPComRest(site);
             isHidden = !site.isVisible();
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetProvider.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetProvider.java
@@ -172,7 +172,7 @@ public class StatsWidgetProvider extends AppWidgetProvider {
             }
 
             // Check if Jetpack or .com
-            if (SiteUtils.isAccessibleViaWPComAPI(site)) {
+            if (SiteUtils.isAccessedViaWPComRest(site)) {
                 // User cannot access stats for this .com blog
                 showMessage(context, widgetIDs, context.getString(R.string.stats_widget_error_no_permissions),
                         siteStore);

--- a/WordPress/src/main/java/org/wordpress/android/ui/suggestion/util/SuggestionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/suggestion/util/SuggestionUtils.java
@@ -17,7 +17,7 @@ public class SuggestionUtils {
     public static SuggestionAdapter setupSuggestions(SiteModel site, Context context,
                                                      SuggestionServiceConnectionManager serviceConnectionManager) {
         return SuggestionUtils.setupSuggestions(site.getSiteId(), context, serviceConnectionManager,
-                SiteUtils.isAccessibleViaWPComAPI(site));
+                SiteUtils.isAccessedViaWPComRest(site));
     }
 
     public static SuggestionAdapter setupSuggestions(final long siteId, Context context,
@@ -41,7 +41,7 @@ public class SuggestionUtils {
     public static TagSuggestionAdapter setupTagSuggestions(SiteModel site, Context context,
                                                            SuggestionServiceConnectionManager serviceConnectionManager) {
         return SuggestionUtils.setupTagSuggestions(site.getSiteId(), context, serviceConnectionManager,
-                SiteUtils.isAccessibleViaWPComAPI(site));
+                SiteUtils.isAccessedViaWPComRest(site));
     }
 
     public static TagSuggestionAdapter setupTagSuggestions(final long siteId, Context context,

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -62,7 +62,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
 
     public static boolean isAccessible(SiteModel site) {
         // themes are only accessible to admin wordpress.com users
-        // TODO: Support themes for Jetpack and AT sites (and use SiteUtils.isAccessibleViaWPComAPI(site))
+        // TODO: Support themes for Jetpack and AT sites (and use SiteUtils.isAccessedViaWPComRest(site))
         return site != null && site.isWPCom() && site.getHasCapabilityEditThemeOptions();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
@@ -114,13 +114,13 @@ public class AnalyticsUtils {
      */
     public static void trackWithSiteDetails(AnalyticsTracker.Stat stat, SiteModel site,
                                             Map<String, Object> properties) {
-        if (site == null || !SiteUtils.isAccessibleViaWPComAPI(site)) {
+        if (site == null || !SiteUtils.isAccessedViaWPComRest(site)) {
             AppLog.w(AppLog.T.STATS, "The passed blog obj is null or it's not a wpcom or Jetpack. Tracking analytics without blog info");
             AnalyticsTracker.track(stat, properties);
             return;
         }
 
-        if (SiteUtils.isAccessibleViaWPComAPI(site)) {
+        if (SiteUtils.isAccessedViaWPComRest(site)) {
             if (properties == null) {
                 properties = new HashMap<>();
             }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -30,10 +30,10 @@ public class SiteUtils {
      * @return true if the site is WPCom or Jetpack and is not private
      */
     public static boolean isPhotonCapable(SiteModel site) {
-        return SiteUtils.isAccessibleViaWPComAPI(site) && !site.isPrivate();
+        return SiteUtils.isAccessedViaWPComRest(site) && !site.isPrivate();
     }
 
-    public static boolean isAccessibleViaWPComAPI(SiteModel site) {
+    public static boolean isAccessedViaWPComRest(SiteModel site) {
         return site.getOrigin() == SiteModel.ORIGIN_WPCOM_REST;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMeShortlinks.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMeShortlinks.java
@@ -64,7 +64,7 @@ public class WPMeShortlinks {
             return null;
         }
 
-        if (!SiteUtils.isAccessibleViaWPComAPI(site)) {
+        if (!SiteUtils.isAccessedViaWPComRest(site)) {
             return null;
         }
 


### PR DESCRIPTION
And improve prevision: almost all jetpack sites are accessible via WPComRest but if they're added as self hosted, they will be accessed via XMLRPC.

cc @aforcier 