### PR TITLE
Fix video preview in Aztec from HTML

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -95,6 +95,7 @@ import org.wordpress.android.ui.photopicker.PhotoPickerFragment.PhotoPickerIcon;
 import org.wordpress.android.ui.photopicker.PhotoPickerFragment.PhotoPickerOption;
 import org.wordpress.android.ui.posts.InsertMediaDialog.InsertMediaCallback;
 import org.wordpress.android.ui.posts.services.AztecImageLoader;
+import org.wordpress.android.ui.posts.services.AztecVideoLoader;
 import org.wordpress.android.ui.posts.services.PostEvents;
 import org.wordpress.android.ui.posts.services.PostUploadService;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -933,6 +934,7 @@ public class EditPostActivity extends AppCompatActivity implements
             AztecEditorFragment aztecEditorFragment = (AztecEditorFragment)mEditorFragment;
             aztecEditorFragment.setEditorBetaClickListener(EditPostActivity.this);
             aztecEditorFragment.setAztecImageLoader(new AztecImageLoader(getBaseContext()));
+            aztecEditorFragment.setAztecVideoLoader(new AztecVideoLoader(getBaseContext()));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2067,8 +2067,10 @@ public class EditPostActivity extends AppCompatActivity implements
         try {
             File outputFile = File.createTempFile("thumb", ".png", getCacheDir());
             FileOutputStream outputStream = new FileOutputStream(outputFile);
-            Bitmap thumb = ThumbnailUtils.createVideoThumbnail(videoPath,
-                    android.provider.MediaStore.Images.Thumbnails.MINI_KIND);
+            Bitmap thumb = ImageUtils.getVideoFrameFromVideo(
+                    videoPath,
+                    ImageUtils.getMaximumThumbnailWidthForEditor(this)
+            );
             if (thumb != null) {
                 thumb.compress(Bitmap.CompressFormat.PNG, 75, outputStream);
                 thumbnailPath = outputFile.getAbsolutePath();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
@@ -1,0 +1,51 @@
+package org.wordpress.android.ui.posts.services;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
+import android.media.ThumbnailUtils;
+import android.os.AsyncTask;
+import android.provider.MediaStore;
+import android.text.TextUtils;
+
+import org.wordpress.android.util.ImageUtils;
+import org.wordpress.aztec.Html;
+
+import java.io.File;
+
+public class AztecVideoLoader implements Html.VideoThumbnailGetter {
+
+    private Context context;
+
+    public AztecVideoLoader(Context context) {
+        this.context = context;
+    }
+
+    public void loadVideoThumbnail(final String url, final Html.VideoThumbnailGetter.Callbacks callbacks, final int maxWidth) {
+        if (TextUtils.isEmpty(url) || maxWidth <= 0) {
+            callbacks.onThumbnailFailed();
+            return;
+        }
+
+        new AsyncTask<Void, Void, Bitmap>() {
+            protected Bitmap doInBackground(Void... params) {
+                callbacks.onThumbnailLoading(null);
+
+                // If local file
+                if (new File(url).exists()) {
+                    Bitmap thumb = ThumbnailUtils.createVideoThumbnail(url, MediaStore.Images.Thumbnails.FULL_SCREEN_KIND);
+                    return ImageUtils.getScaledBitmapAtLongestSide(thumb, maxWidth);
+                }
+
+                return ImageUtils.getVideoFrameFromVideo(url, maxWidth);
+            }
+            protected void onPostExecute(Bitmap thumb) {
+                if (thumb == null) {
+                    callbacks.onThumbnailFailed();
+                }
+                BitmapDrawable bitmapDrawable = new BitmapDrawable(context.getResources(), thumb);
+                callbacks.onThumbnailLoaded(bitmapDrawable);
+            }
+        }.execute();
+    }
+}

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -115,6 +115,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     private SourceViewEditText source;
     private AztecToolbar formattingToolbar;
     private Html.ImageGetter aztecImageLoader;
+    private Html.VideoThumbnailGetter aztecVideoLoader;
 
     private Handler invalidateOptionsHandler;
     private Runnable invalidateOptionsRunnable;
@@ -201,6 +202,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
         Aztec.Factory.with(content, source, formattingToolbar, this)
                 .setImageGetter(aztecImageLoader)
+                .setVideoThumbnailGetter(aztecVideoLoader)
                 .setOnImeBackListener(this)
                 .setHistoryListener(this)
                 .setOnImageTappedListener(this)
@@ -219,6 +221,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     public void setAztecImageLoader(Html.ImageGetter imageLoader) {
         this.aztecImageLoader = imageLoader;
+    }
+
+    public void setAztecVideoLoader(Html.VideoThumbnailGetter videoLoader) {
+        this.aztecVideoLoader = videoLoader;
     }
 
     @Override

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -649,18 +649,18 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             mActionStartedAt = System.currentTimeMillis();
         } else {
             String localMediaId = String.valueOf(mediaFile.getId());
-            final String safeMediaUrl = mediaFile.isVideo() ?
+            final String safeMediaPreviewUrl = mediaFile.isVideo() ?
                     Utils.escapeQuotes(StringUtils.notNullStr(mediaFile.getThumbnailURL())) :
                     Utils.escapeQuotes(mediaUrl);
 
             AztecAttributes attrs = new AztecAttributes();
             attrs.setValue(ATTR_ID_WP, localMediaId);
-            attrs.setValue(ATTR_SRC, safeMediaUrl);
+            attrs.setValue(ATTR_SRC, Utils.escapeQuotes(mediaUrl));
             attrs.setValue(ATTR_CLASS, ATTR_STATUS_UPLOADING);
 
             addDefaultSizeClassIfMissing(attrs);
 
-            Bitmap bitmapToShow = ImageUtils.getWPImageSpanThumbnailFromFilePath(getActivity(), safeMediaUrl, maxWidth);
+            Bitmap bitmapToShow = ImageUtils.getWPImageSpanThumbnailFromFilePath(getActivity(), safeMediaPreviewUrl, maxWidth);
             AztecText.AttributePredicate localMediaIdPredicate = ImagePredicate.getLocalMediaIdPredicate(localMediaId);
 
             if (bitmapToShow != null) {


### PR DESCRIPTION
This PR fixes #6400 CASE A:

start a new draft in Aztec
include a video
wait until it finishes uploading
exit the editor
open the post again
see the Aztec placeholder with the video play overlay instead of a thumbnail with the video play overlay.


cc @mzorz 