### PR TITLE
Post Settings: Updating post status updates publish date view

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1149,7 +1149,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                             runOnUiThread(new Runnable() {
                                 @Override
                                 public void run() {
-                                    mEditPostSettingsFragment.updateStatusTextView();
+                                    mEditPostSettingsFragment.updatePostStatusRelatedViews();
                                 }
                             });
                         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -641,7 +641,7 @@ public class EditPostSettingsFragment extends Fragment {
 
     private void updatePostStatus(String postStatus) {
         getPost().setStatus(postStatus);
-        updateStatusTextView();
+        updatePostStatusRelatedViews();
         updateSaveButton();
     }
 
@@ -650,7 +650,12 @@ public class EditPostSettingsFragment extends Fragment {
         updatePostFormatTextView();
     }
 
-    public void updateStatusTextView() {
+    public void updatePostStatusRelatedViews() {
+        updateStatusTextView();
+        updatePublishDateTextView();
+    }
+
+    private void updateStatusTextView() {
         if (!isAdded()) {
             return;
         }


### PR DESCRIPTION
I am not 100% sure if this is a good change or not, but I thought it's easier to discuss in a PR. The publish date text depends on the post status. If the post is a draft, we'll show "Immediately" for publish date and will change the date upon publish action to current date. Otherwise, the current date field will be shown and won't be affected by updates.

Previous to this PR, after changing the post status, the publish date field would stay the same until user makes a change in the field. However, we'd still use the current status for publish/update actions. For example, there was a chance that the field would show "Immediately" and the post would be posted whatever the date was set to previously.

This is all a little confusing and I don't think there is a perfect solution until we remove status field from post settings and instead use options similar to Calypso. In the current state of things, I think the UI should be consistent with what our actions will be.

cc @maxme what do you think?