### PR TITLE
Clear featured image map when re-loading posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -730,6 +730,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
             // Generate the featured image url for each post
             String imageUrl = null;
+            mFeaturedImageUrls.clear();
             for (PostModel post : tmpPosts) {
                 if (post.isLocalDraft()) {
                     imageUrl = null;


### PR DESCRIPTION
Fixes #6024. `mFeaturedImageUrls` wasn't being cleared so `onBindView` wouldn't hide the featured image container.

To test:
* Add a featured image to a post
* Return to the post list and check that the post is updated to show the featured image
* Edit the post and remove the featured image
* Return to the post list and check that the featured image is hidden on the post