### PR TITLE
Add Optimize video settings to Preferences screen

### DIFF
--- a/WordPress/src/main/assets/licenses.html
+++ b/WordPress/src/main/assets/licenses.html
@@ -34,6 +34,7 @@ libraries are licensed under <a href="http://www.apache.org/licenses/LICENSE-2.0
       <li><a href="https://github.com/xizzhu/simple-tool-tip">Simple Tool Tip</a>: Copyright 2016, Xizhi Zhu</li>
       <li><a href="https://github.com/square/okio">okio/okhttp</a>: Copyright 2013 Square, Inc.</li>
       <li><a href="https://github.com/greenrobot/EventBus">EventBus</a>: Copyright 2012-2016 Markus Junginger, greenrobot</li>
+      <li><a href="https://github.com/INDExOS/media-for-mobile">Mobile 4 Media</a>: Copyright 2016, INDExOS</li>
     </ul>
 
     <br>

--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -26,7 +26,7 @@ import java.io.OutputStream;
 public class WordPressDB {
     private static final String COLUMN_NAME_ID = "_id";
 
-    private static final int DATABASE_VERSION = 56;
+    private static final int DATABASE_VERSION = 57;
 
     // Warning if you rename DATABASE_NAME, that could break previous App backups (see: xml/backup_scheme.xml)
     private static final String DATABASE_NAME = "wordpress";
@@ -209,6 +209,9 @@ public class WordPressDB {
                 currentVersion++;
             case 55:
                 SiteSettingsTable.addSharingColumnsToSiteSettingsTable(db);
+                currentVersion++;
+            case 56:
+                SiteSettingsTable.addVideoResizeWidthAndQualityToSiteSettingsTable(db);
                 currentVersion++;
         }
         db.setVersion(DATABASE_VERSION);

--- a/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
@@ -46,6 +46,14 @@ public final class SiteSettingsTable {
         }
     }
 
+    public static void addVideoResizeWidthAndQualityToSiteSettingsTable(SQLiteDatabase db) {
+        if (db != null) {
+            db.execSQL(SiteSettingsModel.ADD_OPTIMIZED_VIDEO);
+            db.execSQL(SiteSettingsModel.ADD_VIDEO_RESIZE_WIDTH);
+            db.execSQL(SiteSettingsModel.ADD_VIDEO_COMPRESSION_BITRATE);
+        }
+    }
+
     public static void addSharingColumnsToSiteSettingsTable(SQLiteDatabase db) {
         if (db != null) {
             db.execSQL(SiteSettingsModel.ADD_SHARING_LABEL);

--- a/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
@@ -32,6 +32,9 @@ public class SiteSettingsModel {
     public static final String OPTIMIZED_IMAGE_COLUMN_NAME = "optimizedImage";
     public static final String MAX_IMAGE_WIDTH_COLUMN_NAME = "maxImageWidth";
     public static final String IMAGE_ENCODER_QUALITY_COLUMN_NAME = "imageEncoderQuality";
+    public static final String OPTIMIZED_VIDEO_COLUMN_NAME = "optimizedVideo";
+    public static final String MAX_VIDEO_WIDTH_COLUMN_NAME = "maxVideoWidth";
+    public static final String VIDEO_ENCODER_BITRATE_COLUMN_NAME = "videoEncoderBitrate";
     public static final String DEF_CATEGORY_COLUMN_NAME = "defaultCategory";
     public static final String DEF_POST_FORMAT_COLUMN_NAME = "defaultPostFormat";
     public static final String CATEGORIES_COLUMN_NAME = "categories";
@@ -68,6 +71,13 @@ public class SiteSettingsModel {
             " add " + MAX_IMAGE_WIDTH_COLUMN_NAME + " INTEGER;";
     public static final String ADD_IMAGE_COMPRESSION_QUALITY = "alter table " + SETTINGS_TABLE_NAME +
             " add " + IMAGE_ENCODER_QUALITY_COLUMN_NAME + " INTEGER;";
+
+    public static final String ADD_OPTIMIZED_VIDEO = "alter table " + SETTINGS_TABLE_NAME +
+            " add " + OPTIMIZED_VIDEO_COLUMN_NAME + " BOOLEAN;";
+    public static final String ADD_VIDEO_RESIZE_WIDTH = "alter table " + SETTINGS_TABLE_NAME +
+            " add " + MAX_VIDEO_WIDTH_COLUMN_NAME + " INTEGER;";
+    public static final String ADD_VIDEO_COMPRESSION_BITRATE = "alter table " + SETTINGS_TABLE_NAME +
+            " add " + VIDEO_ENCODER_BITRATE_COLUMN_NAME + " INTEGER;";
 
     public static final String ADD_SHARING_LABEL = "alter table " + SETTINGS_TABLE_NAME +
             " add " + SHARING_LABEL_COLUMN_NAME + " TEXT;";
@@ -134,6 +144,9 @@ public class SiteSettingsModel {
     public boolean optimizedImage;
     public int maxImageWidth;
     public int imageQualitySetting;
+    public boolean optimizedVideo;
+    public int maxVideoWidth;
+    public int videoEncoderBitrate;
     public int defaultCategory;
     public CategoryModel[] categories;
     public String defaultPostFormat;
@@ -183,6 +196,9 @@ public class SiteSettingsModel {
                 optimizedImage == otherModel.optimizedImage &&
                 imageQualitySetting == otherModel.imageQualitySetting &&
                 maxImageWidth == otherModel.maxImageWidth &&
+                optimizedVideo == otherModel.optimizedVideo &&
+                videoEncoderBitrate == otherModel.videoEncoderBitrate &&
+                maxVideoWidth == otherModel.maxVideoWidth &&
                 defaultCategory == otherModel.defaultCategory &&
                 showRelatedPosts == otherModel.showRelatedPosts &&
                 showRelatedPostHeader == otherModel.showRelatedPostHeader &&
@@ -232,6 +248,9 @@ public class SiteSettingsModel {
         optimizedImage = other.optimizedImage;
         maxImageWidth = other.maxImageWidth;
         imageQualitySetting = other.imageQualitySetting;
+        optimizedVideo = other.optimizedVideo;
+        videoEncoderBitrate = other.videoEncoderBitrate;
+        maxVideoWidth = other.maxVideoWidth;
         defaultCategory = other.defaultCategory;
         categories = other.categories;
         defaultPostFormat = other.defaultPostFormat;
@@ -294,6 +313,9 @@ public class SiteSettingsModel {
         optimizedImage = getBooleanFromCursor(cursor, OPTIMIZED_IMAGE_COLUMN_NAME);
         maxImageWidth = getIntFromCursor(cursor, MAX_IMAGE_WIDTH_COLUMN_NAME);
         imageQualitySetting = getIntFromCursor(cursor, IMAGE_ENCODER_QUALITY_COLUMN_NAME);
+        optimizedVideo = getBooleanFromCursor(cursor, OPTIMIZED_VIDEO_COLUMN_NAME);
+        maxVideoWidth = getIntFromCursor(cursor, MAX_VIDEO_WIDTH_COLUMN_NAME);
+        videoEncoderBitrate = getIntFromCursor(cursor, VIDEO_ENCODER_BITRATE_COLUMN_NAME);
         hasVerifiedCredentials = getBooleanFromCursor(cursor, CREDS_VERIFIED_COLUMN_NAME);
         allowComments = getBooleanFromCursor(cursor, ALLOW_COMMENTS_COLUMN_NAME);
         sendPingbacks = getBooleanFromCursor(cursor, SEND_PINGBACKS_COLUMN_NAME);
@@ -374,6 +396,9 @@ public class SiteSettingsModel {
         values.put(OPTIMIZED_IMAGE_COLUMN_NAME, optimizedImage);
         values.put(MAX_IMAGE_WIDTH_COLUMN_NAME, maxImageWidth);
         values.put(IMAGE_ENCODER_QUALITY_COLUMN_NAME, imageQualitySetting);
+        values.put(OPTIMIZED_VIDEO_COLUMN_NAME, optimizedVideo);
+        values.put(MAX_VIDEO_WIDTH_COLUMN_NAME, maxVideoWidth);
+        values.put(VIDEO_ENCODER_BITRATE_COLUMN_NAME, videoEncoderBitrate);
         values.put(DEF_CATEGORY_COLUMN_NAME, defaultCategory);
         values.put(CATEGORIES_COLUMN_NAME, categoryIdList(categories));
         values.put(DEF_POST_FORMAT_COLUMN_NAME, defaultPostFormat);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1717,7 +1717,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         }
 
         // Video optimization -> API18 or higher
-        if (isVideo && WPMediaUtils.isVideoOptimizationAvailable(this, mSite)) {
+        if (isVideo && WPMediaUtils.isVideoOptimizationEnabled(this, mSite)) {
             // Setting up the lister that's called when the video optimization finishes
             EditPostActivityVideoHelper.IVideoOptimizationListener listener = new EditPostActivityVideoHelper.IVideoOptimizationListener() {
                 @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1717,7 +1717,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         }
 
         // Video optimization -> API18 or higher
-        if (isVideo && WPMediaUtils.isVideoOptimizationAvailable()) {
+        if (isVideo && WPMediaUtils.isVideoOptimizationAvailable(this, mSite)) {
             // Setting up the lister that's called when the video optimization finishes
             EditPostActivityVideoHelper.IVideoOptimizationListener listener = new EditPostActivityVideoHelper.IVideoOptimizationListener() {
                 @Override
@@ -1731,7 +1731,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 }
             };
             EditPostActivityVideoHelper vHelper = new EditPostActivityVideoHelper(this, listener, path);
-            boolean videoOptimizationStarted = vHelper.startVideoOptimization();
+            boolean videoOptimizationStarted = vHelper.startVideoOptimization(mSite);
             // This is true only when video optimization can be started. In this case we just need to wait until it finishes
             if (videoOptimizationStarted) {
                 return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivityVideoHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivityVideoHelper.java
@@ -56,7 +56,7 @@ public class EditPostActivityVideoHelper {
             return false;
         }
 
-        if (!WPMediaUtils.isVideoOptimizationAvailable(parentActivity, siteModel)) {
+        if (!WPMediaUtils.isVideoOptimizationEnabled(parentActivity, siteModel)) {
             // Video optimization -> API18 or higher
             return false;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -151,6 +151,9 @@ class DotComSiteSettings extends SiteSettingsInterface {
                             boolean optimizedImage = mSettings.optimizedImage;
                             int maxImageWidth = mSettings.maxImageWidth;
                             int imageQualitySetting = mSettings.imageQualitySetting;
+                            boolean optimizedVideo = mSettings.optimizedVideo;
+                            int maxVideoWidth = mSettings.maxVideoWidth;
+                            int videoEncoderBitrate = mSettings.videoEncoderBitrate;
 
                             mSettings.copyFrom(mRemoteSettings);
 
@@ -159,6 +162,9 @@ class DotComSiteSettings extends SiteSettingsInterface {
                             mSettings.optimizedImage = optimizedImage;
                             mSettings.maxImageWidth = maxImageWidth;
                             mSettings.imageQualitySetting = imageQualitySetting;
+                            mSettings.optimizedVideo = optimizedVideo;
+                            mSettings.maxVideoWidth = maxVideoWidth;
+                            mSettings.videoEncoderBitrate = videoEncoderBitrate;
 
                             SiteSettingsTable.saveSettings(mSettings);
                             notifyUpdatedOnUiThread(null);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -67,6 +67,7 @@ import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPActivityUtils;
+import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.util.WPPrefUtils;
 
 import java.util.HashMap;
@@ -742,7 +743,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         setDetailListPreferenceValue(mVideoEncorderBitratePref,
                 String.valueOf(mSiteSettings.getVideoEncoderBitrate()),
                 getLabelForVideoEncoderBitrateValue(mSiteSettings.getVideoEncoderBitrate()));
-        if (!BuildConfig.VIDEO_OPTIMIZATION_AVAILABLE) {
+        if (!WPMediaUtils.isVideoOptimizationAvailable()) {
             WPPrefUtils.removePreference(this, R.string.pref_key_site_this_device, R.string.pref_key_optimize_video);
             WPPrefUtils.removePreference(this, R.string.pref_key_site_this_device, R.string.pref_key_site_video_width);
             WPPrefUtils.removePreference(this, R.string.pref_key_site_this_device, R.string.pref_key_site_video_encoder_bitrate);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -47,6 +47,7 @@ import com.wordpress.rest.RestRequest;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -190,6 +191,9 @@ public class SiteSettingsFragment extends PreferenceFragment
     private WPSwitchPreference mOptimizedImage;
     private DetailListPreference mImageWidthPref;
     private DetailListPreference mImageQualityPref;
+    private WPSwitchPreference mOptimizedVideo;
+    private DetailListPreference mVideoWidthPref;
+    private DetailListPreference mVideoEncorderBitratePref;
 
     // Advanced settings
     private Preference mStartOverPref;
@@ -536,6 +540,20 @@ public class SiteSettingsFragment extends PreferenceFragment
             setDetailListPreferenceValue(mImageQualityPref,
                     newValue.toString(),
                     getLabelForImageQualityValue(mSiteSettings.getImageQuality()));
+        } else if (preference == mOptimizedVideo) {
+            mSiteSettings.setOptimizedVideo((Boolean) newValue);
+            mVideoEncorderBitratePref.setEnabled((Boolean) newValue);
+        } else if (preference == mVideoWidthPref) {
+            int newWidth = Integer.parseInt(newValue.toString());
+            mSiteSettings.setVideoResizeWidth(newWidth);
+            setDetailListPreferenceValue(mVideoWidthPref,
+                    newValue.toString(),
+                    getLabelForVideoMaxWidthValue(mSiteSettings.getMaxVideoWidth()));
+        } else if (preference == mVideoEncorderBitratePref) {
+            mSiteSettings.setVideoEncoderBitrate(Integer.parseInt(newValue.toString()));
+            setDetailListPreferenceValue(mVideoEncorderBitratePref,
+                    newValue.toString(),
+                    getLabelForVideoEncoderBitrateValue(mSiteSettings.getVideoEncoderBitrate()));
         } else if (preference == mCategoryPref) {
             mSiteSettings.setDefaultCategory(Integer.parseInt(newValue.toString()));
             setDetailListPreferenceValue(mCategoryPref,
@@ -679,6 +697,9 @@ public class SiteSettingsFragment extends PreferenceFragment
         mOptimizedImage = (WPSwitchPreference) getChangePref(R.string.pref_key_optimize_image);
         mImageWidthPref = (DetailListPreference) getChangePref(R.string.pref_key_site_image_width);
         mImageQualityPref = (DetailListPreference) getChangePref(R.string.pref_key_site_image_quality);
+        mOptimizedVideo = (WPSwitchPreference) getChangePref(R.string.pref_key_optimize_video);
+        mVideoWidthPref = (DetailListPreference) getChangePref(R.string.pref_key_site_video_width);
+        mVideoEncorderBitratePref = (DetailListPreference) getChangePref(R.string.pref_key_site_video_encoder_bitrate);
         mStartOverPref = getClickPref(R.string.pref_key_site_start_over);
         mExportSitePref = getClickPref(R.string.pref_key_site_export_site);
         mDeleteSitePref = getClickPref(R.string.pref_key_site_delete_site);
@@ -713,6 +734,19 @@ public class SiteSettingsFragment extends PreferenceFragment
         setDetailListPreferenceValue(mImageQualityPref,
                 String.valueOf(mSiteSettings.getImageQuality()),
                 getLabelForImageQualityValue(mSiteSettings.getImageQuality()));
+
+        mOptimizedVideo.setChecked(mSiteSettings.getOptimizedVideo());
+        setDetailListPreferenceValue(mVideoWidthPref,
+                String.valueOf(mSiteSettings.getMaxVideoWidth()),
+                getLabelForVideoMaxWidthValue(mSiteSettings.getMaxVideoWidth()));
+        setDetailListPreferenceValue(mVideoEncorderBitratePref,
+                String.valueOf(mSiteSettings.getVideoEncoderBitrate()),
+                getLabelForVideoEncoderBitrateValue(mSiteSettings.getVideoEncoderBitrate()));
+        if (!BuildConfig.VIDEO_OPTIMIZATION_AVAILABLE) {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_this_device, R.string.pref_key_optimize_video);
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_this_device, R.string.pref_key_site_video_width);
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_this_device, R.string.pref_key_site_video_encoder_bitrate);
+        }
     }
 
     public void setEditingEnabled(boolean enabled) {
@@ -750,6 +784,30 @@ public class SiteSettingsFragment extends PreferenceFragment
     private String getLabelForImageQualityValue(int newValue) {
         String[] values = getActivity().getResources().getStringArray(R.array.site_settings_image_quality_values);
         String[] entries = getActivity().getResources().getStringArray(R.array.site_settings_image_quality_entries);
+        for (int i = 0; i < values.length ; i++) {
+            if (values[i].equals(String.valueOf(newValue))) {
+                return entries[i];
+            }
+        }
+
+        return entries[0];
+    }
+
+    private String getLabelForVideoMaxWidthValue(int newValue) {
+        String[] values = getActivity().getResources().getStringArray(R.array.site_settings_video_width_values);
+        String[] entries = getActivity().getResources().getStringArray(R.array.site_settings_video_width_entries);
+        for (int i = 0; i < values.length ; i++) {
+            if (values[i].equals(String.valueOf(newValue))) {
+                return entries[i];
+            }
+        }
+
+        return entries[0];
+    }
+
+    private String getLabelForVideoEncoderBitrateValue(int newValue) {
+        String[] values = getActivity().getResources().getStringArray(R.array.site_settings_video_bitrate_values);
+        String[] entries = getActivity().getResources().getStringArray(R.array.site_settings_video_bitrate_entries);
         for (int i = 0; i < values.length ; i++) {
             if (values[i].equals(String.valueOf(newValue))) {
                 return entries[i];
@@ -977,6 +1035,14 @@ public class SiteSettingsFragment extends PreferenceFragment
         setDetailListPreferenceValue(mImageQualityPref,
                 String.valueOf(mSiteSettings.getImageQuality()),
                 getLabelForImageQualityValue(mSiteSettings.getImageQuality()));
+
+        mOptimizedVideo.setChecked(mSiteSettings.getOptimizedVideo());
+        setDetailListPreferenceValue(mVideoWidthPref,
+                String.valueOf(mSiteSettings.getMaxVideoWidth()),
+                getLabelForVideoMaxWidthValue(mSiteSettings.getMaxVideoWidth()));
+        setDetailListPreferenceValue(mVideoEncorderBitratePref,
+                String.valueOf(mSiteSettings.getVideoEncoderBitrate()),
+                getLabelForVideoEncoderBitrateValue(mSiteSettings.getVideoEncoderBitrate()));
 
         changeEditTextPreferenceValue(mTitlePref, mSiteSettings.getTitle());
         changeEditTextPreferenceValue(mTaglinePref, mSiteSettings.getTagline());

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -292,6 +292,19 @@ public abstract class SiteSettingsInterface {
         return mSettings.imageQualitySetting > 1 ? mSettings.imageQualitySetting : WPMediaUtils.OPTIMIZE_IMAGE_ENCODER_QUALITY;
     }
 
+    public boolean getOptimizedVideo() {
+        return mSettings.optimizedVideo;
+    }
+
+    public int getMaxVideoWidth() {
+        int resizeWidth = mSettings.maxVideoWidth;
+        return resizeWidth == 0 ? WPMediaUtils.OPTIMIZE_VIDEO_MAX_WIDTH : resizeWidth;
+    }
+
+    public int getVideoEncoderBitrate() {
+        return mSettings.videoEncoderBitrate > 1 ? mSettings.videoEncoderBitrate : WPMediaUtils.OPTIMIZE_VIDEO_ENCODER_BITRATE_KB;
+    }
+
     public @NonNull Map<String, String> getFormats() {
         mSettings.postFormats = new HashMap<>();
         String[] postFormatDisplayNames = mActivity.getResources().getStringArray(R.array.post_format_display_names);
@@ -623,6 +636,18 @@ public abstract class SiteSettingsInterface {
         mSettings.imageQualitySetting = quality;
     }
 
+    public void setOptimizedVideo(boolean optimizedVideo) {
+        mSettings.optimizedVideo = optimizedVideo;
+    }
+
+    public void setVideoResizeWidth(int width) {
+        mSettings.maxVideoWidth = width;
+    }
+
+    public void setVideoEncoderBitrate(int bitrate) {
+        mSettings.videoEncoderBitrate = bitrate;
+    }
+
     public void setAllowComments(boolean allowComments) {
         mSettings.allowComments = allowComments;
     }
@@ -869,6 +894,9 @@ public abstract class SiteSettingsInterface {
             mRemoteSettings.optimizedImage = mSettings.optimizedImage;
             mRemoteSettings.maxImageWidth = mSettings.maxImageWidth;
             mRemoteSettings.imageQualitySetting = mSettings.imageQualitySetting;
+            mRemoteSettings.optimizedVideo = mSettings.optimizedVideo;
+            mRemoteSettings.maxVideoWidth = mSettings.maxVideoWidth;
+            mRemoteSettings.videoEncoderBitrate = mSettings.videoEncoderBitrate;
             notifyUpdatedOnUiThread(null);
         } else {
             mSettings.isInLocalTable = false;

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -15,6 +15,8 @@ public class WPMediaUtils {
     // Max picture size will be 3000px wide. That's the maximum resolution you can set in the current picker.
     public static final int OPTIMIZE_IMAGE_MAX_WIDTH = 3000;
     public static final int OPTIMIZE_IMAGE_ENCODER_QUALITY = 85;
+    public static final int OPTIMIZE_VIDEO_MAX_WIDTH = 1280;
+    public static final int OPTIMIZE_VIDEO_ENCODER_BITRATE_KB = 3000;
 
     public static Uri getOptimizedMedia(Activity activity, SiteModel siteModel, String path, boolean isVideo) {
         if (isVideo) {
@@ -56,7 +58,10 @@ public class WPMediaUtils {
         return null;
     }
 
-    public static boolean isVideoOptimizationAvailable() {
-        return BuildConfig.VIDEO_OPTIMIZATION_AVAILABLE && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2;
+    public static boolean isVideoOptimizationAvailable(Activity activity, SiteModel siteModel) {
+        SiteSettingsInterface siteSettings = SiteSettingsInterface.getInterface(activity, siteModel, null);
+        return BuildConfig.VIDEO_OPTIMIZATION_AVAILABLE
+                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2
+                && siteSettings != null && siteSettings.init(false).getOptimizedVideo();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -58,10 +58,12 @@ public class WPMediaUtils {
         return null;
     }
 
-    public static boolean isVideoOptimizationAvailable(Activity activity, SiteModel siteModel) {
-        SiteSettingsInterface siteSettings = SiteSettingsInterface.getInterface(activity, siteModel, null);
+    public static boolean isVideoOptimizationAvailable() {
         return BuildConfig.VIDEO_OPTIMIZATION_AVAILABLE
-                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2
-                && siteSettings != null && siteSettings.init(false).getOptimizedVideo();
+                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2;
+    }
+    public static boolean isVideoOptimizationEnabled(Activity activity, SiteModel siteModel) {
+        SiteSettingsInterface siteSettings = SiteSettingsInterface.getInterface(activity, siteModel, null);
+        return isVideoOptimizationAvailable() && siteSettings != null && siteSettings.init(false).getOptimizedVideo();
     }
 }

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -307,11 +307,11 @@
     </string-array>
 
     <string-array name="site_settings_video_bitrate_entries" translatable="false">
-        <item>1000 KB</item>
-        <item>2000 KB</item>
-        <item>3000 KB</item>
-        <item>4000 KB</item>
-        <item>5000 KB</item>
+        <item>@string/media_encoder_quality_80</item>
+        <item>@string/media_encoder_quality_85</item>
+        <item>@string/media_encoder_quality_90</item>
+        <item>@string/media_encoder_quality_95</item>
+        <item>@string/media_encoder_quality_100</item>
     </string-array>
 
     <string-array name="site_settings_video_bitrate_values" translatable="false">

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -50,6 +50,9 @@
     <string name="pref_key_optimize_image" translatable="false">wp_pref_key_optimize_image</string>
     <string name="pref_key_site_image_width" translatable="false">wp_pref_site_default_image_width</string>
     <string name="pref_key_site_image_quality" translatable="false">wp_pref_site_default_image_quality</string>
+    <string name="pref_key_optimize_video" translatable="false">wp_pref_key_optimize_video</string>
+    <string name="pref_key_site_video_width" translatable="false">wp_pref_site_default_video_width</string>
+    <string name="pref_key_site_video_encoder_bitrate" translatable="false">wp_pref_site_default_encoder_bitrate</string>
     <string name="pref_key_site_discussion" translatable="false">wp_pref_site_discussion</string>
     <string name="pref_key_site_allow_comments" translatable="false">wp_pref_site_allow_comments</string>
     <string name="pref_key_site_allow_comments_nested" translatable="false">wp_pref_site_allow_comments_nested</string>
@@ -289,6 +292,34 @@
         <item>90</item>
         <item>95</item>
         <item>100</item>
+    </string-array>
+
+    <string-array name="site_settings_video_width_entries" translatable="false">
+        <item>640 px</item>
+        <item>1024 px</item>
+        <item>1280 px</item>
+    </string-array>
+
+    <string-array name="site_settings_video_width_values" translatable="false">
+        <item>640</item>
+        <item>1024</item>
+        <item>1280</item>
+    </string-array>
+
+    <string-array name="site_settings_video_bitrate_entries" translatable="false">
+        <item>1000 KB</item>
+        <item>2000 KB</item>
+        <item>3000 KB</item>
+        <item>4000 KB</item>
+        <item>5000 KB</item>
+    </string-array>
+
+    <string-array name="site_settings_video_bitrate_values" translatable="false">
+        <item>1000</item>
+        <item>2000</item>
+        <item>3000</item>
+        <item>4000</item>
+        <item>5000</item>
     </string-array>
 
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -23,9 +23,9 @@
     <string name="tags_separate_with_commas">Tags (separate tags with commas)</string>
     <string name="post_content">Content (tap to add text and media)</string>
     <string name="max_thumbnail_px_width">Default Image Width</string>
-    <string name="image_quality">Image quality</string>
+    <string name="image_quality">Image Quality</string>
     <string name="max_video_px_width">Default Video Width</string>
-    <string name="video_bitrate">Video Bitrate</string>
+    <string name="video_quality">Video Quality</string>
     <string name="password">Password</string>
     <string name="blogs">Blogs</string>
     <string name="account_details">Account details</string>
@@ -487,7 +487,7 @@
     <string name="site_settings_default_image_quality_title" translatable="false">@string/image_quality</string>
     <string name="site_settings_optimize_videos">Optimize Videos</string>
     <string name="site_settings_default_video_width_title" translatable="false">@string/max_video_px_width</string>
-    <string name="site_settings_default_video_bitrate_title" translatable="false">@string/video_bitrate</string>
+    <string name="site_settings_default_video_quality_title" translatable="false">@string/video_quality</string>
     <string name="site_settings_upload_and_link_image_title" translatable="false">@string/upload_full_size_image</string>
     <string name="site_settings_related_posts_title" translatable="false">@string/related_posts</string>
     <string name="site_settings_more_title" translatable="false">@string/more</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -24,6 +24,8 @@
     <string name="post_content">Content (tap to add text and media)</string>
     <string name="max_thumbnail_px_width">Default Image Width</string>
     <string name="image_quality">Image quality</string>
+    <string name="max_video_px_width">Default Video Width</string>
+    <string name="video_bitrate">Video Bitrate</string>
     <string name="password">Password</string>
     <string name="blogs">Blogs</string>
     <string name="account_details">Account details</string>
@@ -483,6 +485,9 @@
     <string name="site_settings_optimize_images">Optimize Images</string>
     <string name="site_settings_default_image_width_title" translatable="false">@string/max_thumbnail_px_width</string>
     <string name="site_settings_default_image_quality_title" translatable="false">@string/image_quality</string>
+    <string name="site_settings_optimize_videos">Optimize Videos</string>
+    <string name="site_settings_default_video_width_title" translatable="false">@string/max_video_px_width</string>
+    <string name="site_settings_default_video_bitrate_title" translatable="false">@string/video_bitrate</string>
     <string name="site_settings_upload_and_link_image_title" translatable="false">@string/upload_full_size_image</string>
     <string name="site_settings_related_posts_title" translatable="false">@string/related_posts</string>
     <string name="site_settings_more_title" translatable="false">@string/more</string>
@@ -510,6 +515,7 @@
     <string name="site_settings_whitelist_known_summary">Comments from known users</string>
     <string name="site_settings_whitelist_none_summary" translatable="false">@string/none</string>
     <string name="site_settings_optimize_images_summary">Enable to resize and compress pictures</string>
+    <string name="site_settings_optimize_video_summary">Enable to resize and compress videos</string>
 
     <string name="detail_approve_manual">Require manual approval for everyone\'s comments.</string>
     <string name="detail_approve_auto_if_previously_approved">Automatically approve if the user has a previously approved comment</string>
@@ -568,6 +574,8 @@
     <string name="site_settings_format_hint">Sets new post format</string>
     <string name="site_settings_image_width_hint">Resizes images in posts to this width</string>
     <string name="site_settings_image_quality_hint">Quality of pictures. Higher values mean better quality pictures.</string>
+    <string name="site_settings_video_width_hint">Resizes videos in posts to this size</string>
+    <string name="site_settings_video_quality_hint">Quality of videos. Higher values mean better quality videos.</string>
     <string name="site_settings_related_posts_hint">Show or hide related posts in reader</string>
     <string name="site_settings_more_hint">View all available Discussion settings</string>
     <string name="site_settings_discussion_hint">View and change your sites discussion settings</string>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -282,6 +282,31 @@
             android:dependency="@string/pref_key_optimize_image"
             app:longClickHint="@string/site_settings_image_quality_hint" />
 
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
+            android:id="@+id/pref_optimize_video"
+            android:layout="@layout/preference_layout"
+            android:key="@string/pref_key_optimize_video"
+            android:title="@string/site_settings_optimize_videos"
+            android:summary="@string/site_settings_optimize_video_summary"/>
+
+        <org.wordpress.android.ui.prefs.DetailListPreference
+            android:id="@+id/pref_default_video_size"
+            android:key="@string/pref_key_site_video_width"
+            android:title="@string/site_settings_default_video_width_title"
+            android:entries="@array/site_settings_video_width_entries"
+            android:entryValues="@array/site_settings_video_width_values"
+            android:dependency="@string/pref_key_optimize_video"
+            app:longClickHint="@string/site_settings_video_width_hint" />
+
+        <org.wordpress.android.ui.prefs.DetailListPreference
+            android:id="@+id/pref_default_video_quality"
+            android:key="@string/pref_key_site_video_encoder_bitrate"
+            android:title="@string/site_settings_default_video_bitrate_title"
+            android:entries="@array/site_settings_video_bitrate_entries"
+            android:entryValues="@array/site_settings_video_bitrate_values"
+            android:dependency="@string/pref_key_optimize_video"
+            app:longClickHint="@string/site_settings_video_quality_hint" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -301,7 +301,7 @@
         <org.wordpress.android.ui.prefs.DetailListPreference
             android:id="@+id/pref_default_video_quality"
             android:key="@string/pref_key_site_video_encoder_bitrate"
-            android:title="@string/site_settings_default_video_bitrate_title"
+            android:title="@string/site_settings_default_video_quality_title"
             android:entries="@array/site_settings_video_bitrate_entries"
             android:entryValues="@array/site_settings_video_bitrate_values"
             android:dependency="@string/pref_key_optimize_video"


### PR DESCRIPTION
This PR adds video transcoding settings to the Preferences screen. Just below the Image setting items.

Video optimization is OFF by default, you need to manually turn it on. (Like to image optimization).
Also note that it's only available for alpha releases, and debug builds.

Minor:
 - Add license info for Mobile 4 Media library
