### PR TITLE
Pass local post id to Post Preview page

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -162,7 +162,7 @@ public class ActivityLauncher {
         if (post == null) return;
 
         Intent intent = new Intent(activity, PostPreviewActivity.class);
-        intent.putExtra(PostPreviewActivity.EXTRA_POST, post);
+        intent.putExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, post.getId());
         intent.putExtra(WordPress.SITE, site);
         activity.startActivityForResult(intent, RequestCodes.PREVIEW_POST);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -44,6 +44,8 @@ import javax.inject.Inject;
 
 import de.greenrobot.event.EventBus;
 
+import static org.wordpress.android.ui.posts.EditPostActivity.EXTRA_POST_LOCAL_ID;
+
 public class PostPreviewActivity extends AppCompatActivity {
     public static final String EXTRA_POST = "postModel";
 
@@ -70,17 +72,15 @@ public class PostPreviewActivity extends AppCompatActivity {
             actionBar.setDisplayShowTitleEnabled(true);
         }
 
-        if (savedInstanceState != null) {
-            mPost = (PostModel) savedInstanceState.getSerializable(EXTRA_POST);
-        } else {
-            mPost = (PostModel) getIntent().getSerializableExtra(EXTRA_POST);
-        }
-
+        int localPostId;
         if (savedInstanceState == null) {
             mSite = (SiteModel) getIntent().getSerializableExtra(WordPress.SITE);
+            localPostId = getIntent().getIntExtra(EXTRA_POST_LOCAL_ID, 0);
         } else {
             mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
+            localPostId = savedInstanceState.getInt(EXTRA_POST_LOCAL_ID);
         }
+        mPost = mPostStore.getPostByLocalPostId(localPostId);
         if (mSite == null || mPost == null) {
             ToastUtils.showToast(this, R.string.blog_not_found, ToastUtils.Duration.SHORT);
             finish();
@@ -156,7 +156,7 @@ public class PostPreviewActivity extends AppCompatActivity {
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         outState.putSerializable(WordPress.SITE, mSite);
-        outState.putSerializable(EXTRA_POST, mPost);
+        outState.putSerializable(EXTRA_POST_LOCAL_ID, mPost.getId());
         super.onSaveInstanceState(outState);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewActivity.java
@@ -47,8 +47,6 @@ import de.greenrobot.event.EventBus;
 import static org.wordpress.android.ui.posts.EditPostActivity.EXTRA_POST_LOCAL_ID;
 
 public class PostPreviewActivity extends AppCompatActivity {
-    public static final String EXTRA_POST = "postModel";
-
     private boolean mIsUpdatingPost;
 
     private PostModel mPost;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostPreviewFragment.java
@@ -14,11 +14,14 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
+import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPWebViewClient;
 
 import javax.inject.Inject;
+
+import static org.wordpress.android.ui.posts.EditPostActivity.EXTRA_POST_LOCAL_ID;
 
 public class PostPreviewFragment extends Fragment {
     private SiteModel mSite;
@@ -26,21 +29,15 @@ public class PostPreviewFragment extends Fragment {
     private WebView mWebView;
 
     @Inject AccountStore mAccountStore;
+    @Inject PostStore mPostStore;
 
     public static PostPreviewFragment newInstance(SiteModel site, PostModel post) {
         Bundle args = new Bundle();
         args.putSerializable(WordPress.SITE, site);
-        args.putSerializable(PostPreviewActivity.EXTRA_POST, post);
+        args.putInt(EXTRA_POST_LOCAL_ID, post.getId());
         PostPreviewFragment fragment = new PostPreviewFragment();
         fragment.setArguments(args);
         return fragment;
-    }
-
-    @Override
-    public void setArguments(Bundle args) {
-        super.setArguments(args);
-        mSite = (SiteModel) args.getSerializable(WordPress.SITE);
-        mPost = (PostModel) args.getSerializable(PostPreviewActivity.EXTRA_POST);
     }
 
     @Override
@@ -48,16 +45,21 @@ public class PostPreviewFragment extends Fragment {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
-        if (savedInstanceState != null) {
+        int localPostId;
+        if (savedInstanceState == null) {
+            mSite = (SiteModel) getArguments().getSerializable(WordPress.SITE);
+            localPostId = getArguments().getInt(EXTRA_POST_LOCAL_ID);
+        } else {
             mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
-            mPost = (PostModel) savedInstanceState.getSerializable(PostPreviewActivity.EXTRA_POST);
+            localPostId = savedInstanceState.getInt(EXTRA_POST_LOCAL_ID);
         }
+        mPost = mPostStore.getPostByLocalPostId(localPostId);
     }
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
         outState.putSerializable(WordPress.SITE, mSite);
-        outState.putSerializable(PostPreviewActivity.EXTRA_POST, mPost);
+        outState.putSerializable(EXTRA_POST_LOCAL_ID, mPost.getId());
         super.onSaveInstanceState(outState);
     }
 


### PR DESCRIPTION
Fixes #5456. This PR removes the last usage of passing the post object to Fragments & Activities and instead passes the local post id to fetch from Post Store.

To test:
* Go offline
* Create a new post
* Go back so a local draft is created
* Tap on the preview button in the post list for that post
* Make sure the preview is correct (just it showing up should be enough)
* Rotate the screen and check again

Since this is not really a hotfix, I targeted `develop` especially because I don't think this PR will actually fix the crash.

/cc @maxme 