### PR TITLE
Reset selected action index if upgrading from version that stored IDs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -195,6 +195,9 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
             }
         }
         mActionIndex = settings.getInt(SHARE_LAST_USED_ADDTO_KEY, ADD_TO_NEW_POST);
+        if (mActionIndex < 0 || mActionIndex >= mActionGroup.getChildCount()) {
+            mActionIndex = ADD_TO_NEW_POST;
+        }
         mActionGroup.check(getActionId(mActionIndex));
     }
 


### PR DESCRIPTION
Fixes #6042.

cc @aforcier can you take this one?

I decided to simply bound the action index value when retrieving it from preferences. While not _technically_ full-proof it should catch all cases and handle them gracefully.

1. If the user has no preference stored it will default to new post
2. If the user has it stored the new way it will work as expected
3. If the user has it stored the old way it will always choose new post the first time, then work as expected