### PR TITLE
Issue/5891 add media popup

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -147,7 +147,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         fm.addOnBackStackChangedListener(mOnBackStackChangedListener);
 
         mMediaGridFragment = (MediaGridFragment) fm.findFragmentById(R.id.mediaGridFragment);
-        setupAddMenuPopup();
 
         // if media was shared add it to the library
         handleSharedMedia();
@@ -645,6 +644,10 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     }
 
     private void showNewMediaMenu() {
+        if (mAddMediaPopup == null) {
+            setupAddMenuPopup();
+        }
+
         View view = findViewById(R.id.menu_new_media);
         if (view != null) {
             int y_offset = getResources().getDimensionPixelSize(R.dimen.action_bar_spinner_y_offset);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -292,7 +292,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             }
         }
 
-        showAddMediaMenu();
+        showAddMediaPopup();
     }
 
     @Override
@@ -326,7 +326,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             case R.id.menu_new_media:
                 AppLockManager.getInstance().setExtendedTimeout();
                 if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(this, MEDIA_PERMISSION_REQUEST_CODE)) {
-                    showAddMediaMenu();
+                    showAddMediaPopup();
                 }
                 return true;
             case R.id.menu_search:
@@ -605,7 +605,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     };
 
     /** Setup the popup that allows you to add new media from camera, video camera or local files **/
-    private void createAddMenuPopup() {
+    private void createAddMediaPopup() {
         String[] items = new String[]{
                 getString(R.string.photo_picker_capture_photo),
                 getString(R.string.photo_picker_capture_video),
@@ -641,9 +641,9 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         mAddMediaPopup = new PopupWindow(menuView, width, ViewGroup.LayoutParams.WRAP_CONTENT, true);
     }
 
-    private void showAddMediaMenu() {
+    private void showAddMediaPopup() {
         if (mAddMediaPopup == null) {
-            createAddMenuPopup();
+            createAddMediaPopup();
         }
 
         View view = findViewById(R.id.menu_new_media);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -14,7 +14,6 @@ import android.content.pm.PackageManager;
 import android.graphics.drawable.ColorDrawable;
 import android.net.ConnectivityManager;
 import android.net.Uri;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.support.annotation.NonNull;
@@ -609,34 +608,33 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
     /** Setup the popup that allows you to add new media from camera, video camera or local files **/
     private void setupAddMenuPopup() {
-        String capturePhoto = getString(R.string.media_add_popup_capture_photo);
-        String captureVideo = getString(R.string.media_add_popup_capture_video);
-        String pickPhotoFromGallery = getString(R.string.photo_picker_choose_photo);
-        String pickVideoFromGallery = getString(R.string.photo_picker_choose_video);
-        String[] items = new String[] {
-                capturePhoto, captureVideo, pickPhotoFromGallery, pickVideoFromGallery
+        String[] items = new String[]{
+                getString(R.string.photo_picker_capture_photo),
+                getString(R.string.photo_picker_capture_video),
+                getString(R.string.photo_picker_choose_photo),
+                getString(R.string.photo_picker_choose_video)
         };
 
         @SuppressLint("InflateParams")
         View menuView = getLayoutInflater().inflate(R.layout.actionbar_add_media, null, false);
-        final ArrayAdapter<String> adapter = new ArrayAdapter<>(this, R.layout.actionbar_add_media_cell, items);
         ListView listView = (ListView) menuView.findViewById(R.id.actionbar_add_media_listview);
-        listView.setAdapter(adapter);
+        listView.setAdapter(new ArrayAdapter<>(this, R.layout.actionbar_add_media_cell, items));
         listView.setOnItemClickListener(new OnItemClickListener() {
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                adapter.notifyDataSetChanged();
-
-                if (position == 0) {
-                    MediaBrowserActivity enclosingActivity = MediaBrowserActivity.this;
-                    WordPressMediaUtils.launchCamera(enclosingActivity, BuildConfig.APPLICATION_ID, enclosingActivity);
-                } else if (position == 1) {
-                    WordPressMediaUtils.launchVideoCamera(MediaBrowserActivity.this);
-                } else if (position == 2) {
-                    WordPressMediaUtils.launchPictureLibrary(MediaBrowserActivity.this);
-                } else if (position == 3) {
-                    WordPressMediaUtils.launchVideoLibrary(MediaBrowserActivity.this);
+                switch (position) {
+                    case 0:
+                        WordPressMediaUtils.launchCamera(MediaBrowserActivity.this, BuildConfig.APPLICATION_ID, MediaBrowserActivity.this);
+                        break;
+                    case 1:
+                        WordPressMediaUtils.launchVideoCamera(MediaBrowserActivity.this);
+                        break;
+                    case 2:
+                        WordPressMediaUtils.launchPictureLibrary(MediaBrowserActivity.this);
+                        break;
+                    case 3:
+                        WordPressMediaUtils.launchVideoLibrary(MediaBrowserActivity.this);
+                        break;
                 }
-
                 mAddMediaPopup.dismiss();
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -11,7 +11,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.ServiceConnection;
 import android.content.pm.PackageManager;
-import android.graphics.drawable.ColorDrawable;
 import android.net.ConnectivityManager;
 import android.net.Uri;
 import android.os.Bundle;
@@ -293,7 +292,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             }
         }
 
-        showNewMediaMenu();
+        showAddMediaMenu();
     }
 
     @Override
@@ -327,7 +326,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             case R.id.menu_new_media:
                 AppLockManager.getInstance().setExtendedTimeout();
                 if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(this, MEDIA_PERMISSION_REQUEST_CODE)) {
-                    showNewMediaMenu();
+                    showAddMediaMenu();
                 }
                 return true;
             case R.id.menu_search:
@@ -606,7 +605,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     };
 
     /** Setup the popup that allows you to add new media from camera, video camera or local files **/
-    private void setupAddMenuPopup() {
+    private void createAddMenuPopup() {
         String[] items = new String[]{
                 getString(R.string.photo_picker_capture_photo),
                 getString(R.string.photo_picker_capture_video),
@@ -640,12 +639,11 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
         int width = getResources().getDimensionPixelSize(R.dimen.action_bar_spinner_width);
         mAddMediaPopup = new PopupWindow(menuView, width, ViewGroup.LayoutParams.WRAP_CONTENT, true);
-        mAddMediaPopup.setBackgroundDrawable(new ColorDrawable());
     }
 
-    private void showNewMediaMenu() {
+    private void showAddMediaMenu() {
         if (mAddMediaPopup == null) {
-            setupAddMenuPopup();
+            createAddMenuPopup();
         }
 
         View view = findViewById(R.id.menu_new_media);
@@ -653,7 +651,10 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             int y_offset = getResources().getDimensionPixelSize(R.dimen.action_bar_spinner_y_offset);
             int[] loc = new int[2];
             view.getLocationOnScreen(loc);
-            mAddMediaPopup.showAtLocation(view, Gravity.TOP | Gravity.START, loc[0],
+            mAddMediaPopup.showAtLocation(
+                    view,
+                    Gravity.TOP | Gravity.START,
+                    loc[0],
                     loc[1] + view.getHeight() + y_offset);
         } else {
             // In case menu button is not on screen (declared showAsAction="ifRoom"), center the popup in the view.

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -611,8 +611,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     private void setupAddMenuPopup() {
         String capturePhoto = getString(R.string.media_add_popup_capture_photo);
         String captureVideo = getString(R.string.media_add_popup_capture_video);
-        String pickPhotoFromGallery = getString(R.string.select_photo);
-        String pickVideoFromGallery = getString(R.string.select_video);
+        String pickPhotoFromGallery = getString(R.string.photo_picker_choose_photo);
+        String pickVideoFromGallery = getString(R.string.photo_picker_choose_video);
         String[] items = new String[] {
                 capturePhoto, captureVideo, pickPhotoFromGallery, pickVideoFromGallery
         };

--- a/WordPress/src/main/res/layout/actionbar_add_media.xml
+++ b/WordPress/src/main/res/layout/actionbar_add_media.xml
@@ -3,31 +3,29 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/dialog_full_holo_light"
-    android:orientation="vertical" >
+    android:orientation="vertical">
 
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingBottom="15dp"
-        android:paddingLeft="20dp"
-        android:paddingRight="20dp"
-        android:paddingTop="15dp"
+        android:paddingBottom="@dimen/margin_large"
+        android:paddingLeft="@dimen/margin_extra_large"
+        android:paddingRight="@dimen/margin_extra_large"
+        android:paddingTop="@dimen/margin_large"
         android:text="@string/media_add_popup_title"
-        android:textSize="20sp" />
+        android:textSize="@dimen/text_sz_large"
+        android:textStyle="bold" />
 
     <View
         android:layout_width="match_parent"
-        android:layout_height="2dp"
-        android:background="@color/blue_wordpress" />
+        android:layout_height="1dp"
+        android:background="@color/divider_grey" />
 
     <ListView
         android:id="@+id/actionbar_add_media_listview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:divider="@color/blue_wordpress"
-        android:dividerHeight="1dp"
-        android:paddingLeft="20dp"
-        android:paddingRight="20dp" >
-    </ListView>
+        android:paddingLeft="@dimen/margin_extra_large"
+        android:paddingRight="@dimen/margin_extra_large" />
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/actionbar_add_media_cell.xml
+++ b/WordPress/src/main/res/layout/actionbar_add_media_cell.xml
@@ -2,8 +2,8 @@
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingBottom="15dp"
-    android:paddingTop="15dp"
-    android:textSize="16sp" >
+    android:paddingBottom="@dimen/margin_large"
+    android:paddingTop="@dimen/margin_large"
+    android:textSize="@dimen/text_sz_medium" >
 
 </TextView>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -109,8 +109,6 @@
 
     <!-- Media Gallery Action Bar -->
     <string name="media_add_popup_title">Add to media library</string>
-    <string name="media_add_popup_capture_photo">Capture photo</string>
-    <string name="media_add_popup_capture_video">Capture video</string>
 
     <!-- CAB -->
     <string name="cab_selected">%d selected</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -403,8 +403,6 @@
     <string name="no_site_error">Couldn\'t connect to the WordPress site. There is no valid WordPress site at this
         address. Check the site address (URL) you entered.</string>
     <!-- media selection -->
-    <string name="select_photo">Select a photo from gallery</string>
-    <string name="select_video">Select a video from gallery</string>
     <string name="select_from_media_library">Select from media library</string>
 
     <!-- category management -->


### PR DESCRIPTION
Fixes #5891 - Updates the "Add media" popup menu in the media browser to use the same captions we use in the new photo picker. I also did a smattering of code/design cleanup in addition to updating the menu captions.

Before:
![menu-before](https://cloud.githubusercontent.com/assets/3903757/26030008/94763186-3812-11e7-9295-0868a2841fb1.png)

After:
![menu-after](https://cloud.githubusercontent.com/assets/3903757/26030009/9849dc68-3812-11e7-8291-d153f4b29f15.png)

