### PR TITLE
Fixes possible NPE for accessing the site while updating post formats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -766,6 +766,10 @@ public class EditPostSettingsFragment extends Fragment {
         if (getActivity() == null) {
             return;
         }
+        if (getSite() == null) {
+            AppLog.e(T.POSTS, "Current site shouldn't be null while updating post format keys & names");
+            return;
+        }
         // Default values
         mPostFormatKeys = new ArrayList<>(Arrays.asList(getResources().getStringArray(R.array.post_format_keys)));
         mPostFormatNames = new ArrayList<>(Arrays.asList(getResources()
@@ -913,9 +917,8 @@ public class EditPostSettingsFragment extends Fragment {
             AppLog.e(T.POSTS, "An error occurred while updating the post formats with type: " + event.error.type);
             return;
         }
-        if (getSite() != null) {
-            updatePostFormatKeysAndNames();
-        }
+        AppLog.v(T.POSTS, "Post formats successfully fetched!");
+        updatePostFormatKeysAndNames();
     }
 
     /**


### PR DESCRIPTION
Fixes #6319. Since #6325 failed to fix the issue, let's try this version. I have added a couple logs to be able to track if null site is accessed after a callback or not. I am still not sure how it's happening, so this could help.

/cc @tonyr59h 