### PR TITLE
Issue/5959 select newly added site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -300,6 +300,7 @@ public class ActivityLauncher {
     public static void addSelfHostedSiteForResult(Activity activity) {
         Intent intent = new Intent(activity, SignInActivity.class);
         intent.putExtra(SignInActivity.EXTRA_START_FRAGMENT, SignInActivity.ADD_SELF_HOSTED_BLOG);
+        intent.putExtra(SignInActivity.EXTRA_INHIBIT_MAGIC_LOGIN, true);
         activity.startActivityForResult(intent, RequestCodes.ADD_ACCOUNT);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -179,6 +179,8 @@ public class SitePickerActivity extends AppCompatActivity
 
         switch (requestCode) {
             case RequestCodes.ADD_ACCOUNT:
+                getAdapter().loadSites();
+                break;
             case RequestCodes.CREATE_SITE:
                 if (resultCode == RESULT_OK) {
                     getAdapter().loadSites();


### PR DESCRIPTION
Fixes #5959 by remaining on the Site Picker activity after successfully adding a new self-hosted site. Previously the user would return immediately to `WPMainActivity` with the previous site selected.

To test:
* Sign into WP.com
* Add a new self-hosted site from the Site Picker

After adding the site you should be taken back to the Site Picker activity with the new site added to the list. The previous site remains selected but at least the option to change to the new site is one click away.