### PR TITLE
issue/6251-media-video-preview-progress

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -423,9 +423,11 @@ public class MediaPreviewActivity extends AppCompatActivity implements ActivityC
             }
         });
 
+        showProgress(true);
         mVideoView.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
             @Override
             public void onPrepared(MediaPlayer mp) {
+                showProgress(false);
                 controls.show();
                 mp.start();
             }


### PR DESCRIPTION
Fixes #6251 - media preview now shows a progress bar while the video is loading.