### PR TITLE
Copy editor string resources to main project for translation

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -988,9 +988,6 @@
 
     <!-- Aztec -->
     <string name="dialog_link_title">Insert link</string>
-    <string name="dialog_link_edit_hint">http(s)://</string>
-    <string name="dialog_button_ok">OK</string>
-    <string name="dialog_button_cancel">Cancel</string>
 
     <string name="edit_hint">Share your story here&#8230;</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -986,6 +986,30 @@
     <string name="editor_post_settings_set_featured_image">Set Featured Image</string>
 
 
+    <!-- Aztec -->
+    <string name="dialog_title">Insert link</string>
+    <string name="dialog_edit_hint">http(s)://</string>
+    <string name="dialog_button_ok">OK</string>
+    <string name="dialog_button_cancel">Cancel</string>
+
+    <string name="edit_hint">Share your story here&#8230;</string>
+
+    <string name="editor_dropped_html_images_not_allowed">Dropping images while in HTML mode is not allowed</string>
+    <string name="editor_dropped_text_error">Error occurred while dropping text</string>
+    <string name="editor_dropped_title_images_not_allowed">Dropping images in the Title is not allowed</string>
+    <string name="editor_dropped_unsupported_files">Warning: not all dropped items are supported!</string>
+
+    <string name="error_media_small">Media too small to show</string>
+
+    <string name="media_insert_unimplemented">Apologies! Feature not implemented yet :(</string>
+
+    <string name="menu_undo">Undo</string>
+    <string name="menu_redo">Redo</string>
+
+    <string name="post_title">Title</string>
+
+    <string name="upload_finished_toast">Can\'t stop the upload because it\'s already finished</string>
+
     <!-- Post Formats -->
     <string name="post_format_aside">Aside</string>
     <string name="post_format_audio">Audio</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -987,8 +987,6 @@
 
 
     <!-- Aztec -->
-    <string name="dialog_link_title">Insert link</string>
-
     <string name="editor_content_hint">Share your story here&#8230;</string>
 
     <string name="editor_dropped_html_images_not_allowed">Dropping images while in HTML mode is not allowed</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -987,8 +987,8 @@
 
 
     <!-- Aztec -->
-    <string name="dialog_title">Insert link</string>
-    <string name="dialog_edit_hint">http(s)://</string>
+    <string name="dialog_link_title">Insert link</string>
+    <string name="dialog_link_edit_hint">http(s)://</string>
     <string name="dialog_button_ok">OK</string>
     <string name="dialog_button_cancel">Cancel</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -989,7 +989,7 @@
     <!-- Aztec -->
     <string name="dialog_link_title">Insert link</string>
 
-    <string name="edit_hint">Share your story here&#8230;</string>
+    <string name="editor_content_hint">Share your story here&#8230;</string>
 
     <string name="editor_dropped_html_images_not_allowed">Dropping images while in HTML mode is not allowed</string>
     <string name="editor_dropped_text_error">Error occurred while dropping text</string>

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -143,7 +143,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         content = (AztecText)view.findViewById(R.id.aztec);
         source = (SourceViewEditText) view.findViewById(R.id.source);
 
-        source.setHint("<p>" + getString(R.string.edit_hint) + "</p>");
+        source.setHint("<p>" + getString(R.string.editor_content_hint) + "</p>");
 
         formattingToolbar = (AztecToolbar) view.findViewById(R.id.formatting_toolbar);
         formattingToolbar.setEditor(content, source);

--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
@@ -57,7 +57,7 @@
                 <org.wordpress.aztec.AztecText
                     android:id="@+id/aztec"
                     android:gravity="top|start"
-                    android:hint="@string/edit_hint"
+                    android:hint="@string/editor_content_hint"
                     android:inputType="textCapSentences|textMultiLine"
                     android:layout_height="match_parent"
                     android:layout_width="match_parent"

--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -102,9 +102,9 @@
     <string name="editor_dropped_unsupported_files">Warning: not all dropped items are supported!</string>
 
     <!-- AZTEC -->
-    <string name="edit_hint">Share your story here&#8230;</string>
-
     <string name="dialog_link_title">Insert link</string>
+
+    <string name="editor_content_hint">Share your story here&#8230;</string>
 
     <string name="menu_undo">Undo</string>
     <string name="menu_redo">Redo</string>

--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -104,8 +104,8 @@
     <!-- AZTEC -->
     <string name="edit_hint">Share your story here&#8230;</string>
 
-    <string name="dialog_title">Insert link</string>
-    <string name="dialog_edit_hint">http(s)://</string>
+    <string name="dialog_link_title">Insert link</string>
+    <string name="dialog_link_edit_hint">http(s)://</string>
     <string name="dialog_button_ok">OK</string>
     <string name="dialog_button_cancel">Cancel</string>
 

--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -105,9 +105,6 @@
     <string name="edit_hint">Share your story here&#8230;</string>
 
     <string name="dialog_link_title">Insert link</string>
-    <string name="dialog_link_edit_hint">http(s)://</string>
-    <string name="dialog_button_ok">OK</string>
-    <string name="dialog_button_cancel">Cancel</string>
 
     <string name="menu_undo">Undo</string>
     <string name="menu_redo">Redo</string>

--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -101,15 +101,14 @@
     <string name="editor_dropped_html_images_not_allowed">Dropping images while in HTML mode is not allowed</string>
     <string name="editor_dropped_unsupported_files">Warning: not all dropped items are supported!</string>
 
-    <!-- AZTEC -->
-    <string name="dialog_link_title">Insert link</string>
-
+    <!-- Aztec -->
     <string name="editor_content_hint">Share your story here&#8230;</string>
+
+    <string name="media_insert_unimplemented">Apologies! Feature not implemented yet :(</string>
 
     <string name="menu_undo">Undo</string>
     <string name="menu_redo">Redo</string>
 
-    <string name="media_insert_unimplemented">Apologies! Feature not implemented yet :(</string>
     <string name="error_media_load">Unable to load media</string>
     <string name="error_media_small">Media too small to show</string>
 


### PR DESCRIPTION
### Fix
Copy string resources from editor library to main project for translation purposes as described in https://github.com/wordpress-mobile/WordPress-Android/issues/6205.