### PR TITLE
removed unused method

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -846,15 +846,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         }
     };
 
-    /**
-     * Save post content from source HTML.
-     */
-    public void saveContentFromSource() {
-        if (content != null && source != null && source.getVisibility() == View.VISIBLE) {
-            content.fromHtml(source.getPureHtml(false));
-        }
-    }
-
     @Override
     public void onToolbarAddMediaClicked() {
         mEditorFragmentListener.onTrackableEvent(TrackableEvent.MEDIA_BUTTON_TAPPED);


### PR DESCRIPTION
Removes `saveContentFromSource()` from `AztecEditorFragment` as it was not being used

cc @aforcier for review to double check whether this is a method that we might want to use later 