### PR TITLE
Async media: Fix cancelling media from the editors

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -23,6 +23,7 @@ import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.posts.services.MediaUploadReadyProcessor;
+import org.wordpress.android.ui.posts.services.PostEvents;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DateTimeUtils;
@@ -35,6 +36,8 @@ import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
+
+import de.greenrobot.event.EventBus;
 
 /**
  * Started with explicit list of media to upload.
@@ -66,6 +69,7 @@ public class MediaUploadService extends Service {
         ((WordPress) getApplication()).component().inject(this);
         AppLog.i(AppLog.T.MEDIA, "Media Upload Service > created");
         mDispatcher.register(this);
+        EventBus.getDefault().register(this);
         // TODO: recover any media that is in the MediaStore that has not yet been completely uploaded
         // or better yet, create an auxiliary table to host MediaUploadUnitInfo objects
     }
@@ -76,6 +80,7 @@ public class MediaUploadService extends Service {
             cancelUpload(oneUpload);
         }
         mDispatcher.unregister(this);
+        EventBus.getDefault().unregister(this);
         AppLog.i(AppLog.T.MEDIA, "Media Upload Service > destroyed");
         super.onDestroy();
     }
@@ -300,6 +305,25 @@ public class MediaUploadService extends Service {
         if (mPendingUploads.isEmpty() && mInProgressUploads.isEmpty()) {
             AppLog.i(AppLog.T.MEDIA, "No more items pending in queue. Stopping MediaUploadService.");
             stopSelf();
+        }
+    }
+
+    // App events
+
+    @SuppressWarnings("unused")
+    public void onEventMainThread(PostEvents.PostMediaCanceled event) {
+        if (event.post == null) {
+            return;
+        }
+        for (MediaModel inProgressUpload : mInProgressUploads) {
+            if (inProgressUpload.getLocalPostId() == event.post.getId()) {
+                cancelUpload(inProgressUpload);
+            }
+        }
+        for (MediaModel pendingUpload : mPendingUploads) {
+            if (pendingUpload.getLocalPostId() == event.post.getId()) {
+                cancelUpload(pendingUpload);
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2292,10 +2292,13 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     }
 
     @Override
-    public void onMediaUploadCancelClicked(String mediaId, boolean delete) {
-        if (!TextUtils.isEmpty(mediaId)) {
-            int localMediaId = Integer.valueOf(mediaId);
-            EventBus.getDefault().post(new PostEvents.PostMediaCanceled(localMediaId));
+    public void onMediaUploadCancelClicked(String localMediaId, boolean delete) {
+        if (!TextUtils.isEmpty(localMediaId)) {
+            MediaModel mediaModel = mMediaStore.getMediaWithLocalId(Integer.valueOf(localMediaId));
+            if (mediaModel != null) {
+                MediaPayload payload = new MediaPayload(mSite, mediaModel);
+                mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload));
+            }
         } else {
             // Passed mediaId is incorrect: cancel all uploads
             ToastUtils.showToast(this, getString(R.string.error_all_media_upload_canceled));

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2300,9 +2300,9 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload));
             }
         } else {
-            // Passed mediaId is incorrect: cancel all uploads
+            // Passed mediaId is incorrect: cancel all uploads for this post
             ToastUtils.showToast(this, getString(R.string.error_all_media_upload_canceled));
-            EventBus.getDefault().post(new PostEvents.PostMediaCanceled(true));
+            EventBus.getDefault().post(new PostEvents.PostMediaCanceled(mPost));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostEvents.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.posts.services;
 
+import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.util.StringUtils;
 
 public class PostEvents {
@@ -29,15 +30,10 @@ public class PostEvents {
     }
 
     public static class PostMediaCanceled {
-        public int localMediaId;
-        public boolean all;
+        public PostModel post;
 
-        public PostMediaCanceled(int localMediaId) {
-            this.localMediaId = localMediaId;
-            this.all = false;
-        }
-        public PostMediaCanceled(boolean all) {
-            this.all = all;
+        public PostMediaCanceled(PostModel post) {
+            this.post = post;
         }
     }
 }


### PR DESCRIPTION
Restores some changes made in https://github.com/wordpress-mobile/WordPress-Android/pull/5573 that seem to have been lost during a merge. The implementation is quite different since @mzorz has overhauled the `MediaUploadService` in this branch.

To test:
1. While uploading media in the editor, cancel one
2. You should stop receiving `UPLOADED_MEDIA` logs, and the media should not appear in the site's media library

cc @mzorz