### PR TITLE
Fix ConnectionChangeReceiver

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -531,13 +531,6 @@
         <receiver android:name=".ui.notifications.NotificationDismissBroadcastReceiver" />
         <receiver android:name=".ui.notifications.ShareAndDismissNotificationReceiver" />
         <receiver
-            android:name=".networking.ConnectionChangeReceiver"
-            android:enabled="false">
-            <intent-filter>
-                <action android:name="android.net.conn.CONNECTIVITY_CHANGE" />
-            </intent-filter>
-        </receiver>
-        <receiver
             android:name=".ui.stats.StatsWidgetProvider"
             android:label="@string/stats_widget_name">
             <intent-filter>

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -6,7 +6,9 @@ import android.app.Dialog;
 import android.content.ComponentCallbacks2;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.res.Configuration;
+import android.net.ConnectivityManager;
 import android.net.http.HttpResponseCache;
 import android.os.Build;
 import android.os.Bundle;
@@ -295,6 +297,18 @@ public class WordPress extends MultiDexApplication {
         // https://developer.android.com/reference/android/support/v7/app/AppCompatDelegate.html#setCompatVectorFromResourcesEnabled(boolean)
         // Note: if removed, this will cause crashes on Android < 21
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
+
+        // Programmatically registering the ConnectionChangeReceiver here for Android >= N as per this:
+        // https://developer.android.com/reference/android/net/ConnectivityManager.html
+        // "Apps targeting Android 7.0 (API level 24) and higher do not receive this broadcast if they
+        // declare the broadcast receiver in their manifest. Apps will still receive broadcasts if they
+        // register their BroadcastReceiver with Context.registerReceiver() and that context is still valid."
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            registerReceiver(ConnectionChangeReceiver.getInstance(),
+                    new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
+            // disable ConnectionChangeReceive by default
+            ConnectionChangeReceiver.forceSetEnabled(WordPress.this, false);
+        }
     }
 
     private void runFluxCMigration() {

--- a/WordPress/src/main/java/org/wordpress/android/networking/ConnectionChangeReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/ConnectionChangeReceiver.java
@@ -1,12 +1,8 @@
 package org.wordpress.android.networking;
 
-import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.content.BroadcastReceiver;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -21,8 +17,6 @@ import de.greenrobot.event.EventBus;
 public class ConnectionChangeReceiver extends BroadcastReceiver {
     private static boolean mIsFirstReceive = true;
     private static boolean mWasConnected = true;
-    private static boolean mIsEnabled = false; // this value must be synchronized with the ConnectionChangeReceiver
-                                               // state in our AndroidManifest
     private static ConnectionChangeReceiver sInstance;
 
     public static class ConnectionChangeEvent {
@@ -55,27 +49,6 @@ public class ConnectionChangeReceiver extends BroadcastReceiver {
         mWasConnected = isConnected;
         mIsFirstReceive = false;
         EventBus.getDefault().post(new ConnectionChangeEvent(isConnected));
-    }
-
-    public synchronized static void setEnabled(Context context, boolean enabled) {
-        if (mIsEnabled == enabled) {
-            return;
-        }
-        forceSetEnabled(context, enabled);
-    }
-
-    public synchronized static void forceSetEnabled(Context context, boolean enabled) {
-        mIsEnabled = enabled;
-        AppLog.i(T.UTILS, "ConnectionChangeReceiver.setEnabled " + enabled);
-        int flag = (enabled ? PackageManager.COMPONENT_ENABLED_STATE_ENABLED :
-                PackageManager.COMPONENT_ENABLED_STATE_DISABLED);
-        ComponentName component = new ComponentName(context, ConnectionChangeReceiver.class);
-        PackageManager pm = context.getPackageManager();
-        pm.setComponentEnabledSetting(component, flag, PackageManager.DONT_KILL_APP);
-        int  status = pm.getComponentEnabledSetting(component);
-        if (mIsEnabled) {
-            postConnectionChangeEvent(NetworkUtils.isNetworkAvailable(context));
-        }
     }
 
     public static ConnectionChangeReceiver getInstance(){

--- a/WordPress/src/main/java/org/wordpress/android/networking/ConnectionChangeReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/networking/ConnectionChangeReceiver.java
@@ -38,8 +38,7 @@ public class ConnectionChangeReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         boolean isConnected = NetworkUtils.isNetworkAvailable(context);
-        boolean initialStickyBroadcast = isInitialStickyBroadcast();
-        if (mIsFirstReceive || isConnected != mWasConnected || !initialStickyBroadcast) {
+        if (mIsFirstReceive || isConnected != mWasConnected) {
             postConnectionChangeEvent(isConnected);
         }
     }


### PR DESCRIPTION
This PR fixes the `ConnectionChangeReceiver`, which was not being called as of Android N and on [due to the reasons explained here - see `CONNECTIVITY_ACTION`](https://developer.android.com/reference/android/net/ConnectivityManager.html):

> Apps targeting Android 7.0 (API level 24) and higher do not receive this broadcast if they declare the broadcast receiver in their manifest. Apps will still receive broadcasts if they register their BroadcastReceiver with Context.registerReceiver() and that context is still valid.


Ok so once I started registering the BroadcastReceiver programmatically, I observed the enable/disable approach doesn’t seem to be working here for me, as I would get events on every network change no matter what the enabled/disabled state for the Component was on Android 7, so I decided to register/unregister the BroadcastReceiver when going to sleep / going back to foreground instead of enabling/disabling (which, plainly, didn’t seem to have any effect anymore).

_NOTE: If you want to take a look at the branch I abandoned and see for yourself that it’s not working, here it is [`fix/connection-change-receiver-android-n-exploration`](https://github.com/wordpress-mobile/WordPress-Android/tree/fix/connection-change-receiver-android-n-exploration) (see the `onReceive()` method is called every time you set airplane mode on/off, even if the app is in the background, when the Receiver component is supposed to be have been disabled)._

Also, I considered keeping the existing approach for pre-AndroidN, and only coding a special case for Android N+, but that would make it harder to maintain. So here are the changes:

- the BroadcastReceiver is not statically registered in the `AndroidManifest` anymore
- the registration happens programmatically in the app lifecycle `onPause()` and `onResume()` callbacks for the Activity lifecycle listener in the app class `WordPress.java`

**To test:**
1. open the app and check the orange "NO CONNECTION"  bar is not shown
2. switch airplane mode ON, and watch the "NO CONNECTION" bar appear
3. switch airplane mode OFF, and watch the "NO CONNECTION" bar disappear as the device recovers conncetivity
4. Now put the app to the background and wait a few seconds
5. Open the app, the "NO CONNECTION" bar should NOT be there.
6. put the app to the background and wait a few seconds
7. Switch airplane mode ON
8. open the app again, the "NO CONNECTION" bar should be there.
9. Send the app to the background once more, and wait a few (2) seconds
10. switch airplane mode OFF
11.  open the app again, no "NO CONNECTION"bar should be seen.

cc @nbradbury