### PR TITLE
Correctly restore app languages with country codes on restart

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -123,7 +123,7 @@ public class WPActivityUtils {
             if (!locale.equals(contextLanguage)) {
                 Resources resources = context.getResources();
                 Configuration conf = resources.getConfiguration();
-                conf.locale = new Locale(locale);
+                conf.locale = WPPrefUtils.languageLocale(locale);
                 resources.updateConfiguration(conf, resources.getDisplayMetrics());
             }
         }


### PR DESCRIPTION
Fixes #6068. Basically, the wrong constructor was being called. This PR uses an existing helper method to get a valid `Locale` when the app is started.

To test:
* Change you app language to any with a country code
* Force close the app and restart, verify the app language is set to whichever you selected