### PR TITLE
Editor source tracking

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1213,7 +1213,7 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private boolean isFirstTimePublish() {
-        return PostStatus.fromPost(mPost) == PostStatus.PUBLISHED &&
+        return (PostStatus.fromPost(mPost) == PostStatus.UNKNOWN || PostStatus.fromPost(mPost) == PostStatus.PUBLISHED) &&
                 (mPost.isLocalDraft() || PostStatus.fromPost(mOriginalPost) == PostStatus.DRAFT);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -13,6 +13,7 @@ import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.post.PostLocation;
 import org.wordpress.android.fluxc.model.post.PostStatus;
+import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DateTimeUtils;
@@ -123,6 +124,9 @@ public class PostUtils {
                     AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.EDITOR_UPDATED_POST, site, properties);
                 } else {
                     properties.put("word_count", AnalyticsUtils.getWordCount(post.getContent()));
+                    properties.put("editor_source", AppPrefs.isAztecEditorEnabled() ? "aztec" :
+                            AppPrefs.isVisualEditorEnabled() ? "hybrid" : "legacy");
+
                     AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.EDITOR_SCHEDULED_POST, site,
                             properties);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/PostUploadService.java
@@ -286,6 +286,8 @@ public class PostUploadService extends Service {
             // Calculate the words count
             mCurrentUploadingPostAnalyticsProperties = new HashMap<>();
             mCurrentUploadingPostAnalyticsProperties.put("word_count", AnalyticsUtils.getWordCount(mPost.getContent()));
+            mCurrentUploadingPostAnalyticsProperties.put("editor_source", AppPrefs.isAztecEditorEnabled() ? "aztec" :
+                    AppPrefs.isVisualEditorEnabled() ? "hybrid" : "legacy");
 
             if (hasGallery()) {
                 mCurrentUploadingPostAnalyticsProperties.put("with_galleries", true);


### PR DESCRIPTION
Fixes #5696.

This PR adds `editor_source` property tracking to the `wpandroid_editor_post_published` event. 

I had to modify the logic for determining if a post is published for the first time, because right now it's always false. It seems a new post always has an `UNKNOWN` post status, not `PUBLISHED` so that needs to be taken into account.