### PR TITLE
Issue/6288 photo picker multiselect flicker

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
@@ -2,11 +2,13 @@ package org.wordpress.android.ui.photopicker;
 
 import android.content.Context;
 import android.database.Cursor;
+import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Handler;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -78,6 +80,8 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
     private final ThumbnailLoader mThumbnailLoader;
     private final PhotoPickerAdapterListener mListener;
     private final LayoutInflater mInflater;
+    private final Drawable mBackground;
+
     private final ArrayList<PhotoPickerItem> mMediaList = new ArrayList<>();
 
     public PhotoPickerAdapter(Context context,
@@ -87,6 +91,8 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
         mListener = listener;
         mInflater = LayoutInflater.from(context);
         mThumbnailLoader = new ThumbnailLoader(context);
+        mBackground = ContextCompat.getDrawable(context, R.drawable.photo_picker_item_background);
+
         setHasStableIds(true);
     }
 
@@ -167,7 +173,7 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
 
         // clear the thumbnail unless we've temporarily disabled it
         if (!mDisableImageReset) {
-            holder.imgThumbnail.setImageResource(R.drawable.photo_picker_item_background);
+            holder.imgThumbnail.setImageDrawable(mBackground);
         }
 
         // don't load the thumbnail during a fling (reduces memory usage)

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
@@ -72,7 +72,6 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
     private boolean mIsMultiSelectEnabled;
     private boolean mPhotosOnly;
     private boolean mIsListTaskRunning;
-    private boolean mIsFlinging;
     private boolean mDisableImageReset;
 
     private final ThumbnailLoader mThumbnailLoader;
@@ -171,20 +170,8 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
             holder.imgThumbnail.setImageDrawable(null);
         }
 
-        if (!mIsFlinging) {
-            boolean animate = !mDisableImageReset;
-            mThumbnailLoader.loadThumbnail(holder.imgThumbnail, item._id, item.isVideo, animate);
-        }
-    }
-
-    void setIsFlinging(boolean isFlinging) {
-        if (isFlinging != mIsFlinging) {
-            mIsFlinging = isFlinging;
-            AppLog.w(AppLog.T.MEDIA, "isFlinging = " + isFlinging + " " + System.currentTimeMillis());
-            if (!mIsFlinging) {
-                notifyDataSetChangedInternal();
-            }
-        }
+        boolean animate = !mDisableImageReset;
+        mThumbnailLoader.loadThumbnail(holder.imgThumbnail, item._id, item.isVideo, animate);
     }
 
     private PhotoPickerItem getItemAtPosition(int position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
@@ -2,13 +2,11 @@ package org.wordpress.android.ui.photopicker;
 
 import android.content.Context;
 import android.database.Cursor;
-import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Handler;
 import android.provider.MediaStore;
 import android.support.annotation.NonNull;
-import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -80,7 +78,6 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
     private final ThumbnailLoader mThumbnailLoader;
     private final PhotoPickerAdapterListener mListener;
     private final LayoutInflater mInflater;
-    private final Drawable mBackground;
 
     private final ArrayList<PhotoPickerItem> mMediaList = new ArrayList<>();
 
@@ -91,7 +88,6 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
         mListener = listener;
         mInflater = LayoutInflater.from(context);
         mThumbnailLoader = new ThumbnailLoader(context);
-        mBackground = ContextCompat.getDrawable(context, R.drawable.photo_picker_item_background);
 
         setHasStableIds(true);
     }
@@ -171,12 +167,10 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
         holder.imgPreview.setVisibility(item.isVideo ? View.GONE : View.VISIBLE);
         holder.videoOverlay.setVisibility(item.isVideo ? View.VISIBLE : View.GONE);
 
-        // clear the thumbnail unless we've temporarily disabled it
         if (!mDisableImageReset) {
-            holder.imgThumbnail.setImageDrawable(mBackground);
+            holder.imgThumbnail.setImageDrawable(null);
         }
 
-        // don't load the thumbnail during a fling (reduces memory usage)
         if (!mIsFlinging) {
             boolean animate = !mDisableImageReset;
             mThumbnailLoader.loadThumbnail(holder.imgThumbnail, item._id, item.isVideo, animate);

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
@@ -72,6 +72,7 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
     private boolean mIsMultiSelectEnabled;
     private boolean mPhotosOnly;
     private boolean mIsListTaskRunning;
+    private boolean mIsFlinging;
 
     private final ThumbnailLoader mThumbnailLoader;
     private final PhotoPickerAdapterListener mListener;
@@ -163,7 +164,23 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
         holder.imgPreview.setVisibility(item.isVideo ? View.GONE : View.VISIBLE);
         holder.videoOverlay.setVisibility(item.isVideo ? View.VISIBLE : View.GONE);
 
-        mThumbnailLoader.loadThumbnail(holder.imgThumbnail, item._id, item.isVideo);
+        // load the thumbnail unless the user is in a fling, in which case simply show the
+        // placeholder to reduce memory consumption while the fling is in progress
+        if (!mIsFlinging) {
+            mThumbnailLoader.loadThumbnail(holder.imgThumbnail, item._id, item.isVideo);
+        } else {
+            holder.imgThumbnail.setImageResource(R.drawable.photo_picker_item_background);
+        }
+    }
+
+    public void setIsFlinging(boolean isFlinging) {
+        AppLog.w(AppLog.T.MEDIA, "isFlinging = " + isFlinging);
+        if (isFlinging != mIsFlinging) {
+            mIsFlinging = isFlinging;
+            if (!mIsFlinging) {
+                notifyDataSetChanged();
+            }
+        }
     }
 
     private PhotoPickerItem getItemAtPosition(int position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -30,7 +30,6 @@ import org.wordpress.android.ui.photopicker.PhotoPickerAdapter.PhotoPickerAdapte
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.SmartToast;
 import org.wordpress.android.util.WPPermissionUtils;
@@ -85,8 +84,6 @@ public class PhotoPickerFragment extends Fragment {
     private static final String ARG_PHOTOS_ONLY = "photos_only";
     private static final String ARG_DEVICE_ONLY = "device_only";
 
-    private static final int MIN_DISTANCE_DP = 48;
-
     public static PhotoPickerFragment newInstance(@NonNull PhotoPickerListener listener,
                                                   @NonNull EnumSet<PhotoPickerOption> options) {
         Bundle args = new Bundle();
@@ -129,32 +126,6 @@ public class PhotoPickerFragment extends Fragment {
 
         mRecycler = (RecyclerView) view.findViewById(R.id.recycler);
         mRecycler.setHasFixedSize(true);
-
-        // detect flings so we can disable thumbnail loading during them
-        final int minDistancePx = DisplayUtils.dpToPx(getActivity(), MIN_DISTANCE_DP);
-        mRecycler.setOnFlingListener(new RecyclerView.OnFlingListener() {
-            @Override
-            public boolean onFling(int velocityX, int velocityY) {
-                setIsFlinging(true);
-                return false;
-            }
-        });
-        mRecycler.addOnScrollListener(new RecyclerView.OnScrollListener() {
-            @Override
-            public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
-                super.onScrollStateChanged(recyclerView, newState);
-                if (newState == RecyclerView.SCROLL_STATE_IDLE) {
-                    setIsFlinging(false);
-                }
-            }
-            @Override
-            public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
-                super.onScrolled(recyclerView, dx, dy);
-                if (dy <= minDistancePx) {
-                    setIsFlinging(false);
-                }
-            }
-        });
 
         mBottomBar = view.findViewById(R.id.bottom_bar);
         mBottomBar.findViewById(R.id.icon_camera).setOnClickListener(new View.OnClickListener() {
@@ -204,12 +175,6 @@ public class PhotoPickerFragment extends Fragment {
     public void onResume() {
         super.onResume();
         checkStoragePermission();
-    }
-
-    private void setIsFlinging(boolean isFlinging) {
-        if (hasAdapter()) {
-            //getAdapter().setIsFlinging(isFlinging);
-        }
     }
 
     private void doIconClicked(@NonNull PhotoPickerIcon icon) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -30,6 +30,7 @@ import org.wordpress.android.ui.photopicker.PhotoPickerAdapter.PhotoPickerAdapte
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.SmartToast;
 import org.wordpress.android.util.WPPermissionUtils;
@@ -84,6 +85,8 @@ public class PhotoPickerFragment extends Fragment {
     private static final String ARG_PHOTOS_ONLY = "photos_only";
     private static final String ARG_DEVICE_ONLY = "device_only";
 
+    private static final int MIN_DISTANCE_DP = 48;
+
     public static PhotoPickerFragment newInstance(@NonNull PhotoPickerListener listener,
                                                   @NonNull EnumSet<PhotoPickerOption> options) {
         Bundle args = new Bundle();
@@ -100,6 +103,7 @@ public class PhotoPickerFragment extends Fragment {
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
         Bundle args = getArguments();
         if (args != null) {
             mAllowMultiSelect = args.getBoolean(ARG_ALLOW_MULTI_SELECT, false);
@@ -126,10 +130,12 @@ public class PhotoPickerFragment extends Fragment {
         mRecycler = (RecyclerView) view.findViewById(R.id.recycler);
         mRecycler.setHasFixedSize(true);
 
+        // detect flings so we can disable thumbnail loading during them
+        final int minDistancePx = DisplayUtils.dpToPx(getActivity(), MIN_DISTANCE_DP);
         mRecycler.setOnFlingListener(new RecyclerView.OnFlingListener() {
             @Override
             public boolean onFling(int velocityX, int velocityY) {
-                getAdapter().setIsFlinging(true);
+                setIsFlinging(true);
                 return false;
             }
         });
@@ -137,9 +143,15 @@ public class PhotoPickerFragment extends Fragment {
             @Override
             public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
                 super.onScrollStateChanged(recyclerView, newState);
-                if (newState == RecyclerView.SCROLL_STATE_IDLE
-                        || newState == RecyclerView.SCROLL_STATE_SETTLING) {
-                    getAdapter().setIsFlinging(false);
+                if (newState == RecyclerView.SCROLL_STATE_IDLE) {
+                    setIsFlinging(false);
+                }
+            }
+            @Override
+            public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
+                super.onScrolled(recyclerView, dx, dy);
+                if (dy <= minDistancePx) {
+                    setIsFlinging(false);
                 }
             }
         });
@@ -192,6 +204,12 @@ public class PhotoPickerFragment extends Fragment {
     public void onResume() {
         super.onResume();
         checkStoragePermission();
+    }
+
+    private void setIsFlinging(boolean isFlinging) {
+        if (hasAdapter()) {
+            getAdapter().setIsFlinging(isFlinging);
+        }
     }
 
     private void doIconClicked(@NonNull PhotoPickerIcon icon) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -208,7 +208,7 @@ public class PhotoPickerFragment extends Fragment {
 
     private void setIsFlinging(boolean isFlinging) {
         if (hasAdapter()) {
-            getAdapter().setIsFlinging(isFlinging);
+            //getAdapter().setIsFlinging(isFlinging);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -133,6 +133,23 @@ public class PhotoPickerFragment extends Fragment {
 
         mRecycler = (RecyclerView) view.findViewById(R.id.recycler);
         mRecycler.setHasFixedSize(true);
+        mRecycler.setOnFlingListener(new RecyclerView.OnFlingListener() {
+            @Override
+            public boolean onFling(int velocityX, int velocityY) {
+                getAdapter().setIsFlinging(true);
+                return false;
+            }
+        });
+        mRecycler.addOnScrollListener(new RecyclerView.OnScrollListener() {
+            @Override
+            public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
+                super.onScrollStateChanged(recyclerView, newState);
+                if (newState == RecyclerView.SCROLL_STATE_SETTLING
+                        || newState == RecyclerView.SCROLL_STATE_IDLE) {
+                    getAdapter().setIsFlinging(false);
+                }
+            }
+        });
 
         mBottomBar = view.findViewById(R.id.bottom_bar);
         mBottomBar.findViewById(R.id.icon_camera).setOnClickListener(new View.OnClickListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -108,14 +108,6 @@ public class PhotoPickerFragment extends Fragment {
         }
     }
 
-    @Override
-    public void setArguments(Bundle args) {
-        super.setArguments(args);
-        mAllowMultiSelect = args.getBoolean(ARG_ALLOW_MULTI_SELECT);
-        mPhotosOnly = args.getBoolean(ARG_PHOTOS_ONLY);
-        mDeviceOnly = args.getBoolean(ARG_DEVICE_ONLY);
-    }
-
     public void setOptions(@NonNull EnumSet<PhotoPickerOption> options) {
         mAllowMultiSelect = options.contains(PhotoPickerOption.ALLOW_MULTI_SELECT);
         mPhotosOnly = options.contains(PhotoPickerOption.PHOTOS_ONLY);
@@ -133,6 +125,7 @@ public class PhotoPickerFragment extends Fragment {
 
         mRecycler = (RecyclerView) view.findViewById(R.id.recycler);
         mRecycler.setHasFixedSize(true);
+
         mRecycler.setOnFlingListener(new RecyclerView.OnFlingListener() {
             @Override
             public boolean onFling(int velocityX, int velocityY) {
@@ -144,8 +137,8 @@ public class PhotoPickerFragment extends Fragment {
             @Override
             public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
                 super.onScrollStateChanged(recyclerView, newState);
-                if (newState == RecyclerView.SCROLL_STATE_SETTLING
-                        || newState == RecyclerView.SCROLL_STATE_IDLE) {
+                if (newState == RecyclerView.SCROLL_STATE_IDLE
+                        || newState == RecyclerView.SCROLL_STATE_SETTLING) {
                     getAdapter().setIsFlinging(false);
                 }
             }

--- a/WordPress/src/main/res/layout/photo_picker_thumbnail.xml
+++ b/WordPress/src/main/res/layout/photo_picker_thumbnail.xml
@@ -15,6 +15,7 @@
             android:id="@+id/image_thumbnail"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:background="@drawable/photo_picker_item_background"
             android:scaleType="centerCrop"
             tools:src="@drawable/gravatar_placeholder" />
 


### PR DESCRIPTION
Fixes #6288 by letting the adapter determine when to fade in thumbnails and when to reset them. Should also improve the performance of the adapter due to no longer using `setImageResource()` every time a thumbnail is loaded.
