### PR TITLE
Handle new media upload errors

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -142,7 +142,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:60c800b7e991d3acbdcf374d45864f07d7d469e5') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:2d7b093dc615865bd024fef8b963d855a984e55c') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -631,7 +631,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         if (event.isError()) {
             AppLog.d(AppLog.T.MEDIA, "Received onMediaUploaded error:" + event.error.type
                     + " - " + event.error.message);
-            String errorMessage = WPMediaUtils.getErrorMessage(this, mSite, event.media, event.error);
+            String errorMessage = WPMediaUtils.getErrorMessage(this, event.media, event.error);
             if (errorMessage != null) {
                 ToastUtils.showToast(this, errorMessage, ToastUtils.Duration.LONG);
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -632,9 +632,9 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             AppLog.d(AppLog.T.MEDIA, "Received onMediaUploaded error:" + event.error.type
                     + " - " + event.error.message);
 
-            int errorMessageID = WPMediaUtils.getErrorMessageResID(event.error);
-            if (errorMessageID != 0) {
-                showMediaToastError(errorMessageID, null);
+            String errorMessage = WPMediaUtils.getErrorMessageResID(this, event.media, event.error);
+            if (errorMessage != null) {
+                ToastUtils.showToast(this, errorMessage, ToastUtils.Duration.LONG);
             } else {
                 showMediaToastError(R.string.media_upload_error, event.error.message);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -631,15 +631,12 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         if (event.isError()) {
             AppLog.d(AppLog.T.MEDIA, "Received onMediaUploaded error:" + event.error.type
                     + " - " + event.error.message);
-            switch (event.error.type) {
-                case AUTHORIZATION_REQUIRED:
-                    showMediaToastError(R.string.media_error_no_permission, null);
-                    break;
-                case REQUEST_TOO_LARGE:
-                    showMediaToastError(R.string.media_error_too_large_upload, null);
-                    break;
-                default:
-                    showMediaToastError(R.string.media_upload_error, event.error.message);
+
+            int errorMessageID = WPMediaUtils.getErrorMessageResID(event.error);
+            if (errorMessageID != 0) {
+                showMediaToastError(errorMessageID, null);
+            } else {
+                showMediaToastError(R.string.media_upload_error, event.error.message);
             }
             updateViews();
         } else if (event.completed) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -632,7 +632,12 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             AppLog.d(AppLog.T.MEDIA, "Received onMediaUploaded error:" + event.error.type
                     + " - " + event.error.message);
 
-            String errorMessage = WPMediaUtils.getErrorMessageResID(this, event.media, event.error);
+            String errorMessage = WPMediaUtils.getErrorMessage(
+                    this,
+                    WPMediaUtils.isImageOptimizationEnabled(this, mSite),
+                    event.media,
+                    event.error
+            );
             if (errorMessage != null) {
                 ToastUtils.showToast(this, errorMessage, ToastUtils.Duration.LONG);
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -631,13 +631,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         if (event.isError()) {
             AppLog.d(AppLog.T.MEDIA, "Received onMediaUploaded error:" + event.error.type
                     + " - " + event.error.message);
-
-            String errorMessage = WPMediaUtils.getErrorMessage(
-                    this,
-                    WPMediaUtils.isImageOptimizationEnabled(this, mSite),
-                    event.media,
-                    event.error
-            );
+            String errorMessage = WPMediaUtils.getErrorMessage(this, mSite, event.media, event.error);
             if (errorMessage != null) {
                 ToastUtils.showToast(this, errorMessage, ToastUtils.Duration.LONG);
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -792,11 +792,8 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         AnalyticsTracker.track(Stat.EDITOR_UPLOAD_MEDIA_FAILED, properties);
 
         // Display custom error depending on error type
-        final String errorMessage;
-        int errorMessageID = WPMediaUtils.getErrorMessageResID(error);
-        if (errorMessageID != 0) {
-            errorMessage = getString(errorMessageID);
-        } else {
+        String errorMessage = WPMediaUtils.getErrorMessageResID(this, media, error);
+        if (errorMessage == null) {
             errorMessage = TextUtils.isEmpty(error.message) ? getString(R.string.tap_to_try_again) : error.message;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -792,7 +792,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         AnalyticsTracker.track(Stat.EDITOR_UPLOAD_MEDIA_FAILED, properties);
 
         // Display custom error depending on error type
-        String errorMessage = WPMediaUtils.getErrorMessage(this, mSite, media, error);
+        String errorMessage = WPMediaUtils.getErrorMessage(this, media, error);
         if (errorMessage == null) {
             errorMessage = TextUtils.isEmpty(error.message) ? getString(R.string.tap_to_try_again) : error.message;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -792,24 +792,14 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         AnalyticsTracker.track(Stat.EDITOR_UPLOAD_MEDIA_FAILED, properties);
 
         // Display custom error depending on error type
-        String errorMessage;
-        switch (error.type) {
-            case AUTHORIZATION_REQUIRED:
-                errorMessage = getString(R.string.media_error_no_permission_upload);
-                break;
-            case REQUEST_TOO_LARGE:
-                errorMessage = getString(R.string.media_error_too_large_upload);
-                break;
-            case SERVER_ERROR:
-                errorMessage = getString(R.string.media_error_internal_server_error);
-                break;
-            case TIMEOUT:
-                errorMessage = getString(R.string.media_error_timeout);
-                break;
-            case GENERIC_ERROR:
-            default:
-                errorMessage = TextUtils.isEmpty(error.message) ? getString(R.string.tap_to_try_again) : error.message;
+        final String errorMessage;
+        int errorMessageID = WPMediaUtils.getErrorMessageResID(error);
+        if (errorMessageID != 0) {
+            errorMessage = getString(errorMessageID);
+        } else {
+            errorMessage = TextUtils.isEmpty(error.message) ? getString(R.string.tap_to_try_again) : error.message;
         }
+
         if (mEditorMediaUploadListener != null) {
             mEditorMediaUploadListener.onMediaUploadFailed(localMediaId, errorMessage);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -792,12 +792,7 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         AnalyticsTracker.track(Stat.EDITOR_UPLOAD_MEDIA_FAILED, properties);
 
         // Display custom error depending on error type
-        String errorMessage = WPMediaUtils.getErrorMessage(
-                this,
-                WPMediaUtils.isImageOptimizationEnabled(this, mSite),
-                media,
-                error
-        );
+        String errorMessage = WPMediaUtils.getErrorMessage(this, mSite, media, error);
         if (errorMessage == null) {
             errorMessage = TextUtils.isEmpty(error.message) ? getString(R.string.tap_to_try_again) : error.message;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -792,7 +792,12 @@ public class EditPostActivity extends AppCompatActivity implements EditorFragmen
         AnalyticsTracker.track(Stat.EDITOR_UPLOAD_MEDIA_FAILED, properties);
 
         // Display custom error depending on error type
-        String errorMessage = WPMediaUtils.getErrorMessageResID(this, media, error);
+        String errorMessage = WPMediaUtils.getErrorMessage(
+                this,
+                WPMediaUtils.isImageOptimizationEnabled(this, mSite),
+                media,
+                error
+        );
         if (errorMessage == null) {
             errorMessage = TextUtils.isEmpty(error.message) ? getString(R.string.tap_to_try_again) : error.message;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -579,7 +579,6 @@ public class PostUploadService extends Service {
     }
 
     private @NonNull String getErrorMessageFromMediaError(OnMediaUploaded event) {
-        // FIXME : We set isImageOptimizationEnabled and isVideoOptimizationEnabled to true because we don't want display the hint about them.
         String errorMessage = WPMediaUtils.getErrorMessage(mContext, event.media, event.error);
         if (errorMessage == null) {
             // In case of a generic or uncaught error, return the message from the API response or the error type

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -29,7 +29,6 @@ import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.store.MediaStore;
-import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
@@ -580,7 +579,7 @@ public class PostUploadService extends Service {
     }
 
     private @NonNull String getErrorMessageFromMediaError(OnMediaUploaded event) {
-        String errorMessage = WPMediaUtils.getErrorMessageResID(mContext, event.media, event.error);
+        String errorMessage = WPMediaUtils.getErrorMessage(mContext, true, event.media, event.error);
         if (errorMessage == null) {
             // In case of a generic or uncaught error, return the message from the API response or the error type
             errorMessage = TextUtils.isEmpty(event.error.message) ? event.error.type.toString() : event.error.message;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -579,7 +579,8 @@ public class PostUploadService extends Service {
     }
 
     private @NonNull String getErrorMessageFromMediaError(OnMediaUploaded event) {
-        String errorMessage = WPMediaUtils.getErrorMessage(mContext, true, event.media, event.error);
+        // FIXME : We set isImageOptimizationEnabled and isVideoOptimizationEnabled to true because we don't want display the hint about them.
+        String errorMessage = WPMediaUtils.getErrorMessage(mContext, true, true, event.media, event.error);
         if (errorMessage == null) {
             // In case of a generic or uncaught error, return the message from the API response or the error type
             errorMessage = TextUtils.isEmpty(event.error.message) ? event.error.type.toString() : event.error.message;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -580,7 +580,7 @@ public class PostUploadService extends Service {
 
     private @NonNull String getErrorMessageFromMediaError(OnMediaUploaded event) {
         // FIXME : We set isImageOptimizationEnabled and isVideoOptimizationEnabled to true because we don't want display the hint about them.
-        String errorMessage = WPMediaUtils.getErrorMessage(mContext, true, true, event.media, event.error);
+        String errorMessage = WPMediaUtils.getErrorMessage(mContext, event.media, event.error);
         if (errorMessage == null) {
             // In case of a generic or uncaught error, return the message from the API response or the error type
             errorMessage = TextUtils.isEmpty(event.error.message) ? event.error.type.toString() : event.error.message;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -46,6 +46,7 @@ import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.SqlUtils;
+import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 
 import java.io.File;
@@ -579,24 +580,13 @@ public class PostUploadService extends Service {
     }
 
     private @NonNull String getErrorMessageFromMediaError(MediaError error) {
-         switch (error.type) {
-            case FS_READ_PERMISSION_DENIED:
-                return getString(R.string.error_media_insufficient_fs_permissions);
-            case NOT_FOUND:
-                return getString(R.string.error_media_not_found);
-            case AUTHORIZATION_REQUIRED:
-                return getString(R.string.error_media_unauthorized);
-             case PARSE_ERROR:
-                 return getString(R.string.error_media_parse_error);
-            case REQUEST_TOO_LARGE:
-                return getString(R.string.error_media_request_too_large);
-             case SERVER_ERROR:
-                 return getString(R.string.media_error_internal_server_error);
-             case TIMEOUT:
-                 return getString(R.string.media_error_timeout);
+        int errorMessageID = WPMediaUtils.getErrorMessageResID(error);
+        if (errorMessageID != 0) {
+            return getString(errorMessageID);
+        } else {
+            // In case of a generic or uncaught error, return the message from the API response or the error type
+            return TextUtils.isEmpty(error.message) ? error.type.toString() : error.message;
         }
-        // In case of a generic or uncaught error, return the message from the API response or the error type
-        return TextUtils.isEmpty(error.message) ? error.type.toString() : error.message;
     }
 
     private @NonNull String getErrorMessage(PostModel post, String specificMessage) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -579,14 +579,13 @@ public class PostUploadService extends Service {
         return TextUtils.isEmpty(error.message) ? error.type.toString() : error.message;
     }
 
-    private @NonNull String getErrorMessageFromMediaError(MediaError error) {
-        int errorMessageID = WPMediaUtils.getErrorMessageResID(error);
-        if (errorMessageID != 0) {
-            return getString(errorMessageID);
-        } else {
+    private @NonNull String getErrorMessageFromMediaError(OnMediaUploaded event) {
+        String errorMessage = WPMediaUtils.getErrorMessageResID(mContext, event.media, event.error);
+        if (errorMessage == null) {
             // In case of a generic or uncaught error, return the message from the API response or the error type
-            return TextUtils.isEmpty(error.message) ? error.type.toString() : error.message;
+            errorMessage = TextUtils.isEmpty(event.error.message) ? event.error.type.toString() : event.error.message;
         }
+        return errorMessage;
     }
 
     private @NonNull String getErrorMessage(PostModel post, String specificMessage) {
@@ -634,7 +633,7 @@ public class PostUploadService extends Service {
         if (event.isError()) {
             AppLog.e(T.MEDIA, "Media upload failed. " + event.error.type + ": " + event.error.message);
             SiteModel site = mSiteStore.getSiteByLocalId(mCurrentUploadingPost.getLocalSiteId());
-            String message = getErrorMessage(mCurrentUploadingPost, getErrorMessageFromMediaError(event.error));
+            String message = getErrorMessage(mCurrentUploadingPost, getErrorMessageFromMediaError(event));
             mPostUploadNotifier.updateNotificationError(mCurrentUploadingPost, site, message, true);
             mFirstPublishPosts.remove(mCurrentUploadingPost.getId());
             finishUpload();

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -176,8 +176,7 @@ public class WPMediaUtils {
                 if (media.isVideo()) {
                     return context.getString(R.string.media_error_http_too_large_video_upload);
                 } else {
-                    return context.getString(R.string.media_error_http_too_large_photo_upload) + ". " +
-                            context.getString(R.string.media_error_suggest_optimize_image);
+                    return context.getString(R.string.media_error_http_too_large_photo_upload);
                 }
             case SERVER_ERROR:
                 return context.getString(R.string.media_error_internal_server_error);

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -160,7 +160,17 @@ public class WPMediaUtils {
      * @param error The media error occurred
      * @return String  The associated error message.
      */
-    public static String getErrorMessage(final Context context, boolean suggestMediaOptimization, final MediaModel media, final MediaStore.MediaError error) {
+    public static String getErrorMessage(final Activity activity, final  SiteModel siteModel, final MediaModel media, final MediaStore.MediaError error) {
+        if (activity == null || media == null || error == null) {
+            return null;
+        }
+
+        return getErrorMessage(activity.getBaseContext(), WPMediaUtils.isImageOptimizationEnabled(activity, siteModel),
+                WPMediaUtils.isVideoOptimizationEnabled(activity, siteModel), media, error);
+    }
+
+    public static String getErrorMessage(final Context context, boolean isImageOptimizationEnabled, boolean isVideoOptimizationEnabled,
+                                         final MediaModel media, final MediaStore.MediaError error) {
         if (context == null || media == null || error == null) {
             return null;
         }
@@ -176,7 +186,7 @@ public class WPMediaUtils {
                 if (media.isVideo()) {
                     return context.getString(R.string.media_error_http_too_large_video_upload);
                 } else {
-                    if (!suggestMediaOptimization) {
+                    if (isImageOptimizationEnabled) {
                         return context.getString(R.string.media_error_http_too_large_photo_upload);
                     } else {
                         return context.getString(R.string.media_error_http_too_large_photo_upload) + ". " +

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -167,6 +167,10 @@ public class WPMediaUtils {
         }
 
         switch (error.type) {
+            case FS_READ_PERMISSION_DENIED:
+               return R.string.error_media_insufficient_fs_permissions;
+            case NOT_FOUND:
+                return R.string.error_media_not_found;
             case AUTHORIZATION_REQUIRED:
                 return R.string.media_error_no_permission_upload;
             case REQUEST_TOO_LARGE:

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -183,8 +183,7 @@ public class WPMediaUtils {
             case TIMEOUT:
                 return context.getString(R.string.media_error_timeout);
             case CONNECTION_ERROR:
-                return context.getString(R.string.connection_error) + ". "
-                        + context.getString(R.string.media_error_generic_connection_error);
+                return context.getString(R.string.connection_error);
             case EXCEEDS_FILESIZE_LIMIT:
                 return context.getString(R.string.media_error_exceeds_php_filesize);
             case EXCEEDS_MEMORY_LIMIT:

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -160,17 +160,7 @@ public class WPMediaUtils {
      * @param error The media error occurred
      * @return String  The associated error message.
      */
-    public static String getErrorMessage(final Activity activity, final  SiteModel siteModel, final MediaModel media, final MediaStore.MediaError error) {
-        if (activity == null || media == null || error == null) {
-            return null;
-        }
-
-        return getErrorMessage(activity.getBaseContext(), WPMediaUtils.isImageOptimizationEnabled(activity, siteModel),
-                WPMediaUtils.isVideoOptimizationEnabled(activity, siteModel), media, error);
-    }
-
-    public static String getErrorMessage(final Context context, boolean isImageOptimizationEnabled, boolean isVideoOptimizationEnabled,
-                                         final MediaModel media, final MediaStore.MediaError error) {
+    public static String getErrorMessage(final Context context, final MediaModel media, final MediaStore.MediaError error) {
         if (context == null || media == null || error == null) {
             return null;
         }
@@ -186,12 +176,8 @@ public class WPMediaUtils {
                 if (media.isVideo()) {
                     return context.getString(R.string.media_error_http_too_large_video_upload);
                 } else {
-                    if (isImageOptimizationEnabled) {
-                        return context.getString(R.string.media_error_http_too_large_photo_upload);
-                    } else {
-                        return context.getString(R.string.media_error_http_too_large_photo_upload) + ". " +
-                                context.getString(R.string.media_error_suggest_optimize_image);
-                    }
+                    return context.getString(R.string.media_error_http_too_large_photo_upload) + ". " +
+                            context.getString(R.string.media_error_suggest_optimize_image);
                 }
             case SERVER_ERROR:
                 return context.getString(R.string.media_error_internal_server_error);

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -178,9 +178,9 @@ public class WPMediaUtils {
             case CONNECTION_ERROR:
                 return R.string.media_error_generic_connection_error;
             case EXCEEDS_FILESIZE_LIMIT:
-                return R.string.media_error_wp_too_large_upload;
+                return R.string.media_error_exceeds_php_filesize;
             case EXCEEDS_MEMORY_LIMIT:
-                return R.string.media_error_wp_memory_limit;
+                return R.string.media_error_exceeds_memory_limit;
             case PARSE_ERROR:
                 return R.string.error_media_parse_error;
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -1,16 +1,20 @@
 package org.wordpress.android.util;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
+import android.support.annotation.StringRes;
 import android.support.v4.content.ContextCompat;
+import android.text.TextUtils;
 
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 
@@ -150,5 +154,40 @@ public class WPMediaUtils {
         builder.show();
         // Do not ask again
         AppPrefs.setImageOptimizePromoRequired(false);
+    }
+
+
+    /**
+     * Given a media error returns the error message to display on the UI.
+     *
+     * @param error The media error occurred
+     * @return int The associated resource identifier of the message to show to the user.
+     * Returns 0 if no such resource was found. (0 is not a valid resource ID.)
+     */
+    public static int getErrorMessageResID(final MediaStore.MediaError error) {
+        if (error == null) {
+            return 0;
+        }
+
+        switch (error.type) {
+            case AUTHORIZATION_REQUIRED:
+                return R.string.media_error_no_permission_upload;
+            case REQUEST_TOO_LARGE:
+                return R.string.media_error_http_too_large_upload;
+            case SERVER_ERROR:
+                return R.string.media_error_internal_server_error;
+            case TIMEOUT:
+                return R.string.media_error_timeout;
+            case CONNECTION_ERROR:
+                return R.string.media_error_generic_connection_error;
+            case EXCEEDS_FILESIZE_LIMIT:
+                return R.string.media_error_wp_too_large_upload;
+            case EXCEEDS_MEMORY_LIMIT:
+                return R.string.media_error_wp_memory_limit;
+            case PARSE_ERROR:
+                return R.string.error_media_parse_error;
+        }
+
+        return 0;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -1,14 +1,11 @@
 package org.wordpress.android.util;
 
 import android.app.Activity;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
-import android.support.annotation.StringRes;
 import android.support.v4.content.ContextCompat;
-import android.text.TextUtils;
 
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.util;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.pm.PackageManager;
 import android.net.Uri;
@@ -10,6 +11,7 @@ import android.support.v4.content.ContextCompat;
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -153,42 +155,44 @@ public class WPMediaUtils {
         AppPrefs.setImageOptimizePromoRequired(false);
     }
 
-
     /**
      * Given a media error returns the error message to display on the UI.
      *
      * @param error The media error occurred
-     * @return int The associated resource identifier of the message to show to the user.
-     * Returns 0 if no such resource was found. (0 is not a valid resource ID.)
+     * @return String  The associated error message.
      */
-    public static int getErrorMessageResID(final MediaStore.MediaError error) {
-        if (error == null) {
-            return 0;
+    public static String getErrorMessageResID(final Context context, final MediaModel media, final MediaStore.MediaError error) {
+        if (context == null || media == null || error == null) {
+            return null;
         }
 
         switch (error.type) {
             case FS_READ_PERMISSION_DENIED:
-               return R.string.error_media_insufficient_fs_permissions;
+               return context.getString(R.string.error_media_insufficient_fs_permissions);
             case NOT_FOUND:
-                return R.string.error_media_not_found;
+                return context.getString(R.string.error_media_not_found);
             case AUTHORIZATION_REQUIRED:
-                return R.string.media_error_no_permission_upload;
+                return context.getString(R.string.media_error_no_permission_upload);
             case REQUEST_TOO_LARGE:
-                return R.string.media_error_http_too_large_upload;
+                if (!media.isVideo()) {
+                    return context.getString(R.string.media_error_http_too_large_upload);
+                } else {
+                    return context.getString(R.string.media_error_http_too_large_upload);
+                }
             case SERVER_ERROR:
-                return R.string.media_error_internal_server_error;
+                return context.getString(R.string.media_error_internal_server_error);
             case TIMEOUT:
-                return R.string.media_error_timeout;
+                return context.getString(R.string.media_error_timeout);
             case CONNECTION_ERROR:
-                return R.string.media_error_generic_connection_error;
+                return context.getString(R.string.media_error_generic_connection_error);
             case EXCEEDS_FILESIZE_LIMIT:
-                return R.string.media_error_exceeds_php_filesize;
+                return context.getString(R.string.media_error_exceeds_php_filesize);
             case EXCEEDS_MEMORY_LIMIT:
-                return R.string.media_error_exceeds_memory_limit;
+                return context.getString(R.string.media_error_exceeds_memory_limit);
             case PARSE_ERROR:
-                return R.string.error_media_parse_error;
+                return context.getString(R.string.error_media_parse_error);
         }
 
-        return 0;
+        return null;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -75,6 +75,10 @@ public class WPMediaUtils {
         return isVideoOptimizationAvailable() && siteSettings != null && siteSettings.init(false).getOptimizedVideo();
     }
 
+    public static boolean isImageOptimizationEnabled(Activity activity, SiteModel siteModel) {
+        SiteSettingsInterface siteSettings = SiteSettingsInterface.getInterface(activity, siteModel, null);
+        return siteSettings != null && siteSettings.init(false).getOptimizedImage();
+    }
 
     /**
      *
@@ -104,12 +108,7 @@ public class WPMediaUtils {
         }
 
         // Check whether image optimization is already available for the site
-        SiteSettingsInterface siteSettings = SiteSettingsInterface.getInterface(act, site, null);
-        if (siteSettings == null || siteSettings.init(false).getOptimizedImage()) {
-            return false;
-        }
-
-        return true;
+       return !isImageOptimizationEnabled(act, site);
     }
 
     public interface OnAdvertiseImageOptimizationListener {
@@ -161,23 +160,28 @@ public class WPMediaUtils {
      * @param error The media error occurred
      * @return String  The associated error message.
      */
-    public static String getErrorMessageResID(final Context context, final MediaModel media, final MediaStore.MediaError error) {
+    public static String getErrorMessage(final Context context, boolean suggestMediaOptimization, final MediaModel media, final MediaStore.MediaError error) {
         if (context == null || media == null || error == null) {
             return null;
         }
 
         switch (error.type) {
             case FS_READ_PERMISSION_DENIED:
-               return context.getString(R.string.error_media_insufficient_fs_permissions);
+                return context.getString(R.string.error_media_insufficient_fs_permissions);
             case NOT_FOUND:
                 return context.getString(R.string.error_media_not_found);
             case AUTHORIZATION_REQUIRED:
                 return context.getString(R.string.media_error_no_permission_upload);
             case REQUEST_TOO_LARGE:
-                if (!media.isVideo()) {
-                    return context.getString(R.string.media_error_http_too_large_upload);
+                if (media.isVideo()) {
+                    return context.getString(R.string.media_error_http_too_large_video_upload);
                 } else {
-                    return context.getString(R.string.media_error_http_too_large_upload);
+                    if (!suggestMediaOptimization) {
+                        return context.getString(R.string.media_error_http_too_large_photo_upload);
+                    } else {
+                        return context.getString(R.string.media_error_http_too_large_photo_upload) + ". " +
+                                context.getString(R.string.media_error_suggest_optimize_image);
+                    }
                 }
             case SERVER_ERROR:
                 return context.getString(R.string.media_error_internal_server_error);

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -188,7 +188,8 @@ public class WPMediaUtils {
             case TIMEOUT:
                 return context.getString(R.string.media_error_timeout);
             case CONNECTION_ERROR:
-                return context.getString(R.string.media_error_generic_connection_error);
+                return context.getString(R.string.connection_error) + ". "
+                        + context.getString(R.string.media_error_generic_connection_error);
             case EXCEEDS_FILESIZE_LIMIT:
                 return context.getString(R.string.media_error_exceeds_php_filesize);
             case EXCEEDS_MEMORY_LIMIT:

--- a/WordPress/src/main/res/values-en-rAU/strings.xml
+++ b/WordPress/src/main/res/values-en-rAU/strings.xml
@@ -66,7 +66,7 @@ Language: en_AU
 	<string name="button_not_now">Not now</string>
 	<string name="media_error_timeout">Server response timed out, you may have a poor connection or server error</string>
 	<string name="media_error_internal_server_error">Upload error. Try enabling Optimise Images in Site->Settings</string>
-	<string name="media_error_too_large_upload">File too large to upload. Try enabling Optimise Images in Site->Settings</string>
+	<string name="media_error_http_too_large_upload">File too large to upload. Try enabling Optimise Images in Site->Settings</string>
 	<string name="media_downloading">Saving media to this device</string>
 	<string name="error_media_save">Unable to save media</string>
 	<string name="editor_scheduled_post_saved_online">Post scheduled</string>

--- a/WordPress/src/main/res/values-en-rCA/strings.xml
+++ b/WordPress/src/main/res/values-en-rCA/strings.xml
@@ -66,7 +66,7 @@ Language: en_CA
 	<string name="button_not_now">Not now</string>
 	<string name="media_error_timeout">Server response timed out, you may have a poor connection or server error</string>
 	<string name="media_error_internal_server_error">Upload error. Try enabling Optimize Images in Site->Settings</string>
-	<string name="media_error_too_large_upload">File too large to upload. Try enabling Optimize Images in Site->Settings</string>
+	<string name="media_error_http_too_large_upload">File too large to upload. Try enabling Optimize Images in Site->Settings</string>
 	<string name="media_downloading">Saving media to this device</string>
 	<string name="error_media_save">Unable to save media</string>
 	<string name="editor_scheduled_post_saved_online">Post scheduled</string>

--- a/WordPress/src/main/res/values-en-rGB/strings.xml
+++ b/WordPress/src/main/res/values-en-rGB/strings.xml
@@ -66,7 +66,7 @@ Language: en_GB
 	<string name="button_not_now">Not now</string>
 	<string name="media_error_timeout">Server response timed out, you may have a poor connection or server error</string>
 	<string name="media_error_internal_server_error">Upload error. Try enabling Optimise Images in Site->Settings</string>
-	<string name="media_error_too_large_upload">File too large to upload. Try enabling Optimise Images in Site->Settings</string>
+	<string name="media_error_http_too_large_upload">File too large to upload. Try enabling Optimise Images in Site->Settings</string>
 	<string name="media_downloading">Saving media to this device</string>
 	<string name="error_media_save">Unable to save media</string>
 	<string name="editor_scheduled_post_saved_online">Post scheduled</string>

--- a/WordPress/src/main/res/values-es/strings.xml
+++ b/WordPress/src/main/res/values-es/strings.xml
@@ -66,7 +66,7 @@ Language: es
 	<string name="button_not_now">Ahora no</string>
 	<string name="media_error_timeout">Se agotó la respuesta del servidor, puede que tengas una conexión pobre o que sea un error del servidor</string>
 	<string name="media_error_internal_server_error">Error en la subida. Trata de activar Optimizar imágenes en Sitio->Ajustes</string>
-	<string name="media_error_too_large_upload">Archivo a subir demasiado grande. Trata de activar Optimizar imágenes en Sitio->Ajustes</string>
+	<string name="media_error_http_too_large_upload">Archivo a subir demasiado grande. Trata de activar Optimizar imágenes en Sitio->Ajustes</string>
 	<string name="media_downloading">Guardando medios en este dispositivo</string>
 	<string name="error_media_save">No fue posible guardar los medios</string>
 	<string name="editor_scheduled_post_saved_online">Entrada programada</string>

--- a/WordPress/src/main/res/values-fr/strings.xml
+++ b/WordPress/src/main/res/values-fr/strings.xml
@@ -8,7 +8,7 @@ Language: fr
 <resources>
 	<string name="media_error_timeout">Le serveur a mis trop de temps à répondre. Il se peut que vous ayez une connexion trop lente, ou qu\'une erreur serveur soit survenue.</string>
 	<string name="media_error_internal_server_error">Erreur de mise en ligne. Essayez d\'activer l\'option « Optimiser les images » dans l\'écran Site -> Réglages.</string>
-	<string name="media_error_too_large_upload">Le fichier est trop gros pour être mis en ligne. Essayez d\'activer l\'option « Optimiser les images » dans l\'écran Site -> Réglages.</string>
+	<string name="media_error_http_too_large_upload">Le fichier est trop gros pour être mis en ligne. Essayez d\'activer l\'option « Optimiser les images » dans l\'écran Site -> Réglages.</string>
 	<string name="media_downloading">Enregistrement du fichier sur cet appareil</string>
 	<string name="error_media_save">Impossible d’enregistrer les médias</string>
 	<string name="editor_scheduled_post_saved_online">Article programmé</string>

--- a/WordPress/src/main/res/values-it/strings.xml
+++ b/WordPress/src/main/res/values-it/strings.xml
@@ -8,7 +8,7 @@ Language: it
 <resources>
 	<string name="media_error_timeout">Esaurito il tempo di risposta del server, potresti avere una connessione lenta o si è verificato un errore sul server</string>
 	<string name="media_error_internal_server_error">Errore di caricamento. Prova ad abilitare l\'Ottimizzazione immagini in Sito.>Impostazioni</string>
-	<string name="media_error_too_large_upload">File troppo grande per il caicamento. Prova ad abilitare l\'Ottimizzazione immagini in Sito.>Impostazioni</string>
+	<string name="media_error_http_too_large_upload">File troppo grande per il caicamento. Prova ad abilitare l\'Ottimizzazione immagini in Sito.>Impostazioni</string>
 	<string name="media_downloading">Salvataggio elemento media sulla periferica</string>
 	<string name="error_media_save">Non è possibile salvare il media</string>
 	<string name="editor_scheduled_post_saved_online">Pubblicazione programmata</string>

--- a/WordPress/src/main/res/values-pl/strings.xml
+++ b/WordPress/src/main/res/values-pl/strings.xml
@@ -66,7 +66,7 @@ Language: pl
 	<string name="button_not_now">Nie teraz</string>
 	<string name="media_error_timeout">Czas odpowiedzi serwera został przekroczony, możliwe że masz problemy z połączeniem lub jest to błąd serwera</string>
 	<string name="media_error_internal_server_error">Błąd przesyłania. Spróbuj włączyć funkcję optymalizacji obrazków w ustawieniach witryny</string>
-	<string name="media_error_too_large_upload">Plik zbyt duży aby go przesłać. Spróbuj włączyć funkcję optymalizacji obrazków w ustawieniach witryny</string>
+	<string name="media_error_http_too_large_upload">Plik zbyt duży aby go przesłać. Spróbuj włączyć funkcję optymalizacji obrazków w ustawieniach witryny</string>
 	<string name="media_downloading">Zapisywanie mediów na to urządzenie</string>
 	<string name="error_media_save">Nie można zapisać pliku mediów</string>
 	<string name="editor_scheduled_post_saved_online">Publikacja wpisu została zaplanowana</string>

--- a/WordPress/src/main/res/values-ro/strings.xml
+++ b/WordPress/src/main/res/values-ro/strings.xml
@@ -66,7 +66,7 @@ Language: ro
 	<string name="button_not_now">Nu acum</string>
 	<string name="media_error_timeout">Răspunsul serverului a expirat, ar putea fi o conexiune slabă sau o eroare de server</string>
 	<string name="media_error_internal_server_error">Eroare la încărcare. Încearcă activarea Optimizează imagini în Sit->Setări</string>
-	<string name="media_error_too_large_upload">Fișier prea mare pentru a-l încărca. Încearcă activarea Optimizează imagini în Sit->Setări</string>
+	<string name="media_error_http_too_large_upload">Fișier prea mare pentru a-l încărca. Încearcă activarea Optimizează imagini în Sit->Setări</string>
 	<string name="media_downloading">Salvez media pe acest dispozitiv</string>
 	<string name="error_media_save">Nu pot salva media</string>
 	<string name="editor_scheduled_post_saved_online">Articol programat</string>

--- a/WordPress/src/main/res/values-sv/strings.xml
+++ b/WordPress/src/main/res/values-sv/strings.xml
@@ -66,7 +66,7 @@ Language: sv_SE
 	<string name="button_not_now">Inte just nu.</string>
 	<string name="media_error_timeout">Servern tog för lång tid på sig att svara. Det kan vara en dålig förbindelse eller ett serverfel</string>
 	<string name="media_error_internal_server_error">Fel vid uppladdning. Prova att aktivera ”Optimera bilder” under Webbplats->Inställningar</string>
-	<string name="media_error_too_large_upload">Filen är för stor för att kunna laddas upp. Prova att aktivera ”Optimera bilder” under Webbplats->Inställningar</string>
+	<string name="media_error_http_too_large_upload">Filen är för stor för att kunna laddas upp. Prova att aktivera ”Optimera bilder” under Webbplats->Inställningar</string>
 	<string name="media_downloading">Mediafilerna sparas i denna enhet</string>
 	<string name="error_media_save">Kan inte spara media</string>
 	<string name="editor_scheduled_post_saved_online">Inlägget schemalagt</string>

--- a/WordPress/src/main/res/values-tr/strings.xml
+++ b/WordPress/src/main/res/values-tr/strings.xml
@@ -66,7 +66,7 @@ Language: tr
 	<string name="button_not_now">Şimdi değil</string>
 	<string name="media_error_timeout">Sunucu cevabı zaman aşımına uğradı, zayıf bir bağlantınız olabilir ya da sunucu hatası</string>
 	<string name="media_error_internal_server_error">Yükleme hatası. Site->Ayarlar bölümünden görsellerin optimize edilmesini etkinleştirin</string>
-	<string name="media_error_too_large_upload">Dosya yüklemek için çok büyük. Site->Ayarlar bölümünden görsellerin optimize edilmesini etkinleştirmeyi deneyin</string>
+	<string name="media_error_http_too_large_upload">Dosya yüklemek için çok büyük. Site->Ayarlar bölümünden görsellerin optimize edilmesini etkinleştirmeyi deneyin</string>
 	<string name="media_downloading">Ortam dosyaları bu cihazda saklanıyor</string>
 	<string name="error_media_save">Ortam dosyası kaydedilemiyor</string>
 	<string name="editor_scheduled_post_saved_online">Yazı zamanlandı</string>

--- a/WordPress/src/main/res/values-zh-rHK/strings.xml
+++ b/WordPress/src/main/res/values-zh-rHK/strings.xml
@@ -8,7 +8,7 @@ Language: zh_TW
 <resources>
 	<string name="media_error_timeout">伺服器回應逾時，可能是因為你的連線品質不佳或伺服器發生錯誤</string>
 	<string name="media_error_internal_server_error">上傳錯誤。請嘗試在「網站」->「設定」中啟用「將圖片最佳化」的功能</string>
-	<string name="media_error_too_large_upload">檔案太大，無法上傳。請嘗試在「網站」->「設定」中啟用「將圖片最佳化」的功能</string>
+	<string name="media_error_http_too_large_upload">檔案太大，無法上傳。請嘗試在「網站」->「設定」中啟用「將圖片最佳化」的功能</string>
 	<string name="media_downloading">將媒體儲存到此裝置</string>
 	<string name="error_media_save">無法儲存媒體</string>
 	<string name="editor_scheduled_post_saved_online">文章已排程</string>

--- a/WordPress/src/main/res/values-zh-rTW/strings.xml
+++ b/WordPress/src/main/res/values-zh-rTW/strings.xml
@@ -8,7 +8,7 @@ Language: zh_TW
 <resources>
 	<string name="media_error_timeout">伺服器回應逾時，可能是因為你的連線品質不佳或伺服器發生錯誤</string>
 	<string name="media_error_internal_server_error">上傳錯誤。請嘗試在「網站」->「設定」中啟用「將圖片最佳化」的功能</string>
-	<string name="media_error_too_large_upload">檔案太大，無法上傳。請嘗試在「網站」->「設定」中啟用「將圖片最佳化」的功能</string>
+	<string name="media_error_http_too_large_upload">檔案太大，無法上傳。請嘗試在「網站」->「設定」中啟用「將圖片最佳化」的功能</string>
 	<string name="media_downloading">將媒體儲存到此裝置</string>
 	<string name="error_media_save">無法儲存媒體</string>
 	<string name="editor_scheduled_post_saved_online">文章已排程</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -145,7 +145,7 @@
     <string name="media_error_http_too_large_video_upload">Video too large to upload</string>
     <string name="media_error_exceeds_php_filesize">File exceeds the maximum upload size for this site</string>
     <string name="media_error_exceeds_memory_limit">File too large to be uploaded on this site</string>
-    <string name="media_error_generic_connection_error">Connection error. You may have a poor connection or no Internet access</string>
+    <string name="media_error_generic_connection_error">You may have a poor connection or no Internet access</string>
     <string name="media_error_internal_server_error">Upload error. Try enabling Optimize Images in Site->Settings</string>
     <string name="media_error_timeout">Server response timed out, you may have a poor connection or server error</string>
     <string name="access_media_permission_required">Permissions required in order to access media</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -143,8 +143,8 @@
     <string name="media_error_suggest_optimize_image">Try enabling Optimize Images in your site\'s settings</string>
     <string name="media_error_http_too_large_photo_upload">Image too large to upload</string>
     <string name="media_error_http_too_large_video_upload">Video too large to upload</string>
-    <string name="media_error_exceeds_php_filesize">File exceeds the maximum upload size for this site. Change the php.ini upload_max_filesize, and post_max_size settings</string>
-    <string name="media_error_exceeds_memory_limit">File too large to be uploaded on this site. Change the php.ini memory_limit setting</string>
+    <string name="media_error_exceeds_php_filesize">File exceeds the maximum upload size for this site</string>
+    <string name="media_error_exceeds_memory_limit">File too large to be uploaded on this site</string>
     <string name="media_error_generic_connection_error">Connection error. You may have a poor connection or no Internet access</string>
     <string name="media_error_internal_server_error">Upload error. Try enabling Optimize Images in Site->Settings</string>
     <string name="media_error_timeout">Server response timed out, you may have a poor connection or server error</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1143,7 +1143,7 @@
     <string name="error_publish_empty_post">Can\'t publish an empty post</string>
     <string name="error_publish_no_network">Device is offline. Changes saved locally.</string>
     <string name="error_upload_params">Error while uploading the %1$s: %2$s</string>
-    <string name="error_media_insufficient_fs_permissions">Read permission required on media file</string>
+    <string name="error_media_insufficient_fs_permissions">Read permission denied on device media</string>
     <string name="error_media_not_found">Media could not be found</string>
     <string name="error_media_unauthorized">You don\'t have permission to view or edit media</string>
     <string name="error_media_parse_error">Unexpected response from server</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -140,7 +140,10 @@
     <string name="reader_toast_err_get_post">Unable to retrieve this post</string>
     <string name="media_error_no_permission">You don\'t have permission to view the media library</string>
     <string name="media_error_no_permission_upload">You don\'t have permission to upload media to the site</string>
-    <string name="media_error_too_large_upload">File too large to upload. Try enabling Optimize Images in Site->Settings</string>
+    <string name="media_error_http_too_large_upload">File too large to upload. Try enabling Optimize Images in Site->Settings</string>
+    <string name="media_error_wp_too_large_upload">File exceeds the maximum upload size for this site.</string>
+    <string name="media_error_wp_memory_limit">File too large to be uploaded on this site. Change the php.ini memory_limit setting</string>
+    <string name="media_error_generic_connection_error">Connection error. You may have a poor connection or no Internet access</string>
     <string name="media_error_internal_server_error">Upload error. Try enabling Optimize Images in Site->Settings</string>
     <string name="media_error_timeout">Server response timed out, you may have a poor connection or server error</string>
     <string name="access_media_permission_required">Permissions required in order to access media</string>
@@ -1145,10 +1148,8 @@
     <string name="error_media_unauthorized">You don\'t have permission to view or edit media</string>
     <string name="error_media_parse_error">Could not parse response after media upload</string>
     <string name="error_media_upload">An error occurred while uploading media</string>
-    <string name="error_media_upload_connection">A connection error occurred while uploading media</string>
     <string name="error_media_refresh_no_connection">Connection required to refresh library</string>
     <string name="error_media_load">Unable to load media</string>
-    <string name="error_media_request_too_large">Media too large, can\'t be uploaded</string>
     <string name="error_media_save">Unable to save media</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>
     <string name="fatal_db_error">An error occurred while creating the app database. Try reinstalling the app.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -144,9 +144,8 @@
     <string name="media_error_http_too_large_video_upload">Video too large to upload</string>
     <string name="media_error_exceeds_php_filesize">File exceeds the maximum upload size for this site</string>
     <string name="media_error_exceeds_memory_limit">File too large to be uploaded on this site</string>
-    <string name="media_error_generic_connection_error">You may have a poor connection or no Internet access</string>
-    <string name="media_error_internal_server_error">Upload error. Try enabling Optimize Images in Site->Settings</string>
-    <string name="media_error_timeout">Server response timed out, you may have a poor connection or server error</string>
+    <string name="media_error_internal_server_error">Upload error. Try changing Optimize Images in your site\'s settings</string>
+    <string name="media_error_timeout">Server took too long to respond</string>
     <string name="access_media_permission_required">Permissions required in order to access media</string>
     <string name="add_media_permission_required">Permissions required in order to add media</string>
     <string name="media_fetching">Fetching media…</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -140,8 +140,7 @@
     <string name="reader_toast_err_get_post">Unable to retrieve this post</string>
     <string name="media_error_no_permission">You don\'t have permission to view the media library</string>
     <string name="media_error_no_permission_upload">You don\'t have permission to upload media to the site</string>
-    <string name="media_error_suggest_optimize_image">Try changing Optimize Images in your site\'s settings</string>
-    <string name="media_error_http_too_large_photo_upload">Image too large to upload</string>
+    <string name="media_error_http_too_large_photo_upload">Image too large to upload. Try changing Optimize Images in your site\'s settings</string>
     <string name="media_error_http_too_large_video_upload">Video too large to upload</string>
     <string name="media_error_exceeds_php_filesize">File exceeds the maximum upload size for this site</string>
     <string name="media_error_exceeds_memory_limit">File too large to be uploaded on this site</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -141,8 +141,8 @@
     <string name="media_error_no_permission">You don\'t have permission to view the media library</string>
     <string name="media_error_no_permission_upload">You don\'t have permission to upload media to the site</string>
     <string name="media_error_http_too_large_upload">File too large to upload. Try enabling Optimize Images in Site->Settings</string>
-    <string name="media_error_wp_too_large_upload">File exceeds the maximum upload size for this site.</string>
-    <string name="media_error_wp_memory_limit">File too large to be uploaded on this site. Change the php.ini memory_limit setting</string>
+    <string name="media_error_exceeds_php_filesize">File exceeds the maximum upload size for this site. Change the php.ini upload_max_filesize, and post_max_size settings</string>
+    <string name="media_error_exceeds_memory_limit">File too large to be uploaded on this site. Change the php.ini memory_limit setting</string>
     <string name="media_error_generic_connection_error">Connection error. You may have a poor connection or no Internet access</string>
     <string name="media_error_internal_server_error">Upload error. Try enabling Optimize Images in Site->Settings</string>
     <string name="media_error_timeout">Server response timed out, you may have a poor connection or server error</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1146,7 +1146,7 @@
     <string name="error_media_insufficient_fs_permissions">Read permission required on media file</string>
     <string name="error_media_not_found">Media could not be found</string>
     <string name="error_media_unauthorized">You don\'t have permission to view or edit media</string>
-    <string name="error_media_parse_error">Could not parse response after media upload</string>
+    <string name="error_media_parse_error">Unexpected response from server</string>
     <string name="error_media_upload">An error occurred while uploading media</string>
     <string name="error_media_refresh_no_connection">Connection required to refresh library</string>
     <string name="error_media_load">Unable to load media</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -140,7 +140,9 @@
     <string name="reader_toast_err_get_post">Unable to retrieve this post</string>
     <string name="media_error_no_permission">You don\'t have permission to view the media library</string>
     <string name="media_error_no_permission_upload">You don\'t have permission to upload media to the site</string>
-    <string name="media_error_http_too_large_upload">File too large to upload. Try enabling Optimize Images in Site->Settings</string>
+    <string name="media_error_suggest_optimize_image">Try enabling Optimize Images in your site\'s settings</string>
+    <string name="media_error_http_too_large_photo_upload">Image too large to upload</string>
+    <string name="media_error_http_too_large_video_upload">Video too large to upload</string>
     <string name="media_error_exceeds_php_filesize">File exceeds the maximum upload size for this site. Change the php.ini upload_max_filesize, and post_max_size settings</string>
     <string name="media_error_exceeds_memory_limit">File too large to be uploaded on this site. Change the php.ini memory_limit setting</string>
     <string name="media_error_generic_connection_error">Connection error. You may have a poor connection or no Internet access</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -140,7 +140,7 @@
     <string name="reader_toast_err_get_post">Unable to retrieve this post</string>
     <string name="media_error_no_permission">You don\'t have permission to view the media library</string>
     <string name="media_error_no_permission_upload">You don\'t have permission to upload media to the site</string>
-    <string name="media_error_suggest_optimize_image">Try enabling Optimize Images in your site\'s settings</string>
+    <string name="media_error_suggest_optimize_image">Try changing Optimize Images in your site\'s settings</string>
     <string name="media_error_http_too_large_photo_upload">Image too large to upload</string>
     <string name="media_error_http_too_large_video_upload">Video too large to upload</string>
     <string name="media_error_exceeds_php_filesize">File exceeds the maximum upload size for this site</string>


### PR DESCRIPTION
Fixes #6222 by handling `CONNECTION_ERROR`, `EXCEEDS_FILESIZE_LIMIT` and `EXCEEDS_MEMORY_LIMIT` during media uploading. 
There is now a single routine that from a given `MediaError` returns the res ID of the error message. It's going to be used in the Editor, Media Library, and post upload service (mostly from legacy editor).

For reference/details about when these new errors are triggered see the original ticket.

cc @nbradbury for helping about wording these new error strings.
