### PR TITLE
Async media: video support in Aztec

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -357,6 +357,9 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         updateUploadingMediaList();
         overlayProgressingMedia();
 
+        // TODO re-overlay VIDEO items here for re-attachment
+        // overlayVideoIcon(0, );
+
         mAztecReady = true;
 
     }
@@ -1348,7 +1351,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         addDefaultSizeClassIfMissing(attributes);
     }
 
-    private void addDefaultSizeClassIfMissing(AztecAttributes attributes) {
+    private static void addDefaultSizeClassIfMissing(AztecAttributes attributes) {
         AttributesWithClass attrs = new AttributesWithClass(attributes);
         if (!attrs.hasClassStartingWith("size")) {
             attrs.addClass("size-full");
@@ -1360,34 +1363,30 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                                                  String localMediaId, MediaFile mediaFile) {
         if (mediaFile != null) {
             String remoteUrl = Utils.escapeQuotes(mediaFile.getFileURL());
-            if (!mediaFile.isVideo()) {
+            // fill in Aztec with the post's content
+            AztecText content = new AztecText(context);
+            content.fromHtml(postContent);
 
-                // fill in Aztec with the post's content
-                AztecText content = new AztecText(context);
-                content.fromHtml(postContent);
+            ImagePredicate predicate = ImagePredicate.getLocalMediaIdPredicate(localMediaId);
 
-                ImagePredicate predicate = ImagePredicate.getLocalMediaIdPredicate(localMediaId);
+            // remove the uploading class
+            AttributesWithClass attributesWithClass = new AttributesWithClass(
+                    content.getElementAttributes(predicate));
+            attributesWithClass.removeClass(ATTR_STATUS_UPLOADING);
 
-                // remove the uploading class
-                AttributesWithClass attributesWithClass = new AttributesWithClass(
-                        content.getElementAttributes(predicate));
-                attributesWithClass.removeClass(ATTR_STATUS_UPLOADING);
+            // add then new src property with the remoteUrl
+            AztecAttributes attrs = attributesWithClass.getAttributes();
+            attrs.setValue("src", remoteUrl);
 
-                // add then new src property with the remoteUrl
-                AztecAttributes attrs = attributesWithClass.getAttributes();
-                attrs.setValue("src", remoteUrl);
+            addDefaultSizeClassIfMissing(attrs);
 
-                // clear overlay
-                content.clearOverlays(predicate);
-                content.updateElementAttributes(predicate, attrs);
-                content.refreshText();
+            // clear overlay
+            content.clearOverlays(predicate);
+            content.updateElementAttributes(predicate, attrs);
+            content.refreshText();
 
-                // re-set the post content
-                postContent = content.toHtml(false);
-
-            } else {
-                // TODO: update video element
-            }
+            // re-set the post content
+            postContent = content.toHtml(false);
         }
         return postContent;
     }
@@ -1395,31 +1394,25 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     public static String markMediaFailed(Context context, @NonNull String postContent,
                                                  String localMediaId, MediaFile mediaFile) {
         if (mediaFile != null) {
-            if (!mediaFile.isVideo()) {
+            // fill in Aztec with the post's content
+            AztecText content = new AztecText(context);
+            content.fromHtml(postContent);
 
-                // fill in Aztec with the post's content
-                AztecText content = new AztecText(context);
-                content.fromHtml(postContent);
+            ImagePredicate predicate = ImagePredicate.getLocalMediaIdPredicate(localMediaId);
 
-                ImagePredicate predicate = ImagePredicate.getLocalMediaIdPredicate(localMediaId);
+            // remove the uploading class
+            AttributesWithClass attributesWithClass = new AttributesWithClass(
+                    content.getElementAttributes(predicate));
+            attributesWithClass.removeClass(ATTR_STATUS_UPLOADING);
 
-                // remove the uploading class
-                AttributesWithClass attributesWithClass = new AttributesWithClass(
-                        content.getElementAttributes(predicate));
-                attributesWithClass.removeClass(ATTR_STATUS_UPLOADING);
+            // mark failed
+            attributesWithClass.addClass(ATTR_STATUS_FAILED);
 
-                // mark failed
-                attributesWithClass.addClass(ATTR_STATUS_FAILED);
+            content.updateElementAttributes(predicate, attributesWithClass.getAttributes());
+            content.refreshText();
 
-                content.updateElementAttributes(predicate, attributesWithClass.getAttributes());
-                content.refreshText();
-
-                // re-set the post content
-                postContent = content.toHtml(false);
-
-            } else {
-                // TODO: update video element
-            }
+            // re-set the post content
+            postContent = content.toHtml(false);
         }
         return postContent;
     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -886,6 +886,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                     attributesWithClass.removeClass(ATTR_STATUS_UPLOADING);
                     attributesWithClass.addClass(ATTR_STATUS_FAILED);
 
+                    content.clearOverlays(localMediaIdPredicate);
                     overlayFailedMedia(localMediaId, attributesWithClass.getAttributes());
                     content.resetAttributedMediaSpan(localMediaIdPredicate);
                     break;
@@ -1167,6 +1168,9 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                                 content.getElementAttributes(mTappedImagePredicate));
                         attributesWithClass.removeClass(ATTR_STATUS_FAILED);
                         attributesWithClass.addClass(ATTR_STATUS_UPLOADING);
+                        if (mediaType.equals(MediaType.VIDEO)) {
+                            attributesWithClass.addClass(TEMP_VIDEO_UPLOADING_CLASS);
+                        }
 
                         // set intermediate shade overlay
                         content.setOverlay(mTappedImagePredicate, 0,
@@ -1178,6 +1182,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
                         content.setOverlay(mTappedImagePredicate, 1, progressDrawable, Gravity.FILL_HORIZONTAL | Gravity.TOP);
                         content.updateElementAttributes(mTappedImagePredicate, attributesWithClass.getAttributes());
+
+                        if (mediaType.equals(MediaType.VIDEO)) {
+                            overlayVideoIcon(2, mTappedImagePredicate);
+                        }
 
                         content.resetAttributedMediaSpan(mTappedImagePredicate);
                         break;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -126,7 +126,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     private long mActionStartedAt = -1;
 
-    private ImagePredicate mTappedImagePredicate;
+    private MediaPredicate mTappedMediaPredicate;
 
     private EditorBetaClickListener mEditorBetaClickListener;
 
@@ -540,7 +540,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     private void overlayProgressingMedia() {
         for (String localMediaId : mUploadingMediaProgressMax.keySet()) {
-            ImagePredicate predicate = ImagePredicate.getLocalMediaIdPredicate(localMediaId);
+            MediaPredicate predicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
             overlayProgressingMedia(predicate);
             // here check if this is a video uploading in progress or not; if it is, show the video play icon
             for (Attributes attrs : content.getAllElementAttributes(predicate)) {
@@ -557,7 +557,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         content.setOverlay(predicate, overlayLevel, videoDrawable, Gravity.BOTTOM | Gravity.START);
     }
 
-    private void overlayProgressingMedia(ImagePredicate predicate) {
+    private void overlayProgressingMedia(MediaPredicate predicate) {
         // set intermediate shade overlay
         content.setOverlay(predicate, 0,
                 new ColorDrawable(getResources().getColor(R.color.media_shade_overlay_color)),
@@ -575,14 +575,14 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     private void overlayFailedMedia() {
         for (String localMediaId : mFailedMediaIds) {
-            Attributes attributes = content.getElementAttributes(ImagePredicate.getLocalMediaIdPredicate(localMediaId));
+            Attributes attributes = content.getElementAttributes(MediaPredicate.getLocalMediaIdPredicate(localMediaId));
             overlayFailedMedia(localMediaId, attributes);
         }
     }
 
     private void overlayFailedMedia(String localMediaId, Attributes attributes) {
         // set intermediate shade overlay
-        AztecText.AttributePredicate localMediaIdPredicate = ImagePredicate.getLocalMediaIdPredicate(localMediaId);
+        AztecText.AttributePredicate localMediaIdPredicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
         content.setOverlay(localMediaIdPredicate, 0,
                 new ColorDrawable(getResources().getColor(R.color.media_shade_overlay_error_color)),
                 Gravity.FILL);
@@ -661,7 +661,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                     if(mediaFile.isVideo()) {
                         addVideoUploadingClassIfMissing(attributes);
                         content.insertVideo(new BitmapDrawable(getResources(), resizedBitmap), attributes);
-                        overlayVideoIcon(0, new ImagePredicate(mediaUrl, ATTR_SRC));
+                        overlayVideoIcon(0, new MediaPredicate(mediaUrl, ATTR_SRC));
                     } else {
                         content.insertImage(new BitmapDrawable(getResources(), resizedBitmap), attributes);
                     }
@@ -683,7 +683,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             addDefaultSizeClassIfMissing(attrs);
 
             Bitmap bitmapToShow = ImageUtils.getWPImageSpanThumbnailFromFilePath(getActivity(), safeMediaUrl, maxWidth);
-            ImagePredicate localMediaIdPredicate = ImagePredicate.getLocalMediaIdPredicate(localMediaId);
+            MediaPredicate localMediaIdPredicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
 
             if (bitmapToShow != null) {
                 if(mediaFile.isVideo()) {
@@ -773,7 +773,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             MediaType mediaType = EditorFragmentAbstract.getEditorMimeType(mediaFile);
             if (mediaType.equals(MediaType.IMAGE) || mediaType.equals(MediaType.VIDEO)) {
                 // clear overlay
-                ImagePredicate predicate = ImagePredicate.getLocalMediaIdPredicate(localMediaId);
+                MediaPredicate predicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
 
                 // remove the uploading class
                 AttributesWithClass attributesWithClass = new AttributesWithClass(
@@ -807,15 +807,15 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         }
     }
 
-    private static class ImagePredicate implements AztecText.AttributePredicate {
+    private static class MediaPredicate implements AztecText.AttributePredicate {
         private final String mId;
         private final String mAttributeName;
 
-        static ImagePredicate getLocalMediaIdPredicate(String id) {
-            return new ImagePredicate(id, ATTR_ID_WP);
+        static MediaPredicate getLocalMediaIdPredicate(String id) {
+            return new MediaPredicate(id, ATTR_ID_WP);
         }
 
-        ImagePredicate(String id, String attributeName) {
+        MediaPredicate(String id, String attributeName) {
             mId = id;
             mAttributeName = attributeName;
         }
@@ -851,7 +851,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 mUploadingMediaProgressMax.put(localMediaId, maxProgressForLocalMediaId);
 
                 try {
-                    AztecText.AttributePredicate localMediaIdPredicate = ImagePredicate.getLocalMediaIdPredicate(localMediaId);
+                    AztecText.AttributePredicate localMediaIdPredicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
                     content.setOverlayLevel(localMediaIdPredicate, 1, (int) (progress * 10000));
                     content.resetAttributedMediaSpan(localMediaIdPredicate);
                 } catch (IndexOutOfBoundsException ex) {
@@ -879,7 +879,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             switch (mediaType) {
                 case IMAGE:
                 case VIDEO:
-                    ImagePredicate localMediaIdPredicate = ImagePredicate.getLocalMediaIdPredicate(localMediaId);
+                    MediaPredicate localMediaIdPredicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
                     AttributesWithClass attributesWithClass = new AttributesWithClass(
                             content.getElementAttributes(localMediaIdPredicate));
 
@@ -1118,7 +1118,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         }
 
         attrs.setValue(idName, localMediaId);
-        mTappedImagePredicate = new ImagePredicate(localMediaId, idName);
+        mTappedMediaPredicate = new MediaPredicate(localMediaId, idName);
 
         switch (uploadStatus) {
             case ATTR_STATUS_UPLOADING:
@@ -1133,10 +1133,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
                             switch (mediaType) {
                                 case IMAGE:
-                                    content.removeMedia(mTappedImagePredicate);
+                                    content.removeMedia(mTappedMediaPredicate);
                                     break;
                                 case VIDEO:
-                                    content.removeMedia(mTappedImagePredicate);
+                                    content.removeMedia(mTappedMediaPredicate);
                             }
                             mUploadingMediaProgressMax.remove(localMediaId);
                         } else {
@@ -1165,7 +1165,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                     case IMAGE:
                     case VIDEO:
                         AttributesWithClass attributesWithClass = new AttributesWithClass(
-                                content.getElementAttributes(mTappedImagePredicate));
+                                content.getElementAttributes(mTappedMediaPredicate));
                         attributesWithClass.removeClass(ATTR_STATUS_FAILED);
                         attributesWithClass.addClass(ATTR_STATUS_UPLOADING);
                         if (mediaType.equals(MediaType.VIDEO)) {
@@ -1173,21 +1173,21 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                         }
 
                         // set intermediate shade overlay
-                        content.setOverlay(mTappedImagePredicate, 0,
+                        content.setOverlay(mTappedMediaPredicate, 0,
                                 new ColorDrawable(getResources().getColor(R.color.media_shade_overlay_color)), Gravity.FILL);
 
                         Drawable progressDrawable = getResources().getDrawable(android.R.drawable.progress_horizontal);
                         // set the height of the progress bar to 2 (it's in dp since the drawable will be adjusted by the span)
                         progressDrawable.setBounds(0, 0, 0, 4);
 
-                        content.setOverlay(mTappedImagePredicate, 1, progressDrawable, Gravity.FILL_HORIZONTAL | Gravity.TOP);
-                        content.updateElementAttributes(mTappedImagePredicate, attributesWithClass.getAttributes());
+                        content.setOverlay(mTappedMediaPredicate, 1, progressDrawable, Gravity.FILL_HORIZONTAL | Gravity.TOP);
+                        content.updateElementAttributes(mTappedMediaPredicate, attributesWithClass.getAttributes());
 
                         if (mediaType.equals(MediaType.VIDEO)) {
-                            overlayVideoIcon(2, mTappedImagePredicate);
+                            overlayVideoIcon(2, mTappedMediaPredicate);
                         }
 
-                        content.resetAttributedMediaSpan(mTappedImagePredicate);
+                        content.resetAttributedMediaSpan(mTappedMediaPredicate);
                         break;
                 }
                 mFailedMediaIds.remove(localMediaId);
@@ -1271,11 +1271,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         super.onActivityResult(requestCode, resultCode, data);
 
         if (requestCode == ImageSettingsDialogFragment.IMAGE_SETTINGS_DIALOG_REQUEST_CODE) {
-            if (mTappedImagePredicate != null) {
-                AztecAttributes attributes = content.getElementAttributes(mTappedImagePredicate);
+            if (mTappedMediaPredicate != null) {
+                AztecAttributes attributes = content.getElementAttributes(mTappedMediaPredicate);
                 attributes.removeAttribute(TEMP_IMAGE_ID);
 
-                content.updateElementAttributes(mTappedImagePredicate, attributes);
+                content.updateElementAttributes(mTappedMediaPredicate, attributes);
 
                 if (data == null || data.getExtras() == null) {
                     return;
@@ -1348,7 +1348,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                     }
                 }
 
-                mTappedImagePredicate = null;
+                mTappedMediaPredicate = null;
             }
         }
     }
@@ -1391,7 +1391,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             AztecText content = new AztecText(context);
             content.fromHtml(postContent);
 
-            ImagePredicate predicate = ImagePredicate.getLocalMediaIdPredicate(localMediaId);
+            MediaPredicate predicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
 
             // remove the uploading class
             AttributesWithClass attributesWithClass = new AttributesWithClass(
@@ -1425,7 +1425,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             AztecText content = new AztecText(context);
             content.fromHtml(postContent);
 
-            ImagePredicate predicate = ImagePredicate.getLocalMediaIdPredicate(localMediaId);
+            MediaPredicate predicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
 
             // remove the uploading class
             AttributesWithClass attributesWithClass = new AttributesWithClass(


### PR DESCRIPTION
Fixes #6403 , adding asynchronous video upload capabilities to the Aztec editor.

To test: 

**CASE A (normal)**
1. start a new draft  and start a video upload in Aztec
2. wait until it finishes successfully
3. exit the editor
4. open the post back in the editor and verify the video is there (_note known issue about video thumbnails not appearing here #6400_), with a `video play icon` and can be played.

**CASE B (async)**
1. start a new draft  and start a video upload in Aztec
2. exit the editor while the video is uploading
3. verify the post list shows the draft post item with the uploading media progress bar
4. wait until the media and post is finished uploading
5. open the post back in the editor and verify the video is there (_note known issue about video thumbnails not appearing here #6400_), with a `video play icon`,  and if you tap on it you should be able to play it  / prompted by Android system about which app to use to play the video.


**CASE C (async - reattachment)**
1. start a new draft  and start a video upload in Aztec
2. exit the editor while the video is uploading
3. verify the post list shows the draft post item with the uploading media progress bar
4. open the post back in the editor and verify the video is there (_note known issue about video thumbnails not appearing here #6400_), with a `video play icon`, progress re-attachment works (small orange/yellow line on the top border of the icon) and if you tap on it the  "Stop media upload" dialog should appear.
5. Wait until it completes the upload, and verify you can tap on it to play the video.


**CASE D (cancelled)**
1. start a new draft  and start a video upload in Aztec
2. turn airplane mode ON while the video is uploading - do not leave the editor.
3. verify the video gets the failed/retry overlay

**CASE E (async - cancelled)**
1. start a new draft  and start a video upload in Aztec
2. exit the editor while the video is uploading
3. verify the post list shows the draft post item with the uploading media progress bar
4. turn airplane mode ON while the video is uploading
5. verify you get an error on the Posts list `"Media upload failed. Edit the post to retry".`
6. open the post again and verify you have the aztec placeholder representing the video object (again, it should be the thumbnail as of issue #6400) with the failed/retry overlay.
7. turn airplane mode OFF
8. tap on the failed object to retry - it should turn to the video play icon and start showing the progress (little yellow/orange bar at the top border of the icon).

cc @daniloercoli for main review, and pinging @aforcier to keep an eye on it 👍 
