### PR TITLE
avoid refreshing each time by not catching the sticky event anymore

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -214,7 +214,7 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
     @Override
     protected void onStart() {
         super.onStart();
-        EventBus.getDefault().registerSticky(this);
+        EventBus.getDefault().register(this);
         // If the user hasn't used swipe yet and if the adapter is initialised and have at least 2 notifications,
         // show a hint to promote swipe usage on the ViewPager
         if (!AppPrefs.isNotificationsSwipeToNavigateShown() && mAdapter != null && mAdapter.getCount() > 1) {


### PR DESCRIPTION
Fixes #5988 

To test:

1. Go to Notifications tab.
2. Tap any notification.
3. Scroll to middle of notification detail.
4. Tap recents navigation button.
5. Tap WordPress app in list.
6. Notice notification detail screen is not refreshed anymore.

cc @theck13 