### PR TITLE
Show ToastUtils instead of using Toast.makeText directly

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -9,7 +9,6 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.ActivityOptionsCompat;
 import android.text.TextUtils;
-import android.widget.Toast;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -144,7 +143,7 @@ public class ActivityLauncher {
 
     public static void viewCurrentSite(Context context, SiteModel site, boolean openFromHeader) {
         if (site == null) {
-            Toast.makeText(context, context.getText(R.string.blog_not_found), Toast.LENGTH_SHORT).show();
+            ToastUtils.showToast(context, R.string.blog_not_found, ToastUtils.Duration.SHORT);
             return;
         }
 
@@ -156,7 +155,7 @@ public class ActivityLauncher {
 
     public static void viewBlogAdmin(Context context, SiteModel site) {
         if (site == null || site.getAdminUrl() == null) {
-            Toast.makeText(context, context.getText(R.string.blog_not_found), Toast.LENGTH_SHORT).show();
+            ToastUtils.showToast(context, R.string.blog_not_found, ToastUtils.Duration.SHORT);
             return;
         }
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.OPENED_VIEW_ADMIN, site);

--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -20,7 +20,6 @@ import android.widget.ListView;
 import android.widget.RelativeLayout;
 import android.widget.ScrollView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.android.volley.toolbox.NetworkImageView;
 
@@ -33,6 +32,7 @@ import org.wordpress.android.ui.accounts.SignInActivity;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.ToastUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -129,8 +129,8 @@ public class AddQuickPressShortcutActivity extends ListActivity {
         dialogBuilder.setPositiveButton(R.string.add, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int which) {
                 if (TextUtils.isEmpty(quickPressShortcutName.getText())) {
-                    Toast t = Toast.makeText(AddQuickPressShortcutActivity.this, R.string.quickpress_add_error, Toast.LENGTH_LONG);
-                    t.show();
+                    ToastUtils.showToast(AddQuickPressShortcutActivity.this, R.string.quickpress_add_error,
+                            ToastUtils.Duration.LONG);
                 } else {
                     Intent shortcutIntent = new Intent(getApplicationContext(), EditPostActivity.class);
                     shortcutIntent.setAction(Intent.ACTION_MAIN);

--- a/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/WPWebViewActivity.java
@@ -10,7 +10,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.webkit.WebViewClient;
 import android.widget.ProgressBar;
-import android.widget.Toast;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -21,6 +20,7 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.URLFilteredWebViewClient;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPUrlUtils;
@@ -136,8 +136,7 @@ public class WPWebViewActivity extends WebViewActivity {
 
         if (TextUtils.isEmpty(url)) {
             AppLog.e(AppLog.T.UTILS, "Empty or null URL");
-            Toast.makeText(context, context.getResources().getText(R.string.invalid_site_url_message),
-                    Toast.LENGTH_SHORT).show();
+            ToastUtils.showToast(context, R.string.invalid_site_url_message, ToastUtils.Duration.SHORT);
             return;
         }
 
@@ -171,8 +170,7 @@ public class WPWebViewActivity extends WebViewActivity {
 
         if (TextUtils.isEmpty(url)) {
             AppLog.e(AppLog.T.UTILS, "Empty or null URL");
-            Toast.makeText(context, context.getResources().getText(R.string.invalid_site_url_message),
-                    Toast.LENGTH_SHORT).show();
+            ToastUtils.showToast(context, R.string.invalid_site_url_message, ToastUtils.Duration.SHORT);
             return;
         }
 
@@ -192,8 +190,7 @@ public class WPWebViewActivity extends WebViewActivity {
 
         if (TextUtils.isEmpty(url)) {
             AppLog.e(AppLog.T.UTILS, "Empty or null URL passed to openUrlByUsingMainWPCOMCredentials");
-            Toast.makeText(context, context.getResources().getText(R.string.invalid_site_url_message),
-                    Toast.LENGTH_SHORT).show();
+            ToastUtils.showToast(context, R.string.invalid_site_url_message, ToastUtils.Duration.SHORT);
             return false;
         }
         return true;
@@ -279,8 +276,7 @@ public class WPWebViewActivity extends WebViewActivity {
 
         if (TextUtils.isEmpty(addressToLoad) || !UrlUtils.isValidUrlAndHostNotNull(addressToLoad)) {
             AppLog.e(AppLog.T.UTILS, "Empty or null or invalid URL passed to WPWebViewActivity");
-            Toast.makeText(this, getText(R.string.invalid_site_url_message),
-                    Toast.LENGTH_SHORT).show();
+            ToastUtils.showToast(this, R.string.invalid_site_url_message, ToastUtils.Duration.SHORT);
             finish();
             return;
         }
@@ -315,14 +311,13 @@ public class WPWebViewActivity extends WebViewActivity {
         } else {
             if (TextUtils.isEmpty(authURL) || !UrlUtils.isValidUrlAndHostNotNull(authURL)) {
                 AppLog.e(AppLog.T.UTILS, "Empty or null or invalid auth URL passed to WPWebViewActivity");
-                Toast.makeText(this, getText(R.string.invalid_site_url_message),
-                        Toast.LENGTH_SHORT).show();
+                ToastUtils.showToast(this, R.string.invalid_site_url_message, ToastUtils.Duration.SHORT);
                 finish();
             }
 
             if (TextUtils.isEmpty(username)) {
                 AppLog.e(AppLog.T.UTILS, "Username empty/null");
-                Toast.makeText(this, getText(R.string.incorrect_credentials), Toast.LENGTH_SHORT).show();
+                ToastUtils.showToast(this, R.string.incorrect_credentials, ToastUtils.Duration.SHORT);
                 finish();
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -23,7 +23,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewOutlineProvider;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.android.volley.Cache;
 import com.android.volley.Request;
@@ -54,6 +53,7 @@ import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.HelpshiftHelper.Tag;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.io.DataInputStream;
@@ -448,7 +448,8 @@ public class MeFragment extends Fragment {
                         if (downloadedUri != null) {
                             startCropActivity(downloadedUri);
                         } else {
-                            Toast.makeText(getActivity(), getString(R.string.error_downloading_image), Toast.LENGTH_SHORT).show();
+                            ToastUtils.showToast(getActivity(), R.string.error_downloading_image,
+                                    ToastUtils.Duration.SHORT);
                             AppLog.e(AppLog.T.UTILS, "Can't download picked or captured image");
                         }
                     } else {
@@ -462,7 +463,7 @@ public class MeFragment extends Fragment {
                 if (resultCode == Activity.RESULT_OK) {
                     fetchMedia(UCrop.getOutput(data));
                 } else if (resultCode == UCrop.RESULT_ERROR) {
-                    Toast.makeText(getActivity(), getString(R.string.error_cropping_image), Toast.LENGTH_SHORT).show();
+                    ToastUtils.showToast(getActivity(), R.string.error_cropping_image, ToastUtils.Duration.SHORT);
 
                     final Throwable cropError = UCrop.getError(data);
                     AppLog.e(AppLog.T.MAIN, "Image cropping failed!", cropError);
@@ -502,7 +503,7 @@ public class MeFragment extends Fragment {
             if (downloadedUri != null) {
                 startGravatarUpload(MediaUtils.getRealPathFromURI(getActivity(), downloadedUri));
             } else {
-                Toast.makeText(getActivity(), getString(R.string.error_downloading_image), Toast.LENGTH_SHORT).show();
+                ToastUtils.showToast(getActivity(), R.string.error_downloading_image, ToastUtils.Duration.SHORT);
             }
         } else {
             // It is a regular local media file
@@ -512,13 +513,13 @@ public class MeFragment extends Fragment {
 
     private void startGravatarUpload(final String filePath) {
         if (TextUtils.isEmpty(filePath)) {
-            Toast.makeText(getActivity(), getString(R.string.error_locating_image), Toast.LENGTH_SHORT).show();
+            ToastUtils.showToast(getActivity(), R.string.error_locating_image, ToastUtils.Duration.SHORT);
             return;
         }
 
         File file = new File(filePath);
         if (!file.exists()) {
-            Toast.makeText(getActivity(), getString(R.string.error_locating_image), Toast.LENGTH_SHORT).show();
+            ToastUtils.showToast(getActivity(), R.string.error_locating_image, ToastUtils.Duration.SHORT);
             return;
         }
 
@@ -555,7 +556,7 @@ public class MeFragment extends Fragment {
             loadAvatar(avatarUrl, event.filePath);
         } else {
             showGravatarProgressBar(false);
-            Toast.makeText(getActivity(), getString(R.string.error_updating_gravatar), Toast.LENGTH_SHORT).show();
+            ToastUtils.showToast(getActivity(), R.string.error_updating_gravatar, ToastUtils.Duration.SHORT);
         }
     }
 
@@ -569,7 +570,7 @@ public class MeFragment extends Fragment {
 
     public void onEventMainThread(GravatarLoadFinished event) {
         if (!event.success && mIsUpdatingGravatar) {
-            Toast.makeText(getActivity(), getString(R.string.error_refreshing_gravatar), Toast.LENGTH_SHORT).show();
+            ToastUtils.showToast(getActivity(), R.string.error_refreshing_gravatar, ToastUtils.Duration.SHORT);
         }
         showGravatarProgressBar(false);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -43,7 +43,6 @@ import android.widget.ArrayAdapter;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.PopupWindow;
-import android.widget.Toast;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -691,9 +690,9 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
         if (sanitizedIds.size() != ids.size()) {
             if (ids.size() == 1) {
-                Toast.makeText(this, R.string.wait_until_upload_completes, Toast.LENGTH_LONG).show();
+                ToastUtils.showToast(this, R.string.wait_until_upload_completes, ToastUtils.Duration.LONG);
             } else {
-                Toast.makeText(this, R.string.cannot_delete_multi_media_items, Toast.LENGTH_LONG).show();
+                ToastUtils.showToast(this, R.string.cannot_delete_multi_media_items, ToastUtils.Duration.LONG);
             }
         }
 
@@ -865,8 +864,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             if (downloadedUri != null) {
                 queueFileForUpload(getOptimizedPictureIfNecessary(downloadedUri), mimeType);
             } else {
-                Toast.makeText(MediaBrowserActivity.this, getString(R.string.error_downloading_image),
-                        Toast.LENGTH_SHORT).show();
+                ToastUtils.showToast(MediaBrowserActivity.this, R.string.error_downloading_image,
+                        ToastUtils.Duration.SHORT);
             }
         } else {
             queueFileForUpload(getOptimizedPictureIfNecessary(mediaUri), mimeType);
@@ -913,7 +912,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         String path = MediaUtils.getRealPathFromURI(this,uri);
 
         if (TextUtils.isEmpty(path)) {
-            Toast.makeText(this, getString(R.string.file_not_found), Toast.LENGTH_SHORT).show();
+            ToastUtils.showToast(this, R.string.file_not_found, ToastUtils.Duration.SHORT);
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plans/PlansActivity.java
@@ -19,7 +19,6 @@ import android.view.ViewTreeObserver;
 import android.view.animation.AccelerateInterpolator;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
-import android.widget.Toast;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -34,6 +33,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.widgets.WPViewPager;
 
@@ -77,7 +77,7 @@ public class PlansActivity extends AppCompatActivity {
 
         if (mSelectedSite == null) {
             AppLog.e(T.PLANS, "Selected site is null");
-            Toast.makeText(this, R.string.plans_loading_error, Toast.LENGTH_LONG).show();
+            ToastUtils.showToast(this, R.string.plans_loading_error, ToastUtils.Duration.LONG);
             finish();
             return;
         }
@@ -110,7 +110,7 @@ public class PlansActivity extends AppCompatActivity {
                 return;
             }
             if (!PlanUpdateService.startService(this, mSelectedSite)) {
-                Toast.makeText(this, R.string.plans_loading_error, Toast.LENGTH_LONG).show();
+                ToastUtils.showToast(this, R.string.plans_loading_error, ToastUtils.Duration.LONG);
                 finish();
                 return;
             }
@@ -151,7 +151,7 @@ public class PlansActivity extends AppCompatActivity {
     private void setupPlansUI() {
         if (mAvailablePlans == null || mAvailablePlans.length == 0) {
             // This should never be called with empty plans.
-            Toast.makeText(PlansActivity.this, R.string.plans_loading_error, Toast.LENGTH_LONG).show();
+            ToastUtils.showToast(PlansActivity.this, R.string.plans_loading_error, ToastUtils.Duration.LONG);
             finish();
             return;
         }
@@ -303,7 +303,7 @@ public class PlansActivity extends AppCompatActivity {
      */
     @SuppressWarnings("unused")
     public void onEventMainThread(PlanEvents.PlansUpdateFailed event) {
-        Toast.makeText(PlansActivity.this, R.string.plans_loading_error, Toast.LENGTH_LONG).show();
+        ToastUtils.showToast(PlansActivity.this, R.string.plans_loading_error, ToastUtils.Duration.LONG);
         finish();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -39,7 +39,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.webkit.MimeTypeMap;
-import android.widget.Toast;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -852,7 +851,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
     }
 
     private void showErrorAndFinish(int errorMessageId) {
-        Toast.makeText(this, getResources().getText(errorMessageId), Toast.LENGTH_LONG).show();
+        ToastUtils.showToast(this, errorMessageId, ToastUtils.Duration.LONG);
         finish();
     }
 
@@ -1896,8 +1895,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             if (downloadedUri != null) {
                 addMedia(downloadedUri);
             } else {
-                Toast.makeText(EditPostActivity.this, getString(R.string.error_downloading_image),
-                        Toast.LENGTH_SHORT).show();
+                ToastUtils.showToast(EditPostActivity.this, R.string.error_downloading_image,
+                        ToastUtils.Duration.SHORT);
             }
         } else {
             addMedia(mediaUri);
@@ -1915,8 +1914,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
             }
         }
         if (isErrorAddingMedia) {
-            Toast.makeText(EditPostActivity.this, getResources().getText(R.string.gallery_error),
-                    Toast.LENGTH_SHORT).show();
+            ToastUtils.showToast(EditPostActivity.this, R.string.gallery_error, ToastUtils.Duration.SHORT);
         }
     }
 
@@ -2077,14 +2075,14 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
 
         // Invalid file path
         if (TextUtils.isEmpty(path)) {
-            Toast.makeText(this, R.string.editor_toast_invalid_path, Toast.LENGTH_SHORT).show();
+            ToastUtils.showToast(this, R.string.editor_toast_invalid_path, ToastUtils.Duration.SHORT);
             return null;
         }
 
         // File not found
         File file = new File(path);
         if (!file.exists()) {
-            Toast.makeText(this, R.string.file_not_found, Toast.LENGTH_SHORT).show();
+            ToastUtils.showToast(this, R.string.file_not_found, ToastUtils.Duration.SHORT);
             return null;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -18,7 +18,6 @@ import android.widget.BaseAdapter;
 import android.widget.ScrollView;
 import android.widget.Spinner;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import org.apache.commons.lang3.StringUtils;
 import org.greenrobot.eventbus.Subscribe;
@@ -107,7 +106,7 @@ public class StatsActivity extends AppCompatActivity
         ((WordPress) getApplication()).component().inject(this);
 
         if (WordPress.wpDB == null) {
-            Toast.makeText(this, R.string.fatal_db_error, Toast.LENGTH_LONG).show();
+            ToastUtils.showToast(this, R.string.fatal_db_error, ToastUtils.Duration.LONG);
             finish();
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -16,7 +16,6 @@ import android.widget.BaseExpandableListAdapter;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.android.volley.NoConnectionError;
 import com.android.volley.VolleyError;
@@ -196,7 +195,7 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
         }
 
         if (mRemoteBlogID == 0 || mRemoteItemID == null) {
-            Toast.makeText(this, R.string.stats_generic_error, Toast.LENGTH_LONG).show();
+            ToastUtils.showToast(this, R.string.stats_generic_error, ToastUtils.Duration.LONG);
             finish();
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
@@ -9,7 +9,6 @@ import android.text.TextUtils;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -17,6 +16,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 
@@ -121,8 +121,7 @@ public class StatsViewAllActivity extends AppCompatActivity {
         }
 
         if (mStatsViewType == null || mTimeframe == null || mDate == null) {
-            Toast.makeText(this, getResources().getText(R.string.stats_generic_error),
-                    Toast.LENGTH_SHORT).show();
+            ToastUtils.showToast(this, R.string.stats_generic_error, ToastUtils.Duration.SHORT);
             finish();
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsWidgetConfigureActivity.java
@@ -14,7 +14,6 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.Toast;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -139,7 +138,7 @@ public class StatsWidgetConfigureActivity extends AppCompatActivity
 
         if (site == null) {
             AppLog.e(AppLog.T.STATS, "The blog with local_blog_id " + localID + " cannot be loaded from the DB.");
-            Toast.makeText(this, R.string.stats_no_blog, Toast.LENGTH_LONG).show();
+            ToastUtils.showToast(this, R.string.stats_no_blog, ToastUtils.Duration.LONG);
             finish();
             return;
         }
@@ -149,7 +148,7 @@ public class StatsWidgetConfigureActivity extends AppCompatActivity
             // Or a Jetpack blog whose options are not yet synched in the app
             // In both of these cases show a generic message that encourages the user to refresh
             // the blog within the app. There are so many different paths here that's better to handle them in the app.
-            Toast.makeText(this, R.string.stats_widget_error_jetpack_no_blogid, Toast.LENGTH_LONG).show();
+            ToastUtils.showToast(this, R.string.stats_widget_error_jetpack_no_blogid, ToastUtils.Duration.LONG);
             finish();
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -13,7 +13,6 @@ import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.Toast;
 
 import com.android.volley.AuthFailureError;
 import com.android.volley.VolleyError;
@@ -194,7 +193,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
                             }
                             AppLog.d(T.THEMES, getString(R.string.theme_auth_error_authenticate));
                         } else {
-                            Toast.makeText(ThemeBrowserActivity.this, R.string.theme_fetch_failed, Toast.LENGTH_LONG)
+                            ToastUtils.showToast(ThemeBrowserActivity.this, R.string.theme_fetch_failed, ToastUtils.Duration.LONG)
                                     .show();
                             AppLog.d(T.THEMES, getString(R.string.theme_fetch_failed) + ": " + response.toString());
                         }
@@ -399,7 +398,8 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
         }, new ErrorListener() {
             @Override
             public void onErrorResponse(VolleyError error) {
-                Toast.makeText(getApplicationContext(), R.string.theme_activation_error, Toast.LENGTH_SHORT).show();
+                ToastUtils.showToast(ThemeBrowserActivity.this, R.string.theme_activation_error,
+                        ToastUtils.Duration.SHORT);
             }
         });
     }
@@ -459,7 +459,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
             }
         }
 
-        Toast.makeText(this, toastText, Toast.LENGTH_SHORT).show();
+        ToastUtils.showToast(this, toastText, ToastUtils.Duration.SHORT);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -193,8 +193,8 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
                             }
                             AppLog.d(T.THEMES, getString(R.string.theme_auth_error_authenticate));
                         } else {
-                            ToastUtils.showToast(ThemeBrowserActivity.this, R.string.theme_fetch_failed, ToastUtils.Duration.LONG)
-                                    .show();
+                            ToastUtils.showToast(ThemeBrowserActivity.this, R.string.theme_fetch_failed,
+                                    ToastUtils.Duration.LONG);
                             AppLog.d(T.THEMES, getString(R.string.theme_fetch_failed) + ": " + response.toString());
                         }
                         mFetchingThemes = false;

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
@@ -5,7 +5,6 @@ import android.content.Intent;
 import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.widget.Toast;
 
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
@@ -108,8 +107,7 @@ public class ThemeWebActivity extends WPWebViewActivity {
 
         if (TextUtils.isEmpty(url)) {
             AppLog.e(AppLog.T.UTILS, "Empty or null URL passed to openWPCOMURL");
-            Toast.makeText(activity, activity.getResources().getText(R.string.invalid_site_url_message),
-                    Toast.LENGTH_SHORT).show();
+            ToastUtils.showToast(activity, R.string.invalid_site_url_message, ToastUtils.Duration.SHORT);
             return;
         }
 


### PR DESCRIPTION
I realized we were inconsistent with showing the toast, so I thought this PR could help. I specifically didn't make any changes outside of the main repo and kept the usage of `Toast.makeText` where it made sense (custom toasts).
