### PR TITLE
Async media: Notifications for async publish

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
@@ -55,10 +55,8 @@ public class PostUploadNotifier {
         mNotificationBuilder.setSmallIcon(android.R.drawable.stat_sys_upload);
     }
 
-    public void updateNotificationNewPost(PostModel post, String title, String message) {
-        if (title != null) {
-            mNotificationBuilder.setContentTitle(title);
-        }
+    public void updateNotificationNewPost(@NonNull PostModel post, String message) {
+        mNotificationBuilder.setContentTitle(buildNotificationTitleForPost(post));
         if (message != null) {
             mNotificationBuilder.setContentText(message);
         }
@@ -242,5 +240,10 @@ public class PostUploadNotifier {
 
         mNotificationBuilder.setContentText(String.format(mContext.getString(R.string.uploading_total),
                 currentItem, notificationData.totalMediaItems));
+    }
+
+    private String buildNotificationTitleForPost(PostModel post) {
+        String postTitle = TextUtils.isEmpty(post.getTitle()) ? mContext.getString(R.string.untitled) : post.getTitle();
+        return String.format(mContext.getString(R.string.posting_post), postTitle);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
 import android.text.TextUtils;
 import android.util.SparseArray;
@@ -66,6 +67,10 @@ public class PostUploadNotifier {
         notificationData.notificationId = notificationId;
         mPostIdToNotificationData.put(post.getId(), notificationData);
         mService.startForeground(notificationId, mNotificationBuilder.build());
+    }
+
+    public boolean isDisplayingNotificationForPost(@NonNull PostModel post) {
+        return mPostIdToNotificationData.get(post.getId()) != null;
     }
 
     public void updateNotificationIcon(PostModel post, Bitmap icon) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.notifications.ShareAndDismissNotificationReceive
 import org.wordpress.android.ui.posts.PostsListActivity;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.CrashlyticsUtils;
+import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.SystemServiceFactory;
 import org.wordpress.android.util.WPMeShortlinks;
 
@@ -71,6 +72,12 @@ public class PostUploadNotifier {
 
     public boolean isDisplayingNotificationForPost(@NonNull PostModel post) {
         return mPostIdToNotificationData.get(post.getId()) != null;
+    }
+
+    public void updateNotificationMessage(@NonNull PostModel post, String message) {
+        NotificationData notificationData = mPostIdToNotificationData.get(post.getId());
+        mNotificationBuilder.setContentText(StringUtils.notNullStr(message));
+        doNotify(notificationData.notificationId, mNotificationBuilder.build());
     }
 
     public void updateNotificationIcon(PostModel post, Bitmap icon) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
@@ -55,7 +55,7 @@ public class PostUploadNotifier {
         mNotificationBuilder.setSmallIcon(android.R.drawable.stat_sys_upload);
     }
 
-    public void updateNotificationNewPost(@NonNull PostModel post, String message) {
+    public void createNotificationForPost(@NonNull PostModel post, String message) {
         mNotificationBuilder.setContentTitle(buildNotificationTitleForPost(post));
         if (message != null) {
             mNotificationBuilder.setContentText(message);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -219,7 +219,7 @@ public class PostUploadService extends Service {
         for (PostModel postModel : mPostsList) {
             if (MediaUploadService.hasPendingMediaUploadsForPost(postModel)) {
                 if (!mPostUploadNotifier.isDisplayingNotificationForPost(postModel)) {
-                    mPostUploadNotifier.updateNotificationNewPost(postModel, getString(R.string.uploading_post_media));
+                    mPostUploadNotifier.createNotificationForPost(postModel, getString(R.string.uploading_post_media));
                 }
             }
         }
@@ -285,7 +285,7 @@ public class PostUploadService extends Service {
             if (mPostUploadNotifier.isDisplayingNotificationForPost(mPost)) {
                 mPostUploadNotifier.updateNotificationMessage(mPost, uploadingPostMessage);
             } else {
-                mPostUploadNotifier.updateNotificationNewPost(mPost, uploadingPostMessage);
+                mPostUploadNotifier.createNotificationForPost(mPost, uploadingPostMessage);
             }
 
             mSite = mSiteStore.getSiteByLocalId(mPost.getLocalSiteId());

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -167,6 +167,7 @@ public class PostUploadService extends Service {
         }
 
         uploadNextPost();
+        showNotificationsForPendingMediaPosts();
         // We want this service to continue running until it is explicitly stopped, so return sticky.
         return START_STICKY;
     }
@@ -212,6 +213,20 @@ public class PostUploadService extends Service {
         }
         AppLog.d(T.POSTS, "All posts queued for upload have pending media");
         return null;
+    }
+
+    private void showNotificationsForPendingMediaPosts() {
+        for (PostModel postModel : mPostsList) {
+            if (MediaUploadService.hasPendingMediaUploadsForPost(postModel)) {
+                if (!mPostUploadNotifier.isDisplayingNotificationForPost(postModel)) {
+                    String postTitle = TextUtils.isEmpty(postModel.getTitle()) ? getString(R.string.untitled)
+                            : postModel.getTitle();
+                    String uploadingPostTitle = String.format(getString(R.string.posting_post), postTitle);
+                    String uploadingPostMessage = mContext.getString(R.string.uploading_post_media);
+                    mPostUploadNotifier.updateNotificationNewPost(postModel, uploadingPostTitle, uploadingPostMessage);
+                }
+            }
+        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -719,6 +719,9 @@ public class PostUploadService extends Service {
             PostModel postToCancel = removeQueuedPostByLocalId(event.media.getLocalPostId());
             if (postToCancel == null) return;
 
+            SiteModel site = mSiteStore.getSiteByLocalId(postToCancel.getLocalSiteId());
+            String message = getErrorMessage(postToCancel, getErrorMessageFromMediaError(event.error));
+            mPostUploadNotifier.updateNotificationError(postToCancel, site, message, true);
             mFirstPublishPosts.remove(postToCancel.getId());
             EventBus.getDefault().post(new PostEvents.PostUploadCanceled(postToCancel.getLocalSiteId()));
             finishUpload();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -288,7 +288,11 @@ public class PostUploadService extends Service {
                     mPost.isPage() ? getString(R.string.page).toLowerCase() : getString(R.string.post).toLowerCase()
             );
 
-            mPostUploadNotifier.updateNotificationNewPost(mPost, uploadingPostTitle, uploadingPostMessage);
+            if (mPostUploadNotifier.isDisplayingNotificationForPost(mPost)) {
+                mPostUploadNotifier.updateNotificationMessage(mPost, uploadingPostMessage);
+            } else {
+                mPostUploadNotifier.updateNotificationNewPost(mPost, uploadingPostTitle, uploadingPostMessage);
+            }
 
             mSite = mSiteStore.getSiteByLocalId(mPost.getLocalSiteId());
             if (mSite == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -219,11 +219,7 @@ public class PostUploadService extends Service {
         for (PostModel postModel : mPostsList) {
             if (MediaUploadService.hasPendingMediaUploadsForPost(postModel)) {
                 if (!mPostUploadNotifier.isDisplayingNotificationForPost(postModel)) {
-                    String postTitle = TextUtils.isEmpty(postModel.getTitle()) ? getString(R.string.untitled)
-                            : postModel.getTitle();
-                    String uploadingPostTitle = String.format(getString(R.string.posting_post), postTitle);
-                    String uploadingPostMessage = mContext.getString(R.string.uploading_post_media);
-                    mPostUploadNotifier.updateNotificationNewPost(postModel, uploadingPostTitle, uploadingPostMessage);
+                    mPostUploadNotifier.updateNotificationNewPost(postModel, getString(R.string.uploading_post_media));
                 }
             }
         }
@@ -281,8 +277,6 @@ public class PostUploadService extends Service {
         protected Boolean doInBackground(PostModel... posts) {
             mPost = posts[0];
 
-            String postTitle = TextUtils.isEmpty(mPost.getTitle()) ? getString(R.string.untitled) : mPost.getTitle();
-            String uploadingPostTitle = String.format(getString(R.string.posting_post), postTitle);
             String uploadingPostMessage = String.format(
                     getString(R.string.sending_content),
                     mPost.isPage() ? getString(R.string.page).toLowerCase() : getString(R.string.post).toLowerCase()
@@ -291,7 +285,7 @@ public class PostUploadService extends Service {
             if (mPostUploadNotifier.isDisplayingNotificationForPost(mPost)) {
                 mPostUploadNotifier.updateNotificationMessage(mPost, uploadingPostMessage);
             } else {
-                mPostUploadNotifier.updateNotificationNewPost(mPost, uploadingPostTitle, uploadingPostMessage);
+                mPostUploadNotifier.updateNotificationNewPost(mPost, uploadingPostMessage);
             }
 
             mSite = mSiteStore.getSiteByLocalId(mPost.getLocalSiteId());

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -619,12 +619,12 @@ public class PostUploadService extends Service {
         }
     }
 
-    private void cancelPostUploadMatchingMedia(MediaModel media) {
+    private void cancelPostUploadMatchingMedia(MediaModel media, String mediaErrorMessage) {
         PostModel postToCancel = removeQueuedPostByLocalId(media.getLocalPostId());
         if (postToCancel == null) return;
 
         SiteModel site = mSiteStore.getSiteByLocalId(postToCancel.getLocalSiteId());
-        String message = getErrorMessage(postToCancel, getErrorMessageFromMediaError(event.error));
+        String message = getErrorMessage(postToCancel, mediaErrorMessage);
         mPostUploadNotifier.updateNotificationError(postToCancel, site, message, true);
 
         mFirstPublishPosts.remove(postToCancel.getId());
@@ -721,14 +721,15 @@ public class PostUploadService extends Service {
         if (event.isError()) {
             AppLog.e(T.MEDIA, "Media upload failed for post " + event.media.getLocalPostId() + " : " +
                     event.error.type + ": " + event.error.message);
-            cancelPostUploadMatchingMedia(event.media);
+            String errorMessage = getErrorMessageFromMediaError(event.error);
+            cancelPostUploadMatchingMedia(event.media, errorMessage);
             return;
         }
 
         if (event.canceled) {
             AppLog.i(T.MEDIA, "Upload cancelled for post with id " + event.media.getLocalPostId()
                             + " - a media upload for this post has been cancelled, id: " + event.media.getId());
-            cancelPostUploadMatchingMedia(event.media);
+            cancelPostUploadMatchingMedia(event.media, getString(R.string.error_media_canceled));
             return;
         }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1091,6 +1091,7 @@
     <string name="error_media_load">Unable to load media</string>
     <string name="error_media_request_too_large">Media too large, can\'t be uploaded</string>
     <string name="error_media_save">Unable to save media</string>
+    <string name="error_media_canceled">Uploading media were canceled</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>
     <string name="fatal_db_error">An error occurred while creating the app database. Try reinstalling the app.</string>
     <string name="error_copy_to_clipboard">An error occurred while copying text to clipboard</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -391,6 +391,7 @@
     <string name="update_verb">Update</string>
     <string name="sending_content">Uploading %s content</string>
     <string name="uploading_total">Uploading %1$d of %2$d</string>
+    <string name="uploading_post_media">Uploading media…</string>
 
     <!-- new account view -->
     <string name="signing_in">Logging in…</string>


### PR DESCRIPTION
Adds some notification support for async post publishing (#5880). #5880 should be merged first, and then the base branch of this PR updated.

This is intended to be temporary, to give us some visual feedback on what's happening (post waiting for media to finish --> post itself publishing), and also to show an error notification when a post upload is cancelled because it had failed media. It's temporary because the upload UI is getting a major overhaul as part of the async media project, and that will supersede these changes.

To test:
Run the same cases as in #5880. You should get an immediate notification when pressing 'Publish', and you should get an error notification if a media item fails while the post is queued to upload.

cc @mzorz @daniloercoli