### PR TITLE
issue/6289-photo-picker-disable-on-out

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -266,7 +266,7 @@ public class PhotoPickerFragment extends Fragment {
         popup.show();
     }
 
-    void setPhotoPickerListener(PhotoPickerListener listener) {
+    public void setPhotoPickerListener(PhotoPickerListener listener) {
         mListener = listener;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -566,6 +566,7 @@ public class EditPostActivity extends AppCompatActivity implements
         if (!isPhotoPickerShowing()) {
             AniUtils.animateBottomBar(mPhotoPickerContainer, true, AniUtils.Duration.MEDIUM);
             mPhotoPickerFragment.refresh();
+            mPhotoPickerFragment.setPhotoPickerListener(this);
         }
 
         // fade in the overlay atop the editor, which effectively disables the editor
@@ -583,6 +584,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private void hidePhotoPicker() {
         if (isPhotoPickerShowing()) {
             mPhotoPickerFragment.finishActionMode();
+            mPhotoPickerFragment.setPhotoPickerListener(null);
             AniUtils.animateBottomBar(mPhotoPickerContainer, false);
         }
 


### PR DESCRIPTION
Fixes #6289 - previously it was possible to tap a photo picker item while the photo picker animates out, this PR prevents that.

A simple way to test this is to temporarily change [this animation duration](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/6289-photo-picker-disable-on-out/WordPress/src/main/java/org/wordpress/android/util/AniUtils.java#L34) to return 5000. This will make it take five seconds for the picker to animate out, giving plenty of time to test that clicking does nothing.