### PR TITLE
Issue/6063 store permission asked

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.accounts.SignInActivity;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.posts.EditPostActivity;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.SiteUtils;
@@ -125,6 +126,8 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String permissions[],
                                            @NonNull int[] grantResults) {
+        AppPrefs.setPermissionListAsked(permissions);
+
         if (requestCode == SHARE_MEDIA_PERMISSION_REQUEST_CODE) {
             for (int grantResult : grantResults) {
                 if (grantResult == PackageManager.PERMISSION_DENIED) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui;
 
+import android.Manifest;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
@@ -126,8 +127,6 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String permissions[],
                                            @NonNull int[] grantResults) {
-        AppPrefs.setPermissionListAsked(permissions);
-
         if (requestCode == SHARE_MEDIA_PERMISSION_REQUEST_CODE) {
             for (int grantResult : grantResults) {
                 if (grantResult == PackageManager.PERMISSION_DENIED) {
@@ -261,6 +260,7 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
      */
     private void shareIt() {
         if (!isSharingText()) {
+            AppPrefs.setPermissionAsked(Manifest.permission.WRITE_EXTERNAL_STORAGE);
             // If we're sharing media, we must check we have Storage permission (needed for media upload).
             if (!PermissionUtils.checkAndRequestStoragePermission(this, SHARE_MEDIA_PERMISSION_REQUEST_CODE)) {
                 return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui;
 
-import android.Manifest;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
@@ -127,6 +126,7 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String permissions[],
                                            @NonNull int[] grantResults) {
+        WPPermissionUtils.setPermissionListAsked(permissions);
         if (requestCode == SHARE_MEDIA_PERMISSION_REQUEST_CODE) {
             for (int grantResult : grantResults) {
                 if (grantResult == PackageManager.PERMISSION_DENIED) {
@@ -260,7 +260,6 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
      */
     private void shareIt() {
         if (!isSharingText()) {
-            WPPermissionUtils.setPermissionAsked(Manifest.permission.WRITE_EXTERNAL_STORAGE);
             // If we're sharing media, we must check we have Storage permission (needed for media upload).
             if (!PermissionUtils.checkAndRequestStoragePermission(this, SHARE_MEDIA_PERMISSION_REQUEST_CODE)) {
                 return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -26,11 +26,11 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.accounts.SignInActivity;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.posts.EditPostActivity;
-import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.WPPermissionUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -260,7 +260,7 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
      */
     private void shareIt() {
         if (!isSharingText()) {
-            AppPrefs.setPermissionAsked(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+            WPPermissionUtils.setPermissionAsked(Manifest.permission.WRITE_EXTERNAL_STORAGE);
             // If we're sharing media, we must check we have Storage permission (needed for media upload).
             if (!PermissionUtils.checkAndRequestStoragePermission(this, SHARE_MEDIA_PERMISSION_REQUEST_CODE)) {
                 return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -59,6 +59,7 @@ import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.WPPermissionUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
 import org.wordpress.passcodelock.AppLockManager;
 
@@ -206,8 +207,8 @@ public class MeFragment extends Fragment {
                 // and no need to promote the feature any more
                 AppPrefs.setGravatarChangePromoRequired(false);
 
-                AppPrefs.setPermissionAsked(Manifest.permission.CAMERA);
-                AppPrefs.setPermissionAsked(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+                WPPermissionUtils.setPermissionAsked(Manifest.permission.CAMERA);
+                WPPermissionUtils.setPermissionAsked(Manifest.permission.WRITE_EXTERNAL_STORAGE);
                 if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(MeFragment.this,
                         CAMERA_AND_MEDIA_PERMISSION_REQUEST_CODE)) {
                     showPhotoPickerForGravatar();

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.main;
 
+import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -205,6 +206,8 @@ public class MeFragment extends Fragment {
                 // and no need to promote the feature any more
                 AppPrefs.setGravatarChangePromoRequired(false);
 
+                AppPrefs.setPermissionAsked(Manifest.permission.CAMERA);
+                AppPrefs.setPermissionAsked(Manifest.permission.WRITE_EXTERNAL_STORAGE);
                 if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(MeFragment.this,
                         CAMERA_AND_MEDIA_PERMISSION_REQUEST_CODE)) {
                     showPhotoPickerForGravatar();
@@ -441,8 +444,6 @@ public class MeFragment extends Fragment {
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[]
             grantResults) {
-        AppPrefs.setPermissionListAsked(permissions);
-
         switch (requestCode) {
             case CAMERA_AND_MEDIA_PERMISSION_REQUEST_CODE:
                 if (permissions.length == 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -441,6 +441,8 @@ public class MeFragment extends Fragment {
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[]
             grantResults) {
+        AppPrefs.setPermissionListAsked(permissions);
+
         switch (requestCode) {
             case CAMERA_AND_MEDIA_PERMISSION_REQUEST_CODE:
                 if (permissions.length == 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.main;
 
-import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -207,8 +206,6 @@ public class MeFragment extends Fragment {
                 // and no need to promote the feature any more
                 AppPrefs.setGravatarChangePromoRequired(false);
 
-                WPPermissionUtils.setPermissionAsked(Manifest.permission.CAMERA);
-                WPPermissionUtils.setPermissionAsked(Manifest.permission.WRITE_EXTERNAL_STORAGE);
                 if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(MeFragment.this,
                         CAMERA_AND_MEDIA_PERMISSION_REQUEST_CODE)) {
                     showPhotoPickerForGravatar();
@@ -445,6 +442,8 @@ public class MeFragment extends Fragment {
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[]
             grantResults) {
+        WPPermissionUtils.setPermissionListAsked(permissions);
+
         switch (requestCode) {
             case CAMERA_AND_MEDIA_PERMISSION_REQUEST_CODE:
                 if (permissions.length == 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.media;
 
+import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.FragmentManager;
@@ -308,8 +309,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[] results) {
-        AppPrefs.setPermissionListAsked(permissions);
-
         // only MEDIA_PERMISSION_REQUEST_CODE is handled
         if (requestCode != MEDIA_PERMISSION_REQUEST_CODE) {
             return;
@@ -360,6 +359,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                 return true;
             case R.id.menu_new_media:
                 AppLockManager.getInstance().setExtendedTimeout();
+                AppPrefs.setPermissionAsked(Manifest.permission.CAMERA);
+                AppPrefs.setPermissionAsked(Manifest.permission.WRITE_EXTERNAL_STORAGE);
                 if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(this, MEDIA_PERMISSION_REQUEST_CODE)) {
                     showAddMediaPopup();
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -59,6 +59,7 @@ import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaGridFragment.MediaGridListener;
 import org.wordpress.android.ui.media.services.MediaDeleteService;
 import org.wordpress.android.ui.media.services.MediaUploadService;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
@@ -307,6 +308,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[] results) {
+        AppPrefs.setPermissionListAsked(permissions);
+
         // only MEDIA_PERMISSION_REQUEST_CODE is handled
         if (requestCode != MEDIA_PERMISSION_REQUEST_CODE) {
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -309,6 +309,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[] results) {
+        WPPermissionUtils.setPermissionListAsked(permissions);
+
         // only MEDIA_PERMISSION_REQUEST_CODE is handled
         if (requestCode != MEDIA_PERMISSION_REQUEST_CODE) {
             return;
@@ -359,8 +361,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                 return true;
             case R.id.menu_new_media:
                 AppLockManager.getInstance().setExtendedTimeout();
-                WPPermissionUtils.setPermissionAsked(Manifest.permission.CAMERA);
-                WPPermissionUtils.setPermissionAsked(Manifest.permission.WRITE_EXTERNAL_STORAGE);
                 if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(this, MEDIA_PERMISSION_REQUEST_CODE)) {
                     showAddMediaPopup();
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -60,7 +60,6 @@ import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaGridFragment.MediaGridListener;
 import org.wordpress.android.ui.media.services.MediaDeleteService;
 import org.wordpress.android.ui.media.services.MediaUploadService;
-import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
@@ -74,6 +73,7 @@ import org.wordpress.android.util.SmartToast;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPMediaUtils;
+import org.wordpress.android.util.WPPermissionUtils;
 import org.wordpress.passcodelock.AppLockManager;
 
 import java.io.File;
@@ -359,8 +359,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                 return true;
             case R.id.menu_new_media:
                 AppLockManager.getInstance().setExtendedTimeout();
-                AppPrefs.setPermissionAsked(Manifest.permission.CAMERA);
-                AppPrefs.setPermissionAsked(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+                WPPermissionUtils.setPermissionAsked(Manifest.permission.CAMERA);
+                WPPermissionUtils.setPermissionAsked(Manifest.permission.WRITE_EXTERNAL_STORAGE);
                 if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(this, MEDIA_PERMISSION_REQUEST_CODE)) {
                     showAddMediaPopup();
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -572,6 +572,7 @@ public class MediaPreviewActivity extends AppCompatActivity implements ActivityC
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String permissions[],
                                            @NonNull int[] grantResults) {
+        WPPermissionUtils.setPermissionListAsked(permissions);
         if (requestCode == SAVE_MEDIA_PERMISSION_REQUEST_CODE) {
             boolean canSaveMedia = true;
             for (int grantResult : grantResults) {
@@ -620,7 +621,6 @@ public class MediaPreviewActivity extends AppCompatActivity implements ActivityC
                 Manifest.permission.READ_EXTERNAL_STORAGE,
                 Manifest.permission.WRITE_EXTERNAL_STORAGE
         };
-        WPPermissionUtils.setPermissionListAsked(permissionList);
         if (!PermissionUtils.checkAndRequestPermissions(this, SAVE_MEDIA_PERMISSION_REQUEST_CODE, permissionList)) {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -48,6 +48,7 @@ import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
@@ -571,6 +572,8 @@ public class MediaPreviewActivity extends AppCompatActivity implements ActivityC
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String permissions[],
                                            @NonNull int[] grantResults) {
+        AppPrefs.setPermissionListAsked(permissions);
+
         if (requestCode == SAVE_MEDIA_PERMISSION_REQUEST_CODE) {
             boolean canSaveMedia = true;
             for (int grantResult : grantResults) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -48,7 +48,6 @@ import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
-import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
@@ -61,6 +60,7 @@ import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.WPPermissionUtils;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -620,7 +620,7 @@ public class MediaPreviewActivity extends AppCompatActivity implements ActivityC
                 Manifest.permission.READ_EXTERNAL_STORAGE,
                 Manifest.permission.WRITE_EXTERNAL_STORAGE
         };
-        AppPrefs.setPermissionListAsked(permissionList);
+        WPPermissionUtils.setPermissionListAsked(permissionList);
         if (!PermissionUtils.checkAndRequestPermissions(this, SAVE_MEDIA_PERMISSION_REQUEST_CODE, permissionList)) {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -572,8 +572,6 @@ public class MediaPreviewActivity extends AppCompatActivity implements ActivityC
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String permissions[],
                                            @NonNull int[] grantResults) {
-        AppPrefs.setPermissionListAsked(permissions);
-
         if (requestCode == SAVE_MEDIA_PERMISSION_REQUEST_CODE) {
             boolean canSaveMedia = true;
             for (int grantResult : grantResults) {
@@ -622,6 +620,7 @@ public class MediaPreviewActivity extends AppCompatActivity implements ActivityC
                 Manifest.permission.READ_EXTERNAL_STORAGE,
                 Manifest.permission.WRITE_EXTERNAL_STORAGE
         };
+        AppPrefs.setPermissionListAsked(permissionList);
         if (!PermissionUtils.checkAndRequestPermissions(this, SAVE_MEDIA_PERMISSION_REQUEST_CODE, permissionList)) {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -122,6 +122,7 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.WPHtml;
 import org.wordpress.android.util.WPMediaUtils;
+import org.wordpress.android.util.WPPermissionUtils;
 import org.wordpress.android.util.WPUrlUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
@@ -2207,7 +2208,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     @Override
     public void onMediaDropped(final ArrayList<Uri> mediaUris) {
         mDroppedMediaUris = mediaUris;
-        AppPrefs.setPermissionAsked(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        WPPermissionUtils.setPermissionAsked(Manifest.permission.WRITE_EXTERNAL_STORAGE);
         if (PermissionUtils.checkAndRequestStoragePermission(this, DRAG_AND_DROP_MEDIA_PERMISSION_REQUEST_CODE)) {
             runOnUiThread(mFetchMediaRunnable);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -681,6 +681,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String permissions[],
                                            @NonNull int[] grantResults) {
+        WPPermissionUtils.setPermissionListAsked(permissions);
+
         switch (requestCode) {
             case LOCATION_PERMISSION_REQUEST_CODE:
                 boolean shouldShowLocation = false;
@@ -2208,7 +2210,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     @Override
     public void onMediaDropped(final ArrayList<Uri> mediaUris) {
         mDroppedMediaUris = mediaUris;
-        WPPermissionUtils.setPermissionAsked(Manifest.permission.WRITE_EXTERNAL_STORAGE);
         if (PermissionUtils.checkAndRequestStoragePermission(this, DRAG_AND_DROP_MEDIA_PERMISSION_REQUEST_CODE)) {
             runOnUiThread(mFetchMediaRunnable);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -680,8 +680,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String permissions[],
                                            @NonNull int[] grantResults) {
-        AppPrefs.setPermissionListAsked(permissions);
-
         switch (requestCode) {
             case LOCATION_PERMISSION_REQUEST_CODE:
                 boolean shouldShowLocation = false;
@@ -2209,7 +2207,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     @Override
     public void onMediaDropped(final ArrayList<Uri> mediaUris) {
         mDroppedMediaUris = mediaUris;
-
+        AppPrefs.setPermissionAsked(Manifest.permission.WRITE_EXTERNAL_STORAGE);
         if (PermissionUtils.checkAndRequestStoragePermission(this, DRAG_AND_DROP_MEDIA_PERMISSION_REQUEST_CODE)) {
             runOnUiThread(mFetchMediaRunnable);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -680,6 +680,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     public void onRequestPermissionsResult(int requestCode,
                                            @NonNull String permissions[],
                                            @NonNull int[] grantResults) {
+        AppPrefs.setPermissionListAsked(permissions);
+
         switch (requestCode) {
             case LOCATION_PERMISSION_REQUEST_CODE:
                 boolean shouldShowLocation = false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.prefs;
 
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
 import org.wordpress.android.BuildConfig;
@@ -136,7 +137,14 @@ public class AppPrefs {
         // smart toast counters
         SMART_TOAST_PHOTO_PICKER_LONG_PRESS_COUNTER,
         SMART_TOAST_WP_MEDIA_BROWSER_LONG_PRESS_COUNTER,
-        SMART_TOAST_COMMENTS_LONG_PRESS_COUNTER
+        SMART_TOAST_COMMENTS_LONG_PRESS_COUNTER,
+
+        // permission keys - set once a specific permission has been asked, regardless of response
+        ASKED_PERMISSION_STORAGE_WRITE,
+        ASKED_PERMISSION_STORAGE_READ,
+        ASKED_PERMISSION_CAMERA,
+        ASKED_PERMISSION_LOCATION_COURSE,
+        ASKED_PERMISSION_LOCATION_FINE
     }
 
     private static SharedPreferences prefs() {
@@ -589,5 +597,43 @@ public class AppPrefs {
 
     public static void setDraftsMigratedToFluxC(boolean migrated) {
         setBoolean(UndeletablePrefKey.DRAFTS_MIGRATED_TO_FLUXC, migrated);
+    }
+
+
+    /*
+     * returns true if the app has ever asked for the passed permission
+     */
+    public static boolean isPermissionAsked(@NonNull String permission, boolean isAsked) {
+        PrefKey key = getPermissionKey(permission);
+        return key != null ? getBoolean(key, false) : false;
+    }
+
+    /*
+     * stores that the list of permissions has been asked
+     */
+    public static void setPermissionListAsked(@NonNull String[] permissions) {
+        for (int i = 0; i < permissions.length; i++) {
+            PrefKey key = getPermissionKey(permissions[i]);
+            if (key != null) {
+                setBoolean(key, true);
+            }
+        }
+    }
+
+    private static PrefKey getPermissionKey(@NonNull String permission) {
+        switch (permission) {
+            case android.Manifest.permission.WRITE_EXTERNAL_STORAGE:
+                return UndeletablePrefKey.ASKED_PERMISSION_STORAGE_WRITE;
+            case android.Manifest.permission.READ_EXTERNAL_STORAGE:
+                return UndeletablePrefKey.ASKED_PERMISSION_STORAGE_READ;
+            case android.Manifest.permission.CAMERA:
+                return UndeletablePrefKey.ASKED_PERMISSION_CAMERA;
+            case android.Manifest.permission.ACCESS_COARSE_LOCATION:
+                return UndeletablePrefKey.ASKED_PERMISSION_LOCATION_COURSE;
+            case android.Manifest.permission.ACCESS_FINE_LOCATION:
+                return UndeletablePrefKey.ASKED_PERMISSION_LOCATION_FINE;
+            default:
+                return null;
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -202,13 +202,12 @@ public class AppPrefs {
         setString(key, Integer.toString(value));
     }
 
-    private static boolean getBoolean(PrefKey key, boolean def) {
-
+    public static boolean getBoolean(PrefKey key, boolean def) {
         String value = getString(key, Boolean.toString(def));
         return Boolean.parseBoolean(value);
     }
 
-    private static void setBoolean(PrefKey key, boolean value) {
+    public static void setBoolean(PrefKey key, boolean value) {
         setString(key, Boolean.toString(value));
     }
 
@@ -600,47 +599,4 @@ public class AppPrefs {
     }
 
 
-    /*
-     * returns true if the app has ever asked for the passed permission
-     */
-    public static boolean isPermissionAsked(@NonNull String permission, boolean isAsked) {
-        PrefKey key = getPermissionKey(permission);
-        return key != null ? getBoolean(key, false) : false;
-    }
-
-    /*
-     * remember that the passed permissions has been asked
-     */
-    public static void setPermissionAsked(@NonNull String permission) {
-        PrefKey key = getPermissionKey(permission);
-        if (key != null) {
-            setBoolean(key, true);
-        }
-    }
-
-    /*
-     * remember that the list of permissions has been asked
-     */
-    public static void setPermissionListAsked(@NonNull String[] permissions) {
-        for (int i = 0; i < permissions.length; i++) {
-            setPermissionAsked(permissions[i]);
-        }
-    }
-
-    private static PrefKey getPermissionKey(@NonNull String permission) {
-        switch (permission) {
-            case android.Manifest.permission.WRITE_EXTERNAL_STORAGE:
-                return UndeletablePrefKey.ASKED_PERMISSION_STORAGE_WRITE;
-            case android.Manifest.permission.READ_EXTERNAL_STORAGE:
-                return UndeletablePrefKey.ASKED_PERMISSION_STORAGE_READ;
-            case android.Manifest.permission.CAMERA:
-                return UndeletablePrefKey.ASKED_PERMISSION_CAMERA;
-            case android.Manifest.permission.ACCESS_COARSE_LOCATION:
-                return UndeletablePrefKey.ASKED_PERMISSION_LOCATION_COURSE;
-            case android.Manifest.permission.ACCESS_FINE_LOCATION:
-                return UndeletablePrefKey.ASKED_PERMISSION_LOCATION_FINE;
-            default:
-                return null;
-        }
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -215,6 +215,10 @@ public class AppPrefs {
         prefs().edit().remove(key.name()).apply();
     }
 
+    public static boolean keyExists(@NonNull PrefKey key) {
+        return prefs().contains(key.name());
+    }
+
     // Exposed methods
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -609,14 +609,21 @@ public class AppPrefs {
     }
 
     /*
-     * stores that the list of permissions has been asked
+     * remember that the passed permissions has been asked
+     */
+    public static void setPermissionAsked(@NonNull String permission) {
+        PrefKey key = getPermissionKey(permission);
+        if (key != null) {
+            setBoolean(key, true);
+        }
+    }
+
+    /*
+     * remember that the list of permissions has been asked
      */
     public static void setPermissionListAsked(@NonNull String[] permissions) {
         for (int i = 0; i < permissions.length; i++) {
-            PrefKey key = getPermissionKey(permissions[i]);
-            if (key != null) {
-                setBoolean(key, true);
-            }
+            setPermissionAsked(permissions[i]);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
@@ -1,0 +1,52 @@
+package org.wordpress.android.util;
+
+import android.support.annotation.NonNull;
+
+import org.wordpress.android.ui.prefs.AppPrefs;
+
+public class WPPermissionUtils {
+
+    /*
+     * returns true if the app has ever asked for the passed permission
+     */
+    public static boolean isPermissionAsked(@NonNull String permission, boolean isAsked) {
+        AppPrefs.PrefKey key = getPermissionKey(permission);
+        return key != null ? AppPrefs.getBoolean(key, false) : false;
+    }
+
+    /*
+     * remember that the passed permissions has been asked
+     */
+    public static void setPermissionAsked(@NonNull String permission) {
+        AppPrefs.PrefKey key = getPermissionKey(permission);
+        if (key != null) {
+            AppPrefs.setBoolean(key, true);
+        }
+    }
+
+    /*
+     * remember that the list of permissions has been asked
+     */
+    public static void setPermissionListAsked(@NonNull String[] permissions) {
+        for (int i = 0; i < permissions.length; i++) {
+            setPermissionAsked(permissions[i]);
+        }
+    }
+
+    private static AppPrefs.PrefKey getPermissionKey(@NonNull String permission) {
+        switch (permission) {
+            case android.Manifest.permission.WRITE_EXTERNAL_STORAGE:
+                return AppPrefs.UndeletablePrefKey.ASKED_PERMISSION_STORAGE_WRITE;
+            case android.Manifest.permission.READ_EXTERNAL_STORAGE:
+                return AppPrefs.UndeletablePrefKey.ASKED_PERMISSION_STORAGE_READ;
+            case android.Manifest.permission.CAMERA:
+                return AppPrefs.UndeletablePrefKey.ASKED_PERMISSION_CAMERA;
+            case android.Manifest.permission.ACCESS_COARSE_LOCATION:
+                return AppPrefs.UndeletablePrefKey.ASKED_PERMISSION_LOCATION_COURSE;
+            case android.Manifest.permission.ACCESS_FINE_LOCATION:
+                return AppPrefs.UndeletablePrefKey.ASKED_PERMISSION_LOCATION_FINE;
+            default:
+                return null;
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
@@ -76,6 +76,7 @@ public class WPPermissionUtils {
             case android.Manifest.permission.ACCESS_FINE_LOCATION:
                 return AppPrefs.UndeletablePrefKey.ASKED_PERMISSION_LOCATION_FINE;
             default:
+                AppLog.w(AppLog.T.UTILS, "No key for requested permission");
                 return null;
         }
     }


### PR DESCRIPTION
Fixes #6063 - remembers when a permission has been requested, which is necessary to determine whether the user has permanently denied it. Note that the new `WPPermissionUtils` class contains two functions which are unused (`isPermissionAsked` and `isPermissionAlwaysDenied`), but these will be used as part of the soft asks project.

Note: I've marked this as high priority because I'm working on several "soft ask" PRs which require this PR to be merged first.
