### PR TITLE
Issue/editor feedback tag

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/EditorReleaseNotesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/EditorReleaseNotesActivity.java
@@ -74,7 +74,7 @@ public class EditorReleaseNotesActivity extends WebViewActivity {
                 startActivity(Intent.createChooser(share, getText(R.string.share_link)));
                 return true;
             case R.id.menu_bug:
-                HelpshiftHelper.Tag origin = HelpshiftHelper.Tag.ORIGIN_UNKNOWN;
+                HelpshiftHelper.Tag origin = HelpshiftHelper.Tag.ORIGIN_FEEDBACK_AZTEC;
                 HelpshiftHelper.getInstance().showConversation(EditorReleaseNotesActivity.this, mSiteStore, origin, mAccountStore.getAccount().getUserName());
                 return true;
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
@@ -57,7 +57,8 @@ public class HelpshiftHelper {
         ORIGIN_LOGIN_SCREEN_JETPACK("origin:jetpack-login-screen"),
         ORIGIN_SIGNUP_SCREEN("origin:signup-screen"),
         ORIGIN_ME_SCREEN_HELP("origin:me-screen-help"),
-        ORIGIN_DELETE_SITE("origin:delete-site");
+        ORIGIN_DELETE_SITE("origin:delete-site"),
+        ORIGIN_FEEDBACK_AZTEC("origin:aztec-feedback");
 
         private final String mStringValue;
 


### PR DESCRIPTION
### Fix
Add a unique tag, `aztec-feedback`, for Helpshift conversation initiated by tapping the ***Report Bug*** icon from the ***What's New / Release Notes*** interface.