### PR TITLE
Login Rework: email password screen visual touches

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
@@ -131,7 +131,7 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment implements
             return;
         }
 
-        showProgressDialog();
+        startProgress();
 
         mRequestedPassword = mPasswordInput.getEditText().getText().toString();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.accounts.login;
 
 import android.content.Context;
+import android.graphics.Rect;
 import android.os.Bundle;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.Nullable;
@@ -18,6 +19,7 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.ScrollView;
 import android.widget.TextView;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -51,6 +53,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment impleme
 
     public static final String TAG = "login_username_password_fragment_tag";
 
+    private ScrollView mScrollView;
     private WPLoginInputRow mUsernameInput;
     private WPLoginInputRow mPasswordInput;
 
@@ -96,6 +99,8 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment impleme
 
     @Override
     protected void setupContent(ViewGroup rootView) {
+        mScrollView = (ScrollView) rootView.findViewById(R.id.scroll_view);
+
         rootView.findViewById(R.id.login_site_title_static).setVisibility(mIsWpcom ? View.GONE : View.VISIBLE);
         rootView.findViewById(R.id.login_blavatar_static).setVisibility(mIsWpcom ? View.GONE : View.VISIBLE);
         rootView.findViewById(R.id.login_blavatar).setVisibility(mIsWpcom ? View.VISIBLE : View.GONE);
@@ -294,6 +299,17 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment impleme
     private void showError(String errorMessage) {
         mUsernameInput.setError(errorMessage != null ? " " : null);
         mPasswordInput.setError(errorMessage);
+
+        if (errorMessage != null) {
+            mPasswordInput.post(new Runnable() {
+                @Override
+                public void run() {
+                    Rect rect = new Rect(); //coordinates to scroll to
+                    mPasswordInput.getHitRect(rect);
+                    mScrollView.requestChildRectangleOnScreen(mPasswordInput, rect, false);
+                }
+            });
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -1,19 +1,12 @@
 package org.wordpress.android.ui.accounts.login;
 
-import android.content.Context;
 import android.graphics.Rect;
 import android.os.Bundle;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.Nullable;
-import android.support.v7.app.ActionBar;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
@@ -169,24 +162,6 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment impleme
     }
 
     @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-
-        Toolbar toolbar = (Toolbar) view.findViewById(R.id.toolbar);
-        ((AppCompatActivity) getActivity()).setSupportActionBar(toolbar);
-
-        ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
-        if (actionBar != null) {
-            actionBar.setDisplayShowTitleEnabled(false);
-            actionBar.setDisplayHomeAsUpEnabled(true);
-        }
-
-        if (savedInstanceState == null) {
-            EditTextUtils.showSoftInput(mUsernameInput.getEditText());
-        }
-    }
-
-    @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
 
@@ -199,46 +174,12 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment impleme
     }
 
     @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-        if (context instanceof LoginListener) {
-            mLoginListener = (LoginListener) context;
-        } else {
-            throw new RuntimeException(context.toString() + " must implement LoginListener");
-        }
-    }
-
-    @Override
-    public void onDetach() {
-        super.onDetach();
-        mLoginListener = null;
-    }
-
-    @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
 
         outState.putBoolean(KEY_LOGIN_FINISHED, mLoginFinished);
         outState.putString(KEY_REQUESTED_USERNAME, mRequestedUsername);
         outState.putString(KEY_REQUESTED_PASSWORD, mRequestedPassword);
-    }
-
-    @Override
-    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
-        inflater.inflate(R.menu.menu_login, menu);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        if (item.getItemId() == R.id.help) {
-            if (mLoginListener != null) {
-                mLoginListener.help();
-            }
-
-            return true;
-        }
-
-        return false;
     }
 
     protected void next() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -118,6 +118,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment impleme
         mUsernameInput.setOnEditorCommitListener(new OnEditorCommitListener() {
             @Override
             public void OnEditorCommit() {
+                showError(null);
                 mPasswordInput.getEditText().requestFocus();
             }
         });
@@ -273,6 +274,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment impleme
 
     @Override
     public void OnEditorCommit() {
+        showError(null);
         next();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -286,12 +286,11 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment impleme
 
     @Override
     public void onTextChanged(CharSequence s, int start, int before, int count) {
-        mUsernameInput.setError(null);
-        mPasswordInput.setError(null);
+        showError(null);
     }
 
     private void showError(String errorMessage) {
-        mUsernameInput.setError(" ");
+        mUsernameInput.setError(errorMessage != null ? " " : null);
         mPasswordInput.setError(errorMessage);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -193,7 +193,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment impleme
             return;
         }
 
-        showProgressDialog();
+        startProgress();
 
         mRequestedUsername = getCleanedUsername();
         mRequestedPassword = mPasswordInput.getEditText().getText().toString();

--- a/WordPress/src/main/res/layout/login_email_password_screen.xml
+++ b/WordPress/src/main/res/layout/login_email_password_screen.xml
@@ -1,126 +1,72 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingLeft="@dimen/margin_extra_large"
+    android:paddingStart="@dimen/margin_extra_large"
+    android:paddingRight="@dimen/margin_extra_large"
+    android:paddingEnd="@dimen/margin_extra_large"
+    android:layout_marginBottom="@dimen/margin_extra_large">
 
-    <include
-        android:id="@+id/toolbar"
-        layout="@layout/toolbar_login" />
-
-    <ScrollView
+    <TextView
+        style="@style/LoginTheme.TextLabel"
+        android:id="@+id/label"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_below="@+id/toolbar"
-        android:fillViewport="true">
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:layout_marginBottom="@dimen/margin_extra_large"
+        tools:text="@string/enter_site_address" />
 
-        <RelativeLayout
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <ImageView
+            android:id="@+id/login_email_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/login_email_image"
+            android:tint="@color/grey_lighten_10"
+            app:srcCompat="@drawable/ic_user_grey_24dp"/>
+
+        <LinearLayout
+            android:id="@+id/login_email_label_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="@dimen/margin_extra_large">
+            android:orientation="vertical"
+            android:layout_marginLeft="@dimen/margin_extra_large"
+            android:layout_marginStart="@dimen/margin_extra_large">
 
             <TextView
-                style="@style/Base.TextAppearance.AppCompat.Body1"
-                android:id="@+id/label"
+                style="@style/LoginTheme.InputLabelStatic"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_extra_extra_large"
-                android:text="@string/enter_wpcom_password" />
+                android:text="@string/email_address"/>
 
-            <TableLayout
+            <TextView
+                style="@style/LoginTheme.TextLabel"
+                android:id="@+id/login_email"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_below="@id/label"
-                android:layout_marginTop="@dimen/margin_extra_large">
+                tools:text="s@b.com"/>
+        </LinearLayout>
+    </LinearLayout>
 
-                <TableRow
-                    android:gravity="center_vertical">
-
-                    <ImageView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        app:srcCompat="@drawable/ic_user_grey_24dp"/>
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="vertical"
-                        android:layout_weight="1"
-                        android:layout_marginLeft="@dimen/margin_extra_large">
-
-                        <TextView
-                            style="@style/TextAppearance.Design.Hint"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:text="@string/email_address"/>
-
-                        <TextView
-                            style="@style/Base.TextAppearance.AppCompat.Body1"
-                            android:id="@+id/login_email"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            tools:text="s@b.com"/>
-                    </LinearLayout>
-                </TableRow>
-
-                <TableRow
-                    android:layout_marginTop="@dimen/margin_extra_large">
-
-                    <ImageView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="24dp"
-                        app:srcCompat="@drawable/ic_lock_grey_24dp"/>
-
-                    <android.support.design.widget.TextInputLayout
-                        app:theme="@style/LoginTheme.EditText"
-                        android:id="@+id/login_password_layout"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        app:passwordToggleEnabled="true"
-                        app:passwordToggleTint="@color/wp_grey"
-                        android:layout_marginLeft="@dimen/margin_extra_large">
-
-                        <android.support.design.widget.TextInputEditText
-                            android:id="@+id/login_password"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:hint="@string/password"
-                            android:inputType="textPassword"/>
-                    </android.support.design.widget.TextInputLayout>
-                </TableRow>
-            </TableLayout>
-
-            <RelativeLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_alignParentBottom="true">
-
-                <Button
-                    android:theme="@style/LoginTheme.Button"
-                    style="@style/Widget.AppCompat.Button.Colored"
-                    android:id="@+id/login_email_password_next_button"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_centerVertical="true"
-                    android:layout_alignParentRight="true"
-                    android:enabled="false"
-                    android:text="@string/next" />
-
-                <TextView
-                    android:id="@+id/login_lost_password"
-                    style="@style/Base.TextAppearance.AppCompat.Caption"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_toLeftOf="@+id/login_email_password_next_button"
-                    android:layout_marginRight="@dimen/margin_extra_extra_extra_large"
-                    android:layout_centerVertical="true"
-                    android:layout_alignParentLeft="true"
-                    android:textColor="@color/blue_wordpress"
-                    android:text="@string/forgot_password"/>
-            </RelativeLayout>
-        </RelativeLayout>
-    </ScrollView>
-</RelativeLayout>
+    <org.wordpress.android.widgets.WPLoginInputRow
+        android:id="@+id/login_password_row"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:layout_marginBottom="@dimen/margin_extra_extra_large"
+        android:hint="@string/password"
+        android:inputType="textPassword"
+        app:passwordToggleEnabled="true"
+        app:passwordToggleTint="@color/wp_grey"
+        app:wpIconContentDescription="@string/login_password_image"
+        app:wpIconDrawable="@drawable/ic_lock_grey_24dp"/>
+</LinearLayout>

--- a/WordPress/src/main/res/layout/login_form_screen.xml
+++ b/WordPress/src/main/res/layout/login_form_screen.xml
@@ -9,17 +9,16 @@
         layout="@layout/toolbar_login" />
 
     <ScrollView
+        android:id="@+id/scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_below="@+id/toolbar"
-        android:layout_above="@+id/bottom_buttons"
-        android:fillViewport="true">
+        android:layout_above="@+id/bottom_buttons">
 
         <ViewStub
             android:id="@+id/login_form_content_stub"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
             android:layout_marginTop="@dimen/margin_extra_large"
             android:layout_marginBottom="@dimen/margin_extra_large"/>
     </ScrollView>

--- a/WordPress/src/main/res/layout/login_username_password_screen.xml
+++ b/WordPress/src/main/res/layout/login_username_password_screen.xml
@@ -1,176 +1,99 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingLeft="@dimen/margin_extra_large"
+    android:paddingStart="@dimen/margin_extra_large"
+    android:paddingRight="@dimen/margin_extra_large"
+    android:paddingEnd="@dimen/margin_extra_large"
+    android:layout_marginBottom="@dimen/margin_extra_large">
 
-    <include
-        android:id="@+id/toolbar"
-        layout="@layout/toolbar_login" />
-
-    <ScrollView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_below="@+id/toolbar"
-        android:layout_above="@+id/login_bottom_buttons"
-        android:fillViewport="true">
-
-        <TableLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:padding="@dimen/margin_extra_large">
-
-            <TableRow
-                android:gravity="center_vertical"
-                android:layout_marginBottom="@dimen/margin_extra_large">
-
-                <LinearLayout
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical">
-
-                    <org.wordpress.android.widgets.WPNetworkImageView
-                        android:id="@+id/login_blavatar"
-                        android:layout_width="@dimen/blavatar_sz"
-                        android:layout_height="@dimen/blavatar_sz"
-                        android:background="@color/white"
-                        android:gravity="center_vertical"
-                        app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp" />
-
-                    <org.wordpress.android.widgets.WPNetworkImageView
-                        android:id="@+id/login_blavatar_static"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:background="@color/white"
-                        android:gravity="center_vertical"
-                        android:visibility="gone"
-                        app:srcCompat="@drawable/ic_globe_grey_24dp" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:layout_marginStart="@dimen/margin_extra_large"
-                    android:orientation="vertical">
-
-                    <TextView
-                        style="@style/Base.TextAppearance.AppCompat.Caption"
-                        android:id="@+id/login_site_title_static"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="@string/login_site_address"
-                        android:visibility="gone"
-                        tools:visibility="visible"/>
-
-                    <TextView
-                        style="@style/Base.TextAppearance.AppCompat.Body2"
-                        android:id="@+id/login_site_title"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        tools:text="Arround the World with Pam"/>
-
-                    <TextView
-                        style="@style/Base.TextAppearance.AppCompat.Body1"
-                        android:id="@+id/login_site_address"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        tools:text="pamelanguyyen.wordpress.com"/>
-                </LinearLayout>
-            </TableRow>
-
-            <TableRow>
-                <ImageView
-                    android:id="@+id/login_username_icon"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_text_input_layout_baseline"
-                    android:contentDescription="@string/login_username_image"
-                    app:srcCompat="@drawable/ic_user_grey_24dp"/>
-
-                <android.support.design.widget.TextInputLayout
-                    app:theme="@style/LoginTheme.EditText"
-                    android:id="@+id/login_username_layout"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:layout_marginStart="@dimen/margin_extra_large">
-
-                    <android.support.design.widget.TextInputEditText
-                        android:id="@+id/login_username"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:hint="@string/username"/>
-                </android.support.design.widget.TextInputLayout>
-            </TableRow>
-
-            <TableRow
-                android:layout_marginTop="@dimen/margin_small">
-
-                <ImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_text_input_layout_baseline"
-                    android:contentDescription="@string/login_password_image"
-                    app:srcCompat="@drawable/ic_lock_grey_24dp"/>
-
-                <android.support.design.widget.TextInputLayout
-                    app:theme="@style/LoginTheme.EditText"
-                    android:id="@+id/login_password_layout"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    app:passwordToggleEnabled="true"
-                    app:passwordToggleTint="@color/wp_grey"
-                    android:layout_marginStart="@dimen/margin_extra_large">
-
-                    <android.support.design.widget.TextInputEditText
-                        android:id="@+id/login_password"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:hint="@string/password"
-                        android:inputType="textPassword"/>
-                </android.support.design.widget.TextInputLayout>
-            </TableRow>
-        </TableLayout>
-    </ScrollView>
-
-    <RelativeLayout
-        android:id="@+id/login_bottom_buttons"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:padding="@dimen/margin_extra_large">
+        android:gravity="center_vertical"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        android:layout_marginBottom="@dimen/margin_extra_large"
+        android:orientation="horizontal">
 
-        <Button
-            android:theme="@style/LoginTheme.Button"
-            style="@style/Widget.AppCompat.Button.Colored"
-            android:id="@+id/login_username_password_next_button"
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_centerVertical="true"
-            android:layout_alignParentEnd="true"
-            android:enabled="false"
-            android:text="@string/next" />
+            android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/login_lost_password"
-            style="@style/Base.TextAppearance.AppCompat.Caption"
-            android:layout_width="wrap_content"
+            <org.wordpress.android.widgets.WPNetworkImageView
+                android:id="@+id/login_blavatar"
+                android:layout_width="@dimen/blavatar_sz"
+                android:layout_height="@dimen/blavatar_sz"
+                android:background="@color/white"
+                android:gravity="center_vertical"
+                app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp" />
+
+            <org.wordpress.android.widgets.WPNetworkImageView
+                android:id="@+id/login_blavatar_static"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@color/white"
+                android:gravity="center_vertical"
+                android:visibility="gone"
+                app:srcCompat="@drawable/ic_globe_grey_24dp" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:minHeight="@dimen/min_touch_target_sz"
-            android:layout_toStartOf="@+id/login_username_password_next_button"
-            android:layout_marginEnd="@dimen/margin_extra_extra_extra_large"
-            android:layout_centerVertical="true"
-            android:layout_alignParentStart="true"
-            android:gravity="center_vertical"
-            android:textColor="@color/blue_wordpress"
-            android:text="@string/forgot_password"/>
-    </RelativeLayout>
-</RelativeLayout>
+            android:layout_marginStart="@dimen/margin_extra_large"
+            android:orientation="vertical">
+
+            <TextView
+                style="@style/Base.TextAppearance.AppCompat.Caption"
+                android:id="@+id/login_site_title_static"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/login_site_address"
+                android:visibility="gone"
+                tools:visibility="visible"/>
+
+            <TextView
+                style="@style/Base.TextAppearance.AppCompat.Body2"
+                android:id="@+id/login_site_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                tools:text="Arround the World with Pam"/>
+
+            <TextView
+                style="@style/Base.TextAppearance.AppCompat.Body1"
+                android:id="@+id/login_site_address"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                tools:text="pamelanguyyen.wordpress.com"/>
+        </LinearLayout>
+    </LinearLayout>
+
+    <org.wordpress.android.widgets.WPLoginInputRow
+        android:id="@+id/login_username_row"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/username"
+        android:inputType="textPersonName"
+        android:imeOptions="actionNext"
+        app:wpIconContentDescription="@string/login_username_image"
+        app:wpIconDrawable="@drawable/ic_user_grey_24dp"/>
+
+    <org.wordpress.android.widgets.WPLoginInputRow
+        android:id="@+id/login_password_row"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/password"
+        android:inputType="textPassword"
+        app:passwordToggleEnabled="true"
+        app:passwordToggleTint="@color/wp_grey"
+        app:wpIconContentDescription="@string/login_password_image"
+        app:wpIconDrawable="@drawable/ic_lock_grey_24dp"/>
+</LinearLayout>

--- a/WordPress/src/main/res/layout/login_username_password_screen.xml
+++ b/WordPress/src/main/res/layout/login_username_password_screen.xml
@@ -50,7 +50,7 @@
             android:orientation="vertical">
 
             <TextView
-                style="@style/Base.TextAppearance.AppCompat.Caption"
+                style="@style/LoginTheme.InputLabelStatic"
                 android:id="@+id/login_site_title_static"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/login_username_password_screen.xml
+++ b/WordPress/src/main/res/layout/login_username_password_screen.xml
@@ -45,6 +45,7 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/margin_extra_large"
             android:layout_marginStart="@dimen/margin_extra_large"
             android:orientation="vertical">
 

--- a/WordPress/src/main/res/layout/login_username_password_screen.xml
+++ b/WordPress/src/main/res/layout/login_username_password_screen.xml
@@ -36,7 +36,7 @@
                 android:id="@+id/login_blavatar_static"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:background="@color/white"
+                android:background="@color/login_background_color"
                 android:gravity="center_vertical"
                 android:visibility="gone"
                 app:srcCompat="@drawable/ic_globe_grey_24dp" />

--- a/WordPress/src/main/res/layout/login_username_password_screen.xml
+++ b/WordPress/src/main/res/layout/login_username_password_screen.xml
@@ -91,6 +91,7 @@
         android:id="@+id/login_password_row"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_extra_extra_large"
         android:hint="@string/password"
         android:inputType="textPassword"
         app:passwordToggleEnabled="true"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1884,4 +1884,5 @@
     <string name="login_error_while_adding_site">Error while adding site. Error code: %s</string>
     <string name="login_log_in_for_deeplink">Log in to WordPress.com to access the post.</string>
     <string name="login_empty_site_url">Please enter a site address</string>
+    <string name="login_empty_username">Please enter a username</string>
 </resources>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -74,6 +74,10 @@
         <item name="android:lineSpacingExtra">2dp</item>
     </style>
 
+    <style name="LoginTheme.InputLabelStatic" parent="TextAppearance.AppCompat.Body1">
+        <item name="android:textColor">@color/wp_grey</item>
+    </style>
+
     <style name="LoginTheme.EditText" parent="LoginTheme">
         <item name="colorControlNormal">@color/grey</item>
         <item name="android:textColor">@color/grey_dark</item>


### PR DESCRIPTION
**Note: #6304 needs to be merged first.**

This PR is about the visual touches for the wpcom email password input fallback screen.

As with the email screen, the "Next" button is always enabled to allow for an informative error message when the password field is empty.

Screenshots:

| Before |  After |
| --- | --- |
| ![login-emailpass-before](https://user-images.githubusercontent.com/1032913/28268824-68d43e64-6b08-11e7-8337-47508eccac64.jpg)  |  ![login-emailpass-after](https://user-images.githubusercontent.com/1032913/28268823-68b9be54-6b08-11e7-8f9d-d0c5e60e2405.jpg) |


To test:
* With the app data cleaned, launch the app and hit the "Log in" button
* Enter the email address of your WordPress.com account and hit "Next"
* Tap on the secondary action "Enter your password instead"
* Assess the design aspects of the wpcom email password input screen