### PR TITLE
Integrate the latest Aztec release

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -51,8 +51,11 @@ dependencies {
     compile 'com.android.support:design:25.3.1'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.16.0'
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.0-beta.5')
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.0-beta.5')
+    compile ('com.github.wordpress-mobile.AztecEditor-Android:aztec:v1.0-beta.6')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.0-beta.6')
+        {
+            exclude module: 'aztec'
+        }
 }
 
 signing {


### PR DESCRIPTION
Bump Aztec version to `1.0-beta.6`.