### PR TITLE
feature/sharing-use-site-model-not-id

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -61,6 +61,7 @@ import org.wordpress.android.ui.prefs.SiteSettingsFragment;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 import org.wordpress.android.ui.prefs.notifications.NotificationsSettingsFragment;
 import org.wordpress.android.ui.publicize.PublicizeDetailFragment;
+import org.wordpress.android.ui.publicize.PublicizeListActivity;
 import org.wordpress.android.ui.publicize.PublicizeListFragment;
 import org.wordpress.android.ui.publicize.PublicizeWebViewFragment;
 import org.wordpress.android.ui.reader.ReaderCommentListActivity;
@@ -148,6 +149,7 @@ public interface AppComponent {
     void inject(MediaEditFragment object);
     void inject(MediaPreviewActivity object);
 
+    void inject(PublicizeListActivity object);
     void inject(PublicizeWebViewFragment object);
     void inject(PublicizeDetailFragment object);
     void inject(PublicizeListFragment object);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeAccountChooserDialogFragment.java
@@ -17,6 +17,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.models.PublicizeConnection;
 import org.wordpress.android.util.ToastUtils;
 
@@ -32,7 +34,7 @@ public class PublicizeAccountChooserDialogFragment extends DialogFragment implem
     private String mConnectionName = "";
     private String mServiceId = "";
     private int mSelectedIndex = 0;
-    private long mSiteId = 0;
+    private SiteModel mSite;
 
     @NonNull
     @Override
@@ -95,7 +97,7 @@ public class PublicizeAccountChooserDialogFragment extends DialogFragment implem
             public void onClick(DialogInterface dialogInterface, int i) {
                 dialogInterface.dismiss();
                 int keychainId = mNotConnectedAccounts.get(mSelectedIndex).connectionId;
-                EventBus.getDefault().post(new PublicizeEvents.ActionAccountChosen(mSiteId, keychainId));
+                EventBus.getDefault().post(new PublicizeEvents.ActionAccountChosen(mSite.getSiteId(), keychainId));
             }
         });
         builder.setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
@@ -109,7 +111,7 @@ public class PublicizeAccountChooserDialogFragment extends DialogFragment implem
     
     private boolean containsSiteId(long[] array) {
         for (long a : array) {
-            if (a == mSiteId) {
+            if (a == mSite.getSiteId()) {
                 return true;
             }
         }
@@ -120,7 +122,7 @@ public class PublicizeAccountChooserDialogFragment extends DialogFragment implem
     private void retrieveCurrentSiteFromArgs() {
         Bundle args = getArguments();
         if (args != null) {
-            mSiteId = args.getLong(PublicizeConstants.ARG_SITE_ID);
+            mSite = (SiteModel) args.getSerializable(WordPress.SITE);
             mServiceId = args.getString(PublicizeConstants.ARG_SERVICE_ID);
             String jsonString = args.getString(PublicizeConstants.ARG_CONNECTION_ARRAY_JSON);
             addConnectionsToLists(jsonString);
@@ -136,7 +138,7 @@ public class PublicizeAccountChooserDialogFragment extends DialogFragment implem
             for (int i = 0; i < jsonArray.length(); i++) {
                 PublicizeConnection connection = PublicizeConnection.fromJson(jsonArray.getJSONObject(i));
                 if (connection.getService().equals(mServiceId)) {
-                    if (connection.isInSite(mSiteId)) {
+                    if (connection.isInSite(mSite.getSiteId())) {
                         mConnectedAccounts.add(connection);
                     } else {
                         mNotConnectedAccounts.add(connection);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.publicize;
 
 public class PublicizeConstants {
-    public static final String ARG_SITE_ID        = "site_id";
     public static final String ARG_SERVICE_ID     = "service_id";
     public static final String ARG_CONNECTION_ID  = "connection_id";
     public static final String ARG_CONNECTION_ARRAY_JSON = "connection_array_json";

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.publicize;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -10,6 +11,7 @@ import android.widget.TextView;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.PublicizeTable;
+import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.models.PublicizeService;
 import org.wordpress.android.ui.publicize.PublicizeConstants.ConnectAction;
@@ -23,7 +25,7 @@ import org.wordpress.android.widgets.WPNetworkImageView;
 import javax.inject.Inject;
 
 public class PublicizeDetailFragment extends PublicizeBaseFragment implements PublicizeConnectionAdapter.OnAdapterLoadedListener {
-    private long mSiteId;
+    private SiteModel mSite;
     private String mServiceId;
 
     private PublicizeService mService;
@@ -34,9 +36,9 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment implements Pu
 
     @Inject AccountStore mAccountStore;
 
-    public static PublicizeDetailFragment newInstance(long siteId, PublicizeService service) {
+    public static PublicizeDetailFragment newInstance(@NonNull SiteModel site, @NonNull PublicizeService service) {
         Bundle args = new Bundle();
-        args.putLong(PublicizeConstants.ARG_SITE_ID, siteId);
+        args.putSerializable(WordPress.SITE, site);
         args.putString(PublicizeConstants.ARG_SERVICE_ID, service.getId());
 
         PublicizeDetailFragment fragment = new PublicizeDetailFragment();
@@ -50,7 +52,7 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment implements Pu
         super.setArguments(args);
 
         if (args != null) {
-            mSiteId = args.getLong(PublicizeConstants.ARG_SITE_ID);
+            mSite = (SiteModel) args.getSerializable(WordPress.SITE);
             mServiceId = args.getString(PublicizeConstants.ARG_SERVICE_ID);
         }
     }
@@ -61,7 +63,7 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment implements Pu
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
         if (savedInstanceState != null) {
-            mSiteId = savedInstanceState.getLong(PublicizeConstants.ARG_SITE_ID);
+            mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
             mServiceId = savedInstanceState.getString(PublicizeConstants.ARG_SERVICE_ID);
         }
     }
@@ -69,7 +71,7 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment implements Pu
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putLong(PublicizeConstants.ARG_SITE_ID, mSiteId);
+        outState.putSerializable(WordPress.SITE, mSite);
         outState.putString(PublicizeConstants.ARG_SERVICE_ID, mServiceId);
     }
 
@@ -119,7 +121,7 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment implements Pu
 
         long currentUserId = mAccountStore.getAccount().getUserId();
         PublicizeConnectionAdapter adapter = new PublicizeConnectionAdapter(
-                getActivity(), mSiteId, mServiceId, currentUserId);
+                getActivity(), mSite.getSiteId(), mServiceId, currentUserId);
         adapter.setOnPublicizeActionListener(getOnPublicizeActionListener());
         adapter.setOnAdapterLoadedListener(this);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListFragment.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.publicize;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -11,6 +12,7 @@ import android.widget.TextView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter;
 import org.wordpress.android.ui.publicize.adapters.PublicizeServiceAdapter.OnAdapterLoadedListener;
@@ -27,7 +29,7 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
     }
 
     private PublicizeManageConnectionsListener mListener;
-    private long mSiteId;
+    private SiteModel mSite;
     private PublicizeServiceAdapter mAdapter;
     private RecyclerView mRecycler;
     private TextView mEmptyView;
@@ -35,9 +37,9 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
 
     @Inject AccountStore mAccountStore;
 
-    public static PublicizeListFragment newInstance(long siteId) {
+    public static PublicizeListFragment newInstance(@NonNull SiteModel site) {
         Bundle args = new Bundle();
-        args.putLong(PublicizeConstants.ARG_SITE_ID, siteId);
+        args.putSerializable(WordPress.SITE, site);
 
         PublicizeListFragment fragment = new PublicizeListFragment();
         fragment.setArguments(args);
@@ -50,7 +52,7 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
         super.setArguments(args);
 
         if (args != null) {
-            mSiteId = args.getLong(PublicizeConstants.ARG_SITE_ID);
+            mSite = (SiteModel) args.getSerializable(WordPress.SITE);
         }
     }
 
@@ -60,7 +62,7 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
         if (savedInstanceState != null) {
-            mSiteId = savedInstanceState.getLong(PublicizeConstants.ARG_SITE_ID);
+            mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
         }
     }
 
@@ -78,7 +80,7 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putLong(PublicizeConstants.ARG_SITE_ID, mSiteId);
+        outState.putSerializable(WordPress.SITE, mSite);
     }
 
     @Override
@@ -142,7 +144,7 @@ public class PublicizeListFragment extends PublicizeBaseFragment {
         if (mAdapter == null) {
             mAdapter = new PublicizeServiceAdapter(
                     getActivity(),
-                    mSiteId,
+                    mSite.getSiteId(),
                     mAccountStore.getAccount().getUserId());
             mAdapter.setOnAdapterLoadedListener(mAdapterLoadedListener);
             if (getActivity() instanceof OnServiceClickListener) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeWebViewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeWebViewFragment.java
@@ -16,6 +16,7 @@ import android.widget.ProgressBar;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.PublicizeTable;
+import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.models.PublicizeConnection;
 import org.wordpress.android.models.PublicizeService;
@@ -28,7 +29,7 @@ import javax.inject.Inject;
 import de.greenrobot.event.EventBus;
 
 public class PublicizeWebViewFragment extends PublicizeBaseFragment {
-    private long mSiteId;
+    private SiteModel mSite;
     private String mServiceId;
     private int mConnectionId;
     private WebView mWebView;
@@ -41,11 +42,11 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
      * is non-null then we're reconnecting a broken connection, otherwise we're creating a
      * new connection to the service
      */
-    public static PublicizeWebViewFragment newInstance(long siteId,
+    public static PublicizeWebViewFragment newInstance(@NonNull SiteModel site,
                                                        @NonNull PublicizeService service,
                                                        PublicizeConnection connection) {
         Bundle args = new Bundle();
-        args.putSerializable(PublicizeConstants.ARG_SITE_ID, siteId);
+        args.putSerializable(WordPress.SITE, site);
         args.putString(PublicizeConstants.ARG_SERVICE_ID, service.getId());
         if (connection != null) {
             args.putInt(PublicizeConstants.ARG_CONNECTION_ID, connection.connectionId);
@@ -62,7 +63,7 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
         super.setArguments(args);
 
         if (args != null) {
-            mSiteId = args.getLong(PublicizeConstants.ARG_SITE_ID);
+            mSite = (SiteModel) args.getSerializable(WordPress.SITE);
             mServiceId = args.getString(PublicizeConstants.ARG_SERVICE_ID);
             mConnectionId = args.getInt(PublicizeConstants.ARG_CONNECTION_ID);
         }
@@ -74,7 +75,7 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
         if (savedInstanceState != null) {
-            mSiteId = savedInstanceState.getLong(PublicizeConstants.ARG_SITE_ID);
+            mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
             mServiceId = savedInstanceState.getString(PublicizeConstants.ARG_SERVICE_ID);
             mConnectionId = savedInstanceState.getInt(PublicizeConstants.ARG_CONNECTION_ID);
         }
@@ -83,8 +84,7 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putLong(PublicizeConstants.ARG_SITE_ID, mSiteId);
-        outState.putString(PublicizeConstants.ARG_SERVICE_ID, mServiceId);
+        outState.putSerializable(WordPress.SITE, mSite);
         outState.putInt(PublicizeConstants.ARG_CONNECTION_ID, mConnectionId);
         mWebView.saveState(outState);
     }
@@ -176,7 +176,7 @@ public class PublicizeWebViewFragment extends PublicizeBaseFragment {
 
                     long currentUserId = mAccountStore.getAccount().getUserId();
                     // call the endpoint to make the actual connection
-                    PublicizeActions.connect(mSiteId, mServiceId, currentUserId);
+                    PublicizeActions.connect(mSite.getSiteId(), mServiceId, currentUserId);
                     WebViewUtils.clearCookiesAsync();
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/services/PublicizeUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/services/PublicizeUpdateService.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.publicize.services;
 import android.app.IntentService;
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.NonNull;
 
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
@@ -10,6 +11,7 @@ import com.wordpress.rest.RestRequest;
 import org.json.JSONObject;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.PublicizeTable;
+import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.models.PublicizeConnectionList;
 import org.wordpress.android.models.PublicizeServiceList;
 import org.wordpress.android.ui.publicize.PublicizeConstants;
@@ -29,9 +31,9 @@ public class PublicizeUpdateService extends IntentService {
     /*
      * update the publicize connections for the passed site
      */
-    public static void updateConnectionsForSite(Context context, long siteId) {
+    public static void updateConnectionsForSite(Context context, @NonNull SiteModel site) {
         Intent intent = new Intent(context, PublicizeUpdateService.class);
-        intent.putExtra(PublicizeConstants.ARG_SITE_ID, siteId);
+        intent.putExtra(WordPress.SITE, site);
         context.startService(intent);
     }
 
@@ -63,8 +65,8 @@ public class PublicizeUpdateService extends IntentService {
             mHasUpdatedServices = true;
         }
 
-        long siteId = intent.getLongExtra(PublicizeConstants.ARG_SITE_ID, 0);
-        updateConnections(siteId);
+        SiteModel site = (SiteModel) intent.getSerializableExtra(WordPress.SITE);
+        updateConnections(site.getSiteId());
     }
 
     /*


### PR DESCRIPTION
Updates sharing code to pass the SiteModel rather than siteId, as per [this conversation](https://github.com/wordpress-mobile/WordPress-Android/pull/5933#issuecomment-304146829)