### PR TITLE
MediaGridAdapter - just adding another isValidPosition check

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -252,6 +252,9 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                 @Override
                 public void onClick(View v) {
                     int position = getAdapterPosition();
+                    if (!isValidPosition(position)) {
+                        return;
+                    }
                     if (isInMultiSelect()) {
                         if (canSelectPosition(position)) {
                             toggleItemSelected(GridViewHolder.this, position);


### PR DESCRIPTION
Crash report #5853 was already fixed in 7.3.

I've just added another additional `isValidPosition` check to the ViewHolder. This prevent to call a potential MediaGridAdapterCallback with an invalid position.