### PR TITLE
Fix NPE in PostUtils

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -291,8 +291,8 @@ public class PostUtils {
         }
         Date pubDate = DateTimeUtils.dateFromIso8601(postModel.getDateCreated());
         Date now = new Date();
-        // For drafts with publish dates in the past, we should publish immediately
-        return !pubDate.after(now);
+        // Publish immediately for posts that don't have any date set yet and drafts with publish dates in the past
+        return pubDate == null || !pubDate.after(now);
     }
 
     // Only drafts should have the option to publish immediately to avoid user confusion


### PR DESCRIPTION
When a post is first instantiated, it does not have a date set yet. It should be safe to assume we want to publish the post immediately if the user hasn't changed the date.