### PR TITLE
Login Rework: use the new FETCH_WPCOM_SITE_BY_URL FluxC action

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginSiteAddressFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginSiteAddressFragment.java
@@ -360,19 +360,12 @@ public class LoginSiteAddressFragment extends Fragment implements TextWatcher {
         }
 
         if (event.isError()) {
-            if (event.error.type != null && event.error.type == SiteStore.SiteErrorType.UNKNOWN_SITE) {
-                // not a wp.com site so, start the discovery process
-                mDispatcher.dispatch(
-                        AuthenticationActionBuilder.newDiscoverEndpointAction(mRequestedSiteAddress));
-            } else {
-                showError(R.string.no_site_error, NO_SITE_HELPSHIFT_FAQ_ID, NO_SITE_HELPSHIFT_FAQ_SECTION);
-                endProgress();
-            }
+            // not a wp.com site so, start the discovery process
+            mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mRequestedSiteAddress));
         } else {
             if (event.site.isJetpackInstalled()) {
                 // if Jetpack site, treat it as selfhosted and start the discovery process
-                mDispatcher.dispatch(
-                        AuthenticationActionBuilder.newDiscoverEndpointAction(mRequestedSiteAddress));
+                mDispatcher.dispatch(AuthenticationActionBuilder.newDiscoverEndpointAction(mRequestedSiteAddress));
                 return;
             }
 


### PR DESCRIPTION
This PR updates the implementation to use the newly available FluxC API (Action) for checking whether a site is known to WordPress.com. Up to now, the check was manually performed by using a low-level `WPComGsonRequest` request.

To test:
* With the app data cleaned, launch the app and hit the "Log in" button
* Hit the "Log in to your site by entering your site address instead" secondary action at the bottom
* Put in the site address of your site and observe the app behaving correctly. Feel free to check a wpcom site, a selfhosted site or a Jetpack selfhosted site.
