### PR TITLE
Async media: Scroll to failed post from error notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
@@ -11,7 +11,9 @@ import android.view.MenuItem;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.RequestCodes;
@@ -21,6 +23,7 @@ import javax.inject.Inject;
 
 public class PostsListActivity extends AppCompatActivity {
     public static final String EXTRA_VIEW_PAGES = "viewPages";
+    public static final String EXTRA_TARGET_POST_ID = "targetPostId";
     public static final String EXTRA_ERROR_MSG = "errorMessage";
 
     private boolean mIsPage = false;
@@ -28,6 +31,7 @@ public class PostsListActivity extends AppCompatActivity {
     private SiteModel mSite;
 
     @Inject SiteStore mSiteStore;
+    @Inject PostStore mPostStore;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -89,10 +93,16 @@ public class PostsListActivity extends AppCompatActivity {
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
 
+        PostModel targetPost = null;
+        int targetPostId = intent.getIntExtra(EXTRA_TARGET_POST_ID, 0);
+        if (targetPostId > 0) {
+            targetPost = mPostStore.getPostByLocalPostId(intent.getIntExtra(EXTRA_TARGET_POST_ID, 0));
+        }
+
         mPostList = (PostsListFragment) getFragmentManager().findFragmentByTag(PostsListFragment.TAG);
-        if (mPostList == null || siteHasChanged || pageHasChanged) {
+        if (mPostList == null || siteHasChanged || pageHasChanged || targetPost != null) {
             PostsListFragment oldFragment = mPostList;
-            mPostList = PostsListFragment.newInstance(mSite, mIsPage);
+            mPostList = PostsListFragment.newInstance(mSite, mIsPage, targetPost);
             if (oldFragment == null) {
                 getFragmentManager().beginTransaction()
                         .add(R.id.post_list_container, mPostList, PostsListFragment.TAG)

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
@@ -21,7 +21,7 @@ import javax.inject.Inject;
 
 public class PostsListActivity extends AppCompatActivity {
     public static final String EXTRA_VIEW_PAGES = "viewPages";
-    public static final String EXTRA_TARGET_POST_ID = "targetPostId";
+    public static final String EXTRA_TARGET_POST_LOCAL_ID = "targetPostLocalId";
 
     private boolean mIsPage = false;
     private PostsListFragment mPostList;
@@ -91,9 +91,9 @@ public class PostsListActivity extends AppCompatActivity {
         }
 
         PostModel targetPost = null;
-        int targetPostId = intent.getIntExtra(EXTRA_TARGET_POST_ID, 0);
+        int targetPostId = intent.getIntExtra(EXTRA_TARGET_POST_LOCAL_ID, 0);
         if (targetPostId > 0) {
-            targetPost = mPostStore.getPostByLocalPostId(intent.getIntExtra(EXTRA_TARGET_POST_ID, 0));
+            targetPost = mPostStore.getPostByLocalPostId(intent.getIntExtra(EXTRA_TARGET_POST_LOCAL_ID, 0));
         }
 
         mPostList = (PostsListFragment) getFragmentManager().findFragmentByTag(PostsListFragment.TAG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
@@ -1,12 +1,10 @@
 package org.wordpress.android.ui.posts;
 
-import android.app.AlertDialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
-import android.text.TextUtils;
 import android.view.MenuItem;
 
 import org.wordpress.android.R;
@@ -24,7 +22,6 @@ import javax.inject.Inject;
 public class PostsListActivity extends AppCompatActivity {
     public static final String EXTRA_VIEW_PAGES = "viewPages";
     public static final String EXTRA_TARGET_POST_ID = "targetPostId";
-    public static final String EXTRA_ERROR_MSG = "errorMessage";
 
     private boolean mIsPage = false;
     private PostsListFragment mPostList;
@@ -113,8 +110,6 @@ public class PostsListActivity extends AppCompatActivity {
                         .commit();
             }
         }
-
-        showErrorDialogIfNeeded(intent.getExtras());
     }
 
     @Override
@@ -130,30 +125,6 @@ public class PostsListActivity extends AppCompatActivity {
         if (requestCode == RequestCodes.EDIT_POST) {
             mPostList.handleEditPostResult(resultCode, data);
         }
-    }
-
-    /**
-     * intent extras will contain error info if this activity was started from an
-     * upload error notification
-     */
-    private void showErrorDialogIfNeeded(Bundle extras) {
-        if (extras == null || !extras.containsKey(EXTRA_ERROR_MSG) || isFinishing()) {
-            return;
-        }
-
-        final String errorMessage = extras.getString(EXTRA_ERROR_MSG);
-
-        if (TextUtils.isEmpty(errorMessage)) {
-            return;
-        }
-
-        AlertDialog.Builder builder = new AlertDialog.Builder(this);
-        builder.setTitle(getResources().getText(R.string.error))
-               .setMessage(errorMessage)
-               .setPositiveButton(android.R.string.ok, null)
-               .setCancelable(true);
-
-        builder.create().show();
     }
 
     public boolean isRefreshing() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
@@ -94,6 +94,9 @@ public class PostsListActivity extends AppCompatActivity {
         int targetPostId = intent.getIntExtra(EXTRA_TARGET_POST_LOCAL_ID, 0);
         if (targetPostId > 0) {
             targetPost = mPostStore.getPostByLocalPostId(intent.getIntExtra(EXTRA_TARGET_POST_LOCAL_ID, 0));
+            if (targetPost == null) {
+                ToastUtils.showToast(this, R.string.error_post_does_not_exist);
+            }
         }
 
         mPostList = (PostsListFragment) getFragmentManager().findFragmentByTag(PostsListFragment.TAG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -503,6 +503,17 @@ public class PostsListFragment extends Fragment
         } else if (postCount > 0) {
             hideEmptyView();
         }
+
+        // If the activity was given a target post, and this is the first time posts are loaded, scroll to that post
+        if (mTargetPost != null) {
+            if (mPostsListAdapter != null) {
+                final int position = mPostsListAdapter.getPositionForPost(mTargetPost);
+                if (position > -1) {
+                    mRecyclerView.smoothScrollToPosition(position);
+                }
+            }
+            mTargetPost = null;
+        }
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -85,6 +85,7 @@ public class PostsListFragment extends Fragment
 
     private boolean mCanLoadMorePosts = true;
     private boolean mIsPage;
+    private PostModel mTargetPost;
     private boolean mIsFetchingPosts;
     private boolean mShouldCancelPendingDraftNotification = false;
     private int mPostIdForPostToBeDeleted = 0;
@@ -97,11 +98,14 @@ public class PostsListFragment extends Fragment
     @Inject PostStore mPostStore;
     @Inject Dispatcher mDispatcher;
 
-    public static PostsListFragment newInstance(SiteModel site, boolean isPage) {
+    public static PostsListFragment newInstance(SiteModel site, boolean isPage, @Nullable PostModel targetPost) {
         PostsListFragment fragment = new PostsListFragment();
         Bundle bundle = new Bundle();
         bundle.putSerializable(WordPress.SITE, site);
         bundle.putBoolean(PostsListActivity.EXTRA_VIEW_PAGES, isPage);
+        if (targetPost != null) {
+            bundle.putInt(PostsListActivity.EXTRA_TARGET_POST_ID, targetPost.getId());
+        }
         fragment.setArguments(bundle);
         return fragment;
     }
@@ -130,18 +134,23 @@ public class PostsListFragment extends Fragment
             if (getArguments() != null) {
                 mSite = (SiteModel) getArguments().getSerializable(WordPress.SITE);
                 mIsPage = getArguments().getBoolean(PostsListActivity.EXTRA_VIEW_PAGES);
+                mTargetPost = mPostStore.getPostByLocalPostId(
+                        getArguments().getInt(PostsListActivity.EXTRA_TARGET_POST_ID));
             } else {
                 mSite = (SiteModel) getActivity().getIntent().getSerializableExtra(WordPress.SITE);
                 mIsPage = getActivity().getIntent().getBooleanExtra(PostsListActivity.EXTRA_VIEW_PAGES, false);
+                mTargetPost = mPostStore.getPostByLocalPostId(
+                        getActivity().getIntent().getIntExtra(PostsListActivity.EXTRA_TARGET_POST_ID, 0));
             }
         } else {
             mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
             mIsPage = savedInstanceState.getBoolean(PostsListActivity.EXTRA_VIEW_PAGES);
+            mTargetPost = mPostStore.getPostByLocalPostId(
+                    savedInstanceState.getInt(PostsListActivity.EXTRA_TARGET_POST_ID));
         }
 
         if (mSite == null) {
-            ToastUtils.showToast(getActivity(), R.string.blog_not_found,
-                    ToastUtils.Duration.SHORT);
+            ToastUtils.showToast(getActivity(), R.string.blog_not_found, ToastUtils.Duration.SHORT);
             getActivity().finish();
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -509,7 +509,7 @@ public class PostsListFragment extends Fragment
             if (mPostsListAdapter != null) {
                 final int position = mPostsListAdapter.getPositionForPost(mTargetPost);
                 if (position > -1) {
-                    mRecyclerView.smoothScrollToPosition(position);
+                    mRecyclerView.scrollToPosition(position);
                 }
             }
             mTargetPost = null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -13,6 +13,7 @@ import android.support.annotation.Nullable;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.LinearSmoothScroller;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -509,7 +510,15 @@ public class PostsListFragment extends Fragment
             if (mPostsListAdapter != null) {
                 final int position = mPostsListAdapter.getPositionForPost(mTargetPost);
                 if (position > -1) {
-                    mRecyclerView.scrollToPosition(position);
+                    RecyclerView.SmoothScroller smoothScroller = new LinearSmoothScroller(getActivity()) {
+                        @Override
+                        protected int getVerticalSnapPreference() {
+                            return LinearSmoothScroller.SNAP_TO_START;
+                        }
+                    };
+
+                    smoothScroller.setTargetPosition(position);
+                    mRecyclerView.getLayoutManager().startSmoothScroll(smoothScroller);
                 }
             }
             mTargetPost = null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -15,6 +15,7 @@ import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.LinearSmoothScroller;
 import android.support.v7.widget.RecyclerView;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -511,9 +512,20 @@ public class PostsListFragment extends Fragment
                 final int position = mPostsListAdapter.getPositionForPost(mTargetPost);
                 if (position > -1) {
                     RecyclerView.SmoothScroller smoothScroller = new LinearSmoothScroller(getActivity()) {
+                        private static final int SCROLL_OFFSET_DP = 23;
+
                         @Override
                         protected int getVerticalSnapPreference() {
                             return LinearSmoothScroller.SNAP_TO_START;
+                        }
+
+                        @Override
+                        public int calculateDtToFit(int viewStart, int viewEnd, int boxStart, int boxEnd,
+                                                    int snapPreference) {
+                            // Assume SNAP_TO_START, and offset the scroll, so the bottom of the above post shows
+                            int offsetPx = (int) TypedValue.applyDimension(
+                                    TypedValue.COMPLEX_UNIT_DIP, SCROLL_OFFSET_DP, getResources().getDisplayMetrics());
+                            return boxStart - viewStart + offsetPx;
                         }
                     };
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -106,7 +106,7 @@ public class PostsListFragment extends Fragment
         bundle.putSerializable(WordPress.SITE, site);
         bundle.putBoolean(PostsListActivity.EXTRA_VIEW_PAGES, isPage);
         if (targetPost != null) {
-            bundle.putInt(PostsListActivity.EXTRA_TARGET_POST_ID, targetPost.getId());
+            bundle.putInt(PostsListActivity.EXTRA_TARGET_POST_LOCAL_ID, targetPost.getId());
         }
         fragment.setArguments(bundle);
         return fragment;
@@ -137,18 +137,18 @@ public class PostsListFragment extends Fragment
                 mSite = (SiteModel) getArguments().getSerializable(WordPress.SITE);
                 mIsPage = getArguments().getBoolean(PostsListActivity.EXTRA_VIEW_PAGES);
                 mTargetPost = mPostStore.getPostByLocalPostId(
-                        getArguments().getInt(PostsListActivity.EXTRA_TARGET_POST_ID));
+                        getArguments().getInt(PostsListActivity.EXTRA_TARGET_POST_LOCAL_ID));
             } else {
                 mSite = (SiteModel) getActivity().getIntent().getSerializableExtra(WordPress.SITE);
                 mIsPage = getActivity().getIntent().getBooleanExtra(PostsListActivity.EXTRA_VIEW_PAGES, false);
                 mTargetPost = mPostStore.getPostByLocalPostId(
-                        getActivity().getIntent().getIntExtra(PostsListActivity.EXTRA_TARGET_POST_ID, 0));
+                        getActivity().getIntent().getIntExtra(PostsListActivity.EXTRA_TARGET_POST_LOCAL_ID, 0));
             }
         } else {
             mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
             mIsPage = savedInstanceState.getBoolean(PostsListActivity.EXTRA_VIEW_PAGES);
             mTargetPost = mPostStore.getPostByLocalPostId(
-                    savedInstanceState.getInt(PostsListActivity.EXTRA_TARGET_POST_ID));
+                    savedInstanceState.getInt(PostsListActivity.EXTRA_TARGET_POST_LOCAL_ID));
         }
 
         if (mSite == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -632,6 +632,10 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         animOut.start();
     }
 
+    public int getPositionForPost(PostModel post) {
+        return PostUtils.indexOfPostInList(post, mPosts);
+    }
+
     public void loadPosts(LoadMode mode) {
         if (mIsLoadingPosts) {
             AppLog.d(AppLog.T.POSTS, "post adapter > already loading posts");
@@ -642,7 +646,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
     public void updateProgressForPost(@NonNull PostModel post) {
         if (mRecyclerView != null) {
-            int position = PostUtils.indexOfPostInList(post, mPosts);
+            int position = getPositionForPost(post);
             if (position > -1) {
                 RecyclerView.ViewHolder viewHolder = mRecyclerView.findViewHolderForAdapterPosition(position);
                 if (viewHolder instanceof PostViewHolder) {
@@ -661,7 +665,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     public void hidePost(PostModel post) {
         mHiddenPosts.add(post);
 
-        int position = PostUtils.indexOfPostInList(post, mPosts);
+        int position = getPositionForPost(post);
         if (position > -1) {
             mPosts.remove(position);
             if (mPosts.size() > 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -188,6 +188,7 @@ class PostUploadNotifier {
         notificationIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         notificationIntent.putExtra(WordPress.SITE, site);
         notificationIntent.putExtra(PostsListActivity.EXTRA_VIEW_PAGES, post.isPage());
+        notificationIntent.putExtra(PostsListActivity.EXTRA_TARGET_POST_ID, post.getId());
         notificationIntent.putExtra(PostsListActivity.EXTRA_ERROR_MSG, errorMessage);
         notificationIntent.setAction(String.valueOf(notificationId));
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -188,7 +188,7 @@ class PostUploadNotifier {
         notificationIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         notificationIntent.putExtra(WordPress.SITE, site);
         notificationIntent.putExtra(PostsListActivity.EXTRA_VIEW_PAGES, post.isPage());
-        notificationIntent.putExtra(PostsListActivity.EXTRA_TARGET_POST_ID, post.getId());
+        notificationIntent.putExtra(PostsListActivity.EXTRA_TARGET_POST_LOCAL_ID, post.getId());
         notificationIntent.setAction(String.valueOf(notificationId));
 
         PendingIntent pendingIntent = PendingIntent.getActivity(mContext,

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -189,7 +189,6 @@ class PostUploadNotifier {
         notificationIntent.putExtra(WordPress.SITE, site);
         notificationIntent.putExtra(PostsListActivity.EXTRA_VIEW_PAGES, post.isPage());
         notificationIntent.putExtra(PostsListActivity.EXTRA_TARGET_POST_ID, post.getId());
-        notificationIntent.putExtra(PostsListActivity.EXTRA_ERROR_MSG, errorMessage);
         notificationIntent.setAction(String.valueOf(notificationId));
 
         PendingIntent pendingIntent = PendingIntent.getActivity(mContext,

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1163,6 +1163,7 @@
     <string name="error_media_save">Unable to save media</string>
     <string name="error_media_canceled">Uploading media were canceled</string>
     <string name="error_media_recover">We were unable to upload this post\'s media. Please edit the post to try again.</string>
+    <string name="error_post_does_not_exist">This post no longer exists</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>
     <string name="fatal_db_error">An error occurred while creating the app database. Try reinstalling the app.</string>
     <string name="error_copy_to_clipboard">An error occurred while copying text to clipboard</string>


### PR DESCRIPTION
Addresses a suggestion from @iamthomasbishop (marked in the to-do list [here](https://github.com/wordpress-mobile/WordPress-Android/issues/6386#issuecomment-318400411)).

#6420 should be merged before merging this PR.

When tapping a notification for a failed post upload, the post list is opened. Instead of showing a dialog, the list will now scroll down to the post that failed, and a dialog is no longer shown.

![async-scroll-to-failed-post-demo](https://user-images.githubusercontent.com/9613966/28726590-cd396444-738f-11e7-8126-9357a5cfb525.gif)

@iamthomasbishop it looks to me like it would be better to scroll a bit more, so that the post appears at the top of the list (rather than scroll just enough to reveal it at the bottom as in the demo above). I can change that but waiting for any more feedback on that you might have before diving in.

cc @mzorz 