### PR TITLE
Fix long spinner text overlapping right drawable

### DIFF
--- a/WordPress/src/main/res/layout/spinner_menu_dropdown_item.xml
+++ b/WordPress/src/main/res/layout/spinner_menu_dropdown_item.xml
@@ -5,8 +5,8 @@
     style="?android:attr/spinnerDropDownItemStyle"
     android:layout_width="match_parent"
     android:layout_height="@dimen/toolbar_height"
-    android:ellipsize="marquee"
     android:singleLine="true"
+    android:ellipsize="end"
     android:textColor="@color/grey_dark"
     android:textSize="@dimen/text_sz_large"
     tools:text="menu_text_dropdown" />

--- a/WordPress/src/main/res/layout/spinner_menu_dropdown_item.xml
+++ b/WordPress/src/main/res/layout/spinner_menu_dropdown_item.xml
@@ -5,8 +5,9 @@
     style="?android:attr/spinnerDropDownItemStyle"
     android:layout_width="match_parent"
     android:layout_height="@dimen/toolbar_height"
-    android:singleLine="true"
     android:ellipsize="end"
+    android:maxLines="1"
     android:textColor="@color/grey_dark"
     android:textSize="@dimen/text_sz_large"
-    tools:text="menu_text_dropdown" />
+    tools:text="menu_text_dropdown"
+    tools:ignore="RtlSymmetry" />

--- a/WordPress/src/main/res/layout/spinner_menu_dropdown_item.xml
+++ b/WordPress/src/main/res/layout/spinner_menu_dropdown_item.xml
@@ -5,6 +5,8 @@
     style="?android:attr/spinnerDropDownItemStyle"
     android:layout_width="match_parent"
     android:layout_height="@dimen/toolbar_height"
+    android:paddingEnd="@dimen/margin_dialog"
+    android:paddingRight="@dimen/margin_dialog"
     android:ellipsize="end"
     android:maxLines="1"
     android:textColor="@color/grey_dark"


### PR DESCRIPTION
Fixes #5923.

To test:
* Share some media from another app (Gallery, Photos, etc...)
* Select a site with a name long enough to reach the dropdown arrow

The text should terminate with an ellipsis with some space between the text and the dropdown arrow. [Here's a picture of the result.](https://cldup.com/a9z54tgOds.png)