### PR TITLE
Login Rework: Create WP site via the new login flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.ShareIntentReceiverActivity;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.LoginActivity;
+import org.wordpress.android.ui.accounts.LoginEpilogueActivity;
 import org.wordpress.android.ui.accounts.LoginEpilogueFragment;
 import org.wordpress.android.ui.accounts.NewBlogFragment;
 import org.wordpress.android.ui.accounts.NewUserFragment;
@@ -126,6 +127,7 @@ public interface AppComponent {
     void inject(Login2FaFragment object);
     void inject(LoginSiteAddressFragment object);
     void inject(LoginUsernamePasswordFragment object);
+    void inject(LoginEpilogueActivity object);
 
     void inject(StatsWidgetConfigureActivity object);
     void inject(StatsWidgetConfigureAdapter object);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -148,7 +148,8 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
 
     @Override
     public void newUserCreatedButErrored(String email, String password) {
-        // not implemented yet
+        LoginEmailPasswordFragment loginEmailPasswordFragment = LoginEmailPasswordFragment.newInstance(email, password);
+        slideInFragment(loginEmailPasswordFragment, false, LoginEmailPasswordFragment.TAG);
     }
 
     @Override
@@ -157,7 +158,7 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
             LoginMagicLinkRequestFragment loginMagicLinkRequestFragment = LoginMagicLinkRequestFragment.newInstance(email);
             slideInFragment(loginMagicLinkRequestFragment, true, LoginMagicLinkRequestFragment.TAG);
         } else {
-            LoginEmailPasswordFragment loginEmailPasswordFragment = LoginEmailPasswordFragment.newInstance(email);
+            LoginEmailPasswordFragment loginEmailPasswordFragment = LoginEmailPasswordFragment.newInstance(email, null);
             slideInFragment(loginEmailPasswordFragment, true, LoginEmailPasswordFragment.TAG);
         }
     }
@@ -181,7 +182,7 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
 
     @Override
     public void usePasswordInstead(String email) {
-        LoginEmailPasswordFragment loginEmailPasswordFragment = LoginEmailPasswordFragment.newInstance(email);
+        LoginEmailPasswordFragment loginEmailPasswordFragment = LoginEmailPasswordFragment.newInstance(email, null);
         slideInFragment(loginEmailPasswordFragment, true, LoginEmailFragment.TAG);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -137,7 +137,18 @@ public class LoginActivity extends AppCompatActivity implements LoginListener {
 
     @Override
     public void doStartSignup() {
-        ToastUtils.showToast(this, "Signup is not implemented yet");
+        NewUserFragment newUserFragment = NewUserFragment.newInstance();
+        slideInFragment(newUserFragment, true, NewUserFragment.TAG);
+    }
+
+    @Override
+    public void loggedInViaSigUp() {
+        loggedInAndFinish();
+    }
+
+    @Override
+    public void newUserCreatedButErrored(String email, String password) {
+        // not implemented yet
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginEpilogueActivity.java
@@ -1,18 +1,25 @@
 package org.wordpress.android.ui.accounts;
 
 import org.wordpress.android.R;
-import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.ui.ActivityLauncher;
 
 import android.os.Bundle;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
 
+import javax.inject.Inject;
+
 public class LoginEpilogueActivity extends AppCompatActivity implements LoginEpilogueFragment.LoginEpilogueListener {
     public static final String EXTRA_SHOW_AND_RETURN = "EXTRA_SHOW_AND_RETURN";
+
+    protected @Inject AccountStore mAccountStore;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        ((WordPress) getApplication()).component().inject(this);
 
         setContentView(R.layout.login_epilogue_activity);
 
@@ -32,7 +39,13 @@ public class LoginEpilogueActivity extends AppCompatActivity implements LoginEpi
 
     @Override
     public void onConnectAnotherSite() {
-        ToastUtils.showToast(this, "Connect another site is not implemented yet.");
+        if (mAccountStore.hasAccessToken()) {
+            ActivityLauncher.addSelfHostedSiteForResult(this);
+        } else {
+            ActivityLauncher.showSignInForResult(this);
+        }
+
+        finish();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -488,7 +488,6 @@ public class NewUserFragment extends AbstractFragment {
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-
         if (AppPrefs.isLoginWizardStyleActivated()) {
             if (context instanceof LoginListener) {
                 mLoginListener = (LoginListener) context;
@@ -501,7 +500,6 @@ public class NewUserFragment extends AbstractFragment {
     @Override
     public void onDetach() {
         super.onDetach();
-
         mLoginListener = null;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -437,7 +437,6 @@ public class NewUserFragment extends AbstractFragment {
         if (!isAdded()) {
             return;
         }
-        endProgress();
 
         if (AppPrefs.isLoginWizardStyleActivated()) {
             if (mLoginListener != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
@@ -47,6 +47,7 @@ public class LoginEmailPasswordFragment extends Fragment implements TextWatcher 
     private static final String KEY_REQUESTED_PASSWORD = "KEY_REQUESTED_PASSWORD";
 
     private static final String ARG_EMAIL_ADDRESS = "ARG_EMAIL_ADDRESS";
+    private static final String ARG_PASSWORD = "ARG_PASSWORD";
 
     public static final String TAG = "login_email_password_fragment_tag";
 
@@ -61,13 +62,15 @@ public class LoginEmailPasswordFragment extends Fragment implements TextWatcher 
     private String mRequestedPassword;
 
     private String mEmailAddress;
+    private String mPassword;
 
     @Inject Dispatcher mDispatcher;
 
-    public static LoginEmailPasswordFragment newInstance(String emailAddress) {
+    public static LoginEmailPasswordFragment newInstance(String emailAddress, String password) {
         LoginEmailPasswordFragment fragment = new LoginEmailPasswordFragment();
         Bundle args = new Bundle();
         args.putString(ARG_EMAIL_ADDRESS, emailAddress);
+        args.putString(ARG_PASSWORD, password);
         fragment.setArguments(args);
         return fragment;
     }
@@ -78,6 +81,7 @@ public class LoginEmailPasswordFragment extends Fragment implements TextWatcher 
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
         mEmailAddress = getArguments().getString(ARG_EMAIL_ADDRESS);
+        mPassword = getArguments().getString(ARG_PASSWORD);
 
         if (savedInstanceState != null) {
             mRequestedPassword = savedInstanceState.getString(KEY_REQUESTED_PASSWORD);
@@ -93,7 +97,11 @@ public class LoginEmailPasswordFragment extends Fragment implements TextWatcher 
         ((TextView) rootView.findViewById(R.id.login_email)).setText(mEmailAddress);
 
         mPasswordEditText = (EditText) rootView.findViewById(R.id.login_password);
+        if (savedInstanceState == null) {
+            mPasswordEditText.setText(mPassword);
+        }
         mPasswordEditText.addTextChangedListener(this);
+
         mPasswordEditTextLayout = (TextInputLayout) rootView.findViewById(R.id.login_password_layout);
         mPasswordEditText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
@@ -9,6 +9,8 @@ public interface LoginListener {
     void nextPromo();
     void showEmailLoginScreen();
     void doStartSignup();
+    void loggedInViaSigUp();
+    void newUserCreatedButErrored(String email, String password);
 
     // Login Email input callbacks
     void gotWpcomEmail(String email);


### PR DESCRIPTION
**Note: #6149 needs to be merged first.**

This PR wires up the "Create WordPress site" button of the login prologue screen. It directs the user to the (old-styled) create-user-and-site screen. The Create site feature itself is out of scope of the Login Rework project for now.

The final visual touches, the messages and final texts will be done in a future PR.

To test:
* With the app data cleaned up, launch the app
* Tap on the "Create WordPress Site" button
* Input an email, username, password, site address and tap on the "Create account" button
* Wait a few moments and the login epilogue screen should come up on successful creation