### PR TITLE
Moved static xml creation of PostsListFragment to code

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
@@ -63,11 +63,13 @@ public class PostsListActivity extends AppCompatActivity {
             return;
         }
 
-        mPostList = PostsListFragment.newInstance(mSite);
-
-        FragmentTransaction fragmentTransaction = getFragmentManager().beginTransaction();
-        fragmentTransaction.replace(R.id.post_list_container, mPostList);
-        fragmentTransaction.commit();
+        mPostList = (PostsListFragment) getFragmentManager().findFragmentByTag(PostsListFragment.TAG);
+        if (mPostList == null) {
+            mPostList = PostsListFragment.newInstance(mSite);
+            getFragmentManager().beginTransaction()
+                    .add(R.id.post_list_container, mPostList, PostsListFragment.TAG)
+                    .commit();
+        }
 
         showErrorDialogIfNeeded(getIntent().getExtras());
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
@@ -1,7 +1,9 @@
 package org.wordpress.android.ui.posts;
 
 import android.app.AlertDialog;
+import android.app.Fragment;
 import android.app.FragmentManager;
+import android.app.FragmentTransaction;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
@@ -49,7 +51,6 @@ public class PostsListActivity extends AppCompatActivity {
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
 
-        FragmentManager fm = getFragmentManager();
         if (savedInstanceState == null) {
             mSite = (SiteModel) getIntent().getSerializableExtra(WordPress.SITE);
         } else {
@@ -62,7 +63,12 @@ public class PostsListActivity extends AppCompatActivity {
             return;
         }
 
-        mPostList = (PostsListFragment) fm.findFragmentById(R.id.postList);
+        mPostList = PostsListFragment.newInstance(mSite);
+
+        FragmentTransaction fragmentTransaction = getFragmentManager().beginTransaction();
+        fragmentTransaction.replace(R.id.post_list_container, mPostList);
+        fragmentTransaction.commit();
+
         showErrorDialogIfNeeded(getIntent().getExtras());
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -68,6 +68,7 @@ public class PostsListFragment extends Fragment
         PostsListAdapter.OnPostButtonClickListener {
 
     public static final int POSTS_REQUEST_COUNT = 20;
+    public static final String TAG = "posts_list_fragment_tag";
 
     private SwipeToRefreshHelper mSwipeToRefreshHelper;
     private PostsListAdapter mPostsListAdapter;

--- a/WordPress/src/main/res/layout/post_list_activity.xml
+++ b/WordPress/src/main/res/layout/post_list_activity.xml
@@ -8,10 +8,8 @@
         android:id="@+id/toolbar"
         layout="@layout/toolbar" />
 
-    <fragment
-        android:id="@+id/postList"
-        android:name="org.wordpress.android.ui.posts.PostsListFragment"
+    <FrameLayout
+        android:id="@+id/post_list_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-
+        android:layout_height="match_parent"/>
 </LinearLayout>


### PR DESCRIPTION
This PR attempts to fix #5796 (NPE upon `PostsListFragment` creation as the `SiteModel` is null) by making sure the `PostsListFragment` fragment is created through its `newInstance` method and passing the `SiteModel` as a serializable argument.

The way it was being handled was by static xml reference in `post_list_activity.xml`, which could lead to potentially having a situation where the `PostsListActivity` activity's intent extras would still not be present by the time they were needed in `PostsListFragment` (probably after a configuration change?).

