### PR TITLE
Async media: Delete cancelled media from library

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaUploadService.java
@@ -79,7 +79,7 @@ public class MediaUploadService extends Service {
     @Override
     public void onDestroy() {
         for (MediaModel oneUpload : mInProgressUploads) {
-            cancelUpload(oneUpload);
+            cancelUpload(oneUpload, false);
         }
         mDispatcher.unregister(this);
         EventBus.getDefault().unregister(this);
@@ -272,11 +272,11 @@ public class MediaUploadService extends Service {
         }
     }
 
-    private void cancelUpload(MediaModel oneUpload) {
+    private void cancelUpload(MediaModel oneUpload, boolean delete) {
         if (oneUpload != null) {
             SiteModel site = mSiteStore.getSiteByLocalId(oneUpload.getLocalSiteId());
             if (site != null) {
-                dispatchCancelAction(oneUpload, site);
+                dispatchCancelAction(oneUpload, site, delete);
             } else {
                 AppLog.i(T.MEDIA, "Unexpected state, site is null. Skipping cancellation of " +
                         "this request - MediaUploadService.");
@@ -295,10 +295,10 @@ public class MediaUploadService extends Service {
         mDispatcher.dispatch(MediaActionBuilder.newUploadMediaAction(payload));
     }
 
-    private void dispatchCancelAction(@NonNull final MediaModel media, @NonNull final SiteModel site) {
+    private void dispatchCancelAction(@NonNull final MediaModel media, @NonNull final SiteModel site, boolean delete) {
         AppLog.i(T.MEDIA, "Dispatching cancel upload action for media with local id: " + media.getId() +
                 " and path: " + media.getFilePath());
-        CancelMediaPayload payload = new CancelMediaPayload(site, media);
+        CancelMediaPayload payload = new CancelMediaPayload(site, media, delete);
         mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload));
     }
 
@@ -319,12 +319,12 @@ public class MediaUploadService extends Service {
         }
         for (MediaModel inProgressUpload : mInProgressUploads) {
             if (inProgressUpload.getLocalPostId() == event.post.getId()) {
-                cancelUpload(inProgressUpload);
+                cancelUpload(inProgressUpload, true);
             }
         }
         for (MediaModel pendingUpload : mPendingUploads) {
             if (pendingUpload.getLocalPostId() == event.post.getId()) {
-                cancelUpload(pendingUpload);
+                cancelUpload(pendingUpload, true);
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2285,11 +2285,11 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     }
 
     @Override
-    public void onMediaUploadCancelClicked(String localMediaId, boolean delete) {
+    public void onMediaUploadCancelClicked(String localMediaId) {
         if (!TextUtils.isEmpty(localMediaId)) {
             MediaModel mediaModel = mMediaStore.getMediaWithLocalId(Integer.valueOf(localMediaId));
             if (mediaModel != null) {
-                CancelMediaPayload payload = new CancelMediaPayload(mSite, mediaModel, delete);
+                CancelMediaPayload payload = new CancelMediaPayload(mSite, mediaModel);
                 mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload));
             }
         } else {

--- a/libs/editor/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/MockEditorActivity.java
+++ b/libs/editor/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/MockEditorActivity.java
@@ -60,7 +60,7 @@ public class MockEditorActivity extends AppCompatActivity implements EditorFragm
     }
 
     @Override
-    public void onMediaUploadCancelClicked(String mediaId, boolean delete) {
+    public void onMediaUploadCancelClicked(String mediaId) {
 
     }
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -985,7 +985,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                     public void onClick(DialogInterface dialog, int id) {
 
                         if (mUploadingMediaProgressMax.containsKey(localMediaId)) {
-                            mEditorFragmentListener.onMediaUploadCancelClicked(localMediaId, true);
+                            mEditorFragmentListener.onMediaUploadCancelClicked(localMediaId);
 
                             switch (mediaType) {
                                 case IMAGE:

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1336,7 +1336,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 builder.setTitle(getString(R.string.stop_upload_dialog_title));
                 builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
-                        mEditorFragmentListener.onMediaUploadCancelClicked(mediaId, true);
+                        mEditorFragmentListener.onMediaUploadCancelClicked(mediaId);
 
                         mWebView.post(new Runnable() {
                             @Override
@@ -1462,7 +1462,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     public void onMediaRemoved(String mediaId) {
         mUploadingMedia.remove(mediaId);
         mFailedMediaIds.remove(mediaId);
-        mEditorFragmentListener.onMediaUploadCancelClicked(mediaId, true);
+        mEditorFragmentListener.onMediaUploadCancelClicked(mediaId);
     }
 
     @Override

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -174,7 +174,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
         void onSettingsClicked();
         void onAddMediaClicked();
         void onMediaRetryClicked(String mediaId);
-        void onMediaUploadCancelClicked(String mediaId, boolean delete);
+        void onMediaUploadCancelClicked(String mediaId);
         void onFeaturedImageChanged(long mediaId);
         void onVideoPressInfoRequested(String videoId);
         String onAuthHeaderRequested(String url);

--- a/libs/editor/example/src/main/java/org/wordpress/android/editor/example/EditorExampleActivity.java
+++ b/libs/editor/example/src/main/java/org/wordpress/android/editor/example/EditorExampleActivity.java
@@ -197,7 +197,7 @@ public class EditorExampleActivity extends AppCompatActivity implements EditorFr
     }
 
     @Override
-    public void onMediaUploadCancelClicked(String mediaId, boolean delete) {
+    public void onMediaUploadCancelClicked(String mediaId) {
 
     }
 


### PR DESCRIPTION
Fixes #5942 for `feature/async-media`. Most of the work was done in https://github.com/wordpress-mobile/WordPress-Android/pull/6008 and merged into `feature/async-media` - this PR makes some small adjustments and cleanup.

cc @mzorz