### PR TITLE
Login Rework: Enable the new login for all

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -50,14 +50,12 @@ android {
 
     productFlavors {
         vanilla { // used for release and beta
-            buildConfigField "boolean", "LOGIN_WIZARD_STYLE_ACTIVE", "false"
         }
 
         zalpha { // alpha version - enable experimental features
             applicationId "org.wordpress.android"
             buildConfigField "boolean", "SHARING_FEATURE_AVAILABLE", "true"
             buildConfigField "boolean", "VIDEO_OPTIMIZATION_AVAILABLE", "true"
-            buildConfigField "boolean", "LOGIN_WIZARD_STYLE_ACTIVE", "false"
         }
 
         wasabi { // "hot" version, can be installed along release, alpha or beta versions


### PR DESCRIPTION
Sets the feature flag for the new login flows to `true` for all build variants.

To test:
* Build `vanilla` and run the app after cleaning all data. The new style login prologue screen should appear.