### PR TITLE
Fixes #6214: html unescape tags and categories in post settings and tags picker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -40,6 +40,7 @@ import com.google.android.gms.location.places.ui.PlacePicker;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -674,6 +675,7 @@ public class EditPostSettingsFragment extends Fragment {
     private void updateTagsTextView() {
         String tags = TextUtils.join(",", getPost().getTagNameList());
         // If `tags` is empty, the hint "Not Set" will be shown instead
+        tags = StringEscapeUtils.unescapeHtml4(tags);
         mTagsTextView.setText(tags);
     }
 
@@ -721,7 +723,7 @@ public class EditPostSettingsFragment extends Fragment {
             }
         }
         // If `sb` is empty, the hint "Not Set" will be shown instead
-        mCategoriesTextView.setText(sb);
+        mCategoriesTextView.setText(StringEscapeUtils.unescapeHtml4(sb.toString()));
     }
 
     // Post Status Helpers

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsTagsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsTagsActivity.java
@@ -20,6 +20,7 @@ import android.widget.EditText;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.R;
@@ -85,6 +86,7 @@ public class PostSettingsTagsActivity extends AppCompatActivity implements TextW
         if (!TextUtils.isEmpty(tags)) {
             // add a , at the end so the user can start typing a new tag
             tags += ",";
+            tags = StringEscapeUtils.unescapeHtml4(tags);
             mTagsEditText.setText(tags);
             mTagsEditText.setSelection(mTagsEditText.length());
         }
@@ -173,6 +175,7 @@ public class PostSettingsTagsActivity extends AppCompatActivity implements TextW
             updatedText = text.substring(0, endIndex + 1) + selectedTag;
         }
         updatedText += ",";
+        updatedText = StringEscapeUtils.unescapeHtml4(updatedText);
         mTagsEditText.setText(updatedText);
         mTagsEditText.setSelection(mTagsEditText.length());
     }
@@ -206,7 +209,8 @@ public class PostSettingsTagsActivity extends AppCompatActivity implements TextW
 
         @Override
         public void onBindViewHolder(final TagViewHolder holder, int position) {
-            holder.nameTextView.setText(mFilteredTags.get(position).getName());
+            String tag = StringEscapeUtils.unescapeHtml4(mFilteredTags.get(position).getName());
+            holder.nameTextView.setText(tag);
         }
 
         @Override


### PR DESCRIPTION
Fixes #6214

![out1](https://user-images.githubusercontent.com/40213/27818702-0ac1182c-6097-11e7-965c-4ae759329670.png)
![out2](https://user-images.githubusercontent.com/40213/27818701-0ac034ac-6097-11e7-868c-31057a803632.png)
