### PR TITLE
Add Big Style and Compatibility Version for Post Upload Notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.support.v4.app.NotificationCompat;
 import android.text.TextUtils;
 import android.util.SparseArray;
 
@@ -94,7 +95,7 @@ public class PostUploadNotifier {
         }
 
         // Notification builder
-        Notification.Builder notificationBuilder = new Notification.Builder(mContext.getApplicationContext());
+        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(mContext.getApplicationContext());
         String notificationTitle = (String) (post.isPage() ? mContext.getResources().getText(R.string
                 .page_published) : mContext.getResources().getText(R.string.post_published));
         if (!isFirstTimePublish) {
@@ -111,8 +112,10 @@ public class PostUploadNotifier {
         } else {
             notificationBuilder.setLargeIcon(notificationData.latestIcon);
         }
+        String message = post.getTitle();
         notificationBuilder.setContentTitle(notificationTitle);
-        notificationBuilder.setContentText(post.getTitle());
+        notificationBuilder.setContentText(message);
+        notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(message));
         notificationBuilder.setAutoCancel(true);
 
         // Tap notification intent (open the post list)
@@ -150,7 +153,7 @@ public class PostUploadNotifier {
     public void updateNotificationError(PostModel post, SiteModel site, String errorMessage, boolean isMediaError) {
         AppLog.d(AppLog.T.POSTS, "updateNotificationError: " + errorMessage);
 
-        Notification.Builder notificationBuilder = new Notification.Builder(mContext.getApplicationContext());
+        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(mContext.getApplicationContext());
         String postOrPage = (String) (post.isPage() ? mContext.getResources().getText(R.string.page_id)
                 : mContext.getResources().getText(R.string.post_id));
         Intent notificationIntent = new Intent(mContext, PostsListActivity.class);
@@ -168,11 +171,12 @@ public class PostUploadNotifier {
                     + mContext.getResources().getText(R.string.error);
         }
 
+        String message = (isMediaError) ? errorMessage : postOrPage + " " + errorText + ": " + errorMessage;
         notificationBuilder.setSmallIcon(android.R.drawable.stat_notify_error);
         notificationBuilder.setContentTitle((isMediaError) ? errorText :
                 mContext.getResources().getText(R.string.upload_failed));
-        notificationBuilder.setContentText((isMediaError) ? errorMessage : postOrPage + " " + errorText
-                + ": " + errorMessage);
+        notificationBuilder.setContentText(message);
+        notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(message));
         notificationBuilder.setContentIntent(pendingIntent);
         notificationBuilder.setAutoCancel(true);
 


### PR DESCRIPTION
### Fix
Add big style to post upload notifications and update to `NotificationCompat.Builder` to show all content text.  This applies when a post title or an error message is longer than the screen width.  Being able to see the whole post title isn't necessary, but displaying the entire error message can help support and troubleshooting.  See the screenshots below for example success and failure post upload notifications.

![notifications](https://cloud.githubusercontent.com/assets/3827611/26326649/59028dbe-3ef9-11e7-869c-0a8e39d675c3.png)

### Test
***Success***
1. Go to ***Site*** tab.
2. Tap ***Blog Posts*** option.
3. Tap ***Create*** floating button.
4. Enter long text in title field.
5. Tap back arrow.
6. Open notification drawer.
7. Notice all title content is shown.

***Failure***
0. Change [`PostUtils.isPublishable`](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java#L151-L153) to always return `false`.
1. Go to ***Site*** tab.
2. Tap ***Blog Posts*** option.
3. Tap ***Create*** floating button.
4. Tap ***Settings*** action (i.e. gear icon).
5. Enter text in ***Tags*** field.
6. Tap back arrow twice.
7. Open notification drawer.
8. Notice all error content is shown.