### PR TITLE
Adds a11y labels as per descriptions in #6072.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainTabLayout.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainTabLayout.java
@@ -38,9 +38,9 @@ public class WPMainTabLayout extends TabLayout {
 
     public void createTabs() {
         addTab(R.drawable.main_tab_sites, R.string.tabbar_accessibility_label_my_site, false);
-        addTab(R.drawable.main_tab_reader, R.string.reader, false);
+        addTab(R.drawable.main_tab_reader, R.string.tabbar_accessibility_label_reader, false);
         addTab(R.drawable.main_tab_me, R.string.tabbar_accessibility_label_me, false);
-        addTab(R.drawable.main_tab_notifications, R.string.notifications, true);
+        addTab(R.drawable.main_tab_notifications, R.string.tabbar_accessibility_label_notifications, true);
     }
 
     private void addTab(@DrawableRes int iconId, @StringRes int contentDescriptionId, boolean isNoteTab) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1440,8 +1440,10 @@
     <string name="me_disconnect_from_wordpress_com">Log out of WordPress.com</string>
 
     <!--TabBar Accessibility Labels-->
-    <string name="tabbar_accessibility_label_my_site">My Site</string>
-    <string name="tabbar_accessibility_label_me">Me</string>
+    <string name="tabbar_accessibility_label_my_site">My Site. View your site and manage it, including stats.</string>
+    <string name="tabbar_accessibility_label_me">Me. View your profile and make changes.</string>
+    <string name="tabbar_accessibility_label_reader">Reader. Follow content from other sites.</string>
+    <string name="tabbar_accessibility_label_notifications">Notifications. Manage your notifications.</string>
     <string name="site_privacy_private_desc">I would like my site to be private, visible only to users I choose</string>
     <string name="site_privacy_hidden_desc">Discourage search engines from indexing this site</string>
     <string name="site_privacy_public_desc">Allow search engines to index this site</string>


### PR DESCRIPTION
Fixes #6072

To test:
- Start Talk Back
- Open WordPress app
- Check topbar menu items for descriptions.

Verified with @davidakennedy
