### PR TITLE
Issue/editor toolbar state release

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1254,7 +1254,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 case 0:
                     // TODO: Remove editor options after testing.
                     if (mShowAztecEditor) {
-                        mAztecEditorFragment = AztecEditorFragment.newInstance("", "");
+                        mAztecEditorFragment = AztecEditorFragment.newInstance("", "", AppPrefs.isAztecEditorToolbarExpanded());
                         mAztecEditorFragment.setImageLoader(new AztecImageLoader(getBaseContext()));
                         return mAztecEditorFragment;
                     } else if (mShowNewEditor) {
@@ -2279,9 +2279,11 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                 break;
             case ELLIPSIS_COLLAPSE_BUTTON_TAPPED:
                 AnalyticsTracker.track(Stat.EDITOR_TAPPED_ELLIPSIS_COLLAPSE);
+                AppPrefs.setAztecEditorToolbarExpanded(false);
                 break;
             case ELLIPSIS_EXPAND_BUTTON_TAPPED:
                 AnalyticsTracker.track(Stat.EDITOR_TAPPED_ELLIPSIS_EXPAND);
+                AppPrefs.setAztecEditorToolbarExpanded(true);
                 break;
             case HEADING_BUTTON_TAPPED:
                 AnalyticsTracker.track(Stat.EDITOR_TAPPED_HEADING);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -62,6 +62,9 @@ public class AppPrefs {
         // aztec editor enabled
         AZTEC_EDITOR_ENABLED,
 
+        // aztec editor toolbar expanded state
+        AZTEC_EDITOR_TOOLBAR_EXPANDED,
+
         // visual editor enabled
         VISUAL_EDITOR_ENABLED,
 
@@ -415,6 +418,14 @@ public class AppPrefs {
 
     public static boolean isAztecEditorAvailable() {
         return BuildConfig.AZTEC_EDITOR_AVAILABLE || getBoolean(UndeletablePrefKey.AZTEC_EDITOR_AVAILABLE, false);
+    }
+
+    public static boolean isAztecEditorToolbarExpanded() {
+        return getBoolean(DeletablePrefKey.AZTEC_EDITOR_TOOLBAR_EXPANDED, false);
+    }
+
+    public static void setAztecEditorToolbarExpanded(boolean isExpanded) {
+        setBoolean(DeletablePrefKey.AZTEC_EDITOR_TOOLBAR_EXPANDED, isExpanded);
     }
 
     // Visual Editor

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -96,6 +96,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             .MIMETYPE_TEXT_PLAIN, ClipDescription.MIMETYPE_TEXT_HTML);
     private static final List<String> DRAGNDROP_SUPPORTED_MIMETYPES_IMAGE = Arrays.asList("image/jpeg", "image/png");
 
+    private static boolean mIsToolbarExpanded = false;
+
     private boolean mIsKeyboardOpen = false;
     private boolean mEditorWasPaused = false;
     private boolean mHideActionBarOnSoftKeyboardUp = false;
@@ -116,7 +118,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     private ImagePredicate mTappedImagePredicate;
 
-    public static AztecEditorFragment newInstance(String title, String content) {
+    public static AztecEditorFragment newInstance(String title, String content, boolean isExpanded) {
+        mIsToolbarExpanded = isExpanded;
         AztecEditorFragment fragment = new AztecEditorFragment();
         Bundle args = new Bundle();
         args.putString(ARG_PARAM_TITLE, title);
@@ -149,6 +152,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         formattingToolbar = (AztecToolbar) view.findViewById(R.id.formatting_toolbar);
         formattingToolbar.setEditor(content, source);
         formattingToolbar.setToolbarListener(this);
+        formattingToolbar.setExpanded(mIsToolbarExpanded);
 
         title.setOnFocusChangeListener(
             new View.OnFocusChangeListener() {


### PR DESCRIPTION
### Fix
Add flag to persist editor toolbar state (i.e. collapsed or expanded) across sessions.

### Test
1. Go to ***Sites*** tab.
2. Tap ***Blog Posts*** item
3. Tap ***Create*** floating button.
4. Notice editor toolbar is collapsed.
5. Tap back arrow to exit editor.
6. Tap ***Create*** floating button.
7. Notice editor toolbar is collapsed.
8. Tap editor content area to active toolbar.
9. Tap ***Expand Toolbar*** toolbar button.
10. Notice editor toolbar is expanded.
11. Tap back arrow to exit editor.
12. Tap ***Create*** floating button.
13. Notice editor toolbar is expanded.

#### Note
This was branched off `issue/6085-add-toolbar-analytics-release` to avoid merge conflicts and ***should merged after*** https://github.com/wordpress-mobile/WordPress-Android/pull/6212.