### PR TITLE
Issue/photo picker memory usage

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
@@ -73,6 +73,7 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
     private boolean mPhotosOnly;
     private boolean mIsListTaskRunning;
     private boolean mDisableImageReset;
+    private boolean mLoadThumbnails = true;
 
     private final ThumbnailLoader mThumbnailLoader;
     private final PhotoPickerAdapterListener mListener;
@@ -135,6 +136,16 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
         return mMediaList.size() == 0;
     }
 
+    void setLoadThumbnails(boolean loadThumbnails) {
+        if (loadThumbnails != mLoadThumbnails) {
+            mLoadThumbnails = loadThumbnails;
+            AppLog.d(AppLog.T.MEDIA, "PhotoPickerAdapter > loadThumbnails = " + loadThumbnails);
+            if (mLoadThumbnails) {
+                notifyDataSetChangedInternal();
+            }
+        }
+    }
+
     @Override
     public ThumbnailViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View view = mInflater.inflate(R.layout.photo_picker_thumbnail, parent, false);
@@ -170,13 +181,15 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
             holder.imgThumbnail.setImageDrawable(null);
         }
 
-        boolean animate = !mDisableImageReset;
-        mThumbnailLoader.loadThumbnail(
-                holder.imgThumbnail,
-                item._id,
-                item.isVideo,
-                animate,
-                mThumbWidth);
+        if (mLoadThumbnails) {
+            boolean animate = !mDisableImageReset;
+            mThumbnailLoader.loadThumbnail(
+                    holder.imgThumbnail,
+                    item._id,
+                    item.isVideo,
+                    animate,
+                    mThumbWidth);
+        }
     }
 
     private PhotoPickerItem getItemAtPosition(int position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerAdapter.java
@@ -171,7 +171,12 @@ class PhotoPickerAdapter extends RecyclerView.Adapter<PhotoPickerAdapter.Thumbna
         }
 
         boolean animate = !mDisableImageReset;
-        mThumbnailLoader.loadThumbnail(holder.imgThumbnail, item._id, item.isVideo, animate);
+        mThumbnailLoader.loadThumbnail(
+                holder.imgThumbnail,
+                item._id,
+                item.isVideo,
+                animate,
+                mThumbWidth);
     }
 
     private PhotoPickerItem getItemAtPosition(int position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -20,6 +20,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.widget.PopupMenu;
 import android.widget.TextView;
@@ -79,6 +80,7 @@ public class PhotoPickerFragment extends Fragment {
     private boolean mAllowMultiSelect;
     private boolean mPhotosOnly;
     private boolean mDeviceOnly;
+    private boolean mIsFlinging;
 
     private static final String ARG_ALLOW_MULTI_SELECT = "allow_multi_select";
     private static final String ARG_PHOTOS_ONLY = "photos_only";
@@ -126,6 +128,27 @@ public class PhotoPickerFragment extends Fragment {
 
         mRecycler = (RecyclerView) view.findViewById(R.id.recycler);
         mRecycler.setHasFixedSize(true);
+
+        // disable thumbnail loading during a fling to conserve memory
+        final int minDistance = ViewConfiguration.get(getActivity()).getScaledMaximumFlingVelocity() / 2;
+        mRecycler.setOnFlingListener(new RecyclerView.OnFlingListener() {
+            @Override
+            public boolean onFling(int velocityX, int velocityY) {
+                if (Math.abs(velocityY) > minDistance) {
+                    getAdapter().setLoadThumbnails(false);
+                }
+                return false;
+            }
+        });
+        mRecycler.addOnScrollListener(new RecyclerView.OnScrollListener() {
+            @Override
+            public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
+                super.onScrollStateChanged(recyclerView, newState);
+                if (newState == RecyclerView.SCROLL_STATE_IDLE) {
+                    getAdapter().setLoadThumbnails(true);
+                }
+            }
+        });
 
         mBottomBar = view.findViewById(R.id.bottom_bar);
         mBottomBar.findViewById(R.id.icon_camera).setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
Makes a couple of tweaks to the photo picker to reduce memory usage:

1. Loads thumbnails at the exact size needed (previously we stuck with the MINI_KIND size of 512 x 384, which is larger than many devices need).

2. Disables thumbnail loading during a reasonably-sized fling. This is something the Twitter app appears to do as well.

Note that this PR is in response to #6283, but we shouldn't mark that as closed because it suggests that there's a memory problem in Aztec.

