### PR TITLE
Avoid refresh if current Note is similar to refreshed Note

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/Note.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Note.java
@@ -485,7 +485,7 @@ public class Note {
     // this method is used to compare two Notes: as it's potentially a very processing intensive operation,
     // we're only comparing the note id, timestamp, and raw JSON length, which is accurate enough for
     // the purpose of checking if the local Note is any different from a remote note.
-    public boolean similar(Note note) {
+    public boolean equalsTimeAndLength(Note note) {
         if (note == null) {
             return false;
         }

--- a/WordPress/src/main/java/org/wordpress/android/models/Note.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Note.java
@@ -482,6 +482,21 @@ public class Note {
         }
     }
 
+    // this method is used to compare two Notes: as it's potentially a very processing intensive operation,
+    // we're only comparing the note id, timestamp, and raw JSON length, which is accurate enough for
+    // the purpose of checking if the local Note is any different from a remote note.
+    public boolean similar(Note note) {
+        if (note == null) {
+            return false;
+        }
+
+        if (this.getTimestampString().equalsIgnoreCase(note.getTimestampString())
+                && this.getJSON().length() == note.getJSON().length()) {
+            return true;
+        }
+        return false;
+    }
+
     public static synchronized Note buildFromBase64EncodedData(String noteId, String base64FullNoteData) {
         Note note = null;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -136,6 +136,17 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
             return;
         }
 
+        // here compare the current Note - is it any different from the Note the user is
+        // currently viewing?
+        // if it is, then replace the dataset with the new one.
+        // If not, just let it be.
+        if (mAdapter != null) {
+            Note currentNote = mAdapter.getNoteWithId(mNoteId);
+            if (note.similar(currentNote)) {
+                return;
+            }
+        }
+
         NotesAdapter.FILTERS filter = NotesAdapter.FILTERS.FILTER_ALL;
         if (getIntent().hasExtra(NotificationsListFragment.NOTE_CURRENT_LIST_FILTER_EXTRA)) {
             filter = (NotesAdapter.FILTERS) getIntent().getSerializableExtra(NotificationsListFragment.NOTE_CURRENT_LIST_FILTER_EXTRA);
@@ -488,5 +499,15 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
             else
                 return null;
         }
+
+        public Note getNoteWithId(String id){
+            for (Note note : mNoteList) {
+                if (note.getId().equalsIgnoreCase(id)) {
+                    return note;
+                }
+            }
+            return null;
+        }
+
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -142,7 +142,7 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
         // If not, just let it be.
         if (mAdapter != null) {
             Note currentNote = mAdapter.getNoteWithId(mNoteId);
-            if (note.similar(currentNote)) {
+            if (note.equalsTimeAndLength(currentNote)) {
                 return;
             }
         }


### PR DESCRIPTION
This PR is now comparing Notes in `NoteDetailActivity` so it doesn't refresh and reset the screen scroll if the most recent network refresh doesn't show any difference with the currently viewed Note

Fixes #5988 

To test:

1. Go to Notifications tab.
2. Tap any notification.
3. Scroll to middle of notification detail.
4. Tap recents navigation button.
5. Tap WordPress app in list.
6. Notice notification detail screen is not refreshed anymore.

this is take 2 from ~#5997~ :) cc @theck13 