### PR TITLE
Fix #5956: nullify site selection on sign out

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -30,6 +30,7 @@ import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.AccountStore.AuthenticationErrorType;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.PostStore;
@@ -633,7 +634,8 @@ public class WPMainActivity extends AppCompatActivity {
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onAuthenticationChanged(OnAuthenticationChanged event) {
-        if (event.isError() && mSelectedSite != null) {
+        if (event.isError() && mSelectedSite != null
+                && event.error.type == AuthenticationErrorType.INVALID_TOKEN) {
             AuthenticationDialogUtils.showAuthErrorView(this, mSelectedSite);
         }
     }
@@ -676,8 +678,11 @@ public class WPMainActivity extends AppCompatActivity {
 
     private void handleSiteRemoved() {
         if (!FluxCUtils.isSignedInWPComOrHasWPOrgSite(mAccountStore, mSiteStore)) {
-            // User signed-out or removed the last self-hosted site, show `SignInActivity`
+            // User signed-out or removed the last self-hosted site
             resetFragments();
+            // Reset site selection
+            setSelectedSite(null);
+            // Show the sign in screen
             ActivityLauncher.showSignInForResult(this);
         } else {
             SiteModel site = getSelectedSite();


### PR DESCRIPTION
Fix #5956: nullify site selection on sign out and make sure we show the error if the token is invalid

To test:

1. Sign into a WordPress.com account (2fa or not does not matter)
2. Sign out of WordPress.com
3. Enter an invalid username/password and attempt to sign in, you should see an "invalid password" message instead of a new window.

Another test:

1. Sign into a WordPress.com account (2fa or not does not matter).
2. Go to the Web, and invalidate the auth token (User Settings -> Security -> remove app connection).
3. Back to the app, try to refresh the post list (or do anything that requires a network call) make sure you get an dialog asking to sign in again.

