### PR TITLE
Async media: Disable editing posts with uploading media in the visual editor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -39,6 +39,7 @@ import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.posts.PostsListFragment;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.utils.ReaderImageScanner;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.ui.uploads.UploadUtils;
@@ -261,6 +262,9 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             if (UploadService.isPostUploading(post)) {
                 postHolder.disabledOverlay.setVisibility(View.VISIBLE);
                 postHolder.progressBar.setIndeterminate(true);
+            } else if (!AppPrefs.isAztecEditorEnabled() && UploadService.isPostUploadingOrQueued(post)) {
+                // Editing posts with uploading media is only supported in Aztec
+                postHolder.disabledOverlay.setVisibility(View.VISIBLE);
             } else {
                 postHolder.disabledOverlay.setVisibility(View.GONE);
             }
@@ -308,6 +312,9 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             if (UploadService.isPostUploading(post)) {
                 pageHolder.disabledOverlay.setVisibility(View.VISIBLE);
                 pageHolder.progressBar.setIndeterminate(true);
+            } else if (!AppPrefs.isAztecEditorEnabled() && UploadService.isPostUploadingOrQueued(post)) {
+                // Editing posts with uploading media is only supported in Aztec
+                pageHolder.disabledOverlay.setVisibility(View.VISIBLE);
             } else {
                 pageHolder.disabledOverlay.setVisibility(View.GONE);
             }


### PR DESCRIPTION
Since we only support progress reattachment for Aztec, this disables opening a post in the visual editor while it has uploading media ([ref](https://github.com/wordpress-mobile/WordPress-Android/projects/6#card-3450966)).

To test:
1. Exit the visual editor while uploading media and verify that you can't return until the post completely finishes uploading
2. Verify that reattachment still works for Aztec

cc @mzorz