### PR TITLE
Don’t show site picker if a site is already selected

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -681,8 +681,8 @@ public class WPMainActivity extends AppCompatActivity {
             ActivityLauncher.showSignInForResult(this);
         } else {
             SiteModel site = getSelectedSite();
-            if (site != null) {
-                ActivityLauncher.showSitePickerForResult(this, site);
+            if (site == null && mSiteStore.hasSite()) {
+                ActivityLauncher.showSitePickerForResult(this, mSiteStore.getSites().get(0));
             }
         }
     }


### PR DESCRIPTION
Fixes #5961. Now when a site is removed the site picker is only shown if there is no selected site.

To test:
* Login to WP.com
* Add a self-hosted site

Case 1:
* Select newly added site
* Remove it
* Result: You should land on the Site Picker with no site selected. If you return to the main activity the first site should get selected. Or you can pick a site yourself and return to the main activity.

Case 2:
* Select any other site
* Remove the previously added site
* Result: You should land on the Site Picker with your selected site still selected.