### PR TITLE
Issue/editor toolbar state

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -4,7 +4,6 @@ import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Fragment;
 import android.app.FragmentManager;
-import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -45,7 +44,6 @@ import android.widget.Toast;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.m4m.MediaComposer;
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.JavaScriptException;
 import org.wordpress.android.R;
@@ -109,7 +107,6 @@ import org.wordpress.android.util.AutolinkUtils;
 import org.wordpress.android.util.CrashlyticsUtils;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DisplayUtils;
-import org.wordpress.android.util.FileUtils;
 import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.ListUtils;
@@ -124,7 +121,6 @@ import org.wordpress.android.util.WPHtml;
 import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.util.WPPermissionUtils;
 import org.wordpress.android.util.WPUrlUtils;
-import org.wordpress.android.util.WPVideoUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 import org.wordpress.android.util.helpers.MediaGalleryImageSpan;
@@ -135,7 +131,6 @@ import org.wordpress.passcodelock.AppLockManager;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -1259,7 +1254,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 case 0:
                     // TODO: Remove editor options after testing.
                     if (mShowAztecEditor) {
-                        mAztecEditorFragment = AztecEditorFragment.newInstance("", "");
+                        mAztecEditorFragment = AztecEditorFragment.newInstance("", "", AppPrefs.isAztecEditorToolbarExpanded());
                         mAztecEditorFragment.setImageLoader(new AztecImageLoader(getBaseContext()));
                         return mAztecEditorFragment;
                     } else if (mShowNewEditor) {
@@ -2305,9 +2300,11 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 break;
             case ELLIPSIS_COLLAPSE_BUTTON_TAPPED:
                 AnalyticsTracker.track(Stat.EDITOR_TAPPED_ELLIPSIS_COLLAPSE);
+                AppPrefs.setAztecEditorToolbarExpanded(false);
                 break;
             case ELLIPSIS_EXPAND_BUTTON_TAPPED:
                 AnalyticsTracker.track(Stat.EDITOR_TAPPED_ELLIPSIS_EXPAND);
+                AppPrefs.setAztecEditorToolbarExpanded(true);
                 break;
             case HEADING_BUTTON_TAPPED:
                 AnalyticsTracker.track(Stat.EDITOR_TAPPED_HEADING);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -62,6 +62,9 @@ public class AppPrefs {
         // aztec editor enabled
         AZTEC_EDITOR_ENABLED,
 
+        // aztec editor toolbar expanded state
+        AZTEC_EDITOR_TOOLBAR_EXPANDED,
+
         // visual editor enabled
         VISUAL_EDITOR_ENABLED,
 
@@ -415,6 +418,14 @@ public class AppPrefs {
 
     public static boolean isAztecEditorAvailable() {
         return BuildConfig.AZTEC_EDITOR_AVAILABLE || getBoolean(UndeletablePrefKey.AZTEC_EDITOR_AVAILABLE, false);
+    }
+
+    public static boolean isAztecEditorToolbarExpanded() {
+        return getBoolean(DeletablePrefKey.AZTEC_EDITOR_TOOLBAR_EXPANDED, false);
+    }
+
+    public static void setAztecEditorToolbarExpanded(boolean isExpanded) {
+        setBoolean(DeletablePrefKey.AZTEC_EDITOR_TOOLBAR_EXPANDED, isExpanded);
     }
 
     // Visual Editor

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -96,6 +96,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             .MIMETYPE_TEXT_PLAIN, ClipDescription.MIMETYPE_TEXT_HTML);
     private static final List<String> DRAGNDROP_SUPPORTED_MIMETYPES_IMAGE = Arrays.asList("image/jpeg", "image/png");
 
+    private static boolean mIsToolbarExpanded = false;
+
     private boolean mIsKeyboardOpen = false;
     private boolean mEditorWasPaused = false;
     private boolean mHideActionBarOnSoftKeyboardUp = false;
@@ -116,7 +118,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     private ImagePredicate mTappedImagePredicate;
 
-    public static AztecEditorFragment newInstance(String title, String content) {
+    public static AztecEditorFragment newInstance(String title, String content, boolean isExpanded) {
+        mIsToolbarExpanded = isExpanded;
         AztecEditorFragment fragment = new AztecEditorFragment();
         Bundle args = new Bundle();
         args.putString(ARG_PARAM_TITLE, title);
@@ -149,6 +152,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         formattingToolbar = (AztecToolbar) view.findViewById(R.id.formatting_toolbar);
         formattingToolbar.setEditor(content, source);
         formattingToolbar.setToolbarListener(this);
+        formattingToolbar.setExpanded(mIsToolbarExpanded);
 
         title.setOnFocusChangeListener(
             new View.OnFocusChangeListener() {


### PR DESCRIPTION
### Fix
Add flag to persist editor toolbar state (i.e. collapsed or expanded) across sessions.

### Test
0. Update [WordPressEditor dependencies](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/libs/editor/WordPressEditor/build.gradle#L54) to include the following.
```compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:develop-SNAPSHOT')``` and run `./gradlew build --refresh-dependencies`
1. Go to ***Sites*** tab.
2. Tap ***Blog Posts*** item
3. Tap ***Create*** floating button.
4. Notice editor toolbar is collapsed.
5. Tap back arrow to exit editor.
6. Tap ***Create*** floating button.
7. Notice editor toolbar is collapsed.
8. Tap editor content area to active toolbar.
9. Tap ***Expand Toolbar*** toolbar button.
10. Notice editor toolbar is expanded.
11. Tap back arrow to exit editor.
12. Tap ***Create*** floating button.
13. Notice editor toolbar is expanded.

#### Note
The ***branch will not build*** until https://github.com/wordpress-mobile/AztecEditor-Android/pull/392 is merged and the library version containing those changes is included in the [WordPressEditor dependencies](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/libs/editor/WordPressEditor/build.gradle#L54).  This was branched off `issue/6085-add-toolbar-analytics` to avoid merge conflicts and ***should merged after*** https://github.com/wordpress-mobile/WordPress-Android/pull/6126.