### PR TITLE
Media Uploads -  Internal Server and Timeout errors

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -858,6 +858,12 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             case REQUEST_TOO_LARGE:
                 errorMessage = getString(R.string.media_error_too_large_upload);
                 break;
+            case SERVER_ERROR:
+                errorMessage = getString(R.string.media_error_internal_server_error);
+                break;
+            case TIMEOUT:
+                errorMessage = getString(R.string.media_error_timeout);
+                break;
             case GENERIC_ERROR:
             default:
                 errorMessage = TextUtils.isEmpty(error.message) ? getString(R.string.tap_to_try_again) : error.message;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -588,6 +588,10 @@ public class PostUploadService extends Service {
                  return getString(R.string.error_media_parse_error);
             case REQUEST_TOO_LARGE:
                 return getString(R.string.error_media_request_too_large);
+             case SERVER_ERROR:
+                 return getString(R.string.media_error_internal_server_error);
+             case TIMEOUT:
+                 return getString(R.string.media_error_timeout);
         }
         // In case of a generic or uncaught error, return the message from the API response or the error type
         return TextUtils.isEmpty(error.message) ? error.type.toString() : error.message;

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -136,9 +136,9 @@
     <string name="reader_toast_err_get_post">Unable to retrieve this post</string>
     <string name="media_error_no_permission">You don\'t have permission to view the media library</string>
     <string name="media_error_no_permission_upload">You don\'t have permission to upload media to the site</string>
-    <string name="media_error_too_large_upload">The file is too big. Try to upload smaller images by enabling the Optimize Images option in Site->Settings</string>
-    <string name="media_error_internal_server_error">There was an error uploading the media on your site. Try to upload smaller images by enabling the Optimize Images option in Site->Settings</string>
-    <string name="media_error_timeout">Your site is taking to long to respond, this can be caused by either poor connectivity or an error with the servers</string>
+    <string name="media_error_too_large_upload">File too large to upload. Try enabling Optimize Images in Site->Settings</string>
+    <string name="media_error_internal_server_error">Upload error. Try enabling Optimize Images in Site->Settings</string>
+    <string name="media_error_timeout">Server response timed out, you may have a poor connection or server error</string>
     <string name="access_media_permission_required">Permissions required in order to access media</string>
     <string name="add_media_permission_required">Permissions required in order to add media</string>
     <string name="media_fetching">Fetching media…</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -136,7 +136,9 @@
     <string name="reader_toast_err_get_post">Unable to retrieve this post</string>
     <string name="media_error_no_permission">You don\'t have permission to view the media library</string>
     <string name="media_error_no_permission_upload">You don\'t have permission to upload media to the site</string>
-    <string name="media_error_too_large_upload">The file is too big. Please contact the web hosting provider to fix this issue</string>
+    <string name="media_error_too_large_upload">The file is too big. Try to upload smaller images by enabling the Optimize Images option in Site->Settings</string>
+    <string name="media_error_internal_server_error">There was an error uploading the media on your site. Try to upload smaller images by enabling the Optimize Images option in Site->Settings</string>
+    <string name="media_error_timeout">Your site is taking to long to respond, this can be caused by either poor connectivity or an error with the servers</string>
     <string name="access_media_permission_required">Permissions required in order to access media</string>
     <string name="add_media_permission_required">Permissions required in order to add media</string>
     <string name="media_fetching">Fetching media…</string>


### PR DESCRIPTION
Handle the new `Internal Server Error` and `Timeout` error categories introduced in FluxC for media uploads.

In this PR we're introducing a message that says to try with smaller images, and enable the optimize image settings, when an internal server error is received on media uploading.
This is because when we get a Internal server error uploading a Media (only in this case), 99% of times, means the memory_limit was reached on the server. 


To test:

- internal server error could happen when the PHP `memory_limit` or `max_execution_time` is reached.
- timeout happens often on slow connections. I used Charles proxy and set a huge RTL time on the throttling settings screen.