### PR TITLE
Issue/6268 photo picker npe 7.8

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
@@ -71,6 +71,7 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
     private boolean mAllowMultiSelect;
     private boolean mIsMultiSelectEnabled;
     private boolean mPhotosOnly;
+    private boolean mIsListTaskRunning;
 
     private final ThumbnailLoader mThumbnailLoader;
     private final PhotoPickerAdapterListener mListener;
@@ -88,6 +89,11 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
     }
 
     void refresh(boolean forceReload) {
+        if (mIsListTaskRunning) {
+            AppLog.w(AppLog.T.MEDIA, "photo picker > build list task already running");
+            return;
+        }
+
         int displayWidth = DisplayUtils.getDisplayPixelWidth(mContext);
         int thumbWidth = displayWidth / NUM_COLUMNS;
         int thumbHeight = (int) (thumbWidth * 0.75f);
@@ -410,11 +416,26 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
                 return false;
             }
             for (int i = 0; i < tmpList.size(); i++) {
+                if (!isValidPosition(i)) {
+                    return false;
+                }
                 if (tmpList.get(i)._id != mMediaList.get(i)._id) {
                     return false;
                 }
             }
             return true;
+        }
+
+        @Override
+        protected void onPreExecute() {
+            super.onPreExecute();
+            mIsListTaskRunning = true;
+        }
+
+        @Override
+        protected void onCancelled() {
+            super.onCancelled();
+            mIsListTaskRunning = false;
         }
 
         @Override
@@ -427,6 +448,7 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
             if (mListener != null) {
                 mListener.onAdapterLoaded(isEmpty());
             }
+            mIsListTaskRunning = false;
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -445,7 +445,7 @@ public class PhotoPickerFragment extends Fragment {
 
         if (hasStoragePermission()) {
             showSoftAskView(false);
-            if (mAdapter == null || mAdapter.isEmpty()) {
+            if (!hasAdapter()) {
                 reload();
             }
         } else {
@@ -532,7 +532,6 @@ public class PhotoPickerFragment extends Fragment {
         } else if (mSoftAskContainer.getVisibility() == View.VISIBLE) {
             AniUtils.fadeOut(mSoftAskContainer, AniUtils.Duration.MEDIUM);
             showBottomBar();
-            refresh();
         }
     }
 


### PR DESCRIPTION
Fixes #6268 - the problem was caused by the adapter being refreshed in quick succession, which could result in an exception if the media list was being changed at the same time it was being read.

The fix involves preventing the exception by adding `isValidPosition()` before accessing the media list, and preventing the adapter from refreshing when a refresh is already happening.

Note that the only situation that resulted in the multiple refresh was immediately after the user granted storage permission, so that situation was fixed as well.