### PR TITLE
Issue/6245 media video thumbnails

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -142,7 +142,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:43a6ad6068f6963500ed6ed7e60fadec4b2738d7') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:60c800b7e991d3acbdcf374d45864f07d7d469e5') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -172,6 +172,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
 
         if (isImage) {
             holder.fileContainer.setVisibility(View.GONE);
+            holder.imgVideoOverlay.setVisibility(View.GONE);
             if (isLocalFile) {
                 loadLocalImage(media.getFilePath(), holder.imageView);
             } else {
@@ -179,9 +180,11 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             }
         } else if (media.isVideo() && !TextUtils.isEmpty(media.getThumbnailUrl())) {
             holder.fileContainer.setVisibility(View.GONE);
+            holder.imgVideoOverlay.setVisibility(View.VISIBLE);
             WordPressMediaUtils.loadNetworkImage(media.getThumbnailUrl(), holder.imageView, mImageLoader);
         } else {
-            // not an image, so show file name and file type
+            // not an image or video, so show file name and file type
+            holder.imgVideoOverlay.setVisibility(View.GONE);
             holder.imageView.setImageDrawable(null);
             String fileName = media.getFileName();
             String title = media.getTitle();
@@ -255,6 +258,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         private final ViewGroup stateContainer;
         private final ViewGroup fileContainer;
         private final ImageView imgPreview;
+        private final ImageView imgVideoOverlay;
 
         public GridViewHolder(View view) {
             super(view);
@@ -270,6 +274,8 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             titleView = (TextView) fileContainer.findViewById(R.id.media_grid_item_name);
             fileTypeView = (TextView) fileContainer.findViewById(R.id.media_grid_item_filetype);
             fileTypeImageView = (ImageView) fileContainer.findViewById(R.id.media_grid_item_filetype_image);
+
+            imgVideoOverlay = (ImageView) view.findViewById(R.id.image_video_overlay);
 
             ViewGroup previewContainer = (ViewGroup) view.findViewById(R.id.frame_preview);
             previewContainer.setVisibility(mShowPreviewIcon ? View.VISIBLE : View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -177,6 +177,9 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             } else {
                 WordPressMediaUtils.loadNetworkImage(getBestImageUrl(media), holder.imageView, mImageLoader);
             }
+        } else if (media.isVideo() && !TextUtils.isEmpty(media.getThumbnailUrl())) {
+            holder.fileContainer.setVisibility(View.GONE);
+            WordPressMediaUtils.loadNetworkImage(media.getThumbnailUrl(), holder.imageView, mImageLoader);
         } else {
             // not an image, so show file name and file type
             holder.imageView.setImageDrawable(null);

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -13,6 +13,15 @@
         android:layout_height="wrap_content"
         android:scaleType="centerCrop" />
 
+    <ImageView
+        android:id="@+id/image_video_overlay"
+        android:layout_width="28dp"
+        android:layout_height="28dp"
+        android:layout_centerInParent="true"
+        android:src="@drawable/reader_video_overlay"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
     <RelativeLayout
         android:id="@+id/media_grid_item_file_container"
         android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #6245 - videos in the media browser now show a video thumbnail with a "player" overlay. ~~On hold until [this FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/512) is merged.~~

![screenshot_1499379017](https://user-images.githubusercontent.com/3903757/27935491-5d6d40c6-6279-11e7-93cc-2e08e2cc0d76.png)




