### PR TITLE
Check for null media model

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -148,7 +148,7 @@ public class MediaEditFragment extends Fragment {
     }
 
     public void saveChanges() {
-        if (isDirty()) {
+        if (isAdded() && mMediaModel != null && isDirty()) {
             mMediaModel.setTitle(mTitleView.getText().toString());
             mMediaModel.setDescription(mDescriptionView.getText().toString());
             mMediaModel.setCaption(mCaptionView.getText().toString());


### PR DESCRIPTION
Fixes #5887 - this is a quick fix to prevent the NPE in v7.4, but what really needs to happen is a refactoring of the MediaEditFragment. The recent redesign I did of that fragment left most of the old code intact, and it could use some rethinking (especially in regards to how the media ID and media model are handled).

I'll open a separate issue for this.
