### PR TITLE
Unified dateCreated and dateLocallChanged to use UTC time

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -906,7 +906,7 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         PostUtils.updatePublishDateIfShouldBePublishedImmediately(mPost);
-        mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
+        mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromDate(DateTimeUtils.nowUTC()));
     }
 
     private void savePostAsync(final AfterSavePostListener listener) {
@@ -1647,7 +1647,7 @@ public class EditPostActivity extends AppCompatActivity implements
             mPost.setIsLocallyChanged(true);
         }
 
-        mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
+        mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromDate(DateTimeUtils.nowUTC()));
     }
 
     private void updateMediaFileOnServer(MediaFile mediaFile) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -302,7 +302,7 @@ public class PostUtils {
 
     static void updatePublishDateIfShouldBePublishedImmediately(PostModel postModel) {
         if (shouldPublishImmediately(postModel)) {
-            postModel.setDateCreated(DateTimeUtils.iso8601FromDate(new Date()));
+            postModel.setDateCreated(DateTimeUtils.iso8601FromDate(DateTimeUtils.nowUTC()));
         }
     }
 }


### PR DESCRIPTION
The `instantiatePostModel` helper method within FluxC [works with UTC time](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/fluxc/src/main/java/org/wordpress/android/fluxc/store/PostStore.java#L240), while the Android app would re-set it to current device time, making it always appear as a modified Post the first time if the device is set to a negative UTC time.

While this wasn't posing a direct user-facing problem as far as I could see, the time handling should be consistent and this is what this PR tries to address.

cc @tonyr59h 