### PR TITLE
Issue/3953 reader comment count

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderPostTable.java
@@ -367,10 +367,33 @@ public class ReaderPostTable {
         if (post == null) {
             return 0;
         }
-        String[] args = new String[] {Long.toString(post.blogId), Long.toString(post.postId)};
+        return getNumCommentsForPost(post.blogId, post.postId);
+    }
+
+    public static int getNumCommentsForPost(long blogId, long postId) {
+        String[] args = new String[] {Long.toString(blogId), Long.toString(postId)};
         return SqlUtils.intForQuery(ReaderDatabase.getReadableDb(),
                 "SELECT num_replies FROM tbl_posts WHERE blog_id=? AND post_id=?",
                 args);
+    }
+
+    public static void setNumCommentsForPost(long blogId, long postId, int numComments) {
+        String[] args = {Long.toString(blogId), Long.toString(postId)};
+
+        ContentValues values = new ContentValues();
+        values.put("num_replies", numComments);
+
+        ReaderDatabase.getWritableDb().update(
+                "tbl_posts",
+                values,
+                "blog_id=? AND post_id=?",
+                args);
+    }
+
+    public static void incNumCommentsForPost(long blogId, long postId) {
+        int numComments = getNumCommentsForPost(blogId, postId);
+        numComments++;
+        setNumCommentsForPost(blogId, postId, numComments);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -627,6 +627,7 @@ public class ReaderCommentListActivity extends AppCompatActivity {
                     // stop highlighting the fake comment and replace it with the real one
                     getCommentAdapter().setHighlightCommentId(0, false);
                     getCommentAdapter().replaceComment(fakeCommentId, newComment);
+                    getCommentAdapter().refreshPost();
                     setReplyToCommentId(0, false);
                     mEditComment.getAutoSaveTextHelper().clearSavedText(mEditComment);
                 } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/actions/ReaderCommentActions.java
@@ -9,6 +9,7 @@ import org.json.JSONObject;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.ReaderCommentTable;
 import org.wordpress.android.datasets.ReaderLikeTable;
+import org.wordpress.android.datasets.ReaderPostTable;
 import org.wordpress.android.datasets.ReaderUserTable;
 import org.wordpress.android.models.ReaderComment;
 import org.wordpress.android.models.ReaderPost;
@@ -95,6 +96,7 @@ public class ReaderCommentActions {
                 ReaderComment newComment = ReaderComment.fromJson(jsonObject, post.blogId);
                 newComment.pageNumber = pageNumber;
                 ReaderCommentTable.addOrUpdateComment(newComment);
+                ReaderPostTable.incNumCommentsForPost(post.blogId, post.postId);
                 if (actionListener != null) {
                     actionListener.onActionResult(true, newComment);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -329,6 +329,16 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
         return position == 0 ? null : mComments.get(position - NUM_HEADERS);
     }
 
+    /*
+     * refresh the post from the database - used to reflect changes to comment counts, etc.
+     */
+    public void refreshPost() {
+        if (mPost != null) {
+            ReaderPost post = ReaderPostTable.getBlogPost(mPost.blogId, mPost.postId, true);
+            setPost(post);
+        }
+    }
+
     private void showLikeStatus(final CommentHolder holder, int position) {
         ReaderComment comment = getItem(position);
         if (comment == null) {


### PR DESCRIPTION
Fixes #3953 - the post header in the reader comment list now reflects the change to the comment count after successfully replying.

To test:
* Locate a reader post that allows comments
* Tap the comment icon to see the comments
* Add a comment
* Make sure the comment count at the top reflects the change

![screenshot_1495126113](https://cloud.githubusercontent.com/assets/3903757/26213829/685468de-3bc8-11e7-882f-9d1b2aa047e0.png)



