### PR TITLE
Posts section loading posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
@@ -65,7 +65,7 @@ public class PostsListActivity extends AppCompatActivity {
 
         mPostList = (PostsListFragment) getFragmentManager().findFragmentByTag(PostsListFragment.TAG);
         if (mPostList == null) {
-            mPostList = PostsListFragment.newInstance(mSite);
+            mPostList = PostsListFragment.newInstance(mSite, mIsPage);
             getFragmentManager().beginTransaction()
                     .add(R.id.post_list_container, mPostList, PostsListFragment.TAG)
                     .commit();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
@@ -1,9 +1,6 @@
 package org.wordpress.android.ui.posts;
 
 import android.app.AlertDialog;
-import android.app.Fragment;
-import android.app.FragmentManager;
-import android.app.FragmentTransaction;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -133,6 +133,7 @@ public class PostsListFragment extends Fragment
             }
         } else {
             mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
+            mIsPage = savedInstanceState.getBoolean(PostsListActivity.EXTRA_VIEW_PAGES);
         }
 
         if (mSite == null) {
@@ -609,6 +610,7 @@ public class PostsListFragment extends Fragment
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putSerializable(WordPress.SITE, mSite);
+        outState.putSerializable(PostsListActivity.EXTRA_VIEW_PAGES, mIsPage);
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -94,10 +94,11 @@ public class PostsListFragment extends Fragment
     @Inject PostStore mPostStore;
     @Inject Dispatcher mDispatcher;
 
-    public static PostsListFragment newInstance(SiteModel site) {
+    public static PostsListFragment newInstance(SiteModel site, boolean isPage) {
         PostsListFragment fragment = new PostsListFragment();
         Bundle bundle = new Bundle();
         bundle.putSerializable(WordPress.SITE, site);
+        bundle.putBoolean(PostsListActivity.EXTRA_VIEW_PAGES, isPage);
         fragment.setArguments(bundle);
         return fragment;
     }
@@ -111,13 +112,6 @@ public class PostsListFragment extends Fragment
         mDispatcher.register(this);
 
         updateSiteOrFinishActivity(savedInstanceState);
-
-        if (isAdded()) {
-            Bundle extras = getActivity().getIntent().getExtras();
-            if (extras != null) {
-                mIsPage = extras.getBoolean(PostsListActivity.EXTRA_VIEW_PAGES);
-            }
-        }
     }
 
     @Override
@@ -132,8 +126,10 @@ public class PostsListFragment extends Fragment
         if (savedInstanceState == null) {
             if (getArguments() != null) {
                 mSite = (SiteModel) getArguments().getSerializable(WordPress.SITE);
+                mIsPage = getArguments().getBoolean(PostsListActivity.EXTRA_VIEW_PAGES);
             } else {
                 mSite = (SiteModel) getActivity().getIntent().getSerializableExtra(WordPress.SITE);
+                mIsPage = getActivity().getIntent().getBooleanExtra(PostsListActivity.EXTRA_VIEW_PAGES, false);
             }
         } else {
             mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);


### PR DESCRIPTION
Fixes #6027. https://github.com/wordpress-mobile/WordPress-Android/pull/6007 refactored the way the post/page list fragment was instantiated, and it seems that on Android 7.0 devices [`isAdded()` is false here](https://github.com/wordpress-mobile/WordPress-Android/blob/c16be14a4f6932d27e25f1a688b615d9d9063bda/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java#L115), and we never set `mIsPages`.

To test:
1. On an Android 7.0+ device, open the page list
2. Observe pages
3. Rotate, dismiss app, etc

cc @mzorz
