### PR TITLE
Fix Share to media library crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -209,6 +209,7 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
         intent.putExtra(WordPress.SITE, mSiteStore.getSiteByLocalId(mSelectedSiteLocalId));
+        intent.putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, MediaBrowserActivity.MediaBrowserType.BROWSER);
 
         intent.putExtra(Intent.EXTRA_TEXT, getIntent().getStringExtra(Intent.EXTRA_TEXT));
         intent.putExtra(Intent.EXTRA_SUBJECT, getIntent().getStringExtra(Intent.EXTRA_SUBJECT));

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -154,6 +154,12 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             return;
         }
 
+        if (mBrowserType == null) {
+            // default to browser mode if missing type
+            AppLog.w(AppLog.T.MEDIA, "MediaBrowserType is null. Defaulting to MediaBrowserType.BROWSER mode.");
+            mBrowserType = MediaBrowserType.BROWSER;
+        }
+
         setContentView(R.layout.media_browser_activity);
 
         mToolbar = (Toolbar) findViewById(R.id.toolbar);


### PR DESCRIPTION
The parameter MediaBrowserType was not passed when sharing to MediaLibrary resulting in a crash of the app

To test: 
- Open Gallery
- Share to WordPress Media Library
- The app should not crash
