### PR TITLE
Login Rework: Enable SmartLock for Passwords in new login flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -13,6 +13,7 @@ import android.net.http.HttpResponseCache;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
+import android.support.annotation.Nullable;
 import android.support.multidex.MultiDexApplication;
 import android.support.v7.app.AppCompatDelegate;
 import android.text.TextUtils;
@@ -22,8 +23,11 @@ import android.webkit.WebView;
 
 import com.android.volley.RequestQueue;
 import com.crashlytics.android.Crashlytics;
+
+import com.google.android.gms.auth.api.Auth;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
+import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.gcm.GoogleCloudMessaging;
 import com.google.android.gms.iid.InstanceID;
 import com.wordpress.rest.RestClient;
@@ -112,6 +116,8 @@ public class WordPress extends MultiDexApplication {
 
     private static Context mContext;
     private static BitmapLruCache mBitmapCache;
+
+    private static GoogleApiClient mCredentialsClient;
 
     @Inject Dispatcher mDispatcher;
     @Inject AccountStore mAccountStore;
@@ -264,6 +270,16 @@ public class WordPress extends MultiDexApplication {
         // https://developer.android.com/reference/android/support/v7/app/AppCompatDelegate.html#setCompatVectorFromResourcesEnabled(boolean)
         // Note: if removed, this will cause crashes on Android < 21
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
+
+        // setup the Credentials Client so we can clean it up on wpcom logout
+        mCredentialsClient = new GoogleApiClient.Builder(this)
+                .addConnectionCallbacks(new GoogleApiClient.ConnectionCallbacks() {
+                    @Override public void onConnected(@Nullable Bundle bundle) {}
+                    @Override public void onConnectionSuspended(int i) {}
+                })
+                .addApi(Auth.CREDENTIALS_API)
+                .build();
+        mCredentialsClient.connect();
     }
 
     private void initAnalytics(final long elapsedTimeOnCreate) {
@@ -407,6 +423,10 @@ public class WordPress extends MultiDexApplication {
         AnalyticsTracker.track(Stat.ACCOUNT_LOGOUT);
 
         removeWpComUserRelatedData(getApplicationContext());
+
+        if (mCredentialsClient != null && mCredentialsClient.isConnected()) {
+            Auth.CredentialsApi.disableAutoSignIn(mCredentialsClient);
+        }
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -272,7 +272,7 @@ public class ActivityLauncher {
     }
 
     public static void showSignInForResult(Activity activity) {
-        Class<?> loginClass = BuildConfig.LOGIN_WIZARD_STYLE_ACTIVE ? LoginActivity.class : SignInActivity.class;
+        Class<?> loginClass = AppPrefs.isLoginWizardStyleActivated() ? LoginActivity.class : SignInActivity.class;
 
         Intent intent = new Intent(activity, loginClass);
         activity.startActivityForResult(intent, RequestCodes.ADD_ACCOUNT);

--- a/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
@@ -16,6 +16,8 @@ public class RequestCodes {
     public static final int DO_LOGIN = 1100;
     public static final int PHOTO_PICKER = 1200;
     public static final int SHOW_LOGIN_EPILOGUE_AND_RETURN = 1300;
+    public static final int SMART_LOCK_SAVE = 1400;
+    public static final int SMART_LOCK_READ = 1500;
 
     // Media
     public static final int PICTURE_LIBRARY = 2000;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -84,6 +84,16 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
         fragmentTransaction.commitAllowingStateLoss();
     }
 
+    private LoginPrologueFragment getLoginPrologueFragment() {
+        Fragment fragment = getSupportFragmentManager().findFragmentByTag(LoginPrologueFragment.TAG);
+        return fragment == null ? null : (LoginPrologueFragment) fragment;
+    }
+
+    private LoginEmailFragment getLoginEmailFragment() {
+        Fragment fragment = getSupportFragmentManager().findFragmentByTag(LoginEmailFragment.TAG);
+        return fragment == null ? null : (LoginEmailFragment) fragment;
+    }
+
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
@@ -175,7 +185,18 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     }
 
     private void startLogin() {
-        slideInFragment(new LoginEmailFragment(), true, LoginEmailFragment.TAG);
+        if (getLoginEmailFragment() != null) {
+            // email screen is already shown so, login has already started. Just bail.
+            return;
+        }
+
+        if (getLoginPrologueFragment() == null) {
+            // prologue fragment is not shown so, the email screen will be the initial screen on the fragment container
+            showFragment(new LoginEmailFragment(), LoginEmailFragment.TAG);
+        } else {
+            // prologue fragment is shown so, slide in the email screen (and add to history)
+            slideInFragment(new LoginEmailFragment(), true, LoginEmailFragment.TAG);
+        }
     }
 
     // LoginListener implementation methods

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -263,7 +263,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     @Override
     public void usePasswordInstead(String email) {
         LoginEmailPasswordFragment loginEmailPasswordFragment = LoginEmailPasswordFragment.newInstance(email, null);
-        slideInFragment(loginEmailPasswordFragment, true, LoginEmailFragment.TAG);
+        slideInFragment(loginEmailPasswordFragment, true, LoginEmailPasswordFragment.TAG);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInActivity.java
@@ -24,6 +24,7 @@ import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.ActivityId;
+import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.accounts.SmartLockHelper.Callback;
 import org.wordpress.android.ui.accounts.login.MagicLinkRequestFragment;
 import org.wordpress.android.ui.accounts.login.MagicLinkSentFragment;
@@ -38,8 +39,6 @@ public class SignInActivity extends AppCompatActivity implements ConnectionCallb
     public static final int SIGN_IN_REQUEST = 1;
     public static final int REQUEST_CODE = 5000;
     public static final int ADD_SELF_HOSTED_BLOG = 2;
-    public static final int SMART_LOCK_SAVE = 5;
-    public static final int SMART_LOCK_READ = 6;
 
     public static final String EXTRA_START_FRAGMENT = "start-fragment";
     public static final String EXTRA_JETPACK_SITE_AUTH = "EXTRA_JETPACK_SITE_AUTH";
@@ -124,14 +123,14 @@ public class SignInActivity extends AppCompatActivity implements ConnectionCallb
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
-        if (requestCode == SMART_LOCK_SAVE) {
+        if (requestCode == RequestCodes.SMART_LOCK_SAVE) {
             if (resultCode == RESULT_OK) {
                 AnalyticsTracker.track(Stat.LOGIN_AUTOFILL_CREDENTIALS_UPDATED);
                 AppLog.d(T.NUX, "Credentials saved");
             } else {
                 AppLog.d(T.NUX, "Credentials save cancelled");
             }
-        } else if (requestCode == SMART_LOCK_READ) {
+        } else if (requestCode == RequestCodes.SMART_LOCK_READ) {
             if (resultCode == RESULT_OK) {
                 AppLog.d(T.NUX, "Credentials retrieved");
                 Credential credential = data.getParcelableExtra(Credential.EXTRA_KEY);
@@ -269,6 +268,9 @@ public class SignInActivity extends AppCompatActivity implements ConnectionCallb
                         signInFragment.onCredentialRetrieved(credential);
                     }
                 }
+
+                @Override
+                public void onCredentialsUnavailable() {}
             });
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SmartLockHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SmartLockHelper.java
@@ -21,6 +21,7 @@ import com.google.android.gms.common.api.GoogleApiClient.OnConnectionFailedListe
 import com.google.android.gms.common.api.ResultCallback;
 import com.google.android.gms.common.api.Status;
 
+import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -32,6 +33,7 @@ public class SmartLockHelper {
 
     public interface Callback {
         void onCredentialRetrieved(Credential credential);
+        void onCredentialsUnavailable();
     }
 
     public SmartLockHelper(@NonNull FragmentActivity activity) {
@@ -91,13 +93,17 @@ public class SmartLockHelper {
                                         return;
                                     }
                                     // Prompt the user to choose a saved credential
-                                    status.startResolutionForResult(activity, SignInActivity.SMART_LOCK_READ);
+                                    status.startResolutionForResult(activity, RequestCodes.SMART_LOCK_READ);
                                 } catch (IntentSender.SendIntentException e) {
                                     AppLog.d(T.NUX, "SmartLock: Failed to send resolution for credential request");
+
+                                    callback.onCredentialsUnavailable();
                                 }
                             } else {
                                 // The user must create an account or log in manually.
                                 AppLog.d(T.NUX, "SmartLock: Unsuccessful credential request.");
+
+                                callback.onCredentialsUnavailable();
                             }
                         }
                     }
@@ -132,7 +138,7 @@ public class SmartLockHelper {
                                     return;
                                 }
                                 // This prompt the user to resolve the save request
-                                status.startResolutionForResult(activity, SignInActivity.SMART_LOCK_SAVE);
+                                status.startResolutionForResult(activity, RequestCodes.SMART_LOCK_SAVE);
                             } catch (IntentSender.SendIntentException e) {
                                 // Could not resolve the request
                             }
@@ -156,5 +162,9 @@ public class SmartLockHelper {
                                 : "SmartLock: Credentials not deleted for username: " + username );
                     }
                 });
+    }
+
+    public void disableAutoSignIn() {
+        Auth.CredentialsApi.disableAutoSignIn(mCredentialsClient);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/Login2FaFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/Login2FaFragment.java
@@ -7,6 +7,7 @@ import android.support.annotation.StringRes;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
+import android.text.method.DigitsKeyListener;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
@@ -76,6 +77,9 @@ public class Login2FaFragment extends LoginBaseFormFragment implements TextWatch
         m2FaInput = (WPLoginInputRow) rootView.findViewById(R.id.login_2fa_row);
         m2FaInput.addTextChangedListener(this);
         m2FaInput.setOnEditorCommitListener(this);
+
+        // restrict the allowed input chars to just numbers
+        m2FaInput.getEditText().setKeyListener(DigitsKeyListener.getInstance("0123456789"));
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginBaseFormFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginBaseFormFragment.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.accounts.login;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.CallSuper;
 import android.support.annotation.LayoutRes;
@@ -34,10 +35,12 @@ import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.ui.accounts.SmartLockHelper;
 import org.wordpress.android.ui.notifications.services.NotificationsUpdateService;
 import org.wordpress.android.ui.reader.services.ReaderUpdateService;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.EditTextUtils;
+import org.wordpress.android.util.HtmlUtils;
 import org.wordpress.android.util.ToastUtils;
 
 import java.util.EnumSet;
@@ -248,6 +251,15 @@ public abstract class LoginBaseFormFragment extends Fragment implements TextWatc
 
         // Start Notification service
         NotificationsUpdateService.startService(getActivity().getApplicationContext());
+    }
+
+    protected void saveCredentialsInSmartLock(SmartLockHelper smartLockHelper, String username, String password) {
+        // mUsername and mPassword are null when the user log in with a magic link
+        if (smartLockHelper != null) {
+            smartLockHelper.saveCredentialsInSmartLock(username, password,
+                    HtmlUtils.fastUnescapeHtml(mAccountStore.getAccount().getDisplayName()),
+                    Uri.parse(mAccountStore.getAccount().getAvatarUrl()));
+        }
     }
 
     // OnChanged events

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginBaseFormFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginBaseFormFragment.java
@@ -56,6 +56,7 @@ public abstract class LoginBaseFormFragment extends Fragment implements TextWatc
 
     @Inject Dispatcher mDispatcher;
     @Inject SiteStore mSiteStore;
+    @Inject AccountStore mAccountStore;
 
     protected abstract @LayoutRes int getContentLayout();
     protected abstract void setupLabel(TextView label);
@@ -69,6 +70,10 @@ public abstract class LoginBaseFormFragment extends Fragment implements TextWatc
 
     protected boolean isInProgress() {
         return mInProgress;
+    }
+
+    protected Button getPrimaryButton() {
+        return mPrimaryButton;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginBaseFormFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginBaseFormFragment.java
@@ -35,9 +35,12 @@ import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.notifications.services.NotificationsUpdateService;
+import org.wordpress.android.ui.reader.services.ReaderUpdateService;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.ToastUtils;
+
+import java.util.EnumSet;
 
 import javax.inject.Inject;
 
@@ -236,6 +239,17 @@ public abstract class LoginBaseFormFragment extends Fragment implements TextWatc
         }
     }
 
+    protected void startPostLoginServices() {
+        // Get reader tags so they're available as soon as the Reader is accessed - done for
+        // both wp.com and self-hosted (self-hosted = "logged out" reader) - note that this
+        // uses the application context since the activity is finished immediately below
+        ReaderUpdateService.startService(getActivity().getApplicationContext(), EnumSet.of(ReaderUpdateService
+                .UpdateTask.TAGS));
+
+        // Start Notification service
+        NotificationsUpdateService.startService(getActivity().getApplicationContext());
+    }
+
     // OnChanged events
 
     @SuppressWarnings("unused")
@@ -288,8 +302,7 @@ public abstract class LoginBaseFormFragment extends Fragment implements TextWatc
             }
         }
 
-        // Start Notification service
-        NotificationsUpdateService.startService(getActivity().getApplicationContext());
+        startPostLoginServices();
 
         onLoginFinished(true);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
@@ -179,6 +179,9 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment implements
                 showPasswordError();
                 break;
             case NEEDS_2FA:
+                // login credentials were correct anyway so, offer to save to SmartLock
+                saveCredentialsInSmartLock(mLoginListener.getSmartLockHelper(), mEmailAddress, mPassword);
+
                 mLoginListener.needs2fa(mEmailAddress, mRequestedPassword);
                 break;
             case INVALID_REQUEST:
@@ -210,6 +213,8 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment implements
         }
 
         AppLog.i(T.NUX, "onAuthenticationChanged: " + event.toString());
+
+        saveCredentialsInSmartLock(mLoginListener.getSmartLockHelper(), mEmailAddress, mRequestedPassword);
 
         doFinishLogin();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.accounts.login;
 
 import org.wordpress.android.ui.accounts.LoginMode;
+import org.wordpress.android.ui.accounts.SmartLockHelper;
 
 import java.util.ArrayList;
 
@@ -37,6 +38,7 @@ public interface LoginListener {
     void helpWithSiteAddress();
 
     // Login username password callbacks
+    SmartLockHelper getSmartLockHelper();
     void loggedInViaUsernamePassword(ArrayList<Integer> oldSitesIds);
 
     // Help callback

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginSiteAddressFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginSiteAddressFragment.java
@@ -46,7 +46,7 @@ import javax.inject.Inject;
 public class LoginSiteAddressFragment extends LoginBaseFormFragment implements TextWatcher, OnEditorCommitListener {
     private static final String KEY_REQUESTED_SITE_ADDRESS = "KEY_REQUESTED_SITE_ADDRESS";
 
-    public static final String TAG = "login_email_fragment_tag";
+    public static final String TAG = "login_site_address_fragment_tag";
 
     private static final String XMLRPC_BLOCKED_HELPSHIFT_FAQ_SECTION = "10";
     private static final String XMLRPC_BLOCKED_HELPSHIFT_FAQ_ID = "102";

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -415,6 +415,8 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment impleme
         // continue with success, even if the operation was cancelled since the user got logged in regardless. So, go on
         //  with finishing the login process
 
+        startPostLoginServices();
+
         // mark as finished so any subsequent onSiteChanged (e.g. triggered by WPMainActivity) won't be intercepted
         mLoginFinished = true;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.accounts.login;
 
 import android.graphics.Rect;
-import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.Nullable;
@@ -24,11 +23,9 @@ import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
-import org.wordpress.android.ui.accounts.SmartLockHelper;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.EditTextUtils;
-import org.wordpress.android.util.HtmlUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -321,15 +318,6 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment impleme
         }
     }
 
-    private void saveCredentialsInSmartLock(SmartLockHelper smartLockHelper) {
-        // mUsername and mPassword are null when the user log in with a magic link
-        if (smartLockHelper != null) {
-            smartLockHelper.saveCredentialsInSmartLock(mRequestedUsername, mRequestedPassword,
-                    HtmlUtils.fastUnescapeHtml(mAccountStore.getAccount().getDisplayName()),
-                    Uri.parse(mAccountStore.getAccount().getAvatarUrl()));
-        }
-    }
-
     // OnChanged events
 
     @SuppressWarnings("unused")
@@ -422,7 +410,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment impleme
 
         if (mLoginListener != null) {
             if (mIsWpcom) {
-                saveCredentialsInSmartLock(mLoginListener.getSmartLockHelper());
+                saveCredentialsInSmartLock(mLoginListener.getSmartLockHelper(), mRequestedUsername, mRequestedPassword);
             }
 
             mLoginListener.loggedInViaUsernamePassword(mOldSitesIDs);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -215,7 +215,7 @@ public class WPMainActivity extends AppCompatActivity {
         });
 
 
-        String authTokenToSet= null;
+        String authTokenToSet = null;
 
         if (savedInstanceState == null) {
             if (FluxCUtils.isSignedInWPComOrHasWPOrgSite(mAccountStore, mSiteStore)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -271,7 +271,7 @@ public class WPMainActivity extends AppCompatActivity {
             // Save Token to the AccountStore. This will trigger a onAuthenticationChanged.
             AccountStore.UpdateTokenPayload payload = new AccountStore.UpdateTokenPayload(authTokenToSet);
             mDispatcher.dispatch(AccountActionBuilder.newUpdateAccessTokenAction(payload));
-        } else if (getIntent().getBooleanExtra(ARG_SHOW_LOGIN_EPILOGUE, false)) {
+        } else if (getIntent().getBooleanExtra(ARG_SHOW_LOGIN_EPILOGUE, false) && savedInstanceState == null) {
             ActivityLauncher.showLoginEpilogue(this, getIntent().getIntegerArrayListExtra(ARG_OLD_SITES_IDS));
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -534,7 +534,6 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
     @SuppressWarnings("unused")
     public void onEventMainThread(NotificationEvents.NotificationsRefreshError error) {
         if (isAdded()) {
-            ToastUtils.showToast(getActivity(), getString(R.string.error_refresh_notifications));
             mSwipeRefreshLayout.setRefreshing(false);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -5,6 +5,7 @@ import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPLoginInputRow.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPLoginInputRow.java
@@ -20,6 +20,7 @@ import android.widget.TextView;
 import org.wordpress.android.R;
 import org.wordpress.android.util.ViewUtils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -218,6 +219,7 @@ public class WPLoginInputRow extends RelativeLayout {
         SavedState(Parcel in) {
             super(in);
 
+            mIds = new ArrayList<>();
             in.readList(mIds, List.class.getClassLoader());
         }
 

--- a/WordPress/src/main/res/layout/login_2fa_screen.xml
+++ b/WordPress/src/main/res/layout/login_2fa_screen.xml
@@ -23,5 +23,5 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:hint="@string/verification_code"
-        android:inputType="textUri"/>
+        android:inputType="numberDecimal"/>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
+++ b/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:app="http://schemas.android.com/apk/res-auto"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:fillViewport="true">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/nux_login_background"
+    android:fillViewport="true">
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
This PR enables the user of Google's SmartLock for Passwords in the new Login flows.

The user can save their WPCOM username+password pair in SmartLock and use it again later if logging into WPCOM is needed.

This PR enables saving the credentials only when using the username/password flow.

| Native Prompt for saved credentials |
| --- |
| ![prompt-for-saved-creds](https://user-images.githubusercontent.com/1032913/28621416-8a980d60-7219-11e7-9d38-970c1b1ea700.jpg) |

To test:
* With the app data cleaned, launch the app and hit "Log in"
* Tap on the "Log in to your site by entering your site address" secondary button
* Enter the site address *of your WPCOM* site. It's probably something like "<username>.wordpress.com" and hit "Next"
* Enter your username and password and hit "Next"
* Upon successful login, a popup will ask you to optionally save your credentials to SmartLock. Do so by tapping on "SAVE PASSWORD".
* At this point, the epilogue screen is visible. Ignore it and go clean the app data again to start over.
* Launch the app and hit the "Log in" button. A popup appears asking to choose a saved WordPress account from SmartLock. There must be at least one saved account, the one we saved at a previous step. Choose that account.
* The app shows the username+password screen in the background while attempting to login with the saved credentials. It should succeed and jump to the epilogue screen.