### PR TITLE
Fix NFE on image upload cancel/retry (Visual Editor, API16)

### DIFF
--- a/libs/editor/WordPressEditor/src/main/assets/ZSSRichTextEditor.js
+++ b/libs/editor/WordPressEditor/src/main/assets/ZSSRichTextEditor.js
@@ -3569,13 +3569,7 @@ ZSSField.prototype.sendVideoTappedCallback = function( videoNode ) {
 // MARK: - Callback Execution
 
 ZSSField.prototype.callback = function(callbackScheme, callbackPath) {
-    var url = callbackScheme + ":";
-
-    url = url + "id=" + this.getNodeId();
-
-    if (callbackPath) {
-        url = url + defaultCallbackSeparator + callbackPath;
-    }
+    var url = callbackScheme + ":" + callbackPath;
 
     if (isUsingiOS) {
         ZSSEditor.callbackThroughIFrame(url);


### PR DESCRIPTION
Fixes #5673. Removes an unnecessary piece from the callback URL (which is only used on API16), which was causing image taps to have two `id` parameters, so that the parser extracted `zss_field_content` instead of the local id of the media item.

To test:
Case 1:
1. Load the visual editor on an API16 device or emulator
2. Insert an image
3. Tap the image while upload is in progress
4. Select 'OK' on the 'Stop uploading?' dialog
5. No crash, and the image is removed

Case 2:
1. Load the visual editor on an API16 device or emulator
2. Tap to retry a failed media item
3. No crash, and the image upload is restarted and completes successfully