### PR TITLE
Fix possible NPE for updating post formats from callback

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -59,7 +59,6 @@ import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.TaxonomyStore;
 import org.wordpress.android.fluxc.store.TaxonomyStore.OnTaxonomyChanged;
-import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.media.MediaBrowserActivity.MediaBrowserType;
@@ -914,7 +913,9 @@ public class EditPostSettingsFragment extends Fragment {
             AppLog.e(T.POSTS, "An error occurred while updating the post formats with type: " + event.error.type);
             return;
         }
-        updatePostFormatKeysAndNames();
+        if (getSite() != null) {
+            updatePostFormatKeysAndNames();
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #6319. This is an interesting crash, because we dispatch `newFetchPostFormatsAction` when we are certain that the site does exist. The fragment is first created when `SectionsPagerAdapter` is initialized and there is a `null` check for the site before that happens in `EditPostActivity`. So, if I am not mistaken this crash shouldn't ever happen in a regular path. We have the `onPostFormatsChanged` callback that calls `updatePostFormatKeysAndNames` and I think that's when the crash is happening but I am not 100% sure. So, in order to pinpoint the issue and possibly fix it in it's correct place, I suggest we make the changes in this PR.

Please let me know if I am missing something or if there is a better way to go about this.