### PR TITLE
Login rework: Username/Password screen for selfhosted

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -27,6 +27,7 @@ import org.wordpress.android.ui.accounts.login.LoginEmailFragment;
 import org.wordpress.android.ui.accounts.login.LoginEmailPasswordFragment;
 import org.wordpress.android.ui.accounts.login.LoginMagicLinkRequestFragment;
 import org.wordpress.android.ui.accounts.login.LoginSiteAddressFragment;
+import org.wordpress.android.ui.accounts.login.LoginUsernamePasswordFragment;
 import org.wordpress.android.ui.comments.CommentAdapter;
 import org.wordpress.android.ui.comments.CommentDetailFragment;
 import org.wordpress.android.ui.comments.CommentsActivity;
@@ -119,6 +120,7 @@ public interface AppComponent {
     void inject(LoginEmailPasswordFragment object);
     void inject(Login2FaFragment object);
     void inject(LoginSiteAddressFragment object);
+    void inject(LoginUsernamePasswordFragment object);
 
     void inject(StatsWidgetConfigureActivity object);
     void inject(StatsWidgetConfigureAdapter object);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -145,14 +145,14 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
 
     public void gotWpcomSiteInfo(String siteAddress, String siteName, String siteIconUrl) {
         LoginUsernamePasswordFragment loginUsernamePasswordFragment =
-                LoginUsernamePasswordFragment.newInstance(siteAddress, siteName, siteIconUrl, true);
+                LoginUsernamePasswordFragment.newInstance(siteAddress, siteAddress, siteName, siteIconUrl, true);
         slideInFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG);
     }
 
     @Override
-    public void gotXmlRpcEndpoint(String siteAddress) {
+    public void gotXmlRpcEndpoint(String inputSiteAddress, String endpointAddress) {
         LoginUsernamePasswordFragment loginUsernamePasswordFragment =
-                LoginUsernamePasswordFragment.newInstance(siteAddress, null, null, false);
+                LoginUsernamePasswordFragment.newInstance(inputSiteAddress, endpointAddress, null, null, false);
         slideInFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -143,15 +143,16 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
         launchEpilogueAndFinish();
     }
 
-    @Override
-    public void gotWpcomSiteAddress() {
-        ToastUtils.showToast(this, "WPCOM input site address is not implemented yet.");
+    public void gotWpcomSiteAddress(String siteAddress) {
+        LoginUsernamePasswordFragment loginUsernamePasswordFragment =
+                LoginUsernamePasswordFragment.newInstance(siteAddress, true);
+        slideInFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG);
     }
 
     @Override
     public void gotXmlRpcEndpoint(String siteAddress) {
         LoginUsernamePasswordFragment loginUsernamePasswordFragment =
-                LoginUsernamePasswordFragment.newInstance(siteAddress);
+                LoginUsernamePasswordFragment.newInstance(siteAddress, false);
         slideInFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -17,6 +17,7 @@ import org.wordpress.android.ui.accounts.login.LoginMagicLinkRequestFragment;
 import org.wordpress.android.ui.accounts.login.LoginMagicLinkSentFragment;
 import org.wordpress.android.ui.accounts.login.LoginPrologueFragment;
 import org.wordpress.android.ui.accounts.login.LoginSiteAddressFragment;
+import org.wordpress.android.ui.accounts.login.LoginUsernamePasswordFragment;
 import org.wordpress.android.util.ToastUtils;
 
 public class LoginActivity extends AppCompatActivity implements LoginListener {
@@ -149,12 +150,19 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
 
     @Override
     public void gotXmlRpcEndpoint(String siteAddress) {
-        ToastUtils.showToast(this, "Input site address is not implemented yet. Input site address: " + siteAddress);
+        LoginUsernamePasswordFragment loginUsernamePasswordFragment =
+                LoginUsernamePasswordFragment.newInstance(siteAddress);
+        slideInFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG);
     }
 
     @Override
     public void helpWithSiteAddress() {
         ToastUtils.showToast(this, "Help finding site address is not implemented yet.");
+    }
+
+    @Override
+    public void loggedInViaUsernamePassword() {
+        launchEpilogueAndFinish();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -143,16 +143,16 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
         launchEpilogueAndFinish();
     }
 
-    public void gotWpcomSiteAddress(String siteAddress) {
+    public void gotWpcomSiteInfo(String siteAddress, String siteName, String siteIconUrl) {
         LoginUsernamePasswordFragment loginUsernamePasswordFragment =
-                LoginUsernamePasswordFragment.newInstance(siteAddress, true);
+                LoginUsernamePasswordFragment.newInstance(siteAddress, siteName, siteIconUrl, true);
         slideInFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG);
     }
 
     @Override
     public void gotXmlRpcEndpoint(String siteAddress) {
         LoginUsernamePasswordFragment loginUsernamePasswordFragment =
-                LoginUsernamePasswordFragment.newInstance(siteAddress, false);
+                LoginUsernamePasswordFragment.newInstance(siteAddress, null, null, false);
         slideInFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
@@ -25,7 +25,7 @@ public interface LoginListener {
     // Login Site Address input callbacks
     void alreadyLoggedInWpcom();
     void gotWpcomSiteInfo(String siteAddress, String siteName, String siteIconUrl);
-    void gotXmlRpcEndpoint(String siteAddress);
+    void gotXmlRpcEndpoint(String inputSiteAddress, String endpointAddress);
     void helpWithSiteAddress();
 
     // Login username password callbacks

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
@@ -24,7 +24,7 @@ public interface LoginListener {
 
     // Login Site Address input callbacks
     void alreadyLoggedInWpcom();
-    void gotWpcomSiteAddress();
+    void gotWpcomSiteAddress(String siteAddress);
     void gotXmlRpcEndpoint(String siteAddress);
     void helpWithSiteAddress();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
@@ -28,6 +28,9 @@ public interface LoginListener {
     void gotXmlRpcEndpoint(String siteAddress);
     void helpWithSiteAddress();
 
+    // Login username password callbacks
+    void loggedInViaUsernamePassword();
+
     // Help callback
     void help();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
@@ -24,7 +24,7 @@ public interface LoginListener {
 
     // Login Site Address input callbacks
     void alreadyLoggedInWpcom();
-    void gotWpcomSiteAddress(String siteAddress);
+    void gotWpcomSiteInfo(String siteAddress, String siteName, String siteIconUrl);
     void gotXmlRpcEndpoint(String siteAddress);
     void helpWithSiteAddress();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginSiteAddressFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginSiteAddressFragment.java
@@ -215,6 +215,13 @@ public class LoginSiteAddressFragment extends Fragment implements TextWatcher {
                 new Response.Listener<SiteWPComRestResponse>() {
                     @Override
                     public void onResponse(SiteWPComRestResponse response) {
+                        if (response.jetpack) {
+                            // if Jetpack site, treat it as selfhosted and start the discovery process
+                            mDispatcher.dispatch(
+                                    AuthenticationActionBuilder.newDiscoverEndpointAction(mRequestedSiteAddress));
+                            return;
+                        }
+
                         endProgress();
 
                         // it's a wp.com site so, treat it as such.

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginSiteAddressFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginSiteAddressFragment.java
@@ -399,6 +399,9 @@ public class LoginSiteAddressFragment extends Fragment implements TextWatcher {
             return;
         }
 
+        // hold the URL in a variable to use below otherwise it gets cleared up by endProgress
+        final String requestedSiteAddress = mRequestedSiteAddress;
+
         if (mInProgress) {
             endProgress();
         }
@@ -425,6 +428,6 @@ public class LoginSiteAddressFragment extends Fragment implements TextWatcher {
         }
 
         AppLog.i(T.NUX, "Discovery succeeded, endpoint: " + event.xmlRpcEndpoint);
-        mLoginListener.gotXmlRpcEndpoint(event.xmlRpcEndpoint);
+        mLoginListener.gotXmlRpcEndpoint(requestedSiteAddress, event.xmlRpcEndpoint);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginSiteAddressFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginSiteAddressFragment.java
@@ -368,7 +368,7 @@ public class LoginSiteAddressFragment extends Fragment implements TextWatcher {
                     AppLog.e(T.NUX, "User is already logged in WordPress.com: " + currentUsername);
                     mLoginListener.alreadyLoggedInWpcom();
                 } else {
-                    mLoginListener.gotWpcomSiteAddress();
+                    mLoginListener.gotWpcomSiteAddress(event.failedEndpoint);
                 }
 
                 return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -1,0 +1,394 @@
+package org.wordpress.android.ui.accounts.login;
+
+import android.app.ProgressDialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.design.widget.TextInputLayout;
+import android.support.v4.app.Fragment;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.KeyEvent;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.generated.SiteActionBuilder;
+import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.AppLog.T;
+import org.wordpress.android.util.EditTextUtils;
+import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.ToastUtils;
+
+import javax.inject.Inject;
+
+public class LoginUsernamePasswordFragment extends Fragment implements TextWatcher {
+    private static final String KEY_IN_PROGRESS = "KEY_IN_PROGRESS";
+    private static final String KEY_LOGIN_FINISHED = "KEY_LOGIN_FINISHED";
+    private static final String KEY_REQUESTED_USERNAME = "KEY_REQUESTED_USERNAME";
+
+    private static final String ARG_SITE_ADDRESS = "ARG_SITE_ADDRESS";
+
+    public static final String TAG = "login_username_password_fragment_tag";
+
+    private TextInputLayout mUsernameEditTextLayout;
+    private TextInputLayout mPasswordEditTextLayout;
+
+    private EditText mUsernameEditText;
+    private EditText mPasswordEditText;
+    private Button mNextButton;
+    private ProgressDialog mProgressDialog;
+
+    private LoginListener mLoginListener;
+
+    private boolean mInProgress;
+    private boolean mAuthFailed;
+    private boolean mLoginFinished;
+
+    private String mRequestedUsername;
+
+    private String mSiteAddress;
+
+    @Inject Dispatcher mDispatcher;
+
+    public static LoginUsernamePasswordFragment newInstance(String siteAddress) {
+        LoginUsernamePasswordFragment fragment = new LoginUsernamePasswordFragment();
+        Bundle args = new Bundle();
+        args.putString(ARG_SITE_ADDRESS, siteAddress);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ((WordPress) getActivity().getApplication()).component().inject(this);
+
+        mSiteAddress = getArguments().getString(ARG_SITE_ADDRESS);
+
+        setHasOptionsMenu(true);
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.login_username_password_screen, container, false);
+
+        mUsernameEditText = (EditText) rootView.findViewById(R.id.login_username);
+        mUsernameEditText.addTextChangedListener(this);
+
+        mPasswordEditText = (EditText) rootView.findViewById(R.id.login_password);
+        mPasswordEditText.addTextChangedListener(this);
+
+        mUsernameEditTextLayout = (TextInputLayout) rootView.findViewById(R.id.login_username_layout);
+        mPasswordEditTextLayout = (TextInputLayout) rootView.findViewById(R.id.login_password_layout);
+
+        mNextButton = (Button) rootView.findViewById(R.id.login_username_password_next_button);
+        mNextButton.setOnClickListener(new OnClickListener() {
+            public void onClick(View v) {
+                next();
+            }
+        });
+
+        mUsernameEditText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+            @Override
+            public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+                if (event != null
+                        && event.getAction() == KeyEvent.ACTION_UP
+                        && event.getKeyCode() == KeyEvent.KEYCODE_ENTER) {
+                    mPasswordEditText.requestFocus();
+                }
+
+                // always consume the event so the focus stays in the EditText
+                return true;
+            }
+        });
+
+        mPasswordEditText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
+            @Override
+            public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+                if (event != null
+                        && event.getAction() == KeyEvent.ACTION_UP
+                        && event.getKeyCode() == KeyEvent.KEYCODE_ENTER) {
+                    next();
+                }
+
+                // always consume the event so the focus stays in the EditText
+                return true;
+            }
+        });
+
+        rootView.findViewById(R.id.login_lost_password).setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (mLoginListener != null) {
+                    mLoginListener.forgotPassword();
+                }
+            }
+        });
+
+        return rootView;
+    }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        Toolbar toolbar = (Toolbar) view.findViewById(R.id.toolbar);
+        ((AppCompatActivity) getActivity()).setSupportActionBar(toolbar);
+
+        ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayShowTitleEnabled(false);
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+
+        if (savedInstanceState == null) {
+            EditTextUtils.showSoftInput(mUsernameEditText);
+        }
+    }
+
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+
+        if (savedInstanceState != null) {
+            mInProgress = savedInstanceState.getBoolean(KEY_IN_PROGRESS);
+            mLoginFinished = savedInstanceState.getBoolean(KEY_LOGIN_FINISHED);
+
+            mRequestedUsername = savedInstanceState.getString(KEY_REQUESTED_USERNAME);
+
+            if (mInProgress) {
+                showProgressDialog();
+            }
+        }
+    }
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        if (context instanceof LoginListener) {
+            mLoginListener = (LoginListener) context;
+        } else {
+            throw new RuntimeException(context.toString() + " must implement LoginListener");
+        }
+    }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        mLoginListener = null;
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        outState.putBoolean(KEY_IN_PROGRESS, mInProgress);
+        outState.putBoolean(KEY_LOGIN_FINISHED, mLoginFinished);
+        outState.putString(KEY_REQUESTED_USERNAME, mRequestedUsername);
+    }
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        inflater.inflate(R.menu.menu_login, menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == R.id.help) {
+            mLoginListener.help();
+            return true;
+        }
+
+        return false;
+    }
+
+    protected void next() {
+        if (!NetworkUtils.checkConnection(getActivity())) {
+            return;
+        }
+
+        showProgressDialog();
+
+        mRequestedUsername = mUsernameEditText.getText().toString();
+        String password = mPasswordEditText.getText().toString();
+
+        // clear up the authentication-failed flag before
+        mAuthFailed = false;
+
+        SiteStore.RefreshSitesXMLRPCPayload selfHostedPayload = new SiteStore.RefreshSitesXMLRPCPayload();
+        selfHostedPayload.username = mRequestedUsername;
+        selfHostedPayload.password = password;
+        selfHostedPayload.url = mSiteAddress;
+        mDispatcher.dispatch(SiteActionBuilder.newFetchSitesXmlRpcAction(selfHostedPayload));
+    }
+
+    private String getCleanedUsername() {
+        return EditTextUtils.getText(mUsernameEditText).trim();
+    }
+
+    @Override
+    public void afterTextChanged(Editable s) {
+    }
+
+    @Override
+    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+    }
+
+    @Override
+    public void onTextChanged(CharSequence s, int start, int before, int count) {
+        updateNextButton();
+        mUsernameEditTextLayout.setError(null);
+        mPasswordEditTextLayout.setError(null);
+    }
+
+    private void updateNextButton() {
+        mNextButton.setEnabled(getCleanedUsername().length() > 0 && mPasswordEditText.getText().length() > 0);
+    }
+
+    private void showError(String errorMessage) {
+        mUsernameEditTextLayout.setError(" ");
+        mPasswordEditTextLayout.setError(errorMessage);
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        mDispatcher.register(this);
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        mDispatcher.unregister(this);
+    }
+
+    private void showProgressDialog() {
+        mNextButton.setEnabled(false);
+        mProgressDialog =
+                ProgressDialog.show(getActivity(), "", getActivity().getString(R.string.logging_in), true, true,
+                        new DialogInterface.OnCancelListener() {
+                            @Override
+                            public void onCancel(DialogInterface dialogInterface) {
+                                if (mInProgress) {
+                                    endProgress();
+                                }
+                            }
+                        });
+        mInProgress = true;
+    }
+
+    private void endProgress() {
+        mInProgress = false;
+
+        if (mProgressDialog != null) {
+            mProgressDialog.cancel();
+            mProgressDialog = null;
+        }
+
+        mRequestedUsername = null;
+
+        updateNextButton();
+    }
+
+    private void handleAuthError(AccountStore.AuthenticationErrorType error, String errorMessage) {
+        switch (error) {
+            case INCORRECT_USERNAME_OR_PASSWORD:
+            case NOT_AUTHENTICATED: // NOT_AUTHENTICATED is the generic error from XMLRPC response on first call.
+                showError(getString(R.string.username_or_password_incorrect));
+                break;
+            case INVALID_OTP:
+            case INVALID_TOKEN:
+            case AUTHORIZATION_REQUIRED:
+            case NEEDS_2FA:
+                showError("2FA not supported for self-hosted sites. Please use an app-password.");
+                break;
+            default:
+                AppLog.e(T.NUX, "Server response: " + errorMessage);
+
+                ToastUtils.showToast(getActivity(),
+                        errorMessage == null ? getString(R.string.error_generic) : errorMessage);
+                break;
+        }
+    }
+
+    // OnChanged events
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onAuthenticationChanged(AccountStore.OnAuthenticationChanged event) {
+        // only emitted when the login failed (but not when succeeded)
+
+        if (!isAdded() || mLoginFinished || mRequestedUsername == null) {
+            // just bail
+            return;
+        }
+
+        if (event.isError()) {
+            AppLog.e(T.API, "Login with username/pass onAuthenticationChanged has error: " + event.error.type + " - " +
+                    event.error.message);
+
+            mAuthFailed = true;
+
+            handleAuthError(event.error.type, event.error.message);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onSiteChanged(SiteStore.OnSiteChanged event) {
+        if (!isAdded() || mLoginFinished) {
+            return;
+        }
+
+        if (event.isError()) {
+            if (mRequestedUsername == null) {
+                // just bail since the operation was cancelled
+                return;
+            }
+
+            endProgress();
+
+            String errorMessage = event.error.toString();
+            AppLog.e(T.API, "Login with username/pass onSiteChanged has error: " + event.error.type + " - " +
+                    errorMessage);
+
+            if (!mAuthFailed) {
+                // show the error if not already displayed in onAuthenticationChanged (like in username/pass error)
+                showError(errorMessage);
+            }
+
+            return;
+        }
+
+        // continue with success, even if the operation was cancelled since the user got logged in regardless. So, go on
+        //  with finishing the login process
+
+        endProgress();
+
+        // mark as finished so any subsequent onSiteChanged (e.g. triggered by WPMainActivity) won't be intercepted
+        mLoginFinished = true;
+
+        if (mLoginListener != null) {
+            mLoginListener.loggedInViaUsernamePassword();
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -250,7 +250,10 @@ public class LoginUsernamePasswordFragment extends Fragment implements TextWatch
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.help) {
-            mLoginListener.help();
+            if (mLoginListener != null) {
+                mLoginListener.help();
+            }
+
             return true;
         }
 
@@ -363,7 +366,9 @@ public class LoginUsernamePasswordFragment extends Fragment implements TextWatch
             case AUTHORIZATION_REQUIRED:
             case NEEDS_2FA:
                 if (mIsWpcom) {
-                    mLoginListener.needs2fa(mRequestedUsername, mRequestedPassword);
+                    if (mLoginListener != null) {
+                        mLoginListener.needs2fa(mRequestedUsername, mRequestedPassword);
+                    }
                 } else {
                     showError("2FA not supported for self-hosted sites. Please use an app-password.");
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -36,8 +36,10 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.EditTextUtils;
+import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.widgets.WPNetworkImageView;
 
 import javax.inject.Inject;
 
@@ -97,6 +99,17 @@ public class LoginUsernamePasswordFragment extends Fragment implements TextWatch
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.login_username_password_screen, container, false);
+
+        if (mIsWpcom) {
+            ((TextView) rootView.findViewById(R.id.login_site_address)).setText(mSiteAddress);
+
+            WPNetworkImageView imgBlavatar = (WPNetworkImageView) rootView.findViewById(R.id.login_blavatar);
+            int blavatarSz = getResources().getDimensionPixelSize(R.dimen.blavatar_sz_small);
+            imgBlavatar.setImageUrl(GravatarUtils.blavatarFromUrl(mSiteAddress, blavatarSz),
+                    WPNetworkImageView.ImageType.BLAVATAR);
+
+            rootView.findViewById(R.id.login_site_info_layout).setVisibility(View.VISIBLE);
+        }
 
         mUsernameEditText = (EditText) rootView.findViewById(R.id.login_username);
         mUsernameEditText.addTextChangedListener(this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -108,7 +108,9 @@ public class LoginUsernamePasswordFragment extends Fragment implements TextWatch
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.login_username_password_screen, container, false);
 
-        rootView.findViewById(R.id.login_site_info_layout).setVisibility(mIsWpcom ? View.VISIBLE : View.GONE);
+        rootView.findViewById(R.id.login_site_title_static).setVisibility(mIsWpcom ? View.GONE : View.VISIBLE);
+        rootView.findViewById(R.id.login_blavatar_static).setVisibility(mIsWpcom ? View.GONE : View.VISIBLE);
+        rootView.findViewById(R.id.login_blavatar).setVisibility(mIsWpcom ? View.VISIBLE : View.GONE);
 
         if (mSiteIconUrl != null) {
             ((WPNetworkImageView) rootView.findViewById(R.id.login_blavatar)).setImageUrl(mSiteIconUrl,

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -36,7 +36,6 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.EditTextUtils;
-import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
@@ -50,6 +49,8 @@ public class LoginUsernamePasswordFragment extends Fragment implements TextWatch
     private static final String KEY_REQUESTED_PASSWORD = "KEY_REQUESTED_PASSWORD";
 
     private static final String ARG_SITE_ADDRESS = "ARG_SITE_ADDRESS";
+    private static final String ARG_SITE_NAME = "ARG_SITE_NAME";
+    private static final String ARG_SITE_ICON_URL = "ARG_SITE_ICON_URL";
     private static final String ARG_IS_WPCOM = "ARG_IS_WPCOM";
 
     public static final String TAG = "login_username_password_fragment_tag";
@@ -72,14 +73,19 @@ public class LoginUsernamePasswordFragment extends Fragment implements TextWatch
     private String mRequestedPassword;
 
     private String mSiteAddress;
+    private String mSiteName;
+    private String mSiteIconUrl;
     private boolean mIsWpcom;
 
     @Inject Dispatcher mDispatcher;
 
-    public static LoginUsernamePasswordFragment newInstance(String siteAddress, boolean isWpcom) {
+    public static LoginUsernamePasswordFragment newInstance(String siteAddress, String siteName, String siteIconUrl,
+            boolean isWpcom) {
         LoginUsernamePasswordFragment fragment = new LoginUsernamePasswordFragment();
         Bundle args = new Bundle();
         args.putString(ARG_SITE_ADDRESS, siteAddress);
+        args.putString(ARG_SITE_NAME, siteName);
+        args.putString(ARG_SITE_ICON_URL, siteIconUrl);
         args.putBoolean(ARG_IS_WPCOM, isWpcom);
         fragment.setArguments(args);
         return fragment;
@@ -91,6 +97,8 @@ public class LoginUsernamePasswordFragment extends Fragment implements TextWatch
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
         mSiteAddress = getArguments().getString(ARG_SITE_ADDRESS);
+        mSiteName = getArguments().getString(ARG_SITE_NAME);
+        mSiteIconUrl = getArguments().getString(ARG_SITE_ICON_URL);
         mIsWpcom = getArguments().getBoolean(ARG_IS_WPCOM);
 
         setHasOptionsMenu(true);
@@ -100,16 +108,20 @@ public class LoginUsernamePasswordFragment extends Fragment implements TextWatch
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.login_username_password_screen, container, false);
 
-        if (mIsWpcom) {
-            ((TextView) rootView.findViewById(R.id.login_site_address)).setText(mSiteAddress);
+        rootView.findViewById(R.id.login_site_info_layout).setVisibility(mIsWpcom ? View.VISIBLE : View.GONE);
 
-            WPNetworkImageView imgBlavatar = (WPNetworkImageView) rootView.findViewById(R.id.login_blavatar);
-            int blavatarSz = getResources().getDimensionPixelSize(R.dimen.blavatar_sz_small);
-            imgBlavatar.setImageUrl(GravatarUtils.blavatarFromUrl(mSiteAddress, blavatarSz),
+        if (mSiteIconUrl != null) {
+            ((WPNetworkImageView) rootView.findViewById(R.id.login_blavatar)).setImageUrl(mSiteIconUrl,
                     WPNetworkImageView.ImageType.BLAVATAR);
-
-            rootView.findViewById(R.id.login_site_info_layout).setVisibility(View.VISIBLE);
         }
+
+        TextView siteNameView = ((TextView) rootView.findViewById(R.id.login_site_title));
+        siteNameView.setText(mSiteName);
+        siteNameView.setVisibility(mSiteName != null ? View.VISIBLE : View.GONE);
+
+        TextView siteAddressView = ((TextView) rootView.findViewById(R.id.login_site_address));
+        siteAddressView.setText(mSiteAddress);
+        siteAddressView.setVisibility(mSiteAddress != null ? View.VISIBLE : View.GONE);
 
         mUsernameEditText = (EditText) rootView.findViewById(R.id.login_username);
         mUsernameEditText.addTextChangedListener(this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -251,6 +251,7 @@ public class WPMainActivity extends AppCompatActivity {
                     authTokenToSet = getAuthToken();
                 } else {
                     ActivityLauncher.showSignInForResult(this);
+                    finish();
                 }
             }
         }

--- a/WordPress/src/main/res/layout/login_username_password_screen.xml
+++ b/WordPress/src/main/res/layout/login_username_password_screen.xml
@@ -37,14 +37,29 @@
                     android:padding="1dp"
                     app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp" />
 
-                <TextView
-                    style="@style/Base.TextAppearance.AppCompat.Body1"
-                    android:id="@+id/login_site_address"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:layout_marginStart="@dimen/margin_extra_large"
-                    tools:text="pamelanguyyen.wordpress.com"/>
+                    android:orientation="vertical">
+
+                    <TextView
+                        style="@style/Base.TextAppearance.AppCompat.Body2"
+                        android:id="@+id/login_site_title"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        tools:text="Arround the World with Pam"/>
+
+                    <TextView
+                        style="@style/Base.TextAppearance.AppCompat.Body1"
+                        android:id="@+id/login_site_address"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        tools:text="pamelanguyyen.wordpress.com"/>
+                </LinearLayout>
             </TableRow>
 
             <TableRow>

--- a/WordPress/src/main/res/layout/login_username_password_screen.xml
+++ b/WordPress/src/main/res/layout/login_username_password_screen.xml
@@ -22,20 +22,31 @@
             android:padding="@dimen/margin_extra_large">
 
             <TableRow
-                android:id="@+id/login_site_info_layout"
                 android:gravity="center_vertical"
-                android:layout_marginBottom="@dimen/margin_extra_large"
-                android:visibility="gone"
-                tools:visibility="visible">
+                android:layout_marginBottom="@dimen/margin_extra_large">
 
-                <org.wordpress.android.widgets.WPNetworkImageView
-                    android:id="@+id/login_blavatar"
-                    android:layout_width="@dimen/blavatar_sz"
-                    android:layout_height="@dimen/blavatar_sz"
-                    android:background="@color/white"
-                    android:gravity="center_vertical"
-                    android:padding="1dp"
-                    app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp" />
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <org.wordpress.android.widgets.WPNetworkImageView
+                        android:id="@+id/login_blavatar"
+                        android:layout_width="@dimen/blavatar_sz"
+                        android:layout_height="@dimen/blavatar_sz"
+                        android:background="@color/white"
+                        android:gravity="center_vertical"
+                        app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp" />
+
+                    <org.wordpress.android.widgets.WPNetworkImageView
+                        android:id="@+id/login_blavatar_static"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="@color/white"
+                        android:gravity="center_vertical"
+                        android:visibility="gone"
+                        app:srcCompat="@drawable/ic_globe_grey_24dp" />
+                </LinearLayout>
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -43,6 +54,16 @@
                     android:layout_weight="1"
                     android:layout_marginStart="@dimen/margin_extra_large"
                     android:orientation="vertical">
+
+                    <TextView
+                        style="@style/Base.TextAppearance.AppCompat.Caption"
+                        android:id="@+id/login_site_title_static"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/login_site_address"
+                        android:visibility="gone"
+                        tools:visibility="visible"/>
 
                     <TextView
                         style="@style/Base.TextAppearance.AppCompat.Body2"

--- a/WordPress/src/main/res/layout/login_username_password_screen.xml
+++ b/WordPress/src/main/res/layout/login_username_password_screen.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include
+        android:id="@+id/toolbar"
+        layout="@layout/toolbar_login" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@+id/toolbar"
+        android:layout_above="@+id/login_bottom_buttons"
+        android:fillViewport="true">
+
+        <TableLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/margin_extra_large">
+
+            <TableRow
+                android:gravity="center_vertical"
+                android:layout_marginBottom="@dimen/margin_extra_large"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:contentDescription="@string/login_site_address_help_image"
+                    android:scaleType="centerInside"
+                    app:srcCompat="@drawable/ic_globe_grey_24dp"/>
+
+                <LinearLayout
+                    android:id="@+id/login_site_address_layout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical"
+                    android:layout_marginStart="@dimen/margin_extra_large">
+
+                    <TextView
+                        style="@style/TextAppearance.Design.Hint"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:enabled="false"
+                        android:textColor="?android:textColorSecondary"
+                        android:text="@string/login_site_address"/>
+
+                    <TextView
+                        style="@style/Base.TextAppearance.AppCompat.Body1"
+                        android:id="@+id/login_site_address"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_small"
+                        tools:text="pamelanguyyen.com"/>
+                </LinearLayout>
+            </TableRow>
+
+            <TableRow>
+                <ImageView
+                    android:id="@+id/login_username_icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_text_input_layout_baseline"
+                    android:contentDescription="@string/login_username_image"
+                    app:srcCompat="@drawable/ic_user_grey_24dp"/>
+
+                <android.support.design.widget.TextInputLayout
+                    app:theme="@style/LoginTheme.EditText"
+                    android:id="@+id/login_username_layout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_marginStart="@dimen/margin_extra_large">
+
+                    <android.support.design.widget.TextInputEditText
+                        android:id="@+id/login_username"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:hint="@string/username"/>
+                </android.support.design.widget.TextInputLayout>
+            </TableRow>
+
+            <TableRow
+                android:layout_marginTop="@dimen/margin_small">
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_text_input_layout_baseline"
+                    android:contentDescription="@string/login_password_image"
+                    app:srcCompat="@drawable/ic_lock_grey_24dp"/>
+
+                <android.support.design.widget.TextInputLayout
+                    app:theme="@style/LoginTheme.EditText"
+                    android:id="@+id/login_password_layout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    app:passwordToggleEnabled="true"
+                    app:passwordToggleTint="@color/wp_grey"
+                    android:layout_marginStart="@dimen/margin_extra_large">
+
+                    <android.support.design.widget.TextInputEditText
+                        android:id="@+id/login_password"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:hint="@string/password"
+                        android:inputType="textPassword"/>
+                </android.support.design.widget.TextInputLayout>
+            </TableRow>
+        </TableLayout>
+    </ScrollView>
+
+    <RelativeLayout
+        android:id="@+id/login_bottom_buttons"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:padding="@dimen/margin_extra_large">
+
+        <Button
+            android:theme="@style/LoginTheme.Button"
+            style="@style/Widget.AppCompat.Button.Colored"
+            android:id="@+id/login_username_password_next_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:layout_alignParentEnd="true"
+            android:enabled="false"
+            android:text="@string/next" />
+
+        <TextView
+            android:id="@+id/login_lost_password"
+            style="@style/Base.TextAppearance.AppCompat.Caption"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minHeight="@dimen/min_touch_target_sz"
+            android:layout_toStartOf="@+id/login_username_password_next_button"
+            android:layout_marginEnd="@dimen/margin_extra_extra_extra_large"
+            android:layout_centerVertical="true"
+            android:layout_alignParentStart="true"
+            android:gravity="center_vertical"
+            android:textColor="@color/blue_wordpress"
+            android:text="@string/forgot_password"/>
+    </RelativeLayout>
+</RelativeLayout>

--- a/WordPress/src/main/res/layout/login_username_password_screen.xml
+++ b/WordPress/src/main/res/layout/login_username_password_screen.xml
@@ -22,42 +22,29 @@
             android:padding="@dimen/margin_extra_large">
 
             <TableRow
+                android:id="@+id/login_site_info_layout"
                 android:gravity="center_vertical"
                 android:layout_marginBottom="@dimen/margin_extra_large"
                 android:visibility="gone"
                 tools:visibility="visible">
 
-                <ImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:contentDescription="@string/login_site_address_help_image"
-                    android:scaleType="centerInside"
-                    app:srcCompat="@drawable/ic_globe_grey_24dp"/>
+                <org.wordpress.android.widgets.WPNetworkImageView
+                    android:id="@+id/login_blavatar"
+                    android:layout_width="@dimen/blavatar_sz"
+                    android:layout_height="@dimen/blavatar_sz"
+                    android:background="@color/white"
+                    android:gravity="center_vertical"
+                    android:padding="1dp"
+                    app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp" />
 
-                <LinearLayout
-                    android:id="@+id/login_site_address_layout"
+                <TextView
+                    style="@style/Base.TextAppearance.AppCompat.Body1"
+                    android:id="@+id/login_site_address"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:orientation="vertical"
-                    android:layout_marginStart="@dimen/margin_extra_large">
-
-                    <TextView
-                        style="@style/TextAppearance.Design.Hint"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:enabled="false"
-                        android:textColor="?android:textColorSecondary"
-                        android:text="@string/login_site_address"/>
-
-                    <TextView
-                        style="@style/Base.TextAppearance.AppCompat.Body1"
-                        android:id="@+id/login_site_address"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_small"
-                        tools:text="pamelanguyyen.com"/>
-                </LinearLayout>
+                    android:layout_marginStart="@dimen/margin_extra_large"
+                    tools:text="pamelanguyyen.wordpress.com"/>
             </TableRow>
 
             <TableRow>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -304,6 +304,7 @@
     <dimen name="smart_toast_offset_y">48dp</dimen>
 
     <!-- login -->
+    <dimen name="margin_text_input_layout_baseline">20dp</dimen>
     <dimen name="margin_extra_extra_extra_large">92dp</dimen>
     <dimen name="promo_indicator_bullet_size">4dp</dimen>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1120,6 +1120,8 @@
     <string name="cd_related_post_preview_image">Related post preview image</string>
     <string name="login_globe_icon">Site address globe icon</string>
     <string name="login_site_address_help_image">Site address positioning image</string>
+    <string name="login_username_image">Login username icon</string>
+    <string name="login_password_image">Login password icon</string>
 
     <!-- Passcode lock -->
     <string name="passcode_manage">Manage PIN lock</string>


### PR DESCRIPTION
This PR introduces the username+password screen for the selfhosted flow. It supports both selfhosted and WPCOM sites.

The final visual touches, the messages and final texts will be done in a future PR.

To test:
* With the app signed out or its data cleaned, launch the app
* Tap on the "Login" button to go to the email screen
* Tap on the "Log in to your site by entering your site address instead." link on the lower left to go to the site address input screen
* Enter the URL of your selfhosted or wpcom site and tap on "NEXT"
* Enter your username and password in the respective input fields and tap on "NEXT"
* Notice the app do some work (progress popup) and jumping to the epilogue screen on success
