### PR TITLE
Post Settings: Fix initializing post formats crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -800,7 +800,7 @@ public class EditPostSettingsFragment extends Fragment {
     // Post Format Helpers
 
     private void updatePostFormatKeysAndNames() {
-        if (!isAdded()) {
+        if (getActivity() == null) {
             return;
         }
         // Default values


### PR DESCRIPTION
We only care about being able to access the resources in `updatePostFormatKeysAndNames` which means as long as `getActivity()` is not `null` we don't actually care if the fragment is currently added or not. In some cases `isAdded` check here will result in a crash and changing that to the activity `null` check fixes it. Since we don't actually touch the UI in that method, I think this is fine.

Sorry for the one-liner PR, I need this fix in the branch I am working on but it's completely unrelated to that issue, so I need to open this PR now.

cc @nbradbury since you reviewed the original PR.