### PR TITLE
Have Travis grep lint errors in libs as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ install:
   - cp gradle.properties-example gradle.properties
 
 script:
-  - ./gradlew -PdisablePreDex assembleVanillaRelease lint test || (grep -A20 -B2 'severity="Error"' WordPress/build/**/*.xml; exit 1)
+  - ./gradlew -PdisablePreDex assembleVanillaRelease lint test || (grep -A20 -B2 'severity="Error"' -r --include="*.xml" WordPress libs; exit 1)


### PR DESCRIPTION
Sometimes, the lint error can happen in a lib project. Travis still stops in that case but the details of the error are not displayed unless you manually run the lint checks locally. We can save some time by having Travis grep for errors in the libs folder as well.

This PR adds the `libs` directory to the list for grep to look in.