### PR TITLE
Issue/5844 empty post draft

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1225,9 +1225,12 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 boolean hasUnpublishedLocalDraftChanges = PostStatus.fromPost(mPost) == PostStatus.DRAFT &&
                         isPublishable && hasLocalChanges;
 
-                // if post was modified or has unsaved local changes and is publishable, save it
-                boolean shouldSave = (hasChanges || hasUnpublishedLocalDraftChanges) && (isPublishable || !isNewPost());
-                saveResult(shouldSave, false);
+                // if post was modified or has unpublished local changes, save it
+                boolean shouldSave = hasChanges || hasUnpublishedLocalDraftChanges;
+                // if post is publishable or not new, sync it
+                boolean shouldSync = isPublishable || !isNewPost();
+
+                saveResult(shouldSave && shouldSync, false);
 
                 if (shouldSave) {
                     if (isNewPost()) {


### PR DESCRIPTION
### Fix
Save empty post (i.e. no title, no content, and no excerpt) as local draft if changes have been made (i.e. status, format, date, categories, tags, password, featured image, or location) as described in https://github.com/wordpress-mobile/WordPress-Android/issues/5844.

### Test
1. Go to ***Site*** tab.
2. Tap ***Blog Posts*** option.
3. Tap ***Create*** floating button.
4. Tap ***Settings*** action (i.e. gear icon).
5. Enter text in ***Tags*** field.
6. Tap back arrow twice.
7. Notice "Draft saved on device" message is displaying and post contains "Local draft" label.