### PR TITLE
7.4 - Fix picture orientation issues

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -555,6 +555,11 @@ public class MeFragment extends Fragment {
     }
 
     private void startGravatarUpload(final String filePath) {
+        if (TextUtils.isEmpty(filePath)) {
+            Toast.makeText(getActivity(), getString(R.string.error_locating_image), Toast.LENGTH_SHORT).show();
+            return;
+        }
+
         File file = new File(filePath);
         if (!file.exists()) {
             Toast.makeText(getActivity(), getString(R.string.error_locating_image), Toast.LENGTH_SHORT).show();

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -544,54 +544,14 @@ public class MeFragment extends Fragment {
             // Do not download the file in async task. See https://github.com/wordpress-mobile/WordPress-Android/issues/5818
             Uri downloadedUri = MediaUtils.downloadExternalMedia(getActivity(), mediaUri);
             if (downloadedUri != null) {
-                startGravatarUpload(getRealPathFromURI(downloadedUri));
+                startGravatarUpload(MediaUtils.getRealPathFromURI(getActivity(), downloadedUri));
             } else {
                 Toast.makeText(getActivity(), getString(R.string.error_downloading_image), Toast.LENGTH_SHORT).show();
             }
         } else {
             // It is a regular local media file
-            startGravatarUpload(getRealPathFromURI(mediaUri));
+            startGravatarUpload(MediaUtils.getRealPathFromURI(getActivity(), mediaUri));
         }
-    }
-
-    private String getRealPathFromURI(Uri uri) {
-        String path;
-        if ("content".equals(uri.getScheme())) {
-            path = getRealPathFromContentURI(uri);
-        } else if ("file".equals(uri.getScheme())) {
-            path = uri.getPath();
-        } else {
-            path = uri.toString();
-        }
-        return path;
-    }
-
-    private String getRealPathFromContentURI(Uri contentUri) {
-        if (contentUri == null)
-            return null;
-
-        String[] proj = { MediaStore.Images.Media.DATA };
-        CursorLoader loader = new CursorLoader(getActivity(), contentUri, proj, null, null, null);
-        Cursor cursor = loader.loadInBackground();
-
-        if (cursor == null)
-            return null;
-
-        int column_index = cursor.getColumnIndex(MediaStore.Images.Media.DATA);
-        if (column_index == -1) {
-            cursor.close();
-            return null;
-        }
-
-        String path;
-        if (cursor.moveToFirst()) {
-            path = cursor.getString(column_index);
-        } else {
-            path = null;
-        }
-
-        cursor.close();
-        return path;
     }
 
     private void startGravatarUpload(final String filePath) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -685,7 +685,18 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         Uri optimizedMedia = WPMediaUtils.getOptimizedMedia(this, mSite, filePath, false);
         if (optimizedMedia != null) {
             return optimizedMedia;
+        } else {
+            // Optimization is OFF. Make sure the picture is in portrait for .org site
+            // Fix for the rotation issue https://github.com/wordpress-mobile/WordPress-Android/issues/5737
+            if (!mSite.isWPCom()) {
+                // If it's not wpcom we must rotate the picture locally
+                Uri rotatedMedia = WPMediaUtils.fixOrientationIssue(this, filePath, false);
+                if (rotatedMedia != null) {
+                    return rotatedMedia;
+                }
+            }
         }
+
         return originalUri;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -349,8 +349,9 @@ public class MediaPreviewActivity extends AppCompatActivity {
 
         @Override
         protected Bitmap doInBackground(Void... params) {
+            int orientation = ImageUtils.getImageOrientation(MediaPreviewActivity.this, mMediaUri);
             byte[] bytes = ImageUtils.createThumbnailFromUri(
-                    MediaPreviewActivity.this, Uri.parse(mMediaUri), mSize, null, 0);
+                    MediaPreviewActivity.this, Uri.parse(mMediaUri), mSize, null, orientation);
             if (bytes != null) {
                 return BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/ThumbnailLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/ThumbnailLoader.java
@@ -10,6 +10,7 @@ import android.view.View;
 import android.widget.ImageView;
 
 import org.wordpress.android.R;
+import org.wordpress.android.util.ImageUtils;
 
 import java.lang.ref.WeakReference;
 import java.util.concurrent.Executors;
@@ -94,11 +95,10 @@ class ThumbnailLoader {
                         MediaStore.Video.Thumbnails.MINI_KIND,
                         null);
             } else {
-                mThumbnail = MediaStore.Images.Thumbnails.getThumbnail(
+                mThumbnail = ImageUtils.getThumbnail(
                         mContext.getContentResolver(),
                         mImageId,
-                        MediaStore.Images.Thumbnails.MINI_KIND,
-                        null);
+                        MediaStore.Images.Thumbnails.MINI_KIND);
             }
             mHandler.post(new Runnable() {
                 @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1797,6 +1797,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 }
             } else {
                 // It's a wpcom site. Just create a version of the picture rotated for the old visual editor
+                // All the other editors read EXIF data
                 if (mShowNewEditor) {
                     Uri rotatedMedia = WPMediaUtils.fixOrientationIssue(this, path, isVideo);
                     if (rotatedMedia != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1787,12 +1787,23 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             uri = optimizedMedia;
             path = MediaUtils.getRealPathFromURI(this, uri);
         } else {
-            // Fix the rotation of the picture see https://github.com/wordpress-mobile/WordPress-Android/issues/5737
-            // TODO: find a better implementation
-            Uri rotatedMedia = WPMediaUtils.fixOrientationIssue(this, path, isVideo);
-            if (rotatedMedia != null) {
-                uri = rotatedMedia;
-                path = MediaUtils.getRealPathFromURI(this, uri);
+            // Fix for the rotation issue https://github.com/wordpress-mobile/WordPress-Android/issues/5737
+            if (!mSite.isWPCom()) {
+                // If it's not wpcom we must rotate the picture locally
+                Uri rotatedMedia = WPMediaUtils.fixOrientationIssue(this, path, isVideo);
+                if (rotatedMedia != null) {
+                    uri = rotatedMedia;
+                    path = MediaUtils.getRealPathFromURI(this, uri);
+                }
+            } else {
+                // It's a wpcom site. Just create a version of the picture rotated for the old visual editor
+                if (mShowNewEditor) {
+                    Uri rotatedMedia = WPMediaUtils.fixOrientationIssue(this, path, isVideo);
+                    if (rotatedMedia != null) {
+                        // The uri variable should remain the same since wpcom rotates the picture server side
+                        path = MediaUtils.getRealPathFromURI(this, rotatedMedia);
+                    }
+                }
             }
         }
 

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -747,9 +747,9 @@ public class ImageUtils {
             String prefix;
             int dotPos = fileName.indexOf('.');
             if (dotPos > 0) {
-                prefix = fileName.substring(0, dotPos) + "-";
+                prefix = fileName.substring(0, dotPos);
             } else {
-                prefix = fileName + "-";
+                prefix = fileName;
             }
 
             if (prefix.length() < 3) {


### PR DESCRIPTION
This PR fixes #5855 and other small bugs reported below. 

The flow is pretty simple:

- If optimize image is ON there is no picture orientation issues, since the picture is already rotated (if necessary) during the optimization process. 
- If optimize image is OFF 
-- Checks the blog, if it's wpcom do nothing on the original photo. But use the orientation metadata before adding it to the visual editor to provide a tmp version only used by the editor.
-- If it's not on wpcom, rotate the picture since there is no auto-rotating on the server.

Other bugs fixed:
- The new Media Picker now uses orientation data and shows thumbnail properly.
- The Media Preview screen now uses orientation data data and shows the picture properly.
- WP Media Library  now takes in consideration the `optimize images` feature even for local device pictures. It was off before, but we should be consistent. 
- WP Media Library  rotates the picture before uploading if necessary.
