### PR TITLE
Hide some unsupported settings for Jetpack sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DetailListPreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DetailListPreference.java
@@ -19,6 +19,7 @@ import android.widget.ListView;
 import android.widget.RadioButton;
 import android.widget.TextView;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.wordpress.android.R;
 
 /**
@@ -179,6 +180,15 @@ public class DetailListPreference extends ListPreference
     @Override
     public void setHint(String hint) {
         mHint = hint;
+    }
+
+    public void remove(int index) {
+        if (index < 0 || index >= mDetails.length) {
+            return;
+        }
+
+        mDetails = ArrayUtils.remove(mDetails, index);
+        mListAdapter = new DetailListAdapter(getContext(), R.layout.detail_list_preference, mDetails);
     }
 
     public void refreshAdapter() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1400,6 +1400,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     private void removeNonJetpackPreferences() {
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_advanced);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_account);
+        WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_language);
     }
 
     private void removeNonDotComPreferences() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -47,7 +47,6 @@ import com.wordpress.rest.RestRequest;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -44,6 +44,7 @@ import android.widget.TextView;
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -1398,9 +1399,19 @@ public class SiteSettingsFragment extends PreferenceFragment
     }
 
     private void removeNonJetpackPreferences() {
+        removePrivateOptionFromPrivacySetting();
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_advanced);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_account);
-        WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_language);
+        WPPrefUtils.removePreference(this, R.string.pref_key_site_general, R.string.pref_key_site_language);
+    }
+
+    private void removePrivateOptionFromPrivacySetting() {
+        if (mPrivacyPref == null) {
+            return;
+        }
+
+        final CharSequence[] entries = mPrivacyPref.getEntries();
+        mPrivacyPref.remove(ArrayUtils.indexOf(entries, getString(R.string.site_settings_privacy_private_summary)));
     }
 
     private void removeNonDotComPreferences() {


### PR DESCRIPTION
Fixes #6158 

The Language setting is completely removed along with the `Private` Privacy option on Jetpack sites.

To test:
* Sign in with a .com account linked to a Jetpack site
* Go to Site Settings screen and make sure Language is not available and that `Private` is not in the Privacy options list
* Switch to a .com site
* Go to Site Settings screen and make sure Language and `Private` are still available

cc @maxme, kicking off #betterjetpackxp on Android 😄 