### PR TITLE
Login Rework: Login prompt for Jetpack Stats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -296,6 +296,12 @@ public class ActivityLauncher {
         activity.startActivity(intent);
     }
 
+    public static void showLoginEpilogueForResult(Activity activity, boolean showAndReturn) {
+        Intent intent = new Intent(activity, LoginEpilogueActivity.class);
+        intent.putExtra(LoginEpilogueActivity.EXTRA_SHOW_AND_RETURN, showAndReturn);
+        activity.startActivityForResult(intent, RequestCodes.SHOW_LOGIN_EPILOGUE_AND_RETURN);
+    }
+
     public static void viewStatsSinglePostDetails(Context context, SiteModel site, PostModel post, boolean isPage) {
         if (post == null) return;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
@@ -15,6 +15,7 @@ public class RequestCodes {
     public static final int SITE_SETTINGS = 1000;
     public static final int DO_LOGIN = 1100;
     public static final int PHOTO_PICKER = 1200;
+    public static final int SHOW_LOGIN_EPILOGUE_AND_RETURN = 1300;
 
     // Media
     public static final int PICTURE_LIBRARY = 2000;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -11,6 +11,7 @@ import android.view.MenuItem;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.ui.ActivityLauncher;
+import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.accounts.login.Login2FaFragment;
 import org.wordpress.android.ui.accounts.login.LoginEmailFragment;
 import org.wordpress.android.ui.accounts.login.LoginEmailPasswordFragment;
@@ -94,14 +95,24 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
         switch (getLoginMode()) {
             case FULL:
                 ActivityLauncher.showMainActivityAndLoginEpilogue(this);
+                setResult(Activity.RESULT_OK);
+                finish();
                 break;
             case JETPACK_STATS:
-                // nothing specia here. Just go on and finish the activity
+                ActivityLauncher.showLoginEpilogueForResult(this, true);
                 break;
         }
+    }
 
-        setResult(Activity.RESULT_OK);
-        finish();
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == RequestCodes.SHOW_LOGIN_EPILOGUE_AND_RETURN) {
+            // we showed the epilogue screen as informational and sites got loaded so, just return to login caller now
+            setResult(RESULT_OK);
+            finish();
+        }
     }
 
     // LoginListener implementation methods

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -147,6 +147,13 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
     }
 
     @Override
+    public void loginViaWpcomUsernameInstead() {
+        LoginUsernamePasswordFragment loginUsernamePasswordFragment = LoginUsernamePasswordFragment.newInstance(
+                "wordpress.com", "wordpress.com", "WordPress.com", "https://s0.wp.com/i/webclip.png", true);
+        slideInFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG);
+    }
+
+    @Override
     public void showMagicLinkSentScreen(String email) {
         LoginMagicLinkSentFragment loginMagicLinkSentFragment = LoginMagicLinkSentFragment.newInstance(email);
         slideInFragment(loginMagicLinkSentFragment, true, LoginMagicLinkSentFragment.TAG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -8,6 +8,8 @@ import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
 
 public class LoginEpilogueActivity extends AppCompatActivity implements LoginEpilogueFragment.LoginEpilogueListener {
+    public static final String EXTRA_SHOW_AND_RETURN = "EXTRA_SHOW_AND_RETURN";
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -15,12 +17,14 @@ public class LoginEpilogueActivity extends AppCompatActivity implements LoginEpi
         setContentView(R.layout.login_epilogue_activity);
 
         if (savedInstanceState == null) {
-            addPostLoginFragment();
+            boolean showAndReturn = getIntent().getBooleanExtra(EXTRA_SHOW_AND_RETURN, false);
+
+            addPostLoginFragment(showAndReturn);
         }
     }
 
-    protected void addPostLoginFragment() {
-        LoginEpilogueFragment loginEpilogueFragment = new LoginEpilogueFragment();
+    protected void addPostLoginFragment(boolean showAndReturn) {
+        LoginEpilogueFragment loginEpilogueFragment = LoginEpilogueFragment.newInstance(showAndReturn);
         FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
         fragmentTransaction.replace(R.id.fragment_container, loginEpilogueFragment, LoginEpilogueFragment.TAG);
         fragmentTransaction.commit();

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueFragment.java
@@ -37,6 +37,8 @@ public class LoginEpilogueFragment extends android.support.v4.app.Fragment {
 
     private static final String KEY_IN_PROGRESS = "KEY_IN_PROGRESS";
 
+    private static final String ARG_SHOW_AND_RETURN = "ARG_SHOW_AND_RETURN";
+
     private WPNetworkImageView mAvatarImageView;
     private TextView mDisplayNameTextView;
     private TextView mUsernameTextView;
@@ -48,6 +50,7 @@ public class LoginEpilogueFragment extends android.support.v4.app.Fragment {
 
     private boolean mInProgress;
     private SitePickerAdapter mAdapter;
+    private boolean mShowAndReturn;
 
     public interface LoginEpilogueListener {
         void onConnectAnotherSite();
@@ -55,10 +58,20 @@ public class LoginEpilogueFragment extends android.support.v4.app.Fragment {
     }
     private LoginEpilogueListener mLoginEpilogueListener;
 
+    public static LoginEpilogueFragment newInstance(boolean showAndReturn) {
+        LoginEpilogueFragment fragment = new LoginEpilogueFragment();
+        Bundle args = new Bundle();
+        args.putBoolean(ARG_SHOW_AND_RETURN, showAndReturn);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
+
+        mShowAndReturn = getArguments().getBoolean(ARG_SHOW_AND_RETURN);
     }
 
     @Override
@@ -71,7 +84,9 @@ public class LoginEpilogueFragment extends android.support.v4.app.Fragment {
 
         mSitesProgress = rootView.findViewById(R.id.sites_progress);
 
-        rootView.findViewById(R.id.login_connect_more).setOnClickListener(new View.OnClickListener() {
+        View connectMore = rootView.findViewById(R.id.login_connect_more);
+        connectMore.setVisibility(mShowAndReturn ? View.GONE : View.VISIBLE);
+        connectMore.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 if (mLoginEpilogueListener != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginMode.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginMode.java
@@ -1,0 +1,22 @@
+package org.wordpress.android.ui.accounts;
+
+import android.content.Intent;
+
+public enum LoginMode {
+    FULL,
+    JETPACK_STATS;
+
+    private static final String ARG_LOGIN_MODE = "ARG_LOGIN_MODE";
+
+    public static LoginMode fromIntent(Intent intent) {
+        if (intent.hasExtra(ARG_LOGIN_MODE)) {
+            return LoginMode.valueOf(intent.getStringExtra(ARG_LOGIN_MODE));
+        } else {
+            return FULL;
+        }
+    }
+
+    public void putInto(Intent intent) {
+        intent.putExtra(ARG_LOGIN_MODE, this.name());
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
@@ -104,19 +104,23 @@ public class LoginEmailFragment extends Fragment implements TextWatcher {
             }
         });
 
-        View loginViaSiteAddressView = rootView.findViewById(R.id.login_site_address);
+        TextView loginViaSiteAddressView = (TextView) rootView.findViewById(R.id.login_site_address);
         loginViaSiteAddressView.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
                 if (mLoginListener != null) {
-                    mLoginListener.loginViaSiteAddress();
+                    if (mLoginListener.getLoginMode() == LoginMode.JETPACK_STATS) {
+                        mLoginListener.loginViaWpcomUsernameInstead();
+                    } else {
+                        mLoginListener.loginViaSiteAddress();
+                    }
                 }
             }
         });
 
         if (mLoginListener.getLoginMode() == LoginMode.JETPACK_STATS) {
             ((TextView) rootView.findViewById(R.id.label)).setText(R.string.stats_sign_in_jetpack_different_com_account);
-            loginViaSiteAddressView.setVisibility(View.GONE);
+            loginViaSiteAddressView.setText(R.string.enter_username_instead);
         }
 
         return rootView;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
@@ -34,6 +34,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore.OnAvailabilityChecked;
+import org.wordpress.android.ui.accounts.LoginMode;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.EditTextUtils;
@@ -103,7 +104,8 @@ public class LoginEmailFragment extends Fragment implements TextWatcher {
             }
         });
 
-        rootView.findViewById(R.id.login_site_address).setOnClickListener(new OnClickListener() {
+        View loginViaSiteAddressView = rootView.findViewById(R.id.login_site_address);
+        loginViaSiteAddressView.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
                 if (mLoginListener != null) {
@@ -111,6 +113,11 @@ public class LoginEmailFragment extends Fragment implements TextWatcher {
                 }
             }
         });
+
+        if (mLoginListener.getLoginMode() == LoginMode.JETPACK_STATS) {
+            ((TextView) rootView.findViewById(R.id.label)).setText(R.string.stats_sign_in_jetpack_different_com_account);
+            loginViaSiteAddressView.setVisibility(View.GONE);
+        }
 
         return rootView;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
@@ -1,6 +1,10 @@
 package org.wordpress.android.ui.accounts.login;
 
+import org.wordpress.android.ui.accounts.LoginMode;
+
 public interface LoginListener {
+    LoginMode getLoginMode();
+
     // Login Prologue callbacks
     void nextPromo();
     void showEmailLoginScreen();

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
@@ -13,6 +13,7 @@ public interface LoginListener {
     // Login Email input callbacks
     void showMagicLinkRequestScreen(String email);
     void loginViaSiteAddress();
+    void loginViaWpcomUsernameInstead();
 
     // Login Request Magic Link callbacks
     void showMagicLinkSentScreen(String email);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -34,7 +34,6 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.RequestCodes;
-import org.wordpress.android.ui.accounts.SignInActivity;
 import org.wordpress.android.ui.posts.PromoDialog;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AnalyticsUtils;
@@ -189,11 +188,6 @@ public class StatsActivity extends AppCompatActivity
             }
         }
 
-        if (!mAccountStore.hasAccessToken()) {
-            // If the user is not connected to WordPress.com, ask him to connect first.
-            startWPComLoginActivity();
-            return;
-        }
         checkIfSiteHasAccessibleStats(mSite);
 
         // create the fragments without forcing the re-creation. If the activity is restarted fragments can already
@@ -293,16 +287,6 @@ public class StatsActivity extends AppCompatActivity
             // TODO: if Jetpack site, we should check the stats option is enabled
         }
         return true;
-    }
-
-    private void startWPComLoginActivity() {
-        mResultCode = RESULT_CANCELED;
-        Intent signInIntent = new Intent(this, SignInActivity.class);
-        signInIntent.putExtra(SignInActivity.EXTRA_JETPACK_SITE_AUTH, mSite.getId());
-        signInIntent.putExtra(SignInActivity.EXTRA_JETPACK_MESSAGE_AUTH,
-                getString(R.string.stats_sign_in_jetpack_different_com_account)
-        );
-        startActivityForResult(signInIntent, SignInActivity.REQUEST_CODE);
     }
 
     private void trackStatsAnalytics() {
@@ -551,11 +535,6 @@ public class StatsActivity extends AppCompatActivity
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        if (requestCode == SignInActivity.REQUEST_CODE) {
-            if (resultCode == RESULT_CANCELED) {
-                finish();
-            }
-        }
         if (requestCode == RequestCodes.REQUEST_JETPACK) {
             // Refresh the site in case we're back from Jetpack install Webview
             mDispatcher.dispatch(SiteActionBuilder.newFetchSiteAction(mSite));

--- a/WordPress/src/main/res/layout/login_email_screen.xml
+++ b/WordPress/src/main/res/layout/login_email_screen.xml
@@ -71,7 +71,7 @@
                     android:layout_centerVertical="true"
                     android:layout_alignParentLeft="true"
                     android:textColor="@color/blue_wordpress"
-                    android:text="@string/enter_username_password_instead"/>
+                    android:text="@string/enter_site_address_instead"/>
             </RelativeLayout>
         </RelativeLayout>
     </ScrollView>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1787,7 +1787,8 @@
     <string name="enter_email_wordpress_com">Log in to WordPress.com using an email address to manage all your WordPress sites</string>
     <string name="next">Next</string>
     <string name="open_mail">Open mail</string>
-    <string name="enter_username_password_instead">Log in to your site by entering your site address instead.</string>
+    <string name="enter_site_address_instead">Log in to your site by entering your site address instead.</string>
+    <string name="enter_username_instead">Log in with username instead.</string>
     <string name="enter_the_address_of_your_wordpress_site">Enter the address of your WordPress site</string>
     <string name="enter_verification_code">Almost there! Please enter the verification code from your Authenticator app.</string>
     <string name="login_text_otp">Text a code instead.</string>


### PR DESCRIPTION
This PR ports the prompt for WPCOM login to view Jetpack site stats over to the new login flow.

Since the prompt is for asking the user to log into WPCOM, the selfhosted flows are not offered. 

The final visual touches, the messages and final texts will be done in a future PR.

To test:
* With the app logged into a Jetpack site but not in WPCOM, tap on the "Stats" button on the MySites screen
* The email input screen should now be shown. No prologue screen and no "Log in to your site by entering your site address instead" secondary button should be shown.
* Continue with logging in
* App should land on the Stats screen upon successful login without the epilogue screen shown, unless the magiclink flow was used. In the magiclink case, app will show the epilogue and land on the main screen.
