### PR TITLE
Image Setting Screen - Do not download the picture at full size

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
@@ -4,11 +4,13 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.BitmapDrawable;
+import android.net.Uri;
 
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.ImageLoader;
 
 import org.wordpress.android.WordPress;
+import org.wordpress.android.util.ImageUtils;
 import org.wordpress.aztec.Html;
 
 import java.io.File;
@@ -25,9 +27,16 @@ public class AztecImageLoader implements Html.ImageGetter {
     public void loadImage(String url, final Callbacks callbacks, int maxWidth) {
         // TODO: if a local file then load it directly. This is a quick fix though.
         if (new File(url).exists()) {
-            Bitmap bitmap = BitmapFactory.decodeFile(url);
-            BitmapDrawable bitmapDrawable = new BitmapDrawable(context.getResources(), bitmap);
-            callbacks.onImageLoaded(bitmapDrawable);
+            int orientation = ImageUtils.getImageOrientation(this.context, url);
+            byte[] bytes = ImageUtils.createThumbnailFromUri(
+                   context, Uri.parse(url), maxWidth, null, orientation);
+            if (bytes != null) {
+                Bitmap bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
+                BitmapDrawable bitmapDrawable = new BitmapDrawable(context.getResources(), bitmap);
+                callbacks.onImageLoaded(bitmapDrawable);
+            } else {
+                callbacks.onImageFailed();
+            }
             return;
         }
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -370,6 +370,7 @@ public class ImageSettingsDialogFragment extends DialogFragment {
         if (imageUrl == null) {
             AppLog.e(AppLog.T.MEDIA, "Image url is null! Show the default error image.");
             showErrorImage();
+            return;
         }
 
         Uri uri = Uri.parse(imageUrl);

--- a/libs/editor/WordPressEditor/src/main/res/layout/dialog_image_options.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/dialog_image_options.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto" xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@android:color/white">
@@ -19,13 +19,27 @@
             android:orientation="horizontal"
             android:layout_marginBottom="@dimen/image_settings_dialog_thumbnail_container_margin_bottom">
 
-            <com.android.volley.toolbox.NetworkImageView
-                android:id="@+id/image_thumbnail"
-                android:contentDescription="@string/image_thumbnail"
+            <LinearLayout
                 android:layout_width="@dimen/image_settings_dialog_thumbnail_size"
                 android:layout_height="@dimen/image_settings_dialog_thumbnail_size"
+                android:orientation="horizontal"
                 android:layout_marginLeft="@dimen/image_settings_dialog_thumbnail_left_margin"
-                android:layout_marginRight="@dimen/image_settings_dialog_thumbnail_right_margin"/>
+                android:layout_marginRight="@dimen/image_settings_dialog_thumbnail_right_margin"
+                android:gravity="center">
+                <ImageView
+                    android:id="@+id/image_thumbnail"
+                    android:contentDescription="@string/image_thumbnail"
+                    android:layout_width="@dimen/image_settings_dialog_thumbnail_size"
+                    android:layout_height="@dimen/image_settings_dialog_thumbnail_size" />
+
+                <ProgressBar
+                    android:id="@+id/progress"
+                    style="?android:attr/progressBarStyle"
+                    android:layout_width="@dimen/image_settings_dialog_thumbnail_progress_size"
+                    android:layout_height="@dimen/image_settings_dialog_thumbnail_progress_size"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+            </LinearLayout>
 
             <TextView
                 android:id="@+id/image_filename"

--- a/libs/editor/WordPressEditor/src/main/res/values/dimens.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/dimens.xml
@@ -42,6 +42,7 @@
     <dimen name="image_settings_dialog_top_separator_margin_top">16dp</dimen>
     <dimen name="image_settings_dialog_thumbnail_container_margin_bottom">8dp</dimen>
     <dimen name="image_settings_dialog_thumbnail_size">100dp</dimen>
+    <dimen name="image_settings_dialog_thumbnail_progress_size">50dp</dimen>
     <dimen name="image_settings_dialog_thumbnail_left_margin">4dp</dimen>
     <dimen name="image_settings_dialog_thumbnail_right_margin">8dp</dimen>
     <dimen name="image_settings_dialog_filename_margin_left">16dp</dimen>


### PR DESCRIPTION
This fixes the point no.3 reported on this comment [here](https://github.com/wordpress-mobile/WordPress-Android/issues/5701#issuecomment-313857082) by downloading the bitmap, and then displaying a resized version of it on the screen. In case of error a gray picture is shown.
Also added a loading spinner.

*Edit* - Also fixes point no.1 by creating a resizing picture for Aztec Editor. To test this, add a picture in Aztec, and go back to post list before the uploading finishes. Tap on the draft in posts list, and the app should load a resized version of the bitmap from the local file system.