### PR TITLE
Fix crash when creating new user under old login flow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -77,6 +77,8 @@ import java.util.regex.Pattern;
 import javax.inject.Inject;
 
 public class NewUserFragment extends AbstractFragment {
+    private static final String KEY_UNDER_LOGIN_WIZARD = "KEY_UNDER_LOGIN_WIZARD";
+
     public static final String TAG = "new_user_fragment_tag";
 
     public static final int NEW_USER = 1;
@@ -90,6 +92,8 @@ public class NewUserFragment extends AbstractFragment {
     private WPTextView mProgressTextSignIn;
     private RelativeLayout mProgressBarSignIn;
     private boolean mEmailAutoCorrected;
+
+    private boolean mUnderLoginWizard;
 
     private LoginListener mLoginListener;
 
@@ -414,7 +418,7 @@ public class NewUserFragment extends AbstractFragment {
             return;
         }
 
-        if (AppPrefs.isLoginWizardStyleActivated()) {
+        if (mUnderLoginWizard) {
             if (mLoginListener != null) {
                 ArrayList<Integer> oldSitesIDs = SiteUtils.getCurrentSiteIds(mSiteStore, false);
                 mLoginListener.loggedInViaSigUp(oldSitesIDs);
@@ -441,7 +445,7 @@ public class NewUserFragment extends AbstractFragment {
             return;
         }
 
-        if (AppPrefs.isLoginWizardStyleActivated()) {
+        if (mUnderLoginWizard) {
             if (mLoginListener != null) {
                 mLoginListener.newUserCreatedButErrored(getEmail(), getPassword());
             }
@@ -493,9 +497,8 @@ public class NewUserFragment extends AbstractFragment {
         super.onAttach(context);
         if (AppPrefs.isLoginWizardStyleActivated()) {
             if (context instanceof LoginListener) {
+                mUnderLoginWizard = true;
                 mLoginListener = (LoginListener) context;
-            } else {
-                throw new RuntimeException(context.toString() + " must implement LoginListener");
             }
         }
     }
@@ -517,6 +520,10 @@ public class NewUserFragment extends AbstractFragment {
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
         mDispatcher.register(this);
+
+        if (savedInstanceState != null) {
+            mUnderLoginWizard = savedInstanceState.getBoolean(KEY_UNDER_LOGIN_WIZARD);
+        }
     }
 
     @Override
@@ -618,6 +625,13 @@ public class NewUserFragment extends AbstractFragment {
         initPasswordVisibilityButton(rootView, mPasswordTextField);
         initInfoButton(rootView);
         return rootView;
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        outState.putBoolean(KEY_UNDER_LOGIN_WIZARD, mUnderLoginWizard);
     }
 
     private final TextWatcher mCheckFieldsFilledWatcher = new TextWatcher() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -32,7 +32,6 @@ import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.generated.AuthenticationActionBuilder;
 import org.wordpress.android.fluxc.generated.SiteActionBuilder;
-import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.AuthenticatePayload;
@@ -72,7 +71,6 @@ import org.wordpress.persistentedittext.PersistentEditTextHelper;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 


### PR DESCRIPTION
Fixes #6431 

`NewUserFragment` needs to allow attaching to a non `LoginListener` Activity (such as SignInActivity) even if `AppPrefs.isLoginWizardStyleActivated()` is true (which it is by default at the moment). That flow can currently show up when sharing-to-wordpress and no user/site is connected yet.

To test:
* Clean the app data and launch the app
* Tap on "LOG IN" and when on the email input screen, tap on "HELP"
* Tap on "Application log"
* Tap on the "share" action at the top and choose WordPress from the list of app to share to
* App will display the old-style login flow
* Tap on "Create account" and app should display the new user creation screen without crashing