### PR TITLE
Jetpack: Implementation of the Jetpack Monitor security settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
@@ -177,6 +177,9 @@ public class SiteSettingsModel {
     public boolean allowLikeButton;
     public boolean allowCommentLikes;
     public String twitterUsername;
+    public boolean monitorActive;
+    public boolean emailNotifications;
+    public boolean wpNotifications;
 
     @Override
     public boolean equals(Object other) {
@@ -224,6 +227,9 @@ public class SiteSettingsModel {
                 allowReblogButton == otherModel.allowReblogButton &&
                 allowLikeButton == otherModel.allowLikeButton &&
                 allowCommentLikes == otherModel.allowCommentLikes &&
+                monitorActive == otherModel.monitorActive &&
+                emailNotifications == otherModel.emailNotifications &&
+                wpNotifications == otherModel.wpNotifications &&
                 twitterUsername != null && twitterUsername.equals(otherModel.twitterUsername);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
@@ -63,6 +63,9 @@ public class SiteSettingsModel {
     public static final String ALLOW_LIKE_BUTTON_COLUMN_NAME = "allowLikeButton";
     public static final String ALLOW_COMMENT_LIKES_COLUMN_NAME = "allowCommentLikes";
     public static final String TWITTER_USERNAME_COLUMN_NAME = "twitterUsername";
+    public static final String JP_MONITOR_ACTIVE_COLUMN_NAME = "monitorActive";
+    public static final String JP_MONITOR_EMAIL_NOTES_COLUMN_NAME = "jpEmailNotifications";
+    public static final String JP_MONITOR_WP_NOTES_COLUMN_NAME = "jpWpNotifications";
 
     public static final String SETTINGS_TABLE_NAME = "site_settings";
     public static final String ADD_OPTIMIZED_IMAGE = "alter table " + SETTINGS_TABLE_NAME +
@@ -125,6 +128,9 @@ public class SiteSettingsModel {
                     IDENTITY_REQUIRED_COLUMN_NAME + " BOOLEAN, " +
                     USER_ACCOUNT_REQUIRED_COLUMN_NAME + " BOOLEAN, " +
                     WHITELIST_COLUMN_NAME + " BOOLEAN, " +
+                    JP_MONITOR_ACTIVE_COLUMN_NAME + " BOOLEAN, " +
+                    JP_MONITOR_EMAIL_NOTES_COLUMN_NAME + " BOOLEAN, " +
+                    JP_MONITOR_WP_NOTES_COLUMN_NAME + " BOOLEAN, " +
                     MODERATION_KEYS_COLUMN_NAME + " TEXT, " +
                     BLACKLIST_KEYS_COLUMN_NAME + " TEXT" +
                     ");";
@@ -337,6 +343,9 @@ public class SiteSettingsModel {
         commentsRequireIdentity = getBooleanFromCursor(cursor, IDENTITY_REQUIRED_COLUMN_NAME);
         commentsRequireUserAccount = getBooleanFromCursor(cursor, USER_ACCOUNT_REQUIRED_COLUMN_NAME);
         commentAutoApprovalKnownUsers = getBooleanFromCursor(cursor, WHITELIST_COLUMN_NAME);
+        monitorActive = getBooleanFromCursor(cursor, JP_MONITOR_ACTIVE_COLUMN_NAME);
+        emailNotifications = getBooleanFromCursor(cursor, JP_MONITOR_EMAIL_NOTES_COLUMN_NAME);
+        wpNotifications = getBooleanFromCursor(cursor, JP_MONITOR_WP_NOTES_COLUMN_NAME);
 
         String moderationKeys = getStringFromCursor(cursor, MODERATION_KEYS_COLUMN_NAME);
         String blacklistKeys = getStringFromCursor(cursor, BLACKLIST_KEYS_COLUMN_NAME);
@@ -425,6 +434,9 @@ public class SiteSettingsModel {
         values.put(IDENTITY_REQUIRED_COLUMN_NAME, commentsRequireIdentity);
         values.put(USER_ACCOUNT_REQUIRED_COLUMN_NAME, commentsRequireUserAccount);
         values.put(WHITELIST_COLUMN_NAME, commentAutoApprovalKnownUsers);
+        values.put(JP_MONITOR_ACTIVE_COLUMN_NAME, monitorActive);
+        values.put(JP_MONITOR_EMAIL_NOTES_COLUMN_NAME, emailNotifications);
+        values.put(JP_MONITOR_WP_NOTES_COLUMN_NAME, wpNotifications);
 
         String moderationKeys = "";
         if (holdForModeration != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -68,10 +68,6 @@ class DotComSiteSettings extends SiteSettingsInterface {
     private static final String SET_TITLE_KEY = "blogname";
     private static final String SET_DESC_KEY = "blogdescription";
 
-    // JSON response keys
-    private static final String SETTINGS_KEY = "settings";
-    private static final String UPDATED_KEY = "updated";
-
     // WP.com REST keys used in response to a categories GET request
     private static final String CAT_ID_KEY = "ID";
     private static final String CAT_NAME_KEY = "name";
@@ -110,7 +106,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
                         mRemoteSettings.copyFrom(mSettings);
 
                         if (response != null) {
-                            JSONObject updated = response.optJSONObject(UPDATED_KEY);
+                            JSONObject updated = response.optJSONObject("updated");
                             if (updated == null) return;
                             HashMap<String, Object> properties = new HashMap<>();
                             Iterator<String> keys = updated.keys();
@@ -212,9 +208,9 @@ class DotComSiteSettings extends SiteSettingsInterface {
     /**
      * Sets values from a .com REST response object.
      */
-    public void deserializeDotComRestResponse(SiteModel site, JSONObject response) {
+    private void deserializeDotComRestResponse(SiteModel site, JSONObject response) {
         if (site == null || response == null) return;
-        JSONObject settingsObject = response.optJSONObject(SETTINGS_KEY);
+        JSONObject settingsObject = response.optJSONObject("settings");
 
         mRemoteSettings.username = site.getUsername();
         mRemoteSettings.password = site.getPassword();
@@ -280,7 +276,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
      * Using undocumented endpoint WPCOM_JSON_API_Site_Settings_Endpoint
      * https://wpcom.trac.automattic.com/browser/trunk/public.api/rest/json-endpoints.php#L1903
      */
-    public Map<String, String> serializeDotComParams() {
+    private Map<String, String> serializeDotComParams() {
         Map<String, String> params = new HashMap<>();
 
         if (mSettings.title!= null && !mSettings.title.equals(mRemoteSettings.title)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -194,7 +194,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
                 mSite.getSiteId(), new RestRequest.Listener() {
                     @Override
                     public void onResponse(JSONObject response) {
-                        AppLog.d(AppLog.T.API, "Received response to Jetpack Settings REST request.");
+                        AppLog.v(AppLog.T.API, "Received response to Jetpack Settings REST request.");
                         mRemoteSettings.localTableId = mSite.getId();
                         deserializeJetpackRestResponse(mSite, response);
                         mSettings.copyFrom(mRemoteSettings);
@@ -203,7 +203,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
                 }, new RestRequest.ErrorListener() {
                     @Override
                     public void onErrorResponse(VolleyError error) {
-                        AppLog.w(AppLog.T.API, "Error response to Jetpack Settings REST request: " + error);
+                        AppLog.e(AppLog.T.API, "Error response to Jetpack Settings REST request: " + error);
                         notifyUpdatedOnUiThread(error);
                     }
                 });

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -90,10 +90,6 @@ class DotComSiteSettings extends SiteSettingsInterface {
     public void saveSettings() {
         super.saveSettings();
 
-        if (mSite.isJetpackConnected()) {
-            saveJetpackSettings();
-        }
-
         final Map<String, String> params = serializeDotComParams();
         if (params == null || params.isEmpty()) return;
 
@@ -120,6 +116,9 @@ class DotComSiteSettings extends SiteSettingsInterface {
                             AnalyticsUtils.trackWithSiteDetails(
                                     AnalyticsTracker.Stat.SITE_SETTINGS_SAVED_REMOTELY, mSite, properties);
                         }
+                        if (mSite.isJetpackConnected()) {
+                            saveJetpackSettings();
+                        }
                     }
                 }, new RestRequest.ErrorListener() {
                     @Override
@@ -136,9 +135,6 @@ class DotComSiteSettings extends SiteSettingsInterface {
     @Override
     protected void fetchRemoteData() {
         fetchCategories();
-        if (mSite.isJetpackConnected()) {
-            fetchJetpackSettings();
-        }
         WordPress.getRestClientUtils().getGeneralSettings(
                 mSite.getSiteId(), new RestRequest.Listener() {
                     @Override
@@ -174,6 +170,10 @@ class DotComSiteSettings extends SiteSettingsInterface {
 
                             SiteSettingsTable.saveSettings(mSettings);
                             notifyUpdatedOnUiThread(null);
+                        }
+
+                        if (mSite.isJetpackConnected()) {
+                            fetchJetpackSettings();
                         }
                     }
                 }, new RestRequest.ErrorListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -456,7 +456,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
                 }, params);
     }
 
-    public void deserializeJetpackRestResponse(SiteModel site, JSONObject response) {
+    private void deserializeJetpackRestResponse(SiteModel site, JSONObject response) {
         if (site == null || response == null) return;
         JSONObject settingsObject = response.optJSONObject("settings");
         mRemoteSettings.monitorActive = settingsObject.optBoolean(JP_MONITOR_ACTIVE_KEY, false);
@@ -464,7 +464,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
         mRemoteSettings.wpNotifications = settingsObject.optBoolean(JP_MONITOR_WP_NOTES_KEY, false);
     }
 
-    public Map<String, String> serializeJetpackParams() {
+    private Map<String, String> serializeJetpackParams() {
         Map<String, String> params = new HashMap<>();
         params.put(JP_MONITOR_ACTIVE_KEY, String.valueOf(mSettings.monitorActive));
         params.put(JP_MONITOR_EMAIL_NOTES_KEY, String.valueOf(mSettings.emailNotifications));

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -201,6 +201,11 @@ public class SiteSettingsFragment extends PreferenceFragment
     private Preference mExportSitePref;
     private Preference mDeleteSitePref;
 
+    // Jetpack settings
+    private WPSwitchPreference mJpMonitorActivePref;
+    private WPSwitchPreference mJpMonitorEmailNotesPref;
+    private WPSwitchPreference mJpMonitorWpNotesPref;
+
     public boolean mEditingEnabled = true;
 
     // Reference to the state of the fragment
@@ -472,7 +477,16 @@ public class SiteSettingsFragment extends PreferenceFragment
     public boolean onPreferenceChange(Preference preference, Object newValue) {
         if (newValue == null || !mEditingEnabled) return false;
 
-        if (preference == mTitlePref) {
+        if (preference == mJpMonitorActivePref) {
+            mJpMonitorActivePref.setChecked((Boolean) newValue);
+            mSiteSettings.setMonitorActive((Boolean) newValue);
+        } else if (preference == mJpMonitorEmailNotesPref) {
+            mJpMonitorEmailNotesPref.setChecked((Boolean) newValue);
+            mSiteSettings.setEmailNotes((Boolean) newValue);
+        } else if (preference == mJpMonitorWpNotesPref) {
+            mJpMonitorWpNotesPref.setChecked((Boolean) newValue);
+            mSiteSettings.setNoteNotes((Boolean) newValue);
+        } else if (preference == mTitlePref) {
             mSiteSettings.setTitle(newValue.toString());
             changeEditTextPreferenceValue(mTitlePref, mSiteSettings.getTitle());
         } else if (preference == mTaglinePref) {
@@ -710,6 +724,9 @@ public class SiteSettingsFragment extends PreferenceFragment
         mStartOverPref = getClickPref(R.string.pref_key_site_start_over);
         mExportSitePref = getClickPref(R.string.pref_key_site_export_site);
         mDeleteSitePref = getClickPref(R.string.pref_key_site_delete_site);
+        mJpMonitorActivePref = (WPSwitchPreference) getChangePref(R.string.pref_key_site_monitor_uptime);
+        mJpMonitorEmailNotesPref = (WPSwitchPreference) getChangePref(R.string.pref_key_site_send_email_notifications);
+        mJpMonitorWpNotesPref = (WPSwitchPreference) getChangePref(R.string.pref_key_site_send_wp_notifications);
 
         sortLanguages();
 
@@ -1084,6 +1101,9 @@ public class SiteSettingsFragment extends PreferenceFragment
         mRelatedPostsPref.setSummary(mSiteSettings.getRelatedPostsDescription());
         mModerationHoldPref.setSummary(mSiteSettings.getModerationHoldDescription());
         mBlacklistPref.setSummary(mSiteSettings.getBlacklistDescription());
+        mJpMonitorActivePref.setChecked(mSiteSettings.getMonitorActive());
+        mJpMonitorEmailNotesPref.setChecked(mSiteSettings.getEmailNotes());
+        mJpMonitorWpNotesPref.setChecked(mSiteSettings.getNoteNotes());
     }
 
     private void setCategories() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -479,13 +479,13 @@ public class SiteSettingsFragment extends PreferenceFragment
 
         if (preference == mJpMonitorActivePref) {
             mJpMonitorActivePref.setChecked((Boolean) newValue);
-            mSiteSettings.setMonitorActive((Boolean) newValue);
+            mSiteSettings.enableJetpackMonitor((Boolean) newValue);
         } else if (preference == mJpMonitorEmailNotesPref) {
             mJpMonitorEmailNotesPref.setChecked((Boolean) newValue);
-            mSiteSettings.setEmailNotes((Boolean) newValue);
+            mSiteSettings.enableJetpackMonitorEmailNotifications((Boolean) newValue);
         } else if (preference == mJpMonitorWpNotesPref) {
             mJpMonitorWpNotesPref.setChecked((Boolean) newValue);
-            mSiteSettings.setNoteNotes((Boolean) newValue);
+            mSiteSettings.enableJetpackMonitorWpNotifications((Boolean) newValue);
         } else if (preference == mTitlePref) {
             mSiteSettings.setTitle(newValue.toString());
             changeEditTextPreferenceValue(mTitlePref, mSiteSettings.getTitle());
@@ -1101,9 +1101,9 @@ public class SiteSettingsFragment extends PreferenceFragment
         mRelatedPostsPref.setSummary(mSiteSettings.getRelatedPostsDescription());
         mModerationHoldPref.setSummary(mSiteSettings.getModerationHoldDescription());
         mBlacklistPref.setSummary(mSiteSettings.getBlacklistDescription());
-        mJpMonitorActivePref.setChecked(mSiteSettings.getMonitorActive());
-        mJpMonitorEmailNotesPref.setChecked(mSiteSettings.getEmailNotes());
-        mJpMonitorWpNotesPref.setChecked(mSiteSettings.getNoteNotes());
+        mJpMonitorActivePref.setChecked(mSiteSettings.isJetpackMonitorEnabled());
+        mJpMonitorEmailNotesPref.setChecked(mSiteSettings.shouldSendJetpackMonitorEmailNotifications());
+        mJpMonitorWpNotesPref.setChecked(mSiteSettings.shouldSendJetpackMonitorWpNotifications());
     }
 
     private void setCategories() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -583,28 +583,28 @@ public abstract class SiteSettingsInterface {
                 R.string.site_settings_list_editor_summary_other, count);
     }
 
-    public boolean getMonitorActive() {
+    public boolean isJetpackMonitorEnabled() {
         return mSettings.monitorActive;
     }
 
-    public boolean getEmailNotes() {
+    public boolean shouldSendJetpackMonitorEmailNotifications() {
         return mSettings.emailNotifications;
     }
 
-    public boolean getNoteNotes() {
+    public boolean shouldSendJetpackMonitorWpNotifications() {
         return mSettings.wpNotifications;
     }
 
-    public void setMonitorActive(boolean active) {
-        mSettings.monitorActive = active;
+    public void enableJetpackMonitor(boolean monitorActive) {
+        mSettings.monitorActive = monitorActive;
     }
 
-    public void setEmailNotes(boolean notes) {
-        mSettings.emailNotifications = notes;
+    public void enableJetpackMonitorEmailNotifications(boolean emailNotifications) {
+        mSettings.emailNotifications = emailNotifications;
     }
 
-    public void setNoteNotes(boolean notes) {
-        mSettings.wpNotifications = notes;
+    public void enableJetpackMonitorWpNotifications(boolean wpNotifications) {
+        mSettings.wpNotifications = wpNotifications;
     }
 
     public void setTitle(String title) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -581,7 +581,30 @@ public abstract class SiteSettingsInterface {
         return StringUtils.getQuantityString(mActivity, R.string.site_settings_list_editor_no_items_text,
                 R.string.site_settings_list_editor_summary_one,
                 R.string.site_settings_list_editor_summary_other, count);
+    }
 
+    public boolean getMonitorActive() {
+        return mSettings.monitorActive;
+    }
+
+    public boolean getEmailNotes() {
+        return mSettings.emailNotifications;
+    }
+
+    public boolean getNoteNotes() {
+        return mSettings.wpNotifications;
+    }
+
+    public void setMonitorActive(boolean active) {
+        mSettings.monitorActive = active;
+    }
+
+    public void setEmailNotes(boolean notes) {
+        mSettings.emailNotifications = notes;
+    }
+
+    public void setNoteNotes(boolean notes) {
+        mSettings.wpNotifications = notes;
     }
 
     public void setTitle(String title) {

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -76,6 +76,7 @@
     <string name="pref_key_site_blacklist" translatable="false">wp_pref_site_blacklist</string>
     <string name="pref_key_site_danger" translatable="false">wp_pref_site_danger</string>
     <string name="pref_key_site_jetpack_monitor" translatable="false">wp_pref_site_jetpack_monitor</string>
+    <string name="pref_key_site_monitor_uptime" translatable="false">wp_pref_site_monitor_uptime</string>
     <string name="pref_key_site_send_email_notifications" translatable="false">wp_pref_site_send_email_notifications</string>
     <string name="pref_key_site_send_wp_notifications" translatable="false">wp_pref_site_send_wp_notifications</string>
     <string name="pref_key_site_advanced" translatable="false">wp_pref_site_advanced</string>

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -75,6 +75,9 @@
     <string name="pref_key_site_moderation_hold" translatable="false">wp_pref_site_moderation_hold</string>
     <string name="pref_key_site_blacklist" translatable="false">wp_pref_site_blacklist</string>
     <string name="pref_key_site_danger" translatable="false">wp_pref_site_danger</string>
+    <string name="pref_key_site_jetpack_monitor" translatable="false">wp_pref_site_jetpack_monitor</string>
+    <string name="pref_key_site_send_email_notifications" translatable="false">wp_pref_site_send_email_notifications</string>
+    <string name="pref_key_site_send_wp_notifications" translatable="false">wp_pref_site_send_wp_notifications</string>
     <string name="pref_key_site_advanced" translatable="false">wp_pref_site_advanced</string>
     <string name="pref_key_site_start_over" translatable="false">wp_pref_site_start_over</string>
     <string name="pref_key_site_export_site" translatable="false">pref_key_site_export_site</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -499,6 +499,9 @@
     <string name="site_settings_moderation_hold_title">Hold for Moderation</string>
     <string name="site_settings_blacklist_title">Blacklist</string>
     <string name="site_settings_delete_site_title">Delete Site</string>
+    <string name="site_settings_monitor_uptime_title">Monitor your site\'s uptime</string>
+    <string name="site_settings_send_email_notifications_title">Send notifications to your WordPress.com email address</string>
+    <string name="site_settings_send_wp_notifications_title">Send notifications via WordPress.com notification</string>
 
     <!-- Preference Summaries -->
     <string name="site_settings_privacy_public_summary">Public</string>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -310,6 +310,33 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        android:id="@+id/pref_category_jetpack_monitor"
+        android:key="@string/pref_key_site_jetpack_monitor"
+        android:title="Jetpack Monitor">
+
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
+            android:id="@+id/pref_monitor_uptime"
+            android:layout="@layout/preference_layout"
+            android:key="@string/pref_key_site_monitor_uptime"
+            android:title="@string/site_settings_monitor_uptime_title" />
+
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
+            android:id="@+id/pref_jetpack_send_email_notifications"
+            android:layout="@layout/preference_layout"
+            android:key="@string/pref_key_site_send_email_notifications"
+            android:title="@string/site_settings_monitor_uptime_title"
+            android:dependency="@string/pref_key_site_monitor_uptime" />
+
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
+            android:id="@+id/pref_jetpack_send_wp_notifications"
+            android:layout="@layout/preference_layout"
+            android:key="@string/pref_key_site_send_wp_notifications"
+            android:title="@string/site_settings_send_wp_notifications_title"
+            android:dependency="@string/pref_key_site_monitor_uptime" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:id="@+id/pref_advanced"
         android:key="@string/pref_key_site_advanced"
         android:title="@string/site_settings_advanced_header">

--- a/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
+++ b/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
@@ -229,7 +229,7 @@ public class RestClientUtils {
 
     public void getGeneralSettings(long siteId, Listener listener, ErrorListener errorListener) {
         String path = String.format(Locale.US, "sites/%d/settings", siteId);
-        Map<String, String> params = new HashMap<String, String>();
+        Map<String, String> params = new HashMap<>();
         get(path, params, null, listener, errorListener);
     }
 

--- a/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
+++ b/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
@@ -229,8 +229,7 @@ public class RestClientUtils {
 
     public void getGeneralSettings(long siteId, Listener listener, ErrorListener errorListener) {
         String path = String.format(Locale.US, "sites/%d/settings", siteId);
-        Map<String, String> params = new HashMap<>();
-        get(path, params, null, listener, errorListener);
+        get(path, listener, errorListener);
     }
 
     public void setGeneralSiteSettings(long siteId, Listener listener, ErrorListener errorListener,
@@ -241,8 +240,7 @@ public class RestClientUtils {
 
     public void getJetpackSettings(long siteId, Listener listener, ErrorListener errorListener) {
         String path = String.format(Locale.US, "jetpack-blogs/%d", siteId);
-        Map<String, String> params = new HashMap<>();
-        get(path, params, null, listener, errorListener);
+        get(path, listener, errorListener);
     }
 
     public void setJetpackSettings(long siteId, Listener listener, ErrorListener errorListener,

--- a/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
+++ b/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
@@ -239,6 +239,18 @@ public class RestClientUtils {
         post(path, params, null, listener, errorListener);
     }
 
+    public void getJetpackSettings(long siteId, Listener listener, ErrorListener errorListener) {
+        String path = String.format(Locale.US, "jetpack-blogs/%d", siteId);
+        Map<String, String> params = new HashMap<>();
+        get(path, params, null, listener, errorListener);
+    }
+
+    public void setJetpackSettings(long siteId, Listener listener, ErrorListener errorListener,
+                                       Map<String, String> params) {
+        String path = String.format(Locale.US, "jetpack-blogs/%d", siteId);
+        post(path, params, null, listener, errorListener);
+    }
+
     /**
      * Delete a site
      */


### PR DESCRIPTION
This PR adds client REST calls for the `GET/POST /jetpack-blogs/$blog_id` endpoint. I've hooked the calls to the `SwitchPreference`'s in the Site Settings screen, please ignore any UI inconsistencies as they will be fixed in subsequent PR's to the feature branch.

Jetpack Monitor, the first section on [this screen](https://cldup.com/Wu-h_dhFjj.png) in Calypso, is what's being tested. You can get there via: https://wordpress.com/settings/security/myjetpacksite.com.

To sum up the code changes:
1. Local table is updated to hold the new fields
2. REST calls added to hit `jetpack-blogs/$blog_id` endpoint
3. Preferences added to Site Settings screen to update settings

To test:
* From a clean build -> login with an account that has a Jetpack site connected
* Switch to that site -> go to Site Settings
* Toggle each of the three new options -> verify changes on web
* Toggle again -> verify on web again

cc @oguzkocer or @maxme (since Oguz is on Groundskeeping)