### PR TITLE
Fix auto-select of action in Share dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -47,6 +47,9 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
 
     public static final int SHARE_MEDIA_PERMISSION_REQUEST_CODE = 1;
 
+    private static final int ADD_TO_NEW_POST = 0;
+    private static final int ADD_TO_MEDIA_LIBRARY = 1;
+
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
 
@@ -157,6 +160,20 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
             ToastUtils.showToast(getBaseContext(), R.string.cant_share_no_visible_blog, ToastUtils.Duration.LONG);
             finish();
         }
+    }
+
+    private int getActionIndex(int actionId) {
+        if (actionId == R.id.media_library_share_action) {
+            return ADD_TO_MEDIA_LIBRARY;
+        }
+        return ADD_TO_NEW_POST;
+    }
+
+    private int getActionId(int actionIndex) {
+        if (actionIndex == ADD_TO_MEDIA_LIBRARY) {
+            return R.id.media_library_share_action;
+        }
+        return R.id.new_post_share_action;
     }
 
     private int getPositionBySiteId(long localBlogId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -58,7 +58,7 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
     private String mSiteNames[];
     private int mSiteIds[];
     private int mSelectedSiteLocalId;
-    private int mActionId;
+    private int mActionIndex;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -91,7 +91,7 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
 
         // If type is text/plain hide Media Gallery option
         if (isSharingText()) {
-            mActionId = R.id.new_post_share_action;
+            mActionIndex = ADD_TO_NEW_POST;
             mActionGroup.setVisibility(View.GONE);
             findViewById(R.id.action_spinner_title).setVisibility(View.GONE);
             // if text/plain and only one blog, then don't show this fragment, share it directly to a new post
@@ -103,7 +103,7 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
             mActionGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
                 @Override
                 public void onCheckedChanged(RadioGroup group, @IdRes int checkedId) {
-                    mActionId = checkedId;
+                    mActionIndex = getActionIndex(checkedId);
                 }
             });
         }
@@ -194,8 +194,8 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
                 mBlogSpinner.setSelection(position);
             }
         }
-        mActionId = settings.getInt(SHARE_LAST_USED_ADDTO_KEY, R.id.new_post_share_action);
-        mActionGroup.check(mActionId);
+        mActionIndex = settings.getInt(SHARE_LAST_USED_ADDTO_KEY, ADD_TO_NEW_POST);
+        mActionGroup.check(getActionId(mActionIndex));
     }
 
     private boolean isSharingText() {
@@ -243,7 +243,7 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
         PreferenceManager.getDefaultSharedPreferences(this)
                 .edit()
                 .putInt(SHARE_LAST_USED_BLOG_ID_KEY, mSelectedSiteLocalId)
-                .putInt(SHARE_LAST_USED_ADDTO_KEY, mActionId)
+                .putInt(SHARE_LAST_USED_ADDTO_KEY, mActionIndex)
                 .apply();
 
         startActivity(intent);
@@ -261,9 +261,9 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
             }
         }
 
-        if (mActionId == R.id.new_post_share_action) {
+        if (mActionIndex == ADD_TO_NEW_POST) {
             startActivityAndFinish(new Intent(this, EditPostActivity.class));
-        } else if (mActionId == R.id.media_library_share_action) {
+        } else if (mActionIndex == ADD_TO_MEDIA_LIBRARY) {
             startActivityAndFinish(new Intent(this, MediaBrowserActivity.class));
         } else {
             ToastUtils.showToast(this, R.string.cant_share_unknown_action);


### PR DESCRIPTION
Fixes #6017. Rather than storing the resource ID of the share action RadioButton we'll use the index of the last selected action.

To test:
1. Install a clean beta or release build of the app
2. Share a photo to the app
3. Notice "New post" is pre-selected
4. Complete the share, adding the photo to either a new post or the media library
5. Without uninstalling or clearing data, install the build from this branch
6. Share a photo to the app

cc @aforcier 