### PR TITLE
Async media Posts list errors

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -537,6 +537,7 @@ public class PostsListFragment extends Fragment
                 break;
             case PostListButton.BUTTON_SUBMIT:
             case PostListButton.BUTTON_SYNC:
+            case PostListButton.BUTTON_RETRY:
             case PostListButton.BUTTON_PUBLISH:
                 publishPost(post);
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -199,18 +199,11 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     }
 
     private boolean canPublishPost(PostModel post) {
-        // TODO remove the hasFailedMedia(post) check when we get a proper retry mechanism in place,
+        // TODO remove the hasMediaErrorForPost(post) check when we get a proper retry mechanism in place,
         // that retried to upload any failed media along with the post
-        return post != null && !UploadService.isPostUploadingOrQueued(post) && !hasFailedMedia(post) &&
+        return post != null && !UploadService.isPostUploadingOrQueued(post) &&
+                !UploadService.hasMediaErrorForPost(post) &&
                 (post.isLocallyChanged() || post.isLocalDraft() || PostStatus.fromPost(post) == PostStatus.DRAFT);
-    }
-
-    private boolean hasFailedMedia(PostModel post) {
-        UploadService.UploadError error  = UploadService.getUploadErrorForPost(post);
-        if (error != null && error.mediaError != null) {
-            return true;
-        }
-        return false;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -46,7 +46,6 @@ import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DisplayUtils;
-import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.widgets.PostListButton;
 import org.wordpress.android.widgets.WPNetworkImageView;
@@ -399,7 +398,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             int statusColorResId = R.color.grey_darken_10;
             String errorMessage = null;
 
-            UploadService.FailReason reason = UploadService.getFailedReasonForPost(post);
+            UploadService.UploadError reason = UploadService.getUploadErrorForPost(post);
             if (reason != null) {
                 if (reason.mediaError != null) {
                     errorMessage = UploadUtils.getErrorMessageFromMediaError(
@@ -486,7 +485,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             holder.btnView.setButtonType(PostListButton.BUTTON_VIEW);
         }
 
-        if (UploadService.getFailedReasonForPost(post) != null) {
+        if (UploadService.getUploadErrorForPost(post) != null) {
             holder.btnPublish.setButtonType(PostListButton.BUTTON_RETRY);
         } else {
             if (PostStatus.fromPost(post) == PostStatus.SCHEDULED && post.isLocallyChanged()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -486,10 +486,14 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             holder.btnView.setButtonType(PostListButton.BUTTON_VIEW);
         }
 
-        if (PostStatus.fromPost(post) == PostStatus.SCHEDULED && post.isLocallyChanged()) {
-            holder.btnPublish.setButtonType(PostListButton.BUTTON_SYNC);
+        if (UploadService.getFailedReasonForPost(post) != null) {
+            holder.btnPublish.setButtonType(PostListButton.BUTTON_RETRY);
         } else {
-            holder.btnPublish.setButtonType(PostListButton.BUTTON_PUBLISH);
+            if (PostStatus.fromPost(post) == PostStatus.SCHEDULED && post.isLocallyChanged()) {
+                holder.btnPublish.setButtonType(PostListButton.BUTTON_SYNC);
+            } else {
+                holder.btnPublish.setButtonType(PostListButton.BUTTON_PUBLISH);
+            }
         }
 
         boolean canShowStatsButton = canShowStatsForPost(post);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -203,6 +203,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
             if (!pushActionWasDispatched) {
                 // This block only runs if the PUSH_POST action was never dispatched - if it was dispatched, any error
                 // will be handled in OnPostChanged instead of here
+                mPostUploadNotifier.cancelNotification(mPost);
                 mPostUploadNotifier.updateNotificationError(mPost, mSite, mErrorMessage, mIsMediaError);
                 finishUpload();
             }
@@ -576,6 +577,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
             String errorMessage = UploadUtils.getErrorMessageFromPostError(context, event.post, event.error);
             String notificationMessage = UploadUtils.getErrorMessage(context, event.post, errorMessage);
             mPostUploadNotifier.updateNotificationError(event.post, site, notificationMessage, false);
+            mPostUploadNotifier.cancelNotification(event.post);
             sFirstPublishPosts.remove(event.post.getId());
         } else {
             mPostUploadNotifier.cancelNotification(event.post);
@@ -623,6 +625,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
             Context context = WordPress.getContext();
             String errorMessage = UploadUtils.getErrorMessageFromMediaError(context, event.error);
             String notificationMessage = UploadUtils.getErrorMessage(context, sCurrentUploadingPost, errorMessage);
+            mPostUploadNotifier.cancelNotification(sCurrentUploadingPost);
             mPostUploadNotifier.updateNotificationError(sCurrentUploadingPost, site, notificationMessage, true);
             sFirstPublishPosts.remove(sCurrentUploadingPost.getId());
             finishUpload();

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -34,7 +34,7 @@ class PostUploadNotifier {
     private final NotificationManager mNotificationManager;
     private final Notification.Builder mNotificationBuilder;
 
-    private static final SparseArray<NotificationData> mPostIdToNotificationData = new SparseArray<>();
+    private static final SparseArray<NotificationData> sPostIdToNotificationData = new SparseArray<>();
 
     private class NotificationData {
         int notificationId;
@@ -64,32 +64,32 @@ class PostUploadNotifier {
 
         NotificationData notificationData = new NotificationData();
         notificationData.notificationId = notificationId;
-        mPostIdToNotificationData.put(post.getId(), notificationData);
+        sPostIdToNotificationData.put(post.getId(), notificationData);
         mService.startForeground(notificationId, mNotificationBuilder.build());
     }
 
     boolean isDisplayingNotificationForPost(@NonNull PostModel post) {
-        return mPostIdToNotificationData.get(post.getId()) != null;
+        return sPostIdToNotificationData.get(post.getId()) != null;
     }
 
     void updateNotificationMessage(@NonNull PostModel post, String message) {
-        NotificationData notificationData = mPostIdToNotificationData.get(post.getId());
+        NotificationData notificationData = sPostIdToNotificationData.get(post.getId());
         mNotificationBuilder.setContentText(StringUtils.notNullStr(message));
         doNotify(notificationData.notificationId, mNotificationBuilder.build());
     }
 
     void updateNotificationIcon(PostModel post, Bitmap icon) {
-        NotificationData notificationData = mPostIdToNotificationData.get(post.getId());
+        NotificationData notificationData = sPostIdToNotificationData.get(post.getId());
 
         if (icon != null) {
             notificationData.latestIcon = icon;
             mNotificationBuilder.setLargeIcon(notificationData.latestIcon);
         }
-        doNotify(mPostIdToNotificationData.get(post.getId()).notificationId, mNotificationBuilder.build());
+        doNotify(sPostIdToNotificationData.get(post.getId()).notificationId, mNotificationBuilder.build());
     }
 
     void cancelNotification(PostModel post) {
-        NotificationData notificationData = mPostIdToNotificationData.get(post.getId());
+        NotificationData notificationData = sPostIdToNotificationData.get(post.getId());
         if (notificationData != null) {
             mNotificationManager.cancel(notificationData.notificationId);
         }
@@ -97,7 +97,7 @@ class PostUploadNotifier {
     }
 
     void cancelErrorNotification(PostModel post) {
-        NotificationData notificationData = mPostIdToNotificationData.get(post.getId());
+        NotificationData notificationData = sPostIdToNotificationData.get(post.getId());
         if (notificationData != null) {
             mNotificationManager.cancel(notificationData.notificationErrorId);
         }
@@ -131,7 +131,7 @@ class PostUploadNotifier {
         }
         notificationBuilder.setSmallIcon(android.R.drawable.stat_sys_upload_done);
 
-        NotificationData notificationData = mPostIdToNotificationData.get(post.getId());
+        NotificationData notificationData = sPostIdToNotificationData.get(post.getId());
         if (notificationData == null || notificationData.latestIcon == null) {
             notificationBuilder.setLargeIcon(BitmapFactory.decodeResource(mContext.getApplicationContext()
                     .getResources(),
@@ -214,7 +214,7 @@ class PostUploadNotifier {
         notificationBuilder.setContentIntent(pendingIntent);
         notificationBuilder.setAutoCancel(true);
 
-        NotificationData notificationData = mPostIdToNotificationData.get(post.getId());
+        NotificationData notificationData = sPostIdToNotificationData.get(post.getId());
         if (notificationData.notificationErrorId == 0) {
             notificationData.notificationErrorId = notificationData.notificationId + (new Random()).nextInt();
         }
@@ -222,7 +222,7 @@ class PostUploadNotifier {
     }
 
     void updateNotificationProgress(PostModel post, float progress) {
-        NotificationData notificationData = mPostIdToNotificationData.get(post.getId());
+        NotificationData notificationData = sPostIdToNotificationData.get(post.getId());
         if (notificationData.totalMediaItems == 0) {
             return;
         }
@@ -236,7 +236,7 @@ class PostUploadNotifier {
         }
 
         mNotificationBuilder.setProgress(100, (int) Math.ceil(currentChunkProgress), false);
-        doNotify(mPostIdToNotificationData.get(post.getId()).notificationId, mNotificationBuilder.build());
+        doNotify(sPostIdToNotificationData.get(post.getId()).notificationId, mNotificationBuilder.build());
     }
 
     private synchronized void doNotify(long id, Notification notification) {
@@ -249,7 +249,7 @@ class PostUploadNotifier {
     }
 
     void setTotalMediaItems(PostModel post, int totalMediaItems) {
-        NotificationData notificationData = mPostIdToNotificationData.get(post.getId());
+        NotificationData notificationData = sPostIdToNotificationData.get(post.getId());
         if (totalMediaItems <= 0) {
             totalMediaItems = 1;
         }
@@ -259,7 +259,7 @@ class PostUploadNotifier {
     }
 
     void setCurrentMediaItem(PostModel post, int currentItem) {
-        NotificationData notificationData = mPostIdToNotificationData.get(post.getId());
+        NotificationData notificationData = sPostIdToNotificationData.get(post.getId());
         notificationData.currentMediaItem = currentItem;
 
         mNotificationBuilder.setContentText(String.format(mContext.getString(R.string.uploading_total),

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -34,7 +34,7 @@ class PostUploadNotifier {
     private final NotificationManager mNotificationManager;
     private final Notification.Builder mNotificationBuilder;
 
-    private final SparseArray<NotificationData> mPostIdToNotificationData = new SparseArray<>();
+    private static final SparseArray<NotificationData> mPostIdToNotificationData = new SparseArray<>();
 
     private class NotificationData {
         int notificationId;
@@ -94,6 +94,13 @@ class PostUploadNotifier {
             mNotificationManager.cancel(notificationData.notificationId);
         }
         mService.stopForeground(true);
+    }
+
+    void cancelErrorNotification(PostModel post) {
+        NotificationData notificationData = mPostIdToNotificationData.get(post.getId());
+        if (notificationData != null) {
+            mNotificationManager.cancel(notificationData.notificationErrorId);
+        }
     }
 
     void updateNotificationSuccess(PostModel post, SiteModel site, boolean isFirstTimePublish) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -434,7 +434,7 @@ public class UploadService extends Service {
     }
 
     public static boolean removeUploadErrorForPost(PostModel post) {
-        return (sFailedUploadPosts.remove(post.getId()) != null ? true : false);
+        return (sFailedUploadPosts.remove(post.getId()) != null);
     }
 
     public static UploadError getUploadErrorForPost(PostModel post) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -51,7 +51,8 @@ public class UploadService extends Service {
     // the post they're attached to, allowing us to update the post with the media URLs in a single batch at the end
     private static final ConcurrentHashMap<Integer, List<MediaModel>> sCompletedMediaByPost = new ConcurrentHashMap<>();
 
-    // This will hold a map of postID and the corresponding last error if any error occured while uploading
+    // TODO This should be moved to FluxC, perhaps in a new UploadMediaTable
+    // This will hold a map of postID and the corresponding last error if any error occurred while uploading
     private static final ConcurrentHashMap<Integer, UploadError> sFailedUploadPosts = new ConcurrentHashMap<>();
 
     @Inject Dispatcher mDispatcher;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -362,6 +362,12 @@ public class UploadService extends Service {
         return postModel != null && MediaUploadHandler.hasPendingOrInProgressMediaUploadsForPost(postModel);
     }
 
+    public static boolean hasMediaErrorForPost(PostModel post) {
+        UploadError error  = getUploadErrorForPost(post);
+        return error != null && error.mediaError != null;
+    }
+
+
     public static float getMediaUploadProgressForPost(PostModel postModel) {
         if (postModel == null) {
             return 0;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -519,6 +519,8 @@ public class UploadService extends Service {
                 FailReason reason = new FailReason(event.error);
                 addFailedReasonToFailedPosts(event.post, reason);
             }
+        } else {
+            removeFailedReasonForPost(event.post);
         }
         stopServiceIfUploadsComplete();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -460,11 +460,9 @@ public class UploadService extends Service {
                 cancelPostUploadMatchingMedia(event.media, errorMessage);
 
                 // now keep track of the error reason so it can be queried
-                if (event.error != null && event.error != null) {
-                    FailReason reason = new FailReason(event.error);
-                    PostModel failedPost = mPostStore.getPostByLocalPostId(event.media.getLocalPostId());
-                    addFailedReasonToFailedPosts(failedPost, reason);
-                }
+                FailReason reason = new FailReason(event.error);
+                PostModel failedPost = mPostStore.getPostByLocalPostId(event.media.getLocalPostId());
+                addFailedReasonToFailedPosts(failedPost, reason);
             }
             stopServiceIfUploadsComplete();
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -187,7 +187,11 @@ public class UploadService extends Service {
             }
 
             // as user wants to upload this post, remove any failed reasons as it goes to the queue
-            removeFailedReasonForPost(post);
+            if (removeFailedReasonForPost(post)) {
+                // also delete any error notifications still there
+                mPostUploadNotifier.cancelErrorNotification(post);
+            }
+
             if (!hasPendingOrInProgressMediaUploadsForPost(post)) {
                 mPostUploadHandler.upload(post);
             } else {
@@ -429,8 +433,8 @@ public class UploadService extends Service {
         sFailedUploadPosts.put(post.getId(), reason);
     }
 
-    public static void removeFailedReasonForPost(PostModel post) {
-        sFailedUploadPosts.remove(post.getId());
+    public static boolean removeFailedReasonForPost(PostModel post) {
+        return (sFailedUploadPosts.remove(post.getId()) != null ? true : false);
     }
 
     public static FailReason getFailedReasonForPost(PostModel post) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -587,10 +587,8 @@ public class UploadService extends Service {
     @Subscribe(threadMode = ThreadMode.MAIN, priority = 7)
     public void onPostUploaded(OnPostUploaded event) {
         if (event.isError()) {
-            if (event.error != null && event.error != null) {
-                UploadError reason = new UploadError(event.error);
-                addUploadErrorToFailedPosts(event.post, reason);
-            }
+            UploadError reason = new UploadError(event.error);
+            addUploadErrorToFailedPosts(event.post, reason);
         } else {
             removeUploadErrorForPost(event.post);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -9,7 +9,7 @@ import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
 
-class UploadUtils {
+public class UploadUtils {
     /**
      * Returns a post-type specific error message string.
      */
@@ -21,7 +21,7 @@ class UploadUtils {
     /**
      * Returns an error message string for a failed post upload.
      */
-    static @NonNull String getErrorMessageFromPostError(Context context, PostModel post, PostError error) {
+    public static @NonNull String getErrorMessageFromPostError(Context context, PostModel post, PostError error) {
         switch (error.type) {
             case UNKNOWN_POST:
                 return context.getString(R.string.error_unknown_post);
@@ -38,7 +38,7 @@ class UploadUtils {
     /**
      * Returns an error message string for a failed media upload.
      */
-    static @NonNull String getErrorMessageFromMediaError(Context context, MediaError error) {
+    public static @NonNull String getErrorMessageFromMediaError(Context context, MediaError error) {
         switch (error.type) {
             case FS_READ_PERMISSION_DENIED:
                 return context.getString(R.string.error_media_insufficient_fs_permissions);

--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButton.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButton.java
@@ -1,8 +1,12 @@
 package org.wordpress.android.widgets;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.content.res.TypedArray;
+import android.graphics.drawable.Drawable;
+import android.support.v4.graphics.drawable.DrawableCompat;
 import android.util.AttributeSet;
+import android.view.View;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -31,6 +35,7 @@ public class PostListButton extends LinearLayout {
     public static final int BUTTON_MORE     = 9;
     public static final int BUTTON_BACK     = 10;
     public static final int BUTTON_SUBMIT   = 11;
+    public static final int BUTTON_RETRY   = 12;
 
     public PostListButton(Context context){
         super(context);
@@ -81,7 +86,16 @@ public class PostListButton extends LinearLayout {
 
         mButtonType = buttonType;
         mTextView.setText(getButtonTextResId(buttonType));
-        mImageView.setImageResource(getButtonIconResId(buttonType));
+        if (buttonType == BUTTON_RETRY) {
+            mImageView.setImageResource(0);
+            Resources resources = mImageView.getContext().getResources();
+            Drawable drawable =  resources.getDrawable(getButtonIconResId(buttonType));
+            drawable = DrawableCompat.wrap(drawable);
+            DrawableCompat.setTint(drawable, resources.getColor(R.color.blue_medium));
+            mImageView.setImageDrawable(drawable);
+        } else {
+            mImageView.setImageResource(getButtonIconResId(buttonType));
+        }
     }
 
     public static int getButtonTextResId(int buttonType) {
@@ -108,6 +122,8 @@ public class PostListButton extends LinearLayout {
                 return R.string.button_back;
             case BUTTON_SUBMIT:
                 return R.string.submit_for_review;
+            case BUTTON_RETRY:
+                return R.string.button_retry;
             default:
                 return 0;
         }
@@ -135,6 +151,8 @@ public class PostListButton extends LinearLayout {
                 return R.drawable.ic_ellipsis_blue_wordpress_18dp;
             case BUTTON_BACK:
                 return R.drawable.ic_chevron_left_blue_wordpress_18dp;
+            case BUTTON_RETRY:
+                return R.drawable.media_retry_image;
             default:
                 return 0;
         }

--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButton.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButton.java
@@ -1,12 +1,8 @@
 package org.wordpress.android.widgets;
 
 import android.content.Context;
-import android.content.res.Resources;
 import android.content.res.TypedArray;
-import android.graphics.drawable.Drawable;
-import android.support.v4.graphics.drawable.DrawableCompat;
 import android.util.AttributeSet;
-import android.view.View;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -35,7 +31,7 @@ public class PostListButton extends LinearLayout {
     public static final int BUTTON_MORE     = 9;
     public static final int BUTTON_BACK     = 10;
     public static final int BUTTON_SUBMIT   = 11;
-    public static final int BUTTON_RETRY   = 12;
+    public static final int BUTTON_RETRY    = 12;
 
     public PostListButton(Context context){
         super(context);
@@ -86,16 +82,7 @@ public class PostListButton extends LinearLayout {
 
         mButtonType = buttonType;
         mTextView.setText(getButtonTextResId(buttonType));
-        if (buttonType == BUTTON_RETRY) {
-            mImageView.setImageResource(0);
-            Resources resources = mImageView.getContext().getResources();
-            Drawable drawable =  resources.getDrawable(getButtonIconResId(buttonType));
-            drawable = DrawableCompat.wrap(drawable);
-            DrawableCompat.setTint(drawable, resources.getColor(R.color.blue_medium));
-            mImageView.setImageDrawable(drawable);
-        } else {
-            mImageView.setImageResource(getButtonIconResId(buttonType));
-        }
+        mImageView.setImageResource(getButtonIconResId(buttonType));
     }
 
     public static int getButtonTextResId(int buttonType) {
@@ -152,7 +139,7 @@ public class PostListButton extends LinearLayout {
             case BUTTON_BACK:
                 return R.drawable.ic_chevron_left_blue_wordpress_18dp;
             case BUTTON_RETRY:
-                return R.drawable.media_retry_image;
+                return R.drawable.ic_refresh_blue_wordpress_18dp;
             default:
                 return 0;
         }

--- a/WordPress/src/main/res/drawable/ic_refresh_blue_wordpress_18dp.xml
+++ b/WordPress/src/main/res/drawable/ic_refresh_blue_wordpress_18dp.xml
@@ -1,0 +1,18 @@
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="18dp"
+    android:width="18dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0" >
+
+    <path
+        android:pathData="M 0 0 H 24 V 24 H 0 V 0 Z" >
+    </path>
+    <path
+        android:fillColor="@color/blue_wordpress"
+        android:pathData="M17.91 14c-.478 2.833-2.943 5-5.91 5-3.308 0-6-2.692-6-6s2.692-6
+6-6h2.172l-2.086 2.086L13.5 10.5 18 6l-4.5-4.5-1.414 1.414L14.172 5H12c-4.418
+0-8 3.582-8 8s3.582 8 8 8c4.08 0 7.438-3.055 7.93-7h-2.02z" >
+    </path>
+
+</vector>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1157,6 +1157,7 @@
     <string name="error_media_load">Unable to load media</string>
     <string name="error_media_save">Unable to save media</string>
     <string name="error_media_canceled">Uploading media were canceled</string>
+    <string name="error_media_recover">Please edit the post to retry each failed media item</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>
     <string name="fatal_db_error">An error occurred while creating the app database. Try reinstalling the app.</string>
     <string name="error_copy_to_clipboard">An error occurred while copying text to clipboard</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -256,6 +256,7 @@
     <string name="button_more" translatable="false">@string/more</string>
     <string name="button_back">Back</string>
     <string name="button_revert">Revert</string>
+    <string name="button_retry">Retry</string>
 
     <!-- dropdown filter above post cards -->
     <string name="filter_published_posts">Published</string>


### PR DESCRIPTION
This PR keeps track of errors when uploading media / post and updates the corresponding item in the Posts list, and turns the `Publish` button into a `Retry` button as can be seen here:

![screenshot_20170717-184933](https://user-images.githubusercontent.com/6597771/28292091-f8c6c54e-6b23-11e7-8ec5-f6df492966b5.png)

Note a better set of not-so-technical, user friendlier messages could be included, for now this is in parity with the messages shown in the error Notifications, and we can take care of [wording / messages later](https://github.com/wordpress-mobile/WordPress-Android/projects/6#card-3588591).

cc @aforcier 



