### PR TITLE
Issue/5889 media edit fragment refactor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -59,9 +59,6 @@ public class MediaEditFragment extends Fragment {
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
         setHasOptionsMenu(true);
-
-        // retain this fragment across configuration changes
-        setRetainInstance(true);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.media;
 
 import android.app.Fragment;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -43,7 +44,7 @@ public class MediaEditFragment extends Fragment {
     private int mLocalMediaId;
     private SiteModel mSite;
 
-    public static MediaEditFragment newInstance(SiteModel site, int localMediaId) {
+    public static MediaEditFragment newInstance(@NonNull SiteModel site, int localMediaId) {
         MediaEditFragment fragment = new MediaEditFragment();
         Bundle args = new Bundle();
         args.putInt(ARGS_MEDIA_ID, localMediaId);
@@ -143,14 +144,18 @@ public class MediaEditFragment extends Fragment {
             return;
         }
 
-        boolean isDirty = !StringUtils.equals(media.getTitle(), mTitleView.getText().toString())
-                || !StringUtils.equals(media.getCaption(), mCaptionView.getText().toString())
-                || !StringUtils.equals(media.getDescription(), mDescriptionView.getText().toString());
-        if (isDirty) {
+        String thisTitle = EditTextUtils.getText(mTitleView);
+        String thisCaption = EditTextUtils.getText(mCaptionView);
+        String thisDescription = EditTextUtils.getText(mDescriptionView);
+
+        boolean hasChanged = !StringUtils.equals(media.getTitle(), thisTitle)
+                || !StringUtils.equals(media.getCaption(), thisCaption)
+                || !StringUtils.equals(media.getDescription(), thisDescription);
+        if (hasChanged) {
             AppLog.d(AppLog.T.MEDIA, "MediaEditFragment > Saving changes");
-            media.setTitle(mTitleView.getText().toString());
-            media.setDescription(mDescriptionView.getText().toString());
-            media.setCaption(mCaptionView.getText().toString());
+            media.setTitle(thisTitle);
+            media.setCaption(thisCaption);
+            media.setDescription(thisDescription);
             mDispatcher.dispatch(MediaActionBuilder.newPushMediaAction(new MediaPayload(mSite, media)));
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -31,8 +31,7 @@ import javax.inject.Inject;
  */
 public class MediaEditFragment extends Fragment {
     private static final String ARGS_MEDIA_ID = "media_id";
-    // also appears in the layouts, from the strings.xml
-    public static final String TAG = "MediaEditFragment";
+    static final String TAG = "MediaEditFragment";
 
     @Inject Dispatcher mDispatcher;
     @Inject MediaStore mMediaStore;
@@ -126,10 +125,11 @@ public class MediaEditFragment extends Fragment {
         MediaModel media = mMediaStore.getMediaWithLocalId(mLocalMediaId);
         if (media != null) {
             mTitleView.setText(media.getTitle());
-            mTitleView.requestFocus();
-            mTitleView.setSelection(mTitleView.getText().length());
             mCaptionView.setText(media.getCaption());
             mDescriptionView.setText(media.getDescription());
+
+            mTitleView.requestFocus();
+            mTitleView.setSelection(mTitleView.getText().length());
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -21,7 +21,6 @@ import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.EditTextUtils;
-import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 
@@ -152,13 +151,6 @@ public class MediaEditFragment extends Fragment {
         if (mediaModel == null || !isAdded()) {
             return;
         }
-
-        boolean isLocal = MediaUtils.isLocalFile(mediaModel.getUploadState());
-
-        // user can't edit local files
-        mTitleView.setEnabled(!isLocal);
-        mCaptionView.setEnabled(!isLocal);
-        mDescriptionView.setEnabled(!isLocal);
 
         mTitleView.setText(mediaModel.getTitle());
         mTitleView.requestFocus();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -63,11 +63,6 @@ public class MediaEditFragment extends Fragment {
             mLocalMediaId = savedInstanceState.getInt(ARGS_MEDIA_ID);
         }
 
-        if (mSite == null) {
-            ToastUtils.showToast(getActivity(), R.string.blog_not_found, ToastUtils.Duration.SHORT);
-            getActivity().finish();
-        }
-
         setHasOptionsMenu(true);
 
         // retain this fragment across configuration changes
@@ -103,18 +98,19 @@ public class MediaEditFragment extends Fragment {
         mCaptionView = (EditText) view.findViewById(R.id.media_edit_fragment_caption);
         mDescriptionView = (EditText) view.findViewById(R.id.media_edit_fragment_description);
 
-        loadMedia();
-
         return view;
     }
 
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
+
         // force the keyboard to appear on the title when activity is created (but not in landscape)
         if (savedInstanceState == null && !DisplayUtils.isLandscape(getActivity())) {
             EditTextUtils.showSoftInput(mTitleView);
         }
+
+        loadMedia();
     }
 
     @Override
@@ -125,22 +121,20 @@ public class MediaEditFragment extends Fragment {
     }
 
     public void loadMedia() {
-        if (isAdded()) {
-            MediaModel media = mMediaStore.getMediaWithLocalId(mLocalMediaId);
-            if (media != null) {
-                mTitleView.setText(media.getTitle());
-                mTitleView.requestFocus();
-                mTitleView.setSelection(mTitleView.getText().length());
-                mCaptionView.setText(media.getCaption());
-                mDescriptionView.setText(media.getDescription());
-            }
+        if (!isAdded()) return;
+
+        MediaModel media = mMediaStore.getMediaWithLocalId(mLocalMediaId);
+        if (media != null) {
+            mTitleView.setText(media.getTitle());
+            mTitleView.requestFocus();
+            mTitleView.setSelection(mTitleView.getText().length());
+            mCaptionView.setText(media.getCaption());
+            mDescriptionView.setText(media.getDescription());
         }
     }
 
     public void saveChanges() {
-        if (!isAdded()) {
-            return;
-        }
+        if (!isAdded()) return;
 
         MediaModel media = mMediaStore.getMediaWithLocalId(mLocalMediaId);
         if (media == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -109,7 +109,7 @@ public class MediaEditFragment extends Fragment {
         mCaptionView = (EditText) view.findViewById(R.id.media_edit_fragment_caption);
         mDescriptionView = (EditText) view.findViewById(R.id.media_edit_fragment_description);
 
-        loadMedia(mLocalMediaId);
+        loadMedia();
 
         return view;
     }
@@ -130,8 +130,7 @@ public class MediaEditFragment extends Fragment {
         outState.putInt(ARGS_MEDIA_ID, mLocalMediaId);
     }
 
-    public void loadMedia(int localMediaId) {
-        mLocalMediaId = localMediaId;
+    public void loadMedia() {
         if (isAdded()) {
             mMediaModel = mMediaStore.getMediaWithLocalId(mLocalMediaId);
             refreshViews(mMediaModel);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -31,7 +31,7 @@ import javax.inject.Inject;
  * A fragment for editing media on the Media tab
  */
 public class MediaEditFragment extends Fragment {
-    private static final String ARGS_MEDIA_ID = "media_id";
+    private static final String ARGS_LOCAL_MEDIA_ID = "media_id";
     static final String TAG = "MediaEditFragment";
 
     @Inject Dispatcher mDispatcher;
@@ -47,7 +47,7 @@ public class MediaEditFragment extends Fragment {
     public static MediaEditFragment newInstance(@NonNull SiteModel site, int localMediaId) {
         MediaEditFragment fragment = new MediaEditFragment();
         Bundle args = new Bundle();
-        args.putInt(ARGS_MEDIA_ID, localMediaId);
+        args.putInt(ARGS_LOCAL_MEDIA_ID, localMediaId);
         args.putSerializable(WordPress.SITE, site);
         fragment.setArguments(args);
         return fragment;
@@ -58,24 +58,15 @@ public class MediaEditFragment extends Fragment {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
-        if (savedInstanceState != null) {
-            mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
-            mLocalMediaId = savedInstanceState.getInt(ARGS_MEDIA_ID);
+        if (getArguments() != null) {
+            mSite = (SiteModel) getArguments().getSerializable(WordPress.SITE);
+            mLocalMediaId = getArguments().getInt(ARGS_LOCAL_MEDIA_ID);
         }
 
         setHasOptionsMenu(true);
 
         // retain this fragment across configuration changes
-        setRetainInstance(true);
-    }
-
-    @Override
-    public void setArguments(Bundle args) {
-        super.setArguments(args);
-        if (args != null) {
-            mSite = (SiteModel) args.getSerializable(WordPress.SITE);
-            mLocalMediaId = args.getInt(ARGS_MEDIA_ID);
-        }
+        //setRetainInstance(true);
     }
 
     @Override
@@ -111,13 +102,6 @@ public class MediaEditFragment extends Fragment {
         }
 
         loadMedia();
-    }
-
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-        outState.putSerializable(WordPress.SITE, mSite);
-        outState.putInt(ARGS_MEDIA_ID, mLocalMediaId);
     }
 
     public void loadMedia() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -58,15 +58,10 @@ public class MediaEditFragment extends Fragment {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
-        if (getArguments() != null) {
-            mSite = (SiteModel) getArguments().getSerializable(WordPress.SITE);
-            mLocalMediaId = getArguments().getInt(ARGS_LOCAL_MEDIA_ID);
-        }
-
         setHasOptionsMenu(true);
 
         // retain this fragment across configuration changes
-        //setRetainInstance(true);
+        setRetainInstance(true);
     }
 
     @Override
@@ -101,10 +96,16 @@ public class MediaEditFragment extends Fragment {
             EditTextUtils.showSoftInput(mTitleView);
         }
 
+        // getArguments() should never be null but let's check anyway
+        if (getArguments() != null) {
+            mSite = (SiteModel) getArguments().getSerializable(WordPress.SITE);
+            mLocalMediaId = getArguments().getInt(ARGS_LOCAL_MEDIA_ID);
+        }
+
         loadMedia();
     }
 
-    public void loadMedia() {
+    void loadMedia() {
         if (!isAdded()) return;
 
         MediaModel media = mMediaStore.getMediaWithLocalId(mLocalMediaId);
@@ -115,6 +116,8 @@ public class MediaEditFragment extends Fragment {
 
             mTitleView.requestFocus();
             mTitleView.setSelection(mTitleView.getText().length());
+        } else {
+            ToastUtils.showToast(getActivity(), R.string.error_media_load);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -127,36 +127,38 @@ public class MediaEditFragment extends Fragment {
     public void loadMedia() {
         if (isAdded()) {
             MediaModel media = mMediaStore.getMediaWithLocalId(mLocalMediaId);
-            refreshViews(media);
-        }
-    }
-
-    public void saveChanges() {
-        MediaModel media = mMediaStore.getMediaWithLocalId(mLocalMediaId);
-        if (media != null && isAdded()) {
-            boolean isDirty = !StringUtils.equals(media.getTitle(), mTitleView.getText().toString())
-                    || !StringUtils.equals(media.getCaption(), mCaptionView.getText().toString())
-                    || !StringUtils.equals(media.getDescription(), mDescriptionView.getText().toString());
-            if (isDirty) {
-                AppLog.d(AppLog.T.MEDIA, "MediaEditFragment > Saving changes");
-                media.setTitle(mTitleView.getText().toString());
-                media.setDescription(mDescriptionView.getText().toString());
-                media.setCaption(mCaptionView.getText().toString());
-                mDispatcher.dispatch(MediaActionBuilder.newPushMediaAction(new MediaPayload(mSite, media)));
+            if (media != null) {
+                mTitleView.setText(media.getTitle());
+                mTitleView.requestFocus();
+                mTitleView.setSelection(mTitleView.getText().length());
+                mCaptionView.setText(media.getCaption());
+                mDescriptionView.setText(media.getDescription());
             }
         }
     }
 
-    private void refreshViews(MediaModel mediaModel) {
-        if (mediaModel == null || !isAdded()) {
+    public void saveChanges() {
+        if (!isAdded()) {
             return;
         }
 
-        mTitleView.setText(mediaModel.getTitle());
-        mTitleView.requestFocus();
-        mTitleView.setSelection(mTitleView.getText().length());
-        mCaptionView.setText(mediaModel.getCaption());
-        mDescriptionView.setText(mediaModel.getDescription());
+        MediaModel media = mMediaStore.getMediaWithLocalId(mLocalMediaId);
+        if (media == null) {
+            AppLog.w(AppLog.T.MEDIA, "MediaEditFragment > Cannot save null media");
+            ToastUtils.showToast(getActivity(), R.string.media_edit_failure);
+            return;
+        }
+
+        boolean isDirty = !StringUtils.equals(media.getTitle(), mTitleView.getText().toString())
+                || !StringUtils.equals(media.getCaption(), mCaptionView.getText().toString())
+                || !StringUtils.equals(media.getDescription(), mDescriptionView.getText().toString());
+        if (isDirty) {
+            AppLog.d(AppLog.T.MEDIA, "MediaEditFragment > Saving changes");
+            media.setTitle(mTitleView.getText().toString());
+            media.setDescription(mDescriptionView.getText().toString());
+            media.setCaption(mCaptionView.getText().toString());
+            mDispatcher.dispatch(MediaActionBuilder.newPushMediaAction(new MediaPayload(mSite, media)));
+        }
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -43,10 +43,6 @@ public class MediaEditFragment extends Fragment {
     private EditText mCaptionView;
     private EditText mDescriptionView;
 
-    private String mTitleOriginal;
-    private String mDescriptionOriginal;
-    private String mCaptionOriginal;
-
     private int mLocalMediaId;
     private SiteModel mSite;
 
@@ -164,10 +160,6 @@ public class MediaEditFragment extends Fragment {
         mTitleView.setEnabled(!isLocal);
         mCaptionView.setEnabled(!isLocal);
         mDescriptionView.setEnabled(!isLocal);
-
-        mTitleOriginal = mediaModel.getTitle();
-        mCaptionOriginal = mediaModel.getCaption();
-        mDescriptionOriginal = mediaModel.getDescription();
 
         mTitleView.setText(mediaModel.getTitle());
         mTitleView.requestFocus();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaEditFragment.java
@@ -34,7 +34,6 @@ public class MediaEditFragment extends Fragment {
     private static final String ARGS_MEDIA_ID = "media_id";
     // also appears in the layouts, from the strings.xml
     public static final String TAG = "MediaEditFragment";
-    private static final int MISSING_MEDIA_ID = -1;
 
     @Inject Dispatcher mDispatcher;
     @Inject MediaStore mMediaStore;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -293,7 +293,7 @@ public class MediaPreviewActivity extends AppCompatActivity {
             onBackPressed();
             return true;
         } else if (item.getItemId() == R.id.menu_edit) {
-            showEditFragment(mMediaId);
+            showEditFragment();
             return true;
         } else if (item.getItemId() == R.id.menu_share) {
             shareMedia();
@@ -521,10 +521,10 @@ public class MediaPreviewActivity extends AppCompatActivity {
         return null;
     }
 
-    private void showEditFragment(int localMediaId) {
+    private void showEditFragment() {
         MediaEditFragment fragment = getEditFragment();
         if (fragment == null) {
-            fragment = MediaEditFragment.newInstance(mSite, localMediaId);
+            fragment = MediaEditFragment.newInstance(mSite, mMediaId);
             FragmentManager fm = getFragmentManager();
             fm.beginTransaction()
                 .replace(R.id.fragment_container, fragment, MediaEditFragment.TAG)
@@ -532,7 +532,7 @@ public class MediaPreviewActivity extends AppCompatActivity {
                 .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
                 .commitAllowingStateLoss();
         } else {
-            fragment.loadMedia(localMediaId);
+            fragment.loadMedia();
         }
 
         setLookClosable(true);


### PR DESCRIPTION
Fixes #5889 - refactors MediaEditFragment, which was getting crusty. The biggest issue with it was the way the site and media ID arguments were being accessed via both `getArguments()` and the instance state (we can rely solely on `getArguments()`). Also cleans up and simplifies the fragment where possible.
