### PR TITLE
Add pull-to-refresh (PTR) to the site picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -70,6 +70,7 @@ public class SitePickerActivity extends AppCompatActivity
     public static final String KEY_LOCAL_ID = "local_id";
     private static final String KEY_IS_IN_SEARCH_MODE = "is_in_search_mode";
     private static final String KEY_LAST_SEARCH = "last_search";
+    private static final String KEY_REFRESHING = "refreshing_sites";
 
     private SitePickerAdapter mAdapter;
     private RecyclerView mRecycleView;
@@ -96,7 +97,11 @@ public class SitePickerActivity extends AppCompatActivity
         restoreSavedInstanceState(savedInstanceState);
         setupActionBar();
         setupRecycleView();
+
         initSwipeToRefreshHelper(findViewById(android.R.id.content));
+        if (savedInstanceState != null) {
+            mSwipeToRefreshHelper.setRefreshing(savedInstanceState.getBoolean(KEY_REFRESHING, false));
+        }
     }
 
     @Override
@@ -110,6 +115,7 @@ public class SitePickerActivity extends AppCompatActivity
         outState.putInt(KEY_LOCAL_ID, mCurrentLocalId);
         outState.putBoolean(KEY_IS_IN_SEARCH_MODE, getAdapter().getIsInSearchMode());
         outState.putString(KEY_LAST_SEARCH, getAdapter().getLastSearch());
+        outState.putBoolean(KEY_REFRESHING, mSwipeToRefreshHelper.isRefreshing());
         super.onSaveInstanceState(outState);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -230,19 +230,15 @@ public class SitePickerActivity extends AppCompatActivity
     public void onSiteChanged(OnSiteChanged event) {
         if (mSwipeToRefreshHelper.isRefreshing()) {
             mSwipeToRefreshHelper.setRefreshing(false);
-            if (!isFinishing()) {
-                getAdapter().loadSites();
-            }
-        } else {
-            mDebouncer.debounce(Void.class, new Runnable() {
-                @Override
-                public void run() {
-                    if (!isFinishing()) {
-                        getAdapter().loadSites();
-                    }
-                }
-            }, 200, TimeUnit.MILLISECONDS);
         }
+        mDebouncer.debounce(Void.class, new Runnable() {
+            @Override
+            public void run() {
+                if (!isFinishing()) {
+                    getAdapter().loadSites();
+                }
+            }
+        }, 200, TimeUnit.MILLISECONDS);
     }
 
     private void initSwipeToRefreshHelper(View view) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -50,6 +50,8 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.helpers.Debouncer;
+import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
+import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -70,6 +72,7 @@ public class SitePickerActivity extends AppCompatActivity
 
     private SitePickerAdapter mAdapter;
     private RecyclerView mRecycleView;
+    private SwipeToRefreshHelper mSwipeToRefreshHelper;
     private ActionMode mActionMode;
     private MenuItem mMenuEdit;
     private MenuItem mMenuAdd;
@@ -92,6 +95,7 @@ public class SitePickerActivity extends AppCompatActivity
         restoreSavedInstanceState(savedInstanceState);
         setupActionBar();
         setupRecycleView();
+        initSwipeToRefreshHelper(findViewById(android.R.id.content));
     }
 
     @Override
@@ -224,6 +228,23 @@ public class SitePickerActivity extends AppCompatActivity
                 }
             }
         }, 200, TimeUnit.MILLISECONDS);
+    }
+
+    private void initSwipeToRefreshHelper(View view) {
+        if (view == null) {
+            return;
+        }
+        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+                this,
+                (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
+                new SwipeToRefreshHelper.RefreshListener() {
+                    @Override
+                    public void onRefreshStarted() {
+                        if (isFinishing()) {
+                            return;
+                        }
+                    }
+                });
     }
 
     private void setupRecycleView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -256,8 +256,6 @@ public class SitePickerActivity extends AppCompatActivity
                             mSwipeToRefreshHelper.setRefreshing(false);
                             return;
                         }
-                        mDispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction());
-                        mSwipeToRefreshHelper.setRefreshing(true);
                         mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
                     }
                 });

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -192,7 +192,7 @@ public class SitePickerActivity extends AppCompatActivity
             case RequestCodes.ADD_ACCOUNT:
             case RequestCodes.CREATE_SITE:
                 if (resultCode == RESULT_OK) {
-                    getAdapter().loadSites();
+                    debounceLoadSites();
                     setResult(resultCode, data);
                     finish();
                 }
@@ -217,7 +217,7 @@ public class SitePickerActivity extends AppCompatActivity
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteRemoved(OnSiteRemoved event) {
         if (!event.isError()) {
-            getAdapter().loadSites();
+            debounceLoadSites();
         } else {
             // shouldn't happen
             AppLog.e(AppLog.T.DB, "Encountered unexpected error while attempting to remove site: " + event.error);
@@ -231,6 +231,10 @@ public class SitePickerActivity extends AppCompatActivity
         if (mSwipeToRefreshHelper.isRefreshing()) {
             mSwipeToRefreshHelper.setRefreshing(false);
         }
+        debounceLoadSites();
+    }
+
+    private void debounceLoadSites() {
         mDebouncer.debounce(Void.class, new Runnable() {
             @Override
             public void run() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -254,7 +254,6 @@ public class SitePickerActivity extends AppCompatActivity
                         }
                         if (!NetworkUtils.checkConnection(SitePickerActivity.this)) {
                             mSwipeToRefreshHelper.setRefreshing(false);
-                            ToastUtils.showToast(SitePickerActivity.this, R.string.site_picker_no_network_refresh_error);
                             return;
                         }
                         mDispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction());

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -221,13 +221,21 @@ public class SitePickerActivity extends AppCompatActivity
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteChanged(OnSiteChanged event) {
-        mDebouncer.debounce(Void.class, new Runnable() {
-            @Override public void run() {
-                if (!isFinishing()) {
-                    getAdapter().loadSites();
-                }
+        if (mSwipeToRefreshHelper.isRefreshing()) {
+            mSwipeToRefreshHelper.setRefreshing(false);
+            if (!isFinishing()) {
+                getAdapter().loadSites();
             }
-        }, 200, TimeUnit.MILLISECONDS);
+        } else {
+            mDebouncer.debounce(Void.class, new Runnable() {
+                @Override
+                public void run() {
+                    if (!isFinishing()) {
+                        getAdapter().loadSites();
+                    }
+                }
+            }, 200, TimeUnit.MILLISECONDS);
+        }
     }
 
     private void initSwipeToRefreshHelper(View view) {
@@ -243,6 +251,9 @@ public class SitePickerActivity extends AppCompatActivity
                         if (isFinishing()) {
                             return;
                         }
+                        mDispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction());
+                        mSwipeToRefreshHelper.setRefreshing(true);
+                        mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
                     }
                 });
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -47,6 +47,7 @@ import org.wordpress.android.ui.main.SitePickerAdapter.SiteRecord;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.stats.datasets.StatsTable;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.helpers.Debouncer;
@@ -249,6 +250,11 @@ public class SitePickerActivity extends AppCompatActivity
                     @Override
                     public void onRefreshStarted() {
                         if (isFinishing()) {
+                            return;
+                        }
+                        if (!NetworkUtils.checkConnection(SitePickerActivity.this)) {
+                            mSwipeToRefreshHelper.setRefreshing(false);
+                            ToastUtils.showToast(SitePickerActivity.this, R.string.site_picker_no_network_refresh_error);
                             return;
                         }
                         mDispatcher.dispatch(SiteActionBuilder.newRemoveWpcomAndJetpackSitesAction());

--- a/WordPress/src/main/res/layout/site_picker_activity.xml
+++ b/WordPress/src/main/res/layout/site_picker_activity.xml
@@ -1,15 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.v7.widget.RecyclerView
-        android:id="@+id/recycler_view"
+    <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
+        android:id="@+id/ptr_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:scrollbars="vertical" />
+        android:layout_height="match_parent">
+
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:clipToPadding="false"
+            android:paddingTop="@dimen/margin_medium"
+            android:scrollbars="vertical" />
+
+    </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
     <ProgressBar
         android:id="@+id/progress"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1421,7 +1421,6 @@
     <string name="site_picker_create_dotcom">Create WordPress.com site</string>
     <string name="site_picker_cant_hide_current_site">\"%s\" wasn\'t hidden because it\'s the current site</string>
     <string name="site_picker_remove_site_error">Error removing site, try again later</string>
-    <string name="site_picker_no_network_refresh_error">A network connection is required to refresh sites</string>
 
     <!-- Application logs view -->
     <string name="logs_copied_to_clipboard">Application logs have been copied to the clipboard</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1421,6 +1421,7 @@
     <string name="site_picker_create_dotcom">Create WordPress.com site</string>
     <string name="site_picker_cant_hide_current_site">\"%s\" wasn\'t hidden because it\'s the current site</string>
     <string name="site_picker_remove_site_error">Error removing site, try again later</string>
+    <string name="site_picker_no_network_refresh_error">A network connection is required to refresh sites</string>
 
     <!-- Application logs view -->
     <string name="logs_copied_to_clipboard">Application logs have been copied to the clipboard</string>


### PR DESCRIPTION
Fixes #5979.

This PR introduces a PTR view in the sites list that reloads .com+Jetpack sites in case the user has added or removed any since logging into the app. The sites are first cleared via FluxC's `REMOVE_WPCOM_AND_JETPACK_SITES` action before being fetched.

To see it in action take I've recorded two short clips:

[The first](https://cldup.com/EG4q-Fhffc.webm) demonstrates refreshing after adding a site on the web.

[The second](https://cldup.com/7HNxzafJwl.webm) demonstrates refreshing after removing a site.

To test:
1. Login with a .com account and load up the site picker
2. Add a new site on the web (Switch Site -> Add new site)
3. Once the new site is created PTR in the site picker

The list should refresh with the new site added. Now test removing it and refreshing:
1. Remove the site on the web (Site Settings -> General -> Delete your site permanently)
2. Once the site has been removed PTR in the site picker

The list should refresh with the site removed.