### PR TITLE
Default to english if the release notes for a specific language are not translated

### DIFF
--- a/tools/get-translated-release-notes.sh
+++ b/tools/get-translated-release-notes.sh
@@ -33,7 +33,8 @@ function extract_release_notes() {
     code=$(echo $line|cut -d "," -f1|tr -d " ")
     code_play_store=$(echo $line|cut -d "," -f3|tr -d " ")
     if [ -z "$(grep \"$comment\" $TMPDIR/strings-$code.xml | cleanup)" ]; then
-      continue
+      # Force the current language to english
+      code=en-gb
     fi
     echo \<$code_play_store\> >> $OUTFILE
     grep \"$comment\" $TMPDIR/strings-$code.xml | cleanup >> $OUTFILE

--- a/tools/release-notes-language-codes.csv
+++ b/tools/release-notes-language-codes.csv
@@ -17,3 +17,6 @@ pt-br,pt-rBR,pt-BR,Portuguese(Brazil)
 zh-tw,zh-rTW,zh-TW,Chinese(Traditional)
 he,he,iw-IL,Hebrew
 ar,ar,ar,Arabic
+sr,sr,sr,Serbian
+th,th,th,Thai
+vi,vi,vi,Vietnamese


### PR DESCRIPTION
Default to english if the release notes for a specific language are not translated.

Also add 3 missing languages supported in the Play Store.

Note: we can't get en-us from GlotPress directly, but we should find a workaround to get the source language and consider it "en-us".
