### PR TITLE
Async media: Fix foreground notification for repeat post uploads

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -210,7 +210,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
                             : mContext.getString(R.string.post).toLowerCase()
             );
 
-            mPostUploadNotifier.createNotificationForPost(mPost, uploadingPostMessage);
+            mPostUploadNotifier.showForegroundNotificationForPost(mPost, uploadingPostMessage);
 
             mSite = mSiteStore.getSiteByLocalId(mPost.getLocalSiteId());
             if (mSite == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -210,11 +210,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
                             : mContext.getString(R.string.post).toLowerCase()
             );
 
-            if (mPostUploadNotifier.isDisplayingNotificationForPost(mPost)) {
-                mPostUploadNotifier.updateNotificationMessage(mPost, uploadingPostMessage);
-            } else {
-                mPostUploadNotifier.createNotificationForPost(mPost, uploadingPostMessage);
-            }
+            mPostUploadNotifier.createNotificationForPost(mPost, uploadingPostMessage);
 
             mSite = mSiteStore.getSiteByLocalId(mPost.getLocalSiteId());
             if (mSite == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -54,7 +54,7 @@ class PostUploadNotifier {
         mNotificationBuilder.setSmallIcon(android.R.drawable.stat_sys_upload);
     }
 
-    void createNotificationForPost(@NonNull PostModel post, String message) {
+    void showForegroundNotificationForPost(@NonNull PostModel post, String message) {
         mNotificationBuilder.setContentTitle(buildNotificationTitleForPost(post));
         if (message != null) {
             mNotificationBuilder.setContentText(message);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -21,7 +21,6 @@ import org.wordpress.android.ui.notifications.ShareAndDismissNotificationReceive
 import org.wordpress.android.ui.posts.PostsListActivity;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.CrashlyticsUtils;
-import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.SystemServiceFactory;
 import org.wordpress.android.util.WPMeShortlinks;
 
@@ -66,16 +65,6 @@ class PostUploadNotifier {
         notificationData.notificationId = notificationId;
         sPostIdToNotificationData.put(post.getId(), notificationData);
         mService.startForeground(notificationId, mNotificationBuilder.build());
-    }
-
-    boolean isDisplayingNotificationForPost(@NonNull PostModel post) {
-        return sPostIdToNotificationData.get(post.getId()) != null;
-    }
-
-    void updateNotificationMessage(@NonNull PostModel post, String message) {
-        NotificationData notificationData = sPostIdToNotificationData.get(post.getId());
-        mNotificationBuilder.setContentText(StringUtils.notNullStr(message));
-        doNotify(notificationData.notificationId, mNotificationBuilder.build());
     }
 
     void updateNotificationIcon(PostModel post, Bitmap icon) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -403,9 +403,7 @@ public class UploadService extends Service {
     }
 
     private void showNotificationForPostWithPendingMedia(PostModel post) {
-        if (!mPostUploadNotifier.isDisplayingNotificationForPost(post)) {
-            mPostUploadNotifier.createNotificationForPost(post, getString(R.string.uploading_post_media));
-        }
+        mPostUploadNotifier.createNotificationForPost(post, getString(R.string.uploading_post_media));
     }
 
     // this keeps a map for all completed media for each post, so we can process the post easily

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -403,7 +403,7 @@ public class UploadService extends Service {
     }
 
     private void showNotificationForPostWithPendingMedia(PostModel post) {
-        mPostUploadNotifier.createNotificationForPost(post, getString(R.string.uploading_post_media));
+        mPostUploadNotifier.showForegroundNotificationForPost(post, getString(R.string.uploading_post_media));
     }
 
     // this keeps a map for all completed media for each post, so we can process the post easily


### PR DESCRIPTION
Fixes #6377, ensuring that the 'Uploading' notification is created correctly (has the post title, and is foregrounding the `UploadService`) when uploading the same post multiple times.

**To test (no media required)**:
(See #6377 for the previous, incorrect format of the notification.)
1. Create a new post, and upload it
2. Notice that the 'Uploading post content' notification has a title and content
3. Once the upload completes, edit the same post, and upload it again
4. Notice that the 'Uploading post content' notification looks the same as before