### PR TITLE
bump okhttp version and related FluxC branch

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -114,7 +114,7 @@ dependencies {
     compile 'org.wordpress:graphview:3.4.0'
     compile 'org.wordpress:persistentedittext:1.0.2'
     compile 'org.wordpress:emailchecker2:1.1.0'
-    compile 'com.squareup.okio:okio:1.9.0'
+    compile 'com.squareup.okio:okio:1.13.0'
 
     compile ('com.yalantis:ucrop:2.2.0') {
         exclude group: 'com.squareup.okhttp3'
@@ -129,7 +129,7 @@ dependencies {
     androidTestCompile 'org.objenesis:objenesis:2.1'
     androidTestCompile 'org.mockito:mockito-core:1.10.19'
     androidTestCompile 'com.squareup.okhttp:mockwebserver:2.7.5'
-    androidTestCompile 'com.squareup.okio:okio:1.9.0' // explicitly compile okio to match the version needed by ucrop
+    androidTestCompile 'com.squareup.okio:okio:1.13.0'
 
     // Provided by the WordPress-Android Repository
     compile 'org.wordpress:drag-sort-listview:0.6.1' // not found in maven central
@@ -141,7 +141,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:b9f080afc39ceae71a6eac82d0547861eb3055e2') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:fix~hanging-media-uploads-SNAPSHOT') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -141,7 +141,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:fix~hanging-media-uploads-SNAPSHOT') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:4748c6e1ee39ae9c8c9c1fc1a4f503bff7ede7a6') {
         exclude group: "com.android.volley";
     }
 


### PR DESCRIPTION
Fixes #6155

Please first review and merge the related [FluxC PR #494](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/494)

To test:

1. start a new draft post
2. use the media picker to include an image (preferrably a large image so to make testing easier)
3. while the image is uploading, turn the airplane mode ON
4. the image should be marked as FAILED and you should see the "Retry" overlay icon on it.
5. Tap on the image to retry, a number of times. You should see the overlay clears up and appears back again immediately, each time.
6. Turn airplane mode OFF
7. tap on the image to retry again
8. you should see the overlay go away, and at some point (when full connectivity gets restored) the upload progress starts moving again.

cc @aforcier 

