### PR TITLE
issue/5896-media-retry-number-format-exception

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2249,7 +2249,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             AppLog.e(T.MEDIA, "Invalid media id passed to onMediaRetryClicked");
             return;
         }
-        MediaModel media = mMediaStore.getMediaWithLocalId(Integer.valueOf(mediaId));
+        MediaModel media = mMediaStore.getMediaWithLocalId(StringUtils.stringToInt(mediaId));
         if (media == null) {
             AppLog.e(T.MEDIA, "Can't find media with local id: " + mediaId);
             return;


### PR DESCRIPTION
Fixes #5896 - this resolves the problem by ignoring the exception, but a bigger issue that should be addressed is why we're passing the mediaId as a `String` when it's an `int` value, and why the passed value isn't a valid `int` (most likely it's null).