### PR TITLE
Closing keyboard in Post Settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsInputDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsInputDialogFragment.java
@@ -14,6 +14,7 @@ import android.widget.EditText;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
+import org.wordpress.android.util.ActivityUtils;
 
 public class PostSettingsInputDialogFragment extends DialogFragment implements TextWatcher {
     interface PostSettingsInputDialogListener {
@@ -66,6 +67,12 @@ public class PostSettingsInputDialogFragment extends DialogFragment implements T
         args.putBoolean(DISABLE_EMPTY_INPUT_TAG, disableEmptyInput);
         dialogFragment.setArguments(args);
         return dialogFragment;
+    }
+
+    @Override
+    public void onDismiss(DialogInterface dialog) {
+        super.onDismiss(dialog);
+        ActivityUtils.hideKeyboard(getActivity());
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsTagsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsTagsActivity.java
@@ -30,6 +30,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.store.TaxonomyStore;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.WPActivityUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -128,6 +129,8 @@ public class PostSettingsTagsActivity extends AppCompatActivity implements TextW
     }
 
     private void saveAndFinish() {
+        WPActivityUtils.hideKeyboard(mTagsEditText);
+
         Bundle bundle = new Bundle();
         bundle.putString(KEY_SELECTED_TAGS, mTagsEditText.getText().toString());
         Intent intent = new Intent();

--- a/WordPress/src/main/res/layout/post_settings_input_dialog.xml
+++ b/WordPress/src/main/res/layout/post_settings_input_dialog.xml
@@ -9,6 +9,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:maxLines="6"
+        android:inputType="text"
         android:paddingBottom="@dimen/margin_large"
         android:layout_marginLeft="@dimen/post_settings_input_dialog_edit_text_side_margin"
         android:layout_marginEnd="@dimen/post_settings_input_dialog_edit_text_side_margin"


### PR DESCRIPTION
Fixes #6344. This PR fixes the issue where the keyboard will stay visible after a dialog is closed in Post Settings or when the user navigates back from the tags page. I am afraid I spent way too much time on trying to fix this. I really don't understand why this is happening since it doesn't happen in many other places, including the add category dialog. The only differences I can see between them is that we are using `WPEditText` instead of `EditText` (which I am not sure if we need to or not) and we have a text watcher. However, even when I change those, I still had this issue.

I'd really love to learn why this is happening and if there is a better solution for it. /cc @maxme since you worked on the add category dialog and might be familiar with this.

To test:
* Test instructions can be found in the issue.