### PR TITLE
Fix #6441 - crash when onSettingsUpdated is called and fragment is detached

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -174,7 +174,8 @@ public class EditPostSettingsFragment extends Fragment {
                 new SiteSettingsListener() {
                     @Override
                     public void onSettingsUpdated(Exception error) {
-                        if (error == null) {
+                        // mEditPostActivityHook will be null if the fragment is detached
+                        if (error == null && mEditPostActivityHook != null) {
                             updatePostFormat(mSiteSettings.getDefaultPostFormat());
                         }
                     }


### PR DESCRIPTION
Fix #6441 - crash when onSettingsUpdated is called and fragment is detached