### PR TITLE
modified log message

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2387,7 +2387,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         if (isFinishing()) return;
         // event for unknown media, ignoring
         if (event.media == null) {
-            AppLog.w(AppLog.T.MEDIA, "Media event not recognized: " + event.media);
+            AppLog.w(AppLog.T.MEDIA, "Media event carries null media object, not recognized");
             return;
         }
 


### PR DESCRIPTION
This one fixes a lint error for `event.media` being always null. Still keeping the error logging FWIW.
Thank you @oguzkocer for pointing this one out!

cc @oguzkocer 