### PR TITLE
Fix NPE in EditPostSettingsFragment 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -833,9 +833,11 @@ public class EditPostSettingsFragment extends Fragment {
             postFormatKey = POST_FORMAT_STANDARD_KEY;
         }
 
-        for (int i = 0; i < mPostFormatKeys.size(); i++) {
-            if (postFormatKey.equalsIgnoreCase(mPostFormatKeys.get(i))) {
-                return mPostFormatNames.get(i);
+        if (mPostFormatKeys != null) {
+            for (int i = 0; i < mPostFormatKeys.size(); i++) {
+                if (postFormatKey.equalsIgnoreCase(mPostFormatKeys.get(i))) {
+                    return mPostFormatNames.get(i);
+                }
             }
         }
         // Since this is only used as a display name, if we can't find the key, we should just


### PR DESCRIPTION
`mPostFormatKeys` is not available in `refreshViews` when `EditPostSettingsFragment.onCreateView` runs, so we need to check if it null or not before using it.

`refreshViews` is also called later in `onActivityCreated` so the post formats are correctly displayed.
