### PR TITLE
Aztec version 1.0-beta.1

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile 'com.android.support:design:25.3.1'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.16.0'
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.0-beta')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.0-beta.1')
 }
 
 signing {


### PR DESCRIPTION
A new [Aztec release](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.0-beta.1) integration.