### PR TITLE
Async media: Allow posts to be edited while uploading media

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -189,7 +189,7 @@ public class PostPreviewActivity extends AppCompatActivity {
 
         if (mPost == null
                 || mIsUpdatingPost
-                || PostUploadService.isPostUploading(mPost)
+                || PostUploadService.isPostUploadingOrQueued(mPost)
                 || (!mPost.isLocallyChanged() && !mPost.isLocalDraft())
                 && PostStatus.fromPost(mPost) != PostStatus.DRAFT) {
             messageView.setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -520,7 +520,7 @@ public class PostsListFragment extends Fragment
             case PostListButton.BUTTON_TRASH:
             case PostListButton.BUTTON_DELETE:
                 // prevent deleting post while it's being uploaded
-                if (!PostUploadService.isPostUploading(post)) {
+                if (!PostUploadService.isPostUploadingOrQueued(post)) {
                     trashPost(post);
                 }
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -30,6 +30,7 @@ import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.store.MediaStore;
+import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.FetchPostsPayload;
 import org.wordpress.android.fluxc.store.PostStore.OnPostChanged;
@@ -693,6 +694,17 @@ public class PostsListFragment extends Fragment
             if (event.mediaList != null && event.mediaList.size() > 0) {
                 MediaModel mediaModel = event.mediaList.get(0);
                 mPostsListAdapter.mediaChanged(mediaModel);
+            }
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onMediaUploaded(OnMediaUploaded event) {
+        if (event.media != null && event.completed) {
+            PostModel post = mPostStore.getPostByLocalPostId(event.media.getLocalPostId());
+            if (post != null && PostUploadService.isPostUploadingOrQueued(post)) {
+                loadPosts(LoadMode.FORCED);
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -525,6 +525,9 @@ public class PostsListFragment extends Fragment
                 break;
             case PostListButton.BUTTON_TRASH:
             case PostListButton.BUTTON_DELETE:
+                // TODO: Async: Update this behavior to handle pressing Delete/Trash while the post has uploading media
+                // Currently, the button is tappable while media are uploading, but nothing happens
+
                 // prevent deleting post while it's being uploaded
                 if (!PostUploadService.isPostUploadingOrQueued(post)) {
                     trashPost(post);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -502,6 +502,11 @@ public class PostsListFragment extends Fragment
 
         switch (buttonType) {
             case PostListButton.BUTTON_EDIT:
+                if (PostUploadService.isPostUploadingOrQueued(post)) {
+                    // If the post is uploading media, allow the media to continue uploading, but don't upload the
+                    // post itself when they finish (since we're about to edit it again)
+                    PostUploadService.cancelQueuedPostUpload(post);
+                }
                 ActivityLauncher.editPostOrPageForResult(getActivity(), mSite, post);
                 break;
             case PostListButton.BUTTON_SUBMIT:

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -187,7 +187,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     }
 
     private boolean canPublishPost(PostModel post) {
-        return post != null && !PostUploadService.isPostUploading(post) &&
+        return post != null && !PostUploadService.isPostUploadingOrQueued(post) &&
                 (post.isLocallyChanged() || post.isLocalDraft() || PostStatus.fromPost(post) == PostStatus.DRAFT);
     }
 
@@ -243,7 +243,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                 postHolder.btnTrash.setButtonType(PostListButton.BUTTON_TRASH);
             }
 
-            if (PostUploadService.isPostUploading(post)) {
+            if (PostUploadService.isPostUploadingOrQueued(post)) {
                 postHolder.disabledOverlay.setVisibility(View.VISIBLE);
             } else {
                 postHolder.disabledOverlay.setVisibility(View.GONE);
@@ -275,7 +275,8 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             pageHolder.dateHeader.setVisibility(showDate ? View.VISIBLE : View.GONE);
 
             // no "..." more button when uploading
-            pageHolder.btnMore.setVisibility(PostUploadService.isPostUploading(post) ? View.GONE : View.VISIBLE);
+            pageHolder.btnMore.setVisibility(PostUploadService.isPostUploadingOrQueued(post) ? View.GONE :
+                    View.VISIBLE);
             pageHolder.btnMore.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
@@ -286,7 +287,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             // only show the top divider for the first item
             pageHolder.dividerTop.setVisibility(position == 0 ? View.VISIBLE : View.GONE);
 
-            if (PostUploadService.isPostUploading(post)) {
+            if (PostUploadService.isPostUploadingOrQueued(post)) {
                 pageHolder.disabledOverlay.setVisibility(View.VISIBLE);
             } else {
                 pageHolder.disabledOverlay.setVisibility(View.GONE);
@@ -375,7 +376,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             int statusIconResId = 0;
             int statusColorResId = R.color.grey_darken_10;
 
-            if (PostUploadService.isPostUploading(post)) {
+            if (PostUploadService.isPostUploadingOrQueued(post)) {
                 statusTextResId = R.string.post_uploading;
                 statusColorResId = R.color.alert_yellow;
             } else if (post.isLocalDraft()) {
@@ -717,7 +718,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                 // Always update the list if there are uploading posts
                 boolean postsAreUploading = false;
                 for (PostModel post : tmpPosts) {
-                    if (PostUploadService.isPostUploading(post)) {
+                    if (PostUploadService.isPostUploadingOrQueued(post)) {
                         postsAreUploading = true;
                         break;
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -243,7 +243,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                 postHolder.btnTrash.setButtonType(PostListButton.BUTTON_TRASH);
             }
 
-            if (PostUploadService.isPostUploadingOrQueued(post)) {
+            if (PostUploadService.isPostUploading(post)) {
                 postHolder.disabledOverlay.setVisibility(View.VISIBLE);
             } else {
                 postHolder.disabledOverlay.setVisibility(View.GONE);
@@ -287,7 +287,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             // only show the top divider for the first item
             pageHolder.dividerTop.setVisibility(position == 0 ? View.VISIBLE : View.GONE);
 
-            if (PostUploadService.isPostUploadingOrQueued(post)) {
+            if (PostUploadService.isPostUploading(post)) {
                 pageHolder.disabledOverlay.setVisibility(View.VISIBLE);
             } else {
                 pageHolder.disabledOverlay.setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -112,9 +112,11 @@ public class PostUploadService extends Service {
     }
 
     /**
-     * Returns true if the passed post is either uploading or waiting to be uploaded.
+     * Returns true if the passed post is either currently uploading or waiting to be uploaded.
+     * Except for legacy mode, a post counts as 'uploading' if the post content itself is being uploaded - a post
+     * waiting for media to finish uploading counts as 'waiting to be uploaded' until the media uploads complete.
      */
-    public static boolean isPostUploading(PostModel post) {
+    public static boolean isPostUploadingOrQueued(PostModel post) {
         // first check the currently uploading post
         if (mCurrentUploadingPost != null && mCurrentUploadingPost.getId() == post.getId()) {
             return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -144,6 +144,18 @@ public class PostUploadService extends Service {
         return mCurrentUploadingPost != null && mCurrentUploadingPost.getId() == post.getId();
     }
 
+    public static void cancelQueuedPostUpload(PostModel post) {
+        synchronized (mPostsList) {
+            Iterator<PostModel> iterator = mPostsList.iterator();
+            while (iterator.hasNext()) {
+                PostModel postModel = iterator.next();
+                if (postModel.getId() == post.getId()) {
+                    iterator.remove();
+                }
+            }
+        }
+    }
+
     @Override
     public IBinder onBind(Intent intent) {
         return null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -117,11 +117,12 @@ public class PostUploadService extends Service {
      * waiting for media to finish uploading counts as 'waiting to be uploaded' until the media uploads complete.
      */
     public static boolean isPostUploadingOrQueued(PostModel post) {
-        // first check the currently uploading post
-        if (mCurrentUploadingPost != null && mCurrentUploadingPost.getId() == post.getId()) {
+        // First check the currently uploading post
+        if (isPostUploading(post)) {
             return true;
         }
-        // then check the list of posts waiting to be uploaded
+
+        // Then check the list of posts waiting to be uploaded
         if (mPostsList.size() > 0) {
             synchronized (mPostsList) {
                 for (PostModel queuedPost : mPostsList) {
@@ -132,6 +133,15 @@ public class PostUploadService extends Service {
             }
         }
         return false;
+    }
+
+    /**
+     * Returns true if the passed post is currently uploading.
+     * Except for legacy mode, a post counts as 'uploading' if the post content itself is being uploaded - a post
+     * waiting for media to finish uploading counts as 'waiting to be uploaded' until the media uploads complete.
+     */
+    public static boolean isPostUploading(PostModel post) {
+        return mCurrentUploadingPost != null && mCurrentUploadingPost.getId() == post.getId();
     }
 
     @Override


### PR DESCRIPTION
Bridges async publishing (https://github.com/wordpress-mobile/WordPress-Android/pull/5880) with progress reattachment (https://github.com/wordpress-mobile/WordPress-Android/pull/5780). Without this PR, exiting a post while media are uploading will queue the post for upload, and save it as a remote draft (where applicable) once the media complete. During this time, the 'Uploading' overlay is present, blocking the post from being edited, even though that is now supported thanks to the reattachment work.

With this PR, we only show the overlay while the post content itself is uploading (and not while its media are uploading). The post is removed from the upload queue if it's re-opened, allowing the media to complete but preventing the post from being uploaded while it's being edited.

Note: The UI for the post list with uploading posts will be overhauled as part of the async redesign - I just made the minimal changes necessary to support reattachment for the moment.

To test:
1. Make sure Aztec is enabled
2. Add media to a post, and exit while they are progressing
3. Notice that the post in the post list is marked 'Uploading', but is tappable
4. Edit the post, observe that the progress of the media is updated
5. Repeat 2-3, but this time wait until media complete (and the post content itself starts uploading)
6. Observe that the grayed-out overlay is shown above the post item in the list, making it untappable

cc @mzorz 