### PR TITLE
Async media: Display media progress in post list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -428,6 +428,13 @@ public class PostsListFragment extends Fragment
         }
     }
 
+    @SuppressWarnings("unused")
+    public void onEventMainThread(PostEvents.PostUploadProgress event) {
+        if (isAdded() && event.post != null && mSite.getId() == event.post.getLocalSiteId()) {
+            // TODO
+        }
+    }
+
     private void updateEmptyView(EmptyViewMessageType emptyViewMessageType) {
         int stringId;
         switch (emptyViewMessageType) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -431,7 +431,7 @@ public class PostsListFragment extends Fragment
     @SuppressWarnings("unused")
     public void onEventMainThread(PostEvents.PostUploadProgress event) {
         if (isAdded() && event.post != null && mSite.getId() == event.post.getLocalSiteId()) {
-            // TODO
+            mPostsListAdapter.reloadPost(event.post);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -12,7 +12,6 @@ import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.SimpleItemAnimator;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -159,8 +158,6 @@ public class PostsListFragment extends Fragment
 
         Context context = getActivity();
         mRecyclerView.setLayoutManager(new LinearLayoutManager(context));
-        // Disable flashing animation when a list item is updated (prevents flashing due to progress bar updates)
-        ((SimpleItemAnimator) mRecyclerView.getItemAnimator()).setSupportsChangeAnimations(false);
 
         int spacingVertical = mIsPage ? 0 : context.getResources().getDimensionPixelSize(R.dimen.card_gutters);
         int spacingHorizontal = context.getResources().getDimensionPixelSize(R.dimen.content_margin);
@@ -774,7 +771,7 @@ public class PostsListFragment extends Fragment
 
         PostModel post = mPostStore.getPostByLocalPostId(event.media.getLocalPostId());
         if (post != null) {
-            mPostsListAdapter.reloadPost(post);
+            mPostsListAdapter.updateProgressForPost(post);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -12,6 +12,7 @@ import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.SimpleItemAnimator;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -158,6 +159,8 @@ public class PostsListFragment extends Fragment
 
         Context context = getActivity();
         mRecyclerView.setLayoutManager(new LinearLayoutManager(context));
+        // Disable flashing animation when a list item is updated (prevents flashing due to progress bar updates)
+        ((SimpleItemAnimator) mRecyclerView.getItemAnimator()).setSupportsChangeAnimations(false);
 
         int spacingVertical = mIsPage ? 0 : context.getResources().getDimensionPixelSize(R.dimen.card_gutters);
         int spacingHorizontal = context.getResources().getDimensionPixelSize(R.dimen.content_margin);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -770,16 +770,7 @@ public class PostsListFragment extends Fragment
         }
 
         PostModel post = mPostStore.getPostByLocalPostId(event.media.getLocalPostId());
-        if (post == null) {
-            return;
-        }
-
-        if (event.completed) {
-            if (UploadService.isPostUploadingOrQueued(post)) {
-                loadPosts(LoadMode.FORCED);
-            }
-        } else {
-            // Reload the post to update the progress
+        if (post != null) {
             mPostsListAdapter.reloadPost(post);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -37,11 +37,11 @@ import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.PostStore;
-import org.wordpress.android.ui.uploads.UploadService;
 import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.posts.PostsListFragment;
 import org.wordpress.android.ui.reader.utils.ReaderImageScanner;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
+import org.wordpress.android.ui.uploads.UploadService;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DisplayUtils;
@@ -378,10 +378,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     private void updatePostUploadProgressBar(ProgressBar view, PostModel post) {
         if (UploadService.isPostUploadingOrQueued(post)) {
             view.setVisibility(View.VISIBLE);
-            // ToDo: update current progress here by some means from the new UploadService
-//            view.setProgress(90);
-            // ToDo: when we have information from PostUploadService, delete the below line
-            view.setIndeterminate(true);
+            view.setProgress(Math.min(90, Math.round(UploadService.getMediaUploadProgressForPost(post) * 100)));
         } else {
             view.setVisibility(View.GONE);
         }
@@ -580,6 +577,13 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             AppLog.d(AppLog.T.POSTS, "post adapter > already loading posts");
         } else {
             new LoadPostsTask(mode).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        }
+    }
+
+    public void reloadPost(@NonNull PostModel post) {
+        int position = PostUtils.indexOfPostInList(post, mPosts);
+        if (position > -1) {
+            notifyItemChanged(position);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -587,10 +587,17 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         }
     }
 
-    public void reloadPost(@NonNull PostModel post) {
-        int position = PostUtils.indexOfPostInList(post, mPosts);
-        if (position > -1) {
-            notifyItemChanged(position);
+    public void updateProgressForPost(@NonNull PostModel post) {
+        if (mRecyclerView != null) {
+            int position = PostUtils.indexOfPostInList(post, mPosts);
+            if (position > -1) {
+                RecyclerView.ViewHolder viewHolder = mRecyclerView.findViewHolderForAdapterPosition(position);
+                if (viewHolder instanceof PostViewHolder) {
+                    updatePostUploadProgressBar(((PostViewHolder) viewHolder).progressBar, post);
+                } else if (viewHolder instanceof PageViewHolder) {
+                    updatePostUploadProgressBar(((PageViewHolder) viewHolder).progressBar, post);
+                }
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -96,6 +96,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     private final List<PostModel> mHiddenPosts = new ArrayList<>();
     private final Map<Integer, String> mFeaturedImageUrls = new HashMap<>();
 
+    private RecyclerView mRecyclerView;
     private final LayoutInflater mLayoutInflater;
 
     @Inject Dispatcher mDispatcher;
@@ -148,6 +149,12 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
     private boolean isValidPostPosition(int position) {
         return (position >= 0 && position < mPosts.size());
+    }
+
+    @Override
+    public void onAttachedToRecyclerView(RecyclerView recyclerView) {
+        super.onAttachedToRecyclerView(recyclerView);
+        mRecyclerView = recyclerView;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -63,6 +63,7 @@ import javax.inject.Inject;
  */
 public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     private static final long ROW_ANIM_DURATION = 150;
+    private static final int MAX_DISPLAYED_UPLOAD_PROGRESS = 90;
 
     private static final int VIEW_TYPE_POST_OR_PAGE = 0;
     private static final int VIEW_TYPE_ENDLIST_INDICATOR = 1;
@@ -385,7 +386,10 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     private void updatePostUploadProgressBar(ProgressBar view, PostModel post) {
         if (UploadService.isPostUploadingOrQueued(post)) {
             view.setVisibility(View.VISIBLE);
-            view.setProgress(Math.min(90, Math.round(UploadService.getMediaUploadProgressForPost(post) * 100)));
+            int overallProgress = Math.round(UploadService.getMediaUploadProgressForPost(post) * 100);
+            // Sometimes the progress bar can be stuck at 100% for a long time while further processing happens
+            // Cap the progress bar at MAX_DISPLAYED_UPLOAD_PROGRESS (until we move past the 'uploading media' phase)
+            view.setProgress(Math.min(MAX_DISPLAYED_UPLOAD_PROGRESS, overallProgress));
         } else {
             view.setVisibility(View.GONE);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -49,6 +49,7 @@ public class MediaUploadHandler implements UploadHandler<MediaModel> {
     }
 
     void unregister() {
+        sProgressByMediaId.clear();
         mDispatcher.unregister(this);
         EventBus.getDefault().unregister(this);
     }
@@ -141,7 +142,7 @@ public class MediaUploadHandler implements UploadHandler<MediaModel> {
      */
     static float getProgressForMedia(MediaModel media) {
         Float progress = sProgressByMediaId.get(media.getId());
-        return progress == null ? 1 : progress;
+        return progress == null ? 0 : progress;
     }
 
     private void handleOnMediaUploadedSuccess(@NonNull OnMediaUploaded event) {
@@ -207,7 +208,7 @@ public class MediaUploadHandler implements UploadHandler<MediaModel> {
         MediaModel media = getMediaFromInProgressQueueById(id);
         if (media != null) {
             sInProgressUploads.remove(media);
-            sProgressByMediaId.remove(media.getId());
+            sProgressByMediaId.put(media.getId(), 1F);
             trackUploadMediaEvents(AnalyticsTracker.Stat.MEDIA_UPLOAD_STARTED, media, null);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -21,6 +21,7 @@ import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -115,6 +116,30 @@ public class MediaUploadHandler implements UploadHandler<MediaModel> {
         }
 
         return false;
+    }
+
+    static List<MediaModel> getPendingOrInProgressMediaUploadsForPost(PostModel postModel) {
+        if (postModel == null) {
+            return Collections.emptyList();
+        }
+
+        List<MediaModel> mediaList = new ArrayList<>();
+        synchronized (sInProgressUploads) {
+            for (MediaModel queuedMedia : sInProgressUploads) {
+                if (queuedMedia.getLocalPostId() == postModel.getId()) {
+                    mediaList.add(queuedMedia);
+                }
+            }
+        }
+
+        synchronized (sPendingUploads) {
+            for (MediaModel queuedMedia : sPendingUploads) {
+                if (queuedMedia.getLocalPostId() == postModel.getId()) {
+                    mediaList.add(queuedMedia);
+                }
+            }
+        }
+        return mediaList;
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -107,15 +107,8 @@ public class MediaUploadHandler implements UploadHandler<MediaModel> {
             return false;
         }
 
-        if (hasInProgressMediaUploadsForPost(postModel)) {
-            return true;
-        }
-
-        if (hasPendingMediaUploadsForPost(postModel)) {
-            return true;
-        }
-
-        return false;
+        // Check if there are media in the in-progress or the pending queue attached to the given post
+        return hasInProgressMediaUploadsForPost(postModel) || hasPendingMediaUploadsForPost(postModel);
     }
 
     static List<MediaModel> getPendingOrInProgressMediaUploadsForPost(PostModel postModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -167,7 +167,10 @@ public class MediaUploadHandler implements UploadHandler<MediaModel> {
             uploadNextInQueue();
         } else {
             AppLog.i(T.MEDIA, "MediaUploadHandler > " + event.media.getId() + " - progress: " + event.progress);
-            sProgressByMediaId.put(event.media.getId(), event.progress);
+            Float previousProgress = sProgressByMediaId.get(event.media.getId());
+            if (previousProgress == null || previousProgress < event.progress) {
+                sProgressByMediaId.put(event.media.getId(), event.progress);
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostEvents.java
@@ -44,14 +44,4 @@ public class PostEvents {
             this.post = post;
         }
     }
-
-    public static class PostUploadProgress {
-        public PostModel post;
-        public float progress;
-
-        public PostUploadProgress(PostModel post, float progress) {
-            this.post = post;
-            this.progress = progress;
-        }
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostEvents.java
@@ -44,4 +44,14 @@ public class PostEvents {
             this.post = post;
         }
     }
+
+    public static class PostUploadProgress {
+        public PostModel post;
+        public float progress;
+
+        public PostUploadProgress(PostModel post, float progress) {
+            this.post = post;
+            this.progress = progress;
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -41,7 +41,6 @@ import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.SqlUtils;
-import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.util.helpers.MediaFile;
 
 import java.io.File;
@@ -126,16 +125,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
     }
 
     static boolean isPostUploadingOrQueued(PostModel post) {
-        if (post == null) {
-            return false;
-        }
-
-        // First check the currently uploading post
-        if (isPostUploading(post)) {
-            return true;
-        }
-
-        return isPostQueued(post);
+        return post != null && (isPostUploading(post) || isPostQueued(post));
     }
 
     static boolean isPostQueued(PostModel post) {
@@ -143,7 +133,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
             return false;
         }
 
-        // Then check the list of posts waiting to be uploaded
+        // Check the list of posts waiting to be uploaded
         if (sQueuedPostsList.size() > 0) {
             synchronized (sQueuedPostsList) {
                 for (PostModel queuedPost : sQueuedPostsList) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -502,20 +502,6 @@ public class UploadService extends Service {
                 }
             }
             stopServiceIfUploadsComplete();
-            return;
-        }
-
-        if (event.media.getLocalPostId() > 0) {
-            for (UploadingPost post : sPostsWithPendingMedia) {
-                if (post.postModel.getId() == event.media.getLocalPostId()) {
-                    // Received a progress event for FluxC for a media item we have a queued post for
-                    // Calculate the overall media progress for this post, and emit an event
-                    float overallProgress = getOverallProgressForMediaList(post.pendingMedia);
-                    EventBus.getDefault().post(new PostEvents.PostUploadProgress(post.postModel, overallProgress));
-                    AppLog.i(T.POSTS, "Upload progress for post " + post.postModel.getId() + ": " + overallProgress);
-                    return;
-                }
-            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -259,12 +259,8 @@ public class UploadService extends Service {
             return false;
         }
 
-        // First check for posts strictly queued inside the PostUploadManager
-        if (PostUploadHandler.isPostQueued(post)) {
-            return true;
-        }
-
-        return false;
+        // Check for posts queued inside the PostUploadManager
+        return PostUploadHandler.isPostQueued(post);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -321,6 +321,23 @@ public class UploadService extends Service {
         return postModel != null && MediaUploadHandler.hasPendingOrInProgressMediaUploadsForPost(postModel);
     }
 
+    public static float getMediaUploadProgressForPost(PostModel postModel) {
+        if (postModel == null) {
+            return 0;
+        }
+
+        for (UploadingPost uploadingPost : sPostsWithPendingMedia) {
+            if (uploadingPost.postModel.getId() == postModel.getId()) {
+                float overallProgress = getOverallProgressForMediaList(uploadingPost.pendingMedia);
+                AppLog.i(T.MAIN, "Overall progress for post with id " + uploadingPost.postModel.getId()
+                        + ": " + overallProgress);
+                return overallProgress;
+            }
+        }
+
+        return 1;
+    }
+
     private void showNotificationForPostWithPendingMedia(PostModel post) {
         if (!mPostUploadNotifier.isDisplayingNotificationForPost(post)) {
             mPostUploadNotifier.createNotificationForPost(post, getString(R.string.uploading_post_media));
@@ -416,6 +433,20 @@ public class UploadService extends Service {
             }
         }
         return null;
+    }
+
+    private static float getOverallProgressForMediaList(List<MediaModel> pendingMediaList) {
+        if (pendingMediaList.size() == 0) {
+            return 1;
+        }
+
+        float overallProgress = 0;
+        for (MediaModel pendingMedia : pendingMediaList) {
+            overallProgress += MediaUploadHandler.getProgressForMedia(pendingMedia);
+        }
+        overallProgress /= pendingMediaList.size();
+
+        return overallProgress;
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -324,10 +324,7 @@ public class UploadService extends Service {
 
         for (UploadingPost uploadingPost : sPostsWithPendingMedia) {
             if (uploadingPost.postModel.getId() == postModel.getId()) {
-                float overallProgress = getOverallProgressForMediaList(uploadingPost.pendingMedia);
-                AppLog.i(T.MAIN, "Overall progress for post with id " + uploadingPost.postModel.getId()
-                        + ": " + overallProgress);
-                return overallProgress;
+                return getOverallProgressForMediaList(uploadingPost.pendingMedia);
             }
         }
 
@@ -505,6 +502,20 @@ public class UploadService extends Service {
                 }
             }
             stopServiceIfUploadsComplete();
+            return;
+        }
+
+        if (event.media.getLocalPostId() > 0) {
+            for (UploadingPost post : sPostsWithPendingMedia) {
+                if (post.postModel.getId() == event.media.getLocalPostId()) {
+                    // Received a progress event for FluxC for a media item we have a queued post for
+                    // Calculate the overall media progress for this post, and emit an event
+                    float overallProgress = getOverallProgressForMediaList(post.pendingMedia);
+                    EventBus.getDefault().post(new PostEvents.PostUploadProgress(post.postModel, overallProgress));
+                    AppLog.i(T.POSTS, "Upload progress for post " + post.postModel.getId() + ": " + overallProgress);
+                    return;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Provides a method for obtaining the total progress of media for a post from the `UploadService`, and displays a determinate progress bar for those posts in the post list. ([ref](https://github.com/wordpress-mobile/WordPress-Android/projects/6#card-3450986)) Builds on @mzorz's UI work in https://github.com/wordpress-mobile/WordPress-Android/pull/6290.

![determinate-progress-bar](https://user-images.githubusercontent.com/9613966/28318801-1049cd3a-6b9a-11e7-8b26-73737e07d79c.png)

#### Note/question:
Media upload progress events matching a post in the list now [trigger a `notifyItemChanged()`](https://github.com/wordpress-mobile/WordPress-Android/compare/feature/async-media...feature/async-global-post-progress?expand=1#diff-167de1d12c4fee063112c77ac2c6c2adR586). By default, this will show a flashing animation on the updated item, but this is quite annoying for progress bar updates which can happen multiple times per second. So I [disabled the change animations](https://github.com/wordpress-mobile/WordPress-Android/compare/feature/async-media...feature/async-global-post-progress?expand=1#diff-b77d01da8893da62a4b6bbc5f0b06c3cR163) for the post list.

I'm not sure we care to preserve the flash in other cases (it's not something we explicitly enabled), which is why I went with this solution. If there are differing points of view we can look at a more selective method (☸️ --> @nbradbury perhaps you have some thoughts?).

cc @mzorz 