### PR TITLE
Better stretching of promo anims on big landscapes

### DIFF
--- a/WordPress/src/main/res/layout-sw600dp-land/login_intro_template_view.xml
+++ b/WordPress/src/main/res/layout-sw600dp-land/login_intro_template_view.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:background="@color/blue_medium"
+    android:layout_height="match_parent"
+    android:paddingRight="@dimen/margin_extra_extra_large"
+    android:paddingEnd="@dimen/margin_extra_extra_large"
+    android:paddingTop="32dp">
+
+    <org.wordpress.android.widgets.WPTextView
+        style="@style/LoginTheme.PromoText"
+        android:id="@+id/promo_text"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_toLeftOf="@+id/animation_view"
+        android:layout_toStartOf="@+id/animation_view"
+        android:padding="@dimen/margin_extra_extra_large"
+        tools:text="@string/login_promo_text_anytime"/>
+
+    <com.airbnb.lottie.LottieAnimationView
+        android:id="@+id/animation_view"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:adjustViewBounds="true"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentRight="true"
+        android:layout_alignParentEnd="true"/>
+</RelativeLayout>


### PR DESCRIPTION
Fixes #6442 

On bigger tablets/landscape we have a broken window due to the way the animation view is laid out.

This PR fixes the layout for larger tablets while in landscape mode.

To test:
* Clean up the app data and launch the app on a +7" tablet, while in landscape mode. Alternatively, a similar emulator can do.
* Observe the promo screens. There should be no overlap between the promo texts and the animations.