### PR TITLE
Login rework: Password reset jump

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.accounts.login.LoginPrologueFragment;
 import org.wordpress.android.util.ToastUtils;
 
 public class LoginActivity extends AppCompatActivity implements LoginListener {
+    private static final String FORGOT_PASSWORD_URL = "https://wordpress.com/wp-login.php?action=lostpassword";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -113,7 +114,7 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
 
     @Override
     public void forgotPassword() {
-        ToastUtils.showToast(this, "Forgot password is not implemented yet");
+        ActivityLauncher.openUrlExternal(this, FORGOT_PASSWORD_URL);
     }
 
     @Override


### PR DESCRIPTION
The PR introduces the jump to external browser to perform the password reset procedure.

The final visual touches, the messages and final texts will be done in a future PR.

To test:
* With the app logged out or its data cleaned, launch the app and hit "Login"
* Input your wpcom account email address and hit Next
* Hit the "Enter your password instead" action instead of the "SEND LINK"
* Tap on the "Lost your password?" action on the password screen
* Notice the external browser coming up, pointing to WordPress.com and offering the guide about how to change your password. That's all, no need to change your password or anything else.