### PR TITLE
Issue/6269 media insertion fail

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -552,7 +552,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     public void onMediaItemSelected(View sourceView, int localMediaId) {
         MediaModel media = mMediaStore.getMediaWithLocalId(localMediaId);
         if (media == null) {
-            AppLog.w(AppLog.T.MEDIA, "onMediaItemSelected > unable to load localMediaId = " + localMediaId);
+            AppLog.w(AppLog.T.MEDIA, "Media browser > unable to load localMediaId = " + localMediaId);
             ToastUtils.showToast(this, R.string.error_media_load);
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -552,6 +552,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     public void onMediaItemSelected(View sourceView, int localMediaId) {
         MediaModel media = mMediaStore.getMediaWithLocalId(localMediaId);
         if (media == null) {
+            AppLog.w(AppLog.T.MEDIA, "onMediaItemSelected > unable to load localMediaId = " + localMediaId);
             ToastUtils.showToast(this, R.string.error_media_load);
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -395,6 +395,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         if (isValidPosition(position)) {
             return mMediaList.get(position).getId();
         }
+        AppLog.w(AppLog.T.MEDIA, "MediaGridAdapter > Invalid position " + position);
         return INVALID_POSITION;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -546,30 +546,27 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
     /*
      * returns true if the passed list is the same as the existing one
      */
-    private boolean isSameList(@NonNull List<MediaModel> mediaList) {
-        if (mediaList.size() != mMediaList.size()) {
+    private boolean isSameList(@NonNull List<MediaModel> otherList) {
+        if (otherList.size() != mMediaList.size()) {
             return false;
         }
 
-        for (MediaModel media: mediaList) {
-            if (getMediaFromMediaId(media.getMediaId()) == null) {
+        for (MediaModel otherMedia: otherList) {
+            boolean foundMatch = false;
+            for (MediaModel thisMedia: mMediaList) {
+                // compare both local and remote IDs since local IDs are reset by FluxC upon refresh
+                if (thisMedia.getId() == otherMedia.getId()
+                        && thisMedia.getMediaId() == otherMedia.getMediaId()) {
+                    foundMatch = true;
+                    break;
+                }
+            }
+            if (!foundMatch) {
                 return false;
             }
         }
 
         return true;
-    }
-
-    /*
-     * returns the media item with the passed (remote) media ID in the current media list
-     */
-    private MediaModel getMediaFromMediaId(long mediaId) {
-        for (int i = 0; i < mMediaList.size(); i++) {
-            if (mMediaList.get(i).getMediaId() == mediaId) {
-                return mMediaList.get(i);
-            }
-        }
-        return null;
     }
 
     private String getLabelForMediaUploadState(MediaUploadState uploadState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -110,11 +110,9 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
     }
 
     public void setMediaList(@NonNull List<MediaModel> mediaList) {
-        if (!isSameList(mediaList)) {
-            mMediaList.clear();
-            mMediaList.addAll(mediaList);
-            notifyDataSetChanged();
-        }
+        mMediaList.clear();
+        mMediaList.addAll(mediaList);
+        notifyDataSetChanged();
     }
 
     @Override
@@ -541,32 +539,6 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             mCallback.onAdapterSelectionCountChanged(mSelectedItems.size());
         }
         notifyDataSetChanged();
-    }
-
-    /*
-     * returns true if the passed list is the same as the existing one
-     */
-    private boolean isSameList(@NonNull List<MediaModel> otherList) {
-        if (otherList.size() != mMediaList.size()) {
-            return false;
-        }
-
-        for (MediaModel otherMedia: otherList) {
-            boolean foundMatch = false;
-            for (MediaModel thisMedia: mMediaList) {
-                // compare both local and remote IDs since local IDs are reset by FluxC upon refresh
-                if (thisMedia.getId() == otherMedia.getId()
-                        && thisMedia.getMediaId() == otherMedia.getMediaId()) {
-                    foundMatch = true;
-                    break;
-                }
-            }
-            if (!foundMatch) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     private String getLabelForMediaUploadState(MediaUploadState uploadState) {


### PR DESCRIPTION
Fixes #6269 - I wasn't able to reproduce this bug, but after a bit of detective work I tracked it down. The problem is the `isSameList()` comparison - which determines whether to update the adapter when we pass it a media list - only compared remote IDs.

This fails because when FluxC requests media, it clears existing media even if the requested list is the same as local. When this happens, new local IDs are created for pre-existing media. The end result is the adapter could have outdated local IDs.

This PR addresses this by *always* updating the adapter when we pass it a media list. The downside is the grid will flicker with each refresh even if it *looks* like the media list hasn't changed, but this isn't something we should address in WP Android. We should instead change FluxC to not reset local IDs for pre-existing media, and then restore the previous `isSameList()` comparison.

cc: @daniloercoli 