### PR TITLE
Login Rework: Use the new login flow via Site Picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -333,10 +333,16 @@ public class ActivityLauncher {
     }
 
     public static void addSelfHostedSiteForResult(Activity activity) {
-        Class<?> loginClass = BuildConfig.LOGIN_WIZARD_STYLE_ACTIVE ? LoginActivity.class : SignInActivity.class;
+        Intent intent;
 
-        Intent intent = new Intent(activity, loginClass);
-        intent.putExtra(SignInActivity.EXTRA_START_FRAGMENT, SignInActivity.ADD_SELF_HOSTED_BLOG);
+        if (AppPrefs.isLoginWizardStyleActivated()) {
+            intent = new Intent(activity, LoginActivity.class);
+            LoginMode.SELFHOSTED_ONLY.putInto(intent);
+        } else {
+            intent = new Intent(activity, SignInActivity.class);
+            intent.putExtra(SignInActivity.EXTRA_START_FRAGMENT, SignInActivity.ADD_SELF_HOSTED_BLOG);
+        }
+
         activity.startActivityForResult(intent, RequestCodes.ADD_ACCOUNT);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -102,10 +102,14 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
                 setResult(Activity.RESULT_OK);
                 finish();
                 break;
-            case SELFHOSTED_ONLY:
             case JETPACK_STATS:
             case WPCOM_LOGIN_DEEPLINK:
                 ActivityLauncher.showLoginEpilogueForResult(this, true);
+                break;
+            case SELFHOSTED_ONLY:
+                // skip the epilogue when only added a selfhosted site
+                setResult(Activity.RESULT_OK);
+                finish();
                 break;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -40,6 +40,9 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
                 case FULL:
                     showFragment(new LoginPrologueFragment(), LoginPrologueFragment.TAG);
                     break;
+                case SELFHOSTED_ONLY:
+                    showFragment(new LoginSiteAddressFragment(), LoginSiteAddressFragment.TAG);
+                    break;
                 case JETPACK_STATS:
                 case WPCOM_LOGIN_DEEPLINK:
                     showFragment(new LoginEmailFragment(), LoginEmailFragment.TAG);
@@ -99,6 +102,7 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
                 setResult(Activity.RESULT_OK);
                 finish();
                 break;
+            case SELFHOSTED_ONLY:
             case JETPACK_STATS:
             case WPCOM_LOGIN_DEEPLINK:
                 ActivityLauncher.showLoginEpilogueForResult(this, true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueFragment.java
@@ -120,8 +120,10 @@ public class LoginEpilogueFragment extends android.support.v4.app.Fragment {
         super.onActivityCreated(savedInstanceState);
 
         if (savedInstanceState == null) {
-            mInProgress = true;
-            mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
+            if (mAccountStore.hasAccessToken()) {
+                mInProgress = true;
+                mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
+            }
         } else {
             mInProgress = savedInstanceState.getBoolean(KEY_IN_PROGRESS);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginMode.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginMode.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 
 public enum LoginMode {
     FULL,
+    SELFHOSTED_ONLY,
     JETPACK_STATS,
     WPCOM_LOGIN_DEEPLINK;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -191,7 +191,7 @@ public class MySiteFragment extends Fragment
             public void onClick(View v) {
                 if (!mAccountStore.hasAccessToken()) {
                     // If the user is not connected to WordPress.com, ask him to connect first.
-                    startWPComLoginActivity();
+                    startWPComLoginForJetpackStats();
                 } else {
                     ActivityLauncher.viewBlogStats(getActivity(), getSelectedSite());
                 }
@@ -278,7 +278,7 @@ public class MySiteFragment extends Fragment
         return rootView;
     }
 
-    private void startWPComLoginActivity() {
+    private void startWPComLoginForJetpackStats() {
         Intent loginIntent = new Intent(getActivity(), LoginActivity.class);
         LoginMode.JETPACK_STATS.putInto(loginIntent);
         startActivityForResult(loginIntent, RequestCodes.DO_LOGIN);


### PR DESCRIPTION
**Note: #6137 needs to be merged first.**

This PR enables the new login flow to add a selfhosted site from the Site Picker. Only the selfhosted flow is offered via the site picker.

The final visual touches, the messages and final texts will be done in a future PR.

To test:
* With a wpcom or selfhosted site already logged in the app, tap on the "Switch Site" option in MySite
* Tap on the "+" action to add a new site
* Input the site URL of the selfhosted site and hit "NEXT"
* Input the site username and password and hit "NEXT"
* ~The epilogue screen should come up, listing the new site among the previous ones. Only the "CONTINUE" button should be available. Tap on it.~
* The MySite screen should now be visible, displaying the site originally selected