### PR TITLE
Login Rework: Connect more from the epilogue screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.ShareIntentReceiverActivity;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.LoginActivity;
+import org.wordpress.android.ui.accounts.LoginEpilogueActivity;
 import org.wordpress.android.ui.accounts.LoginEpilogueFragment;
 import org.wordpress.android.ui.accounts.NewBlogFragment;
 import org.wordpress.android.ui.accounts.NewUserFragment;
@@ -126,6 +127,7 @@ public interface AppComponent {
     void inject(Login2FaFragment object);
     void inject(LoginSiteAddressFragment object);
     void inject(LoginUsernamePasswordFragment object);
+    void inject(LoginEpilogueActivity object);
 
     void inject(StatsWidgetConfigureActivity object);
     void inject(StatsWidgetConfigureAdapter object);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -1,18 +1,25 @@
 package org.wordpress.android.ui.accounts;
 
 import org.wordpress.android.R;
-import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.ui.ActivityLauncher;
 
 import android.os.Bundle;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
 
+import javax.inject.Inject;
+
 public class LoginEpilogueActivity extends AppCompatActivity implements LoginEpilogueFragment.LoginEpilogueListener {
     public static final String EXTRA_SHOW_AND_RETURN = "EXTRA_SHOW_AND_RETURN";
+
+    protected @Inject AccountStore mAccountStore;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        ((WordPress) getApplication()).component().inject(this);
 
         setContentView(R.layout.login_epilogue_activity);
 
@@ -32,7 +39,13 @@ public class LoginEpilogueActivity extends AppCompatActivity implements LoginEpi
 
     @Override
     public void onConnectAnotherSite() {
-        ToastUtils.showToast(this, "Connect another site is not implemented yet.");
+        if (mAccountStore.hasAccessToken()) {
+            ActivityLauncher.addSelfHostedSiteForResult(this);
+        } else {
+            ActivityLauncher.showSignInForResult(this);
+        }
+
+        finish();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -448,7 +448,21 @@ public class LoginUsernamePasswordFragment extends Fragment implements TextWatch
 
             endProgress();
 
-            String errorMessage = event.error.toString();
+            String errorMessage;
+            if (event.error.type == SiteStore.SiteErrorType.DUPLICATE_SITE) {
+                if (event.rowsAffected == 0) {
+                    // If there is a duplicate site and not any site has been added, show an error and
+                    // stop the sign in process
+                    errorMessage = getString(R.string.cannot_add_duplicate_site);
+                } else {
+                    // If there is a duplicate site, notify the user something could be wrong,
+                    // but continue the sign in process
+                    errorMessage = getString(R.string.duplicate_site_detected);
+                }
+            } else {
+                errorMessage = getString(R.string.login_error_while_adding_site, event.error.type.toString());
+            }
+
             AppLog.e(T.API, "Login with username/pass onSiteChanged has error: " + event.error.type + " - " +
                     errorMessage);
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1812,4 +1812,5 @@
     <string name="login_site_address_help_content">Your site address appears in the bar at the top of the screen when you visit your site in Chrome.</string>
     <string name="login_site_address_more_help">Need more help?</string>
     <string name="login_checking_site_address">Checking site address</string>
+    <string name="login_error_while_adding_site">Error while adding site. Error code: %s</string>
 </resources>


### PR DESCRIPTION
**Note: #6147 needs to be merged first.**

This PR wires up the "Connect another site" button of the login epilogue screen. Depending on whether the user is already logged in WPCOM or not, tapping the button jumps to a different position inside the login flow.

The final visual touches, the messages and final texts will be done in a future PR.

To test 1:
* With the app data cleaned up, launch the app
* Log into WordPress.com with your email and password (don't use the magiclink flow)
* On the epilogue screen, tap on the "Connect another site" button
* The site address screen should come up. Continue with logging into a selfhosted site.
* Upon successful login, the epilogue screen should come up again, this time with the "Connect another site" button missing. Tap on "Continue".
* App's MySite screen is displayed

To test 2:
* With the app data cleaned up, launch the app
* Log into a selfhosted site. Upon successful login, the epilogue screen should come up.
* Tap on the "Connect another site" button
* The prologue screen should come up, and "Log in" should allow both WPCOM and selfhosted sites login
