### PR TITLE
Async media: Design and copy updates

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -194,7 +194,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
                 // This block only runs if the PUSH_POST action was never dispatched - if it was dispatched, any error
                 // will be handled in OnPostChanged instead of here
                 mPostUploadNotifier.cancelNotification(mPost);
-                mPostUploadNotifier.updateNotificationError(mPost, mSite, mErrorMessage, mIsMediaError);
+                mPostUploadNotifier.updateNotificationError(mPost, mSite, mErrorMessage);
                 finishUpload();
             }
         }
@@ -561,8 +561,8 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
                     + event.error.message);
             Context context = WordPress.getContext();
             String errorMessage = UploadUtils.getErrorMessageFromPostError(context, event.post, event.error);
-            String notificationMessage = UploadUtils.getErrorMessage(context, event.post, errorMessage);
-            mPostUploadNotifier.updateNotificationError(event.post, site, notificationMessage, false);
+            String notificationMessage = UploadUtils.getErrorMessage(context, event.post, errorMessage, false);
+            mPostUploadNotifier.updateNotificationError(event.post, site, notificationMessage);
             mPostUploadNotifier.cancelNotification(event.post);
             sFirstPublishPosts.remove(event.post.getId());
         } else {
@@ -610,9 +610,10 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
             SiteModel site = mSiteStore.getSiteByLocalId(sCurrentUploadingPost.getLocalSiteId());
             Context context = WordPress.getContext();
             String errorMessage = UploadUtils.getErrorMessageFromMediaError(context, event.media, event.error);
-            String notificationMessage = UploadUtils.getErrorMessage(context, sCurrentUploadingPost, errorMessage);
+            String notificationMessage =
+                    UploadUtils.getErrorMessage(context, sCurrentUploadingPost, errorMessage, true);
             mPostUploadNotifier.cancelNotification(sCurrentUploadingPost);
-            mPostUploadNotifier.updateNotificationError(sCurrentUploadingPost, site, notificationMessage, true);
+            mPostUploadNotifier.updateNotificationError(sCurrentUploadingPost, site, notificationMessage);
             sFirstPublishPosts.remove(sCurrentUploadingPost.getId());
             finishUpload();
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -106,13 +106,15 @@ class PostUploadNotifier {
                 new NotificationCompat.Builder(mContext.getApplicationContext());
         String notificationTitle;
         if (PostStatus.DRAFT.equals(PostStatus.fromPost(post))) {
-            notificationTitle = (String) mContext.getResources().getText(R.string.draft_uploaded);
+            notificationTitle = mContext.getString(R.string.draft_uploaded);
+        } else if (PostStatus.SCHEDULED.equals(PostStatus.fromPost(post))) {
+            notificationTitle = mContext.getString(post.isPage() ? R.string.page_scheduled : R.string.post_scheduled);
         } else {
             if (post.isPage()) {
-                notificationTitle = (String) mContext.getResources().getText(
+                notificationTitle = mContext.getString(
                         isFirstTimePublish ? R.string.page_published : R.string.page_updated);
             } else {
-                notificationTitle = (String) mContext.getResources().getText(
+                notificationTitle = mContext.getString(
                         isFirstTimePublish ? R.string.post_published : R.string.post_updated);
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -166,12 +166,11 @@ class PostUploadNotifier {
         return post.getLocalSiteId() + remotePostId;
     }
 
-    void updateNotificationError(PostModel post, SiteModel site, String errorMessage, boolean isMediaError) {
+    void updateNotificationError(PostModel post, SiteModel site, String errorMessage) {
         AppLog.d(AppLog.T.POSTS, "updateNotificationError: " + errorMessage);
 
-        NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(mContext.getApplicationContext());
-        String postOrPage = (String) (post.isPage() ? mContext.getResources().getText(R.string.page_id)
-                : mContext.getResources().getText(R.string.post_id));
+        NotificationCompat.Builder notificationBuilder =
+                new NotificationCompat.Builder(mContext.getApplicationContext());
 
         long notificationId = getNotificationIdForPost(post);
         // Tap notification intent (open the post list)
@@ -187,18 +186,10 @@ class PostUploadNotifier {
                 (int)notificationId,
                 notificationIntent, PendingIntent.FLAG_ONE_SHOT);
 
-        String errorText = mContext.getResources().getText(R.string.upload_failed).toString();
-        if (isMediaError) {
-            errorText = mContext.getResources().getText(R.string.media) + " "
-                    + mContext.getResources().getText(R.string.error);
-        }
-
-        String message = (isMediaError) ? errorMessage : postOrPage + " " + errorText + ": " + errorMessage;
         notificationBuilder.setSmallIcon(android.R.drawable.stat_notify_error);
-        notificationBuilder.setContentTitle((isMediaError) ? errorText :
-                mContext.getResources().getText(R.string.upload_failed));
-        notificationBuilder.setContentText(message);
-        notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(message));
+        notificationBuilder.setContentTitle(mContext.getString(R.string.upload_failed));
+        notificationBuilder.setContentText(errorMessage);
+        notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(errorMessage));
         notificationBuilder.setContentIntent(pendingIntent);
         notificationBuilder.setAutoCancel(true);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -256,6 +256,6 @@ class PostUploadNotifier {
 
     private String buildNotificationTitleForPost(PostModel post) {
         String postTitle = TextUtils.isEmpty(post.getTitle()) ? mContext.getString(R.string.untitled) : post.getTitle();
-        return String.format(mContext.getString(R.string.posting_post), postTitle);
+        return String.format(mContext.getString(R.string.uploading_post), postTitle);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -105,10 +105,16 @@ class PostUploadNotifier {
         NotificationCompat.Builder notificationBuilder =
                 new NotificationCompat.Builder(mContext.getApplicationContext());
         String notificationTitle;
+        String notificationMessage;
+
+        String postTitle = TextUtils.isEmpty(post.getTitle()) ? mContext.getString(R.string.untitled) : post.getTitle();
+
         if (PostStatus.DRAFT.equals(PostStatus.fromPost(post))) {
             notificationTitle = mContext.getString(R.string.draft_uploaded);
+            notificationMessage = String.format(mContext.getString(R.string.post_draft_param), postTitle);
         } else if (PostStatus.SCHEDULED.equals(PostStatus.fromPost(post))) {
             notificationTitle = mContext.getString(post.isPage() ? R.string.page_scheduled : R.string.post_scheduled);
+            notificationMessage = String.format(mContext.getString(R.string.post_scheduled_param), postTitle);
         } else {
             if (post.isPage()) {
                 notificationTitle = mContext.getString(
@@ -117,6 +123,8 @@ class PostUploadNotifier {
                 notificationTitle = mContext.getString(
                         isFirstTimePublish ? R.string.post_published : R.string.post_updated);
             }
+            notificationMessage = String.format(mContext.getString(
+                    isFirstTimePublish ? R.string.post_published_param : R.string.post_updated_param), postTitle);
         }
 
         notificationBuilder.setSmallIcon(android.R.drawable.stat_sys_upload_done);
@@ -129,10 +137,9 @@ class PostUploadNotifier {
         } else {
             notificationBuilder.setLargeIcon(notificationData.latestIcon);
         }
-        String message = post.getTitle();
         notificationBuilder.setContentTitle(notificationTitle);
-        notificationBuilder.setContentText(message);
-        notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(message));
+        notificationBuilder.setContentText(notificationMessage);
+        notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(notificationMessage));
         notificationBuilder.setAutoCancel(true);
 
         long notificationId = getNotificationIdForPost(post);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -524,8 +524,8 @@ public class UploadService extends Service {
         SiteModel site = mSiteStore.getSiteByLocalId(postToCancel.getLocalSiteId());
         mPostUploadNotifier.cancelNotification(postToCancel);
         if (showErrorNotification) {
-            String message = UploadUtils.getErrorMessage(this, postToCancel, mediaErrorMessage);
-            mPostUploadNotifier.updateNotificationError(postToCancel, site, message, true);
+            String message = UploadUtils.getErrorMessage(this, postToCancel, mediaErrorMessage, true);
+            mPostUploadNotifier.updateNotificationError(postToCancel, site, message);
         }
 
         mPostUploadHandler.unregisterPostForAnalyticsTracking(postToCancel);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -15,9 +15,11 @@ public class UploadUtils {
     /**
      * Returns a post-type specific error message string.
      */
-    static @NonNull String getErrorMessage(Context context, PostModel post, String specificMessage) {
+    static @NonNull String getErrorMessage(Context context, PostModel post, String errorMessage, boolean isMediaError) {
+        String baseErrorString = context.getString(
+                isMediaError ? R.string.error_upload_post_media_params : R.string.error_upload_post_params);
         String postType = context.getString(post.isPage() ? R.string.page : R.string.post).toLowerCase();
-        return String.format(context.getText(R.string.error_upload_params).toString(), postType, specificMessage);
+        return String.format(baseErrorString, postType, errorMessage);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -187,7 +187,7 @@ public class WPMediaUtils {
             case TIMEOUT:
                 return context.getString(R.string.media_error_timeout);
             case CONNECTION_ERROR:
-                return context.getString(R.string.connection_error);
+                return context.getString(R.string.connection_to_server_lost);
             case EXCEEDS_FILESIZE_LIMIT:
                 return context.getString(R.string.media_error_exceeds_php_filesize);
             case EXCEEDS_MEMORY_LIMIT:

--- a/WordPress/src/main/res/layout/post_cardview.xml
+++ b/WordPress/src/main/res/layout/post_cardview.xml
@@ -67,7 +67,7 @@
                 android:id="@+id/image_status"
                 android:layout_width="16dp"
                 android:layout_height="16dp"
-                android:layout_gravity="bottom"
+                android:layout_gravity="center"
                 android:layout_marginRight="@dimen/margin_small"
                 tools:src="@drawable/ic_gridicons_cloud_upload"
                 />

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -67,6 +67,7 @@
     <string name="edit_post">Edit post</string>
     <string name="add_comment">Add comment</string>
     <string name="connection_error">Connection error</string>
+    <string name="connection_to_server_lost">The connection to the server was lost</string>
     <string name="category_refresh_error">Category refresh error</string>
     <string name="incorrect_credentials">Incorrect username or password.</string>
     <string name="cancel_edit">Cancel edit</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -267,6 +267,12 @@
         <item>@string/filter_trashed_posts</item>
     </string-array>
 
+    <!-- post uploads -->
+    <string name="post_published_param">\"%s\" has been published!</string>
+    <string name="post_updated_param">\"%s\" has been updated!</string>
+    <string name="post_scheduled_param">\"%s\" has been scheduled!</string>
+    <string name="post_draft_param">\"%s\" has been saved as a draft!</string>
+
     <!-- post view -->
     <string name="post_id">Post</string>
     <string name="upload_failed">Upload failed</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1183,7 +1183,7 @@
     <string name="error_fetch_site_after_creation">Site has been created, you might need to refresh your sites in the site picker.</string>
 
     <!-- Post Error -->
-    <string name="error_unknown_post">Unknown post, local copy of this post may be out of sync with the server</string>
+    <string name="error_unknown_post">Could not find the post on the server</string>
     <string name="error_unknown_post_type">Unknown post format</string>
 
     <!-- Image Descriptions for Accessibility -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1142,7 +1142,8 @@
     <string name="error_edit_comment">An error occurred while editing the comment</string>
     <string name="error_publish_empty_post">Can\'t publish an empty post</string>
     <string name="error_publish_no_network">Device is offline. Changes saved locally.</string>
-    <string name="error_upload_params">Error while uploading the %1$s: %2$s</string>
+    <string name="error_upload_post_params">There was an error uploading this %1$s: %2$s</string>
+    <string name="error_upload_post_media_params">There was an error uploading the media in this %1$s: %2$s</string>
     <string name="error_media_insufficient_fs_permissions">Read permission denied on device media</string>
     <string name="error_media_not_found">Media could not be found</string>
     <string name="error_media_unauthorized">You don\'t have permission to view or edit media</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -84,7 +84,7 @@
     <string name="sign_in_wpcom">Log in to WordPress.com</string>
     <string name="upload">Upload</string>
     <string name="learn_more">Learn more</string>
-    <string name="posting_post">Posting \"%s\"</string>
+    <string name="uploading_post">Uploading \"%s\"</string>
     <string name="language">Language</string>
     <string name="interface_language">Interface Language</string>
     <string name="signout">Log out</string>
@@ -400,7 +400,7 @@
     <string name="view_in_browser">View in browser</string>
     <string name="preview">Preview</string>
     <string name="update_verb">Update</string>
-    <string name="sending_content">Uploading %s content</string>
+    <string name="sending_content">Uploading %s content…</string>
     <string name="uploading_total">Uploading %1$d of %2$d</string>
     <string name="uploading_post_media">Uploading media…</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1161,7 +1161,7 @@
     <string name="error_media_load">Unable to load media</string>
     <string name="error_media_save">Unable to save media</string>
     <string name="error_media_canceled">Uploading media were canceled</string>
-    <string name="error_media_recover">Media upload failed. Edit the post to retry.</string>
+    <string name="error_media_recover">We were unable to upload this post\'s media. Please edit the post to try again.</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>
     <string name="fatal_db_error">An error occurred while creating the app database. Try reinstalling the app.</string>
     <string name="error_copy_to_clipboard">An error occurred while copying text to clipboard</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -954,7 +954,7 @@
     <string name="editor_draft_saved_locally">Draft saved on device</string>
     <string name="editor_scheduled_post_saved_online">Post scheduled</string>
     <string name="editor_post_saved_locally_failed_media">The post has failed media uploads and has been saved locally</string>
-    <string name="editor_uploading_post">Your post is being sent online</string>
+    <string name="editor_uploading_post">Your post is uploading</string>
     <string name="visual_editor_enabled">Visual Editor enabled</string>
     <string name="visual_editor_disabled">Visual Editor disabled</string>
     <string name="aztec_editor_enabled" translatable="false">Aztec Editor enabled</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1150,8 +1150,8 @@
     <string name="error_edit_comment">An error occurred while editing the comment</string>
     <string name="error_publish_empty_post">Can\'t publish an empty post</string>
     <string name="error_publish_no_network">Device is offline. Changes saved locally.</string>
-    <string name="error_upload_post_params">There was an error uploading this %1$s: %2$s</string>
-    <string name="error_upload_post_media_params">There was an error uploading the media in this %1$s: %2$s</string>
+    <string name="error_upload_post_params">There was an error uploading this %1$s: %2$s.</string>
+    <string name="error_upload_post_media_params">There was an error uploading the media in this %1$s: %2$s.</string>
     <string name="error_media_insufficient_fs_permissions">Read permission denied on device media</string>
     <string name="error_media_not_found">Media could not be found</string>
     <string name="error_media_unauthorized">You don\'t have permission to view or edit media</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -273,6 +273,8 @@
     <string name="draft_uploaded">Draft uploaded</string>
     <string name="post_published">Post published</string>
     <string name="page_published">Page published</string>
+    <string name="post_scheduled">Post scheduled</string>
+    <string name="page_scheduled">Page scheduled</string>
     <string name="post_updated">Post updated</string>
     <string name="page_updated">Page updated</string>
     <string name="caption">Caption (optional)</string>


### PR DESCRIPTION
Addresses design and copy feedback from #6386. (Some things have been filed as separate issues, see [this to-do list](https://github.com/wordpress-mobile/WordPress-Android/issues/6386#issuecomment-318400411).)

* [x] Updated the snackbar text in the post list when uploads begin to say "Your post is uploading"
* [x] Updated the in-progress upload notification wording
* [x] Updated the wording on the successful upload notifications

Here's the current flow of uploading a post with media (asynchronously), showing the above changes:

![async-successful-media-post-upload-demo](https://user-images.githubusercontent.com/9613966/28719975-c774b3a8-7379-11e7-89b9-55e7d81738dc.gif)

([video link for the above](https://cloudup.com/cz6B-rstzRv))

Here are the rest of the success notifications:

![async-success-notifications](https://user-images.githubusercontent.com/9613966/28719685-cbeaaf06-7378-11e7-9097-7215d5493283.png)

* [x] Updated the wording on the post error and media error notifications:

![async-upload-error-notifications](https://user-images.githubusercontent.com/9613966/28720701-f050aa1e-737b-11e7-90cf-b5b4a1f37c8e.png)

* [x] Updated the wording of the post list error status for failed media (not the final fix, we should allow retries and give more specific error messages/suggestions when possible, tracked in https://github.com/wordpress-mobile/WordPress-Android/issues/6407)

![async-post-list-media-error](https://user-images.githubusercontent.com/9613966/28721008-d31228fa-737c-11e7-9de7-50bc35e76f79.png)

Here's a demo of the flow for a post upload with a media error:

![async-media-error-post-upload-demo](https://user-images.githubusercontent.com/9613966/28720467-44581d0a-737b-11e7-8679-6e670e7c77d4.gif)

([video link](https://cloudup.com/cRUmbKvmR0b))

cc @iamthomasbishop, @michelleweber, @mzorz