### PR TITLE
Discard empty new posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1169,13 +1169,14 @@ public class EditPostActivity extends AppCompatActivity implements
                     return;
                 }
 
-                boolean hasChanges = mOriginalPost != null && PostUtils.postHasEdits(mOriginalPost, mPost);
+                boolean hasChanges = PostUtils.postHasEdits(mOriginalPost, mPost);
                 boolean isPublishable = PostUtils.isPublishable(mPost);
                 boolean hasUnpublishedLocalDraftChanges = PostStatus.fromPost(mPost) == PostStatus.DRAFT &&
                         isPublishable && hasLocalChanges;
 
                 // if post was modified or has unpublished local changes, save it
-                boolean shouldSave = hasChanges || hasUnpublishedLocalDraftChanges;
+                boolean shouldSave = (mOriginalPost != null && hasChanges)
+                        || hasUnpublishedLocalDraftChanges || (isPublishable && isNewPost());
                 // if post is publishable or not new, sync it
                 boolean shouldSync = isPublishable || !isNewPost();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1169,7 +1169,7 @@ public class EditPostActivity extends AppCompatActivity implements
                     return;
                 }
 
-                boolean hasChanges = PostUtils.postHasEdits(mOriginalPost, mPost);
+                boolean hasChanges = mOriginalPost != null && PostUtils.postHasEdits(mOriginalPost, mPost);
                 boolean isPublishable = PostUtils.isPublishable(mPost);
                 boolean hasUnpublishedLocalDraftChanges = PostStatus.fromPost(mPost) == PostStatus.DRAFT &&
                         isPublishable && hasLocalChanges;


### PR DESCRIPTION
Only check for changes if there was a original post to compare against

Fixes #6079 

To test:
1. start new draft
2. exit the editor
3. you should not see any new posts in the posts list

cc @aforcier 
