### PR TITLE
7.3 - Fix pictures orientation issues

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -698,7 +698,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
     private void queueFileForUpload(Uri uri, String mimeType) {
         // It is a regular local media file
-        String path = getRealPathFromURI(uri);
+        String path = MediaUtils.getRealPathFromURI(this,uri);
 
         if (path == null || path.equals("")) {
             Toast.makeText(this, "Error opening file", Toast.LENGTH_SHORT).show();
@@ -784,18 +784,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             }
             startService(intent);
         }
-    }
-
-    private String getRealPathFromURI(Uri uri) {
-        String path;
-        if ("content".equals(uri.getScheme())) {
-            path = MediaUtils.getPath(this, uri);
-        } else if ("file".equals(uri.getScheme())) {
-            path = uri.getPath();
-        } else {
-            path = uri.toString();
-        }
-        return path;
     }
 
     private void updateViews() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1786,6 +1786,14 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         if (optimizedMedia != null) {
             uri = optimizedMedia;
             path = MediaUtils.getRealPathFromURI(this, uri);
+        } else {
+            // Fix the rotation of the picture see https://github.com/wordpress-mobile/WordPress-Android/issues/5737
+            // TODO: find a better implementation
+            Uri rotatedMedia = WPMediaUtils.fixOrientationIssue(this, path, isVideo);
+            if (rotatedMedia != null) {
+                uri = rotatedMedia;
+                path = MediaUtils.getRealPathFromURI(this, uri);
+            }
         }
 
         MediaModel media = queueFileForUpload(uri, getContentResolver().getType(uri));

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1775,13 +1775,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     }
 
     private boolean addMediaVisualEditor(Uri uri, boolean isVideo) {
-        String path;
-        if (uri.toString().contains("content:")) {
-            path = MediaUtils.getPath(this, uri);
-        } else {
-            // File is not in media library
-            path = uri.toString().replace("file://", "");
-        }
+        String path = MediaUtils.getRealPathFromURI(this, uri);
 
         if (path == null) {
             ToastUtils.showToast(this, R.string.file_not_found, Duration.SHORT);
@@ -1791,6 +1785,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         Uri optimizedMedia = WPMediaUtils.getOptimizedMedia(this, mSite, path, isVideo);
         if (optimizedMedia != null) {
             uri = optimizedMedia;
+            path = MediaUtils.getRealPathFromURI(this, uri);
         }
 
         MediaModel media = queueFileForUpload(uri, getContentResolver().getType(uri));

--- a/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/AnalyticsUtils.java
@@ -329,12 +329,7 @@ public class AnalyticsUtils {
         }
 
         if(mediaURI != null) {
-            if (mediaURI.toString().contains("content:")) {
-                path = MediaUtils.getPath(context, mediaURI);
-            } else {
-                // File is not in media library
-                path = mediaURI.toString().replace("file://", "");
-            }
+            path = MediaUtils.getRealPathFromURI(context, mediaURI);
         }
 
         if (TextUtils.isEmpty(path) ) {

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -39,4 +39,18 @@ public class WPMediaUtils {
         }
         return null;
     }
+
+
+    public static Uri fixOrientationIssue(Activity activity, String path, boolean isVideo) {
+        if (isVideo) {
+            return null;
+        }
+
+        String rotatedPath = ImageUtils.rotateImageIfNecessary(activity, path);
+        if (rotatedPath != null) {
+            return Uri.parse(rotatedPath);
+        }
+
+        return null;
+    }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -719,4 +719,92 @@ public class ImageUtils {
         maximumThumbnailWidthForEditor -= padding;
         return maximumThumbnailWidthForEditor;
     }
+
+    /**
+     * Given the path to an image, rotate it by using EXIF info
+     * @param context the passed context
+     * @param path the path to the original image
+     * @return the path to the rotated image or null
+     */
+    public static String rotateImageIfNecessary(Context context, String path) {
+        if (context == null || TextUtils.isEmpty(path)) {
+            return null;
+        }
+
+        File file = new File(path);
+        if (!file.exists()) {
+            return null;
+        }
+
+        String mimeType = MediaUtils.getMediaFileMimeType(file);
+        if (mimeType.equals("image/gif")) {
+            // Don't rotate gifs to maintain their quality
+            return null;
+        }
+
+        Uri srcImageUri = Uri.parse(path);
+        if (srcImageUri == null) {
+            return null;
+        }
+
+        String fileName = MediaUtils.getMediaFileName(file, mimeType);
+        String fileExtension = MimeTypeMap.getFileExtensionFromUrl(fileName).toLowerCase();
+
+        int selectedWidth = getImageSize(srcImageUri, context)[0];
+        if (selectedWidth == 0) {
+            // Can't read the src dimensions.
+            return null;
+        }
+
+        int orientation = getImageOrientation(context, path);
+        // Do not rotate portrait pictures
+        if (orientation == 0) {
+            return  null;
+        }
+
+        File resizedImageFile;
+        FileOutputStream out;
+
+        try {
+            resizedImageFile = File.createTempFile("wp-image-", "." + fileExtension);
+            out = new FileOutputStream(resizedImageFile);
+        } catch (IOException e) {
+            AppLog.e(AppLog.T.MEDIA, "Failed to create the temp file on storage. Use the original picture instead.");
+            return null;
+        } catch (SecurityException e) {
+            AppLog.e(AppLog.T.MEDIA, "Can't write the tmp file due to security restrictions. Use the original picture instead.");
+            return null;
+        }
+
+        try {
+            boolean res = resizeImageAndWriteToStream(context, srcImageUri, fileExtension, selectedWidth, orientation, 85, out);
+            if (!res) {
+                AppLog.w(AppLog.T.MEDIA, "Failed to compress the rotate image. Use the original picture instead.");
+                return null;
+            }
+        } catch (IOException e) {
+            AppLog.e(AppLog.T.MEDIA, "Failed to create rotated image. Use the original picture instead.");
+            return null;
+        } catch (OutOfMemoryError e) {
+            AppLog.e(AppLog.T.MEDIA, "Can't rotate the picture due to low memory. Use the original picture instead.");
+            return null;
+        } finally {
+            // close the stream
+            try {
+                out.flush();
+                out.close();
+            } catch (IOException e) {
+                //nope
+            }
+        }
+
+        String tempFilePath = resizedImageFile.getPath();
+        if (!TextUtils.isEmpty(tempFilePath)) {
+            return tempFilePath;
+        } else {
+            AppLog.e(AppLog.T.MEDIA, "Failed to create rotated image. Use the full picture instead.");
+        }
+
+        return null;
+    }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -769,24 +769,24 @@ public class ImageUtils {
             resizedImageFile = File.createTempFile("wp-image-", "." + fileExtension);
             out = new FileOutputStream(resizedImageFile);
         } catch (IOException e) {
-            AppLog.e(AppLog.T.MEDIA, "Failed to create the temp file on storage. Use the original picture instead.");
+            AppLog.e(AppLog.T.MEDIA, "Failed to create the temp file on storage.");
             return null;
         } catch (SecurityException e) {
-            AppLog.e(AppLog.T.MEDIA, "Can't write the tmp file due to security restrictions. Use the original picture instead.");
+            AppLog.e(AppLog.T.MEDIA, "Can't write the tmp file due to security restrictions.");
             return null;
         }
 
         try {
             boolean res = resizeImageAndWriteToStream(context, srcImageUri, fileExtension, selectedWidth, orientation, 85, out);
             if (!res) {
-                AppLog.w(AppLog.T.MEDIA, "Failed to compress the rotate image. Use the original picture instead.");
+                AppLog.w(AppLog.T.MEDIA, "Failed to compress the rotates image.");
                 return null;
             }
         } catch (IOException e) {
-            AppLog.e(AppLog.T.MEDIA, "Failed to create rotated image. Use the original picture instead.");
+            AppLog.e(AppLog.T.MEDIA, "Failed to create rotated image.");
             return null;
         } catch (OutOfMemoryError e) {
-            AppLog.e(AppLog.T.MEDIA, "Can't rotate the picture due to low memory. Use the original picture instead.");
+            AppLog.e(AppLog.T.MEDIA, "Can't rotate the picture due to low memory.");
             return null;
         } finally {
             // close the stream
@@ -802,7 +802,7 @@ public class ImageUtils {
         if (!TextUtils.isEmpty(tempFilePath)) {
             return tempFilePath;
         } else {
-            AppLog.e(AppLog.T.MEDIA, "Failed to create rotated image. Use the full picture instead.");
+            AppLog.e(AppLog.T.MEDIA, "Failed to create rotated image.");
         }
 
         return null;

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -395,6 +395,18 @@ public class MediaUtils {
         return fileExtensionFromMimeType.toLowerCase();
     }
 
+    public static String getRealPathFromURI(final Context context, Uri uri) {
+        String path;
+        if ("content".equals(uri.getScheme())) {
+            path = MediaUtils.getPath(context, uri);
+        } else if ("file".equals(uri.getScheme())) {
+            path = uri.getPath();
+        } else {
+            path = uri.toString();
+        }
+        return path;
+    }
+
     /**
      * Get a file path from a Uri. This will get the the path for Storage Access
      * Framework Documents, as well as the _data field for the MediaStore and
@@ -405,7 +417,7 @@ public class MediaUtils {
      * @param context The context.
      * @param uri The Uri to query.
      */
-    public static String getPath(final Context context, final Uri uri) {
+    private static String getPath(final Context context, final Uri uri) {
         String path = getDocumentProviderPathKitkatOrHigher(context, uri);
 
         if (path != null) {


### PR DESCRIPTION
Fixes #5737 by rotating the picture according to the picture EXIF metadata field named `Orientation	` 
Rotation of the picture is not necessary if the `optimize picture` feature is set to ON, since it already rotates the picture.

Things we need to fix soon:
- This is just a quick fix for 7.3,i'm going to investigate a better way to fix the issue, since the current implementation uses an additional file in `cache` folder. It also erases EXIF metadata.
- `MediaBrowserActivity` should call the same function before adding a media from device library.
- Not strictly related to this PR, but we we need to provide a way of cleaning the `cache` folder.

