### PR TITLE
Add missing "all" string and improve notification tabs string names

### DIFF
--- a/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
+++ b/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
@@ -94,7 +94,7 @@
                         android:id="@+id/notifications_filter_all"
                         style="@style/Calypso.SegmentedControl"
                         android:background="@drawable/calypso_segmented_control_button_start"
-                        android:text="@string/all" />
+                        android:text="@string/notifications_tab_title_all" />
 
                     <RadioButton
                         android:id="@+id/notifications_filter_unread"
@@ -102,7 +102,7 @@
                         android:layout_marginLeft="-1dp"
                         android:layout_marginStart="-1dp"
                         android:background="@drawable/calypso_segmented_control_button"
-                        android:text="@string/unread" />
+                        android:text="@string/notifications_tab_title_unread" />
 
                     <RadioButton
                         android:id="@+id/notifications_filter_comments"
@@ -110,7 +110,7 @@
                         android:layout_marginLeft="-1dp"
                         android:layout_marginStart="-1dp"
                         android:background="@drawable/calypso_segmented_control_button"
-                        android:text="@string/tab_comments" />
+                        android:text="@string/notifications_tab_title_comments" />
 
                     <RadioButton
                         android:id="@+id/notifications_filter_follows"
@@ -118,7 +118,7 @@
                         android:layout_marginLeft="-1dp"
                         android:layout_marginStart="-1dp"
                         android:background="@drawable/calypso_segmented_control_button"
-                        android:text="@string/follows" />
+                        android:text="@string/notifications_tab_title_follows" />
 
                     <RadioButton
                         android:id="@+id/notifications_filter_likes"
@@ -126,7 +126,7 @@
                         android:layout_marginLeft="-1dp"
                         android:layout_marginStart="-1dp"
                         android:background="@drawable/calypso_segmented_control_button_end"
-                        android:text="@string/stats_likes" />
+                        android:text="@string/notifications_tab_title_likes" />
                 </RadioGroup>
             </HorizontalScrollView>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -197,9 +197,6 @@
     <string name="media_details_copy_url">Copy URL</string>
     <string name="media_details_copy_url_toast">URL copied to clipboard</string>
 
-    <!-- tab titles -->
-    <string name="tab_comments" translatable="false">@string/comments</string>
-
     <!-- themes -->
     <string name="themes_live_preview">Live preview</string>
     <string name="themes_details_label">Details</string>
@@ -892,10 +889,14 @@
     <string name="error_notification_open">Could not open notification</string>
     <string name="ignore">Ignore</string>
     <string name="push_auth_expired">The request has expired. Log in to WordPress.com to try again.</string>
-    <string name="unread">Unread</string>
     <string name="follows">Follows</string>
     <string name="notifications_label_new_notifications">New notifications</string>
     <string name="notifications_label_new_notifications_subtitle">Tap to show them</string>
+    <string name="notifications_tab_title_all">All</string>
+    <string name="notifications_tab_title_unread">Unread</string>
+    <string name="notifications_tab_title_comments" translatable="false">@string/comments</string>
+    <string name="notifications_tab_title_follows" translatable="false">@string/follows</string>
+    <string name="notifications_tab_title_likes" translatable="false">@string/stats_likes</string>
 
     <!-- Notification Settings -->
     <string name="notification_settings">Notification Settings</string>


### PR DESCRIPTION
Fixes #6308. This PR adds the missing "all" string resource and while at it improves the naming for the notification tab titles. Since the translations will be overridden, they haven't been changed.

To test:
* Go into navigation tab and make sure the tab names are correct. (Keep in mind that "all" & "unread" resources will need to be translated)

P.S: Friendly reminder to merge the release branch back to develop when this PR is merged. Thanks!