### PR TITLE
Verify non-empty credentials required by Smart Lock

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SmartLockHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SmartLockHelper.java
@@ -106,6 +106,12 @@ public class SmartLockHelper {
 
     public void saveCredentialsInSmartLock(@NonNull final String username, @NonNull final String password,
                                            @NonNull final String displayName, @Nullable final Uri profilePicture) {
+        // need username and password fields for Smart Lock
+        // https://github.com/wordpress-mobile/WordPress-Android/issues/5850
+        if (password.isEmpty() || username.isEmpty()) {
+            return;
+        }
+
         Activity activity = getActivityAndCheckAvailability();
         if (activity == null || mCredentialsClient == null || !mCredentialsClient.isConnected()) {
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SmartLockHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SmartLockHelper.java
@@ -6,6 +6,7 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentActivity;
+import android.text.TextUtils;
 
 import com.google.android.gms.auth.api.Auth;
 import com.google.android.gms.auth.api.credentials.Credential;
@@ -108,7 +109,7 @@ public class SmartLockHelper {
                                            @NonNull final String displayName, @Nullable final Uri profilePicture) {
         // need username and password fields for Smart Lock
         // https://github.com/wordpress-mobile/WordPress-Android/issues/5850
-        if (password.isEmpty() || username.isEmpty()) {
+        if (TextUtils.isEmpty(password) || TextUtils.isEmpty(username)) {
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SmartLockHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SmartLockHelper.java
@@ -110,6 +110,8 @@ public class SmartLockHelper {
         // need username and password fields for Smart Lock
         // https://github.com/wordpress-mobile/WordPress-Android/issues/5850
         if (TextUtils.isEmpty(password) || TextUtils.isEmpty(username)) {
+            AppLog.i(T.MAIN, String.format(
+                    "Cannot save Smart Lock credentials, username (%s) or password (%s) is empty", username, password));
             return;
         }
 


### PR DESCRIPTION
Fixes #5850 by verifying username and password fields are not empty.

It looks like any call to create a new site is behind an [isUserDataValid](https://github.com/wordpress-mobile/WordPress-Android/blob/45224a17fa4939743added2652792eafcfa0c863/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java#L145) call so I don't know why the fields would be empty when building the credentials. Maybe another call to `isUserDataValid` would be appropriate [here](https://github.com/wordpress-mobile/WordPress-Android/blob/45224a17fa4939743added2652792eafcfa0c863/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java#L636) instead of checking in `SmartLockHelper`?

cc @maxme 