### PR TITLE
Issue/6152 improve media search

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -141,7 +141,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:7e4d2f150cf09bca488b66ce097ef19e5b206bf9') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:a259364ff0efa6157216ca9c37e3854df082f477') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -141,7 +141,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:develop-SNAPSHOT') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:10aeea1792924c473e9e23e39e7d072fa941ef40') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -141,7 +141,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:a259364ff0efa6157216ca9c37e3854df082f477') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:develop-SNAPSHOT') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -316,7 +316,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
 
     public void search(String searchTerm) {
         mSearchTerm = searchTerm;
-        List<MediaModel> mediaList = mMediaStore.searchSiteMediaByTitle(mSite, mSearchTerm);
+        List<MediaModel> mediaList = mMediaStore.searchSiteMedia(mSite, mSearchTerm);
         mGridAdapter.setMediaList(mediaList);
     }
 


### PR DESCRIPTION
Fixes #6152 - no real logic changes were made in WPAndroid, this simply relies on [a FluxC change](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/482) to match additional fields in media search.
