### PR TITLE
Advertise image optimization

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -343,17 +343,10 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             case RequestCodes.TAKE_PHOTO:
                 if (resultCode == Activity.RESULT_OK) {
                     WordPressMediaUtils.scanMediaFile(this, mMediaCapturePath);
-                    if (WPMediaUtils.shouldAdvertiseImageOptimization(this, mSite)) {
-                        WPMediaUtils.advertiseImageOptimization(this, mSite,
-                                new WPMediaUtils.OnAdvertiseImageOptimizationListener() {
-                                    @Override
-                                    public void done() {
-                                        enqueueLastTakenPicture();
-                                    }
-                                });
-                    } else {
-                        enqueueLastTakenPicture();
-                    }
+                    Uri uri = getOptimizedPictureIfNecessary(Uri.parse(mMediaCapturePath));
+                    mMediaCapturePath = null;
+                    queueFileForUpload(uri, getContentResolver().getType(uri));
+                    trackAddMediaFromDeviceEvents(true, false, uri);
                 }
                 break;
             case RequestCodes.TAKE_VIDEO:
@@ -364,13 +357,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                 }
                 break;
         }
-    }
-
-    private void enqueueLastTakenPicture() {
-        Uri uri = getOptimizedPictureIfNecessary(Uri.parse(mMediaCapturePath));
-        mMediaCapturePath = null;
-        queueFileForUpload(uri, getContentResolver().getType(uri));
-        trackAddMediaFromDeviceEvents(true, false, uri);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -328,32 +328,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
         switch (requestCode) {
             case RequestCodes.PICTURE_LIBRARY:
-                if (resultCode == Activity.RESULT_OK && data != null) {
-                    final Uri imageUri = data.getData();
-                    final String mimeType = getContentResolver().getType(imageUri);
-                    if (WPMediaUtils.shouldAdvertiseImageOptimization(this, mSite)) {
-                        WPMediaUtils.advertiseImageOptimization(this, mSite,
-                                new WPMediaUtils.OnAdvertiseImageOptimizationListener() {
-                                    @Override
-                                    public void done() {
-                                        fetchMedia(imageUri, mimeType);
-                                        trackAddMediaFromDeviceEvents(
-                                                false,
-                                                false,
-                                                imageUri
-                                        );
-                                    }
-                                });
-                    } else {
-                        fetchMedia(imageUri, mimeType);
-                        trackAddMediaFromDeviceEvents(
-                                false,
-                                false,
-                                imageUri
-                        );
-                    }
-                }
-                break;
             case RequestCodes.VIDEO_LIBRARY:
                 if (resultCode == Activity.RESULT_OK && data != null) {
                     Uri imageUri = data.getData();
@@ -361,7 +335,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                     fetchMedia(imageUri, mimeType);
                     trackAddMediaFromDeviceEvents(
                             false,
-                            true,
+                            requestCode == RequestCodes.VIDEO_LIBRARY,
                             imageUri
                     );
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -328,6 +328,32 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
         switch (requestCode) {
             case RequestCodes.PICTURE_LIBRARY:
+                if (resultCode == Activity.RESULT_OK && data != null) {
+                    final Uri imageUri = data.getData();
+                    final String mimeType = getContentResolver().getType(imageUri);
+                    if (WPMediaUtils.shouldAdvertiseImageOptimization(this, mSite)) {
+                        WPMediaUtils.advertiseImageOptimization(this, mSite,
+                                new WPMediaUtils.OnAdvertiseImageOptimizationListener() {
+                                    @Override
+                                    public void done() {
+                                        fetchMedia(imageUri, mimeType);
+                                        trackAddMediaFromDeviceEvents(
+                                                false,
+                                                false,
+                                                imageUri
+                                        );
+                                    }
+                                });
+                    } else {
+                        fetchMedia(imageUri, mimeType);
+                        trackAddMediaFromDeviceEvents(
+                                false,
+                                false,
+                                imageUri
+                        );
+                    }
+                }
+                break;
             case RequestCodes.VIDEO_LIBRARY:
                 if (resultCode == Activity.RESULT_OK && data != null) {
                     Uri imageUri = data.getData();
@@ -335,7 +361,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                     fetchMedia(imageUri, mimeType);
                     trackAddMediaFromDeviceEvents(
                             false,
-                            requestCode == RequestCodes.VIDEO_LIBRARY,
+                            true,
                             imageUri
                     );
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1783,9 +1783,20 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                     // No need to bump analytics here. Bumped later in handleMediaPickerResult-> addExistingMediaToEditor
                     break;
                 case RequestCodes.PICTURE_LIBRARY:
-                    Uri imageUri = data.getData();
-                    fetchMedia(imageUri);
-                    trackAddMediaFromDeviceEvents(false, false, imageUri);
+                    final Uri imageUri = data.getData();
+                    if (WPMediaUtils.shouldAdvertiseImageOptimization(this, mSite)) {
+                        WPMediaUtils.advertiseImageOptimization(this, mSite,
+                                new WPMediaUtils.OnAdvertiseImageOptimizationListener() {
+                                    @Override
+                                    public void done() {
+                                        fetchMedia(imageUri);
+                                        trackAddMediaFromDeviceEvents(false, false, imageUri);
+                                    }
+                                });
+                    } else {
+                        fetchMedia(imageUri);
+                        trackAddMediaFromDeviceEvents(false, false, imageUri);
+                    }
                     break;
                 case RequestCodes.TAKE_PHOTO:
                     if (WPMediaUtils.shouldAdvertiseImageOptimization(this, mSite)) {
@@ -1839,7 +1850,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             AppLog.e(T.POSTS, e);
         }
     }
-
 
     private ArrayList<MediaModel> mPendingUploads = new ArrayList<>();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -585,8 +585,34 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
      * called by PhotoPickerFragment when media is selected - may be a single item or a list of items
      */
     @Override
-    public void onPhotoPickerMediaChosen(@NonNull List<Uri> uriList) {
+    public void onPhotoPickerMediaChosen(@NonNull final List<Uri> uriList) {
         hidePhotoPicker();
+
+        if (WPMediaUtils.shouldAdvertiseImageOptimization(this, mSite)) {
+            boolean hasSelectedPicture = false;
+            for (Uri uri : uriList) {
+                if (!MediaUtils.isVideo(uri.toString())) {
+                    hasSelectedPicture = true;
+                    break;
+                }
+            }
+            if (hasSelectedPicture) {
+                WPMediaUtils.advertiseImageOptimization(this, mSite,
+                        new WPMediaUtils.OnAdvertiseImageOptimizationListener() {
+                            @Override
+                            public void done() {
+                                for (Uri uri: uriList) {
+                                    if (addMedia(uri)) {
+                                        boolean isVideo = MediaUtils.isVideo(uri.toString());
+                                        trackAddMediaFromDeviceEvents(false, isVideo, uri);
+                                    }
+                                }
+                            }
+                        });
+                return;
+            }
+        }
+
         for (Uri uri: uriList) {
             if (addMedia(uri)) {
                 boolean isVideo = MediaUtils.isVideo(uri.toString());
@@ -1850,7 +1876,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             AppLog.e(T.POSTS, e);
         }
     }
-
 
     private ArrayList<MediaModel> mPendingUploads = new ArrayList<>();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1783,20 +1783,9 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                     // No need to bump analytics here. Bumped later in handleMediaPickerResult-> addExistingMediaToEditor
                     break;
                 case RequestCodes.PICTURE_LIBRARY:
-                    final Uri imageUri = data.getData();
-                    if (WPMediaUtils.shouldAdvertiseImageOptimization(this, mSite)) {
-                        WPMediaUtils.advertiseImageOptimization(this, mSite,
-                                new WPMediaUtils.OnAdvertiseImageOptimizationListener() {
-                                    @Override
-                                    public void done() {
-                                        fetchMedia(imageUri);
-                                        trackAddMediaFromDeviceEvents(false, false, imageUri);
-                                    }
-                                });
-                    } else {
-                        fetchMedia(imageUri);
-                        trackAddMediaFromDeviceEvents(false, false, imageUri);
-                    }
+                    Uri imageUri = data.getData();
+                    fetchMedia(imageUri);
+                    trackAddMediaFromDeviceEvents(false, false, imageUri);
                     break;
                 case RequestCodes.TAKE_PHOTO:
                     if (WPMediaUtils.shouldAdvertiseImageOptimization(this, mSite)) {
@@ -1850,6 +1839,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             AppLog.e(T.POSTS, e);
         }
     }
+
 
     private ArrayList<MediaModel> mPendingUploads = new ArrayList<>();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2139,12 +2139,12 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         if (!isPhotoPickerShowing()) {
             showPhotoPicker();
             if (WPMediaUtils.shouldAdvertiseImageOptimization(this, mSite)) {
-                android.app.AlertDialog.Builder builder = new android.app.AlertDialog.Builder(this);
-                builder.setTitle(R.string.image_optimization_promo_title);
-                builder.setMessage(R.string.image_optimization_promo_desc);
-                builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
+                        if (which != DialogInterface.BUTTON_POSITIVE) {
+                            return;
+                        }
                         SiteSettingsInterface siteSettings = SiteSettingsInterface.getInterface(EditPostActivity.this, mSite, null);
                         if (siteSettings == null || siteSettings.init(false).getOptimizedImage()) {
                             // null or image optimization already ON. We should not be here though.
@@ -2153,11 +2153,9 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                             siteSettings.saveSettings();
                         }
                     }
-                });
-                builder.setNegativeButton(R.string.no, null);
-                builder.show();
-                // Do not ask again
-                AppPrefs.setImageOptimizePromoRequired(false);
+                };
+
+                WPMediaUtils.advertiseImageOptimization(this, listener, null);
             }
         } else {
             hidePhotoPicker();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.ui.posts;
 
-import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Fragment;
@@ -8,7 +7,6 @@ import android.app.FragmentManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.database.Cursor;
 import android.graphics.Bitmap;
@@ -24,7 +22,6 @@ import android.support.annotation.NonNull;
 import android.support.v13.app.FragmentPagerAdapter;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.FragmentTransaction;
-import android.support.v4.content.ContextCompat;
 import android.support.v4.content.CursorLoader;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
@@ -2141,7 +2138,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     public void onAddMediaClicked() {
         if (!isPhotoPickerShowing()) {
             showPhotoPicker();
-            if (shouldAdvertiseImageOptimization()) {
+            if (WPMediaUtils.shouldAdvertiseImageOptimization(this, mSite)) {
                 android.app.AlertDialog.Builder builder = new android.app.AlertDialog.Builder(this);
                 builder.setTitle(R.string.image_optimization_promo_title);
                 builder.setMessage(R.string.image_optimization_promo_desc);
@@ -2165,28 +2162,6 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         } else {
             hidePhotoPicker();
         }
-    }
-
-    private boolean shouldAdvertiseImageOptimization() {
-        boolean isPromoRequired = AppPrefs.isImageOptimizePromoRequired();
-        if (!isPromoRequired) {
-            return false;
-        }
-
-        // Check we can access storage before asking for optimizing image
-        boolean hasStoreAccess = ContextCompat.checkSelfPermission(
-                this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
-        if (!hasStoreAccess) {
-            return false;
-        }
-
-        // Check whether image optimization is already available for the site
-        SiteSettingsInterface siteSettings = SiteSettingsInterface.getInterface(EditPostActivity.this, mSite, null);
-        if (siteSettings == null || siteSettings.init(false).getOptimizedImage()) {
-            return false;
-        }
-
-        return true;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1783,9 +1783,20 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                     // No need to bump analytics here. Bumped later in handleMediaPickerResult-> addExistingMediaToEditor
                     break;
                 case RequestCodes.PICTURE_LIBRARY:
-                    Uri imageUri = data.getData();
-                    fetchMedia(imageUri);
-                    trackAddMediaFromDeviceEvents(false, false, imageUri);
+                    final Uri imageUri = data.getData();
+                    if (WPMediaUtils.shouldAdvertiseImageOptimization(this, mSite)) {
+                        WPMediaUtils.advertiseImageOptimization(this, mSite,
+                                new WPMediaUtils.OnAdvertiseImageOptimizationListener() {
+                                    @Override
+                                    public void done() {
+                                        fetchMedia(imageUri);
+                                        trackAddMediaFromDeviceEvents(false, false, imageUri);
+                                    }
+                                });
+                    } else {
+                        fetchMedia(imageUri);
+                        trackAddMediaFromDeviceEvents(false, false, imageUri);
+                    }
                     break;
                 case RequestCodes.TAKE_PHOTO:
                     if (WPMediaUtils.shouldAdvertiseImageOptimization(this, mSite)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -107,6 +107,9 @@ public class AppPrefs {
         // When we need to show the new editor promo dialog
         AZTEC_EDITOR_PROMO_REQUIRED,
 
+        // When we need to show the new image optimize promo dialog
+        IMAGE_OPTIMIZE_PROMO_REQUIRED,
+
         // Global plans features
         GLOBAL_PLANS_PLANS_FEATURES,
 
@@ -445,6 +448,14 @@ public class AppPrefs {
    public static void setNewEditorPromoRequired(boolean required) {
        setBoolean(UndeletablePrefKey.AZTEC_EDITOR_PROMO_REQUIRED, required);
    }
+
+    public static boolean isImageOptimizePromoRequired() {
+        return getBoolean(UndeletablePrefKey.IMAGE_OPTIMIZE_PROMO_REQUIRED, true);
+    }
+
+    public static void setImageOptimizePromoRequired(boolean required) {
+        setBoolean(UndeletablePrefKey.IMAGE_OPTIMIZE_PROMO_REQUIRED, required);
+    }
 
     public static boolean isGravatarChangePromoRequired() {
         return getBoolean(UndeletablePrefKey.GRAVATAR_CHANGE_PROMO_REQUIRED, true);

--- a/WordPress/src/main/java/org/wordpress/android/util/SmartToast.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SmartToast.java
@@ -24,7 +24,7 @@ public class SmartToast {
 
     private static final int MAX_TIMES_TO_SHOW = 3;
 
-    public static void show(@NonNull Context context, @NonNull SmartToastType type) {
+    public static boolean show(@NonNull Context context, @NonNull SmartToastType type) {
         UndeletablePrefKey keyCounter;
         int stringResId;
         switch (type) {
@@ -41,11 +41,11 @@ public class SmartToast {
                 stringResId = R.string.smart_toast_comments_long_press;
                 break;
             default:
-                return;
+                return false;
         }
         int numTimesShown = AppPrefs.getInt(keyCounter);
         if (numTimesShown >= MAX_TIMES_TO_SHOW) {
-            return;
+            return false;
         }
 
         int yOffset = context.getResources().getDimensionPixelOffset(R.dimen.smart_toast_offset_y);
@@ -55,5 +55,6 @@ public class SmartToast {
 
         numTimesShown++;
         AppPrefs.setInt(keyCounter, numTimesShown);
+        return true;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.util;
 
-import android.*;
 import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.pm.PackageManager;
@@ -8,12 +7,10 @@ import android.net.Uri;
 import android.os.Build;
 import android.support.v4.content.ContextCompat;
 
-import org.wordpress.android.*;
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -2,6 +2,7 @@ package org.wordpress.android.util;
 
 import android.*;
 import android.app.Activity;
+import android.content.DialogInterface;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
@@ -9,8 +10,10 @@ import android.support.v4.content.ContextCompat;
 
 import org.wordpress.android.*;
 import org.wordpress.android.BuildConfig;
+import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 
@@ -107,5 +110,19 @@ public class WPMediaUtils {
         }
 
         return true;
+    }
+
+    public static void advertiseImageOptimization(final Activity act,
+                                                  DialogInterface.OnClickListener listener,
+                                                  DialogInterface.OnCancelListener onCancelListener) {
+        android.app.AlertDialog.Builder builder = new android.app.AlertDialog.Builder(act);
+        builder.setTitle(org.wordpress.android.R.string.image_optimization_promo_title);
+        builder.setMessage(org.wordpress.android.R.string.image_optimization_promo_desc);
+        builder.setPositiveButton(org.wordpress.android.R.string.yes, listener);
+        builder.setNegativeButton(R.string.no, listener);
+        builder.setOnCancelListener(onCancelListener);
+        builder.show();
+        // Do not ask again
+        AppPrefs.setImageOptimizePromoRequired(false);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -144,8 +144,8 @@ public class WPMediaUtils {
         android.app.AlertDialog.Builder builder = new android.app.AlertDialog.Builder(activity);
         builder.setTitle(org.wordpress.android.R.string.image_optimization_promo_title);
         builder.setMessage(org.wordpress.android.R.string.image_optimization_promo_desc);
-        builder.setPositiveButton(org.wordpress.android.R.string.yes, onClickListener);
-        builder.setNegativeButton(R.string.no, onClickListener);
+        builder.setPositiveButton(R.string.turn_on, onClickListener);
+        builder.setNegativeButton(R.string.leave_off, onClickListener);
         builder.setOnCancelListener(onCancelListener);
         builder.show();
         // Do not ask again

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1781,6 +1781,8 @@
 
 
     <!-- Image Optimization promo -->
+    <string name="turn_on">Turn on</string>
+    <string name="leave_off">Leave off</string>
     <string name="image_optimization_promo_title">Turn on image optimization?</string>
     <string name="image_optimization_promo_desc">Image optimization shrinks images for quicker uploading.\n\nYou can change this any time in site settings.</string>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1778,4 +1778,9 @@
     <!-- Video Optimization -->
     <string name="video_optimization_in_progress">Optimizing your video&#8230;</string>
     <string name="video_optimization_generic_error_message">An error occurred while compressing your video. Using the original file.</string>
+
+
+    <!-- Image Optimization promo -->
+    <string name="image_optimization_promo_title">Enable image optimization?</string>
+    <string name="image_optimization_promo_desc">Enabling image optimization will resize and compress pictures before uploading to save bandwidth, and upload time.\n\nYou can always enable it later in Site->Settings.</string>
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1781,6 +1781,6 @@
 
 
     <!-- Image Optimization promo -->
-    <string name="image_optimization_promo_title">Enable image optimization?</string>
-    <string name="image_optimization_promo_desc">Enabling image optimization will resize and compress pictures before uploading to save bandwidth, and upload time.\n\nYou can always enable it later in Site->Settings.</string>
+    <string name="image_optimization_promo_title">Turn on image optimization?</string>
+    <string name="image_optimization_promo_desc">Image optimization shrinks images for quicker uploading.\n\nYou can change this any time in site settings.</string>
 </resources>


### PR DESCRIPTION
Fixes #5572 by showing a dialog when the user taps on `Add media` button in the toolbar.

This image optimization promo dialog is shown on the screen when all of the following conditions are met:
1. Image optimization is OFF on the site.
2. Didn't already ask to enable the feature.
3. <del>The user has granted storage access to the app. *This is because we don't want to ask so much things to users the first time they try to add a picture to the app.*</del>

cc @nbradbury Any thoughts on this? 
Do you think the button is the right place to show this promo dialog?

