### PR TITLE
Post Settings: Status

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1226,7 +1226,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                             runOnUiThread(new Runnable() {
                                 @Override
                                 public void run() {
-                                    mEditPostSettingsFragment.updateStatusSpinner();
+                                    mEditPostSettingsFragment.updateStatusTextView();
                                 }
                             });
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.posts;
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.app.DatePickerDialog;
 import android.app.Fragment;
 import android.app.TimePickerDialog;
@@ -1036,6 +1037,15 @@ public class EditPostSettingsFragment extends Fragment
     }
 
     private void showStatusDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(R.string.post_format_status);
+        builder.setSingleChoiceItems(R.array.post_settings_statuses, 0, null);
+        builder.setPositiveButton(R.string.dialog_button_ok, new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int which) {
+            }
+        });
+        builder.setNegativeButton(R.string.cancel, null);
+        builder.show();
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -1022,8 +1022,8 @@ public class EditPostSettingsFragment extends Fragment
         builder.setSingleChoiceItems(R.array.post_settings_statuses, checkedItem, null);
         builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int which) {
-                ListView lw = ((AlertDialog)dialog).getListView();
-                String newStatus = (String) lw.getAdapter().getItem(lw.getCheckedItemPosition());
+                ListView listView = ((AlertDialog)dialog).getListView();
+                String newStatus = (String) listView.getAdapter().getItem(listView.getCheckedItemPosition());
                 mStatusTextView.setText(newStatus);
                 updatePostSettingsAndSaveButton();
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -382,7 +382,7 @@ public class EditPostSettingsFragment extends Fragment
             mPasswordEditText.setText(mPost.getPassword());
         }
 
-        updateStatusSpinner();
+        updateStatusTextView();
         if (AppPrefs.isVisualEditorEnabled() || AppPrefs.isAztecEditorEnabled()) {
             updateFeaturedImage(mPost.getFeaturedImageId());
         }
@@ -397,7 +397,7 @@ public class EditPostSettingsFragment extends Fragment
         }
     }
 
-    public void updateStatusSpinner() {
+    public void updateStatusTextView() {
         String[] statuses = getResources().getStringArray(R.array.post_settings_statuses);
         switch (PostStatus.fromPost(mPost)) {
             case PUBLISHED:
@@ -414,6 +414,22 @@ public class EditPostSettingsFragment extends Fragment
             case PRIVATE:
                 mStatusTextView.setText(statuses[3]);
                 break;
+        }
+    }
+
+    private PostStatus getCurrentPostStatus() {
+        String[] statuses = getResources().getStringArray(R.array.post_settings_statuses);
+        String currentStatus = mStatusTextView.getText().toString();
+        if (currentStatus.equalsIgnoreCase(statuses[0])) {
+            return PostStatus.PUBLISHED;
+        } else if (currentStatus.equalsIgnoreCase(statuses[1])) {
+            return PostStatus.DRAFT;
+        } else if (currentStatus.equalsIgnoreCase(statuses[2])) {
+            return PostStatus.PENDING;
+        } else if (currentStatus.equalsIgnoreCase(statuses[3])) {
+            return PostStatus.PRIVATE;
+        } else {
+            return PostStatus.UNKNOWN;
         }
     }
 
@@ -458,22 +474,6 @@ public class EditPostSettingsFragment extends Fragment
         intent.putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, MediaBrowserType.SINGLE_SELECT_PICKER);
         intent.putExtra(MediaBrowserActivity.ARG_IMAGES_ONLY, true);
         startActivityForResult(intent, RequestCodes.SINGLE_SELECT_MEDIA_PICKER);
-    }
-
-    private PostStatus getCurrentPostStatus() {
-        String[] statuses = getResources().getStringArray(R.array.post_settings_statuses);
-        String currentStatus = mStatusTextView.getText().toString();
-        if (currentStatus.equalsIgnoreCase(statuses[0])) {
-            return PostStatus.PUBLISHED;
-        } else if (currentStatus.equalsIgnoreCase(statuses[1])) {
-            return PostStatus.DRAFT;
-        } else if (currentStatus.equalsIgnoreCase(statuses[2])) {
-            return PostStatus.PENDING;
-        } else if (currentStatus.equalsIgnoreCase(statuses[3])) {
-            return PostStatus.PRIVATE;
-        } else {
-            return PostStatus.UNKNOWN;
-        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -1020,7 +1020,7 @@ public class EditPostSettingsFragment extends Fragment
             checkedItem = 0;
         }
         builder.setSingleChoiceItems(R.array.post_settings_statuses, checkedItem, null);
-        builder.setPositiveButton(R.string.dialog_button_ok, new DialogInterface.OnClickListener() {
+        builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int which) {
                 ListView lw = ((AlertDialog)dialog).getListView();
                 String newStatus = (String) lw.getAdapter().getItem(lw.getCheckedItemPosition());

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -1013,7 +1013,7 @@ public class EditPostSettingsFragment extends Fragment
 
     private void showStatusDialog() {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        builder.setTitle(R.string.post_format_status);
+        builder.setTitle(R.string.post_settings_status);
         int checkedItem = getCurrentPostStatusIndex();
         // Current index should never be -1, but if if is, we don't want to crash
         if (checkedItem == -1) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -108,6 +108,7 @@ public class EditPostSettingsFragment extends Fragment
     private TextView mExcerptTextView;
     private TextView mSlugTextView;
     private TextView mTagsTextView;
+    private TextView mStatusTextView;
     private TextView mPubDateText;
     private ViewGroup mSectionCategories;
     private NetworkImageView mFeaturedImageView;
@@ -215,6 +216,7 @@ public class EditPostSettingsFragment extends Fragment
         mExcerptTextView = (TextView) rootView.findViewById(R.id.post_excerpt);
         mSlugTextView = (TextView) rootView.findViewById(R.id.post_slug);
         mTagsTextView = (TextView) rootView.findViewById(R.id.post_tags);
+        mStatusTextView = (TextView) rootView.findViewById(R.id.post_status);
         mPasswordEditText = (EditText) rootView.findViewById(R.id.post_password);
         mPubDateText = (TextView) rootView.findViewById(R.id.pubDate);
         mPubDateText.setOnClickListener(this);
@@ -278,6 +280,14 @@ public class EditPostSettingsFragment extends Fragment
             @Override
             public void onClick(View view) {
                 showTagsActivity();
+            }
+        });
+
+        final LinearLayout statusContainer = (LinearLayout) rootView.findViewById(R.id.post_status_container);
+        statusContainer.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                showStatusDialog();
             }
         });
 
@@ -361,6 +371,7 @@ public class EditPostSettingsFragment extends Fragment
         mCurrentSlug = mPost.getSlug();
         mExcerptTextView.setText(mCurrentExcerpt);
         mSlugTextView.setText(mCurrentSlug);
+        mStatusTextView.setText(mPost.getStatus());
         updateTagsTextView();
 
         String[] items = new String[]{getResources().getString(R.string.publish_post),
@@ -1022,6 +1033,9 @@ public class EditPostSettingsFragment extends Fragment
         String tags = TextUtils.join(",", mPost.getTagNameList());
         tagsIntent.putExtra(PostSettingsTagsActivity.KEY_TAGS, tags);
         startActivityForResult(tagsIntent, ACTIVITY_REQUEST_CODE_SELECT_TAGS);
+    }
+
+    private void showStatusDialog() {
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -34,6 +34,7 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
+import android.widget.ListView;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.TimePicker;
@@ -1006,6 +1007,9 @@ public class EditPostSettingsFragment extends Fragment
         builder.setSingleChoiceItems(R.array.post_settings_statuses, 0, null);
         builder.setPositiveButton(R.string.dialog_button_ok, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int which) {
+                ListView lw = ((AlertDialog)dialog).getListView();
+                String newStatus = (String) lw.getAdapter().getItem(lw.getCheckedItemPosition());
+                mStatusTextView.setText(newStatus);
                 updatePostSettingsAndSaveButton();
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -418,19 +418,30 @@ public class EditPostSettingsFragment extends Fragment
     }
 
     private PostStatus getCurrentPostStatus() {
+        int index = getCurrentPostStatusIndex();
+        switch (index) {
+            case 0:
+                return PostStatus.PUBLISHED;
+            case 1:
+                return PostStatus.DRAFT;
+            case 2:
+                return PostStatus.PENDING;
+            case 3:
+                return PostStatus.PRIVATE;
+            default:
+                return PostStatus.UNKNOWN;
+        }
+    }
+
+    private int getCurrentPostStatusIndex() {
         String[] statuses = getResources().getStringArray(R.array.post_settings_statuses);
         String currentStatus = mStatusTextView.getText().toString();
-        if (currentStatus.equalsIgnoreCase(statuses[0])) {
-            return PostStatus.PUBLISHED;
-        } else if (currentStatus.equalsIgnoreCase(statuses[1])) {
-            return PostStatus.DRAFT;
-        } else if (currentStatus.equalsIgnoreCase(statuses[2])) {
-            return PostStatus.PENDING;
-        } else if (currentStatus.equalsIgnoreCase(statuses[3])) {
-            return PostStatus.PRIVATE;
-        } else {
-            return PostStatus.UNKNOWN;
+        for (int i = 0; i < statuses.length; i++) {
+            if (currentStatus.equalsIgnoreCase(statuses[i])) {
+                return i;
+            }
         }
+        return -1;
     }
 
     public long getFeaturedImageId() {
@@ -1003,7 +1014,12 @@ public class EditPostSettingsFragment extends Fragment
     private void showStatusDialog() {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setTitle(R.string.post_format_status);
-        builder.setSingleChoiceItems(R.array.post_settings_statuses, 0, null);
+        int checkedItem = getCurrentPostStatusIndex();
+        // Current index should never be -1, but if if is, we don't want to crash
+        if (checkedItem == -1) {
+            checkedItem = 0;
+        }
+        builder.setSingleChoiceItems(R.array.post_settings_statuses, checkedItem, null);
         builder.setPositiveButton(R.string.dialog_button_ok, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int which) {
                 ListView lw = ((AlertDialog)dialog).getListView();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -383,6 +383,9 @@ public class EditPostSettingsFragment extends Fragment
         }
 
         updateStatusSpinner();
+        if (AppPrefs.isVisualEditorEnabled() || AppPrefs.isAztecEditorEnabled()) {
+            updateFeaturedImage(mPost.getFeaturedImageId());
+        }
     }
 
     private void updateTagsTextView() {
@@ -411,10 +414,6 @@ public class EditPostSettingsFragment extends Fragment
             case PRIVATE:
                 mStatusTextView.setText(statuses[3]);
                 break;
-        }
-
-        if (AppPrefs.isVisualEditorEnabled() || AppPrefs.isAztecEditorEnabled()) {
-            updateFeaturedImage(mPost.getFeaturedImageId());
         }
     }
 

--- a/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
+++ b/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
@@ -74,6 +74,25 @@
                 android:layout_height="wrap_content"
                 android:textColor="@color/grey_darken_10"
                 android:text="@string/not_set"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/post_status_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textColor="@color/grey_dark"
+                android:text="@string/post_format_status"/>
+
+            <TextView
+                android:id="@+id/post_status"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textColor="@color/grey_darken_10"/>
 
         </LinearLayout>
 

--- a/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
+++ b/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
@@ -86,7 +86,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:textColor="@color/grey_dark"
-                android:text="@string/status"/>
+                android:text="@string/post_settings_status"/>
 
             <TextView
                 android:id="@+id/post_status"

--- a/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
+++ b/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
@@ -103,13 +103,6 @@
             android:layout_height="wrap_content"
             android:text="@string/status" />
 
-        <Spinner
-            android:id="@+id/status"
-            android:paddingTop="@dimen/margin_small"
-            android:paddingBottom="@dimen/margin_small"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/pubDateLabel"
             style="@style/WordPressSubHeader"

--- a/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
+++ b/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
@@ -86,7 +86,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:textColor="@color/grey_dark"
-                android:text="@string/post_format_status"/>
+                android:text="@string/status"/>
 
             <TextView
                 android:id="@+id/post_status"
@@ -95,13 +95,6 @@
                 android:textColor="@color/grey_darken_10"/>
 
         </LinearLayout>
-
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/statusLabel"
-            style="@style/WordPressSubHeader"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/status" />
 
         <org.wordpress.android.widgets.WPTextView
             android:id="@+id/pubDateLabel"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -977,6 +977,12 @@
     <string name="post_slug_dialog_hint">The slug is the URL-friendly version of the post title.</string>
     <string name="editor_post_settings_featured_image">Featured Image</string>
     <string name="editor_post_settings_set_featured_image">Set Featured Image</string>
+    <string-array name="post_settings_statuses" translatable="false">
+        <item>@string/publish_post</item>
+        <item>@string/draft</item>
+        <item>@string/pending_review</item>
+        <item>@string/post_private</item>
+    </string-array>
 
 
     <!-- Post Formats -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -27,7 +27,6 @@
     <string name="password">Password</string>
     <string name="blogs">Blogs</string>
     <string name="account_details">Account details</string>
-    <string name="status">Status</string>
 
     <!-- comment form labels -->
     <string name="anonymous">Anonymous</string>
@@ -977,6 +976,7 @@
     <string name="post_slug_dialog_hint">The slug is the URL-friendly version of the post title.</string>
     <string name="editor_post_settings_featured_image">Featured Image</string>
     <string name="editor_post_settings_set_featured_image">Set Featured Image</string>
+    <string name="post_settings_status">Status</string>
     <string-array name="post_settings_statuses" translatable="false">
         <item>@string/publish_post</item>
         <item>@string/draft</item>


### PR DESCRIPTION
This PR is a part of changes to the Post Settings. The goal for the PR is just to remove the previous spinner and use the new dialog to update the status. The way the status is saved & retrieved is not the best right now, however, I am still in the process of figuring out how we want to save things locally and remotely and I'd rather make this change along with that. So long story short, please treat this PR as an intermediary change. Having said that, I am open to suggestions to better handle them, even if it won't happen in this PR.

To test:
* Go into Post Settings & change the status to play with different scenarios. (Notice that you can set a published post the Draft and go back to the post list, what should happen then and many more questions like this will be handled in the future PRs)

/cc @tonyr59h & @maxme (whoever can get to it sooner)
