### PR TITLE
Allow translation of the TOS url

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1055,7 +1055,7 @@
     <string name="publisher">Publisher:</string>
     <string name="automattic_inc" translatable="false">Automattic, Inc</string>
     <string name="automattic_url" translatable="false">automattic.com</string>
-    <string name="wordpresscom_tos_url" translatable="false">https://en.wordpress.com/tos</string>
+    <string name="wordpresscom_tos_url">https://en.wordpress.com/tos</string>
     <string name="version">Version</string>
     <string name="tos">Terms of Service</string>
     <string name="privacy_policy">Privacy policy</string>


### PR DESCRIPTION
We have a few translated versions we should be able to link to.

To test: when generating the strings file, the string `wordpresscom_tos_url` is added.
I haven't built/tested that the string is actually going to use the translations, I just assume it will :)

