### PR TITLE
Enable back button in ImageSettingsDialogFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -718,6 +718,10 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         Fragment fragment = getFragmentManager().findFragmentByTag(
                 ImageSettingsDialogFragment.IMAGE_SETTINGS_DIALOG_TAG);
         if (fragment != null && fragment.isVisible()) {
+            if (fragment instanceof  ImageSettingsDialogFragment) {
+                ImageSettingsDialogFragment imFragment = (ImageSettingsDialogFragment) fragment;
+                imFragment.dismissFragment();
+            }
             return false;
         }
         if (mViewPager.getCurrentItem() > PAGE_CONTENT) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -252,7 +252,6 @@ public class ImageSettingsDialogFragment extends DialogFragment {
         int id = item.getItemId();
 
         if (id == android.R.id.home) {
-            dismissFragment();
             return true;
         }
         return super.onOptionsItemSelected(item);


### PR DESCRIPTION
This PR enables using the back button in the `ImageSettingsDialogFragment` to close the settings dialog. Prior to this PR the user had to click on the `X` button in the top toolbar. The back button was disabled.

*Testing steps*
- Start writing a new post
- Add a picture
- Tap on the picture to open settings screen
- Add a title, tap the back button
- You should see the discard/cancel prompt
- Repeat the last 2 steps above without making any changes to settings
