### PR TITLE
Feature/media two fixes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -554,6 +554,9 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         if (!mIsRefreshing) {
             setRefreshing(true);
             updateEmptyView(EmptyViewMessageType.LOADING);
+            if (loadMore) {
+                mSwipeToRefreshHelper.setRefreshing(true);
+            }
 
             FetchMediaListPayload payload =
                     new FetchMediaListPayload(mSite, NUM_MEDIA_PER_FETCH, loadMore, mFilter.toMimeType());

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -30,8 +30,8 @@
 
             <ImageView
                 android:id="@+id/media_grid_item_filetype_image"
-                android:layout_width="48dp"
-                android:layout_height="48dp"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
                 android:layout_gravity="center_horizontal"
                 android:tint="@color/grey_dark"
                 tools:src="@drawable/media_document" />


### PR DESCRIPTION
Fixes #6240 and fixes #6241 - reduces the size of the media placeholder icon so the filename is no longer cut off, and shows the swipe-to-refresh progress when loading more.

cc @daniloercoli 