### PR TITLE
Update FluxC hash for 7.5

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -136,7 +136,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:9745efa8afca82418c6bb82e592bca8d15e6f2f2') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:116c712bcaa901a357fff869cac8ed30d036a045') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -331,7 +331,7 @@ public class EditPostSettingsFragment extends Fragment
                 launchMediaGalleryActivity();
                 return true;
             case CLEAR_FEATURED_IMAGE_MENU_POSITION:
-                mFeaturedImageId = -1;
+                mFeaturedImageId = 0;
                 mFeaturedImageView.setVisibility(View.GONE);
                 mFeaturedImageButton.setVisibility(View.VISIBLE);
                 return true;


### PR DESCRIPTION
Brings in @tonyr59h's FluxC-side fix for #5930 (https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/461), as well as @maxme's FluxC-side fix for empty tags on self-hosted sites (https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/458).