### PR TITLE
Adds sharing columns to the site settings table

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -26,7 +26,7 @@ import java.io.OutputStream;
 public class WordPressDB {
     private static final String COLUMN_NAME_ID = "_id";
 
-    private static final int DATABASE_VERSION = 55;
+    private static final int DATABASE_VERSION = 56;
 
     // Warning if you rename DATABASE_NAME, that could break previous App backups (see: xml/backup_scheme.xml)
     private static final String DATABASE_NAME = "wordpress";
@@ -206,6 +206,9 @@ public class WordPressDB {
                 currentVersion++;
             case 54:
                 SiteSettingsTable.addImageResizeWidthAndQualityToSiteSettingsTable(db);
+                currentVersion++;
+            case 55:
+                SiteSettingsTable.addSharingColumnsToSiteSettingsTable(db);
                 currentVersion++;
         }
         db.setVersion(DATABASE_VERSION);

--- a/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
@@ -46,6 +46,17 @@ public final class SiteSettingsTable {
         }
     }
 
+    public static void addSharingColumnsToSiteSettingsTable(SQLiteDatabase db) {
+        if (db != null) {
+            db.execSQL(SiteSettingsModel.ADD_SHARING_LABEL);
+            db.execSQL(SiteSettingsModel.ADD_SHARING_BUTTON_STYLE);
+            db.execSQL(SiteSettingsModel.ADD_ALLOW_REBLOG_BUTTON);
+            db.execSQL(SiteSettingsModel.ADD_ALLOW_LIKE_BUTTON);
+            db.execSQL(SiteSettingsModel.ADD_ALLOW_COMMENT_LIKES);
+            db.execSQL(SiteSettingsModel.ADD_TWITTER_USERNAME);
+        }
+    }
+
     public static Map<Integer, CategoryModel> getAllCategories() {
         String sqlCommand = sqlSelectAllCategories() + ";";
         Cursor cursor = WordPress.wpDB.getDatabase().rawQuery(sqlCommand, null);

--- a/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
@@ -68,6 +68,20 @@ public class SiteSettingsModel {
             " add " + MAX_IMAGE_WIDTH_COLUMN_NAME + " INTEGER;";
     public static final String ADD_IMAGE_COMPRESSION_QUALITY = "alter table " + SETTINGS_TABLE_NAME +
             " add " + IMAGE_ENCODER_QUALITY_COLUMN_NAME + " INTEGER;";
+
+    public static final String ADD_SHARING_LABEL = "alter table " + SETTINGS_TABLE_NAME +
+            " add " + SHARING_LABEL_COLUMN_NAME + " TEXT;";
+    public static final String ADD_SHARING_BUTTON_STYLE = "alter table " + SETTINGS_TABLE_NAME +
+            " add " + SHARING_BUTTON_STYLE_COLUMN_NAME + " TEXT;";
+    public static final String ADD_ALLOW_REBLOG_BUTTON = "alter table " + SETTINGS_TABLE_NAME +
+            " add " + ALLOW_REBLOG_BUTTON_COLUMN_NAME + " BOOLEAN;";
+    public static final String ADD_ALLOW_LIKE_BUTTON = "alter table " + SETTINGS_TABLE_NAME +
+            " add " + ALLOW_LIKE_BUTTON_COLUMN_NAME + " BOOLEAN;";
+    public static final String ADD_ALLOW_COMMENT_LIKES = "alter table " + SETTINGS_TABLE_NAME +
+            " add " + ALLOW_COMMENT_LIKES_COLUMN_NAME + " BOOLEAN;";
+    public static final String ADD_TWITTER_USERNAME = "alter table " + SETTINGS_TABLE_NAME +
+            " add " + TWITTER_USERNAME_COLUMN_NAME + " TEXT;";
+
     public static final String CREATE_SETTINGS_TABLE_SQL =
             "CREATE TABLE IF NOT EXISTS " +
                     SETTINGS_TABLE_NAME +


### PR DESCRIPTION
Fixes #6105 - adds the missing sharing columns to the site settings table when the database already exists
