### PR TITLE
7.5 - Image thumbnails for Aztec fix

### DIFF
--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -337,12 +337,7 @@ public class ImageUtils {
             return null;
         }
 
-        Uri curUri;
-        if (!filePath.contains("content://")) {
-            curUri = Uri.parse("content://media" + filePath);
-        } else {
-            curUri = Uri.parse(filePath);
-        }
+        Uri curUri = Uri.parse(filePath);
 
         if (filePath.contains("video")) {
             // Load the video thumbnail from the MediaStore


### PR DESCRIPTION
Fixes #5936 by removing unnecessary code in the routine that generates the picture thumbnail. 

I bet it was used before we refactored media and image utils routines.


Please test this well with the old visual editor too, since this is going to be merged in 7.5
