### PR TITLE
Issue/6355 photo picker upload role

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2155,10 +2155,13 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onAddMediaClicked() {
-        if (!isPhotoPickerShowing()) {
+        if (isPhotoPickerShowing()) {
+            hidePhotoPicker();
+        } else if (WordPressMediaUtils.currentUserCanUploadMedia(mSite)) {
             showPhotoPicker();
         } else {
-            hidePhotoPicker();
+            // show the WP media library instead of the photo picker if the user doesn't have upload permission
+            ActivityLauncher.viewMediaPickerForResult(this, mSite);
         }
     }
 


### PR DESCRIPTION
Fixes #6355 - if the user doesn't have permission to upload media, when they tap the "Add Media" button in the editor we now skip showing the photo picker (which enables uploading media) and instead show the WP media library instead.

To test:
* Login to the app using an account that has a Contributor role for a site
* Add a new post
* Tap the "Add media" (plus icon)
* It should show the WP media library picker

~~This is on hold until #6356 has been merged.~~
