### PR TITLE
Users that lack 'publish' capability can't post with the app

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1032,6 +1032,12 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         @Override
         protected Void doInBackground(Void... params) {
 
+            if (!mSite.getHasCapabilityPublishPosts()) {
+               if (PostStatus.fromPost(mPost) != PostStatus.DRAFT && PostStatus.fromPost(mPost) != PostStatus.PENDING) {
+                   mPost.setStatus(PostStatus.PENDING.toString());
+               }
+            }
+
             PostUtils.trackSavePostAnalytics(mPost, mSiteStore.getSiteByLocalId(mPost.getLocalSiteId()));
 
             if (isFirstTimePublish) {


### PR DESCRIPTION
Fixes #6011 by checking the status of the post before sending it to the blog.

We should probably improve this by disabling/enabling items in the post status spinner in a future.

**Test**
- Add a user as Contributor to a blog, and publish with the app. The new post should end up on the blog with the "pending" status.
- Try to modify the status to something != draft or pending. The app should switch it back to pending.

cc @tonyr59h who worked on this https://github.com/wordpress-mobile/WordPress-Android/pull/5430