### PR TITLE
Fix Followers screen does not load from notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -39,6 +39,7 @@ import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
 import org.wordpress.android.ui.stats.StatsAbstractFragment;
+import org.wordpress.android.ui.stats.StatsActivity;
 import org.wordpress.android.ui.stats.StatsTimeframe;
 import org.wordpress.android.ui.stats.StatsViewAllActivity;
 import org.wordpress.android.ui.stats.StatsViewType;
@@ -360,7 +361,9 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
             intent.putExtra(StatsAbstractFragment.ARGS_VIEW_TYPE, StatsViewType.FOLLOWERS);
             intent.putExtra(StatsAbstractFragment.ARGS_TIMEFRAME, StatsTimeframe.DAY);
             intent.putExtra(StatsAbstractFragment.ARGS_SELECTED_DATE, "");
-            intent.putExtra(WordPress.SITE, site);
+            intent.putExtra(StatsAbstractFragment.ARGS_IS_SINGLE_VIEW, true);
+            intent.putExtra(StatsActivity.ARG_LOCAL_TABLE_SITE_ID, site.getId());
+
             intent.putExtra(StatsViewAllActivity.ARG_STATS_VIEW_ALL_TITLE, getString(R.string.stats_view_followers));
             startActivity(intent);
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAbstractFragment.java
@@ -29,7 +29,7 @@ public abstract class StatsAbstractFragment extends Fragment {
     public static final String ARGS_TIMEFRAME = "ARGS_TIMEFRAME";
     public static final String ARGS_SELECTED_DATE = "ARGS_SELECTED_DATE";
     static final String ARG_REST_RESPONSE = "ARG_REST_RESPONSE";
-    static final String ARGS_IS_SINGLE_VIEW = "ARGS_IS_SINGLE_VIEW";
+    public static final String ARGS_IS_SINGLE_VIEW = "ARGS_IS_SINGLE_VIEW";
 
     // The number of results to return for NON Paged REST endpoints.
     private static final int MAX_RESULTS_REQUESTED = 100;


### PR DESCRIPTION
Fixes #5597 by passing the correct `blog_id` parameter to the Stats - followers activity.

To test:
1. Go to ***Notifications*** tab.
2. Tap ***Follows*** button.
3. Scroll to bottom of list.
4. Tap ***See all of your followers*** button link.
