### PR TITLE
Login rework: WPCOM login via password

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -23,6 +23,7 @@ import org.wordpress.android.ui.accounts.SignInActivity;
 import org.wordpress.android.ui.accounts.SignInDialogFragment;
 import org.wordpress.android.ui.accounts.SignInFragment;
 import org.wordpress.android.ui.accounts.login.LoginEmailFragment;
+import org.wordpress.android.ui.accounts.login.LoginEmailPasswordFragment;
 import org.wordpress.android.ui.accounts.login.LoginMagicLinkRequestFragment;
 import org.wordpress.android.ui.comments.CommentAdapter;
 import org.wordpress.android.ui.comments.CommentDetailFragment;
@@ -113,6 +114,7 @@ public interface AppComponent {
     void inject(LoginActivity object);
     void inject(LoginEmailFragment object);
     void inject(LoginMagicLinkRequestFragment object);
+    void inject(LoginEmailPasswordFragment object);
 
     void inject(StatsWidgetConfigureActivity object);
     void inject(StatsWidgetConfigureAdapter object);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -25,6 +25,7 @@ import org.wordpress.android.ui.accounts.LoginEpilogueActivity;
 import org.wordpress.android.ui.accounts.SignInActivity;
 import org.wordpress.android.ui.comments.CommentsActivity;
 import org.wordpress.android.ui.main.SitePickerActivity;
+import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.media.MediaBrowserActivity.MediaBrowserType;
 import org.wordpress.android.ui.media.WordPressMediaUtils;
@@ -58,6 +59,13 @@ import org.wordpress.passcodelock.AppLockManager;
 import java.util.ArrayList;
 
 public class ActivityLauncher {
+
+    public static void showMainActivityAndLoginEpilogue(Activity activity) {
+        Intent intent = new Intent(activity, WPMainActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        intent.putExtra(WPMainActivity.ARG_SHOW_LOGIN_EPILOGUE, true);
+        activity.startActivity(intent);
+    }
 
     public static void showSitePickerForResult(Activity activity, SiteModel site) {
         Intent intent = new Intent(activity, SitePickerActivity.class);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -8,7 +8,9 @@ import android.view.MenuItem;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.accounts.login.LoginEmailFragment;
+import org.wordpress.android.ui.accounts.login.LoginEmailPasswordFragment;
 import org.wordpress.android.ui.accounts.login.LoginListener;
 import org.wordpress.android.ui.accounts.login.LoginMagicLinkRequestFragment;
 import org.wordpress.android.ui.accounts.login.LoginMagicLinkSentFragment;
@@ -94,7 +96,19 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
 
     @Override
     public void usePasswordInstead(String email) {
-        ToastUtils.showToast(this, "Fall back to password is not implemented yet. Email: " + email);
+        LoginEmailPasswordFragment loginEmailPasswordFragment = LoginEmailPasswordFragment.newInstance(email);
+        slideInFragment(loginEmailPasswordFragment, true, LoginEmailFragment.TAG);
+    }
+
+    @Override
+    public void forgotPassword() {
+        ToastUtils.showToast(this, "Forgot password is not implemented yet");
+    }
+
+    @Override
+    public void loggedInViaPassword() {
+        ActivityLauncher.showMainActivityAndLoginEpilogue(this);
+        finish();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
@@ -312,6 +312,7 @@ public class LoginEmailFragment extends Fragment implements TextWatcher {
                     // email address is available on wpcom, so apparently the user can't login with that one.
                     showEmailError(R.string.email_not_registered_wpcom);
                 } else if (mLoginListener != null) {
+                    EditTextUtils.hideSoftInput(mEmailEditText);
                     mLoginListener.showMagicLinkRequestScreen(event.value);
                 }
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
@@ -183,7 +183,10 @@ public class LoginEmailPasswordFragment extends Fragment implements TextWatcher 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.help) {
-            mLoginListener.help();
+            if (mLoginListener != null) {
+                mLoginListener.help();
+            }
+
             return true;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
@@ -1,0 +1,283 @@
+package org.wordpress.android.ui.accounts.login;
+
+import android.app.ProgressDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.design.widget.TextInputLayout;
+import android.support.v4.app.Fragment;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.KeyEvent;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
+import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.NetworkUtils;
+
+import javax.inject.Inject;
+
+public class LoginEmailPasswordFragment extends Fragment implements TextWatcher {
+    private static final String KEY_IN_PROGRESS = "KEY_IN_PROGRESS";
+
+    private static final String ARG_EMAIL_ADDRESS = "ARG_EMAIL_ADDRESS";
+
+    public static final String TAG = "login_email_password_fragment_tag";
+
+    private TextInputLayout mPasswordEditTextLayout;
+    private EditText mPasswordEditText;
+    private Button mNextButton;
+    private ProgressDialog mProgressDialog;
+
+    private LoginListener mLoginListener;
+
+    private boolean mInProgress;
+
+    private String mEmailAddress;
+
+    @Inject Dispatcher mDispatcher;
+
+    public static LoginEmailPasswordFragment newInstance(String emailAddress) {
+        LoginEmailPasswordFragment fragment = new LoginEmailPasswordFragment();
+        Bundle args = new Bundle();
+        args.putString(ARG_EMAIL_ADDRESS, emailAddress);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ((WordPress) getActivity().getApplication()).component().inject(this);
+
+        mEmailAddress = getArguments().getString(ARG_EMAIL_ADDRESS);
+
+        setHasOptionsMenu(true);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.login_email_password_screen, container, false);
+
+        ((TextView) rootView.findViewById(R.id.login_email)).setText(mEmailAddress);
+
+        mPasswordEditText = (EditText) rootView.findViewById(R.id.login_password);
+        mPasswordEditText.addTextChangedListener(this);
+        mPasswordEditTextLayout = (TextInputLayout) rootView.findViewById(R.id.login_password_layout);
+        mPasswordEditText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+            @Override
+            public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+                if (event != null
+                        && event.getAction() == KeyEvent.ACTION_UP
+                        && event.getKeyCode() == KeyEvent.KEYCODE_ENTER) {
+                    next();
+                }
+
+                // always consume the event so the focus stays in the EditText
+                return true;
+            }
+        });
+
+        mNextButton = (Button) rootView.findViewById(R.id.login_email_password_next_button);
+        mNextButton.setOnClickListener(new OnClickListener() {
+            public void onClick(View v) {
+                next();
+            }
+        });
+
+        rootView.findViewById(R.id.login_lost_password).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (mLoginListener != null) {
+                    mLoginListener.forgotPassword();
+                }
+            }
+        });
+
+        return rootView;
+    }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        Toolbar toolbar = (Toolbar) view.findViewById(R.id.toolbar);
+        ((AppCompatActivity) getActivity()).setSupportActionBar(toolbar);
+
+        ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayShowTitleEnabled(false);
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+    }
+
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        if (savedInstanceState != null) {
+            mInProgress = savedInstanceState.getBoolean(KEY_IN_PROGRESS);
+
+            if (mInProgress) {
+                showProgressDialog();
+            }
+        }
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        if (context instanceof LoginListener) {
+            mLoginListener = (LoginListener) context;
+        } else {
+            throw new RuntimeException(context.toString() + " must implement LoginListener");
+        }
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        mLoginListener = null;
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        outState.putBoolean(KEY_IN_PROGRESS, mInProgress);
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.menu_login, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.help) {
+            mLoginListener.help();
+            return true;
+        }
+
+        return false;
+    }
+
+    protected void next() {
+        if (!NetworkUtils.checkConnection(getActivity())) {
+            return;
+        }
+
+        showProgressDialog();
+
+        String password = mPasswordEditText.getText().toString();
+
+        AccountStore.AuthenticatePayload payload = new AccountStore.AuthenticatePayload(mEmailAddress, password);
+        mDispatcher.dispatch(AuthenticationActionBuilder.newAuthenticateAction(payload));
+    }
+
+    @Override
+    public void afterTextChanged(Editable s) {
+    }
+
+    @Override
+    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+    }
+
+    @Override
+    public void onTextChanged(CharSequence s, int start, int before, int count) {
+        updateNextButton();
+        mPasswordEditTextLayout.setError(null);
+    }
+
+    private void updateNextButton() {
+        mNextButton.setEnabled(mPasswordEditText.getText().length() > 0);
+    }
+
+    private void showPasswordError() {
+        mPasswordEditTextLayout.setError(getString(R.string.password_incorrect));
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        mDispatcher.register(this);
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        mDispatcher.unregister(this);
+    }
+
+    private void showProgressDialog() {
+        mNextButton.setEnabled(false);
+        mProgressDialog =
+                ProgressDialog.show(getActivity(), "", getActivity().getString(R.string.logging_in), true, true,
+                        new DialogInterface.OnCancelListener() {
+                            @Override
+                            public void onCancel(DialogInterface dialogInterface) {
+                                if (mInProgress) {
+                                    endProgress();
+                                }
+                            }
+                        });
+        mInProgress = true;
+    }
+
+    private void endProgress() {
+        mInProgress = false;
+
+        if (mProgressDialog != null) {
+            mProgressDialog.cancel();
+            mProgressDialog = null;
+        }
+
+        updateNextButton();
+    }
+
+    // OnChanged events
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onAuthenticationChanged(OnAuthenticationChanged event) {
+        endProgress();
+
+        if (event.isError()) {
+            AppLog.e(T.API, "onAuthenticationChanged has error: " + event.error.type + " - " + event.error.message);
+
+            if (isAdded()) {
+                showPasswordError();
+            }
+
+            return;
+        }
+
+        AppLog.i(T.NUX, "onAuthenticationChanged: " + event.toString());
+
+        if (mLoginListener != null) {
+            mLoginListener.loggedInViaPassword();
+        }
+    }
+
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
@@ -35,6 +35,7 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 
@@ -131,6 +132,10 @@ public class LoginEmailPasswordFragment extends Fragment implements TextWatcher 
         if (actionBar != null) {
             actionBar.setDisplayShowTitleEnabled(false);
             actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+
+        if (savedInstanceState == null) {
+            EditTextUtils.showSoftInput(mPasswordEditText);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
@@ -12,9 +12,13 @@ public interface LoginListener {
     // Login Request Magic Link callbacks
     void showMagicLinkSentScreen(String email);
     void usePasswordInstead(String email);
+    void forgotPassword();
 
     // Login Magic Link Sent callbacks
     void openEmailClient();
+
+    // Login email password callbacks
+    void loggedInViaPassword();
 
     // Login Site Address input callbacks
     void gotSiteAddress(String siteAddress);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -83,6 +83,7 @@ import de.greenrobot.event.EventBus;
  */
 public class WPMainActivity extends AppCompatActivity {
     public static final String ARG_OPENED_FROM_PUSH = "opened_from_push";
+    public static final String ARG_SHOW_LOGIN_EPILOGUE = "show_login_epilogue";
 
     private WPViewPager mViewPager;
     private WPMainTabLayout mTabLayout;
@@ -268,6 +269,8 @@ public class WPMainActivity extends AppCompatActivity {
             // Save Token to the AccountStore. This will trigger a onAuthenticationChanged.
             AccountStore.UpdateTokenPayload payload = new AccountStore.UpdateTokenPayload(authTokenToSet);
             mDispatcher.dispatch(AccountActionBuilder.newUpdateAccessTokenAction(payload));
+        } else if (getIntent().getBooleanExtra(ARG_SHOW_LOGIN_EPILOGUE, false)) {
+            ActivityLauncher.showLoginEpilogue(this);
         }
     }
 

--- a/WordPress/src/main/res/drawable/ic_lock_grey_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_lock_grey_24dp.xml
@@ -1,0 +1,13 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:fillColor="@color/grey"
+        android:pathData="M18,8h-1V7c0,-2.757 -2.243,-5 -5,-5S7,4.243 7,7v1H6c-1.105,0 -2,0.895 -2,2v10c0,1.105 0.895,2 2,2h12c1.105,0 2,-0.895 2,-2V10C20,8.895 19.105,8 18,8zM9,7c0,-1.654 1.346,-3 3,-3s3,1.346 3,3v1H9V7zM13,15.723V18h-2v-2.277c-0.595,-0.346 -1,-0.984 -1,-1.723c0,-1.105 0.895,-2 2,-2s2,0.895 2,2C14,14.738 13.595,15.376 13,15.723z" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/layout/login_email_password_screen.xml
+++ b/WordPress/src/main/res/layout/login_email_password_screen.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include
+        android:id="@+id/toolbar"
+        layout="@layout/toolbar_login" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@+id/toolbar"
+        android:fillViewport="true">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/margin_extra_large">
+
+            <TextView
+                style="@style/Base.TextAppearance.AppCompat.Body1"
+                android:id="@+id/label"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_extra_extra_large"
+                android:text="@string/enter_wpcom_password" />
+
+            <TableLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/label"
+                android:layout_marginTop="@dimen/margin_extra_large">
+
+                <TableRow
+                    android:gravity="center_vertical">
+
+                    <ImageView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        app:srcCompat="@drawable/ic_user_grey_24dp"/>
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:layout_weight="1"
+                        android:layout_marginLeft="@dimen/margin_extra_large">
+
+                        <TextView
+                            style="@style/TextAppearance.Design.Hint"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="@string/email_address"/>
+
+                        <TextView
+                            style="@style/Base.TextAppearance.AppCompat.Body1"
+                            android:id="@+id/login_email"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            tools:text="s@b.com"/>
+                    </LinearLayout>
+                </TableRow>
+
+                <TableRow
+                    android:gravity="center_vertical"
+                    android:layout_marginTop="@dimen/margin_extra_large">
+
+                    <ImageView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        app:srcCompat="@drawable/ic_lock_grey_24dp"/>
+
+                    <android.support.design.widget.TextInputLayout
+                        app:theme="@style/LoginTheme.EditText"
+                        android:id="@+id/login_password_layout"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        app:passwordToggleEnabled="true"
+                        app:passwordToggleTint="@color/wp_grey"
+                        android:layout_marginLeft="@dimen/margin_extra_large">
+
+                        <android.support.design.widget.TextInputEditText
+                            android:id="@+id/login_password"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:hint="@string/password"
+                            android:inputType="textPassword"/>
+                    </android.support.design.widget.TextInputLayout>
+                </TableRow>
+            </TableLayout>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentBottom="true">
+
+                <Button
+                    android:theme="@style/LoginTheme.Button"
+                    style="@style/Widget.AppCompat.Button.Colored"
+                    android:id="@+id/login_email_password_next_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_centerVertical="true"
+                    android:layout_alignParentRight="true"
+                    android:enabled="false"
+                    android:text="@string/next" />
+
+                <TextView
+                    android:id="@+id/login_lost_password"
+                    style="@style/Base.TextAppearance.AppCompat.Caption"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_toLeftOf="@+id/login_email_next_button"
+                    android:layout_marginRight="@dimen/margin_extra_extra_extra_large"
+                    android:layout_centerVertical="true"
+                    android:layout_alignParentLeft="true"
+                    android:textColor="@color/blue_wordpress"
+                    android:text="@string/forgot_password"/>
+            </RelativeLayout>
+        </RelativeLayout>
+    </ScrollView>
+</RelativeLayout>

--- a/WordPress/src/main/res/layout/login_email_password_screen.xml
+++ b/WordPress/src/main/res/layout/login_email_password_screen.xml
@@ -65,12 +65,12 @@
                 </TableRow>
 
                 <TableRow
-                    android:gravity="center_vertical"
                     android:layout_marginTop="@dimen/margin_extra_large">
 
                     <ImageView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:layout_marginTop="24dp"
                         app:srcCompat="@drawable/ic_lock_grey_24dp"/>
 
                     <android.support.design.widget.TextInputLayout

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1696,14 +1696,15 @@
     <string name="enter_username_password_instead">Log in to your site by entering your site address instead.</string>
     <string name="enter_the_address_of_your_wordpress_site">Enter the address of your WordPress site</string>
     <string name="email_not_registered_wpcom">This email is not registered on WordPress.com</string>
+    <string name="password_incorrect">It looks like this password is incorrect. Please double check your information and try again.</string>
     <string name="login_error_while_checking_email">An error occurred while checking the email address!</string>
     <string name="login_magic_links_label">We\'ll email you a magic link that\'ll log you in instantly, no password needed. Hunt and peck no more!</string>
     <string name="login_magic_links_sent_label">Your magic link is on its way! Check your email on this device and tap the link in the email you received from WordPress.com.</string>
     <string name="login_magic_links_sent_description">Magic link sent illustration</string>
     <string name="login_magic_link_email_requesting">Requesting log-in email</string>
+    <string name="enter_wpcom_password">Enter your WordPress.com password.</string>
     <string name="connect_more">Connect Another Site</string>
     <string name="login_continue">Continue</string>
     <string name="login_already_logged_in_wpcom">Already logged in to WordPress.com</string>
     <string name="login_username_at">\@%s</string>
-
 </resources>


### PR DESCRIPTION
This PR introduces the password entry screen for logging in to WordPress.com with an email+password combo.

2FA is not implemented yet and will be added with a future PR.

The final visual touches, the messages and final texts will be done in a future PR.

To test:
* With the app logged out or data cleaned up, run the app
* Tap "LOG IN" on the prologue screen
* Input a valid WPCOM email that doesn't correspond to a 2FA-enabled account
* Hit "NEXT"
* Tap on the "Enter your password instead" link on the next screen
* Input an invalid password. Feel free to test out the "reveal password" button while at it.
* Hit "NEXT" and notice the "It looks like this password is incorrect..." message be displayed
* Put in the correct password this time and hit "NEXT"
* Notice the epilogue screen coming up and your sites be listed in it.
* Hit back or "CONTINUE" to enter the main app
