### PR TITLE
Issue/6167 add media popup back button

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -420,6 +420,15 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     }
 
     @Override
+    public void onBackPressed() {
+        if (mAddMediaPopup != null && mAddMediaPopup.isShowing()) {
+            mAddMediaPopup.dismiss();
+        } else {
+            super.onBackPressed();
+        }
+    }
+
+    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
@@ -739,7 +748,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         });
 
         int width = getResources().getDimensionPixelSize(R.dimen.action_bar_spinner_width);
-        mAddMediaPopup = new PopupWindow(menuView, width, ViewGroup.LayoutParams.WRAP_CONTENT, true);
+        mAddMediaPopup = new PopupWindow(menuView, width, ViewGroup.LayoutParams.WRAP_CONTENT, false);
     }
 
     private void showAddMediaPopup() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -435,7 +435,11 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                 onBackPressed();
                 return true;
             case R.id.menu_new_media:
-                showAddMediaPopup();
+                if (isAddMediaPopupShowing()) {
+                    hideAddMediaPopup();
+                } else {
+                    showAddMediaPopup();
+                }
                 return true;
             case R.id.menu_search:
                 mSearchMenuItem = item;
@@ -749,6 +753,16 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
         int width = getResources().getDimensionPixelSize(R.dimen.action_bar_spinner_width);
         mAddMediaPopup = new PopupWindow(menuView, width, ViewGroup.LayoutParams.WRAP_CONTENT, false);
+    }
+
+    private boolean isAddMediaPopupShowing() {
+        return mAddMediaPopup != null && mAddMediaPopup.isShowing();
+    }
+
+    private void hideAddMediaPopup() {
+        if (mAddMediaPopup != null) {
+            mAddMediaPopup.dismiss();
+        }
     }
 
     private void showAddMediaPopup() {


### PR DESCRIPTION
Fixes #6167 - enables using the back button in the media browser to hide the Add Media popup menu. Also enables tapping the "+" icon when the popup is showing to hide it.

To test:
* Tap Media on the My Site page
* Tap the "+ icon to add menu
* Tap the back button

The popup window should disappear.
