### PR TITLE
issue/6096-dot-org-always-pending-7.7

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -462,7 +462,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     }
 
     private String getSaveButtonText() {
-        if (!canPublishPost()) {
+        if (!userCanPublishPosts()) {
             return getString(R.string.submit_for_review);
         }
 
@@ -946,7 +946,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
      * returns true if the user has permission to publish the post - assumed to be true for
      * dot.org sites because we can't retrieve their capabilities
      */
-    private boolean canPublishPost() {
+    private boolean userCanPublishPosts() {
         if (SiteUtils.isAccessedViaWPComRest(mSite)) {
             return mSite.getHasCapabilityPublishPosts();
         } else {
@@ -965,7 +965,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         @Override
         protected Void doInBackground(Void... params) {
             // mark as pending if the user doesn't have publishing rights
-            if (!canPublishPost()) {
+            if (!userCanPublishPosts()) {
                if (PostStatus.fromPost(mPost) != PostStatus.DRAFT && PostStatus.fromPost(mPost) != PostStatus.PENDING) {
                    mPost.setStatus(PostStatus.PENDING.toString());
                }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -462,7 +462,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     }
 
     private String getSaveButtonText() {
-        if (SiteUtils.isAccessedViaWPComRest(mSite) && !mSite.getHasCapabilityPublishPosts()) {
+        if (!canPublishPost()) {
             return getString(R.string.submit_for_review);
         }
 
@@ -942,6 +942,18 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         return mIsNewPost;
     }
 
+    /*
+     * returns true if the user has permission to publish the post - assumed to be true for
+     * dot.org sites because we can't retrieve their capabilities
+     */
+    private boolean canPublishPost() {
+        if (SiteUtils.isAccessedViaWPComRest(mSite)) {
+            return mSite.getHasCapabilityPublishPosts();
+        } else {
+            return true;
+        }
+    }
+
     private class SavePostOnlineAndFinishTask extends AsyncTask<Void, Void, Void> {
 
         boolean isFirstTimePublish;
@@ -952,8 +964,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
         @Override
         protected Void doInBackground(Void... params) {
-            // mark as pending if this is a wp.com/jp site and the user doesn't have publish rights
-            if (SiteUtils.isAccessedViaWPComRest(mSite) && !mSite.getHasCapabilityPublishPosts()) {
+            // mark as pending if the user doesn't have publishing rights
+            if (!canPublishPost()) {
                if (PostStatus.fromPost(mPost) != PostStatus.DRAFT && PostStatus.fromPost(mPost) != PostStatus.PENDING) {
                    mPost.setStatus(PostStatus.PENDING.toString());
                }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -462,7 +462,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     }
 
     private String getSaveButtonText() {
-        if (!mSite.getHasCapabilityPublishPosts()) {
+        if (SiteUtils.isAccessedViaWPComRest(mSite) && !mSite.getHasCapabilityPublishPosts()) {
             return getString(R.string.submit_for_review);
         }
 
@@ -952,8 +952,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
         @Override
         protected Void doInBackground(Void... params) {
-
-            if (!mSite.getHasCapabilityPublishPosts()) {
+            // mark as pending if this is a wp.com/jp site and the user doesn't have publish rights
+            if (SiteUtils.isAccessedViaWPComRest(mSite) && !mSite.getHasCapabilityPublishPosts()) {
                if (PostStatus.fromPost(mPost) != PostStatus.DRAFT && PostStatus.fromPost(mPost) != PostStatus.PENDING) {
                    mPost.setStatus(PostStatus.PENDING.toString());
                }


### PR DESCRIPTION
Fixes #6096 

To test: publish a post from a .org site. Prior to this fix it would show as PENDING, it should now show as PUBLISHED.
