### PR TITLE
Fix media uploads from legacy editor

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -136,7 +136,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:e914459b1a99febf2d40b06e3bada80c755f083b') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:9745efa8afca82418c6bb82e592bca8d15e6f2f2') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -343,7 +343,7 @@ public class PostUploadService extends Service {
                 if (m.find()) {
                     String imageUri = m.group(1);
                     if (!imageUri.equals("")) {
-                        MediaModel mediaModel = mMediaStore.getPostMediaWithPath(mPost.getId(), imageUri);
+                        MediaModel mediaModel = mMediaStore.getPostMediaWithPath(mPost, imageUri);
                         if (mediaModel == null) {
                             mIsMediaError = true;
                             continue;

--- a/WordPress/src/main/java/org/wordpress/android/util/HtmlToSpannedConverter.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HtmlToSpannedConverter.java
@@ -365,7 +365,7 @@ public class HtmlToSpannedConverter implements ContentHandler {
             WPImageSpan is = new WPImageSpan(mContext, resizedBitmap, curStream);
 
             // Get the MediaFile data from db
-            MediaModel mediaModel = mMediaStore.getPostMediaWithPath(mPost.getId(), src);
+            MediaModel mediaModel = mMediaStore.getPostMediaWithPath(mPost, src);
             MediaFile mediaFile = FluxCUtils.mediaFileFromMediaModel(mediaModel);
 
             if (mediaFile != null) {


### PR DESCRIPTION
Fixes #5939. We were incorrectly using the remote post ID instead of the local post ID to retrieve the stored `MediaModel`. This caused media uploads to fail, and prevented thumbnails from being displayed in the legacy editor.

~https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/453 should be reviewed and merged first, and this PR updated to use the latest FluxC `develop` hash.~

To test:
1. Using the legacy editor, insert a local image
2. A thumbnail for the image should be displayed
3. Upload the post
4. The upload should succeed