### PR TITLE
Fix possible NPE in PublicizeUpdateService

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeListActivity.java
@@ -16,7 +16,6 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.datasets.PublicizeTable;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.model.SitesModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.models.PublicizeConnection;
 import org.wordpress.android.models.PublicizeService;
@@ -59,6 +58,11 @@ public class PublicizeListActivity extends AppCompatActivity
             mSite = (SiteModel) getIntent().getSerializableExtra(WordPress.SITE);
             PublicizeTable.createTables(WordPress.wpDB.getDatabase());
             showListFragment();
+            if (mSite == null) {
+                ToastUtils.showToast(this, R.string.blog_not_found, ToastUtils.Duration.SHORT);
+                finish();
+                return;
+            }
             PublicizeUpdateService.updateConnectionsForSite(this, mSite);
         } else {
             mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);


### PR DESCRIPTION
Fixes #6148. This is an interesting crash as in I don't think it's supposed to happen. I opted to add a null check in `PublicizeListActivity` instead of doing just before the `site.getSiteId()` call in `PublicizeUpdateService`. This is a pattern we use in a lot of places and I thought it'd be better to just bail out from the activity if somehow the site is `null`. Also, the code seems to be changed since the crash happened, so I wasn't completely sure if it still is a valid crash.

To test:
* Go to sharing in blog settings and make sure it doesn't crash. I don't think there is anything else to test here.

/cc @nbradbury 
