### PR TITLE
Issue/5924 wpmedia picker preview

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -47,6 +47,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
 
     private boolean mAllowMultiselect;
     private boolean mInMultiSelect;
+    private boolean mShowPreviewIcon;
 
     private final Handler mHandler;
     private final LayoutInflater mInflater;
@@ -87,6 +88,15 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         mThumbHeight = (int) (mThumbWidth * 0.75f);
 
         setImageLoader(imageLoader);
+    }
+
+    public void setShowPreviewIcon(boolean show) {
+        if (show != mShowPreviewIcon) {
+            mShowPreviewIcon = show;
+            if (getItemCount() > 0) {
+                notifyDataSetChanged();;
+            }
+        }
     }
 
     @Override
@@ -236,21 +246,25 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             fileTypeView = (TextView) fileContainer.findViewById(R.id.media_grid_item_filetype);
             fileTypeImageView = (ImageView) fileContainer.findViewById(R.id.media_grid_item_filetype_image);
 
-            imgPreview = (ImageView) view.findViewById(R.id.image_preview);
-            imgPreview.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    int position = getAdapterPosition();
-                    if (isValidPosition(position)) {
-                        MediaModel media = mMediaList.get(position);
-                        MediaPreviewActivity.showPreview(
-                                v.getContext(),
-                                imgPreview,
-                                media.getUrl(),
-                                media.isVideo());
+            ViewGroup previewContainer = (ViewGroup) view.findViewById(R.id.frame_preview);
+            previewContainer.setVisibility(mShowPreviewIcon ? View.VISIBLE : View.GONE);
+            imgPreview = (ImageView) previewContainer.findViewById(R.id.image_preview);
+            if (mShowPreviewIcon) {
+                imgPreview.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        int position = getAdapterPosition();
+                        if (isValidPosition(position)) {
+                            MediaModel media = mMediaList.get(position);
+                            MediaPreviewActivity.showPreview(
+                                    v.getContext(),
+                                    imgPreview,
+                                    mSite,
+                                    media.getId());
+                        }
                     }
-                }
-            });
+                });
+            }
 
             // make the progress bar white
             progressUpload.getIndeterminateDrawable().setColorFilter(Color.WHITE, PorterDuff.Mode.MULTIPLY);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -32,7 +32,6 @@ import org.wordpress.android.util.ImageUtils.BitmapWorkerCallback;
 import org.wordpress.android.util.ImageUtils.BitmapWorkerTask;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.PhotonUtils;
-import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.UrlUtils;
 
 import java.util.ArrayList;
@@ -220,6 +219,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         private final ProgressBar progressUpload;
         private final ViewGroup stateContainer;
         private final ViewGroup fileContainer;
+        private final ImageView imgPreview;
 
         public GridViewHolder(View view) {
             super(view);
@@ -235,6 +235,22 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             titleView = (TextView) fileContainer.findViewById(R.id.media_grid_item_name);
             fileTypeView = (TextView) fileContainer.findViewById(R.id.media_grid_item_filetype);
             fileTypeImageView = (ImageView) fileContainer.findViewById(R.id.media_grid_item_filetype_image);
+
+            imgPreview = (ImageView) view.findViewById(R.id.image_preview);
+            imgPreview.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    int position = getAdapterPosition();
+                    if (isValidPosition(position)) {
+                        MediaModel media = mMediaList.get(position);
+                        MediaPreviewActivity.showPreview(
+                                v.getContext(),
+                                imgPreview,
+                                media.getUrl(),
+                                media.isVideo());
+                    }
+                }
+            });
 
             // make the progress bar white
             progressUpload.getIndeterminateDrawable().setColorFilter(Color.WHITE, PorterDuff.Mode.MULTIPLY);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -195,6 +195,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         mGridAdapter = new MediaGridAdapter(getActivity(), mSite, mImageLoader);
         mGridAdapter.setCallback(this);
         mGridAdapter.setAllowMultiselect(mBrowserType != MediaBrowserType.SINGLE_SELECT_PICKER);
+        mGridAdapter.setShowPreviewIcon(mBrowserType.isPicker());
         mRecycler.setAdapter(mGridAdapter);
 
         mEmptyView = (LinearLayout) view.findViewById(R.id.empty_view);

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
@@ -111,6 +112,19 @@
         android:textSize="@dimen/text_sz_large"
         android:visibility="gone"
         tools:text="5"
+        tools:visibility="visible" />
+
+    <ImageView
+        android:id="@+id/image_preview"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:layout_alignParentBottom="true"
+        android:layout_marginBottom="@dimen/margin_small"
+        android:layout_marginLeft="@dimen/margin_small"
+        android:background="@drawable/preview_icon_background"
+        android:padding="@dimen/margin_medium"
+        android:visibility="visible"
+        app:srcCompat="@drawable/ic_preview_white_24dp"
         tools:visibility="visible" />
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -124,8 +124,8 @@
 
         <ImageView
             android:id="@+id/image_preview"
-            android:layout_width="36dp"
-            android:layout_height="36dp"
+            android:layout_width="@dimen/photo_picker_preview_icon"
+            android:layout_height="@dimen/photo_picker_preview_icon"
             android:layout_marginBottom="@dimen/margin_small"
             android:layout_marginLeft="@dimen/margin_small"
             android:background="@drawable/preview_icon_background"

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -114,17 +114,22 @@
         tools:text="5"
         tools:visibility="visible" />
 
-    <ImageView
-        android:id="@+id/image_preview"
-        android:layout_width="36dp"
-        android:layout_height="36dp"
+    <FrameLayout
+        android:id="@+id/frame_preview"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
-        android:layout_marginBottom="@dimen/margin_small"
-        android:layout_marginLeft="@dimen/margin_small"
-        android:background="@drawable/preview_icon_background"
-        android:padding="@dimen/margin_medium"
-        android:visibility="visible"
-        app:srcCompat="@drawable/ic_preview_white_24dp"
-        tools:visibility="visible" />
+        android:visibility="gone"
+        tools:visibility="visible">
 
+        <ImageView
+            android:id="@+id/image_preview"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:layout_marginBottom="@dimen/margin_small"
+            android:layout_marginLeft="@dimen/margin_small"
+            android:background="@drawable/preview_icon_background"
+            android:padding="@dimen/margin_medium"
+            app:srcCompat="@drawable/ic_preview_white_24dp" />
+    </FrameLayout>
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/photo_picker_thumbnail.xml
+++ b/WordPress/src/main/res/layout/photo_picker_thumbnail.xml
@@ -43,8 +43,8 @@
 
     <ImageView
         android:id="@+id/image_preview"
-        android:layout_width="36dp"
-        android:layout_height="36dp"
+        android:layout_width="@dimen/photo_picker_preview_icon"
+        android:layout_height="@dimen/photo_picker_preview_icon"
         android:layout_gravity="bottom"
         android:layout_marginBottom="@dimen/margin_small"
         android:layout_marginLeft="@dimen/margin_small"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -295,6 +295,7 @@
     <dimen name="photo_picker_selected_item_padding">4dp</dimen>
     <dimen name="photo_picker_icon">48dp</dimen>
     <dimen name="photo_picker_video_overlay">36dp</dimen>
+    <dimen name="photo_picker_preview_icon">36dp</dimen>
 
     <dimen name="smart_toast_offset_y">48dp</dimen>
 </resources>


### PR DESCRIPTION
Fixes #5924 - adds a preview feature to the WP media library picker.

To test:

1. Edit a post or create a new one
2. Tap to add media
3. Tap the "W" icon to add from the WP media library
4. There should be a preview icon on each item

![screenshot_1495580508](https://cloud.githubusercontent.com/assets/3903757/26380099/8d23fb9a-3fea-11e7-9001-93e26a14be84.png)


