### PR TITLE
Possible fix to duplicate gravatar/blavatar issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/CommentUserNoteBlock.java
@@ -81,7 +81,7 @@ public class CommentUserNoteBlock extends UserNoteBlock {
                 noteBlockHolder.avatarImageView.setOnTouchListener(null);
             }
         } else {
-            noteBlockHolder.avatarImageView.showDefaultGravatarImage();
+            noteBlockHolder.avatarImageView.showDefaultGravatarImageAndNullifyUrl();
             noteBlockHolder.avatarImageView.setOnTouchListener(null);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/UserNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/UserNoteBlock.java
@@ -96,7 +96,7 @@ public class UserNoteBlock extends NoteBlock {
                 noteBlockHolder.rootView.setOnClickListener(null);
             }
         } else {
-            noteBlockHolder.avatarImageView.showDefaultGravatarImage();
+            noteBlockHolder.avatarImageView.showDefaultGravatarImageAndNullifyUrl();
             noteBlockHolder.avatarImageView.setOnTouchListener(null);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeConnectionAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/adapters/PublicizeConnectionAdapter.java
@@ -95,7 +95,7 @@ public class PublicizeConnectionAdapter extends RecyclerView.Adapter<PublicizeCo
             holder.imgAvatar.setImageUrl(connection.getExternalProfilePictureUrl(),
                     WPNetworkImageView.ImageType.AVATAR);
         } else {
-            holder.imgAvatar.showDefaultGravatarImage();
+            holder.imgAvatar.showDefaultGravatarImageAndNullifyUrl();
         }
 
         holder.btnConnect.setAction(PublicizeConstants.ConnectAction.DISCONNECT);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderCommentAdapter.java
@@ -230,7 +230,7 @@ public class ReaderCommentAdapter extends RecyclerView.Adapter<RecyclerView.View
             String avatarUrl = GravatarUtils.fixGravatarUrl(comment.getAuthorAvatar(), mAvatarSz);
             commentHolder.imgAvatar.setImageUrl(avatarUrl, WPNetworkImageView.ImageType.AVATAR);
         } else {
-            commentHolder.imgAvatar.showDefaultGravatarImage();
+            commentHolder.imgAvatar.showDefaultGravatarImageAndNullifyUrl();
         }
 
         // tapping avatar or author name opens blog preview

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -336,7 +336,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                     GravatarUtils.fixGravatarUrl(post.getPostAvatar(), mAvatarSzSmall),
                     WPNetworkImageView.ImageType.AVATAR);
         } else {
-            holder.imgAvatar.showDefaultGravatarImage();
+            holder.imgAvatar.showDefaultGravatarImageAndNullifyUrl();
         }
 
         if (post.hasBlogImageUrl()) {
@@ -535,7 +535,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 if (discoverData.hasAvatarUrl()) {
                     postHolder.imgDiscoverAvatar.setImageUrl(GravatarUtils.fixGravatarUrl(discoverData.getAvatarUrl(), mAvatarSzSmall), WPNetworkImageView.ImageType.AVATAR);
                 } else {
-                    postHolder.imgDiscoverAvatar.showDefaultGravatarImage();
+                    postHolder.imgDiscoverAvatar.showDefaultGravatarImageAndNullifyUrl();
                 }
                 // tapping an editor pick opens the source post, which is handled by the existing
                 // post selection handler

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -344,7 +344,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                     GravatarUtils.fixGravatarUrl(post.getBlogImageUrl(), mAvatarSzSmall),
                     WPNetworkImageView.ImageType.BLAVATAR);
         } else {
-            holder.imgBlavatar.showDefaultBlavatarImage();
+            holder.imgBlavatar.showDefaultBlavatarImageAndNullifyUrl();
         }
 
         holder.txtTitle.setText(ReaderXPostUtils.getXPostTitle(post));
@@ -554,7 +554,7 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                     postHolder.imgDiscoverAvatar.setImageUrl(
                             GravatarUtils.fixGravatarUrl(discoverData.getAvatarUrl(), mAvatarSzSmall), WPNetworkImageView.ImageType.BLAVATAR);
                 } else {
-                    postHolder.imgDiscoverAvatar.showDefaultBlavatarImage();
+                    postHolder.imgDiscoverAvatar.showDefaultBlavatarImageAndNullifyUrl();
                 }
                 // site picks show "Visit [BlogName]" link - tapping opens the blog preview if
                 // we have the blogId, if not show blog in internal webView

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderUserAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderUserAdapter.java
@@ -77,7 +77,7 @@ public class ReaderUserAdapter  extends RecyclerView.Adapter<ReaderUserAdapter.U
                     GravatarUtils.fixGravatarUrl(user.getAvatarUrl(), mAvatarSz),
                     WPNetworkImageView.ImageType.AVATAR);
         } else {
-            holder.imgAvatar.showDefaultGravatarImage();
+            holder.imgAvatar.showDefaultGravatarImageAndNullifyUrl();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
@@ -441,7 +441,11 @@ public class WPNetworkImageView extends AppCompatImageView {
         }
     }
 
-    public void showDefaultGravatarImage() {
+    public void showDefaultGravatarImageAndNullifyUrl() {
+        setImageUrl(null, ImageType.AVATAR);
+    }
+
+    private void showDefaultGravatarImage() {
         if (getContext() == null) return;
         try {
             new ShapeBitmapTask(ShapeType.CIRCLE, null).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, BitmapFactory.decodeResource(
@@ -451,7 +455,6 @@ public class WPNetworkImageView extends AppCompatImageView {
         } catch (RejectedExecutionException e) {
             AppLog.w(AppLog.T.UTILS, "Too many tasks already available in the default AsyncTask.THREAD_POOL_EXECUTOR queue. " +
                     "The current DefaultGravatarImage was rejected");
-            return;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
@@ -442,6 +442,7 @@ public class WPNetworkImageView extends AppCompatImageView {
     }
 
     public void showDefaultGravatarImageAndNullifyUrl() {
+        // Setting the image url `null` will result in showing the default image by calling `showErrorImage`
         setImageUrl(null, ImageType.AVATAR);
     }
 
@@ -459,6 +460,7 @@ public class WPNetworkImageView extends AppCompatImageView {
     }
 
     public void showDefaultBlavatarImageAndNullifyUrl() {
+        // Setting the image url `null` will result in showing the default image by calling `showErrorImage`
         setImageUrl(null, ImageType.BLAVATAR);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNetworkImageView.java
@@ -458,7 +458,11 @@ public class WPNetworkImageView extends AppCompatImageView {
         }
     }
 
-    public void showDefaultBlavatarImage() {
+    public void showDefaultBlavatarImageAndNullifyUrl() {
+        setImageUrl(null, ImageType.BLAVATAR);
+    }
+
+    private void showDefaultBlavatarImage() {
         setImageResource(R.drawable.ic_placeholder_blavatar_grey_lighten_20_40dp);
     }
 


### PR DESCRIPTION
Fixes #4709. I believe the reason we have these duplicate gravatar issues is that we are using the `WPNetworkImageView.showDefaultGravatarImage` directly which means we bypass all the `null` handling logic in `WPNetworkImageView.loadImageIfNecessary`. Here is an easily reproducible example where this can be showcased:

In `ReaderUserAdapter.onBindViewHolder` add the following code at the end and comment out the `if/else` statement for setting the `imgAvatar`:

```
holder.imgAvatar.setImageUrl("http://lorempixel.com/400/200/", WPNetworkImageView.ImageType.AVATAR);
holder.imgAvatar.showDefaultGravatarImage();
```

You can either do this on `develop` or change the `showDefaultGravatarImage` back to public in this branch. Now, go into any reader post, open the likes view and you should see the gravatars popping up for all users even though the last call we make is for showing the default gravatar. This happens because when the callback happens for the previous url, the `imgAvatar` will still think that it's showing that particular url (since it's never nullified), so it'll update the image.

Please note that for subsequent tests, you may need to change the lorempixel url (just change the size), so that the caching doesn't come into play.

Now try the following instead and observe that default gravatars are shown for all users as expected:

```
holder.imgAvatar.setImageUrl("http://lorempixel.com/400/200/", WPNetworkImageView.ImageType.AVATAR);
holder.imgAvatar.showDefaultGravatarImageAndNullifyUrl();
```

Please note that the reason this works is if the url is `null` for the network image, it'll show the error image which will be the default gravatar if the type is `AVATAR` and the default blavatar if the type is `BLAVATAR`. It'll also cancel all pending requests and nullify the view's url which is why we shouldn't have bypassed all that.

-------------------------

Assuming that I am correct about why this is happening, I think we should never expose the `showDefaultGravatarImage` & `showDefaultBlavatarImage` methods to make sure that the urls are properly nullified. I have introduced new helper methods that'll handle all this for us and will still have the name `showDefaultGravatar`, so we don't have to know how all this works.


To test:
* Testing instructions are explained in the PR description as this is a hard case to reproduce and testing steps is a part of the explanation

/cc @nbradbury 
