### PR TITLE
Fix Jetpack Monitor toggle

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -175,7 +175,6 @@ class DotComSiteSettings extends SiteSettingsInterface {
 
                         if (mSite.isJetpackConnected()) {
                             fetchJetpackSettings();
-                            fetchJetpackMonitorSettings();
                         }
                     }
                 }, new RestRequest.ErrorListener() {
@@ -188,6 +187,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
     }
 
     private void fetchJetpackSettings() {
+        fetchJetpackMonitorSettings();
         WordPress.getRestClientUtils().getJetpackSettings(
                 mSite.getSiteId(), new RestRequest.Listener() {
                     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -454,7 +454,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
 
     private void updateJetpackMonitorSettings() {
         WordPress.getRestClientUtils().setJetpackMonitor(
-                mSite.getSiteId(), new RestRequest.Listener() {
+                mSite.getSiteId(), mJpSettings.monitorActive, new RestRequest.Listener() {
                     @Override
                     public void onResponse(JSONObject response) {
                         mRemoteJpSettings.monitorActive = response.optBoolean("active");
@@ -466,7 +466,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
                     public void onErrorResponse(VolleyError error) {
                         AppLog.w(AppLog.T.API, "Error updating Jetpack Monitor settings: " + error);
                     }
-                }, mJpSettings.monitorActive);
+                });
     }
 
     private void saveJetpackSettings() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -56,7 +56,6 @@ class DotComSiteSettings extends SiteSettingsInterface {
     private static final String SHARING_LIKES_DISABLED_KEY = "disabled_likes";
     private static final String SHARING_COMMENT_LIKES_KEY = "jetpack_comment_likes_enabled";
     private static final String TWITTER_USERNAME_KEY = "twitter_via";
-    private static final String JP_MONITOR_ACTIVE_KEY = "monitor_active";
     private static final String JP_MONITOR_EMAIL_NOTES_KEY = "email_notifications";
     private static final String JP_MONITOR_WP_NOTES_KEY = "wp_note_notifications";
 
@@ -176,6 +175,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
 
                         if (mSite.isJetpackConnected()) {
                             fetchJetpackSettings();
+                            fetchJetpackMonitorSettings();
                         }
                     }
                 }, new RestRequest.ErrorListener() {
@@ -196,7 +196,6 @@ class DotComSiteSettings extends SiteSettingsInterface {
                         mRemoteJpSettings.localTableId = mSite.getId();
                         deserializeJetpackRestResponse(mSite, response);
                         mJpSettings.localTableId = mRemoteJpSettings.localTableId;
-                        mJpSettings.monitorActive = mRemoteJpSettings.monitorActive;
                         mJpSettings.emailNotifications = mRemoteJpSettings.emailNotifications;
                         mJpSettings.wpNotifications = mRemoteJpSettings.wpNotifications;
                         SiteSettingsTable.saveJpSettings(mJpSettings);
@@ -436,7 +435,42 @@ class DotComSiteSettings extends SiteSettingsInterface {
                 });
     }
 
+    private void fetchJetpackMonitorSettings() {
+        WordPress.getRestClientUtils().getJetpackMonitor(
+                mSite.getSiteId(), new RestRequest.Listener() {
+                    @Override
+                    public void onResponse(JSONObject response) {
+                        mRemoteJpSettings.monitorActive = response.optBoolean("active");
+                        mJpSettings.monitorActive = mRemoteJpSettings.monitorActive;
+                        notifyUpdatedOnUiThread(null);
+                    }
+                }, new RestRequest.ErrorListener() {
+                    @Override
+                    public void onErrorResponse(VolleyError error) {
+                        AppLog.w(AppLog.T.API, "Error getting Jetpack Monitor settings: " + error);
+                    }
+                });
+    }
+
+    private void updateJetpackMonitorSettings() {
+        WordPress.getRestClientUtils().setJetpackMonitor(
+                mSite.getSiteId(), new RestRequest.Listener() {
+                    @Override
+                    public void onResponse(JSONObject response) {
+                        mRemoteJpSettings.monitorActive = response.optBoolean("active");
+                        mJpSettings.monitorActive = mRemoteJpSettings.monitorActive;
+                        notifySavedOnUiThread(null);
+                    }
+                }, new RestRequest.ErrorListener() {
+                    @Override
+                    public void onErrorResponse(VolleyError error) {
+                        AppLog.w(AppLog.T.API, "Error updating Jetpack Monitor settings: " + error);
+                    }
+                }, mJpSettings.monitorActive);
+    }
+
     private void saveJetpackSettings() {
+        updateJetpackMonitorSettings();
         final Map<String, String> params = serializeJetpackParams();
         if (params == null || params.isEmpty()) return;
 
@@ -445,7 +479,6 @@ class DotComSiteSettings extends SiteSettingsInterface {
                     @Override
                     public void onResponse(JSONObject response) {
                         AppLog.d(AppLog.T.API, "Jetpack Settings saved remotely");
-                        mRemoteJpSettings.monitorActive = mJpSettings.monitorActive;
                         mRemoteJpSettings.emailNotifications = mJpSettings.emailNotifications;
                         mRemoteJpSettings.wpNotifications = mJpSettings.wpNotifications;
                         notifySavedOnUiThread(null);
@@ -462,14 +495,12 @@ class DotComSiteSettings extends SiteSettingsInterface {
     private void deserializeJetpackRestResponse(SiteModel site, JSONObject response) {
         if (site == null || response == null) return;
         JSONObject settingsObject = response.optJSONObject("settings");
-        mRemoteJpSettings.monitorActive = settingsObject.optBoolean(JP_MONITOR_ACTIVE_KEY, false);
         mRemoteJpSettings.emailNotifications = settingsObject.optBoolean(JP_MONITOR_EMAIL_NOTES_KEY, false);
         mRemoteJpSettings.wpNotifications = settingsObject.optBoolean(JP_MONITOR_WP_NOTES_KEY, false);
     }
 
     private Map<String, String> serializeJetpackParams() {
         Map<String, String> params = new HashMap<>();
-        params.put(JP_MONITOR_ACTIVE_KEY, String.valueOf(mJpSettings.monitorActive));
         params.put(JP_MONITOR_EMAIL_NOTES_KEY, String.valueOf(mJpSettings.emailNotifications));
         params.put(JP_MONITOR_WP_NOTES_KEY, String.valueOf(mJpSettings.wpNotifications));
         return params;

--- a/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
+++ b/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
@@ -243,7 +243,7 @@ public class RestClientUtils {
         get(path, listener, errorListener);
     }
 
-    public void setJetpackMonitor(long siteId, Listener listener, ErrorListener errorListener, boolean enabled) {
+    public void setJetpackMonitor(long siteId, boolean enabled, Listener listener, ErrorListener errorListener) {
         String path = String.format(Locale.US, "sites/%d/jetpack/modules/monitor", siteId);
         Map<String, String> params = new HashMap<>();
         params.put("active", String.valueOf(enabled));

--- a/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
+++ b/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
@@ -243,6 +243,18 @@ public class RestClientUtils {
         get(path, listener, errorListener);
     }
 
+    public void setJetpackMonitor(long siteId, Listener listener, ErrorListener errorListener, boolean enabled) {
+        String path = String.format(Locale.US, "sites/%d/jetpack/modules/monitor", siteId);
+        Map<String, String> params = new HashMap<>();
+        params.put("active", String.valueOf(enabled));
+        post(path, params, null, listener, errorListener);
+    }
+
+    public void getJetpackMonitor(long siteId, Listener listener, ErrorListener errorListener) {
+        String path = String.format(Locale.US, "sites/%d/jetpack/modules/monitor", siteId);
+        get(path, listener, errorListener);
+    }
+
     public void setJetpackSettings(long siteId, Listener listener, ErrorListener errorListener,
                                        Map<String, String> params) {
         String path = String.format(Locale.US, "jetpack-blogs/%d", siteId);


### PR DESCRIPTION
This PR changes how `monitorActive` is fetched/updated by pinging the monitor module endpoint.

To test:
1. Sign into Jetpack site
2. Go to security settings
3. Toggle Jetpack Monitor on/off on the web+mobile

cc @oguzkocer 