### PR TITLE
Move Jetpack settings into a subscreen of Site Settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
@@ -6,6 +6,7 @@ import android.database.sqlite.SQLiteDatabase;
 
 import org.wordpress.android.WordPress;
 import org.wordpress.android.models.CategoryModel;
+import org.wordpress.android.models.JetpackSettingsModel;
 import org.wordpress.android.models.SiteSettingsModel;
 
 import java.util.HashMap;
@@ -29,6 +30,7 @@ public final class SiteSettingsTable {
     public static void createTable(SQLiteDatabase db) {
         if (db != null) {
             db.execSQL(SiteSettingsModel.CREATE_SETTINGS_TABLE_SQL);
+            db.execSQL(JetpackSettingsModel.CREATE_JP_SETTINGS_TABLE_SQL);
             db.execSQL(CREATE_CATEGORIES_TABLE_SQL);
         }
     }
@@ -96,6 +98,13 @@ public final class SiteSettingsTable {
         return WordPress.wpDB.getDatabase().rawQuery(sqlCommand, null);
     }
 
+    public static Cursor getJpSettings(long id) {
+        if (id < 0) return null;
+
+        String sqlCommand = sqlSelectAllJpSettings() + sqlWhere(JetpackSettingsModel.ID_COLUMN_NAME, Long.toString(id)) + ";";
+        return WordPress.wpDB.getDatabase().rawQuery(sqlCommand, null);
+    }
+
     public static void saveCategory(CategoryModel category) {
         if (category == null) return;
 
@@ -110,6 +119,14 @@ public final class SiteSettingsTable {
         for (CategoryModel category : categories) {
             saveCategory(category);
         }
+    }
+
+    public static void saveJpSettings(JetpackSettingsModel settings) {
+        if (settings == null) return;
+
+        ContentValues values = settings.serializeToDatabase();
+        WordPress.wpDB.getDatabase().insertWithOnConflict(
+                JetpackSettingsModel.JP_SETTINGS_TABLE_NAME, null, values, SQLiteDatabase.CONFLICT_REPLACE);
     }
 
     public static void saveSettings(SiteSettingsModel settings) {
@@ -128,6 +145,10 @@ public final class SiteSettingsTable {
 
     private static String sqlSelectAllSettings() {
         return "SELECT * FROM " + SiteSettingsModel.SETTINGS_TABLE_NAME + " ";
+    }
+
+    private static String sqlSelectAllJpSettings() {
+        return "SELECT * FROM " + JetpackSettingsModel.JP_SETTINGS_TABLE_NAME + " ";
     }
 
     private static String sqlWhere(String variable, String value) {

--- a/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
@@ -94,14 +94,16 @@ public final class SiteSettingsTable {
     public static Cursor getSettings(long id) {
         if (id < 0) return null;
 
-        String sqlCommand = sqlSelectAllSettings() + sqlWhere(SiteSettingsModel.ID_COLUMN_NAME, Long.toString(id)) + ";";
+        String whereClause = sqlWhere(SiteSettingsModel.ID_COLUMN_NAME, Long.toString(id));
+        String sqlCommand = sqlSelectAllSettings() + whereClause + ";";
         return WordPress.wpDB.getDatabase().rawQuery(sqlCommand, null);
     }
 
     public static Cursor getJpSettings(long id) {
         if (id < 0) return null;
 
-        String sqlCommand = sqlSelectAllJpSettings() + sqlWhere(JetpackSettingsModel.ID_COLUMN_NAME, Long.toString(id)) + ";";
+        String whereClause = sqlWhere(JetpackSettingsModel.ID_COLUMN_NAME, Long.toString(id));
+        String sqlCommand = sqlSelectAllJpSettings() + whereClause + ";";
         return WordPress.wpDB.getDatabase().rawQuery(sqlCommand, null);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
@@ -14,7 +14,23 @@ import java.util.HashMap;
 import java.util.Map;
 
 public final class SiteSettingsTable {
-    public static final String CATEGORIES_TABLE_NAME = "site_categories";
+    private static final String ID_COLUMN_NAME = "id";
+    private static final String JP_MONITOR_ACTIVE_COLUMN_NAME = "monitorActive";
+    private static final String JP_MONITOR_EMAIL_NOTES_COLUMN_NAME = "jpEmailNotifications";
+    private static final String JP_MONITOR_WP_NOTES_COLUMN_NAME = "jpWpNotifications";
+
+    private static final String JP_SETTINGS_TABLE_NAME = "jp_site_settings";
+    private static final String CREATE_JP_SETTINGS_TABLE_SQL =
+            "CREATE TABLE IF NOT EXISTS " +
+                    JP_SETTINGS_TABLE_NAME +
+                    " (" +
+                    ID_COLUMN_NAME + " INTEGER PRIMARY KEY, " +
+                    JP_MONITOR_ACTIVE_COLUMN_NAME + " BOOLEAN, " +
+                    JP_MONITOR_EMAIL_NOTES_COLUMN_NAME + " BOOLEAN, " +
+                    JP_MONITOR_WP_NOTES_COLUMN_NAME + " BOOLEAN" +
+                    ");";
+
+    private static final String CATEGORIES_TABLE_NAME = "site_categories";
 
     private static final String CREATE_CATEGORIES_TABLE_SQL =
             "CREATE TABLE IF NOT EXISTS " +
@@ -31,7 +47,7 @@ public final class SiteSettingsTable {
     public static void createTable(SQLiteDatabase db) {
         if (db != null) {
             db.execSQL(SiteSettingsModel.CREATE_SETTINGS_TABLE_SQL);
-            db.execSQL(JetpackSettingsModel.CREATE_JP_SETTINGS_TABLE_SQL);
+            db.execSQL(CREATE_JP_SETTINGS_TABLE_SQL);
             db.execSQL(CREATE_CATEGORIES_TABLE_SQL);
         }
     }
@@ -70,19 +86,16 @@ public final class SiteSettingsTable {
 
     public static void deserializeJetpackDatabaseCursor(final @NonNull JetpackSettingsModel jpSettings, Cursor cursor) {
         if (cursor == null || !cursor.moveToFirst() || cursor.getCount() == 0) return;
-        jpSettings.monitorActive = getBooleanFromCursor(cursor,
-                JetpackSettingsModel.JP_MONITOR_ACTIVE_COLUMN_NAME);
-        jpSettings.emailNotifications = getBooleanFromCursor(cursor,
-                JetpackSettingsModel.JP_MONITOR_EMAIL_NOTES_COLUMN_NAME);
-        jpSettings.wpNotifications = getBooleanFromCursor(cursor,
-                JetpackSettingsModel.JP_MONITOR_WP_NOTES_COLUMN_NAME);
+        jpSettings.monitorActive = getBooleanFromCursor(cursor, JP_MONITOR_ACTIVE_COLUMN_NAME);
+        jpSettings.emailNotifications = getBooleanFromCursor(cursor, JP_MONITOR_EMAIL_NOTES_COLUMN_NAME);
+        jpSettings.wpNotifications = getBooleanFromCursor(cursor, JP_MONITOR_WP_NOTES_COLUMN_NAME);
     }
 
     public static ContentValues serializeJetpackSettingsToDatabase(final @NonNull JetpackSettingsModel jpSettings) {
         ContentValues values = new ContentValues();
-        values.put(JetpackSettingsModel.JP_MONITOR_ACTIVE_COLUMN_NAME, jpSettings.monitorActive);
-        values.put(JetpackSettingsModel.JP_MONITOR_EMAIL_NOTES_COLUMN_NAME, jpSettings.emailNotifications);
-        values.put(JetpackSettingsModel.JP_MONITOR_WP_NOTES_COLUMN_NAME, jpSettings.wpNotifications);
+        values.put(JP_MONITOR_ACTIVE_COLUMN_NAME, jpSettings.monitorActive);
+        values.put(JP_MONITOR_EMAIL_NOTES_COLUMN_NAME, jpSettings.emailNotifications);
+        values.put(JP_MONITOR_WP_NOTES_COLUMN_NAME, jpSettings.wpNotifications);
         return values;
     }
 
@@ -121,7 +134,7 @@ public final class SiteSettingsTable {
     public static Cursor getJpSettings(long id) {
         if (id < 0) return null;
 
-        String whereClause = sqlWhere(JetpackSettingsModel.ID_COLUMN_NAME, Long.toString(id));
+        String whereClause = sqlWhere(ID_COLUMN_NAME, Long.toString(id));
         String sqlCommand = sqlSelectAllJpSettings() + whereClause + ";";
         return WordPress.wpDB.getDatabase().rawQuery(sqlCommand, null);
     }
@@ -147,7 +160,7 @@ public final class SiteSettingsTable {
 
         ContentValues values = serializeJetpackSettingsToDatabase(settings);
         WordPress.wpDB.getDatabase().insertWithOnConflict(
-                JetpackSettingsModel.JP_SETTINGS_TABLE_NAME, null, values, SQLiteDatabase.CONFLICT_REPLACE);
+                JP_SETTINGS_TABLE_NAME, null, values, SQLiteDatabase.CONFLICT_REPLACE);
     }
 
     public static void saveSettings(SiteSettingsModel settings) {
@@ -169,7 +182,7 @@ public final class SiteSettingsTable {
     }
 
     private static String sqlSelectAllJpSettings() {
-        return "SELECT * FROM " + JetpackSettingsModel.JP_SETTINGS_TABLE_NAME + " ";
+        return "SELECT * FROM " + JP_SETTINGS_TABLE_NAME + " ";
     }
 
     private static String sqlWhere(String variable, String value) {

--- a/WordPress/src/main/java/org/wordpress/android/models/JetpackSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/JetpackSettingsModel.java
@@ -1,0 +1,56 @@
+package org.wordpress.android.models;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+
+public class JetpackSettingsModel {
+    public static final String ID_COLUMN_NAME = "id";
+    private static final String JP_MONITOR_ACTIVE_COLUMN_NAME = "monitorActive";
+    private static final String JP_MONITOR_EMAIL_NOTES_COLUMN_NAME = "jpEmailNotifications";
+    private static final String JP_MONITOR_WP_NOTES_COLUMN_NAME = "jpWpNotifications";
+
+    public static final String JP_SETTINGS_TABLE_NAME = "jp_site_settings";
+    public static final String CREATE_JP_SETTINGS_TABLE_SQL =
+            "CREATE TABLE IF NOT EXISTS " +
+                    JP_SETTINGS_TABLE_NAME +
+                    " (" +
+                    ID_COLUMN_NAME + " INTEGER PRIMARY KEY, " +
+                    JP_MONITOR_ACTIVE_COLUMN_NAME + " BOOLEAN, " +
+                    JP_MONITOR_EMAIL_NOTES_COLUMN_NAME + " BOOLEAN, " +
+                    JP_MONITOR_WP_NOTES_COLUMN_NAME + " BOOLEAN" +
+                    ");";
+
+    public long localTableId;
+    public boolean monitorActive;
+    public boolean emailNotifications;
+    public boolean wpNotifications;
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof JetpackSettingsModel)) return false;
+        JetpackSettingsModel otherModel = (JetpackSettingsModel) other;
+        return monitorActive == otherModel.monitorActive &&
+                emailNotifications == otherModel.emailNotifications &&
+                wpNotifications == otherModel.wpNotifications;
+    }
+
+    public void deserializeOptionsDatabaseCursor(Cursor cursor) {
+        if (cursor == null || !cursor.moveToFirst() || cursor.getCount() == 0) return;
+        monitorActive = getBooleanFromCursor(cursor, JP_MONITOR_ACTIVE_COLUMN_NAME);
+        emailNotifications = getBooleanFromCursor(cursor, JP_MONITOR_EMAIL_NOTES_COLUMN_NAME);
+        wpNotifications = getBooleanFromCursor(cursor, JP_MONITOR_WP_NOTES_COLUMN_NAME);
+    }
+
+    public ContentValues serializeToDatabase() {
+        ContentValues values = new ContentValues();
+        values.put(JP_MONITOR_ACTIVE_COLUMN_NAME, monitorActive);
+        values.put(JP_MONITOR_EMAIL_NOTES_COLUMN_NAME, emailNotifications);
+        values.put(JP_MONITOR_WP_NOTES_COLUMN_NAME, wpNotifications);
+        return values;
+    }
+
+    private boolean getBooleanFromCursor(Cursor cursor, String columnName) {
+        int columnIndex = cursor.getColumnIndex(columnName);
+        return columnIndex != -1 && cursor.getInt(columnIndex) != 0;
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/models/JetpackSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/JetpackSettingsModel.java
@@ -1,22 +1,6 @@
 package org.wordpress.android.models;
 
 public class JetpackSettingsModel {
-    public static final String ID_COLUMN_NAME = "id";
-    public static final String JP_MONITOR_ACTIVE_COLUMN_NAME = "monitorActive";
-    public static final String JP_MONITOR_EMAIL_NOTES_COLUMN_NAME = "jpEmailNotifications";
-    public static final String JP_MONITOR_WP_NOTES_COLUMN_NAME = "jpWpNotifications";
-
-    public static final String JP_SETTINGS_TABLE_NAME = "jp_site_settings";
-    public static final String CREATE_JP_SETTINGS_TABLE_SQL =
-            "CREATE TABLE IF NOT EXISTS " +
-                    JP_SETTINGS_TABLE_NAME +
-                    " (" +
-                    ID_COLUMN_NAME + " INTEGER PRIMARY KEY, " +
-                    JP_MONITOR_ACTIVE_COLUMN_NAME + " BOOLEAN, " +
-                    JP_MONITOR_EMAIL_NOTES_COLUMN_NAME + " BOOLEAN, " +
-                    JP_MONITOR_WP_NOTES_COLUMN_NAME + " BOOLEAN" +
-                    ");";
-
     public long localTableId;
     public boolean monitorActive;
     public boolean emailNotifications;

--- a/WordPress/src/main/java/org/wordpress/android/models/JetpackSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/JetpackSettingsModel.java
@@ -1,13 +1,10 @@
 package org.wordpress.android.models;
 
-import android.content.ContentValues;
-import android.database.Cursor;
-
 public class JetpackSettingsModel {
     public static final String ID_COLUMN_NAME = "id";
-    private static final String JP_MONITOR_ACTIVE_COLUMN_NAME = "monitorActive";
-    private static final String JP_MONITOR_EMAIL_NOTES_COLUMN_NAME = "jpEmailNotifications";
-    private static final String JP_MONITOR_WP_NOTES_COLUMN_NAME = "jpWpNotifications";
+    public static final String JP_MONITOR_ACTIVE_COLUMN_NAME = "monitorActive";
+    public static final String JP_MONITOR_EMAIL_NOTES_COLUMN_NAME = "jpEmailNotifications";
+    public static final String JP_MONITOR_WP_NOTES_COLUMN_NAME = "jpWpNotifications";
 
     public static final String JP_SETTINGS_TABLE_NAME = "jp_site_settings";
     public static final String CREATE_JP_SETTINGS_TABLE_SQL =
@@ -32,25 +29,5 @@ public class JetpackSettingsModel {
         return monitorActive == otherModel.monitorActive &&
                 emailNotifications == otherModel.emailNotifications &&
                 wpNotifications == otherModel.wpNotifications;
-    }
-
-    public void deserializeOptionsDatabaseCursor(Cursor cursor) {
-        if (cursor == null || !cursor.moveToFirst() || cursor.getCount() == 0) return;
-        monitorActive = getBooleanFromCursor(cursor, JP_MONITOR_ACTIVE_COLUMN_NAME);
-        emailNotifications = getBooleanFromCursor(cursor, JP_MONITOR_EMAIL_NOTES_COLUMN_NAME);
-        wpNotifications = getBooleanFromCursor(cursor, JP_MONITOR_WP_NOTES_COLUMN_NAME);
-    }
-
-    public ContentValues serializeToDatabase() {
-        ContentValues values = new ContentValues();
-        values.put(JP_MONITOR_ACTIVE_COLUMN_NAME, monitorActive);
-        values.put(JP_MONITOR_EMAIL_NOTES_COLUMN_NAME, emailNotifications);
-        values.put(JP_MONITOR_WP_NOTES_COLUMN_NAME, wpNotifications);
-        return values;
-    }
-
-    private boolean getBooleanFromCursor(Cursor cursor, String columnName) {
-        int columnIndex = cursor.getColumnIndex(columnName);
-        return columnIndex != -1 && cursor.getInt(columnIndex) != 0;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
@@ -63,9 +63,6 @@ public class SiteSettingsModel {
     public static final String ALLOW_LIKE_BUTTON_COLUMN_NAME = "allowLikeButton";
     public static final String ALLOW_COMMENT_LIKES_COLUMN_NAME = "allowCommentLikes";
     public static final String TWITTER_USERNAME_COLUMN_NAME = "twitterUsername";
-    public static final String JP_MONITOR_ACTIVE_COLUMN_NAME = "monitorActive";
-    public static final String JP_MONITOR_EMAIL_NOTES_COLUMN_NAME = "jpEmailNotifications";
-    public static final String JP_MONITOR_WP_NOTES_COLUMN_NAME = "jpWpNotifications";
 
     public static final String SETTINGS_TABLE_NAME = "site_settings";
     public static final String ADD_OPTIMIZED_IMAGE = "alter table " + SETTINGS_TABLE_NAME +
@@ -128,9 +125,6 @@ public class SiteSettingsModel {
                     IDENTITY_REQUIRED_COLUMN_NAME + " BOOLEAN, " +
                     USER_ACCOUNT_REQUIRED_COLUMN_NAME + " BOOLEAN, " +
                     WHITELIST_COLUMN_NAME + " BOOLEAN, " +
-                    JP_MONITOR_ACTIVE_COLUMN_NAME + " BOOLEAN, " +
-                    JP_MONITOR_EMAIL_NOTES_COLUMN_NAME + " BOOLEAN, " +
-                    JP_MONITOR_WP_NOTES_COLUMN_NAME + " BOOLEAN, " +
                     MODERATION_KEYS_COLUMN_NAME + " TEXT, " +
                     BLACKLIST_KEYS_COLUMN_NAME + " TEXT" +
                     ");";
@@ -183,9 +177,6 @@ public class SiteSettingsModel {
     public boolean allowLikeButton;
     public boolean allowCommentLikes;
     public String twitterUsername;
-    public boolean monitorActive;
-    public boolean emailNotifications;
-    public boolean wpNotifications;
 
     @Override
     public boolean equals(Object other) {
@@ -233,9 +224,6 @@ public class SiteSettingsModel {
                 allowReblogButton == otherModel.allowReblogButton &&
                 allowLikeButton == otherModel.allowLikeButton &&
                 allowCommentLikes == otherModel.allowCommentLikes &&
-                monitorActive == otherModel.monitorActive &&
-                emailNotifications == otherModel.emailNotifications &&
-                wpNotifications == otherModel.wpNotifications &&
                 twitterUsername != null && twitterUsername.equals(otherModel.twitterUsername);
     }
 
@@ -284,9 +272,6 @@ public class SiteSettingsModel {
         commentsRequireIdentity = other.commentsRequireIdentity;
         commentsRequireUserAccount = other.commentsRequireUserAccount;
         commentAutoApprovalKnownUsers = other.commentAutoApprovalKnownUsers;
-        monitorActive = other.monitorActive;
-        emailNotifications = other.emailNotifications;
-        wpNotifications = other.wpNotifications;
         maxLinks = other.maxLinks;
         if (other.holdForModeration != null) {
             holdForModeration = new ArrayList<>(other.holdForModeration);
@@ -346,9 +331,6 @@ public class SiteSettingsModel {
         commentsRequireIdentity = getBooleanFromCursor(cursor, IDENTITY_REQUIRED_COLUMN_NAME);
         commentsRequireUserAccount = getBooleanFromCursor(cursor, USER_ACCOUNT_REQUIRED_COLUMN_NAME);
         commentAutoApprovalKnownUsers = getBooleanFromCursor(cursor, WHITELIST_COLUMN_NAME);
-        monitorActive = getBooleanFromCursor(cursor, JP_MONITOR_ACTIVE_COLUMN_NAME);
-        emailNotifications = getBooleanFromCursor(cursor, JP_MONITOR_EMAIL_NOTES_COLUMN_NAME);
-        wpNotifications = getBooleanFromCursor(cursor, JP_MONITOR_WP_NOTES_COLUMN_NAME);
 
         String moderationKeys = getStringFromCursor(cursor, MODERATION_KEYS_COLUMN_NAME);
         String blacklistKeys = getStringFromCursor(cursor, BLACKLIST_KEYS_COLUMN_NAME);
@@ -437,9 +419,6 @@ public class SiteSettingsModel {
         values.put(IDENTITY_REQUIRED_COLUMN_NAME, commentsRequireIdentity);
         values.put(USER_ACCOUNT_REQUIRED_COLUMN_NAME, commentsRequireUserAccount);
         values.put(WHITELIST_COLUMN_NAME, commentAutoApprovalKnownUsers);
-        values.put(JP_MONITOR_ACTIVE_COLUMN_NAME, monitorActive);
-        values.put(JP_MONITOR_EMAIL_NOTES_COLUMN_NAME, emailNotifications);
-        values.put(JP_MONITOR_WP_NOTES_COLUMN_NAME, wpNotifications);
 
         String moderationKeys = "";
         if (holdForModeration != null) {

--- a/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
@@ -15,54 +15,54 @@ import java.util.Map;
  */
 
 public class SiteSettingsModel {
-    public static final int RELATED_POSTS_ENABLED_FLAG = 0x1;
-    public static final int RELATED_POST_HEADER_FLAG = 0x2;
-    public static final int RELATED_POST_IMAGE_FLAG = 0x4;
+    private static final int RELATED_POSTS_ENABLED_FLAG = 0x1;
+    private static final int RELATED_POST_HEADER_FLAG = 0x2;
+    private static final int RELATED_POST_IMAGE_FLAG = 0x4;
 
     // Settings table column names
     public static final String ID_COLUMN_NAME = "id";
-    public static final String ADDRESS_COLUMN_NAME = "address";
-    public static final String USERNAME_COLUMN_NAME = "username";
-    public static final String PASSWORD_COLUMN_NAME = "password";
-    public static final String TITLE_COLUMN_NAME = "title";
-    public static final String TAGLINE_COLUMN_NAME = "tagline";
-    public static final String LANGUAGE_COLUMN_NAME = "language";
-    public static final String PRIVACY_COLUMN_NAME = "privacy";
-    public static final String LOCATION_COLUMN_NAME = "location";
-    public static final String OPTIMIZED_IMAGE_COLUMN_NAME = "optimizedImage";
-    public static final String MAX_IMAGE_WIDTH_COLUMN_NAME = "maxImageWidth";
-    public static final String IMAGE_ENCODER_QUALITY_COLUMN_NAME = "imageEncoderQuality";
-    public static final String OPTIMIZED_VIDEO_COLUMN_NAME = "optimizedVideo";
-    public static final String MAX_VIDEO_WIDTH_COLUMN_NAME = "maxVideoWidth";
-    public static final String VIDEO_ENCODER_BITRATE_COLUMN_NAME = "videoEncoderBitrate";
-    public static final String DEF_CATEGORY_COLUMN_NAME = "defaultCategory";
-    public static final String DEF_POST_FORMAT_COLUMN_NAME = "defaultPostFormat";
-    public static final String CATEGORIES_COLUMN_NAME = "categories";
-    public static final String POST_FORMATS_COLUMN_NAME = "postFormats";
-    public static final String CREDS_VERIFIED_COLUMN_NAME = "credsVerified";
-    public static final String RELATED_POSTS_COLUMN_NAME = "relatedPosts";
-    public static final String ALLOW_COMMENTS_COLUMN_NAME = "allowComments";
-    public static final String SEND_PINGBACKS_COLUMN_NAME = "sendPingbacks";
-    public static final String RECEIVE_PINGBACKS_COLUMN_NAME = "receivePingbacks";
-    public static final String SHOULD_CLOSE_AFTER_COLUMN_NAME = "shouldCloseAfter";
-    public static final String CLOSE_AFTER_COLUMN_NAME = "closeAfter";
-    public static final String SORT_BY_COLUMN_NAME = "sortBy";
-    public static final String SHOULD_THREAD_COLUMN_NAME = "shouldThread";
-    public static final String THREADING_COLUMN_NAME = "threading";
-    public static final String SHOULD_PAGE_COLUMN_NAME = "shouldPage";
-    public static final String PAGING_COLUMN_NAME = "paging";
-    public static final String MANUAL_APPROVAL_COLUMN_NAME = "manualApproval";
-    public static final String IDENTITY_REQUIRED_COLUMN_NAME = "identityRequired";
-    public static final String USER_ACCOUNT_REQUIRED_COLUMN_NAME = "userAccountRequired";
-    public static final String WHITELIST_COLUMN_NAME = "whitelist";
-    public static final String MODERATION_KEYS_COLUMN_NAME = "moderationKeys";
-    public static final String BLACKLIST_KEYS_COLUMN_NAME = "blacklistKeys";
-    public static final String SHARING_LABEL_COLUMN_NAME = "sharingLabel";
-    public static final String SHARING_BUTTON_STYLE_COLUMN_NAME = "sharingButtonStyle";
-    public static final String ALLOW_REBLOG_BUTTON_COLUMN_NAME = "allowReblogButton";
-    public static final String ALLOW_LIKE_BUTTON_COLUMN_NAME = "allowLikeButton";
-    public static final String ALLOW_COMMENT_LIKES_COLUMN_NAME = "allowCommentLikes";
-    public static final String TWITTER_USERNAME_COLUMN_NAME = "twitterUsername";
+    private static final String ADDRESS_COLUMN_NAME = "address";
+    private static final String USERNAME_COLUMN_NAME = "username";
+    private static final String PASSWORD_COLUMN_NAME = "password";
+    private static final String TITLE_COLUMN_NAME = "title";
+    private static final String TAGLINE_COLUMN_NAME = "tagline";
+    private static final String LANGUAGE_COLUMN_NAME = "language";
+    private static final String PRIVACY_COLUMN_NAME = "privacy";
+    private static final String LOCATION_COLUMN_NAME = "location";
+    private static final String OPTIMIZED_IMAGE_COLUMN_NAME = "optimizedImage";
+    private static final String MAX_IMAGE_WIDTH_COLUMN_NAME = "maxImageWidth";
+    private static final String IMAGE_ENCODER_QUALITY_COLUMN_NAME = "imageEncoderQuality";
+    private static final String OPTIMIZED_VIDEO_COLUMN_NAME = "optimizedVideo";
+    private static final String MAX_VIDEO_WIDTH_COLUMN_NAME = "maxVideoWidth";
+    private static final String VIDEO_ENCODER_BITRATE_COLUMN_NAME = "videoEncoderBitrate";
+    private static final String DEF_CATEGORY_COLUMN_NAME = "defaultCategory";
+    private static final String DEF_POST_FORMAT_COLUMN_NAME = "defaultPostFormat";
+    private static final String CATEGORIES_COLUMN_NAME = "categories";
+    private static final String POST_FORMATS_COLUMN_NAME = "postFormats";
+    private static final String CREDS_VERIFIED_COLUMN_NAME = "credsVerified";
+    private static final String RELATED_POSTS_COLUMN_NAME = "relatedPosts";
+    private static final String ALLOW_COMMENTS_COLUMN_NAME = "allowComments";
+    private static final String SEND_PINGBACKS_COLUMN_NAME = "sendPingbacks";
+    private static final String RECEIVE_PINGBACKS_COLUMN_NAME = "receivePingbacks";
+    private static final String SHOULD_CLOSE_AFTER_COLUMN_NAME = "shouldCloseAfter";
+    private static final String CLOSE_AFTER_COLUMN_NAME = "closeAfter";
+    private static final String SORT_BY_COLUMN_NAME = "sortBy";
+    private static final String SHOULD_THREAD_COLUMN_NAME = "shouldThread";
+    private static final String THREADING_COLUMN_NAME = "threading";
+    private static final String SHOULD_PAGE_COLUMN_NAME = "shouldPage";
+    private static final String PAGING_COLUMN_NAME = "paging";
+    private static final String MANUAL_APPROVAL_COLUMN_NAME = "manualApproval";
+    private static final String IDENTITY_REQUIRED_COLUMN_NAME = "identityRequired";
+    private static final String USER_ACCOUNT_REQUIRED_COLUMN_NAME = "userAccountRequired";
+    private static final String WHITELIST_COLUMN_NAME = "whitelist";
+    private static final String MODERATION_KEYS_COLUMN_NAME = "moderationKeys";
+    private static final String BLACKLIST_KEYS_COLUMN_NAME = "blacklistKeys";
+    private static final String SHARING_LABEL_COLUMN_NAME = "sharingLabel";
+    private static final String SHARING_BUTTON_STYLE_COLUMN_NAME = "sharingButtonStyle";
+    private static final String ALLOW_REBLOG_BUTTON_COLUMN_NAME = "allowReblogButton";
+    private static final String ALLOW_LIKE_BUTTON_COLUMN_NAME = "allowLikeButton";
+    private static final String ALLOW_COMMENT_LIKES_COLUMN_NAME = "allowCommentLikes";
+    private static final String TWITTER_USERNAME_COLUMN_NAME = "twitterUsername";
 
     public static final String SETTINGS_TABLE_NAME = "site_settings";
     public static final String ADD_OPTIMIZED_IMAGE = "alter table " + SETTINGS_TABLE_NAME +
@@ -444,7 +444,7 @@ public class SiteSettingsModel {
         return values;
     }
 
-    public int getRelatedPostsFlags() {
+    private int getRelatedPostsFlags() {
         int flags = 0;
 
         if (showRelatedPosts) flags |= RELATED_POSTS_ENABLED_FLAG;
@@ -454,7 +454,7 @@ public class SiteSettingsModel {
         return flags;
     }
 
-    public void setRelatedPostsFlags(int flags) {
+    private void setRelatedPostsFlags(int flags) {
         showRelatedPosts = (flags & RELATED_POSTS_ENABLED_FLAG) > 0;
         showRelatedPostHeader = (flags & RELATED_POST_HEADER_FLAG) > 0;
         showRelatedPostImages = (flags & RELATED_POST_IMAGE_FLAG) > 0;

--- a/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
@@ -284,6 +284,9 @@ public class SiteSettingsModel {
         commentsRequireIdentity = other.commentsRequireIdentity;
         commentsRequireUserAccount = other.commentsRequireUserAccount;
         commentAutoApprovalKnownUsers = other.commentAutoApprovalKnownUsers;
+        monitorActive = other.monitorActive;
+        emailNotifications = other.emailNotifications;
+        wpNotifications = other.wpNotifications;
         maxLinks = other.maxLinks;
         if (other.holdForModeration != null) {
             holdForModeration = new ArrayList<>(other.holdForModeration);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -90,6 +90,11 @@ class DotComSiteSettings extends SiteSettingsInterface {
     public void saveSettings() {
         super.saveSettings();
 
+        // save any Jetpack changes
+        if (mSite.isJetpackConnected()) {
+            saveJetpackSettings();
+        }
+
         final Map<String, String> params = serializeDotComParams();
         if (params == null || params.isEmpty()) return;
 
@@ -115,9 +120,6 @@ class DotComSiteSettings extends SiteSettingsInterface {
                             }
                             AnalyticsUtils.trackWithSiteDetails(
                                     AnalyticsTracker.Stat.SITE_SETTINGS_SAVED_REMOTELY, mSite, properties);
-                        }
-                        if (mSite.isJetpackConnected()) {
-                            saveJetpackSettings();
                         }
                     }
                 }, new RestRequest.ErrorListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -24,45 +24,45 @@ import java.util.Map;
 
 class DotComSiteSettings extends SiteSettingsInterface {
     // WP.com REST keys used in response to a settings GET and POST request
-    public static final String LANGUAGE_ID_KEY = "lang_id";
-    public static final String PRIVACY_KEY = "blog_public";
-    public static final String URL_KEY = "URL";
-    public static final String DEF_CATEGORY_KEY = "default_category";
-    public static final String DEF_POST_FORMAT_KEY = "default_post_format";
-    public static final String RELATED_POSTS_ALLOWED_KEY = "jetpack_relatedposts_allowed";
-    public static final String RELATED_POSTS_ENABLED_KEY = "jetpack_relatedposts_enabled";
-    public static final String RELATED_POSTS_HEADER_KEY = "jetpack_relatedposts_show_headline";
-    public static final String RELATED_POSTS_IMAGES_KEY = "jetpack_relatedposts_show_thumbnails";
-    public static final String ALLOW_COMMENTS_KEY = "default_comment_status";
-    public static final String SEND_PINGBACKS_KEY = "default_pingback_flag";
-    public static final String RECEIVE_PINGBACKS_KEY = "default_ping_status";
-    public static final String CLOSE_OLD_COMMENTS_KEY = "close_comments_for_old_posts";
-    public static final String CLOSE_OLD_COMMENTS_DAYS_KEY = "close_comments_days_old";
-    public static final String THREAD_COMMENTS_KEY = "thread_comments";
-    public static final String THREAD_COMMENTS_DEPTH_KEY = "thread_comments_depth";
-    public static final String PAGE_COMMENTS_KEY = "page_comments";
-    public static final String PAGE_COMMENT_COUNT_KEY = "comments_per_page";
-    public static final String COMMENT_SORT_ORDER_KEY = "comment_order";
-    public static final String COMMENT_MODERATION_KEY = "comment_moderation";
-    public static final String REQUIRE_IDENTITY_KEY = "require_name_email";
-    public static final String REQUIRE_USER_ACCOUNT_KEY = "comment_registration";
-    public static final String WHITELIST_KNOWN_USERS_KEY = "comment_whitelist";
-    public static final String MAX_LINKS_KEY = "comment_max_links";
-    public static final String MODERATION_KEYS_KEY = "moderation_keys";
-    public static final String BLACKLIST_KEYS_KEY = "blacklist_keys";
-    public static final String SHARING_LABEL_KEY = "sharing_label";
-    public static final String SHARING_BUTTON_STYLE_KEY = "sharing_button_style";
-    public static final String SHARING_REBLOGS_DISABLED_KEY = "disabled_reblogs";
-    public static final String SHARING_LIKES_DISABLED_KEY = "disabled_likes";
-    public static final String SHARING_COMMENT_LIKES_KEY = "jetpack_comment_likes_enabled";
-    public static final String TWITTER_USERNAME_KEY = "twitter_via";
-    public static final String JP_MONITOR_ACTIVE_KEY = "monitor_active";
-    public static final String JP_MONITOR_EMAIL_NOTES_KEY = "email_notifications";
-    public static final String JP_MONITOR_WP_NOTES_KEY = "wp_notifications";
+    private static final String LANGUAGE_ID_KEY = "lang_id";
+    private static final String PRIVACY_KEY = "blog_public";
+    private static final String URL_KEY = "URL";
+    private static final String DEF_CATEGORY_KEY = "default_category";
+    private static final String DEF_POST_FORMAT_KEY = "default_post_format";
+    private static final String RELATED_POSTS_ALLOWED_KEY = "jetpack_relatedposts_allowed";
+    private static final String RELATED_POSTS_ENABLED_KEY = "jetpack_relatedposts_enabled";
+    private static final String RELATED_POSTS_HEADER_KEY = "jetpack_relatedposts_show_headline";
+    private static final String RELATED_POSTS_IMAGES_KEY = "jetpack_relatedposts_show_thumbnails";
+    private static final String ALLOW_COMMENTS_KEY = "default_comment_status";
+    private static final String SEND_PINGBACKS_KEY = "default_pingback_flag";
+    private static final String RECEIVE_PINGBACKS_KEY = "default_ping_status";
+    private static final String CLOSE_OLD_COMMENTS_KEY = "close_comments_for_old_posts";
+    private static final String CLOSE_OLD_COMMENTS_DAYS_KEY = "close_comments_days_old";
+    private static final String THREAD_COMMENTS_KEY = "thread_comments";
+    private static final String THREAD_COMMENTS_DEPTH_KEY = "thread_comments_depth";
+    private static final String PAGE_COMMENTS_KEY = "page_comments";
+    private static final String PAGE_COMMENT_COUNT_KEY = "comments_per_page";
+    private static final String COMMENT_SORT_ORDER_KEY = "comment_order";
+    private static final String COMMENT_MODERATION_KEY = "comment_moderation";
+    private static final String REQUIRE_IDENTITY_KEY = "require_name_email";
+    private static final String REQUIRE_USER_ACCOUNT_KEY = "comment_registration";
+    private static final String WHITELIST_KNOWN_USERS_KEY = "comment_whitelist";
+    private static final String MAX_LINKS_KEY = "comment_max_links";
+    private static final String MODERATION_KEYS_KEY = "moderation_keys";
+    private static final String BLACKLIST_KEYS_KEY = "blacklist_keys";
+    private static final String SHARING_LABEL_KEY = "sharing_label";
+    private static final String SHARING_BUTTON_STYLE_KEY = "sharing_button_style";
+    private static final String SHARING_REBLOGS_DISABLED_KEY = "disabled_reblogs";
+    private static final String SHARING_LIKES_DISABLED_KEY = "disabled_likes";
+    private static final String SHARING_COMMENT_LIKES_KEY = "jetpack_comment_likes_enabled";
+    private static final String TWITTER_USERNAME_KEY = "twitter_via";
+    private static final String JP_MONITOR_ACTIVE_KEY = "monitor_active";
+    private static final String JP_MONITOR_EMAIL_NOTES_KEY = "email_notifications";
+    private static final String JP_MONITOR_WP_NOTES_KEY = "wp_notifications";
 
     // WP.com REST keys used to GET certain site settings
-    public static final String GET_TITLE_KEY = "name";
-    public static final String GET_DESC_KEY = "description";
+    private static final String GET_TITLE_KEY = "name";
+    private static final String GET_DESC_KEY = "description";
 
     // WP.com REST keys used to POST updates to site settings
     private static final String SET_TITLE_KEY = "blogname";
@@ -77,7 +77,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
     private static final String CAT_POST_COUNT_KEY = "post_count";
     private static final String CAT_NUM_POSTS_KEY = "found";
     private static final String CATEGORIES_KEY = "categories";
-    public static final String DEFAULT_SHARING_BUTTON_STYLE = "icon-only";
+    private static final String DEFAULT_SHARING_BUTTON_STYLE = "icon-only";
 
     /**
      * Only instantiated by {@link SiteSettingsInterface}.

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -437,15 +437,16 @@ class DotComSiteSettings extends SiteSettingsInterface {
     private void saveJetpackSettings() {
         final Map<String, String> params = serializeJetpackParams();
         if (params == null || params.isEmpty()) return;
+
         WordPress.getRestClientUtils().setJetpackSettings(
                 mSite.getSiteId(), new RestRequest.Listener() {
                     @Override
                     public void onResponse(JSONObject response) {
                         AppLog.d(AppLog.T.API, "Jetpack Settings saved remotely");
-                        notifySavedOnUiThread(null);
                         mRemoteJpSettings.monitorActive = mJpSettings.monitorActive;
                         mRemoteJpSettings.emailNotifications = mJpSettings.emailNotifications;
                         mRemoteJpSettings.wpNotifications = mJpSettings.wpNotifications;
+                        notifySavedOnUiThread(null);
                     }
                 }, new RestRequest.ErrorListener() {
                     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -58,7 +58,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
     private static final String TWITTER_USERNAME_KEY = "twitter_via";
     private static final String JP_MONITOR_ACTIVE_KEY = "monitor_active";
     private static final String JP_MONITOR_EMAIL_NOTES_KEY = "email_notifications";
-    private static final String JP_MONITOR_WP_NOTES_KEY = "wp_notifications";
+    private static final String JP_MONITOR_WP_NOTES_KEY = "wp_note_notifications";
 
     // WP.com REST keys used to GET certain site settings
     private static final String GET_TITLE_KEY = "name";

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -191,9 +191,13 @@ class DotComSiteSettings extends SiteSettingsInterface {
                     @Override
                     public void onResponse(JSONObject response) {
                         AppLog.v(AppLog.T.API, "Received response to Jetpack Settings REST request.");
-                        mRemoteSettings.localTableId = mSite.getId();
+                        mRemoteJpSettings.localTableId = mSite.getId();
                         deserializeJetpackRestResponse(mSite, response);
-                        mSettings.copyFrom(mRemoteSettings);
+                        mJpSettings.localTableId = mRemoteJpSettings.localTableId;
+                        mJpSettings.monitorActive = mRemoteJpSettings.monitorActive;
+                        mJpSettings.emailNotifications = mRemoteJpSettings.emailNotifications;
+                        mJpSettings.wpNotifications = mRemoteJpSettings.wpNotifications;
+                        SiteSettingsTable.saveJpSettings(mJpSettings);
                         notifyUpdatedOnUiThread(null);
                     }
                 }, new RestRequest.ErrorListener() {
@@ -439,9 +443,9 @@ class DotComSiteSettings extends SiteSettingsInterface {
                     public void onResponse(JSONObject response) {
                         AppLog.d(AppLog.T.API, "Jetpack Settings saved remotely");
                         notifySavedOnUiThread(null);
-                        mRemoteSettings.monitorActive = mSettings.monitorActive;
-                        mRemoteSettings.emailNotifications = mSettings.emailNotifications;
-                        mRemoteSettings.wpNotifications = mSettings.wpNotifications;
+                        mRemoteJpSettings.monitorActive = mJpSettings.monitorActive;
+                        mRemoteJpSettings.emailNotifications = mJpSettings.emailNotifications;
+                        mRemoteJpSettings.wpNotifications = mJpSettings.wpNotifications;
                     }
                 }, new RestRequest.ErrorListener() {
                     @Override
@@ -455,16 +459,16 @@ class DotComSiteSettings extends SiteSettingsInterface {
     private void deserializeJetpackRestResponse(SiteModel site, JSONObject response) {
         if (site == null || response == null) return;
         JSONObject settingsObject = response.optJSONObject("settings");
-        mRemoteSettings.monitorActive = settingsObject.optBoolean(JP_MONITOR_ACTIVE_KEY, false);
-        mRemoteSettings.emailNotifications = settingsObject.optBoolean(JP_MONITOR_EMAIL_NOTES_KEY, false);
-        mRemoteSettings.wpNotifications = settingsObject.optBoolean(JP_MONITOR_WP_NOTES_KEY, false);
+        mRemoteJpSettings.monitorActive = settingsObject.optBoolean(JP_MONITOR_ACTIVE_KEY, false);
+        mRemoteJpSettings.emailNotifications = settingsObject.optBoolean(JP_MONITOR_EMAIL_NOTES_KEY, false);
+        mRemoteJpSettings.wpNotifications = settingsObject.optBoolean(JP_MONITOR_WP_NOTES_KEY, false);
     }
 
     private Map<String, String> serializeJetpackParams() {
         Map<String, String> params = new HashMap<>();
-        params.put(JP_MONITOR_ACTIVE_KEY, String.valueOf(mSettings.monitorActive));
-        params.put(JP_MONITOR_EMAIL_NOTES_KEY, String.valueOf(mSettings.emailNotifications));
-        params.put(JP_MONITOR_WP_NOTES_KEY, String.valueOf(mSettings.wpNotifications));
+        params.put(JP_MONITOR_ACTIVE_KEY, String.valueOf(mJpSettings.monitorActive));
+        params.put(JP_MONITOR_EMAIL_NOTES_KEY, String.valueOf(mJpSettings.emailNotifications));
+        params.put(JP_MONITOR_WP_NOTES_KEY, String.valueOf(mJpSettings.wpNotifications));
         return params;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1450,6 +1450,7 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void removeNonDotComPreferences() {
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_account);
+        WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_jetpack_settings);
     }
 
     private Preference getChangePref(int id) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -727,10 +727,10 @@ public class SiteSettingsFragment extends PreferenceFragment
         mStartOverPref = getClickPref(R.string.pref_key_site_start_over);
         mExportSitePref = getClickPref(R.string.pref_key_site_export_site);
         mDeleteSitePref = getClickPref(R.string.pref_key_site_delete_site);
-        mJpSecuritySettings = (PreferenceScreen) getClickPref(R.string.pref_key_jetpack_security_site_setting);
-        mJpMonitorActivePref = (WPSwitchPreference) getChangePref(R.string.pref_key_site_monitor_uptime);
-        mJpMonitorEmailNotesPref = (WPSwitchPreference) getChangePref(R.string.pref_key_site_send_email_notifications);
-        mJpMonitorWpNotesPref = (WPSwitchPreference) getChangePref(R.string.pref_key_site_send_wp_notifications);
+        mJpSecuritySettings = (PreferenceScreen) getClickPref(R.string.pref_key_jetpack_security_screen);
+        mJpMonitorActivePref = (WPSwitchPreference) getChangePref(R.string.pref_key_jetpack_monitor_uptime);
+        mJpMonitorEmailNotesPref = (WPSwitchPreference) getChangePref(R.string.pref_key_jetpack_send_email_notifications);
+        mJpMonitorWpNotesPref = (WPSwitchPreference) getChangePref(R.string.pref_key_jetpack_send_wp_notifications);
 
         sortLanguages();
 
@@ -1388,7 +1388,7 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void setupJetpackSecurityScreen() {
         if (mJpSecuritySettings == null || !isAdded()) return;
-        String title = getString(R.string.site_settings_jetpack_security_screen_title);
+        String title = getString(R.string.jetpack_security_settings_screen_title);
         Dialog dialog = mJpSecuritySettings.getDialog();
         if (dialog != null) {
             setupPreferenceList((ListView) dialog.findViewById(android.R.id.list), getResources());

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1388,7 +1388,7 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void setupJetpackSecurityScreen() {
         if (mJpSecuritySettings == null || !isAdded()) return;
-        String title = getString(R.string.jetpack_security_settings_screen_title);
+        String title = getString(R.string.jetpack_security_setting_title);
         Dialog dialog = mJpSecuritySettings.getDialog();
         if (dialog != null) {
             setupPreferenceList((ListView) dialog.findViewById(android.R.id.list), getResources());

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -202,6 +202,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     private Preference mDeleteSitePref;
 
     // Jetpack settings
+    private PreferenceScreen mJpSecuritySettings;
     private WPSwitchPreference mJpMonitorActivePref;
     private WPSwitchPreference mJpMonitorEmailNotesPref;
     private WPSwitchPreference mJpMonitorWpNotesPref;
@@ -417,6 +418,8 @@ public class SiteSettingsFragment extends PreferenceFragment
                     AnalyticsTracker.Stat.SITE_SETTINGS_ACCESSED_MORE_SETTINGS, mSite);
 
             return setupMorePreferenceScreen();
+        } else if (preference == mJpSecuritySettings) {
+            setupJetpackSecurityScreen();
         } else if (preference == findPreference(getString(R.string.pref_key_site_start_over_screen))) {
             Dialog dialog = ((PreferenceScreen) preference).getDialog();
             if (mSite == null || dialog == null) return false;
@@ -724,6 +727,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         mStartOverPref = getClickPref(R.string.pref_key_site_start_over);
         mExportSitePref = getClickPref(R.string.pref_key_site_export_site);
         mDeleteSitePref = getClickPref(R.string.pref_key_site_delete_site);
+        mJpSecuritySettings = (PreferenceScreen) getClickPref(R.string.pref_key_jetpack_security_site_setting);
         mJpMonitorActivePref = (WPSwitchPreference) getChangePref(R.string.pref_key_site_monitor_uptime);
         mJpMonitorEmailNotesPref = (WPSwitchPreference) getChangePref(R.string.pref_key_site_send_email_notifications);
         mJpMonitorWpNotesPref = (WPSwitchPreference) getChangePref(R.string.pref_key_site_send_wp_notifications);
@@ -1380,6 +1384,16 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     public boolean shouldShowListPreference(DetailListPreference preference) {
         return preference != null && preference.getEntries() != null && preference.getEntries().length > 0;
+    }
+
+    private void setupJetpackSecurityScreen() {
+        if (mJpSecuritySettings == null || !isAdded()) return;
+        String title = getString(R.string.site_settings_jetpack_security_screen_title);
+        Dialog dialog = mJpSecuritySettings.getDialog();
+        if (dialog != null) {
+            setupPreferenceList((ListView) dialog.findViewById(android.R.id.list), getResources());
+            WPActivityUtils.addToolbarToDialog(this, dialog, title);
+        }
     }
 
     private boolean setupMorePreferenceScreen() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -882,7 +882,7 @@ public abstract class SiteSettingsInterface {
         Cursor localSettings = SiteSettingsTable.getJpSettings(mSite.getId());
 
         if (localSettings != null && localSettings.getCount() > 0) {
-            mJpSettings.deserializeOptionsDatabaseCursor(localSettings);
+            SiteSettingsTable.deserializeJetpackDatabaseCursor(mJpSettings, localSettings);
             notifyUpdatedOnUiThread(null);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnPostFormatsChanged;
 import org.wordpress.android.models.CategoryModel;
+import org.wordpress.android.models.JetpackSettingsModel;
 import org.wordpress.android.models.SiteSettingsModel;
 import org.wordpress.android.util.LanguageUtils;
 import org.wordpress.android.util.SiteUtils;
@@ -207,6 +208,8 @@ public abstract class SiteSettingsInterface {
     protected final SiteSettingsListener mListener;
     protected final SiteSettingsModel mSettings;
     protected final SiteSettingsModel mRemoteSettings;
+    protected final JetpackSettingsModel mJpSettings;
+    protected final JetpackSettingsModel mRemoteJpSettings;
     private final Map<String, String> mLanguageCodes;
 
     @Inject SiteStore mSiteStore;
@@ -220,6 +223,8 @@ public abstract class SiteSettingsInterface {
         mListener = listener;
         mSettings = new SiteSettingsModel();
         mRemoteSettings = new SiteSettingsModel();
+        mJpSettings = new JetpackSettingsModel();
+        mRemoteJpSettings = new JetpackSettingsModel();
         mLanguageCodes = WPPrefUtils.generateLanguageMap(host);
     }
 
@@ -584,27 +589,27 @@ public abstract class SiteSettingsInterface {
     }
 
     public boolean isJetpackMonitorEnabled() {
-        return mSettings.monitorActive;
+        return mJpSettings.monitorActive;
     }
 
     public boolean shouldSendJetpackMonitorEmailNotifications() {
-        return mSettings.emailNotifications;
+        return mJpSettings.emailNotifications;
     }
 
     public boolean shouldSendJetpackMonitorWpNotifications() {
-        return mSettings.wpNotifications;
+        return mJpSettings.wpNotifications;
     }
 
     public void enableJetpackMonitor(boolean monitorActive) {
-        mSettings.monitorActive = monitorActive;
+        mJpSettings.monitorActive = monitorActive;
     }
 
     public void enableJetpackMonitorEmailNotifications(boolean emailNotifications) {
-        mSettings.emailNotifications = emailNotifications;
+        mJpSettings.emailNotifications = emailNotifications;
     }
 
     public void enableJetpackMonitorWpNotifications(boolean wpNotifications) {
-        mSettings.wpNotifications = wpNotifications;
+        mJpSettings.wpNotifications = wpNotifications;
     }
 
     public void setTitle(String title) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -866,12 +866,29 @@ public abstract class SiteSettingsInterface {
     public SiteSettingsInterface init(boolean fetchRemote) {
         loadCachedSettings();
 
+        if (mSite.isJetpackConnected()) {
+            loadCachedJpSettings();
+        }
+
         if (fetchRemote) {
             fetchRemoteData();
             mDispatcher.dispatch(SiteActionBuilder.newFetchPostFormatsAction(mSite));
         }
 
         return this;
+    }
+
+    private void loadCachedJpSettings() {
+        Cursor localSettings = SiteSettingsTable.getJpSettings(mSite.getId());
+
+        if (localSettings != null && localSettings.getCount() > 0) {
+            mJpSettings.deserializeOptionsDatabaseCursor(localSettings);
+            notifyUpdatedOnUiThread(null);
+        }
+
+        if (localSettings != null) {
+            localSettings.close();
+        }
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -76,22 +76,22 @@ public abstract class SiteSettingsInterface {
     /**
      * Name of the {@link SharedPreferences} that is used to store local settings.
      */
-    public static final String SITE_SETTINGS_PREFS = "site-settings-prefs";
+    private static final String SITE_SETTINGS_PREFS = "site-settings-prefs";
 
     /**
      * Key used to access the language preference stored in {@link SharedPreferences}.
      */
-    public static final String LANGUAGE_PREF_KEY = "site-settings-language-pref";
+    private static final String LANGUAGE_PREF_KEY = "site-settings-language-pref";
 
     /**
      * Key used to access the default category preference stored in {@link SharedPreferences}.
      */
-    public static final String DEF_CATEGORY_PREF_KEY = "site-settings-category-pref";
+    private static final String DEF_CATEGORY_PREF_KEY = "site-settings-category-pref";
 
     /**
      * Key used to access the default post format preference stored in {@link SharedPreferences}.
      */
-    public static final String DEF_FORMAT_PREF_KEY = "site-settings-format-pref";
+    private static final String DEF_FORMAT_PREF_KEY = "site-settings-format-pref";
 
     /**
      * Key used to access the sharing button style stored in {@link SharedPreferences}.
@@ -101,17 +101,17 @@ public abstract class SiteSettingsInterface {
     /**
      * Identifies an Ascending (oldest to newest) sort order.
      */
-    public static final int ASCENDING_SORT = 0;
+    static final int ASCENDING_SORT = 0;
 
     /**
      * Identifies an Descending (newest to oldest) sort order.
      */
-    public static final int DESCENDING_SORT = 1;
+    static final int DESCENDING_SORT = 1;
 
     /**
      * Used to prefix keys in an analytics property list.
      */
-    protected static final String SAVED_ITEM_PREFIX = "item_saved_";
+    static final String SAVED_ITEM_PREFIX = "item_saved_";
 
     /**
      * Key for the Standard post format. Used as default if post format is not set/known.

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -75,6 +75,8 @@
     <string name="pref_key_site_moderation_hold" translatable="false">wp_pref_site_moderation_hold</string>
     <string name="pref_key_site_blacklist" translatable="false">wp_pref_site_blacklist</string>
     <string name="pref_key_site_danger" translatable="false">wp_pref_site_danger</string>
+    <string name="pref_key_site_jetpack" translatable="false">wp_pref_site_jetpack</string>
+    <string name="pref_key_site_jetpack_security" translatable="false">wp_pref_site_jetpack_security</string>
     <string name="pref_key_site_jetpack_monitor" translatable="false">wp_pref_site_jetpack_monitor</string>
     <string name="pref_key_site_monitor_uptime" translatable="false">wp_pref_site_monitor_uptime</string>
     <string name="pref_key_site_send_email_notifications" translatable="false">wp_pref_site_send_email_notifications</string>

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -76,7 +76,7 @@
     <string name="pref_key_site_blacklist" translatable="false">wp_pref_site_blacklist</string>
     <string name="pref_key_site_danger" translatable="false">wp_pref_site_danger</string>
     <string name="pref_key_site_jetpack" translatable="false">wp_pref_site_jetpack</string>
-    <string name="jetpack_security_site_setting" translatable="false">wp_pref_site_jetpack_security</string>
+    <string name="pref_key_jetpack_security_site_setting" translatable="false">wp_pref_site_jetpack_security</string>
     <string name="pref_key_site_jetpack_monitor" translatable="false">wp_pref_site_jetpack_monitor</string>
     <string name="pref_key_site_monitor_uptime" translatable="false">wp_pref_site_monitor_uptime</string>
     <string name="pref_key_site_send_email_notifications" translatable="false">wp_pref_site_send_email_notifications</string>

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -94,6 +94,7 @@
     <string name="pref_key_twitter_category" translatable="false">wp_pref_twitter_category</string>
 
     <!-- Jetpack Security -->
+    <string name="pref_key_jetpack_settings" translatable="false">wp_pref_jetpack_settings</string>
     <string name="pref_key_jetpack_security_screen" translatable="false">wp_pref_jetpack_security_screen</string>
     <string name="pref_key_jetpack_monitor_uptime" translatable="false">wp_pref_jetpack_monitor_uptime</string>
     <string name="pref_key_jetpack_send_email_notifications" translatable="false">wp_pref_jetpack_send_email_notifications</string>

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -75,18 +75,6 @@
     <string name="pref_key_site_moderation_hold" translatable="false">wp_pref_site_moderation_hold</string>
     <string name="pref_key_site_blacklist" translatable="false">wp_pref_site_blacklist</string>
     <string name="pref_key_site_danger" translatable="false">wp_pref_site_danger</string>
-    <string name="pref_key_site_jetpack" translatable="false">wp_pref_site_jetpack</string>
-    <string name="pref_key_jetpack_security_site_setting" translatable="false">wp_pref_site_jetpack_security</string>
-    <string name="pref_key_site_jetpack_monitor" translatable="false">wp_pref_site_jetpack_monitor</string>
-    <string name="pref_key_site_jetpack_brute_force" translatable="false">wp_pref_site_jetpack_brute_force</string>
-    <string name="pref_key_site_jetpack_wpcom_sign_in" translatable="false">wp_pref_site_jetpack_wpcom_sign_in</string>
-    <string name="pref_key_site_jetpack_prevent_brute_force" translatable="false">wp_pref_site_jetpack_prevent_brute_force</string>
-    <string name="pref_key_site_jetpack_allow_wpcom_sign_in" translatable="false">wp_pref_site_jetpack_allow_wpcom_sign_in</string>
-    <string name="pref_key_site_jetpack_match_via_email" translatable="false">wp_pref_site_jetpack_match_via_email</string>
-    <string name="pref_key_site_jetpack_require_two_factor" translatable="false">wp_pref_site_jetpack_require_two_factor</string>
-    <string name="pref_key_site_monitor_uptime" translatable="false">wp_pref_site_monitor_uptime</string>
-    <string name="pref_key_site_send_email_notifications" translatable="false">wp_pref_site_send_email_notifications</string>
-    <string name="pref_key_site_send_wp_notifications" translatable="false">wp_pref_site_send_wp_notifications</string>
     <string name="pref_key_site_advanced" translatable="false">wp_pref_site_advanced</string>
     <string name="pref_key_site_start_over" translatable="false">wp_pref_site_start_over</string>
     <string name="pref_key_site_export_site" translatable="false">pref_key_site_export_site</string>
@@ -104,6 +92,17 @@
     <string name="pref_key_comment_likes" translatable="false">wp_pref_comment_likes</string>
     <string name="pref_key_more_buttons" translatable="false">wp_pref_more_buttons</string>
     <string name="pref_key_twitter_category" translatable="false">wp_pref_twitter_category</string>
+
+    <!-- Jetpack Security -->
+    <string name="pref_key_jetpack_security_screen" translatable="false">wp_pref_jetpack_security_screen</string>
+    <string name="pref_key_jetpack_monitor_uptime" translatable="false">wp_pref_jetpack_monitor_uptime</string>
+    <string name="pref_key_jetpack_send_email_notifications" translatable="false">wp_pref_jetpack_send_email_notifications</string>
+    <string name="pref_key_jetpack_send_wp_notifications" translatable="false">wp_pref_jetpack_send_wp_notifications</string>
+    <string name="pref_key_jetpack_prevent_brute_force" translatable="false">wp_pref_jetpack_prevent_brute_force</string>
+    <string name="pref_key_jetpack_brute_force_whitelist" translatable="false">wp_pref_jetpack_brute_force_whitelist</string>
+    <string name="pref_key_jetpack_allow_wpcom_sign_in" translatable="false">wp_pref_jetpack_allow_wpcom_sign_in</string>
+    <string name="pref_key_jetpack_match_via_email" translatable="false">wp_pref_jetpack_match_via_email</string>
+    <string name="pref_key_jetpack_require_two_factor" translatable="false">wp_pref_jetpack_require_two_factor</string>
 
     <!-- Notifications -->
     <string-array name="notifications_blog_settings_values" translatable="false">

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -78,6 +78,12 @@
     <string name="pref_key_site_jetpack" translatable="false">wp_pref_site_jetpack</string>
     <string name="pref_key_jetpack_security_site_setting" translatable="false">wp_pref_site_jetpack_security</string>
     <string name="pref_key_site_jetpack_monitor" translatable="false">wp_pref_site_jetpack_monitor</string>
+    <string name="pref_key_site_jetpack_brute_force" translatable="false">wp_pref_site_jetpack_brute_force</string>
+    <string name="pref_key_site_jetpack_wpcom_sign_in" translatable="false">wp_pref_site_jetpack_wpcom_sign_in</string>
+    <string name="pref_key_site_jetpack_prevent_brute_force" translatable="false">wp_pref_site_jetpack_prevent_brute_force</string>
+    <string name="pref_key_site_jetpack_allow_wpcom_sign_in" translatable="false">wp_pref_site_jetpack_allow_wpcom_sign_in</string>
+    <string name="pref_key_site_jetpack_match_via_email" translatable="false">wp_pref_site_jetpack_match_via_email</string>
+    <string name="pref_key_site_jetpack_require_two_factor" translatable="false">wp_pref_site_jetpack_require_two_factor</string>
     <string name="pref_key_site_monitor_uptime" translatable="false">wp_pref_site_monitor_uptime</string>
     <string name="pref_key_site_send_email_notifications" translatable="false">wp_pref_site_send_email_notifications</string>
     <string name="pref_key_site_send_wp_notifications" translatable="false">wp_pref_site_send_wp_notifications</string>

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -76,7 +76,7 @@
     <string name="pref_key_site_blacklist" translatable="false">wp_pref_site_blacklist</string>
     <string name="pref_key_site_danger" translatable="false">wp_pref_site_danger</string>
     <string name="pref_key_site_jetpack" translatable="false">wp_pref_site_jetpack</string>
-    <string name="pref_key_site_jetpack_security" translatable="false">wp_pref_site_jetpack_security</string>
+    <string name="jetpack_security_site_setting" translatable="false">wp_pref_site_jetpack_security</string>
     <string name="pref_key_site_jetpack_monitor" translatable="false">wp_pref_site_jetpack_monitor</string>
     <string name="pref_key_site_monitor_uptime" translatable="false">wp_pref_site_monitor_uptime</string>
     <string name="pref_key_site_send_email_notifications" translatable="false">wp_pref_site_send_email_notifications</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -502,6 +502,10 @@
     <string name="site_settings_monitor_uptime_title">Monitor your site\'s uptime</string>
     <string name="site_settings_send_email_notifications_title">Send notifications to your WordPress.com email address</string>
     <string name="site_settings_send_wp_notifications_title">Send notifications via WordPress.com notification</string>
+    <string name="site_settings_prevent_brute_force_title">Prevent and block malicious login attempts</string>
+    <string name="site_settings_allow_wpcom_sign_in_title">Allow sign in using WordPress.com accounts</string>
+    <string name="site_settings_match_wpcom_via_email_title">Match accounts using email addresses</string>
+    <string name="site_settings_require_two_factor_title">Require two-step authentication</string>
     <string name="site_settings_jetpack_category_title">Jetpack Settings</string>
     <string name="site_settings_jetpack_security_title">Security</string>
     <string name="site_settings_jetpack_security_screen_title">Jetpack Security Settings</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -514,7 +514,6 @@
     <string name="jetpack_allow_wpcom_sign_in_title">Allow login using WordPress.com accounts</string>
     <string name="jetpack_match_wpcom_via_email_title">Match accounts using email addresses</string>
     <string name="jetpack_require_two_factor_title">Require two-step authentication</string>
-    <string name="jetpack_security_settings_screen_title">Jetpack Security Settings</string>
 
     <!-- Preference Summaries -->
     <string name="site_settings_privacy_public_summary">Public</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -499,17 +499,22 @@
     <string name="site_settings_moderation_hold_title">Hold for Moderation</string>
     <string name="site_settings_blacklist_title">Blacklist</string>
     <string name="site_settings_delete_site_title">Delete Site</string>
-    <string name="site_settings_monitor_uptime_title">Monitor your site\'s uptime</string>
-    <string name="site_settings_send_email_notifications_title">Send notifications to your WordPress.com email address</string>
-    <string name="site_settings_send_wp_notifications_title">Send notifications via WordPress.com notification</string>
-    <string name="site_settings_prevent_brute_force_title">Prevent and block malicious login attempts</string>
-    <string name="site_settings_allow_wpcom_sign_in_title">Allow sign in using WordPress.com accounts</string>
-    <string name="site_settings_match_wpcom_via_email_title">Match accounts using email addresses</string>
-    <string name="site_settings_require_two_factor_title">Require two-step authentication</string>
-    <string name="site_settings_jetpack_category_title">Jetpack Settings</string>
-    <string name="site_settings_jetpack_security_title">Security</string>
-    <string name="site_settings_jetpack_security_screen_title">Jetpack Security Settings</string>
-    <string name="site_settings_jetpack_monitor_category_title">Jetpack Monitor</string>
+
+    <!-- Jetpack settings -->
+    <string name="jetpack_site_settings_category_title">Jetpack Settings</string>
+    <string name="jetpack_security_setting_title">Security</string>
+    <string name="jetpack_monitor_category_title">Jetpack Monitor</string>
+    <string name="jetpack_monitor_uptime_title">Monitor your site\'s uptime</string>
+    <string name="jetpack_send_email_notifications_title">Send notifications to your WordPress.com email address</string>
+    <string name="jetpack_send_wp_notifications_title">Send notifications via WordPress.com notification</string>
+    <string name="jetpack_prevent_brute_force_category_title">Brute force attack protection</string>
+    <string name="jetpack_prevent_brute_force_title">Block malicious login attempts</string>
+    <string name="jetpack_brute_force_whitelist_title">Whitelisted IP addresses</string>
+    <string name="jetpack_wpcom_sign_in_category_title">WordPress.com login</string>
+    <string name="jetpack_allow_wpcom_sign_in_title">Allow login using WordPress.com accounts</string>
+    <string name="jetpack_match_wpcom_via_email_title">Match accounts using email addresses</string>
+    <string name="jetpack_require_two_factor_title">Require two-step authentication</string>
+    <string name="jetpack_security_settings_screen_title">Jetpack Security Settings</string>
 
     <!-- Preference Summaries -->
     <string name="site_settings_privacy_public_summary">Public</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -503,7 +503,6 @@
     <!-- Jetpack settings -->
     <string name="jetpack_site_settings_category_title">Jetpack Settings</string>
     <string name="jetpack_security_setting_title">Security</string>
-    <string name="jetpack_monitor_category_title">Jetpack Monitor</string>
     <string name="jetpack_monitor_uptime_title">Monitor your site\'s uptime</string>
     <string name="jetpack_send_email_notifications_title">Send notifications to your WordPress.com email address</string>
     <string name="jetpack_send_wp_notifications_title">Send notifications via WordPress.com notification</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -503,7 +503,8 @@
     <string name="site_settings_send_email_notifications_title">Send notifications to your WordPress.com email address</string>
     <string name="site_settings_send_wp_notifications_title">Send notifications via WordPress.com notification</string>
     <string name="site_settings_jetpack_category_title">Jetpack Settings</string>
-    <string name="site_settings_jetpack_security_screen_title">Security</string>
+    <string name="site_settings_jetpack_security_title">Security</string>
+    <string name="site_settings_jetpack_security_screen_title">Jetpack Security Settings</string>
     <string name="site_settings_jetpack_monitor_category_title">Jetpack Monitor</string>
 
     <!-- Preference Summaries -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -502,6 +502,9 @@
     <string name="site_settings_monitor_uptime_title">Monitor your site\'s uptime</string>
     <string name="site_settings_send_email_notifications_title">Send notifications to your WordPress.com email address</string>
     <string name="site_settings_send_wp_notifications_title">Send notifications via WordPress.com notification</string>
+    <string name="site_settings_jetpack_category_title">Jetpack Settings</string>
+    <string name="site_settings_jetpack_security_screen_title">Security</string>
+    <string name="site_settings_jetpack_monitor_category_title">Jetpack Monitor</string>
 
     <!-- Preference Summaries -->
     <string name="site_settings_privacy_public_summary">Public</string>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -259,13 +259,13 @@
 
         <PreferenceScreen
             android:id="@+id/pref_screen_jetpack_security"
-            android:key="@string/jetpack_security_site_setting"
-            android:title="@string/jetpack_security_site_setting_title">
+            android:key="@string/pref_key_jetpack_security_site_setting"
+            android:title="@string/site_settings_jetpack_security_title">
 
             <PreferenceCategory
                 android:id="@+id/pref_category_jetpack_monitor"
                 android:key="@string/pref_key_site_jetpack_monitor"
-                android:title="@string/jetpack_monitor_security_pref_category_title">
+                android:title="@string/site_settings_jetpack_monitor_category_title">
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_monitor_uptime"

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -259,7 +259,7 @@
 
         <PreferenceScreen
             android:id="@+id/pref_screen_jetpack_security"
-            android:key="@string/pref_key_site_jetpack_security"
+            android:key="@string/jetpack_security_site_setting"
             android:title="@string/jetpack_security_site_setting_title">
 
             <PreferenceCategory
@@ -345,33 +345,6 @@
             android:entryValues="@array/site_settings_video_bitrate_values"
             android:dependency="@string/pref_key_optimize_video"
             app:longClickHint="@string/site_settings_video_quality_hint" />
-
-    </PreferenceCategory>
-
-    <PreferenceCategory
-        android:id="@+id/pref_category_jetpack_monitor"
-        android:key="@string/pref_key_site_jetpack_monitor"
-        android:title="Jetpack Monitor">
-
-        <org.wordpress.android.ui.prefs.WPSwitchPreference
-            android:id="@+id/pref_monitor_uptime"
-            android:layout="@layout/preference_layout"
-            android:key="@string/pref_key_site_monitor_uptime"
-            android:title="@string/site_settings_monitor_uptime_title" />
-
-        <org.wordpress.android.ui.prefs.WPSwitchPreference
-            android:id="@+id/pref_jetpack_send_email_notifications"
-            android:layout="@layout/preference_layout"
-            android:key="@string/pref_key_site_send_email_notifications"
-            android:title="@string/site_settings_monitor_uptime_title"
-            android:dependency="@string/pref_key_site_monitor_uptime" />
-
-        <org.wordpress.android.ui.prefs.WPSwitchPreference
-            android:id="@+id/pref_jetpack_send_wp_notifications"
-            android:layout="@layout/preference_layout"
-            android:key="@string/pref_key_site_send_wp_notifications"
-            android:title="@string/site_settings_send_wp_notifications_title"
-            android:dependency="@string/pref_key_site_monitor_uptime" />
 
     </PreferenceCategory>
 

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -255,17 +255,17 @@
     <PreferenceCategory
         android:id="@+id/site_settings_jetpack_category"
         android:key="@string/pref_key_site_jetpack"
-        android:title="Jetpack Settings">
+        android:title="@string/site_settings_jetpack_category_title">
 
         <PreferenceScreen
             android:id="@+id/pref_screen_jetpack_security"
             android:key="@string/pref_key_site_jetpack_security"
-            android:title="Security">
+            android:title="@string/jetpack_security_site_setting_title">
 
             <PreferenceCategory
                 android:id="@+id/pref_category_jetpack_monitor"
                 android:key="@string/pref_key_site_jetpack_monitor"
-                android:title="Jetpack Monitor">
+                android:title="@string/jetpack_monitor_security_pref_category_title">
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_monitor_uptime"

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -288,6 +288,46 @@
                     android:dependency="@string/pref_key_site_monitor_uptime" />
 
             </PreferenceCategory>
+
+            <PreferenceCategory
+                android:id="@+id/pref_category_brute_force"
+                android:key="@string/pref_key_site_jetpack_brute_force"
+                android:title="Prevent brute force login attacks">
+
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_prevent_brute_force"
+                    android:layout="@layout/preference_layout"
+                    android:key="@string/pref_key_site_jetpack_prevent_brute_force"
+                    android:title="@string/site_settings_prevent_brute_force_title" />
+
+            </PreferenceCategory>
+
+            <PreferenceCategory
+                android:id="@+id/pref_category_jetpack_wpcom_sign_in"
+                android:key="@string/pref_key_site_jetpack_wpcom_sign_in"
+                android:title="WordPress.com sign in">
+
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_allow_wpcom_sign_in"
+                    android:layout="@layout/preference_layout"
+                    android:key="@string/pref_key_site_jetpack_allow_wpcom_sign_in"
+                    android:title="@string/site_settings_allow_wpcom_sign_in_title" />
+
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_jetpack_match_wpcom_email"
+                    android:layout="@layout/preference_layout"
+                    android:key="@string/pref_key_site_jetpack_match_via_email"
+                    android:title="@string/site_settings_match_wpcom_via_email_title"
+                    android:dependency="@string/pref_key_site_jetpack_allow_wpcom_sign_in" />
+
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_jetpack_require_two_factor"
+                    android:layout="@layout/preference_layout"
+                    android:key="@string/pref_key_site_jetpack_require_two_factor"
+                    android:title="@string/site_settings_require_two_factor_title"
+                    android:dependency="@string/pref_key_site_jetpack_allow_wpcom_sign_in" />
+
+            </PreferenceCategory>
         </PreferenceScreen>
     </PreferenceCategory>
 

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -254,6 +254,7 @@
 
     <PreferenceCategory
         android:id="@+id/jetpack_settings_category"
+        android:key="@string/pref_key_jetpack_settings"
         android:title="@string/jetpack_site_settings_category_title">
 
         <PreferenceScreen

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -261,31 +261,25 @@
             android:key="@string/pref_key_jetpack_security_screen"
             android:title="@string/jetpack_security_setting_title">
 
-            <PreferenceCategory
-                android:id="@+id/pref_category_jetpack_monitor"
-                android:title="@string/jetpack_monitor_category_title">
+            <org.wordpress.android.ui.prefs.WPSwitchPreference
+                android:id="@+id/pref_monitor_uptime"
+                android:layout="@layout/preference_layout"
+                android:key="@string/pref_key_jetpack_monitor_uptime"
+                android:title="@string/jetpack_monitor_uptime_title" />
 
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_monitor_uptime"
-                    android:layout="@layout/preference_layout"
-                    android:key="@string/pref_key_jetpack_monitor_uptime"
-                    android:title="@string/jetpack_monitor_uptime_title" />
+            <org.wordpress.android.ui.prefs.WPSwitchPreference
+                android:id="@+id/pref_jetpack_send_email_notifications"
+                android:layout="@layout/preference_layout"
+                android:key="@string/pref_key_jetpack_send_email_notifications"
+                android:title="@string/jetpack_send_email_notifications_title"
+                android:dependency="@string/pref_key_jetpack_monitor_uptime" />
 
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_jetpack_send_email_notifications"
-                    android:layout="@layout/preference_layout"
-                    android:key="@string/pref_key_jetpack_send_email_notifications"
-                    android:title="@string/jetpack_send_email_notifications_title"
-                    android:dependency="@string/pref_key_jetpack_monitor_uptime" />
-
-                <org.wordpress.android.ui.prefs.WPSwitchPreference
-                    android:id="@+id/pref_jetpack_send_wp_notifications"
-                    android:layout="@layout/preference_layout"
-                    android:key="@string/pref_key_jetpack_send_wp_notifications"
-                    android:title="@string/jetpack_send_wp_notifications_title"
-                    android:dependency="@string/pref_key_jetpack_monitor_uptime" />
-
-            </PreferenceCategory>
+            <org.wordpress.android.ui.prefs.WPSwitchPreference
+                android:id="@+id/pref_jetpack_send_wp_notifications"
+                android:layout="@layout/preference_layout"
+                android:key="@string/pref_key_jetpack_send_wp_notifications"
+                android:title="@string/jetpack_send_wp_notifications_title"
+                android:dependency="@string/pref_key_jetpack_monitor_uptime" />
 
             <PreferenceCategory
                 android:id="@+id/pref_category_jetpack_brute_force"

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -253,6 +253,45 @@
     </PreferenceCategory>
 
     <PreferenceCategory
+        android:id="@+id/site_settings_jetpack_category"
+        android:key="@string/pref_key_site_jetpack"
+        android:title="Jetpack Settings">
+
+        <PreferenceScreen
+            android:id="@+id/pref_screen_jetpack_security"
+            android:key="@string/pref_key_site_jetpack_security"
+            android:title="Security">
+
+            <PreferenceCategory
+                android:id="@+id/pref_category_jetpack_monitor"
+                android:key="@string/pref_key_site_jetpack_monitor"
+                android:title="Jetpack Monitor">
+
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_monitor_uptime"
+                    android:layout="@layout/preference_layout"
+                    android:key="@string/pref_key_site_monitor_uptime"
+                    android:title="@string/site_settings_monitor_uptime_title" />
+
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_jetpack_send_email_notifications"
+                    android:layout="@layout/preference_layout"
+                    android:key="@string/pref_key_site_send_email_notifications"
+                    android:title="@string/site_settings_monitor_uptime_title"
+                    android:dependency="@string/pref_key_site_monitor_uptime" />
+
+                <org.wordpress.android.ui.prefs.WPSwitchPreference
+                    android:id="@+id/pref_jetpack_send_wp_notifications"
+                    android:layout="@layout/preference_layout"
+                    android:key="@string/pref_key_site_send_wp_notifications"
+                    android:title="@string/site_settings_send_wp_notifications_title"
+                    android:dependency="@string/pref_key_site_monitor_uptime" />
+
+            </PreferenceCategory>
+        </PreferenceScreen>
+    </PreferenceCategory>
+
+    <PreferenceCategory
         android:id="@+id/pref_this_device"
         android:key="@string/pref_key_site_this_device"
         android:title="@string/site_settings_this_device_header">

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -253,79 +253,82 @@
     </PreferenceCategory>
 
     <PreferenceCategory
-        android:id="@+id/site_settings_jetpack_category"
-        android:key="@string/pref_key_site_jetpack"
-        android:title="@string/site_settings_jetpack_category_title">
+        android:id="@+id/jetpack_settings_category"
+        android:title="@string/jetpack_site_settings_category_title">
 
         <PreferenceScreen
-            android:id="@+id/pref_screen_jetpack_security"
-            android:key="@string/pref_key_jetpack_security_site_setting"
-            android:title="@string/site_settings_jetpack_security_title">
+            android:id="@+id/jetpack_security_settings_screen"
+            android:key="@string/pref_key_jetpack_security_screen"
+            android:title="@string/jetpack_security_setting_title">
 
             <PreferenceCategory
                 android:id="@+id/pref_category_jetpack_monitor"
-                android:key="@string/pref_key_site_jetpack_monitor"
-                android:title="@string/site_settings_jetpack_monitor_category_title">
+                android:title="@string/jetpack_monitor_category_title">
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_monitor_uptime"
                     android:layout="@layout/preference_layout"
-                    android:key="@string/pref_key_site_monitor_uptime"
-                    android:title="@string/site_settings_monitor_uptime_title" />
+                    android:key="@string/pref_key_jetpack_monitor_uptime"
+                    android:title="@string/jetpack_monitor_uptime_title" />
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_jetpack_send_email_notifications"
                     android:layout="@layout/preference_layout"
-                    android:key="@string/pref_key_site_send_email_notifications"
-                    android:title="@string/site_settings_monitor_uptime_title"
-                    android:dependency="@string/pref_key_site_monitor_uptime" />
+                    android:key="@string/pref_key_jetpack_send_email_notifications"
+                    android:title="@string/jetpack_send_email_notifications_title"
+                    android:dependency="@string/pref_key_jetpack_monitor_uptime" />
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_jetpack_send_wp_notifications"
                     android:layout="@layout/preference_layout"
-                    android:key="@string/pref_key_site_send_wp_notifications"
-                    android:title="@string/site_settings_send_wp_notifications_title"
-                    android:dependency="@string/pref_key_site_monitor_uptime" />
+                    android:key="@string/pref_key_jetpack_send_wp_notifications"
+                    android:title="@string/jetpack_send_wp_notifications_title"
+                    android:dependency="@string/pref_key_jetpack_monitor_uptime" />
 
             </PreferenceCategory>
 
             <PreferenceCategory
-                android:id="@+id/pref_category_brute_force"
-                android:key="@string/pref_key_site_jetpack_brute_force"
-                android:title="Prevent brute force login attacks">
+                android:id="@+id/pref_category_jetpack_brute_force"
+                android:title="@string/jetpack_prevent_brute_force_category_title">
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_prevent_brute_force"
                     android:layout="@layout/preference_layout"
-                    android:key="@string/pref_key_site_jetpack_prevent_brute_force"
-                    android:title="@string/site_settings_prevent_brute_force_title" />
+                    android:key="@string/pref_key_jetpack_prevent_brute_force"
+                    android:title="@string/jetpack_prevent_brute_force_title" />
+
+                <org.wordpress.android.ui.prefs.WPPreference
+                    android:id="@+id/pref_brute_force_whitelist"
+                    android:layout="@layout/preference_layout"
+                    android:key="@string/pref_key_jetpack_brute_force_whitelist"
+                    android:dependency="@string/pref_key_jetpack_prevent_brute_force"
+                    android:title="@string/jetpack_brute_force_whitelist_title" />
 
             </PreferenceCategory>
 
             <PreferenceCategory
                 android:id="@+id/pref_category_jetpack_wpcom_sign_in"
-                android:key="@string/pref_key_site_jetpack_wpcom_sign_in"
-                android:title="WordPress.com sign in">
+                android:title="@string/jetpack_wpcom_sign_in_category_title">
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_allow_wpcom_sign_in"
                     android:layout="@layout/preference_layout"
-                    android:key="@string/pref_key_site_jetpack_allow_wpcom_sign_in"
-                    android:title="@string/site_settings_allow_wpcom_sign_in_title" />
+                    android:key="@string/pref_key_jetpack_allow_wpcom_sign_in"
+                    android:title="@string/jetpack_allow_wpcom_sign_in_title" />
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_jetpack_match_wpcom_email"
                     android:layout="@layout/preference_layout"
-                    android:key="@string/pref_key_site_jetpack_match_via_email"
-                    android:title="@string/site_settings_match_wpcom_via_email_title"
-                    android:dependency="@string/pref_key_site_jetpack_allow_wpcom_sign_in" />
+                    android:key="@string/pref_key_jetpack_match_via_email"
+                    android:title="@string/jetpack_match_wpcom_via_email_title"
+                    android:dependency="@string/pref_key_jetpack_allow_wpcom_sign_in" />
 
                 <org.wordpress.android.ui.prefs.WPSwitchPreference
                     android:id="@+id/pref_jetpack_require_two_factor"
                     android:layout="@layout/preference_layout"
-                    android:key="@string/pref_key_site_jetpack_require_two_factor"
-                    android:title="@string/site_settings_require_two_factor_title"
-                    android:dependency="@string/pref_key_site_jetpack_allow_wpcom_sign_in" />
+                    android:key="@string/pref_key_jetpack_require_two_factor"
+                    android:title="@string/jetpack_require_two_factor_title"
+                    android:dependency="@string/pref_key_jetpack_allow_wpcom_sign_in" />
 
             </PreferenceCategory>
         </PreferenceScreen>


### PR DESCRIPTION
This PR is a continuation of #6273 that has two main changes:

1. The UI is updated to match the designs found in #6194. The Jetpack settings now reside in their own sub-screen.
2. Jetpack settings are moved out of `SiteSettingsModel` into `JetpackSettingsModel` to provide a clear separation of options.

cc @oguzkocer 😄 