### PR TITLE
Login Rework: New login flow for deepinking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -352,12 +352,16 @@ public class ActivityLauncher {
     }
 
     public static void loginWithoutMagicLink(Activity activity) {
-        Class<?> loginClass = BuildConfig.LOGIN_WIZARD_STYLE_ACTIVE ? LoginActivity.class : SignInActivity.class;
-
-        Intent signInIntent = new Intent(activity, loginClass);
-        signInIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        signInIntent.putExtra(SignInActivity.EXTRA_INHIBIT_MAGIC_LOGIN, true);
-        activity.startActivityForResult(signInIntent, RequestCodes.DO_LOGIN);
+        if (AppPrefs.isLoginWizardStyleActivated()) {
+            Intent loginIntent = new Intent(activity, LoginActivity.class);
+            LoginMode.WPCOM_LOGIN_DEEPLINK.putInto(loginIntent);
+            activity.startActivityForResult(loginIntent, RequestCodes.DO_LOGIN);
+        } else {
+            Intent signInIntent = new Intent(activity, SignInActivity.class);
+            signInIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            signInIntent.putExtra(SignInActivity.EXTRA_INHIBIT_MAGIC_LOGIN, true);
+            activity.startActivityForResult(signInIntent, RequestCodes.DO_LOGIN);
+        }
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -341,27 +341,31 @@ public class ActivityLauncher {
     }
 
     public static void loginForDeeplink(Activity activity) {
+        Intent intent;
+
         if (AppPrefs.isLoginWizardStyleActivated()) {
-            Intent loginIntent = new Intent(activity, LoginActivity.class);
-            LoginMode.WPCOM_LOGIN_DEEPLINK.putInto(loginIntent);
-            activity.startActivityForResult(loginIntent, RequestCodes.DO_LOGIN);
+            intent = new Intent(activity, LoginActivity.class);
+            LoginMode.WPCOM_LOGIN_DEEPLINK.putInto(intent);
         } else {
-            Intent intent = new Intent(activity, SignInActivity.class);
-            activity.startActivityForResult(intent, RequestCodes.DO_LOGIN);
+            intent = new Intent(activity, SignInActivity.class);
         }
+
+        activity.startActivityForResult(intent, RequestCodes.DO_LOGIN);
     }
 
     public static void loginWithoutMagicLink(Activity activity) {
+        Intent intent;
+
         if (AppPrefs.isLoginWizardStyleActivated()) {
-            Intent loginIntent = new Intent(activity, LoginActivity.class);
-            LoginMode.WPCOM_LOGIN_DEEPLINK.putInto(loginIntent);
-            activity.startActivityForResult(loginIntent, RequestCodes.DO_LOGIN);
+            intent = new Intent(activity, LoginActivity.class);
+            LoginMode.WPCOM_LOGIN_DEEPLINK.putInto(intent);
         } else {
-            Intent signInIntent = new Intent(activity, SignInActivity.class);
-            signInIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-            signInIntent.putExtra(SignInActivity.EXTRA_INHIBIT_MAGIC_LOGIN, true);
-            activity.startActivityForResult(signInIntent, RequestCodes.DO_LOGIN);
+            intent = new Intent(activity, SignInActivity.class);
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            intent.putExtra(SignInActivity.EXTRA_INHIBIT_MAGIC_LOGIN, true);
         }
+
+        activity.startActivityForResult(intent, RequestCodes.DO_LOGIN);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.networking.SSLCertsViewActivity;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.LoginActivity;
+import org.wordpress.android.ui.accounts.LoginMode;
 import org.wordpress.android.ui.accounts.NewBlogActivity;
 import org.wordpress.android.ui.accounts.LoginEpilogueActivity;
 import org.wordpress.android.ui.accounts.SignInActivity;
@@ -36,6 +37,7 @@ import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.PostPreviewActivity;
 import org.wordpress.android.ui.posts.PostsListActivity;
 import org.wordpress.android.ui.prefs.AccountSettingsActivity;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.AppSettingsActivity;
 import org.wordpress.android.ui.prefs.BlogPreferencesActivity;
 import org.wordpress.android.ui.prefs.MyProfileActivity;
@@ -336,6 +338,17 @@ public class ActivityLauncher {
         Intent intent = new Intent(activity, loginClass);
         intent.putExtra(SignInActivity.EXTRA_START_FRAGMENT, SignInActivity.ADD_SELF_HOSTED_BLOG);
         activity.startActivityForResult(intent, RequestCodes.ADD_ACCOUNT);
+    }
+
+    public static void loginForDeeplink(Activity activity) {
+        if (AppPrefs.isLoginWizardStyleActivated()) {
+            Intent loginIntent = new Intent(activity, LoginActivity.class);
+            LoginMode.WPCOM_LOGIN_DEEPLINK.putInto(loginIntent);
+            activity.startActivityForResult(loginIntent, RequestCodes.DO_LOGIN);
+        } else {
+            Intent intent = new Intent(activity, SignInActivity.class);
+            activity.startActivityForResult(intent, RequestCodes.DO_LOGIN);
+        }
     }
 
     public static void loginWithoutMagicLink(Activity activity) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
@@ -10,7 +10,6 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.store.AccountStore;
-import org.wordpress.android.ui.accounts.SignInActivity;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
@@ -27,8 +26,6 @@ import javax.inject.Inject;
  * Redirects users to the reader activity along with IDs passed in the intent
  */
 public class DeepLinkingIntentReceiverActivity extends AppCompatActivity {
-    private static final int INTENT_WELCOME = 0;
-
     private String mInterceptedUri;
     private String mBlogId;
     private String mPostId;
@@ -57,8 +54,7 @@ public class DeepLinkingIntentReceiverActivity extends AppCompatActivity {
             if (mAccountStore.hasAccessToken()) {
                 showPost();
             } else {
-                Intent intent = new Intent(this, SignInActivity.class);
-                startActivityForResult(intent, INTENT_WELCOME);
+                ActivityLauncher.loginForDeeplink(this);
             }
         } else {
             finish();
@@ -69,8 +65,9 @@ public class DeepLinkingIntentReceiverActivity extends AppCompatActivity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         // show the post if user is returning from successful login
-        if (requestCode == INTENT_WELCOME && resultCode == RESULT_OK)
+        if (requestCode == RequestCodes.DO_LOGIN && resultCode == RESULT_OK) {
             showPost();
+        }
     }
 
     private void showPost() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/DeepLinkingIntentReceiverActivity.java
@@ -53,6 +53,7 @@ public class DeepLinkingIntentReceiverActivity extends AppCompatActivity {
             // and then show the post once the user has signed in
             if (mAccountStore.hasAccessToken()) {
                 showPost();
+                finish();
             } else {
                 ActivityLauncher.loginForDeeplink(this);
             }
@@ -68,6 +69,8 @@ public class DeepLinkingIntentReceiverActivity extends AppCompatActivity {
         if (requestCode == RequestCodes.DO_LOGIN && resultCode == RESULT_OK) {
             showPost();
         }
+
+        finish();
     }
 
     private void showPost() {
@@ -87,8 +90,6 @@ public class DeepLinkingIntentReceiverActivity extends AppCompatActivity {
         } else {
             ToastUtils.showToast(this, R.string.error_generic);
         }
-
-        finish();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -43,6 +43,9 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
                 case JETPACK_STATS:
                     showFragment(new LoginEmailFragment(), LoginEmailFragment.TAG);
                     break;
+                case WPCOM_LOGIN_DEEPLINK:
+                    showFragment(new LoginEmailFragment(), LoginEmailFragment.TAG);
+                    break;
             }
         }
     }
@@ -101,6 +104,9 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
             case JETPACK_STATS:
                 ActivityLauncher.showLoginEpilogueForResult(this, true);
                 break;
+            case WPCOM_LOGIN_DEEPLINK:
+                ActivityLauncher.showLoginEpilogueForResult(this, true);
+                break;
         }
     }
 
@@ -135,9 +141,14 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
     }
 
     @Override
-    public void showMagicLinkRequestScreen(String email) {
-        LoginMagicLinkRequestFragment loginMagicLinkRequestFragment = LoginMagicLinkRequestFragment.newInstance(email);
-        slideInFragment(loginMagicLinkRequestFragment, true, LoginMagicLinkRequestFragment.TAG);
+    public void gotWpcomEmail(String email) {
+        if (getLoginMode() != LoginMode.WPCOM_LOGIN_DEEPLINK) {
+            LoginMagicLinkRequestFragment loginMagicLinkRequestFragment = LoginMagicLinkRequestFragment.newInstance(email);
+            slideInFragment(loginMagicLinkRequestFragment, true, LoginMagicLinkRequestFragment.TAG);
+        } else {
+            LoginEmailPasswordFragment loginEmailPasswordFragment = LoginEmailPasswordFragment.newInstance(email);
+            slideInFragment(loginEmailPasswordFragment, true, LoginEmailPasswordFragment.TAG);
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -41,8 +41,6 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
                     showFragment(new LoginPrologueFragment(), LoginPrologueFragment.TAG);
                     break;
                 case JETPACK_STATS:
-                    showFragment(new LoginEmailFragment(), LoginEmailFragment.TAG);
-                    break;
                 case WPCOM_LOGIN_DEEPLINK:
                     showFragment(new LoginEmailFragment(), LoginEmailFragment.TAG);
                     break;
@@ -102,8 +100,6 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
                 finish();
                 break;
             case JETPACK_STATS:
-                ActivityLauncher.showLoginEpilogueForResult(this, true);
-                break;
             case WPCOM_LOGIN_DEEPLINK:
                 ActivityLauncher.showLoginEpilogueForResult(this, true);
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginMode.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginMode.java
@@ -4,7 +4,8 @@ import android.content.Intent;
 
 public enum LoginMode {
     FULL,
-    JETPACK_STATS;
+    JETPACK_STATS,
+    WPCOM_LOGIN_DEEPLINK;
 
     private static final String ARG_LOGIN_MODE = "ARG_LOGIN_MODE";
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
@@ -34,7 +34,6 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore.OnAvailabilityChecked;
-import org.wordpress.android.ui.accounts.LoginMode;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.EditTextUtils;
@@ -114,9 +113,18 @@ public class LoginEmailFragment extends Fragment implements TextWatcher {
             }
         });
 
-        if (mLoginListener.getLoginMode() == LoginMode.JETPACK_STATS) {
-            ((TextView) rootView.findViewById(R.id.label)).setText(R.string.stats_sign_in_jetpack_different_com_account);
-            loginViaSiteAddressView.setVisibility(View.GONE);
+        switch (mLoginListener.getLoginMode()) {
+            case FULL:
+                // all features enabled and with typical values
+                break;
+            case JETPACK_STATS:
+                ((TextView) rootView.findViewById(R.id.label))
+                        .setText(R.string.stats_sign_in_jetpack_different_com_account);
+                loginViaSiteAddressView.setVisibility(View.GONE);
+                break;
+            case WPCOM_LOGIN_DEEPLINK:
+                loginViaSiteAddressView.setVisibility(View.GONE);
+                break;
         }
 
         return rootView;
@@ -320,7 +328,7 @@ public class LoginEmailFragment extends Fragment implements TextWatcher {
                     showEmailError(R.string.email_not_registered_wpcom);
                 } else if (mLoginListener != null) {
                     EditTextUtils.hideSoftInput(mEmailEditText);
-                    mLoginListener.showMagicLinkRequestScreen(event.value);
+                    mLoginListener.gotWpcomEmail(event.value);
                 }
                 break;
             default:

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
@@ -11,7 +11,7 @@ public interface LoginListener {
     void doStartSignup();
 
     // Login Email input callbacks
-    void showMagicLinkRequestScreen(String email);
+    void gotWpcomEmail(String email);
     void loginViaSiteAddress();
 
     // Login Request Magic Link callbacks


### PR DESCRIPTION
**Note: #6119 needs to be merged first.**

This PR enables the new login flow for the deeplinking entry points. When the deeplink points to a private WPCOM site, the app prompts the user to log into WordPress.com to be able to read the post.

Since the prompt is for asking the user to log into WPCOM, the selfhosted flows are not offered. At the epilogue screen, only the "Continue" button is offered.

The final visual touches, the messages and final texts will be done in a future PR.

To test:
* With the app not logged in WPCOM, trigger a deeplink to a private site's post URL. You may [use adb for that](https://developer.android.com/training/app-indexing/deep-linking.html#testing-filters).
* Notice the app launching, failing to display the post and offering the button to log into WPCOM. Tap the button.
* Notice the login screen asking for the WPCOM email in order to show the post. Only the "NEXT" button is available. Magiclinks is also not available. Continue logging in with your password.
* The epilogue screen is shown. Only "Continue" should be available. Tap it.
* App returns to the reader screen, loading the deeplinked post.