### PR TITLE
issue/5944-reader-featured-image-class

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderHtmlUtils.java
@@ -37,6 +37,11 @@ public class ReaderHtmlUtils {
             "src\\s*=\\s*(?:'|\")(.*?)(?:'|\")",
             Pattern.DOTALL|Pattern.CASE_INSENSITIVE);
 
+    // regex for matching class attributes in tags
+    private static final Pattern CLASS_ATTR_PATTERN = Pattern.compile(
+            "class\\s*=\\s*(?:'|\")(.*?)(?:'|\")",
+            Pattern.DOTALL|Pattern.CASE_INSENSITIVE);
+
 
     /*
     * returns the integer value from the data-orig-size attribute in the passed html tag
@@ -108,6 +113,23 @@ public class ReaderHtmlUtils {
         if (matcher.find()) {
             // remove "src=" and quotes from the result
             return tag.substring(matcher.start() + 5, matcher.end() - 1);
+        } else {
+            return null;
+        }
+    }
+
+    /*
+     * returns the value from class src attribute in the passed html tag
+     */
+    public static String getClassAttrValue(final String tag) {
+        if (tag == null) {
+            return null;
+        }
+
+        Matcher matcher = CLASS_ATTR_PATTERN.matcher(tag);
+        if (matcher.find()) {
+            // remove "class=" and quotes from the result
+            return tag.substring(matcher.start() + 7, matcher.end() - 1);
         } else {
             return null;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.reader.utils;
 
+import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
 import org.wordpress.android.ui.reader.models.ReaderImageList;
@@ -105,10 +106,21 @@ public class ReaderImageScanner {
             if (width > currentMaxWidth) {
                 currentImageUrl = imageUrl;
                 currentMaxWidth = width;
+            } else if (currentImageUrl == null && hasSuitableClassForFeaturedImage(imgTag)) {
+                currentImageUrl = imageUrl;
             }
         }
 
         return currentImageUrl;
+    }
+
+    /*
+     * returns true if the passed image tag has a "size-full" or "size-large" class attribute,
+     * which would make it suitable for use as a featured image
+     */
+    private boolean hasSuitableClassForFeaturedImage(@NonNull String imageTag) {
+        String tagClass = ReaderHtmlUtils.getClassAttrValue(imageTag);
+        return (tagClass != null && (tagClass.contains("size-full") || tagClass.contains("size-large")));
     }
 
     /*


### PR DESCRIPTION
Fixes #5944 -When the reader scans a post for a suitable featured image, in the past it only considered the size attributes. This PR updates the scan to also look for images that use the `size-full` or `size-large` class attributes.

To test this, follow @elibud's blog at https://elibudandpets.com/ - it contains several posts with images that are suitable to be featured but don't use size attributes.

Note: the iOS app also considers `size-medium` to be suitable as a featured image, but I think these are too small and would appear pixelated - @aerych, can you confirm?
