### PR TITLE
Pass category id list from select categories to post settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -89,9 +89,9 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import static org.wordpress.android.ui.posts.EditPostActivity.EXTRA_POST_LOCAL_ID;
-import static org.wordpress.android.ui.posts.SelectCategoriesActivity.KEY_SELECTED_CATEGORIES;
 import static android.app.Activity.RESULT_OK;
+import static org.wordpress.android.ui.posts.EditPostActivity.EXTRA_POST_LOCAL_ID;
+import static org.wordpress.android.ui.posts.SelectCategoriesActivity.KEY_SELECTED_CATEGORY_IDS;
 
 public class EditPostSettingsFragment extends Fragment {
     private static final String POST_FORMAT_STANDARD_KEY = "standard";
@@ -428,9 +428,9 @@ public class EditPostSettingsFragment extends Fragment {
                     break;
                 case ACTIVITY_REQUEST_CODE_SELECT_CATEGORIES:
                     extras = data.getExtras();
-                    if (extras != null && extras.containsKey(KEY_SELECTED_CATEGORIES)) {
+                    if (extras != null && extras.containsKey(KEY_SELECTED_CATEGORY_IDS)) {
                         @SuppressWarnings("unchecked")
-                        List<TermModel> categoryList = (List<TermModel>) extras.getSerializable(KEY_SELECTED_CATEGORIES);
+                        List<Long> categoryList = (ArrayList<Long>) extras.getSerializable(KEY_SELECTED_CATEGORY_IDS);
                         updateCategories(categoryList);
                     }
                     break;
@@ -695,15 +695,11 @@ public class EditPostSettingsFragment extends Fragment {
         }
     }
 
-    private void updateCategories(List<TermModel> categoryList) {
+    private void updateCategories(List<Long> categoryList) {
         if (categoryList == null) {
             return;
         }
-        List<Long> categoryIds = new ArrayList<>();
-        for (TermModel category : categoryList) {
-            categoryIds.add(category.getRemoteTermId());
-        }
-        mPost.setCategoryIdList(categoryIds);
+        mPost.setCategoryIdList(categoryList);
         dispatchUpdatePostAction();
         updateCategoriesTextView();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
@@ -40,14 +40,13 @@ import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 
 import javax.inject.Inject;
 
 import static org.wordpress.android.ui.posts.EditPostActivity.EXTRA_POST_LOCAL_ID;
 
 public class SelectCategoriesActivity extends AppCompatActivity {
-    public static final String KEY_SELECTED_CATEGORIES = "KEY_SELECTED_CATEGORIES";
+    public static final String KEY_SELECTED_CATEGORY_IDS = "KEY_SELECTED_CATEGORY_IDS";
 
     private ListView mListView;
     private TextView mEmptyView;
@@ -255,11 +254,7 @@ public class SelectCategoriesActivity extends AppCompatActivity {
     private void saveAndFinish() {
         Bundle bundle = new Bundle();
         updateSelectedCategoryList();
-        List<TermModel> categories = new ArrayList<>();
-        for (Long categoryRemoteId : mSelectedCategories) {
-            categories.add(mTaxonomyStore.getCategoryByRemoteId(mSite, categoryRemoteId));
-        }
-        bundle.putSerializable(KEY_SELECTED_CATEGORIES, new ArrayList<>(categories));
+        bundle.putSerializable(KEY_SELECTED_CATEGORY_IDS, new ArrayList<>(mSelectedCategories));
         Intent mIntent = new Intent();
         mIntent.putExtras(bundle);
         setResult(RESULT_OK, mIntent);


### PR DESCRIPTION
This PR fixes the NPE @tonyr59h documented [here](https://github.com/wordpress-mobile/WordPress-Android/pull/6082#issuecomment-308868839). Since we only use the category id list, we should be passing them from `SelectCategoriesActivity` back to `EditPostSettingsFragment` which is both more efficient and less error prone. It should also fix the NPE, since we don't actually call the `getRemoteTermId` anymore.

To test:
* Go into post settings and select new categories, add new categories etc and make sure they are reflected in Post Settings