### PR TITLE
Issue/beta editor label

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -642,14 +642,14 @@
     <string name="preference_editor">Editor</string>
     <string name="preference_editor_type">Set editor type</string>
 
+    <string name="preference_editor_beta" translatable="false">Beta</string>
     <string name="preference_editor_legacy">Legacy</string>
     <string name="preference_editor_visual">Visual</string>
-    <string name="preference_editor_aztec" translatable="false">Aztec</string>
 
     <string-array name="editor_entries" translatable="false">
         <item>@string/preference_editor_legacy</item>
         <item>@string/preference_editor_visual</item>
-        <item>@string/preference_editor_aztec</item>
+        <item>@string/preference_editor_beta</item>
     </string-array>
 
     <string-array name="editor_entries_without_aztec" translatable="false">


### PR DESCRIPTION
### Fix
Rename label in ***Me*** > ***App Settings*** > ***Editor*** > ***Set editor type*** from ***Aztec*** to ***Beta***.

### Test
1. Go to ***Me*** tab.
2. Tap ***App Settings*** option.
3. Tap ***Set editor type*** item under ***Editor*** section.
4. Notice ***Beta*** is shown at the bottom.