### PR TITLE
Feature/hide gplus conditional

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
@@ -5,6 +5,9 @@ public class PublicizeConstants {
     public static final String ARG_CONNECTION_ID  = "connection_id";
     public static final String ARG_CONNECTION_ARRAY_JSON = "connection_array_json";
 
+    // G+ no longers supports authentication via a WebView, so we hide it here unless the
+    // user already has a connection - and if they do, we hide the ability to connect
+    // another G+ account
     public static final String GOOGLE_PLUS_ID = "google_plus";
 
     public enum ConnectAction {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
@@ -5,9 +5,6 @@ public class PublicizeConstants {
     public static final String ARG_CONNECTION_ID  = "connection_id";
     public static final String ARG_CONNECTION_ARRAY_JSON = "connection_array_json";
 
-    // G+ no longers supports authentication via a WebView, so we hide it here unless the
-    // user already has a connection - and if they do, we hide the ability to connect
-    // another G+ account
     public static final String GOOGLE_PLUS_ID = "google_plus";
 
     public enum ConnectAction {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeConstants.java
@@ -5,6 +5,8 @@ public class PublicizeConstants {
     public static final String ARG_CONNECTION_ID  = "connection_id";
     public static final String ARG_CONNECTION_ARRAY_JSON = "connection_array_json";
 
+    public static final String GOOGLE_PLUS_ID = "google_plus";
+
     public enum ConnectAction {
         CONNECT,
         DISCONNECT,

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
@@ -102,6 +102,7 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment implements Pu
 
         setTitle(mService.getLabel());
 
+        // disable the ability to add another G+ connection
         if (mService.getId().equals(PublicizeConstants.GOOGLE_PLUS_ID)) {
             mServiceCardView.setVisibility(View.GONE);
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeDetailFragment.java
@@ -29,6 +29,7 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment implements Pu
     private ConnectButton mConnectBtn;
     private RecyclerView mRecycler;
     private View mConnectionsCardView;
+    private ViewGroup mServiceCardView;
 
     @Inject AccountStore mAccountStore;
 
@@ -75,8 +76,9 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment implements Pu
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         ViewGroup rootView = (ViewGroup) inflater.inflate(R.layout.publicize_detail_fragment, container, false);
 
-        mConnectBtn = (ConnectButton) rootView.findViewById(R.id.button_connect);
         mConnectionsCardView = rootView.findViewById(R.id.card_view_connections);
+        mServiceCardView = (ViewGroup) rootView.findViewById(R.id.card_view_service);
+        mConnectBtn = (ConnectButton) mServiceCardView.findViewById(R.id.button_connect);
         mRecycler = (RecyclerView) rootView.findViewById(R.id.recycler_view);
 
         return rootView;
@@ -100,13 +102,17 @@ public class PublicizeDetailFragment extends PublicizeBaseFragment implements Pu
 
         setTitle(mService.getLabel());
 
-        String serviceLabel = String.format(getString(R.string.connection_service_label), mService.getLabel());
-        TextView txtService = (TextView) getView().findViewById(R.id.text_service);
-        txtService.setText(serviceLabel);
+        if (mService.getId().equals(PublicizeConstants.GOOGLE_PLUS_ID)) {
+            mServiceCardView.setVisibility(View.GONE);
+        } else {
+            String serviceLabel = String.format(getString(R.string.connection_service_label), mService.getLabel());
+            TextView txtService = (TextView) mServiceCardView.findViewById(R.id.text_service);
+            txtService.setText(serviceLabel);
 
-        String description = String.format(getString(R.string.connection_service_description), mService.getLabel());
-        TextView txtDescription = (TextView) getView().findViewById(R.id.text_description);
-        txtDescription.setText(description);
+            String description = String.format(getString(R.string.connection_service_description), mService.getLabel());
+            TextView txtDescription = (TextView) mServiceCardView.findViewById(R.id.text_description);
+            txtDescription.setText(description);
+        }
 
         long currentUserId = mAccountStore.getAccount().getUserId();
         PublicizeConnectionAdapter adapter = new PublicizeConnectionAdapter(

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -241,7 +241,11 @@ public class PublicizeListActivity extends AppCompatActivity
             @Override
             public void onClick(DialogInterface dialog, int id) {
                 PublicizeActions.disconnect(publicizeConnection);
-                reloadDetailFragment();
+                if (publicizeConnection.getService().equals(PublicizeConstants.GOOGLE_PLUS_ID)) {
+                    returnToListFragment();
+                } else {
+                    reloadDetailFragment();
+                }
             }
         });
         builder.setNegativeButton(R.string.cancel, null);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -241,6 +241,8 @@ public class PublicizeListActivity extends AppCompatActivity
             @Override
             public void onClick(DialogInterface dialog, int id) {
                 PublicizeActions.disconnect(publicizeConnection);
+                // if the user disconnected from G+, return to the list fragment since the
+                // detail fragment would give them the ability to reconnect
                 if (publicizeConnection.getService().equals(PublicizeConstants.GOOGLE_PLUS_ID)) {
                     returnToListFragment();
                 } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
@@ -17,6 +17,7 @@ import org.wordpress.android.models.PublicizeConnection;
 import org.wordpress.android.models.PublicizeConnectionList;
 import org.wordpress.android.models.PublicizeService;
 import org.wordpress.android.models.PublicizeServiceList;
+import org.wordpress.android.ui.publicize.PublicizeConstants;
 import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
@@ -155,8 +156,6 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
      */
     private boolean mIsTaskRunning = false;
     private class LoadServicesTask extends AsyncTask<Void, Void, Boolean> {
-        private static final String GOOGLE_PLUS_ID = "google_plus";
-
         private final PublicizeServiceList tmpServices = new PublicizeServiceList();
         private final PublicizeConnectionList tmpConnections = new PublicizeConnectionList();
 
@@ -176,7 +175,7 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
 
             PublicizeConnectionList connections = PublicizeTable.getConnectionsForSite(mSiteId);
             for (PublicizeConnection connection: connections) {
-                if (connection.getService().equals(GOOGLE_PLUS_ID)) {
+                if (connection.getService().equals(PublicizeConstants.GOOGLE_PLUS_ID)) {
                     hideGPlus = false;
                 }
                 tmpConnections.add(connection);
@@ -184,7 +183,7 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
 
             PublicizeServiceList services = PublicizeTable.getServiceList();
             for (PublicizeService service: services) {
-                if (!service.getId().equals(GOOGLE_PLUS_ID) || !hideGPlus) {
+                if (!service.getId().equals(PublicizeConstants.GOOGLE_PLUS_ID) || !hideGPlus) {
                     tmpServices.add(service);
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
@@ -169,6 +169,8 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
         }
         @Override
         protected Boolean doInBackground(Void... params) {
+            // G+ no longers supports authentication via a WebView, so we hide it here unless the
+            // user already has a connection
             boolean hideGPlus = true;
 
             PublicizeConnectionList connections = PublicizeTable.getConnectionsForSite(mSiteId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
@@ -170,17 +170,22 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
         }
         @Override
         protected Boolean doInBackground(Void... params) {
-            PublicizeServiceList services = PublicizeTable.getServiceList();
-            for (PublicizeService service: services) {
-                if (!service.getId().equals(GOOGLE_PLUS_ID)) {
-                    tmpServices.add(service);
-                }
-            }
+            // G+ no longer supports auth in a WebView, so we hide it here unless the user
+            // already has a G+ connection
+            boolean hideGPlus = true;
 
             PublicizeConnectionList connections = PublicizeTable.getConnectionsForSite(mSiteId);
             for (PublicizeConnection connection: connections) {
-                if (!connection.getService().equals(GOOGLE_PLUS_ID)) {
-                    tmpConnections.add(connection);
+                if (connection.getService().equals(GOOGLE_PLUS_ID)) {
+                    hideGPlus = false;
+                }
+                tmpConnections.add(connection);
+            }
+
+            PublicizeServiceList services = PublicizeTable.getServiceList();
+            for (PublicizeService service: services) {
+                if (!service.getId().equals(GOOGLE_PLUS_ID) || !hideGPlus) {
+                    tmpServices.add(service);
                 }
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeServiceAdapter.java
@@ -169,8 +169,6 @@ public class PublicizeServiceAdapter extends RecyclerView.Adapter<PublicizeServi
         }
         @Override
         protected Boolean doInBackground(Void... params) {
-            // G+ no longer supports auth in a WebView, so we hide it here unless the user
-            // already has a G+ connection
             boolean hideGPlus = true;
 
             PublicizeConnectionList connections = PublicizeTable.getConnectionsForSite(mSiteId);


### PR DESCRIPTION
In #6124 we chose to completely hide Google+ from publicize, but as per [iOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/7437#issuecomment-311169522) this PR updates that to only hide G+ if there isn't already a connection.

In order to do this correctly, this PR also dealt with the following:

* If we show G+ when there's a connection, then the user has the ability to connect another G+ account - which goes through the same auth process (and fails).
* If they disconnect G+, they end up on a screen that enables them to connect again - which also fails.