### PR TITLE
issue/5944-reader-featured-image-class-take2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
@@ -115,12 +115,15 @@ public class ReaderImageScanner {
     }
 
     /*
-     * returns true if the passed image tag has a "size-full" or "size-large" class attribute,
-     * which would make it suitable for use as a featured image
+     * returns true if the passed image tag has a "size-" class attribute which would make it
+     * suitable for use as a featured image
      */
     private boolean hasSuitableClassForFeaturedImage(@NonNull String imageTag) {
         String tagClass = ReaderHtmlUtils.getClassAttrValue(imageTag);
-        return (tagClass != null && (tagClass.contains("size-full") || tagClass.contains("size-large")));
+        return (tagClass != null
+                && (tagClass.contains("size-full")
+                 || tagClass.contains("size-large")
+                 || tagClass.contains("size-medium")));
     }
 
     /*


### PR DESCRIPTION
This is a follow-up on #5944 based on [this comment](https://github.com/wordpress-mobile/WordPress-Android/pull/5946#issuecomment-307880435). Both the iOS and Calypso readers consider "size-medium" images to be large enough to be used as featured images, so this PR follows suit.