### PR TITLE
Post Settings: Publish Date

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -917,6 +917,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         if (mEditPostSettingsFragment != null) {
             mEditPostSettingsFragment.updatePostSettings(mPost);
         }
+        PostUtils.updatePublishDateIfShouldBePublishedImmediately(mPost);
 
         mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -84,7 +84,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
@@ -585,7 +584,7 @@ public class EditPostSettingsFragment extends Fragment {
         datePickerDialog.setButton(DialogInterface.BUTTON_NEUTRAL, neutralButtonTitle,
                 new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
-                        updatePublishDate(new Date());
+                        updatePublishDate(Calendar.getInstance());
                     }
                 });
         datePickerDialog.setButton(DialogInterface.BUTTON_NEGATIVE, resources.getString(android.R.string.cancel),
@@ -600,16 +599,16 @@ public class EditPostSettingsFragment extends Fragment {
         if (!isAdded()) {
             return;
         }
-        Calendar calendar = getCurrentPublishDateAsCalendar();
+        final Calendar calendar = getCurrentPublishDateAsCalendar();
         int hour = calendar.get(Calendar.HOUR_OF_DAY);
         int minute = calendar.get(Calendar.MINUTE);
         final TimePickerDialog timePickerDialog = new TimePickerDialog(getActivity(),
                 new TimePickerDialog.OnTimeSetListener() {
                     @Override
                     public void onTimeSet(TimePicker timePicker, int selectedHour, int selectedMinute) {
-                        Date javaDate = new Date(selectedYear - 1900, selectedMonth, selectedDay,
-                                selectedHour, selectedMinute);
-                        updatePublishDate(javaDate);
+                        Calendar selectedCalendar = Calendar.getInstance();
+                        selectedCalendar.set(selectedYear, selectedMonth, selectedDay, selectedHour, selectedMinute);
+                        updatePublishDate(selectedCalendar);
                     }
                 }, hour, minute, DateFormat.is24HourFormat(getActivity()));
         timePickerDialog.setTitle(R.string.select_time);
@@ -722,8 +721,8 @@ public class EditPostSettingsFragment extends Fragment {
         }
     }
 
-    private void updatePublishDate(Date date) {
-        mPost.setDateCreated(DateTimeUtils.iso8601FromDate(date));
+    private void updatePublishDate(Calendar calendar) {
+        mPost.setDateCreated(DateTimeUtils.iso8601FromDate(calendar.getTime()));
         updatePublishDateTextView();
         dispatchUpdatePostAction();
         updateSaveButton();
@@ -898,14 +897,11 @@ public class EditPostSettingsFragment extends Fragment {
     // Publish Date Helpers
 
     private Calendar getCurrentPublishDateAsCalendar() {
-        Date date;
         if (PostUtils.shouldPublishImmediately(mPost)) {
-            date = new Date();
-        } else {
-            date = DateTimeUtils.dateFromIso8601(mPost.getDateCreated());
+            return Calendar.getInstance();
         }
         Calendar calendar = Calendar.getInstance();
-        calendar.setTime(date);
+        calendar.setTime(DateTimeUtils.dateFromIso8601(mPost.getDateCreated()));
         return calendar;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -584,7 +584,8 @@ public class EditPostSettingsFragment extends Fragment {
         datePickerDialog.setButton(DialogInterface.BUTTON_NEUTRAL, neutralButtonTitle,
                 new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
-                        updatePublishDate(Calendar.getInstance());
+                        Calendar now = Calendar.getInstance();
+                        updatePublishDate(now);
                     }
                 });
         datePickerDialog.setButton(DialogInterface.BUTTON_NEGATIVE, resources.getString(android.R.string.cancel),
@@ -734,12 +735,12 @@ public class EditPostSettingsFragment extends Fragment {
     }
 
     private void updatePublishDateTextView() {
-        if (!isAdded() || TextUtils.isEmpty(mPost.getDateCreated())) {
+        if (!isAdded()) {
             return;
         }
         if (PostUtils.shouldPublishImmediately(mPost)) {
             mPublishDateTextView.setText(R.string.immediately);
-        } else {
+        } else if (!TextUtils.isEmpty(mPost.getDateCreated())){
             String formattedDate = DateUtils.formatDateTime(getActivity(),
                     DateTimeUtils.timestampFromIso8601Millis(mPost.getDateCreated()), getDateTimeFlags());
             mPublishDateTextView.setText(formattedDate);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -5,6 +5,7 @@ import android.app.Fragment;
 import android.app.TimePickerDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.res.Resources;
 import android.location.Address;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -572,9 +573,11 @@ public class EditPostSettingsFragment extends Fragment {
         int month = c.get(Calendar.MONTH);
         int day = c.get(Calendar.DAY_OF_MONTH);
 
+        Resources resources = getResources();
+
         final DatePickerDialog datePickerDialog = new DatePickerDialog(getActivity(), null, year, month, day);
         datePickerDialog.setTitle(R.string.select_date);
-        datePickerDialog.setButton(DialogInterface.BUTTON_POSITIVE, getResources().getText(android.R.string.ok),
+        datePickerDialog.setButton(DialogInterface.BUTTON_POSITIVE, resources.getString(android.R.string.ok),
                 new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         int selectedYear = datePickerDialog.getDatePicker().getYear();
@@ -583,16 +586,16 @@ public class EditPostSettingsFragment extends Fragment {
                         showPostTimeSelectionDialog(selectedYear, selectedMonth, selectedDate);
                     }
                 });
-        if (PostUtils.shouldPublishImmediatelyOptionBeAvailable(mPost)) {
-            datePickerDialog.setButton(DialogInterface.BUTTON_NEUTRAL, getResources().getText(R.string.immediately),
-                    new DialogInterface.OnClickListener() {
-                        public void onClick(DialogInterface dialog, int id) {
-                            updatePublishDate(new Date());
-                            updatePublishDateTextView();
-                        }
-                    });
-        }
-        datePickerDialog.setButton(DialogInterface.BUTTON_NEGATIVE, getResources().getText(android.R.string.cancel),
+        String neutralButtonTitle = PostUtils.shouldPublishImmediatelyOptionBeAvailable(mPost)
+                ? resources.getString(R.string.immediately) : resources.getString(R.string.now);
+        datePickerDialog.setButton(DialogInterface.BUTTON_NEUTRAL, neutralButtonTitle,
+                new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        updatePublishDate(new Date());
+                        updatePublishDateTextView();
+                    }
+                });
+        datePickerDialog.setButton(DialogInterface.BUTTON_NEGATIVE, resources.getString(android.R.string.cancel),
                 new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -25,6 +25,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.DatePicker;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.TextView;
@@ -568,10 +569,11 @@ public class EditPostSettingsFragment extends Fragment {
         if (!isAdded()) {
             return;
         }
-        Calendar c = Calendar.getInstance();
-        int year = c.get(Calendar.YEAR);
-        int month = c.get(Calendar.MONTH);
-        int day = c.get(Calendar.DAY_OF_MONTH);
+
+        Calendar calendar = getCurrentPublishDateAsCalendar();
+        int year = calendar.get(Calendar.YEAR);
+        int month = calendar.get(Calendar.MONTH);
+        int day = calendar.get(Calendar.DAY_OF_MONTH);
 
         Resources resources = getResources();
 
@@ -580,10 +582,11 @@ public class EditPostSettingsFragment extends Fragment {
         datePickerDialog.setButton(DialogInterface.BUTTON_POSITIVE, resources.getString(android.R.string.ok),
                 new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
-                        int selectedYear = datePickerDialog.getDatePicker().getYear();
-                        int selectedMonth = datePickerDialog.getDatePicker().getMonth();
-                        int selectedDate = datePickerDialog.getDatePicker().getDayOfMonth();
-                        showPostTimeSelectionDialog(selectedYear, selectedMonth, selectedDate);
+                        DatePicker datePicker = datePickerDialog.getDatePicker();
+                        int selectedYear = datePicker.getYear();
+                        int selectedMonth = datePicker.getMonth();
+                        int selectedDay = datePicker.getDayOfMonth();
+                        showPostTimeSelectionDialog(selectedYear, selectedMonth, selectedDay);
                     }
                 });
         String neutralButtonTitle = PostUtils.shouldPublishImmediatelyOptionBeAvailable(mPost)
@@ -607,9 +610,9 @@ public class EditPostSettingsFragment extends Fragment {
         if (!isAdded()) {
             return;
         }
-        Calendar c = Calendar.getInstance();
-        int hour = c.get(Calendar.HOUR_OF_DAY);
-        int minute = c.get(Calendar.MINUTE);
+        Calendar calendar = getCurrentPublishDateAsCalendar();
+        int hour = calendar.get(Calendar.HOUR_OF_DAY);
+        int minute = calendar.get(Calendar.MINUTE);
         final TimePickerDialog timePickerDialog = new TimePickerDialog(getActivity(),
                 new TimePickerDialog.OnTimeSetListener() {
                     @Override
@@ -899,6 +902,20 @@ public class EditPostSettingsFragment extends Fragment {
         intent.putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, MediaBrowserType.SINGLE_SELECT_PICKER);
         intent.putExtra(MediaBrowserActivity.ARG_IMAGES_ONLY, true);
         startActivityForResult(intent, RequestCodes.SINGLE_SELECT_MEDIA_PICKER);
+    }
+
+    // Publish Date Helpers
+
+    private Calendar getCurrentPublishDateAsCalendar() {
+        Date date;
+        if (PostUtils.shouldPublishImmediately(mPost)) {
+            date = new Date();
+        } else {
+            date = DateTimeUtils.dateFromIso8601(mPost.getDateCreated());
+        }
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(date);
+        return calendar;
     }
 
     // FluxC events

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -592,6 +592,11 @@ public class EditPostSettingsFragment extends Fragment {
                     public void onClick(DialogInterface dialog, int id) {
                     }
                 });
+        if (PostUtils.shouldPublishImmediatelyOptionBeAvailable(mPost)) {
+            // We shouldn't let the user pick a past date since we'll just override it to Immediately if they do
+            // We can't set the min date to now, so we need to subtract some amount of time
+            datePickerDialog.getDatePicker().setMinDate(System.currentTimeMillis() - 1000);
+        }
         datePickerDialog.show();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -907,7 +907,10 @@ public class EditPostSettingsFragment extends Fragment {
             return Calendar.getInstance();
         }
         Calendar calendar = Calendar.getInstance();
-        calendar.setTime(DateTimeUtils.dateFromIso8601(mPost.getDateCreated()));
+        // Set the currently selected time if available
+        if (!TextUtils.isEmpty(mPost.getDateCreated())) {
+            calendar.setTime(DateTimeUtils.dateFromIso8601(mPost.getDateCreated()));
+        }
         return calendar;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -764,12 +764,7 @@ public class EditPostSettingsFragment extends Fragment {
         if (!isAdded() || TextUtils.isEmpty(mPost.getDateCreated())) {
             return;
         }
-        boolean isDraft = PostStatus.fromPost(mPost) == PostStatus.DRAFT;
-        Date pubDate = DateTimeUtils.dateFromIso8601(mPost.getDateCreated());
-        Date now = new Date();
-        // If the publish date is now or in the past and it's a draft we should show "immediately"
-        // For this case, we'll also update the date just before publishing so it's published at current time
-        if (isDraft && !pubDate.after(now)) {
+        if (PostUtils.shouldPublishImmediately(mPost)) {
             mPublishDateTextView.setText(R.string.immediately);
         } else {
             String formattedDate = DateUtils.formatDateTime(getActivity(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -583,13 +583,15 @@ public class EditPostSettingsFragment extends Fragment {
                         showPostTimeSelectionDialog(selectedYear, selectedMonth, selectedDate);
                     }
                 });
-        datePickerDialog.setButton(DialogInterface.BUTTON_NEUTRAL, getResources().getText(R.string.immediately),
-                new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
-                        updatePublishDate(new Date());
-                        updatePublishDateTextView();
-                    }
-                });
+        if (PostUtils.shouldPublishImmediatelyOptionBeAvailable(mPost)) {
+            datePickerDialog.setButton(DialogInterface.BUTTON_NEUTRAL, getResources().getText(R.string.immediately),
+                    new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int id) {
+                            updatePublishDate(new Date());
+                            updatePublishDateTextView();
+                        }
+                    });
+        }
         datePickerDialog.setButton(DialogInterface.BUTTON_NEGATIVE, getResources().getText(android.R.string.cancel),
                 new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -392,15 +392,6 @@ public class EditPostSettingsFragment extends Fragment {
         }
     }
 
-    private int getDateTimeFlags() {
-        int flags = 0;
-        flags |= android.text.format.DateUtils.FORMAT_SHOW_DATE;
-        flags |= android.text.format.DateUtils.FORMAT_ABBREV_MONTH;
-        flags |= android.text.format.DateUtils.FORMAT_SHOW_YEAR;
-        flags |= android.text.format.DateUtils.FORMAT_SHOW_TIME;
-        return flags;
-    }
-
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
@@ -595,7 +586,6 @@ public class EditPostSettingsFragment extends Fragment {
                 new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         updatePublishDate(new Date());
-                        updatePublishDateTextView();
                     }
                 });
         datePickerDialog.setButton(DialogInterface.BUTTON_NEGATIVE, resources.getString(android.R.string.cancel),
@@ -734,6 +724,7 @@ public class EditPostSettingsFragment extends Fragment {
 
     private void updatePublishDate(Date date) {
         mPost.setDateCreated(DateTimeUtils.iso8601FromDate(date));
+        updatePublishDateTextView();
         dispatchUpdatePostAction();
         updateSaveButton();
     }
@@ -916,6 +907,15 @@ public class EditPostSettingsFragment extends Fragment {
         Calendar calendar = Calendar.getInstance();
         calendar.setTime(date);
         return calendar;
+    }
+
+    private int getDateTimeFlags() {
+        int flags = 0;
+        flags |= android.text.format.DateUtils.FORMAT_SHOW_DATE;
+        flags |= android.text.format.DateUtils.FORMAT_ABBREV_MONTH;
+        flags |= android.text.format.DateUtils.FORMAT_SHOW_YEAR;
+        flags |= android.text.format.DateUtils.FORMAT_SHOW_TIME;
+        return flags;
     }
 
     // FluxC events

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -761,18 +761,20 @@ public class EditPostSettingsFragment extends Fragment {
     }
 
     private void updatePublishDateTextView() {
-        if (!isAdded()) {
+        if (!isAdded() || TextUtils.isEmpty(mPost.getDateCreated())) {
             return;
         }
-        String pubDate = mPost.getDateCreated();
-        if (StringUtils.isNotEmpty(pubDate)) {
-            try {
-                String formattedDate = DateUtils.formatDateTime(getActivity(),
-                        DateTimeUtils.timestampFromIso8601Millis(pubDate), getDateTimeFlags());
-                mPublishDateTextView.setText(formattedDate);
-            } catch (RuntimeException e) {
-                AppLog.e(T.POSTS, e);
-            }
+        boolean isDraft = PostStatus.fromPost(mPost) == PostStatus.DRAFT;
+        Date pubDate = DateTimeUtils.dateFromIso8601(mPost.getDateCreated());
+        Date now = new Date();
+        // If the publish date is now or in the past and it's a draft we should show "immediately"
+        // For this case, we'll also update the date just before publishing so it's published at current time
+        if (isDraft && !pubDate.after(now)) {
+            mPublishDateTextView.setText(R.string.immediately);
+        } else {
+            String formattedDate = DateUtils.formatDateTime(getActivity(),
+                    DateTimeUtils.timestampFromIso8601Millis(mPost.getDateCreated()), getDateTimeFlags());
+            mPublishDateTextView.setText(formattedDate);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -286,11 +286,13 @@ public class PostUtils {
     }
 
     static boolean shouldPublishImmediately(PostModel postModel) {
-        boolean optionAvailable = shouldPublishImmediatelyOptionBeAvailable(postModel);
+        if (!shouldPublishImmediatelyOptionBeAvailable(postModel)) {
+            return false;
+        }
         Date pubDate = DateTimeUtils.dateFromIso8601(postModel.getDateCreated());
         Date now = new Date();
         // For drafts with publish dates in the past, we should publish immediately
-        return optionAvailable && !pubDate.after(now);
+        return !pubDate.after(now);
     }
 
     // Only drafts should have the option to publish immediately to avoid user confusion

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -297,4 +297,10 @@ public class PostUtils {
     static boolean shouldPublishImmediatelyOptionBeAvailable(PostModel postModel) {
         return PostStatus.fromPost(postModel) == PostStatus.DRAFT;
     }
+
+    static void updatePublishDateIfShouldBePublishedImmediately(PostModel postModel) {
+        if (shouldPublishImmediately(postModel)) {
+            postModel.setDateCreated(DateTimeUtils.iso8601FromDate(new Date()));
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -286,10 +286,15 @@ public class PostUtils {
     }
 
     static boolean shouldPublishImmediately(PostModel postModel) {
-        boolean isDraft = PostStatus.fromPost(postModel) == PostStatus.DRAFT;
+        boolean optionAvailable = shouldPublishImmediatelyOptionBeAvailable(postModel);
         Date pubDate = DateTimeUtils.dateFromIso8601(postModel.getDateCreated());
         Date now = new Date();
         // For drafts with publish dates in the past, we should publish immediately
-        return isDraft && !pubDate.after(now);
+        return optionAvailable && !pubDate.after(now);
+    }
+
+    // Only drafts should have the option to publish immediately to avoid user confusion
+    static boolean shouldPublishImmediatelyOptionBeAvailable(PostModel postModel) {
+        return PostStatus.fromPost(postModel) == PostStatus.DRAFT;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -21,6 +21,7 @@ import org.wordpress.android.widgets.WPAlertDialogFragment;
 
 import java.text.BreakIterator;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -282,5 +283,13 @@ public class PostUtils {
             }
         }
         return list;
+    }
+
+    static boolean shouldPublishImmediately(PostModel postModel) {
+        boolean isDraft = PostStatus.fromPost(postModel) == PostStatus.DRAFT;
+        Date pubDate = DateTimeUtils.dateFromIso8601(postModel.getDateCreated());
+        Date now = new Date();
+        // For drafts with publish dates in the past, we should publish immediately
+        return isDraft && !pubDate.after(now);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -523,6 +523,7 @@ public class PostsListFragment extends Fragment
             return;
         }
 
+        PostUtils.updatePublishDateIfShouldBePublishedImmediately(post);
         post.setStatus(PostStatus.PUBLISHED.toString());
 
         PostUploadService.addPostToUpload(post);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -962,6 +962,7 @@
     <!-- post date selection -->
     <string name="publish_date">Publish</string>
     <string name="immediately">Immediately</string>
+    <string name="now">Now</string>
     <string name="select_date">Select date</string>
     <string name="select_time">Select time</string>
 


### PR DESCRIPTION
Fixes #5989, #5927, #2891, #5990. This PR updates the publish date flow completely. We have been discussing this for a while now and trying to come up with a good solution. I think this is the best solution available to us.

A bit about the problem:

A user can do several things with publish date. They can set a past date, set it to immediately, schedule it to future, update it on remote and so on. However, the only field available to us in the API is `date` which doesn't tell us enough. It's added when a draft is first created, updated automatically when it's published and can be updated by the user in several ways. As far as we can tell, there is no perfect solution in the current structure.

Our solution:
1. Always use & show the `date` property in "Publish Date" and let the user update it to whenever they want (including past dates)
2. If the post is a draft, let the user set a future date. If a future date is set, treat it like the option 1.
3. Don't let the user set a past date for a draft. Theoretically they can do so if they select the current date and a prior time, but this doesn't matter too much. The only reason we do this is to avoid confusing the user due to 4 & 5.
4. If the post is a draft and if the `date` field is now or in the past, show "Immediately" instead
5. If 4 is true, just before a post is published, update the date field to current time which should be consistent with Calypso and wp-admin.

To test:
* Make sure to try each case for both drafts and published posts (or any other status like private, pending review etc)
* Since the solution section is pretty detailed and test-like, please make sure the follow the flows described and make sure to add a comment if a certain scenario is missed.
* This PR should, hopefully, be closing multiple issues. We should check each one before merging this PR. I'll do that as well.

cc @tonyr59h @maxme 
