### PR TITLE
issue/5981-captured-photo-not-in-device-gallery

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -265,6 +265,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                 break;
             case RequestCodes.TAKE_PHOTO:
                 if (resultCode == Activity.RESULT_OK) {
+                    WordPressMediaUtils.scanMediaFile(this, mMediaCapturePath);
                     Uri uri = getOptimizedPictureIfNecessary(Uri.parse(mMediaCapturePath));
                     mMediaCapturePath = null;
                     queueFileForUpload(uri, getContentResolver().getType(uri));

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
@@ -6,9 +6,11 @@ import android.app.Fragment;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.media.MediaScannerConnection;
 import android.net.Uri;
 import android.os.Environment;
 import android.provider.MediaStore;
+import android.support.annotation.NonNull;
 import android.support.v4.content.FileProvider;
 
 import com.android.volley.toolbox.ImageLoader;
@@ -273,5 +275,20 @@ public class WordPressMediaUtils {
         }
 
         return posterUrl;
+    }
+
+    /*
+     * passes a newly-created media file to the media scanner service so it's available to
+     * the media content provider - use this after capturing or downloading media to ensure
+     * that it appears in the stock Gallery app
+     */
+    public static void scanMediaFile(@NonNull Context context, @NonNull String localMediaPath) {
+        MediaScannerConnection.scanFile(context,
+                new String[]{localMediaPath}, null,
+                new MediaScannerConnection.OnScanCompletedListener() {
+                    public void onScanCompleted(String path, Uri uri) {
+                        AppLog.d(T.MEDIA, "Media scanner finished scanning " + path);
+                    }
+                });
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -139,6 +139,7 @@ public class PhotoPickerActivity extends AppCompatActivity
             // user took a photo with the device camera
             case RequestCodes.TAKE_PHOTO:
                 try {
+                    WordPressMediaUtils.scanMediaFile(this, mMediaCapturePath);
                     File f = new File(mMediaCapturePath);
                     Uri capturedImageUri = Uri.fromFile(f);
                     mediaSelected(capturedImageUri, PhotoPickerMediaSource.ANDROID_CAMERA);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1844,6 +1844,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                     break;
                 case RequestCodes.TAKE_PHOTO:
                     try {
+                        WordPressMediaUtils.scanMediaFile(this, mMediaCapturePath);
                         File f = new File(mMediaCapturePath);
                         Uri capturedImageUri = Uri.fromFile(f);
                         if (!addMedia(capturedImageUri)) {


### PR DESCRIPTION
Fixes #5981 - previously, when a photo was captured and added to the WP media library, it wouldn't appear in the device's stock Gallery app. This PR addresses this by using [MediaScannerConnection](https://developer.android.com/reference/android/media/MediaScannerConnection.html) to add the captured photo to the media provider after ~~upload~~ capture completes.

To test:

* Tap Media on the My Sites page
* Tap the plus icon
* Select Take Photo
* Capture a photo and wait for it to upload
* Check the stock Gallery app and ensure it appears there

Note that you should be sure to check the Gallery app rather than Google Photos, since Google Photos was somehow smart enough to automatically add the captured photo prior to this PR.