### PR TITLE
Fix post upload notification messaging and analytics tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -308,6 +308,7 @@ public class EditPostActivity extends AppCompatActivity implements
                     postFormat = SiteSettingsInterface.getDefaultFormat(WordPress.getContext());
                 }
                 mPost = mPostStore.instantiatePostModel(mSite, mIsPage, categories, postFormat);
+                mPost.setStatus(PostStatus.PUBLISHED.toString());
             } else if (extras != null) {
                 // Load post passed in extras
                 mPost = mPostStore.getPostByLocalPostId(extras.getInt(EXTRA_POST_LOCAL_ID));

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -526,9 +526,15 @@ public class PostsListFragment extends Fragment
         }
 
         PostUtils.updatePublishDateIfShouldBePublishedImmediately(post);
+        boolean isFirstTimePublish = PostStatus.fromPost(post) == PostStatus.DRAFT
+                || (PostStatus.fromPost(post) == PostStatus.PUBLISHED && post.isLocalDraft());
         post.setStatus(PostStatus.PUBLISHED.toString());
 
-        PostUploadService.addPostToUpload(post);
+        if (isFirstTimePublish) {
+            PostUploadService.addPostToUploadAndTrackAnalytics(post);
+        } else {
+            PostUploadService.addPostToUpload(post);
+        }
         getActivity().startService(new Intent(getActivity(), PostUploadService.class));
 
         PostUtils.trackSavePostAnalytics(post, mSite);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadNotifier.java
@@ -95,22 +95,21 @@ public class PostUploadNotifier {
         }
 
         // Notification builder
-        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(mContext.getApplicationContext());
+        NotificationCompat.Builder notificationBuilder =
+                new NotificationCompat.Builder(mContext.getApplicationContext());
         String notificationTitle;
         if (PostStatus.DRAFT.equals(PostStatus.fromPost(post))) {
-            notificationTitle = (String) mContext.getResources().getText(R.string
-                    .draft_uploaded);
-        } else if (post.isPage()) {
-            notificationTitle = (String) mContext.getResources().getText(R.string
-                    .page_published);
+            notificationTitle = (String) mContext.getResources().getText(R.string.draft_uploaded);
         } else {
-            notificationTitle = (String) mContext.getResources().getText(R .string.post_published);
+            if (post.isPage()) {
+                notificationTitle = (String) mContext.getResources().getText(
+                        isFirstTimePublish ? R.string.page_published : R.string.page_updated);
+            } else {
+                notificationTitle = (String) mContext.getResources().getText(
+                        isFirstTimePublish ? R.string.post_published : R.string.post_updated);
+            }
         }
 
-        if (!isFirstTimePublish) {
-            notificationTitle = (String) (post.isPage() ? mContext.getResources().getText(R.string
-                    .page_updated) : mContext.getResources().getText(R.string.post_updated));
-        }
         notificationBuilder.setSmallIcon(android.R.drawable.stat_sys_upload_done);
 
         NotificationData notificationData = mPostIdToNotificationData.get(post.getId());


### PR DESCRIPTION
Fixes #6272.

There were three issues addressed:
1. The `PostUploadNotifier` wasn't displaying 'Draft uploaded' when uploading a draft post
2. The post list was not doing a 'first time publish' check (this also means we weren't tracking `EDITOR_PUBLISHED_POST` events when uploading posts from the first time from the post list)
3. We seem to be no longer initializing new posts with a default status, so the [`isFirstTimePublish()`](https://github.com/wordpress-mobile/WordPress-Android/blob/787a8e271d2456fc9ca1d081d66711bd6ee7ed39/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L1215) check was returning false negatives for new posts, also affecting messaging and analytics tracking