### PR TITLE
Issue/6078 update format buttons

### DIFF
--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_bold.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_bold.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_bold_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_bold_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_bold_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_bold_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_horizontal.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_horizontal.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_horizontal_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_horizontal_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_vertical.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_vertical.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_vertical_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ellipsis_vertical_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_1.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_1.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_1_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_1_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_1_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_1_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_2.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_2.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_2_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_2_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_2_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_2_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_3.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_3.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_3_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_3_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_3_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_3_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_4.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_4.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_4_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_4_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_4_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_4_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_5.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_5.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_5_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_5_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_5_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_5_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_6.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_6.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_6_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_6_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_6_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_6_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_heading_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_horizontal_rule.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_horizontal_rule.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_horizontal_rule_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_horizontal_rule_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_horizontal_rule_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_horizontal_rule_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_html.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_html.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_html_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_html_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_html_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_html_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_italic.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_italic.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_italic_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_italic_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_italic_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_italic_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_link.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_link.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_link_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_link_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_link_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_link_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_media.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_media.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_media_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_media_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_media_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_media_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_more.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_more.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_more_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_more_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_more_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_more_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ol.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ol.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ol_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ol_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ol_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ol_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_page.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_page.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_page_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_page_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_page_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_page_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_quote.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_quote.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_quote_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_quote_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_quote_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_quote_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_strikethrough.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_strikethrough.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_strikethrough_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_strikethrough_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_strikethrough_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_strikethrough_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ul.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ul.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ul_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ul_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ul_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ul_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_underline.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_underline.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_underline_disabled.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_underline_disabled.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_underline_highlighted.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_underline_highlighted.xml
@@ -2,8 +2,8 @@
 
 <vector
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:height="48dp"
-    android:width="48dp"
+    android:height="44dp"
+    android:width="44dp"
     android:viewportHeight="48"
     android:viewportWidth="48" >
 

--- a/libs/editor/WordPressEditor/src/main/res/values/dimens.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/dimens.xml
@@ -2,7 +2,7 @@
 
 <resources>
 
-    <dimen name="format_bar_height">48dp</dimen>
+    <dimen name="format_bar_height">44dp</dimen>
     <dimen name="format_bar_height_tablet">49dp</dimen>
     <dimen name="format_bar_left_margin">5dp</dimen>
     <dimen name="format_bar_right_margin">2dp</dimen>


### PR DESCRIPTION
### Fix
Revert editor format toolbar buttons to 44dp to fix squashed icons as described in https://github.com/wordpress-mobile/WordPress-Android/issues/6150.

### Test
0. Enable ***Visual*** editor.
1. Go to ***Sites*** tab.
2. Tap ***Create*** floating button.
3. Tap content text field.
4. Notice unsquashed format toolbar button icons.

#### Note
This is actually a _*partial*_ reversion to https://github.com/wordpress-mobile/WordPress-Android/pull/6084 which changed the buttons from 44dp to 48dp.  The `android:height` and `android:width` attributes were reverted back to 44dp, but the `android:viewportHeight` and `android:viewportWidth` attributes were kept at 48 to avoid reverting then reverting the reverting of the `android:pathData` attribute when the buttons are ready to be updated to 48dp.  Keeping the the `android:viewportHeight` and `android:viewportWidth` attributes at 48 will not interfere with the toolbar and button size of 44dp.