### PR TITLE
Issue/6141 photo picker tweaks

### DIFF
--- a/WordPress/src/main/res/drawable/ic_camera_alt_48px.xml
+++ b/WordPress/src/main/res/drawable/ic_camera_alt_48px.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp" android:viewportHeight="48.0"
-    android:viewportWidth="48.0" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="M24,24m-6.4,0a6.4,6.4 0,1 1,12.8 0a6.4,6.4 0,1 1,-12.8 0"/>
-    <path android:fillColor="#FF000000" android:pathData="M18,4l-3.66,4L8,8c-2.21,0 -4,1.79 -4,4v24c0,2.21 1.79,4 4,4h32c2.21,0 4,-1.79 4,-4L44,12c0,-2.21 -1.79,-4 -4,-4h-6.34L30,4L18,4zM24,34c-5.52,0 -10,-4.48 -10,-10s4.48,-10 10,-10 10,4.48 10,10 -4.48,10 -10,10z"/>
-</vector>

--- a/WordPress/src/main/res/drawable/ic_collections_48px.xml
+++ b/WordPress/src/main/res/drawable/ic_collections_48px.xml
@@ -1,4 +1,0 @@
-<vector android:height="24dp" android:viewportHeight="48.0"
-    android:viewportWidth="48.0" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="M44,32L44,8c0,-2.21 -1.79,-4 -4,-4L16,4c-2.21,0 -4,1.79 -4,4v24c0,2.21 1.79,4 4,4h24c2.21,0 4,-1.79 4,-4zM22,24l4.06,5.42L32,22l8,10L16,32l6,-8zM4,12v28c0,2.21 1.79,4 4,4h28v-4L8,40L8,12L4,12z"/>
-</vector>

--- a/WordPress/src/main/res/drawable/ic_fullscreen_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_fullscreen_white_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M21,3v6h-2L19,6.41l-3.29,3.3 -1.42,-1.42L17.59,5L15,5L15,3zM3,3v6h2L5,6.41l3.29,3.3 1.42,-1.42L6.41,5L9,5L9,3zM21,21v-6h-2v2.59l-3.29,-3.29 -1.41,1.41L17.59,19L15,19v2zM9,21v-2L6.41,19l3.29,-3.29 -1.41,-1.42L5,17.59L5,15L3,15v6z"/>
+</vector>

--- a/WordPress/src/main/res/drawable/ic_image_white_48dp.xml
+++ b/WordPress/src/main/res/drawable/ic_image_white_48dp.xml
@@ -1,0 +1,4 @@
+<vector android:height="48dp" android:viewportHeight="24.0"
+    android:viewportWidth="24.0" android:width="48dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M13,9.5c0,-0.828 0.672,-1.5 1.5,-1.5s1.5,0.672 1.5,1.5 -0.672,1.5 -1.5,1.5 -1.5,-0.672 -1.5,-1.5zM22,6v12c0,1.105 -0.895,2 -2,2L4,20c-1.105,0 -2,-0.895 -2,-2L2,6c0,-1.105 0.895,-2 2,-2h16c1.105,0 2,0.895 2,2zM20,6L4,6v7.444L8,9l5.895,6.55 1.587,-1.85c0.798,-0.932 2.24,-0.932 3.037,0L20,15.426L20,6z"/>
+</vector>

--- a/WordPress/src/main/res/drawable/preview_icon_background.xml
+++ b/WordPress/src/main/res/drawable/preview_icon_background.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@drawable/shape_oval_blue" android:state_pressed="true" />
-    <item android:drawable="@drawable/shape_oval_blue" android:state_selected="true" />
-    <item android:drawable="@drawable/shape_oval_translucent" />
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/blue_medium" />
+        </shape>
+    </item>
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/blue_medium" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/black_translucent_50" />
+        </shape>
+    </item>
 </selector>

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -127,10 +127,8 @@
             android:id="@+id/image_preview"
             android:layout_width="@dimen/photo_picker_preview_icon"
             android:layout_height="@dimen/photo_picker_preview_icon"
-            android:layout_marginBottom="@dimen/margin_small"
-            android:layout_marginLeft="@dimen/margin_small"
             android:background="@drawable/preview_icon_background"
-            android:padding="@dimen/margin_medium"
-            app:srcCompat="@drawable/ic_preview_white_24dp" />
+            android:padding="@dimen/margin_small"
+            app:srcCompat="@drawable/ic_fullscreen_white_24dp" />
     </FrameLayout>
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/photo_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/photo_picker_fragment.xml
@@ -97,7 +97,7 @@
             android:background="?android:selectableItemBackground"
             android:padding="@dimen/margin_medium"
             android:tint="@color/white"
-            app:srcCompat="@drawable/ic_camera_alt_48px" />
+            app:srcCompat="@drawable/ic_camera_white_48dp" />
 
         <ImageView
             android:id="@+id/icon_wpmedia"

--- a/WordPress/src/main/res/layout/photo_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/photo_picker_fragment.xml
@@ -87,7 +87,7 @@
             android:background="?android:selectableItemBackground"
             android:padding="@dimen/margin_medium"
             android:tint="@color/white"
-            app:srcCompat="@drawable/ic_collections_48px" />
+            app:srcCompat="@drawable/ic_image_white_48dp" />
 
         <ImageView
             android:id="@+id/icon_camera"

--- a/WordPress/src/main/res/layout/photo_picker_thumbnail.xml
+++ b/WordPress/src/main/res/layout/photo_picker_thumbnail.xml
@@ -50,6 +50,6 @@
         android:layout_marginLeft="@dimen/margin_small"
         android:background="@drawable/preview_icon_background"
         android:padding="@dimen/margin_medium"
-        app:srcCompat="@drawable/ic_preview_white_24dp" />
+        app:srcCompat="@drawable/ic_fullscreen_white_24dp" />
 
 </FrameLayout>

--- a/WordPress/src/main/res/layout/photo_picker_thumbnail.xml
+++ b/WordPress/src/main/res/layout/photo_picker_thumbnail.xml
@@ -46,10 +46,8 @@
         android:layout_width="@dimen/photo_picker_preview_icon"
         android:layout_height="@dimen/photo_picker_preview_icon"
         android:layout_gravity="bottom"
-        android:layout_marginBottom="@dimen/margin_small"
-        android:layout_marginLeft="@dimen/margin_small"
         android:background="@drawable/preview_icon_background"
-        android:padding="@dimen/margin_medium"
+        android:padding="@dimen/margin_small"
         app:srcCompat="@drawable/ic_fullscreen_white_24dp" />
 
 </FrameLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -295,7 +295,7 @@
     <dimen name="photo_picker_selected_item_padding">4dp</dimen>
     <dimen name="photo_picker_icon">48dp</dimen>
     <dimen name="photo_picker_video_overlay">36dp</dimen>
-    <dimen name="photo_picker_preview_icon">36dp</dimen>
+    <dimen name="photo_picker_preview_icon">28dp</dimen>
 
     <dimen name="smart_toast_offset_y">48dp</dimen>
 


### PR DESCRIPTION
Fixes #6141 - updates the preview (fullscreen), camera, and image icons in the photo picker to use the appropriate gridicons.
