### PR TITLE
Login Rework: sequencing for the epilogue actions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueFragment.java
@@ -212,6 +212,7 @@ public class LoginEpilogueFragment extends android.support.v4.app.Fragment {
         if (event.isError()) {
             AppLog.e(AppLog.T.API, "onAccountChanged has error: " + event.error.type + " - " + event.error.message);
             ToastUtils.showToast(getContext(), R.string.error_fetch_my_profile);
+            return;
         }
 
         if (event.causeOfChange == AccountAction.FETCH_ACCOUNT) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueFragment.java
@@ -107,8 +107,6 @@ public class LoginEpilogueFragment extends android.support.v4.app.Fragment {
         if (savedInstanceState == null) {
             mInProgress = true;
             mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
-            mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
-            mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
         } else {
             mInProgress = savedInstanceState.getBoolean(KEY_IN_PROGRESS);
         }
@@ -207,7 +205,7 @@ public class LoginEpilogueFragment extends android.support.v4.app.Fragment {
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onAccountChanged(AccountStore.OnAccountChanged event) {
-        if (!isAdded() || event.causeOfChange != AccountAction.FETCH_ACCOUNT) {
+        if (!isAdded()) {
             return;
         }
 
@@ -216,7 +214,15 @@ public class LoginEpilogueFragment extends android.support.v4.app.Fragment {
             ToastUtils.showToast(getContext(), R.string.error_fetch_my_profile);
         }
 
-        refreshAccountDetails();
+        if (event.causeOfChange == AccountAction.FETCH_ACCOUNT) {
+            refreshAccountDetails();
+
+            // The user's account info has been fetched and stored - next, fetch the user's settings
+            mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
+        } else if (event.causeOfChange == AccountAction.FETCH_SETTINGS) {
+            // The user's account settings have also been fetched and stored - now we can fetch the user's sites
+            mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
+        }
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
Following suit with #6012 's sequencing of the account, account settings and sites network fetches, wait for the account fetch to finish first.

To test:
* Login to wpcom. The epilogue screen should normally display the logged in account sites.
