### PR TITLE
issue/5957-media-download-toast

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -599,14 +599,11 @@ public class MediaPreviewActivity extends AppCompatActivity implements ActivityC
                 query.setFilterById(mDownloadId);
                 DownloadManager dm = (DownloadManager) getSystemService(DOWNLOAD_SERVICE);
                 Cursor cursor = dm.query(query);
-                int reason = 0;
                 if (cursor.moveToFirst()) {
-                    reason = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_REASON));
-                }
-                if (reason == DownloadManager.STATUS_FAILED) {
-                    ToastUtils.showToast(MediaPreviewActivity.this, R.string.error_media_save);
-                } else {
-                    ToastUtils.showToast(MediaPreviewActivity.this, R.string.media_saved_to_device);
+                    int reason = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_REASON));
+                    if (reason == DownloadManager.STATUS_FAILED) {
+                        ToastUtils.showToast(MediaPreviewActivity.this, R.string.error_media_save);
+                    }
                 }
                 mDownloadId = 0;
                 invalidateOptionsMenu();
@@ -636,6 +633,8 @@ public class MediaPreviewActivity extends AppCompatActivity implements ActivityC
             ToastUtils.showToast(this, R.string.error_media_not_found);
             return;
         }
+
+        ToastUtils.showToast(this, R.string.media_downloading);
 
         DownloadManager dm = (DownloadManager) getSystemService(DOWNLOAD_SERVICE);
         DownloadManager.Request request = new DownloadManager.Request(Uri.parse(media.getUrl()));

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -128,7 +128,7 @@
     <string name="media_insert_title">Add multiple photos</string>
     <string name="media_insert_individually">Add individually</string>
     <string name="media_insert_as_gallery">Add as gallery</string>
-    <string name="media_saved_to_device">Media saved to this device</string>
+    <string name="media_downloading">Saving media to this device</string>
     <string name="wp_media_title">WordPress media</string>
     <string name="pick_photo">Select photo</string>
     <string name="pick_video">Select video</string>


### PR DESCRIPTION
Fixes #5957 - changes media downloading to show a toast before the download instead of after.

* Go to the media browser
* Tap an image to preview it
* Tap the cloud icon to download it

