### PR TITLE
Login rework: 2FA screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -22,6 +22,7 @@ import org.wordpress.android.ui.accounts.NewUserFragment;
 import org.wordpress.android.ui.accounts.SignInActivity;
 import org.wordpress.android.ui.accounts.SignInDialogFragment;
 import org.wordpress.android.ui.accounts.SignInFragment;
+import org.wordpress.android.ui.accounts.login.Login2FaFragment;
 import org.wordpress.android.ui.accounts.login.LoginEmailFragment;
 import org.wordpress.android.ui.accounts.login.LoginEmailPasswordFragment;
 import org.wordpress.android.ui.accounts.login.LoginMagicLinkRequestFragment;
@@ -115,6 +116,7 @@ public interface AppComponent {
     void inject(LoginEmailFragment object);
     void inject(LoginMagicLinkRequestFragment object);
     void inject(LoginEmailPasswordFragment object);
+    void inject(Login2FaFragment object);
 
     void inject(StatsWidgetConfigureActivity object);
     void inject(StatsWidgetConfigureAdapter object);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -9,6 +9,7 @@ import android.view.MenuItem;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.ui.ActivityLauncher;
+import org.wordpress.android.ui.accounts.login.Login2FaFragment;
 import org.wordpress.android.ui.accounts.login.LoginEmailFragment;
 import org.wordpress.android.ui.accounts.login.LoginEmailPasswordFragment;
 import org.wordpress.android.ui.accounts.login.LoginListener;
@@ -114,6 +115,12 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
     @Override
     public void forgotPassword() {
         ToastUtils.showToast(this, "Forgot password is not implemented yet");
+    }
+
+    @Override
+    public void needs2fa(String email, String password) {
+        Login2FaFragment login2FaFragment = Login2FaFragment.newInstance(email, password);
+        slideInFragment(login2FaFragment, true, Login2FaFragment.TAG);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
@@ -19,6 +19,7 @@ public interface LoginListener {
     void openEmailClient();
 
     // Login email password callbacks
+    void needs2fa(String email, String password);
     void loggedInViaPassword();
 
     // Login Site Address input callbacks

--- a/WordPress/src/main/res/layout/login_2fa_screen.xml
+++ b/WordPress/src/main/res/layout/login_2fa_screen.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">

--- a/WordPress/src/main/res/layout/login_2fa_screen.xml
+++ b/WordPress/src/main/res/layout/login_2fa_screen.xml
@@ -64,10 +64,12 @@
                     style="@style/Base.TextAppearance.AppCompat.Caption"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:minHeight="48dp"
                     android:layout_toLeftOf="@+id/login_email_next_button"
                     android:layout_marginRight="@dimen/margin_extra_extra_extra_large"
                     android:layout_centerVertical="true"
                     android:layout_alignParentLeft="true"
+                    android:gravity="center_vertical"
                     android:textColor="@color/blue_wordpress"
                     android:text="@string/login_text_otp"/>
             </RelativeLayout>

--- a/WordPress/src/main/res/layout/login_2fa_screen.xml
+++ b/WordPress/src/main/res/layout/login_2fa_screen.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include
+        android:id="@+id/toolbar"
+        layout="@layout/toolbar_login" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@+id/toolbar"
+        android:fillViewport="true"
+        android:padding="@dimen/margin_extra_large">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                style="@style/Base.TextAppearance.AppCompat.Body1"
+                android:id="@+id/label"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_extra_extra_large"
+                android:text="@string/enter_verification_code" />
+
+            <android.support.design.widget.TextInputLayout
+                app:theme="@style/LoginTheme.EditText"
+                android:id="@+id/login_2fa_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/label"
+                android:layout_marginTop="@dimen/margin_extra_large">
+
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/login_2fa"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/verification_code"/>
+            </android.support.design.widget.TextInputLayout>
+
+            <RelativeLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentBottom="true">
+
+                <Button
+                    android:theme="@style/LoginTheme.Button"
+                    style="@style/Widget.AppCompat.Button.Colored"
+                    android:id="@+id/login_2fa_next_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_centerVertical="true"
+                    android:layout_alignParentRight="true"
+                    android:enabled="false"
+                    android:text="@string/next" />
+
+                <TextView
+                    android:id="@+id/login_text_otp"
+                    style="@style/Base.TextAppearance.AppCompat.Caption"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_toLeftOf="@+id/login_email_next_button"
+                    android:layout_marginRight="@dimen/margin_extra_extra_extra_large"
+                    android:layout_centerVertical="true"
+                    android:layout_alignParentLeft="true"
+                    android:textColor="@color/blue_wordpress"
+                    android:text="@string/login_text_otp"/>
+            </RelativeLayout>
+        </RelativeLayout>
+    </ScrollView>
+</RelativeLayout>

--- a/WordPress/src/main/res/layout/login_2fa_screen.xml
+++ b/WordPress/src/main/res/layout/login_2fa_screen.xml
@@ -63,7 +63,7 @@
                     style="@style/Base.TextAppearance.AppCompat.Caption"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:minHeight="48dp"
+                    android:minHeight="@dimen/min_touch_target_sz"
                     android:layout_toLeftOf="@+id/login_email_next_button"
                     android:layout_marginRight="@dimen/margin_extra_extra_extra_large"
                     android:layout_centerVertical="true"

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <dimen name="min_touch_target_sz">48dp</dimen>
+
     <dimen name="settings_padding">16dp</dimen>
     <dimen name="category_row_height">60dp</dimen>
     <dimen name="category_parent_spinner_row_height">40dp</dimen>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1699,6 +1699,9 @@
     <string name="open_mail">Open mail</string>
     <string name="enter_username_password_instead">Log in to your site by entering your site address instead.</string>
     <string name="enter_the_address_of_your_wordpress_site">Enter the address of your WordPress site</string>
+    <string name="enter_verification_code">Almost there! Please enter the verification code from your Authenticator app.</string>
+    <string name="login_text_otp">Text a code instead.</string>
+    <string name="requesting_otp">Requesting a verification code via SMS.</string>
     <string name="email_not_registered_wpcom">This email is not registered on WordPress.com</string>
     <string name="password_incorrect">It looks like this password is incorrect. Please double check your information and try again.</string>
     <string name="login_error_while_checking_email">An error occurred while checking the email address!</string>


### PR DESCRIPTION
This PR introduces the 2FA verification code input screen for logging in to WordPress.com with an email+password combo.

The final visual touches, the messages and final texts will be done in a future PR.

To test:
* Try to login with an wpcom account that has 2FA enabled. Go through the "Login" screen, then input your email and hit Next.
* Tap on the "Enter your password instead" option
* Enter your password and hit Next
* The Verification code screen should come up. Put in a code from your Authenticator app or the SMS if one has already arrived. You might want to test out the "Text a code instead." action as well, to trigger an SMS request on the spot.
* After a successful code is inputted, the login epilogue screen should come up and your sites list visible in it