### PR TITLE
Post Settings NPEs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -105,6 +105,10 @@ public class EditPostSettingsFragment extends Fragment {
     private EditPostActivityHook mEditPostActivityHook;
     private SiteSettingsInterface mSiteSettings;
 
+    private LinearLayout mCategoriesContainer;
+    private LinearLayout mExcerptContainer;
+    private LinearLayout mFormatContainer;
+    private LinearLayout mTagsContainer;
     private TextView mExcerptTextView;
     private TextView mSlugTextView;
     private TextView mLocationTextView;
@@ -141,6 +145,11 @@ public class EditPostSettingsFragment extends Fragment {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplicationContext()).component().inject(this);
         mDispatcher.register(this);
+    }
+
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
 
         updatePostFormatKeysAndNames();
         fetchSiteSettingsAndUpdateDefaultPostFormat();
@@ -151,6 +160,8 @@ public class EditPostSettingsFragment extends Fragment {
         if (!getPost().isPage()) {
             mDispatcher.dispatch(TaxonomyActionBuilder.newFetchCategoriesAction(siteModel));
         }
+
+        refreshViews();
     }
 
     private void fetchSiteSettingsAndUpdateDefaultPostFormat() {
@@ -243,8 +254,8 @@ public class EditPostSettingsFragment extends Fragment {
             featuredImageCardView.setVisibility(View.GONE);
         }
 
-        final LinearLayout excerptContainer = (LinearLayout) rootView.findViewById(R.id.post_excerpt_container);
-        excerptContainer.setOnClickListener(new View.OnClickListener() {
+        mExcerptContainer = (LinearLayout) rootView.findViewById(R.id.post_excerpt_container);
+        mExcerptContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 showPostExcerptDialog();
@@ -267,16 +278,16 @@ public class EditPostSettingsFragment extends Fragment {
             }
         });
 
-        final LinearLayout categoriesContainer = (LinearLayout) rootView.findViewById(R.id.post_categories_container);
-        categoriesContainer.setOnClickListener(new View.OnClickListener() {
+        mCategoriesContainer = (LinearLayout) rootView.findViewById(R.id.post_categories_container);
+        mCategoriesContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 showCategoriesActivity();
             }
         });
 
-        final LinearLayout tagsContainer = (LinearLayout) rootView.findViewById(R.id.post_tags_container);
-        tagsContainer.setOnClickListener(new View.OnClickListener() {
+        mTagsContainer = (LinearLayout) rootView.findViewById(R.id.post_tags_container);
+        mTagsContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 showTagsActivity();
@@ -291,8 +302,8 @@ public class EditPostSettingsFragment extends Fragment {
             }
         });
 
-        final LinearLayout formatContainer = (LinearLayout) rootView.findViewById(R.id.post_format_container);
-        formatContainer.setOnClickListener(new View.OnClickListener() {
+        mFormatContainer = (LinearLayout) rootView.findViewById(R.id.post_format_container);
+        mFormatContainer.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 showPostFormatDialog();
@@ -315,14 +326,6 @@ public class EditPostSettingsFragment extends Fragment {
             }
         });
 
-        if (getPost().isPage()) { // remove post specific views
-            excerptContainer.setVisibility(View.GONE);
-            categoriesContainer.setVisibility(View.GONE);
-            tagsContainer.setVisibility(View.GONE);
-            formatContainer.setVisibility(View.GONE);
-        }
-
-        refreshViews();
         return rootView;
     }
 
@@ -350,7 +353,15 @@ public class EditPostSettingsFragment extends Fragment {
         if (!isAdded()) {
             return;
         }
+
         PostModel postModel = getPost();
+        if (postModel.isPage()) {
+            // remove post specific views
+            mCategoriesContainer.setVisibility(View.GONE);
+            mExcerptContainer.setVisibility(View.GONE);
+            mFormatContainer.setVisibility(View.GONE);
+            mTagsContainer.setVisibility(View.GONE);
+        }
         mExcerptTextView.setText(postModel.getExcerpt());
         mSlugTextView.setText(postModel.getSlug());
         mPasswordTextView.setText(postModel.getPassword());

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -152,7 +152,7 @@ public class EditPostSettingsFragment extends Fragment {
         super.onActivityCreated(savedInstanceState);
 
         updatePostFormatKeysAndNames();
-        fetchSiteSettingsAndUpdateDefaultPostFormat();
+        fetchSiteSettingsAndUpdateDefaultPostFormatIfNecessary();
 
         // Update post formats and categories, in case anything changed.
         SiteModel siteModel = getSite();
@@ -164,13 +164,17 @@ public class EditPostSettingsFragment extends Fragment {
         refreshViews();
     }
 
-    private void fetchSiteSettingsAndUpdateDefaultPostFormat() {
+    private void fetchSiteSettingsAndUpdateDefaultPostFormatIfNecessary() {
+        // A format is already set for the post, no need to fetch the default post format
+        if (!TextUtils.isEmpty(getPost().getPostFormat())) {
+            return;
+        }
         // we need to fetch site settings in order to get the latest default post format
         mSiteSettings = SiteSettingsInterface.getInterface(getActivity(), getSite(),
                 new SiteSettingsListener() {
                     @Override
                     public void onSettingsUpdated(Exception error) {
-                        if (error == null && TextUtils.isEmpty(getPost().getPostFormat())) {
+                        if (error == null) {
                             updatePostFormat(mSiteSettings.getDefaultPostFormat());
                         }
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -616,10 +616,18 @@ public class EditPostSettingsFragment extends Fragment {
     // Helpers
 
     private PostModel getPost() {
+        if (mEditPostActivityHook == null) {
+            // This can only happen during a callback while activity is re-created for some reason (config changes etc)
+            return null;
+        }
         return mEditPostActivityHook.getPost();
     }
 
     private SiteModel getSite() {
+        if (mEditPostActivityHook == null) {
+            // This can only happen during a callback while activity is re-created for some reason (config changes etc)
+            return null;
+        }
         return mEditPostActivityHook.getSite();
     }
 
@@ -730,6 +738,10 @@ public class EditPostSettingsFragment extends Fragment {
     }
 
     private void updateCategoriesTextView() {
+        if (getPost() == null || getSite() == null) {
+            // Since this method can get called after a callback, we have to make sure we have the post and site
+            return;
+        }
         List<TermModel> categories = mTaxonomyStore.getCategoriesForPost(getPost(), getSite());
         StringBuilder sb = new StringBuilder();
         Iterator<TermModel> it = categories.iterator();
@@ -778,11 +790,8 @@ public class EditPostSettingsFragment extends Fragment {
     // Post Format Helpers
 
     private void updatePostFormatKeysAndNames() {
-        if (getActivity() == null) {
-            return;
-        }
-        if (getSite() == null) {
-            AppLog.e(T.POSTS, "Current site shouldn't be null while updating post format keys & names");
+        if (getActivity() == null || getSite() == null) {
+            // Since this method can get called after a callback, we have to make sure we have the site
             return;
         }
         // Default values


### PR DESCRIPTION
This is a much better fix for #6319. The issue we were having is that when the activity was getting re-created, the fragment was calling `onCreate` before the activity calls its. Moving the initialization to `onActivityCreated` fixes most of the issues, but NPEs could still happen in callbacks. So, a few additional checks has been added to handle edge cases. Ignoring some callbacks is not great, but I think this is the best we can do right now and it should only happen if a callback happens while activity is being re-created.

To test:
* Enable "Do not keep activities" in settings
* Go into Post Settings, go to bg and re-open the app. (The keyboard will open automatically as a result and this will be handled separately in #6361.

/cc @maxme 