### PR TITLE
Fix Post updated when opening and closing the editor

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -911,7 +911,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // only makes sense to change the publish date and locallychanged date if the Post was actaully changed
         if (postTitleOrContentChanged) {
             PostUtils.updatePublishDateIfShouldBePublishedImmediately(mPost);
-            mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromDate(DateTimeUtils.nowUTC()));
+            mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
         }
     }
 
@@ -1655,7 +1655,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
         if (!mPost.isLocalDraft() && (titleChanged || contentChanged)) {
             mPost.setIsLocallyChanged(true);
-            mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromDate(DateTimeUtils.nowUTC()));
+            mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
         }
 
         return titleChanged || contentChanged;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -896,18 +896,23 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         // Update post object from fragment fields
+        boolean postTitleOrContentChanged = false;
         if (mEditorFragment != null) {
             if (mShowNewEditor || mShowAztecEditor) {
-                updatePostContentNewEditor(isAutosave, (String) mEditorFragment.getTitle(),
+                postTitleOrContentChanged =
+                        updatePostContentNewEditor(isAutosave, (String) mEditorFragment.getTitle(),
                         (String) mEditorFragment.getContent());
             } else {
                 // TODO: Remove when legacy editor is dropped
-                updatePostContent(isAutosave);
+                postTitleOrContentChanged = updatePostContent(isAutosave);
             }
         }
 
-        PostUtils.updatePublishDateIfShouldBePublishedImmediately(mPost);
-        mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromDate(DateTimeUtils.nowUTC()));
+        // only makes sense to change the publish date and locallychanged date if the Post was actaully changed
+        if (postTitleOrContentChanged) {
+            PostUtils.updatePublishDateIfShouldBePublishedImmediately(mPost);
+            mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromDate(DateTimeUtils.nowUTC()));
+        }
     }
 
     private void savePostAsync(final AfterSavePostListener listener) {
@@ -1542,9 +1547,9 @@ public class EditPostActivity extends AppCompatActivity implements
     /**
      * Updates post object with content of this fragment
      */
-    public void updatePostContent(boolean isAutoSave) throws IllegalEditorStateException {
+    public boolean updatePostContent(boolean isAutoSave) throws IllegalEditorStateException {
         if (mPost == null) {
-            return;
+            return false;
         }
         String title = StringUtils.notNullStr((String) mEditorFragment.getTitle());
         SpannableStringBuilder postContent;
@@ -1629,14 +1634,16 @@ public class EditPostActivity extends AppCompatActivity implements
         if (!mPost.isLocalDraft() && (titleChanged || contentChanged)) {
             mPost.setIsLocallyChanged(true);
         }
+
+        return titleChanged || contentChanged;
     }
 
     /**
      * Updates post object with given title and content
      */
-    public void updatePostContentNewEditor(boolean isAutoSave, String title, String content) {
+    public boolean updatePostContentNewEditor(boolean isAutoSave, String title, String content) {
         if (mPost == null) {
-            return;
+            return false;
         }
 
         if (!isAutoSave) {
@@ -1650,6 +1657,8 @@ public class EditPostActivity extends AppCompatActivity implements
             mPost.setIsLocallyChanged(true);
             mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromDate(DateTimeUtils.nowUTC()));
         }
+
+        return titleChanged || contentChanged;
     }
 
     private void updateMediaFileOnServer(MediaFile mediaFile) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1621,10 +1621,10 @@ public class EditPostActivity extends AppCompatActivity implements
             content = postContent.toString();
         }
 
-        mPost.setTitle(title);
-        mPost.setContent(content);
+        boolean titleChanged = PostUtils.updatePostTitleIfDifferent(mPost, title);
+        boolean contentChanged = PostUtils.updatePostContentIfDifferent(mPost, content);
 
-        if (!mPost.isLocalDraft()) {
+        if (!mPost.isLocalDraft() && (titleChanged || contentChanged)) {
             mPost.setIsLocallyChanged(true);
         }
     }
@@ -1641,14 +1641,13 @@ public class EditPostActivity extends AppCompatActivity implements
             // TODO: Shortcode handling, media handling
         }
 
-        mPost.setTitle(title);
-        mPost.setContent(content);
+        boolean titleChanged = PostUtils.updatePostTitleIfDifferent(mPost, title);
+        boolean contentChanged = PostUtils.updatePostContentIfDifferent(mPost, content);
 
-        if (!mPost.isLocalDraft()) {
+        if (!mPost.isLocalDraft() && (titleChanged || contentChanged)) {
             mPost.setIsLocallyChanged(true);
+            mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
         }
-
-        mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
     }
 
     private void updateMediaFileOnServer(MediaFile mediaFile) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -302,7 +302,7 @@ public class PostUtils {
 
     static void updatePublishDateIfShouldBePublishedImmediately(PostModel postModel) {
         if (shouldPublishImmediately(postModel)) {
-            postModel.setDateCreated(DateTimeUtils.iso8601FromDate(DateTimeUtils.nowUTC()));
+            postModel.setDateCreated(DateTimeUtils.iso8601FromDate(new Date()));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -305,4 +305,20 @@ public class PostUtils {
             postModel.setDateCreated(DateTimeUtils.iso8601FromDate(new Date()));
         }
     }
+
+    static boolean updatePostTitleIfDifferent(PostModel post, String newTitle) {
+        if (post.getTitle().compareTo(newTitle) != 0) {
+            post.setTitle(newTitle);
+            return true;
+        }
+        return false;
+    }
+
+    static boolean updatePostContentIfDifferent(PostModel post, String newContent) {
+        if (post.getContent().compareTo(newContent) != 0) {
+            post.setContent(newContent);
+            return true;
+        }
+        return false;
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -289,8 +289,8 @@ public class PostUtils {
         if (!shouldPublishImmediatelyOptionBeAvailable(postModel)) {
             return false;
         }
-        Date pubDate = DateTimeUtils.dateFromIso8601(postModel.getDateCreated());
-        Date now = new Date();
+        Date pubDate = DateTimeUtils.dateUTCFromIso8601(postModel.getDateCreated());
+        Date now = DateTimeUtils.nowUTC();
         // Publish immediately for posts that don't have any date set yet and drafts with publish dates in the past
         return pubDate == null || !pubDate.after(now);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -289,8 +289,8 @@ public class PostUtils {
         if (!shouldPublishImmediatelyOptionBeAvailable(postModel)) {
             return false;
         }
-        Date pubDate = DateTimeUtils.dateUTCFromIso8601(postModel.getDateCreated());
-        Date now = DateTimeUtils.nowUTC();
+        Date pubDate = DateTimeUtils.dateFromIso8601(postModel.getDateCreated());
+        Date now = new Date();
         // Publish immediately for posts that don't have any date set yet and drafts with publish dates in the past
         return pubDate == null || !pubDate.after(now);
     }


### PR DESCRIPTION
Fixes #6382

This PR checks whether the Title or Post content of a `PostModel` differ from the current PostModel values before trying to set them up, and checks if they have been changed in order to know whether this Post should or should not be updated.

To test:
1. Go to the Posts list and start a new draft
2. Write a title and some content
3. Exit the editor, and see the post be uploaded
4. Tap on the recently uploaded post
5. Exit the editor without modifying anything
6. Observe the Post is not re-uploaded unnecessarily

cc @aforcier 
