### PR TITLE
Fix NFE in Visual Editor - bonus round

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1446,7 +1446,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 if (mediaFile == null) {
                     continue;
                 }
-                String replacement = getUploadErrorHtml(mediaFile.getMediaId(), mediaFile.getFilePath());
+                String replacement = getUploadErrorHtml(String.valueOf(mediaFile.getId()), mediaFile.getFilePath());
                 matcher.appendReplacement(stringBuffer, replacement);
             }
             matcher.appendTail(stringBuffer);

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     compile 'com.android.support:support-v4:25.1.1'
     compile 'com.android.support:design:25.1.1'
     compile 'org.apache.commons:commons-lang3:3.5'
-    compile 'org.wordpress:utils:1.+'
+    compile 'org.wordpress:utils:1.15.0'
     compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.0-beta')
 }
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1324,8 +1324,9 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         });
     }
 
-    public void onMediaTapped(final String mediaId, final MediaType mediaType, final JSONObject meta, String uploadStatus) {
-        if (mediaType == null || !isAdded()) {
+    public void onMediaTapped(final String mediaId, final MediaType mediaType, final JSONObject meta,
+                              String uploadStatus) {
+        if (mediaType == null || !isAdded() || TextUtils.isEmpty(mediaId) || StringUtils.stringToInt(mediaId) <= 0) {
             return;
         }
 


### PR DESCRIPTION
Fixes #5949. Mostly this was done in https://github.com/wordpress-mobile/WordPress-Android/pull/5941, but there's at least one more case involving legacy drafts.

274b356 uses the local ID when migrating in-progress media in drafts, instead of incorrectly using the remote media id (which is null for unuploaded media).

f5b4825 suppresses taps for invalid media (with null IDs, for example) in the visual editor. This is to catch existing posts that already have null uploaded media IDs, and prevent them from crashing the app (they will need to be deleted from the posts manually).