### PR TITLE
Issue/5953 video dont force landscape

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -9,7 +9,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.graphics.Bitmap;
@@ -215,7 +214,6 @@ public class MediaPreviewActivity extends AppCompatActivity implements ActivityC
         mVideoView.setVisibility(mIsVideo ? View.VISIBLE : View.GONE);
 
         if (mIsVideo) {
-            setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
             playVideo(mediaUri);
         } else {
             loadImage(mediaUri);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -155,6 +155,7 @@ public class MediaPreviewActivity extends AppCompatActivity implements ActivityC
         ((WordPress) getApplication()).component().inject(this);
 
         setContentView(R.layout.media_preview_activity);
+        View videoFrame = findViewById(R.id.frame_video);
         mImageView = (ImageView) findViewById(R.id.image_preview);
         mVideoView = (VideoView) findViewById(R.id.video_preview);
         mMetadataView = (ViewGroup) findViewById(R.id.layout_metadata);
@@ -211,7 +212,7 @@ public class MediaPreviewActivity extends AppCompatActivity implements ActivityC
         }
 
         mImageView.setVisibility(mIsVideo ?  View.GONE : View.VISIBLE);
-        mVideoView.setVisibility(mIsVideo ? View.VISIBLE : View.GONE);
+        videoFrame.setVisibility(mIsVideo ? View.VISIBLE : View.GONE);
 
         if (mIsVideo) {
             playVideo(mediaUri);

--- a/WordPress/src/main/res/layout/media_preview_activity.xml
+++ b/WordPress/src/main/res/layout/media_preview_activity.xml
@@ -16,13 +16,20 @@
         android:layout_height="match_parent"
         android:layout_below="@+id/toolbar" />
 
-    <VideoView
-        android:id="@+id/video_preview"
+    <FrameLayout
+        android:id="@+id/frame_video"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@+id/toolbar"
         android:visibility="gone"
-        tools:visibility="visible" />
+        tools:visibility="visible">
+
+        <VideoView
+            android:id="@+id/video_preview"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center" />
+    </FrameLayout>
 
     <ProgressBar
         android:id="@+id/progress"


### PR DESCRIPTION
Fixes #5953 - the media preview activity no longer forces videos to be shown in landscape. Instead they're shown using the current orientation, and the video was moved inside a `FrameLayout` so it could be centered as recommended [here](https://stackoverflow.com/a/4855315/1673548).
