### PR TITLE
Issue/6391 media disable audio

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -283,7 +283,7 @@ public class ActivityLauncher {
     public static void viewMediaPickerForResult(Activity activity, @NonNull SiteModel site) {
         Intent intent = new Intent(activity, MediaBrowserActivity.class);
         intent.putExtra(WordPress.SITE, site);
-        intent.putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, MediaBrowserType.IMAGE_AND_VIDEO_PICKER);
+        intent.putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, MediaBrowserType.MULTI_SELECT_IMAGE_AND_VIDEO_PICKER);
         activity.startActivityForResult(intent, RequestCodes.MULTI_SELECT_MEDIA_PICKER);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -283,7 +283,7 @@ public class ActivityLauncher {
     public static void viewMediaPickerForResult(Activity activity, @NonNull SiteModel site) {
         Intent intent = new Intent(activity, MediaBrowserActivity.class);
         intent.putExtra(WordPress.SITE, site);
-        intent.putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, MediaBrowserType.MULTI_SELECT_PICKER);
+        intent.putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, MediaBrowserType.IMAGE_AND_VIDEO_PICKER);
         activity.startActivityForResult(intent, RequestCodes.MULTI_SELECT_MEDIA_PICKER);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -98,17 +98,16 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         WordPressMediaUtils.LaunchCameraCallback {
 
     public enum MediaBrowserType {
-        BROWSER,                  // browse & manage media
-        IMAGE_AND_VIDEO_PICKER,   // select multiple images or videos
-        SINGLE_SELECT_PICKER;     // select a single media item
+        BROWSER,                              // browse & manage media
+        MULTI_SELECT_IMAGE_AND_VIDEO_PICKER,  // select multiple images or videos
+        SINGLE_SELECT_IMAGE_PICKER;           // select a single image
 
         public boolean isPicker() {
-            return this == IMAGE_AND_VIDEO_PICKER || this == SINGLE_SELECT_PICKER;
+            return this == MULTI_SELECT_IMAGE_AND_VIDEO_PICKER || this == SINGLE_SELECT_IMAGE_PICKER;
         }
     }
 
     public static final String ARG_BROWSER_TYPE = "media_browser_type";
-    public static final String ARG_IMAGES_ONLY = "images_only";
     public static final String ARG_FILTER = "filter";
     public static final String RESULT_IDS = "result_ids";
 
@@ -133,7 +132,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
     private String mQuery;
     private String mMediaCapturePath;
-    private boolean mImagesOnly;
     private MediaBrowserType mBrowserType;
     private int mLastAddMediaItemClickedPosition;
 
@@ -146,11 +144,9 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         if (savedInstanceState == null) {
             mSite = (SiteModel) getIntent().getSerializableExtra(WordPress.SITE);
             mBrowserType = (MediaBrowserType) getIntent().getSerializableExtra(ARG_BROWSER_TYPE);
-            mImagesOnly = getIntent().getBooleanExtra(ARG_IMAGES_ONLY, false);
         } else {
             mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
             mBrowserType = (MediaBrowserType) savedInstanceState.getSerializable(ARG_BROWSER_TYPE);
-            mImagesOnly = savedInstanceState.getBoolean(ARG_IMAGES_ONLY);
             mMediaCapturePath = savedInstanceState.getString(BUNDLE_MEDIA_CAPTURE_PATH);
             mQuery = savedInstanceState.getString(SAVED_QUERY);
         }
@@ -182,7 +178,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         // if media was shared add it to the library
         handleSharedMedia();
 
-        if (savedInstanceState == null && mBrowserType != MediaBrowserType.SINGLE_SELECT_PICKER) {
+        if (savedInstanceState == null && mBrowserType != MediaBrowserType.SINGLE_SELECT_IMAGE_PICKER) {
             SmartToast.show(this, SmartToast.SmartToastType.WP_MEDIA_BROWSER_LONG_PRESS);
         }
 
@@ -190,7 +186,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         setupTabs();
 
         MediaFilter filter;
-        if (mImagesOnly) {
+        if (mBrowserType == MediaBrowserType.SINGLE_SELECT_IMAGE_PICKER) {
             filter = MediaFilter.FILTER_IMAGES;
         } else if (savedInstanceState != null) {
             filter = (MediaFilter) savedInstanceState.getSerializable(ARG_FILTER);
@@ -353,7 +349,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         outState.putString(SAVED_QUERY, mQuery);
         outState.putSerializable(WordPress.SITE, mSite);
         outState.putSerializable(ARG_BROWSER_TYPE, mBrowserType);
-        outState.putBoolean(ARG_IMAGES_ONLY, mImagesOnly);
         if (mMediaGridFragment != null) {
             outState.putSerializable(ARG_FILTER, mMediaGridFragment.getFilter());
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -99,11 +99,11 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
     public enum MediaBrowserType {
         BROWSER,                  // browse & manage media
-        MULTI_SELECT_PICKER,      // select multiple media items
+        IMAGE_AND_VIDEO_PICKER,   // select multiple images or videos
         SINGLE_SELECT_PICKER;     // select a single media item
 
         public boolean isPicker() {
-            return this == MULTI_SELECT_PICKER || this == SINGLE_SELECT_PICKER;
+            return this == IMAGE_AND_VIDEO_PICKER || this == SINGLE_SELECT_PICKER;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -266,7 +266,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
 
     private MediaGridAdapter getAdapter() {
         if (!hasAdapter()) {
-            boolean canMultiSelect = mBrowserType != MediaBrowserType.SINGLE_SELECT_PICKER
+            boolean canMultiSelect = mBrowserType != MediaBrowserType.SINGLE_SELECT_IMAGE_PICKER
                     && WordPressMediaUtils.currentUserCanDeleteMedia(mSite);
             mGridAdapter = new MediaGridAdapter(getActivity(), mSite);
             mGridAdapter.setCallback(this);
@@ -310,6 +310,21 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
             return mMediaStore.searchSiteMedia(mSite, mSearchTerm);
         }
 
+        if (mBrowserType == MediaBrowserType.MULTI_SELECT_IMAGE_AND_VIDEO_PICKER) {
+            List<MediaModel> allMedia = mMediaStore.getAllSiteMedia(mSite);
+            List<MediaModel> imagesAndVideos = new ArrayList<>();
+            for (MediaModel media: allMedia) {
+                String mime = media.getMimeType();
+                if (mime != null && (mime.startsWith("image") || mime.startsWith("video"))) {
+                    imagesAndVideos.add(media);
+                }
+            }
+            return imagesAndVideos;
+        } else if (mBrowserType == MediaBrowserType.SINGLE_SELECT_IMAGE_PICKER) {
+            return mMediaStore.getSiteImages(mSite);
+        }
+
+
         switch (mFilter) {
             case FILTER_IMAGES:
                 return mMediaStore.getSiteImages(mSite);
@@ -320,19 +335,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
             case FILTER_AUDIO:
                 return mMediaStore.getSiteAudio(mSite);
             default:
-                if (mBrowserType == MediaBrowserType.IMAGE_AND_VIDEO_PICKER) {
-                    List<MediaModel> allMedia = mMediaStore.getAllSiteMedia(mSite);
-                    List<MediaModel> filteredMedia = new ArrayList<>();
-                    for (MediaModel media: allMedia) {
-                        String mime = media.getMimeType();
-                        if (mime != null && (mime.startsWith("image") || mime.startsWith("video"))) {
-                            filteredMedia.add(media);
-                        }
-                    }
-                    return filteredMedia;
-                } else {
-                    return mMediaStore.getAllSiteMedia(mSite);
-                }
+                return mMediaStore.getAllSiteMedia(mSite);
         }
     }
 
@@ -389,7 +392,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
 
     @Override
     public void onAdapterSelectionCountChanged(int count) {
-        if (mBrowserType == MediaBrowserType.SINGLE_SELECT_PICKER) {
+        if (mBrowserType == MediaBrowserType.SINGLE_SELECT_IMAGE_PICKER) {
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -320,7 +320,19 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
             case FILTER_AUDIO:
                 return mMediaStore.getSiteAudio(mSite);
             default:
-                return mMediaStore.getAllSiteMedia(mSite);
+                if (mBrowserType == MediaBrowserType.IMAGE_AND_VIDEO_PICKER) {
+                    List<MediaModel> allMedia = mMediaStore.getAllSiteMedia(mSite);
+                    List<MediaModel> filteredMedia = new ArrayList<>();
+                    for (MediaModel media: allMedia) {
+                        String mime = media.getMimeType();
+                        if (mime != null && (mime.startsWith("image") || mime.startsWith("video"))) {
+                            filteredMedia.add(media);
+                        }
+                    }
+                    return filteredMedia;
+                } else {
+                    return mMediaStore.getAllSiteMedia(mSite);
+                }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -865,8 +865,7 @@ public class EditPostSettingsFragment extends Fragment {
         }
         Intent intent = new Intent(getActivity(), MediaBrowserActivity.class);
         intent.putExtra(WordPress.SITE, getSite());
-        intent.putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, MediaBrowserType.SINGLE_SELECT_PICKER);
-        intent.putExtra(MediaBrowserActivity.ARG_IMAGES_ONLY, true);
+        intent.putExtra(MediaBrowserActivity.ARG_BROWSER_TYPE, MediaBrowserType.SINGLE_SELECT_IMAGE_PICKER);
         startActivityForResult(intent, RequestCodes.SINGLE_SELECT_MEDIA_PICKER);
     }
 


### PR DESCRIPTION
Fixes #6391 - our editors only support images & video, so adding an audio or document file to a post would result in what appeared to be a broken image. This PR prevents this by only allowing images or videos to be added to a post.

Note that this PR is a temporary solution until Aztec is the sole editor and it supports other file types.
