### PR TITLE
Fix image editing in visual editor

### DIFF
--- a/libs/editor/WordPressEditor/src/main/assets/ZSSRichTextEditor.js
+++ b/libs/editor/WordPressEditor/src/main/assets/ZSSRichTextEditor.js
@@ -3569,7 +3569,10 @@ ZSSField.prototype.sendVideoTappedCallback = function( videoNode ) {
 // MARK: - Callback Execution
 
 ZSSField.prototype.callback = function(callbackScheme, callbackPath) {
-    var url = callbackScheme + ":" + callbackPath;
+    var url = callbackScheme;
+    if (callbackPath) {
+        url = url + ":" + callbackPath;
+    }
 
     if (isUsingiOS) {
         ZSSEditor.callbackThroughIFrame(url);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1326,12 +1326,16 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
 
     public void onMediaTapped(final String mediaId, final MediaType mediaType, final JSONObject meta,
                               String uploadStatus) {
-        if (mediaType == null || !isAdded() || TextUtils.isEmpty(mediaId) || StringUtils.stringToInt(mediaId) <= 0) {
+        if (mediaType == null || !isAdded()) {
             return;
         }
 
         switch (uploadStatus) {
             case ATTR_STATUS_UPLOADING:
+                if (TextUtils.isEmpty(mediaId) || StringUtils.stringToInt(mediaId) <= 0) {
+                    return;
+                }
+
                 // Display 'cancel upload' dialog
                 AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
                 builder.setTitle(getString(R.string.stop_upload_dialog_title));
@@ -1366,6 +1370,10 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 dialog.show();
                 break;
             case ATTR_STATUS_FAILED:
+                if (TextUtils.isEmpty(mediaId) || StringUtils.stringToInt(mediaId) <= 0) {
+                    return;
+                }
+
                 // Retry media upload
                 mEditorFragmentListener.onMediaRetryClicked(mediaId);
 


### PR DESCRIPTION
Fixes #6049. A change in https://github.com/wordpress-mobile/WordPress-Android/pull/5996 was over-zealous about protecting against invalid `mediaId`s, but this wasn't required for the edit image case.

To test:
Attempt to edit an image in the visual editor (also check cancelling and retrying uploads).