### PR TITLE
Preliminary themes code maintenance

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ThemeTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ThemeTable.java
@@ -1,0 +1,152 @@
+package org.wordpress.android.datasets;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.DatabaseUtils;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteException;
+
+import org.wordpress.android.models.Theme;
+
+public class ThemeTable {
+    private static final String COLUMN_NAME_ID = "_id";
+    private static final String THEMES_TABLE = "themes";
+    private static final String DROP_TABLE_PREFIX = "DROP TABLE IF EXISTS ";
+    private static final String CREATE_TABLE_THEMES = "create table if not exists themes ("
+            + COLUMN_NAME_ID + " integer primary key autoincrement, "
+            + Theme.ID + " text, "
+            + Theme.AUTHOR + " text, "
+            + Theme.SCREENSHOT + " text, "
+            + Theme.AUTHOR_URI + " text, "
+            + Theme.DEMO_URI + " text, "
+            + Theme.NAME + " text, "
+            + Theme.STYLESHEET + " text, "
+            + Theme.PRICE + " text, "
+            + Theme.BLOG_ID + " text, "
+            + Theme.IS_CURRENT + " boolean default false);";
+
+    public static void createTables(SQLiteDatabase db) {
+        db.execSQL(CREATE_TABLE_THEMES);
+    }
+
+    public static void resetTables(SQLiteDatabase db) {
+        db.execSQL(DROP_TABLE_PREFIX + THEMES_TABLE);
+        db.execSQL(CREATE_TABLE_THEMES);
+    }
+
+    private static final Object mSyncObject = new Object();
+    public static boolean saveTheme(SQLiteDatabase db, Theme theme) {
+        boolean returnValue = false;
+
+        ContentValues values = new ContentValues();
+        values.put(Theme.ID, theme.getId());
+        values.put(Theme.AUTHOR, theme.getAuthor());
+        values.put(Theme.SCREENSHOT, theme.getScreenshot());
+        values.put(Theme.AUTHOR_URI, theme.getAuthorURI());
+        values.put(Theme.DEMO_URI, theme.getDemoURI());
+        values.put(Theme.NAME, theme.getName());
+        values.put(Theme.STYLESHEET, theme.getStylesheet());
+        values.put(Theme.PRICE, theme.getPrice());
+        values.put(Theme.BLOG_ID, theme.getBlogId());
+        values.put(Theme.IS_CURRENT, theme.getIsCurrent() ? 1 : 0);
+
+        synchronized (mSyncObject) {
+            int result = db.update(
+                    THEMES_TABLE,
+                    values,
+                    Theme.ID + "=?",
+                    new String[]{theme.getId()});
+            if (result == 0)
+                returnValue = db.insert(THEMES_TABLE, null, values) > 0;
+        }
+
+        return (returnValue);
+    }
+
+    public static Cursor getThemesAll(SQLiteDatabase db, String blogId) {
+        String[] columns = {COLUMN_NAME_ID, Theme.ID, Theme.NAME, Theme.SCREENSHOT, Theme.PRICE, Theme.IS_CURRENT};
+        String[] selection = {blogId};
+
+        return db.query(THEMES_TABLE, columns, Theme.BLOG_ID + "=?", selection, null, null, null);
+    }
+
+    public static Cursor getThemesFree(SQLiteDatabase db, String blogId) {
+        String[] columns = {COLUMN_NAME_ID, Theme.ID, Theme.NAME, Theme.SCREENSHOT, Theme.PRICE, Theme.IS_CURRENT};
+        String[] selection = {blogId, ""};
+
+        return db.query(THEMES_TABLE, columns, Theme.BLOG_ID + "=? AND " + Theme.PRICE + "=?", selection, null, null, null);
+    }
+
+    public static Cursor getThemesPremium(SQLiteDatabase db, String blogId) {
+        String[] columns = {COLUMN_NAME_ID, Theme.ID, Theme.NAME, Theme.SCREENSHOT, Theme.PRICE, Theme.IS_CURRENT};
+        String[] selection = {blogId, ""};
+
+        return db.query(THEMES_TABLE, columns, Theme.BLOG_ID + "=? AND " + Theme.PRICE + "!=?", selection, null, null, null);
+    }
+
+    public static String getCurrentThemeId(SQLiteDatabase db, String blogId) {
+        String[] selection = {blogId, String.valueOf(1)};
+        String currentThemeId;
+        try {
+            currentThemeId = DatabaseUtils.stringForQuery(db, "SELECT " + Theme.ID + " FROM " + THEMES_TABLE + " WHERE " + Theme.BLOG_ID + "=? and " + Theme.IS_CURRENT + "=?", selection);
+        } catch (SQLiteException e) {
+            currentThemeId = "";
+        }
+
+        return currentThemeId;
+    }
+
+    public static void setCurrentTheme(SQLiteDatabase db, String blogId, String id) {
+        // update any old themes that are set to true to false
+        ContentValues values = new ContentValues();
+        values.put(Theme.IS_CURRENT, false);
+        db.update(THEMES_TABLE, values, Theme.BLOG_ID + "=?", new String[] { blogId });
+
+        values = new ContentValues();
+        values.put(Theme.IS_CURRENT, true);
+        db.update(THEMES_TABLE, values, Theme.BLOG_ID + "=? AND " + Theme.ID + "=?", new String[] { blogId, id });
+    }
+
+    public static int getThemeCount(SQLiteDatabase db, String blogId) {
+        return getThemesAll(db, blogId).getCount();
+    }
+
+    public static Cursor getThemes(SQLiteDatabase db, String blogId, String searchTerm) {
+        String[] columns = {COLUMN_NAME_ID, Theme.ID, Theme.NAME, Theme.SCREENSHOT, Theme.PRICE, Theme.IS_CURRENT};
+        String[] selection = {blogId, "%" + searchTerm + "%"};
+
+        return db.query(THEMES_TABLE, columns, Theme.BLOG_ID + "=? AND " + Theme.NAME + " LIKE ?", selection, null, null, null);
+    }
+
+    public static Theme getTheme(SQLiteDatabase db, String blogId, String themeId) {
+        String[] columns = {COLUMN_NAME_ID, Theme.ID, Theme.AUTHOR, Theme.SCREENSHOT, Theme.AUTHOR_URI, Theme.DEMO_URI, Theme.NAME, Theme.STYLESHEET, Theme.PRICE, Theme.IS_CURRENT};
+        String[] selection = {blogId, themeId};
+        Cursor cursor = db.query(THEMES_TABLE, columns, Theme.BLOG_ID + "=? AND " + Theme.ID + "=?", selection, null, null, null);
+
+        if (cursor.moveToFirst()) {
+            String id = cursor.getString(cursor.getColumnIndex(Theme.ID));
+            String author = cursor.getString(cursor.getColumnIndex(Theme.AUTHOR));
+            String screenshot = cursor.getString(cursor.getColumnIndex(Theme.SCREENSHOT));
+            String authorURI = cursor.getString(cursor.getColumnIndex(Theme.AUTHOR_URI));
+            String demoURI = cursor.getString(cursor.getColumnIndex(Theme.DEMO_URI));
+            String name = cursor.getString(cursor.getColumnIndex(Theme.NAME));
+            String stylesheet = cursor.getString(cursor.getColumnIndex(Theme.STYLESHEET));
+            String price = cursor.getString(cursor.getColumnIndex(Theme.PRICE));
+            boolean isCurrent = cursor.getInt(cursor.getColumnIndex(Theme.IS_CURRENT)) > 0;
+
+            Theme theme = new Theme(id, author, screenshot, authorURI, demoURI, name, stylesheet, price, blogId, isCurrent);
+            cursor.close();
+
+            return theme;
+        } else {
+            cursor.close();
+            return null;
+        }
+    }
+
+    public static Theme getCurrentTheme(SQLiteDatabase db, String blogId) {
+        String currentThemeId = getCurrentThemeId(db, blogId);
+
+        return getTheme(db, blogId, currentThemeId);
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/models/Theme.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Theme.java
@@ -2,7 +2,6 @@ package org.wordpress.android.models;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.wordpress.android.fluxc.model.SiteModel;
 
 public class Theme {
     public static final String ID = "id";
@@ -16,9 +15,9 @@ public class Theme {
     public static final String BLOG_ID = "blogId";
     public static final String IS_CURRENT = "isCurrent";
 
-    public static final String PREVIEW_URL = "preview_url";
-    public static final String COST = "cost";
-    public static final String DISPLAY = "display";
+    private static final String PREVIEW_URL = "preview_url";
+    private static final String COST = "cost";
+    private static final String DISPLAY = "display";
 
     private String mId;
     private String mAuthor;
@@ -31,7 +30,7 @@ public class Theme {
     private String mBlogId;
     private boolean mIsCurrent;
 
-    public static Theme fromJSONV1_1(JSONObject object, SiteModel site) throws JSONException {
+    public static Theme fromJSONV1_1(JSONObject object, long siteId) throws JSONException {
         if (object == null) {
             return null;
         } else {
@@ -51,11 +50,11 @@ public class Theme {
             }
 
             return new Theme(id, author, screenshot, authorURI, demoURI, name, stylesheet, price,
-                    String.valueOf(site.getSiteId()), false);
+                    String.valueOf(siteId), false);
         }
     }
 
-    public static Theme fromJSONV1_2(JSONObject object, SiteModel site) throws JSONException {
+    public static Theme fromJSONV1_2(JSONObject object, long siteId) throws JSONException {
         if (object == null) {
             return null;
         } else {
@@ -74,7 +73,7 @@ public class Theme {
             }
 
             return new Theme(id, author, screenshot, authorURI, demoURI, name, stylesheet, price,
-                    String.valueOf(site.getSiteId()), false);
+                    String.valueOf(siteId), false);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/models/Theme.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Theme.java
@@ -2,6 +2,7 @@ package org.wordpress.android.models;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.wordpress.android.fluxc.model.SiteModel;
 
 public class Theme {
     public static final String ID = "id";
@@ -15,9 +16,9 @@ public class Theme {
     public static final String BLOG_ID = "blogId";
     public static final String IS_CURRENT = "isCurrent";
 
-    private static final String PREVIEW_URL = "preview_url";
-    private static final String COST = "cost";
-    private static final String DISPLAY = "display";
+    public static final String PREVIEW_URL = "preview_url";
+    public static final String COST = "cost";
+    public static final String DISPLAY = "display";
 
     private String mId;
     private String mAuthor;
@@ -30,7 +31,7 @@ public class Theme {
     private String mBlogId;
     private boolean mIsCurrent;
 
-    public static Theme fromJSONV1_1(JSONObject object, long siteId) throws JSONException {
+    public static Theme fromJSONV1_1(JSONObject object, SiteModel site) throws JSONException {
         if (object == null) {
             return null;
         } else {
@@ -50,11 +51,11 @@ public class Theme {
             }
 
             return new Theme(id, author, screenshot, authorURI, demoURI, name, stylesheet, price,
-                    String.valueOf(siteId), false);
+                    String.valueOf(site.getSiteId()), false);
         }
     }
 
-    public static Theme fromJSONV1_2(JSONObject object, long siteId) throws JSONException {
+    public static Theme fromJSONV1_2(JSONObject object, SiteModel site) throws JSONException {
         if (object == null) {
             return null;
         } else {
@@ -73,7 +74,7 @@ public class Theme {
             }
 
             return new Theme(id, author, screenshot, authorURI, demoURI, name, stylesheet, price,
-                    String.valueOf(siteId), false);
+                    String.valueOf(site.getSiteId()), false);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/models/Theme.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/Theme.java
@@ -2,7 +2,6 @@ package org.wordpress.android.models;
 
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.SiteModel;
 
 public class Theme {
@@ -175,9 +174,5 @@ public class Theme {
 
     public boolean isPremium() {
         return !mPrice.equals("");
-    }
-
-    public void save() {
-        WordPress.wpDB.saveTheme(this);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -413,13 +413,11 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
     }
 
     private void activateTheme(final String themeId) {
-        final String newThemeId = themeId;
-
         WordPress.getRestClientUtils().setTheme(mSite.getSiteId(), themeId, new Listener() {
             @Override
             public void onResponse(JSONObject response) {
-                WordPress.wpDB.setCurrentTheme(String.valueOf(mSite.getSiteId()), newThemeId);
-                Theme newTheme = WordPress.wpDB.getTheme(String.valueOf(mSite.getSiteId()), newThemeId);
+                WordPress.wpDB.setCurrentTheme(String.valueOf(mSite.getSiteId()), themeId);
+                Theme newTheme = WordPress.wpDB.getTheme(String.valueOf(mSite.getSiteId()), themeId);
 
                 Map<String, Object> themeProperties = new HashMap<>();
                 themeProperties.put(THEME_ID, themeId);

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -271,7 +271,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
                     @Override
                     public void onResponse(JSONObject response) {
                         try {
-                            mCurrentTheme = Theme.fromJSONV1_1(response, mSite);
+                            mCurrentTheme = Theme.fromJSONV1_1(response, mSite.getSiteId());
                             if (mCurrentTheme == null) {
                                 return;
                             }
@@ -519,7 +519,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
             for (int i = 0; i < count; i++) {
                 try {
                     JSONObject object = array.getJSONObject(i);
-                    Theme theme = Theme.fromJSONV1_2(object, mSite);
+                    Theme theme = Theme.fromJSONV1_2(object, mSite.getSiteId());
                     if (theme != null) {
                         WordPress.wpDB.saveTheme(theme);
                         themes.add(theme);

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -210,8 +210,8 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
             page = mThemeSearchFragment.getPage();
         }
 
-        WordPress.getRestClientUtilsV1_2().getFreeSearchThemes(mSite.getSiteId(), THEME_FETCH_MAX, page, searchTerm, new
-                Listener() {
+        WordPress.getRestClientUtilsV1_2().getFreeSearchThemes(mSite.getSiteId(), THEME_FETCH_MAX, page, searchTerm,
+                new Listener() {
                     @Override
                     public void onResponse(JSONObject response) {
                         new DeserializeThemesRestResponse().execute(response);
@@ -244,20 +244,21 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
                     public void onResponse(JSONObject response) {
                         try {
                             mCurrentTheme = Theme.fromJSONV1_1(response, mSite);
-                            if (mCurrentTheme != null) {
-                                mCurrentTheme.setIsCurrent(true);
-                                mCurrentTheme.save();
-                                WordPress.wpDB.setCurrentTheme(String.valueOf(mSite.getSiteId()), mCurrentTheme.getId());
-                                if (mThemeBrowserFragment != null) {
-                                    mThemeBrowserFragment.setRefreshing(false);
-                                    if (mThemeBrowserFragment.getCurrentThemeTextView() != null) {
-                                        mThemeBrowserFragment.getCurrentThemeTextView().setText(mCurrentTheme.getName());
-                                        mThemeBrowserFragment.setCurrentThemeId(mCurrentTheme.getId());
-                                    }
+                            if (mCurrentTheme == null) {
+                                return;
+                            }
+                            mCurrentTheme.setIsCurrent(true);
+                            mCurrentTheme.save();
+                            WordPress.wpDB.setCurrentTheme(String.valueOf(mSite.getSiteId()), mCurrentTheme.getId());
+                            if (mThemeBrowserFragment != null) {
+                                mThemeBrowserFragment.setRefreshing(false);
+                                if (mThemeBrowserFragment.getCurrentThemeTextView() != null) {
+                                    mThemeBrowserFragment.getCurrentThemeTextView().setText(mCurrentTheme.getName());
+                                    mThemeBrowserFragment.setCurrentThemeId(mCurrentTheme.getId());
                                 }
-                                if (mThemeSearchFragment != null && mThemeSearchFragment.isVisible()) {
-                                    mThemeSearchFragment.setRefreshing(false);
-                                }
+                            }
+                            if (mThemeSearchFragment != null && mThemeSearchFragment.isVisible()) {
+                                mThemeSearchFragment.setRefreshing(false);
                             }
                         } catch (JSONException e) {
                             AppLog.e(T.THEMES, e);
@@ -409,7 +410,8 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
 
         String thanksMessage = String.format(getString(R.string.theme_prompt), newTheme.getName());
         if (!newTheme.getAuthor().isEmpty()) {
-            thanksMessage = thanksMessage + " " + String.format(getString(R.string.theme_by_author_prompt_append), newTheme.getAuthor());
+            String append = String.format(getString(R.string.theme_by_author_prompt_append), newTheme.getAuthor());
+            thanksMessage = thanksMessage + " " + append;
         }
 
         dialogBuilder.setMessage(thanksMessage);

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -175,7 +175,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
         WordPress.getRestClientUtilsV1_2().getFreeThemes(mSite.getSiteId(), THEME_FETCH_MAX, page, new Listener() {
                     @Override
                     public void onResponse(JSONObject response) {
-                        new FetchThemesTask().execute(response);
+                        new DeserializeThemesRestResponse().execute(response);
                     }
                 }, new ErrorListener() {
                     @Override
@@ -214,7 +214,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
                 Listener() {
                     @Override
                     public void onResponse(JSONObject response) {
-                        new FetchThemesTask().execute(response);
+                        new DeserializeThemesRestResponse().execute(response);
                     }
                 }, new ErrorListener() {
                     @Override
@@ -307,7 +307,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
             WordPress.getRestClientUtilsV1_1().getPurchasedThemes(mSite.getSiteId(), new Listener() {
                 @Override
                 public void onResponse(JSONObject response) {
-                    new FetchThemesTask().execute(response);
+                    new DeserializeThemesRestResponse().execute(response);
                 }
             }, new ErrorListener() {
                 @Override
@@ -494,7 +494,11 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
         addSearchFragment();
     }
 
-    public class FetchThemesTask extends AsyncTask<JSONObject, Void, ArrayList<Theme>> {
+    /**
+     * Converts themes from a JSON REST response object to a list of {@link Theme}'s and saves them to local database.
+     * A {@link JSONObject} containing a {@link JSONArray} with key "themes" is expected.
+     */
+    private class DeserializeThemesRestResponse extends AsyncTask<JSONObject, Void, ArrayList<Theme>> {
         @Override
         protected ArrayList<Theme> doInBackground(JSONObject... args) {
             JSONObject response = args[0];

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -503,24 +503,26 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
     private class DeserializeThemesRestResponse extends AsyncTask<JSONObject, Void, ArrayList<Theme>> {
         @Override
         protected ArrayList<Theme> doInBackground(JSONObject... args) {
-            JSONObject response = args[0];
+            if (args[0] == null) {
+                return null;
+            }
+
+            // JSONArray of themes is required
+            final JSONArray array = args[0].optJSONArray("themes");
+            if (array == null) {
+                return null;
+            }
+
+            // convert JSON themes to Theme models and store them in database
             final ArrayList<Theme> themes = new ArrayList<>();
-
-            if (response != null) {
-                JSONArray array;
+            final int count = array.length();
+            for (int i = 0; i < count; i++) {
                 try {
-                    array = response.getJSONArray("themes");
-
-                    if (array != null) {
-                        int count = array.length();
-                        for (int i = 0; i < count; i++) {
-                            JSONObject object = array.getJSONObject(i);
-                            Theme theme = Theme.fromJSONV1_2(object, mSite);
-                            if (theme != null) {
-                                theme.save();
-                                themes.add(theme);
-                            }
-                        }
+                    JSONObject object = array.getJSONObject(i);
+                    Theme theme = Theme.fromJSONV1_2(object, mSite);
+                    if (theme != null) {
+                        theme.save();
+                        themes.add(theme);
                     }
                 } catch (JSONException e) {
                     AppLog.e(T.THEMES, e);
@@ -529,11 +531,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
 
             fetchCurrentTheme();
 
-            if (themes.size() > 0) {
-                return themes;
-            }
-
-            return null;
+            return themes.size() > 0 ? themes : null;
         }
 
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -271,7 +271,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
                     @Override
                     public void onResponse(JSONObject response) {
                         try {
-                            mCurrentTheme = Theme.fromJSONV1_1(response, mSite.getSiteId());
+                            mCurrentTheme = Theme.fromJSONV1_1(response, mSite);
                             if (mCurrentTheme == null) {
                                 return;
                             }
@@ -519,7 +519,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
             for (int i = 0; i < count; i++) {
                 try {
                     JSONObject object = array.getJSONObject(i);
-                    Theme theme = Theme.fromJSONV1_2(object, mSite.getSiteId());
+                    Theme theme = Theme.fromJSONV1_2(object, mSite);
                     if (theme != null) {
                         WordPress.wpDB.saveTheme(theme);
                         themes.add(theme);

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -94,10 +94,6 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
         showToolbar();
     }
 
-    private void setCurrentThemeFromDB() {
-        mCurrentTheme = WordPress.wpDB.getCurrentTheme(String.valueOf(mSite.getSiteId()));
-    }
-
     @Override
     protected void onResume() {
         super.onResume();
@@ -157,6 +153,38 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
                 activateTheme(themeId);
             }
         }
+    }
+
+    @Override
+    public void onActivateSelected(String themeId) {
+        activateTheme(themeId);
+    }
+
+    @Override
+    public void onTryAndCustomizeSelected(String themeId) {
+        startWebActivity(themeId, ThemeWebActivity.ThemeWebActivityType.PREVIEW);
+    }
+
+    @Override
+    public void onViewSelected(String themeId) {
+        startWebActivity(themeId, ThemeWebActivity.ThemeWebActivityType.DEMO);
+    }
+
+    @Override
+    public void onDetailsSelected(String themeId) {
+        startWebActivity(themeId, ThemeWebActivity.ThemeWebActivityType.DETAILS);
+    }
+
+    @Override
+    public void onSupportSelected(String themeId) {
+        startWebActivity(themeId, ThemeWebActivity.ThemeWebActivityType.SUPPORT);
+    }
+
+    @Override
+    public void onSearchClicked() {
+        mIsInSearchMode = true;
+        AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.THEMES_ACCESSED_SEARCH, mSite);
+        addSearchFragment();
     }
 
     public void setIsInSearchMode(boolean isInSearchMode) {
@@ -292,6 +320,24 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
         mThemeSearchFragment = themeSearchFragment;
     }
 
+    protected void showToolbar() {
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayShowTitleEnabled(true);
+            actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setTitle(R.string.themes);
+            findViewById(R.id.toolbar).setVisibility(View.VISIBLE);
+            findViewById(R.id.toolbar_search).setVisibility(View.GONE);
+        }
+    }
+
+    private void setCurrentThemeFromDB() {
+        mCurrentTheme = WordPress.wpDB.getCurrentTheme(String.valueOf(mSite.getSiteId()));
+    }
+
     private void fetchThemesIfNoneAvailable() {
         if (NetworkUtils.isNetworkAvailable(this)
                 && WordPress.wpDB.getThemeCount(String.valueOf(mSite.getSiteId())) == 0) {
@@ -322,18 +368,6 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
                 mThemeBrowserFragment.setRefreshing(true);
             }
         }
-    }
-
-    protected void showToolbar() {
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-        setSupportActionBar(toolbar);
-
-        ActionBar actionBar = getSupportActionBar();
-        actionBar.setDisplayShowTitleEnabled(true);
-        actionBar.setDisplayHomeAsUpEnabled(true);
-        actionBar.setTitle(R.string.themes);
-        findViewById(R.id.toolbar).setVisibility(View.VISIBLE);
-        findViewById(R.id.toolbar_search).setVisibility(View.GONE);
     }
 
     private void showCorrectToolbar() {
@@ -462,38 +496,6 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
         }
 
         ToastUtils.showToast(this, toastText, ToastUtils.Duration.SHORT);
-    }
-
-    @Override
-    public void onActivateSelected(String themeId) {
-        activateTheme(themeId);
-    }
-
-    @Override
-    public void onTryAndCustomizeSelected(String themeId) {
-        startWebActivity(themeId, ThemeWebActivity.ThemeWebActivityType.PREVIEW);
-    }
-
-    @Override
-    public void onViewSelected(String themeId) {
-        startWebActivity(themeId, ThemeWebActivity.ThemeWebActivityType.DEMO);
-    }
-
-    @Override
-    public void onDetailsSelected(String themeId) {
-        startWebActivity(themeId, ThemeWebActivity.ThemeWebActivityType.DETAILS);
-    }
-
-    @Override
-    public void onSupportSelected(String themeId) {
-        startWebActivity(themeId, ThemeWebActivity.ThemeWebActivityType.SUPPORT);
-    }
-
-    @Override
-    public void onSearchClicked() {
-        mIsInSearchMode = true;
-        AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.THEMES_ACCESSED_SEARCH, mSite);
-        addSearchFragment();
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -515,8 +515,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
 
             // convert JSON themes to Theme models and store them in database
             final ArrayList<Theme> themes = new ArrayList<>();
-            final int count = array.length();
-            for (int i = 0; i < count; i++) {
+            for (int i = 0; i < array.length(); i++) {
                 try {
                     JSONObject object = array.getJSONObject(i);
                     Theme theme = Theme.fromJSONV1_2(object, mSite);

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -276,7 +276,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
                                 return;
                             }
                             mCurrentTheme.setIsCurrent(true);
-                            mCurrentTheme.save();
+                            WordPress.wpDB.saveTheme(mCurrentTheme);
                             WordPress.wpDB.setCurrentTheme(String.valueOf(mSite.getSiteId()), mCurrentTheme.getId());
                             if (mThemeBrowserFragment != null) {
                                 mThemeBrowserFragment.setRefreshing(false);
@@ -521,7 +521,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
                     JSONObject object = array.getJSONObject(i);
                     Theme theme = Theme.fromJSONV1_2(object, mSite);
                     if (theme != null) {
-                        theme.save();
+                        WordPress.wpDB.saveTheme(theme);
                         themes.add(theme);
                     }
                 } catch (JSONException e) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -24,6 +24,7 @@ import com.android.volley.toolbox.ImageLoader.ImageListener;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.datasets.ThemeTable;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.models.Theme;
 import org.wordpress.android.util.NetworkUtils;
@@ -318,12 +319,12 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener, 
         String blogId = String.valueOf(mSite.getSiteId());
         switch (position) {
             case THEME_FILTER_PREMIUM_INDEX:
-                return WordPress.wpDB.getThemesPremium(blogId);
+                return ThemeTable.getThemesPremium(WordPress.wpDB.getDatabase(), blogId);
             case THEME_FILTER_ALL_INDEX:
-                return WordPress.wpDB.getThemesAll(blogId);
+                return ThemeTable.getThemesAll(WordPress.wpDB.getDatabase(), blogId);
             case THEME_FILTER_FREE_INDEX:
             default:
-                return WordPress.wpDB.getThemesFree(blogId);
+                return ThemeTable.getThemesFree(WordPress.wpDB.getDatabase(), blogId);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
@@ -12,6 +12,7 @@ import android.view.View;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.datasets.ThemeTable;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -154,7 +155,7 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
     @Override
     protected Cursor fetchThemes(int position) {
         String blogId = String.valueOf(mSite.getSiteId());
-        return WordPress.wpDB.getThemes(blogId, mLastSearch);
+        return ThemeTable.getThemes(WordPress.wpDB.getDatabase(), blogId, mLastSearch);
     }
 
     public void search(String searchTerm) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
@@ -13,6 +13,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.datasets.ThemeTable;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.models.Theme;
 import org.wordpress.android.ui.ActivityLauncher;
@@ -41,7 +42,8 @@ public class ThemeWebActivity extends WPWebViewActivity {
 
     public static void openTheme(Activity activity, SiteModel site, String themeId, ThemeWebActivityType type,
                                  boolean isCurrentTheme) {
-        Theme currentTheme = WordPress.wpDB.getTheme(String.valueOf(site.getSiteId()), themeId);
+        Theme currentTheme = ThemeTable.getTheme(WordPress.wpDB.getDatabase(),
+                String.valueOf(site.getSiteId()), themeId);
         if (currentTheme == null) {
             ToastUtils.showToast(activity, R.string.could_not_load_theme);
             return;
@@ -64,7 +66,7 @@ public class ThemeWebActivity extends WPWebViewActivity {
      * opens the current theme for the current blog
      */
     public static void openCurrentTheme(Activity activity, SiteModel site, ThemeWebActivityType type) {
-        String themeId = WordPress.wpDB.getCurrentThemeId(String.valueOf(site.getSiteId()));
+        String themeId = ThemeTable.getCurrentThemeId(WordPress.wpDB.getDatabase(), String.valueOf(site.getSiteId()));
         if (themeId.isEmpty()) {
             requestAndOpenCurrentTheme(activity, site);
         } else {
@@ -81,8 +83,9 @@ public class ThemeWebActivity extends WPWebViewActivity {
                     Theme currentTheme = Theme.fromJSONV1_1(response, site);
                     if (currentTheme != null) {
                         currentTheme.setIsCurrent(true);
-                        WordPress.wpDB.saveTheme(currentTheme);
-                        WordPress.wpDB.setCurrentTheme(String.valueOf(site.getSiteId()), currentTheme.getId());
+                        ThemeTable.saveTheme(WordPress.wpDB.getDatabase(), currentTheme);
+                        ThemeTable.setCurrentTheme(WordPress.wpDB.getDatabase(),
+                                String.valueOf(site.getSiteId()), currentTheme.getId());
                         openTheme(activity, site, currentTheme.getId(), ThemeWebActivityType.PREVIEW, true);
                     }
                 } catch (JSONException e) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
@@ -81,7 +81,7 @@ public class ThemeWebActivity extends WPWebViewActivity {
                     Theme currentTheme = Theme.fromJSONV1_1(response, site);
                     if (currentTheme != null) {
                         currentTheme.setIsCurrent(true);
-                        currentTheme.save();
+                        WordPress.wpDB.saveTheme(currentTheme);
                         WordPress.wpDB.setCurrentTheme(String.valueOf(site.getSiteId()), currentTheme.getId());
                         openTheme(activity, site, currentTheme.getId(), ThemeWebActivityType.PREVIEW, true);
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
@@ -78,7 +78,7 @@ public class ThemeWebActivity extends WPWebViewActivity {
             @Override
             public void onResponse(JSONObject response) {
                 try {
-                    Theme currentTheme = Theme.fromJSONV1_1(response, site);
+                    Theme currentTheme = Theme.fromJSONV1_1(response, site.getSiteId());
                     if (currentTheme != null) {
                         currentTheme.setIsCurrent(true);
                         WordPress.wpDB.saveTheme(currentTheme);

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
@@ -78,7 +78,7 @@ public class ThemeWebActivity extends WPWebViewActivity {
             @Override
             public void onResponse(JSONObject response) {
                 try {
-                    Theme currentTheme = Theme.fromJSONV1_1(response, site.getSiteId());
+                    Theme currentTheme = Theme.fromJSONV1_1(response, site);
                     if (currentTheme != null) {
                         currentTheme.setIsCurrent(true);
                         WordPress.wpDB.saveTheme(currentTheme);


### PR DESCRIPTION
This PR contains a bunch of code maintenance that's been done as a pre-cursor to adding Jetpack themes support. No major logic changes here. The biggest changes are to `FetchThemesTask` (now `DeserializeThemesRestResponse`) but even those are minimal.

1. Eliminated some dependencies from the `Theme` data model
2. Re-named and documented `FetchThemesTask`
3. Fixed a bunch of warnings

To test:
1. Make sure the Themes browser still works as expected

cc @oguzkocer