### PR TITLE
Use locale in tos string url

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -2,8 +2,6 @@ package org.wordpress.android.ui.accounts;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.content.res.Configuration;
-import android.content.res.Resources;
 import android.os.Bundle;
 import android.support.v4.view.ViewCompat;
 import android.text.Editable;
@@ -490,14 +488,12 @@ public class NewUserFragment extends AbstractFragment {
         termsOfServiceTextView.setOnClickListener(new OnClickListener() {
                                                       @Override
                                                       public void onClick(View v) {
-                                                          Resources res = getResources();
-                                                          Configuration conf = res.getConfiguration();
-                                                          String localString = conf.locale.toString();
+                                                          String localString =  LanguageUtils.getPatchedCurrentDeviceLanguage(v.getContext());
                                                           if (localString.contains("_")) {
                                                               localString = localString.substring(0, localString.indexOf("_"));
                                                           }
                                                           ActivityLauncher.openUrlExternal(getContext(),
-                                                                  getString(R.string.wordpresscom_tos_url).replace( "en", localString ));
+                                                                  String.format(getString(R.string.wordpresscom_tos_url ), localString));
                                                       }
                                                   }
         );

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -2,6 +2,8 @@ package org.wordpress.android.ui.accounts;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.os.Bundle;
 import android.support.v4.view.ViewCompat;
 import android.text.Editable;
@@ -488,8 +490,14 @@ public class NewUserFragment extends AbstractFragment {
         termsOfServiceTextView.setOnClickListener(new OnClickListener() {
                                                       @Override
                                                       public void onClick(View v) {
+                                                          Resources res = getResources();
+                                                          Configuration conf = res.getConfiguration();
+                                                          String localString = conf.locale.toString();
+                                                          if (localString.contains("_")) {
+                                                              localString = localString.substring(0, localString.indexOf("_"));
+                                                          }
                                                           ActivityLauncher.openUrlExternal(getContext(),
-                                                                  getString(R.string.wordpresscom_tos_url));
+                                                                  getString(R.string.wordpresscom_tos_url).replace( "en", localString ));
                                                       }
                                                   }
         );

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1091,7 +1091,7 @@
     <string name="publisher">Publisher:</string>
     <string name="automattic_inc" translatable="false">Automattic, Inc</string>
     <string name="automattic_url" translatable="false">automattic.com</string>
-    <string name="wordpresscom_tos_url" translatable="false">https://en.wordpress.com/tos</string>
+    <string name="wordpresscom_tos_url" translatable="false">https://%s.wordpress.com/tos</string>
     <string name="version">Version</string>
     <string name="tos">Terms of Service</string>
     <string name="privacy_policy">Privacy policy</string>


### PR DESCRIPTION
We should link to the locale subdomain at WordPress.com for the TOS. Some have a translated version.

To test: the TOS URL on user account creation points to {locale}.wordpress.com
Replaces #6224 
