### PR TITLE
Async media: Tweak media error messaging in post list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -31,7 +31,6 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
-import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.post.PostStatus;
@@ -42,8 +41,8 @@ import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.posts.PostsListFragment;
 import org.wordpress.android.ui.reader.utils.ReaderImageScanner;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
-import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.ui.uploads.UploadService;
+import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DisplayUtils;
@@ -413,17 +412,13 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             UploadService.UploadError reason = UploadService.getUploadErrorForPost(post);
             if (reason != null) {
                 if (reason.mediaError != null) {
-                    // Get the first failed media for this post
-                    MediaModel failedMedia = mMediaStore.getMediaForPostWithState(post, MediaUploadState.FAILED).get(0);
-                    errorMessage = UploadUtils.getErrorMessageFromMediaError(
-                            txtStatus.getContext(), failedMedia, reason.mediaError)  + " - " +
-                            txtStatus.getContext().getString(R.string.error_media_recover);
+                    errorMessage = txtStatus.getContext().getString(R.string.error_media_recover);
                 } else if (reason.postError != null) {
                     errorMessage = UploadUtils.getErrorMessageFromPostError(
                             txtStatus.getContext(), post, reason.postError);
                 }
                 statusIconResId = R.drawable.ic_notice_48dp;
-                statusColorResId = R.color.alert_yellow;
+                statusColorResId = R.color.alert_red;
             } else if (UploadService.isPostUploading(post)) {
                 statusTextResId = R.string.post_uploading;
                 statusIconResId = R.drawable.ic_gridicons_cloud_upload;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -31,6 +31,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
+import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.post.PostStatus;
@@ -412,8 +413,10 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             UploadService.UploadError reason = UploadService.getUploadErrorForPost(post);
             if (reason != null) {
                 if (reason.mediaError != null) {
+                    // Get the first failed media for this post
+                    MediaModel failedMedia = mMediaStore.getMediaForPostWithState(post, MediaUploadState.FAILED).get(0);
                     errorMessage = UploadUtils.getErrorMessageFromMediaError(
-                            txtStatus.getContext(), reason.mediaError)  + " - " +
+                            txtStatus.getContext(), failedMedia, reason.mediaError)  + " - " +
                             txtStatus.getContext().getString(R.string.error_media_recover);
                 } else if (reason.postError != null) {
                     errorMessage = UploadUtils.getErrorMessageFromPostError(

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -613,7 +613,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
                     + event.error.message);
             SiteModel site = mSiteStore.getSiteByLocalId(sCurrentUploadingPost.getLocalSiteId());
             Context context = WordPress.getContext();
-            String errorMessage = UploadUtils.getErrorMessageFromMediaError(context, event.error);
+            String errorMessage = UploadUtils.getErrorMessageFromMediaError(context, event.media, event.error);
             String notificationMessage = UploadUtils.getErrorMessage(context, sCurrentUploadingPost, errorMessage);
             mPostUploadNotifier.cancelNotification(sCurrentUploadingPost);
             mPostUploadNotifier.updateNotificationError(sCurrentUploadingPost, site, notificationMessage, true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -520,7 +520,7 @@ public class UploadService extends Service {
             if (event.media.getLocalPostId() > 0) {
                 AppLog.w(T.MAIN, "UploadService > Media upload failed for post " + event.media.getLocalPostId() + " : "
                         + event.error.type + ": " + event.error.message);
-                String errorMessage = UploadUtils.getErrorMessageFromMediaError(this, event.error);
+                String errorMessage = UploadUtils.getErrorMessageFromMediaError(this, event.media, event.error);
                 cancelPostUploadMatchingMedia(event.media, errorMessage);
 
                 // now keep track of the error reason so it can be queried

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -5,9 +5,11 @@ import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
 import org.wordpress.android.R;
+import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
+import org.wordpress.android.util.WPMediaUtils;
 
 public class UploadUtils {
     /**
@@ -38,25 +40,14 @@ public class UploadUtils {
     /**
      * Returns an error message string for a failed media upload.
      */
-    public static @NonNull String getErrorMessageFromMediaError(Context context, MediaError error) {
-        switch (error.type) {
-            case FS_READ_PERMISSION_DENIED:
-                return context.getString(R.string.error_media_insufficient_fs_permissions);
-            case NOT_FOUND:
-                return context.getString(R.string.error_media_not_found);
-            case AUTHORIZATION_REQUIRED:
-                return context.getString(R.string.error_media_unauthorized);
-            case PARSE_ERROR:
-                return context.getString(R.string.error_media_parse_error);
-            case REQUEST_TOO_LARGE:
-                return context.getString(R.string.error_media_request_too_large);
-            case SERVER_ERROR:
-                return context.getString(R.string.media_error_internal_server_error);
-            case TIMEOUT:
-                return context.getString(R.string.media_error_timeout);
+    public static @NonNull String getErrorMessageFromMediaError(Context context, MediaModel media, MediaError error) {
+        String errorMessage = WPMediaUtils.getErrorMessage(context, media, error);
+
+        if (errorMessage == null) {
+            // In case of a generic or uncaught error, return the message from the API response or the error type
+            errorMessage = TextUtils.isEmpty(error.message) ? error.type.toString() : error.message;
         }
 
-        // In case of a generic or uncaught error, return the message from the API response or the error type
-        return TextUtils.isEmpty(error.message) ? error.type.toString() : error.message;
+        return errorMessage;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -6,6 +6,7 @@ import android.content.DialogInterface;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
+import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 
 import org.wordpress.android.BuildConfig;
@@ -160,8 +161,9 @@ public class WPMediaUtils {
      * @param error The media error occurred
      * @return String  The associated error message.
      */
-    public static String getErrorMessage(final Context context, final MediaModel media, final MediaStore.MediaError error) {
-        if (context == null || media == null || error == null) {
+    public static @Nullable String getErrorMessage(final Context context, final MediaModel media,
+                                                   final MediaStore.MediaError error) {
+        if (context == null || error == null) {
             return null;
         }
 
@@ -173,6 +175,8 @@ public class WPMediaUtils {
             case AUTHORIZATION_REQUIRED:
                 return context.getString(R.string.media_error_no_permission_upload);
             case REQUEST_TOO_LARGE:
+                if (media == null) return null;
+
                 if (media.isVideo()) {
                     return context.getString(R.string.media_error_http_too_large_video_upload);
                 } else {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1152,7 +1152,7 @@
     <string name="error_media_load">Unable to load media</string>
     <string name="error_media_save">Unable to save media</string>
     <string name="error_media_canceled">Uploading media were canceled</string>
-    <string name="error_media_recover">Please edit the post to retry each failed media item</string>
+    <string name="error_media_recover">Media upload failed. Edit the post to retry.</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>
     <string name="fatal_db_error">An error occurred while creating the app database. Try reinstalling the app.</string>
     <string name="error_copy_to_clipboard">An error occurred while copying text to clipboard</string>


### PR DESCRIPTION
Fixes #6293, using the new media error messaging cases added in https://github.com/wordpress-mobile/WordPress-Android/pull/6285, and removing some duplication with conversion of media errors from FluxC to user-facing strings.

Also fixes #6365, updating the style and messaging shown when a post has failed media:

![post-list-media-error](https://user-images.githubusercontent.com/9613966/28469560-9c908858-6e04-11e7-93ab-86fd8439bdbf.png)

cc @daniloercoli