### PR TITLE
Fix for copy/paste not appearing

### DIFF
--- a/WordPress/src/main/res/layout/login_input_row.xml
+++ b/WordPress/src/main/res/layout/login_input_row.xml
@@ -31,7 +31,6 @@
             android:layout_height="wrap_content"
             android:layout_marginRight="@dimen/textinputlayout_correction_margin_right"
             android:layout_marginEnd="@dimen/textinputlayout_correction_margin_right"
-            android:translationX="@dimen/textinputlayout_correction_padding"
             android:hint="@string/email_address"/>
     </org.wordpress.android.widgets.WPTextInputLayout>
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/login_username_password_screen.xml
+++ b/WordPress/src/main/res/layout/login_username_password_screen.xml
@@ -22,6 +22,8 @@
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginRight="@dimen/textinputlayout_correction_padding"
+            android:layout_marginEnd="@dimen/textinputlayout_correction_padding"
             android:orientation="vertical">
 
             <org.wordpress.android.widgets.WPNetworkImageView

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -326,7 +326,7 @@
     <dimen name="margin_extra_extra_extra_large">92dp</dimen>
     <dimen name="promo_indicator_bullet_size">4dp</dimen>
     <dimen name="textinputlayout_baseline_correction">2dp</dimen>
-    <dimen name="textinputlayout_correction_padding">-4.3dp</dimen>
+    <dimen name="textinputlayout_correction_padding">4.3dp</dimen>
     <dimen name="textinputlayout_correction_margin_right">-8.6dp</dimen>
     <dimen name="magic_link_sent_illustration_sz">120dp</dimen>
 </resources>


### PR DESCRIPTION
Fixes #6435 

The use of a negative `translationX` breaks the copy/paste functionality on some devices. That `translationX` was put in place to correct the excess left padding of the TextInputLayout as it currently is implemented in the support library. I've removed that correction and instead put it on the static icon used in the username/password screen where it actually is needed.

To test:
* With the app data cleaned, launch the app and tap on the "LOG IN" button to go to the email input screen
* Try to engage the copy paste functionality on the input field by long-pressing. It should popup the usual copy/paste popup.