### PR TITLE
Issue/6279 post list missing featured image

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -225,10 +225,11 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                 postHolder.txtExcerpt.setVisibility(View.GONE);
             }
 
-            if (post.getFeaturedImageId() > 0 || mFeaturedImageUrls.containsKey(post.getId())) {
+            if (mFeaturedImageUrls.containsKey(post.getId())) {
+                String imageUrl = mFeaturedImageUrls.get(post.getId());
+                AppLog.w(AppLog.T.READER, "featured = " + imageUrl);
                 postHolder.imgFeatured.setVisibility(View.VISIBLE);
-                postHolder.imgFeatured.setImageUrl(mFeaturedImageUrls.get(post.getId()),
-                        WPNetworkImageView.ImageType.PHOTO);
+                postHolder.imgFeatured.setImageUrl(imageUrl, WPNetworkImageView.ImageType.PHOTO);
             } else {
                 postHolder.imgFeatured.setVisibility(View.GONE);
             }
@@ -745,7 +746,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                     } else if (StringUtils.isNotEmpty(post.getContent())) {
                         imageUrl = new ReaderImageScanner(post.getContent(), mSite.isPrivate()).getLargestImage();
                     }
-                    if (!TextUtils.isEmpty(imageUrl)) {
+                    if (!TextUtils.isEmpty(imageUrl) && imageUrl.startsWith("http")) {
                         mFeaturedImageUrls.put(post.getId(), ReaderUtils.getResizedImageUrl(imageUrl, mPhotonWidth,
                                 mPhotonHeight, mSite.isPrivate()));
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -7,7 +7,6 @@ import android.animation.PropertyValuesHolder;
 import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
 import android.support.annotation.NonNull;
@@ -44,6 +43,7 @@ import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DisplayUtils;
+import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.widgets.PostListButton;
 import org.wordpress.android.widgets.WPNetworkImageView;
@@ -310,11 +310,13 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         if (imageUrl == null) {
             imgFeatured.setVisibility(View.GONE);
         } else if (imageUrl.startsWith("http")) {
-            String photonUrl =  ReaderUtils.getResizedImageUrl(imageUrl, mPhotonWidth, mPhotonHeight, mSite.isPrivate());
+            String photonUrl =  ReaderUtils.getResizedImageUrl(
+                    imageUrl, mPhotonWidth, mPhotonHeight, !SiteUtils.isPhotonCapable(mSite));
             imgFeatured.setVisibility(View.VISIBLE);
             imgFeatured.setImageUrl(photonUrl, WPNetworkImageView.ImageType.PHOTO);
         } else {
-            Bitmap bmp = fastResizeBitmap(imageUrl, mPhotonWidth);
+            Bitmap bmp = ImageUtils.getWPImageSpanThumbnailFromFilePath(
+                    imgFeatured.getContext(), imageUrl, mPhotonWidth);
             if (bmp != null) {
                 imgFeatured.setVisibility(View.VISIBLE);
                 imgFeatured.setImageBitmap(bmp);
@@ -322,27 +324,6 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                 imgFeatured.setVisibility(View.GONE);
             }
         }
-    }
-
-    // TODO: once this is proven we can move it to ImageUtils
-    private static Bitmap fastResizeBitmap(@NonNull String imageUri, int maxWidth) {
-        BitmapFactory.Options opt = new BitmapFactory.Options();
-        opt.inJustDecodeBounds = true;
-        BitmapFactory.decodeFile(imageUri, opt);
-        int srcWidth = opt.outWidth;
-        if (srcWidth <= maxWidth) {
-            return BitmapFactory.decodeFile(imageUri, null);
-        }
-
-        // scale must be a power of two
-        double scale = Math.pow(2, (int) Math.round(Math.log(maxWidth / (double) srcWidth) / Math.log(0.5)));
-
-        opt.inJustDecodeBounds = false;
-        opt.inScaled = true;
-        opt.inSampleSize = (int) scale;
-        opt.inDensity = srcWidth;
-        opt.inTargetDensity =  maxWidth * opt.inSampleSize;
-        return BitmapFactory.decodeFile(imageUri, opt);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -752,6 +752,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
             // Generate the featured image url for each post
             mFeaturedImageUrls.clear();
+            boolean isPrivate = !SiteUtils.isPhotonCapable(mSite);
             for (PostModel post : tmpPosts) {
                 String imageUrl = null;
                 if (post.getFeaturedImageId() != 0) {
@@ -764,7 +765,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                         mediaIdsToUpdate.add(post.getFeaturedImageId());
                     }
                 } else {
-                    imageUrl = new ReaderImageScanner(post.getContent(), mSite.isPrivate()).getLargestImage();
+                    imageUrl = new ReaderImageScanner(post.getContent(), isPrivate).getLargestImage();
                 }
                 if (!TextUtils.isEmpty(imageUrl)) {
                     mFeaturedImageUrls.put(post.getId(), imageUrl);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -673,7 +673,12 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         for (int position : indexList) {
             PostModel post = getItem(position);
             if (post != null) {
-                mFeaturedImageUrls.put(post.getId(), mediaModel.getUrl());
+                String imageUrl = mediaModel.getUrl();
+                if (imageUrl != null && imageUrl.startsWith("http")) {
+                    mFeaturedImageUrls.put(post.getId(), imageUrl);
+                } else {
+                    mFeaturedImageUrls.remove(post.getId());
+                }
                 notifyItemChanged(position);
             }
         }


### PR DESCRIPTION
Fixes #6279 - the problem was due to choosing a featured image from the post content when the image is still uploading. This resulted in choosing a local file (ex: `/storage/emulated/0/Download/IMG_q5m29m.jpg`) as a featured image, and the post adapter didn't support displaying device images.

This PR corrects this by supporting device images, and also fixes a few problems in the existing featured image code.

**Note:** As part of this PR, I added [this routine](https://github.com/wordpress-mobile/WordPress-Android/blob/d5d7ae968dc260d6421bf42a45f25ba8c8dd0f55/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java#L328) to load resized bitmaps more efficiently than similar routines in [ImageUtils](https://github.com/wordpress-mobile/WordPress-Utils-Android/blob/develop/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java#L598). At some point we'll want to move that routine to `ImageUtils`, but for now I'd like to keep it inside `PostListAdapter`.