### PR TITLE
Update editor toolbar format button descriptions

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1720,17 +1720,23 @@
     <string name="image_width">Width</string>
 
     <!-- Editor: Accessibility - format bar button descriptions -->
+    <string name="format_bar_description_media">Media</string>
+    <string name="format_bar_description_heading">Heading</string>
+    <string name="format_bar_description_list">List</string>
+    <string name="format_bar_description_ol">Ordered List</string>
+    <string name="format_bar_description_ul">Unordered List</string>
+    <string name="format_bar_description_quote">Block Quote</string>
     <string name="format_bar_description_bold">Bold</string>
     <string name="format_bar_description_italic">Italic</string>
+    <string name="format_bar_description_link">Link</string>
     <string name="format_bar_description_underline">Underline</string>
     <string name="format_bar_description_strike">Strikethrough</string>
-    <string name="format_bar_description_quote">Block quote</string>
-    <string name="format_bar_description_link">Insert link</string>
-    <string name="format_bar_description_more">Insert more</string>
-    <string name="format_bar_description_media">Insert media</string>
-    <string name="format_bar_description_ul">Unordered list</string>
-    <string name="format_bar_description_ol">Ordered list</string>
-    <string name="format_bar_description_html">HTML mode</string>
+    <string name="format_bar_description_horizontal_rule">Horizontal Rule</string>
+    <string name="format_bar_description_more">Read More</string>
+    <string name="format_bar_description_page">Page Break</string>
+    <string name="format_bar_description_html">HTML</string>
+    <string name="format_bar_description_ellipsis_collapse">Collapse Toolbar</string>
+    <string name="format_bar_description_ellipsis_expand">Expand Toolbar</string>
     <string name="visual_editor">Visual editor</string>
     <string name="image_thumbnail">Image thumbnail</string>
 


### PR DESCRIPTION
### Fix
Update editor toolbar format buttons descriptions to match the changes in https://github.com/wordpress-mobile/WordPress-Android/pull/6093.

### Test
0. Enable ***Beta*** editor.
1. Go to ***Sites*** tab.
2. Tap ***Create*** floating button.
3. Tap content text field.
4. Long-press on leftmost toolbar format button.
5. Notice ***Media*** message is displayed.