### PR TITLE
Upgrade WPNetworkImageView code to be in par with Volley

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/WordPressMediaUtils.java
@@ -239,28 +239,6 @@ public class WordPressMediaUtils {
     /**
      * Loads the given network image URL into the {@link NetworkImageView}.
      */
-    public static void loadNetworkImage(String imageUrl, NetworkImageView imageView, ImageLoader imageLoader) {
-        if (imageUrl != null) {
-            Uri uri = Uri.parse(imageUrl);
-            String filepath = uri.getLastPathSegment();
-
-            int placeholderResId = WordPressMediaUtils.getPlaceholder(filepath);
-            imageView.setErrorImageResId(placeholderResId);
-
-            // default image while downloading
-            imageView.setDefaultImageResId(R.drawable.media_item_background);
-
-            if (MediaUtils.isValidImage(filepath)) {
-                imageView.setTag(imageUrl);
-                imageView.setImageUrl(imageUrl, imageLoader);
-            } else {
-                imageView.setImageResource(placeholderResId);
-            }
-        } else {
-            imageView.setImageResource(0);
-        }
-    }
-
     public static void loadNetworkImage(String imageUrl, WPNetworkImageView imageView) {
         if (imageUrl != null) {
             Uri uri = Uri.parse(imageUrl);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -31,7 +31,6 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.TimePicker;
 
-import com.android.volley.toolbox.NetworkImageView;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
 import com.google.android.gms.common.GooglePlayServicesRepairableException;
@@ -128,7 +127,6 @@ public class EditPostSettingsFragment extends Fragment {
     @Inject MediaStore mMediaStore;
     @Inject TaxonomyStore mTaxonomyStore;
     @Inject Dispatcher mDispatcher;
-    @Inject FluxCImageLoader mImageLoader;
 
     interface EditPostActivityHook {
         PostModel getPost();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -77,6 +77,7 @@ import org.wordpress.android.util.ListUtils;
 import org.wordpress.android.util.PhotonUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -115,7 +116,7 @@ public class EditPostSettingsFragment extends Fragment {
     private TextView mPostFormatTextView;
     private TextView mPasswordTextView;
     private TextView mPublishDateTextView;
-    private NetworkImageView mFeaturedImageView;
+    private WPNetworkImageView mFeaturedImageView;
     private Button mFeaturedImageButton;
 
     private PostLocation mPostLocation;
@@ -223,7 +224,7 @@ public class EditPostSettingsFragment extends Fragment {
         mPasswordTextView = (TextView) rootView.findViewById(R.id.post_password);
         mPublishDateTextView = (TextView) rootView.findViewById(R.id.publish_date);
 
-        mFeaturedImageView = (NetworkImageView) rootView.findViewById(R.id.post_featured_image);
+        mFeaturedImageView = (WPNetworkImageView) rootView.findViewById(R.id.post_featured_image);
         mFeaturedImageButton = (Button) rootView.findViewById(R.id.post_add_featured_image_button);
         CardView featuredImageCardView = (CardView) rootView.findViewById(R.id.post_featured_image_card_view);
 
@@ -853,7 +854,7 @@ public class EditPostSettingsFragment extends Fragment {
             mediaUri = PhotonUtils.getPhotonImageUrl(mediaUri, size, 0);
         }
 
-        WordPressMediaUtils.loadNetworkImage(mediaUri, mFeaturedImageView, mImageLoader);
+        WordPressMediaUtils.loadNetworkImage(mediaUri, mFeaturedImageView);
     }
 
     private void launchFeaturedMediaPicker() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserAdapter.java
@@ -16,13 +16,11 @@ import android.widget.PopupMenu;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import com.android.volley.toolbox.NetworkImageView;
-
 import org.wordpress.android.R;
-import org.wordpress.android.WordPress;
 import org.wordpress.android.models.Theme;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.widgets.HeaderGridView;
+import org.wordpress.android.widgets.WPNetworkImageView;
 
 /**
  * Adapter for the {@link ThemeBrowserFragment}'s listview
@@ -43,7 +41,7 @@ public class ThemeBrowserAdapter extends CursorAdapter {
 
     private static class ThemeViewHolder {
         private final CardView cardView;
-        private final NetworkImageView imageView;
+        private final WPNetworkImageView imageView;
         private final TextView nameView;
         private final TextView activeView;
         private final TextView priceView;
@@ -53,7 +51,7 @@ public class ThemeBrowserAdapter extends CursorAdapter {
 
         ThemeViewHolder(View view) {
             cardView = (CardView) view.findViewById(R.id.theme_grid_card);
-            imageView = (NetworkImageView) view.findViewById(R.id.theme_grid_item_image);
+            imageView = (WPNetworkImageView) view.findViewById(R.id.theme_grid_item_image);
             nameView = (TextView) view.findViewById(R.id.theme_grid_item_name);
             priceView = (TextView) view.findViewById(R.id.theme_grid_item_price);
             activeView = (TextView) view.findViewById(R.id.theme_grid_item_active);
@@ -122,7 +120,7 @@ public class ThemeBrowserAdapter extends CursorAdapter {
             requestURL = screenshotURL;
         }
 
-        themeViewHolder.imageView.setImageUrl(requestURL + THEME_IMAGE_PARAMETER + mViewWidth, WordPress.sImageLoader);
+        themeViewHolder.imageView.setImageUrl(requestURL + THEME_IMAGE_PARAMETER + mViewWidth, WPNetworkImageView.ImageType.PHOTO);
         themeViewHolder.frameLayout.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -21,7 +21,6 @@ import android.widget.TextView;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.ImageLoader.ImageContainer;
 import com.android.volley.toolbox.ImageLoader.ImageListener;
-import com.android.volley.toolbox.NetworkImageView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -33,6 +32,7 @@ import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper.RefreshListener;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 import org.wordpress.android.widgets.HeaderGridView;
+import org.wordpress.android.widgets.WPNetworkImageView;
 
 /**
  * A fragment display the themes on a grid view.
@@ -364,7 +364,7 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener, 
     @Override
     public void onMovedToScrapHeap(View view) {
         // cancel image fetch requests if the view has been moved to recycler.
-        NetworkImageView niv = (NetworkImageView) view.findViewById(R.id.theme_grid_item_image);
+        WPNetworkImageView niv = (WPNetworkImageView) view.findViewById(R.id.theme_grid_item_image);
         if (niv != null) {
             // this tag is set in the ThemeBrowserAdapter class
             String requestUrl = (String) niv.getTag();

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
@@ -15,6 +15,7 @@ import android.support.v7.widget.AppCompatImageView;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.View;
+import android.view.ViewGroup;
 
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.ImageLoader;
@@ -159,6 +160,23 @@ public class WPNetworkImageView extends AppCompatImageView {
             return;
         }
 
+        int width = getWidth();
+        int height = getHeight();
+        ScaleType scaleType = getScaleType();
+
+        boolean wrapWidth = false, wrapHeight = false;
+        if (getLayoutParams() != null) {
+            wrapWidth = getLayoutParams().width == ViewGroup.LayoutParams.WRAP_CONTENT;
+            wrapHeight = getLayoutParams().height == ViewGroup.LayoutParams.WRAP_CONTENT;
+        }
+
+        // if the view's bounds aren't known yet, and this is not a wrap-content/wrap-content
+        // view, hold off on loading the image.
+        boolean isFullyWrapContent = wrapWidth && wrapHeight;
+        if (width == 0 && height == 0 && !isFullyWrapContent) {
+            return;
+        }
+
         // if the URL to be loaded in this view is empty, cancel any old requests and clear the
         // currently loaded image.
         if (TextUtils.isEmpty(mUrl)) {
@@ -193,10 +211,15 @@ public class WPNetworkImageView extends AppCompatImageView {
             return;
         }
 
+
+        // Calculate the max image width / height to use while ignoring WRAP_CONTENT dimens.
+        int maxWidth = wrapWidth ? 0 : width;
+        int maxHeight = wrapHeight ? 0 : height;
+
         // The pre-existing content of this view didn't match the current URL. Load the new image
         // from the network.
         ImageLoader.ImageContainer newContainer = WordPress.sImageLoader.get(mUrl,
-                new WPNetworkImageLoaderListener(mUrl, isInLayoutPass, imageLoadListener), 0, 0, getScaleType());
+                new WPNetworkImageLoaderListener(mUrl, isInLayoutPass, imageLoadListener), maxWidth, maxHeight, scaleType);
         // update the ImageContainer to be the new bitmap container.
         mImageContainer = newContainer;
     }

--- a/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
+++ b/WordPress/src/main/res/layout/edit_post_settings_fragment.xml
@@ -139,7 +139,7 @@
                         android:layout_height="wrap_content"
                         android:text="@string/post_settings_set_featured_image"/>
 
-                    <com.android.volley.toolbox.NetworkImageView
+                    <org.wordpress.android.widgets.WPNetworkImageView
                         android:id="@+id/post_featured_image"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/theme_grid_item.xml
+++ b/WordPress/src/main/res/layout/theme_grid_item.xml
@@ -26,7 +26,7 @@
                 android:layout_height="wrap_content"
                 android:foreground="?android:attr/selectableItemBackground">
 
-                <org.wordpress.android.ui.FadeInNetworkImageView
+                <org.wordpress.android.widgets.WPNetworkImageView
                     android:id="@+id/theme_grid_item_image"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
Fixes #6296 & #6300

Upgraded `WPNetworkImageView` to be in par with the latest version of the code available in Volley. Basically there is just an additional check to not draw the picture when the dimensions are not known, and it's not a wrap-content/wrap-content view item.

This PR also fixes an issue on Themes, where the app was crashing since `FadeInNetworkImage` was recently removed without checking usage in XML files. Shame on me for this.

Also use `WPNetworkImageView` for featured images, and get rid of duplicate code in Utils.

cc @nbradbury 