### PR TITLE
issue/media-browser-smarter-refresh

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -142,7 +142,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:2d7b093dc615865bd024fef8b963d855a984e55c') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:0f45e36dcca7e825d27f7cc3bac593f3d6790c85') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -101,9 +101,11 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
     }
 
     public void setMediaList(@NonNull List<MediaModel> mediaList) {
-        mMediaList.clear();
-        mMediaList.addAll(mediaList);
-        notifyDataSetChanged();
+        if (!isSameList(mediaList)) {
+            mMediaList.clear();
+            mMediaList.addAll(mediaList);
+            notifyDataSetChanged();
+        }
     }
 
     @Override
@@ -548,5 +550,29 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                 return mContext.getString(R.string.media_upload_state_uploaded);
         }
         return "";
+    }
+
+    /*
+     * returns true if the passed list is the same as the existing one
+     */
+    private boolean isSameList(@NonNull List<MediaModel> otherList) {
+        if (otherList.size() != mMediaList.size()) {
+            return false;
+        }
+
+        for (MediaModel otherMedia : otherList) {
+            boolean exists = false;
+            for (MediaModel thisMedia: mMediaList) {
+                if (thisMedia.getId() == otherMedia.getId()) {
+                    exists = true;
+                    break;
+                }
+            }
+            if (!exists) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
This PR resolves the flickering media browser as described [here](https://github.com/wordpress-mobile/WordPress-Android/pull/6271) by relying on [this recent FluxC fix](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/514) to only reload the adapter when the media list has changed.