### PR TITLE
Posts list - post upload trash/delete confirm dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -560,12 +560,13 @@ public class PostsListFragment extends Fragment
                     AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
                     builder.setTitle(getResources().getText(R.string.delete_post))
                             .setMessage(R.string.dialog_confirm_cancel_post_media_uploading)
-                            .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                            .setPositiveButton(R.string.delete, new DialogInterface.OnClickListener() {
                                 @Override
                                 public void onClick(DialogInterface dialogInterface, int i) {
                                     trashPost(post);
                                 }
                             })
+                            .setNegativeButton(R.string.cancel, null)
                             .setCancelable(true);
                     builder.create().show();
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -558,7 +558,7 @@ public class PostsListFragment extends Fragment
                     trashPost(post);
                 } else {
                     AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-                    builder.setTitle(getResources().getText(R.string.error))
+                    builder.setTitle(getResources().getText(R.string.delete_post))
                             .setMessage(R.string.dialog_confirm_cancel_post_media_uploading)
                             .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
                                 @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.posts;
 import android.app.Activity;
 import android.app.Fragment;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
@@ -10,6 +11,7 @@ import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -516,11 +518,11 @@ public class PostsListFragment extends Fragment
      * called by the adapter when the user clicks the edit/view/stats/trash button for a post
      */
     @Override
-    public void onPostButtonClicked(int buttonType, PostModel post) {
+    public void onPostButtonClicked(int buttonType, PostModel postClicked) {
         if (!isAdded()) return;
 
         // Get the latest version of the post, in case it's changed since the last time we refreshed the post list
-        post = mPostStore.getPostByLocalPostId(post.getId());
+        final PostModel post = mPostStore.getPostByLocalPostId(postClicked.getId());
         if (post == null) {
             loadPosts(LoadMode.FORCED);
             return;
@@ -552,14 +554,20 @@ public class PostsListFragment extends Fragment
                 break;
             case PostListButton.BUTTON_TRASH:
             case PostListButton.BUTTON_DELETE:
-                // TODO: Async: Update this behavior to handle pressing Delete/Trash while the post has uploading media
-                // Currently, the button is tappable while media are uploading, but nothing happens
-
-                // prevent deleting post while it's being uploaded
                 if (!UploadService.isPostUploadingOrQueued(post)) {
                     trashPost(post);
                 } else {
-                    ToastUtils.showToast(getActivity(), R.string.toast_err_post_media_uploading);
+                    AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+                    builder.setTitle(getResources().getText(R.string.error))
+                            .setMessage(R.string.dialog_confirm_cancel_post_media_uploading)
+                            .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialogInterface, int i) {
+                                    trashPost(post);
+                                }
+                            })
+                            .setCancelable(true);
+                    builder.create().show();
                 }
                 break;
         }
@@ -652,6 +660,9 @@ public class PostsListFragment extends Fragment
                 // times - this way the above check prevents us making the call to delete it twice
                 // https://code.google.com/p/android/issues/detail?id=190529
                 mTrashedPosts.remove(post);
+
+                // here cancel all media uploads related to this Post
+                UploadService.immediatelyAbortPostAndRelatedMediaUpload(post);
 
                 if (post.isLocalDraft()) {
                     mDispatcher.dispatch(PostActionBuilder.newRemovePostAction(post));

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -662,7 +662,7 @@ public class PostsListFragment extends Fragment
                 mTrashedPosts.remove(post);
 
                 // here cancel all media uploads related to this Post
-                UploadService.immediatelyAbortPostAndRelatedMediaUpload(post);
+                UploadService.abortPostAndRelatedMediaUpload(post);
 
                 if (post.isLocalDraft()) {
                     mDispatcher.dispatch(PostActionBuilder.newRemovePostAction(post));

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -662,7 +662,7 @@ public class PostsListFragment extends Fragment
                 mTrashedPosts.remove(post);
 
                 // here cancel all media uploads related to this Post
-                UploadService.abortPostAndRelatedMediaUpload(post);
+                UploadService.cancelQueuedPostUploadAndRelatedMedia(post);
 
                 if (post.isLocalDraft()) {
                     mDispatcher.dispatch(PostActionBuilder.newRemovePostAction(post));

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -318,6 +318,20 @@ public class UploadService extends Service {
         return post != null && PostUploadHandler.isPostUploading(post);
     }
 
+    public static void immediatelyAbortPostAndRelatedMediaUpload(PostModel post) {
+        if (post != null) {
+            synchronized (sPostsWithPendingMedia) {
+                for (UploadingPost uploadingPost : sPostsWithPendingMedia) {
+                    PostModel postModel = uploadingPost.postModel;
+                    if (postModel.getId() == post.getId()) {
+                        uploadingPost.isCancelled = true;
+                    }
+                }
+            }
+            EventBus.getDefault().post(new PostEvents.PostMediaCanceled(post));
+        }
+    }
+
     public static void cancelQueuedPostUpload(PostModel post) {
         if (post != null) {
             synchronized (sPostsWithPendingMedia) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -318,16 +318,9 @@ public class UploadService extends Service {
         return post != null && PostUploadHandler.isPostUploading(post);
     }
 
-    public static void abortPostAndRelatedMediaUpload(PostModel post) {
+    public static void cancelQueuedPostUploadAndRelatedMedia(PostModel post) {
         if (post != null) {
-            synchronized (sPostsWithPendingMedia) {
-                for (UploadingPost uploadingPost : sPostsWithPendingMedia) {
-                    PostModel postModel = uploadingPost.postModel;
-                    if (postModel.getId() == post.getId()) {
-                        uploadingPost.isCancelled = true;
-                    }
-                }
-            }
+            cancelQueuedPostUpload(post);
             EventBus.getDefault().post(new PostEvents.PostMediaCanceled(post));
         }
     }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -289,7 +289,7 @@
     <string name="posts_fetching">Fetching posts…</string>
     <string name="pages_fetching">Fetching pages…</string>
     <string name="toast_err_post_uploading">Unable to open post while it\'s uploading</string>
-    <string name="dialog_confirm_cancel_post_media_uploading">Related media for this post is uploading. Cancel upload and delete post?</string>
+    <string name="dialog_confirm_cancel_post_media_uploading">Are you sure? Deleting this post will also cancel the media upload.</string>
 
     <!-- reload drop down -->
     <string name="loading">Loading…</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -289,7 +289,7 @@
     <string name="posts_fetching">Fetching posts…</string>
     <string name="pages_fetching">Fetching pages…</string>
     <string name="toast_err_post_uploading">Unable to open post while it\'s uploading</string>
-    <string name="toast_err_post_media_uploading">Unable to delete a post while it\'s uploading</string>
+    <string name="dialog_confirm_cancel_post_media_uploading">Related media for this post is uploading. Cancel upload and delete post?</string>
 
     <!-- reload drop down -->
     <string name="loading">Loading…</string>


### PR DESCRIPTION
Fixes #6306 

To test:
1. Start a new draft
2. include some media in it (preferrably some big images to make sure it takes some time to upload)
3. exit the editor
4. check the upload is progressing in the Posts list and the notifications
5. tap on "trash/delete" on the post being uploaded in the post list
6. the dialog is shown

![screenshot_20170725-103137](https://user-images.githubusercontent.com/6597771/28574615-dd33a9b2-7124-11e7-8510-4ffb89aad97c.png)


7. tap on OK
8. You'll see the post is hidden and the toast "Post deleted - UNDO" is shown.
9. wait a few seconds and verify the snackbar is gone and the notification is cleared as well when the snackbar is hidden.

cc @nbradbury @aforcier 
