### PR TITLE
Show "Draft uploaded" when a draft is first saved remotely

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
@@ -96,9 +96,16 @@ public class PostUploadNotifier {
 
         // Notification builder
         NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(mContext.getApplicationContext());
-        String notificationTitle = PostStatus.DRAFT.equals(PostStatus.fromPost(post)) ? (String) mContext.getResources().getText(R.string
-                .draft_uploaded) : ((String) (post.isPage() ? mContext.getResources().getText(R.string
-                .page_published) : mContext.getResources().getText(R.string.post_published)));
+        String notificationTitle;
+        if (PostStatus.DRAFT.equals(PostStatus.fromPost(post))) {
+            notificationTitle = (String) mContext.getResources().getText(R.string
+                    .draft_uploaded);
+        } else if (post.isPage()) {
+            notificationTitle = (String) mContext.getResources().getText(R.string
+                    .page_published);
+        } else {
+            notificationTitle = (String) mContext.getResources().getText(R .string.post_published);
+        }
 
         if (!isFirstTimePublish) {
             notificationTitle = (String) (post.isPage() ? mContext.getResources().getText(R.string

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
@@ -96,8 +96,10 @@ public class PostUploadNotifier {
 
         // Notification builder
         NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(mContext.getApplicationContext());
-        String notificationTitle = (String) (post.isPage() ? mContext.getResources().getText(R.string
-                .page_published) : mContext.getResources().getText(R.string.post_published));
+        String notificationTitle = PostStatus.DRAFT.equals(PostStatus.fromPost(post)) ? (String) mContext.getResources().getText(R.string
+                .draft_uploaded) : ((String) (post.isPage() ? mContext.getResources().getText(R.string
+                .page_published) : mContext.getResources().getText(R.string.post_published)));
+
         if (!isFirstTimePublish) {
             notificationTitle = (String) (post.isPage() ? mContext.getResources().getText(R.string
                     .page_updated) : mContext.getResources().getText(R.string.post_updated));

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -263,6 +263,7 @@
     <!-- post view -->
     <string name="post_id">Post</string>
     <string name="upload_failed">Upload failed</string>
+    <string name="draft_uploaded">Draft uploaded</string>
     <string name="post_published">Post published</string>
     <string name="page_published">Page published</string>
     <string name="post_updated">Post updated</string>


### PR DESCRIPTION
Fixes #6140 

To test:
1. start a new draft, enter some text
2. leave the editor
3. see the progressing notification
4. finally see the final notification show "Draft uploaded" instead of "Post published"

cc @aforcier 