### PR TITLE
Issue/6075 add toolbar toggle

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile 'com.android.support:design:25.3.1'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.16.0'
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.0-beta.1')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.0-beta.2')
 }
 
 signing {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -51,7 +51,7 @@ import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 import org.wordpress.aztec.AztecAttributes;
 import org.wordpress.aztec.AztecText;
-import org.wordpress.aztec.AztecText.OnMediaTappedListener;
+import org.wordpress.aztec.AztecText.OnImageTappedListener;
 import org.wordpress.aztec.HistoryListener;
 import org.wordpress.aztec.Html;
 import org.wordpress.aztec.source.SourceViewEditText;
@@ -71,7 +71,7 @@ import java.util.UUID;
 public class AztecEditorFragment extends EditorFragmentAbstract implements
         OnImeBackListener,
         EditorMediaUploadListener,
-        OnMediaTappedListener,
+        OnImageTappedListener,
         AztecToolbarClickListener,
         HistoryListener {
 
@@ -164,7 +164,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
         content.getHistory().setHistoryListener(this);
 
-        content.setOnMediaTappedListener(this);
+        content.setOnImageTappedListener(this);
 
         mEditorFragmentListener.onEditorFragmentInitialized();
 
@@ -468,7 +468,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                         AztecAttributes attributes = new AztecAttributes();
                         attributes.setValue(ATTR_SRC, mediaUrl);
                         setAttributeValuesIfNotDefault(attributes, mediaFile);
-                        content.insertMedia(drawable, attributes);
+                        content.insertImage(drawable, attributes);
                     }
 
                     @Override
@@ -490,12 +490,12 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                             // Bitmap is too small.  Show image placeholder.
                             ToastUtils.showToast(getActivity(), R.string.error_media_small);
                             Drawable drawable = getResources().getDrawable(R.drawable.ic_image_loading_grey_a_40_48dp);
-                            content.insertMedia(drawable, attributes);
+                            content.insertImage(drawable, attributes);
                             return;
                         }
 
                         Bitmap resizedBitmap = ImageUtils.getScaledBitmapAtLongestSide(downloadedBitmap, DisplayUtils.getDisplayPixelWidth(getActivity()));
-                        content.insertMedia(new BitmapDrawable(getResources(), resizedBitmap), attributes);
+                        content.insertImage(new BitmapDrawable(getResources(), resizedBitmap), attributes);
                     }
                 }, 0, 0);
             }
@@ -518,13 +518,13 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 Bitmap bitmapToShow = ImageUtils.getWPImageSpanThumbnailFromFilePath(getActivity(), safeMediaUrl, maxWidth);
 
                 if (bitmapToShow != null) {
-                    content.insertMedia(new BitmapDrawable(getResources(), bitmapToShow), attrs);
+                    content.insertImage(new BitmapDrawable(getResources(), bitmapToShow), attrs);
                 } else {
                     // Failed to retrieve bitmap.  Show failed placeholder.
                     ToastUtils.showToast(getActivity(), R.string.error_media_load);
                     Drawable drawable = getResources().getDrawable(R.drawable.ic_image_failed_grey_a_40_48dp);
                     drawable.setBounds(0, 0, maxWidth, maxWidth);
-                    content.insertMedia(drawable, attrs);
+                    content.insertImage(drawable, attrs);
                 }
 
                 // set intermediate shade overlay
@@ -868,7 +868,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
-    public void mediaTapped(@NotNull AztecAttributes attrs, int naturalWidth, int naturalHeight) {
+    public void onImageTapped(@NotNull AztecAttributes attrs, int naturalWidth, int naturalHeight) {
         Set<String> classes = MetadataUtils.getClassAttribute(attrs);
 
         String idName;

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_horizontal.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_horizontal.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="48dp"
+    android:width="48dp"
+    android:viewportHeight="48"
+    android:viewportWidth="48" >
+
+    <!-- @color/wp_grey -->
+    <path
+        android:fillColor="#ff87a6bc"
+        android:pathData="M18.5,24c0,1.2-1,2.2-2.2,2.2s-2.2-1-2.2-2.2s1-2.2,2.2-2.2S18.5,22.8,18.5,24z M31.6,21.8c-1.2,0-2.2,1-2.2,2.2 s1,2.2,2.2,2.2c1.2,0,2.2-1,2.2-2.2S32.8,21.8,31.6,21.8z M24,21.8c-1.2,0-2.2,1-2.2,2.2s1,2.2,2.2,2.2c1.2,0,2.2-1,2.2-2.2 S25.2,21.8,24,21.8z" >
+    </path>
+
+</vector>

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_horizontal_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_horizontal_disabled.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="48dp"
+    android:width="48dp"
+    android:viewportHeight="48"
+    android:viewportWidth="48" >
+
+    <!-- @color/wp_grey_lighten_20 -->
+    <path
+        android:fillColor="#ffc8d7e1"
+        android:pathData="M18.5,24c0,1.2-1,2.2-2.2,2.2s-2.2-1-2.2-2.2s1-2.2,2.2-2.2S18.5,22.8,18.5,24z M31.6,21.8c-1.2,0-2.2,1-2.2,2.2 s1,2.2,2.2,2.2c1.2,0,2.2-1,2.2-2.2S32.8,21.8,31.6,21.8z M24,21.8c-1.2,0-2.2,1-2.2,2.2s1,2.2,2.2,2.2c1.2,0,2.2-1,2.2-2.2 S25.2,21.8,24,21.8z" >
+    </path>
+
+</vector>

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_horizontal_selector.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_horizontal_selector.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/format_bar_button_ellipsis_horizontal_disabled" android:state_enabled="false" />
+    <item android:drawable="@drawable/format_bar_button_ellipsis_horizontal" />
+
+</selector>

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_vertical.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_vertical.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="48dp"
+    android:width="48dp"
+    android:viewportHeight="48"
+    android:viewportWidth="48" >
+
+    <!-- @color/wp_grey -->
+    <path
+        android:fillColor="#ff87a6bc"
+        android:pathData="M23.9,29.4c1.2,0,2.2,1,2.2,2.2c0,1.2-1,2.2-2.2,2.2s-2.2-1-2.2-2.2C21.7,30.4,22.7,29.4,23.9,29.4z M21.7,16.3 c0,1.2,1,2.2,2.2,2.2s2.2-1,2.2-2.2c0-1.2-1-2.2-2.2-2.2S21.7,15.1,21.7,16.3z M21.7,23.9c0,1.2,1,2.2,2.2,2.2s2.2-1,2.2-2.2 s-1-2.2-2.2-2.2S21.7,22.7,21.7,23.9z" >
+    </path>
+
+</vector>

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_vertical_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_vertical_disabled.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="48dp"
+    android:width="48dp"
+    android:viewportHeight="48"
+    android:viewportWidth="48" >
+
+    <!-- @color/wp_grey_lighten_20 -->
+    <path
+        android:fillColor="#ffc8d7e1"
+        android:pathData="M23.9,29.4c1.2,0,2.2,1,2.2,2.2c0,1.2-1,2.2-2.2,2.2s-2.2-1-2.2-2.2C21.7,30.4,22.7,29.4,23.9,29.4z M21.7,16.3 c0,1.2,1,2.2,2.2,2.2s2.2-1,2.2-2.2c0-1.2-1-2.2-2.2-2.2S21.7,15.1,21.7,16.3z M21.7,23.9c0,1.2,1,2.2,2.2,2.2s2.2-1,2.2-2.2 s-1-2.2-2.2-2.2S21.7,22.7,21.7,23.9z" >
+    </path>
+
+</vector>

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_vertical_selector.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_vertical_selector.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector
+    xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item android:drawable="@drawable/format_bar_button_ellipsis_vertical_disabled" android:state_enabled="false" />
+    <item android:drawable="@drawable/format_bar_button_ellipsis_vertical" />
+
+</selector>

--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
@@ -11,7 +11,8 @@
         android:id="@+id/formatting_toolbar"
         android:layout_alignParentBottom="true"
         android:layout_height="@dimen/format_bar_height"
-        android:layout_width="match_parent" >
+        android:layout_width="match_parent"
+        aztec:advanced="true" >
     </org.wordpress.aztec.toolbar.AztecToolbar>
 
     <ScrollView

--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -71,17 +71,24 @@
     </string-array>
 
     <!-- Accessibility - format bar button descriptions -->
+    <string name="format_bar_description_media">Media</string>
+    <string name="format_bar_description_heading">Heading</string>
+    <string name="format_bar_description_list">List</string>
+    <string name="format_bar_description_ol">Ordered List</string>
+    <string name="format_bar_description_ul">Unordered List</string>
+    <string name="format_bar_description_quote">Block Quote</string>
     <string name="format_bar_description_bold">Bold</string>
     <string name="format_bar_description_italic">Italic</string>
+    <string name="format_bar_description_link">Link</string>
     <string name="format_bar_description_underline">Underline</string>
     <string name="format_bar_description_strike">Strikethrough</string>
-    <string name="format_bar_description_quote">Block quote</string>
-    <string name="format_bar_description_link">Insert link</string>
-    <string name="format_bar_description_more">Insert more</string>
-    <string name="format_bar_description_media">Insert media</string>
-    <string name="format_bar_description_ul">Unordered list</string>
-    <string name="format_bar_description_ol">Ordered list</string>
-    <string name="format_bar_description_html">HTML mode</string>
+    <string name="format_bar_description_horizontal_rule">Horizontal Rule</string>
+    <string name="format_bar_description_more">Read More</string>
+    <string name="format_bar_description_page">Page Break</string>
+    <string name="format_bar_description_html">HTML</string>
+    <string name="format_bar_description_ellipsis_collapse">Collapse Toolbar</string>
+    <string name="format_bar_description_ellipsis_expand">Expand Toolbar</string>
+
     <string name="visual_editor">Visual editor</string>
     <string name="image_thumbnail">Image thumbnail</string>
 


### PR DESCRIPTION
### Fix
Add ellipsis icons for expand/collapse buttons and `aztec:advanced` attribute to `AztecToolbar` view as described in https://github.com/wordpress-mobile/WordPress-Android/issues/6075.

### Test
0. Enable ***Beta*** editor.
1. Go to ***Sites*** tab.
2. Tap ***Create*** floating button.
3. Tap content text field.
4. Notice toolbar contains the following format buttons:
- Media
- Headings
- Lists
- Quote
- Bold
- Italic
5. Tap horizontal ellipsis button.
6. Notice toolbar expands to contain the following format buttons:
- Media
- Headings
- Lists
- Quote
- Bold
- Italic
- Link
- Underline
- Strikethrough
- Horizontal Rule
- More
- HTML
7. Tap vertical ellipsis button.
8. Notice toolbar collapses to contain the original format buttons.

#### Note
The ***branch will not build*** and the expand/collapse buttons will not be shown until https://github.com/wordpress-mobile/AztecEditor-Android/pull/388 is merged and the version containing those changes is included in the [WordPressEditor dependencies](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/libs/editor/WordPressEditor/build.gradle#L54).