### PR TITLE
issue/photon-for-self-hosted-7.4

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -139,8 +139,10 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             } else {
                 // if this isn't a private site use Photon to request the image at the exact size,
                 // otherwise append the standard wp query params to request the desired size
+                // TODO: we should drop using Photon for self-hosted sites once the media model
+                // has been updated to include the various image sizes
                 String thumbUrl;
-                if (SiteUtils.isPhotonCapable(mSite)) {
+                if (!mSite.isPrivate()) {
                     thumbUrl = PhotonUtils.getPhotonImageUrl(media.getUrl(), mThumbWidth, mThumbHeight);
                 } else {
                     thumbUrl = UrlUtils.removeQuery(media.getUrl()) + "?w=" + mThumbWidth + "&h=" + mThumbHeight;


### PR DESCRIPTION
This simple changes uses Photon for all non-private sites so we avoid loading full-sized images in the media browser.

This is a temporary solution until v7.5, which will be able to store the various sizes of media items (see [here](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/448)).
