### PR TITLE
issue/6278-remove-unused-libs

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -133,8 +133,6 @@ dependencies {
     androidTestCompile 'com.squareup.okio:okio:1.13.0'
 
     // Provided by the WordPress-Android Repository
-    compile 'org.wordpress:drag-sort-listview:0.6.1' // not found in maven central
-    compile 'org.wordpress:slidinguppanel:1.0.0' // not found in maven central
     compile 'org.wordpress:passcodelock:1.5.1'
 
     // Dagger

--- a/WordPress/src/main/assets/licenses.html
+++ b/WordPress/src/main/assets/licenses.html
@@ -29,7 +29,6 @@ libraries are licensed under <a href="http://www.apache.org/licenses/LICENSE-2.0
       <li><a href="https://github.com/google/gson">gson</a>: Copyright 2002-2008, Google</li>
       <li><a href="https://github.com/chrisbanes/PhotoView">PhotoView</a>: Copyright 2011-2012, Chris Banes</li>
       <li><a href="https://github.com/jukka/tagsoup">TagSoup</a>: Copyright 2002-2008, John Cowan</li>
-      <li><a href="https://github.com/bauerca/drag-sort-listview">DragSortListView</a>: Copyright 2012, Carl Bauer</li>
       <li><a href="https://github.com/Yalantis/uCrop">uCrop</a>: Copyright 2017, Yalantis</li>
       <li><a href="https://github.com/xizzhu/simple-tool-tip">Simple Tool Tip</a>: Copyright 2016, Xizhi Zhu</li>
       <li><a href="https://github.com/square/okio">okio/okhttp</a>: Copyright 2013 Square, Inc.</li>


### PR DESCRIPTION
Fixes #6278 - removes the now-unused DragSortListView and SlidingUpPanel from the project.
