### PR TITLE
Fix #5866: remove PlanPostPurchaseActivity from the manifest

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -202,8 +202,6 @@
         <!-- plans -->
         <activity android:name=".ui.plans.PlansActivity"
                   android:theme="@style/Calypso.NoActionBar"/>
-        <activity android:name=".ui.plans.PlanPostPurchaseActivity"
-                  android:theme="@style/Calypso.NoActionBar"/>
 
         <!-- Stats Activities -->
         <activity


### PR DESCRIPTION
Fix #5866: remove PlanPostPurchaseActivity from the manifest