### PR TITLE
Issue/6115 sharing dialog rotation take2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPPrefView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPPrefView.java
@@ -28,6 +28,7 @@ import android.widget.TextView;
 import org.wordpress.android.R;
 import org.wordpress.android.util.StringUtils;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 
 /**
@@ -89,7 +90,7 @@ public class WPPrefView extends LinearLayout implements
     /*
      * single item when this is a list preference
      */
-    public static class PrefListItem {
+    public static class PrefListItem implements Serializable {
         private final String mItemName;   // name to display for this item
         private final String mItemValue;  // value for this item (can be same as name)
         private boolean mIsChecked;       // whether this item is checked
@@ -228,8 +229,8 @@ public class WPPrefView extends LinearLayout implements
     @Override
     public Parcelable onSaveInstanceState() {
         Bundle bundle = new Bundle();
-        bundle.putParcelable(KEY_SUPER_STATE, super.onSaveInstanceState());
         bundle.putSerializable(KEY_LIST_ITEMS, mListItems);
+        bundle.putParcelable(KEY_SUPER_STATE, super.onSaveInstanceState());
         return bundle;
     }
 
@@ -342,6 +343,7 @@ public class WPPrefView extends LinearLayout implements
                 if (getContext() instanceof Activity) {
                     Activity activity = (Activity) getContext();
                     WPPrefDialogFragment fragment = WPPrefDialogFragment.newInstance(this);
+                    activity.getFragmentManager().executePendingTransactions();
                     fragment.show(activity.getFragmentManager(), "pref_dialog_tag");
                 }
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPPrefView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPPrefView.java
@@ -9,6 +9,7 @@ import android.content.DialogInterface;
 import android.content.res.TypedArray;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AlertDialog;
@@ -219,6 +220,27 @@ public class WPPrefView extends LinearLayout implements
                 a.recycle();
             }
         }
+    }
+
+    private static final String KEY_LIST_ITEMS = "prefview_listitems";
+
+    @Override
+    public Parcelable onSaveInstanceState() {
+        Bundle bundle = new Bundle();
+        bundle.putParcelable("superState", super.onSaveInstanceState());
+        bundle.putSerializable(KEY_LIST_ITEMS, mListItems);
+        return bundle;
+    }
+
+    @Override
+    public void onRestoreInstanceState(Parcelable state) {
+        if (state instanceof Bundle) {
+            Bundle bundle = (Bundle) state;
+            PrefListItems items = (PrefListItems) bundle.getSerializable(KEY_LIST_ITEMS);
+            setListItems(items);
+            state = bundle.getParcelable("superState");
+        }
+        super.onRestoreInstanceState(state);
     }
 
     public void setOnPrefChangedListener(OnPrefChangedListener listener) {

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPPrefView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPPrefView.java
@@ -83,6 +83,9 @@ public class WPPrefView extends LinearLayout implements
     private String mTextDialogSubtitle;
     private OnPrefChangedListener mListener;
 
+    private static final String KEY_LIST_ITEMS = "prefview_listitems";
+    private static final String KEY_SUPER_STATE = "prefview_super_state";
+
     /*
      * single item when this is a list preference
      */
@@ -222,12 +225,10 @@ public class WPPrefView extends LinearLayout implements
         }
     }
 
-    private static final String KEY_LIST_ITEMS = "prefview_listitems";
-
     @Override
     public Parcelable onSaveInstanceState() {
         Bundle bundle = new Bundle();
-        bundle.putParcelable("superState", super.onSaveInstanceState());
+        bundle.putParcelable(KEY_SUPER_STATE, super.onSaveInstanceState());
         bundle.putSerializable(KEY_LIST_ITEMS, mListItems);
         return bundle;
     }
@@ -238,7 +239,7 @@ public class WPPrefView extends LinearLayout implements
             Bundle bundle = (Bundle) state;
             PrefListItems items = (PrefListItems) bundle.getSerializable(KEY_LIST_ITEMS);
             setListItems(items);
-            state = bundle.getParcelable("superState");
+            state = bundle.getParcelable(KEY_SUPER_STATE);
         }
         super.onRestoreInstanceState(state);
     }


### PR DESCRIPTION
Fixes #6115 - WPPrefView now uses a `DialogFragment` to avoid having the dialog disappear after rotating the device.

To test:

* Tap Sharing on the My Site tab
* Tap Manage
* Tap any of the first four settings (the ones that show a dialog)
* Rotate the device

Dialog should remain visible after rotation.
