### PR TITLE
Async media: Fix progress bars being stuck in indeterminate state

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -262,6 +262,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                 postHolder.disabledOverlay.setVisibility(View.VISIBLE);
                 postHolder.progressBar.setIndeterminate(true);
             } else {
+                postHolder.progressBar.setIndeterminate(false);
                 postHolder.disabledOverlay.setVisibility(View.GONE);
             }
 
@@ -310,6 +311,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                 pageHolder.progressBar.setIndeterminate(true);
             } else {
                 pageHolder.disabledOverlay.setVisibility(View.GONE);
+                pageHolder.progressBar.setIndeterminate(false);
             }
         }
 


### PR DESCRIPTION
Fixes an issue where progress bars in the post list would sometimes be in the indeterminate state, even though they were getting progress updates from media uploads. The reason is because the progress bar elements are recycled, and we weren't resetting their state with `setIndeterminate(false)`.

To reproduce the original issue:
1. Create a new post with media, and upload it
2. Wait for the upload to complete (you should see a determinate bar during media upload, then indeterminate during the post content upload)
3. Edit that same post, and upload it again
4. The second time, you should see an indeterminate progress the whole time

With this PR, you should always see a determinate progress bar while media are uploading.

cc @mzorz