### PR TITLE
Prevent content loss on failed post upload

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -971,6 +971,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
                }
             }
 
+            savePostToDb();
             PostUtils.trackSavePostAnalytics(mPost, mSiteStore.getSiteByLocalId(mPost.getLocalSiteId()));
 
             if (isFirstTimePublish) {


### PR DESCRIPTION
Fixes #6226. We used to update the post in the database before starting the upload, to ensure an up-to-date local version existed in case anything went wrong. This change restores that behavior.

This has the added benefit of updating the post list with the latest changes to the post while uploading (it used to show a blank excerpt during upload for new posts, for example):

![upload-post-list-fix](https://user-images.githubusercontent.com/9613966/27865686-88d5807a-6161-11e7-80fa-863410ca3569.png)

To test:
1. Write a short new post
2. Publish it and induce an upload error
3. Notice that the post is saved, intact, as a local draft

cc @mzorz