### PR TITLE
Marking failed image uploads in Aztec as FAILED upon start

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -323,6 +323,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         content.fromHtml(text.toString());
         updateFailedMediaList();
         overlayFailedMedia();
+
+        // ToDo:  this is to be removed when feature/async-media is merged
+        // If there are images that are still in progress (because the editor exited before they completed),
+        // set them to failed, so the user can restart them (otherwise they will stay stuck in 'uploading' mode)
+        convertUploadingUponStartToFailed();
     }
 
     /**
@@ -396,6 +401,34 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     @Override
     public boolean isActionInProgress() {
         return System.currentTimeMillis() - mActionStartedAt < MAX_ACTION_TIME_MS;
+    }
+
+    private void convertUploadingUponStartToFailed() {
+        // first obtain all the media currently marked as "uploading"
+        AztecText.AttributePredicate uploadingPredicate = new AztecText.AttributePredicate() {
+            @Override
+            public boolean matches(@NonNull Attributes attrs) {
+                AttributesWithClass attributesWithClass = new AttributesWithClass(attrs);
+                return attributesWithClass.hasClass(ATTR_STATUS_UPLOADING);
+            }
+        };
+
+        Set<String> uploadingIdsUponStart = new HashSet<>();
+        for (Attributes attrs : content.getAllElementAttributes(uploadingPredicate)) {
+            uploadingIdsUponStart.add(attrs.getValue(ATTR_ID_WP));
+        }
+
+        // now re-mark them as "failed"
+        for (String mediaId : uploadingIdsUponStart) {
+            if (mediaId != null) {
+                AttributesWithClass attributesWithClass = new AttributesWithClass(
+                        content.getElementAttributes(ImagePredicate.getLocalMediaIdPredicate(mediaId)));
+                attributesWithClass.removeClass(ATTR_STATUS_UPLOADING);
+                attributesWithClass.addClass(ATTR_STATUS_FAILED);
+                overlayFailedMedia(mediaId, attributesWithClass.getAttributes());
+                mFailedMediaIds.add(mediaId);
+            }
+        }
     }
 
     private void updateFailedMediaList() {
@@ -949,6 +982,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                         AttributesWithClass attributesWithClass = new AttributesWithClass(
                                 content.getElementAttributes(mTappedImagePredicate));
                         attributesWithClass.removeClass(ATTR_STATUS_FAILED);
+                        attributesWithClass.addClass(ATTR_STATUS_UPLOADING);
 
                         // set intermediate shade overlay
                         content.setOverlay(mTappedImagePredicate, 0,

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -327,7 +327,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         // ToDo:  this is to be removed when feature/async-media is merged
         // If there are images that are still in progress (because the editor exited before they completed),
         // set them to failed, so the user can restart them (otherwise they will stay stuck in 'uploading' mode)
-        convertUploadingUponStartToFailed();
+        markAllUploadingMediaAsFailed();
     }
 
     /**
@@ -403,7 +403,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         return System.currentTimeMillis() - mActionStartedAt < MAX_ACTION_TIME_MS;
     }
 
-    private void convertUploadingUponStartToFailed() {
+    private void markAllUploadingMediaAsFailed() {
         // first obtain all the media currently marked as "uploading"
         AztecText.AttributePredicate uploadingPredicate = new AztecText.AttributePredicate() {
             @Override


### PR DESCRIPTION
Fixes #6153 

This behavior mimmicks the same [we have for the Visual Editor](https://github.com/wordpress-mobile/WordPress-Android/blob/feature/async-media/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java#L1228): 
When the content is set (i.e. the Editor is started) we convert all `UPLOADING` images to `FAILED`.

To test:
1. start a new draft using the Aztec editor
2. insert an image using the image picker
3. as the image starts uploading, exit the Editor
4. tap into the draft post to open the Editor again
5. verify the image has the "Failed" overlay (sepia tone and retry icon)
6. tapping on the image should start the upload again
7. repeat steps 3-6 a couple of times to verify the image gets the FAILED state every time you exit/enter again, and you can always tap the image to start uploading again.
8. finally let the image finish uploading, then exit, come back and verify the image loaded is the remote version of it (i.e. it first shows the placeholder, then it shows the image after having loaded it from its remote URL).


cc @aforcier 