### PR TITLE
Fix reattachment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -432,12 +432,10 @@ public class EditPostActivity extends AppCompatActivity implements
 
         if (mEditorMediaUploadListener != null) {
             List<MediaModel> uploadingMediaInPost = UploadService.getPendingMediaForPost(mPost);
-            if (uploadingMediaInPost != null) {
-                for (MediaModel media : uploadingMediaInPost) {
-                    if (media != null) {
-                        mEditorMediaUploadListener.onMediaUploadReattached(String.valueOf(media.getId()),
-                                UploadService.getUploadProgressForMedia(media));
-                    }
+            for (MediaModel media : uploadingMediaInPost) {
+                if (media != null) {
+                    mEditorMediaUploadListener.onMediaUploadReattached(String.valueOf(media.getId()),
+                            UploadService.getUploadProgressForMedia(media));
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -429,6 +429,18 @@ public class EditPostActivity extends AppCompatActivity implements
         super.onResume();
         mHandler = new Handler();
         mHandler.postDelayed(mAutoSave, AUTOSAVE_INTERVAL_MILLIS);
+
+        if (mEditorMediaUploadListener != null) {
+            List<MediaModel> uploadingMediaInPost = UploadService.getPendingMediaForPost(mPost);
+            if (uploadingMediaInPost != null) {
+                for (MediaModel media : uploadingMediaInPost) {
+                    if (media != null) {
+                        mEditorMediaUploadListener.onMediaUploadReattached(String.valueOf(media.getId()),
+                                UploadService.getUploadProgressForMedia(media));
+                    }
+                }
+            }
+        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -27,6 +27,7 @@ import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.FluxCUtils;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -413,13 +414,13 @@ public class UploadService extends Service {
         return MediaUploadHandler.getProgressForMedia(mediaModel);
     }
 
-    public static List<MediaModel> getPendingMediaForPost(PostModel postModel) {
+    public static @NonNull List<MediaModel> getPendingMediaForPost(PostModel postModel) {
         for (UploadingPost uploadingPost : sPostsWithPendingMedia) {
             if (uploadingPost.postModel.getId() == postModel.getId()) {
                 return uploadingPost.pendingMedia;
             }
         }
-        return null;
+        return Collections.emptyList();
     }
 
     private void showNotificationForPostWithPendingMedia(PostModel post) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -409,6 +409,19 @@ public class UploadService extends Service {
         return 1;
     }
 
+    public static float getUploadProgressForMedia(MediaModel mediaModel) {
+        return MediaUploadHandler.getProgressForMedia(mediaModel);
+    }
+
+    public static List<MediaModel> getPendingMediaForPost(PostModel postModel) {
+        for (UploadingPost uploadingPost : sPostsWithPendingMedia) {
+            if (uploadingPost.postModel.getId() == postModel.getId()) {
+                return uploadingPost.pendingMedia;
+            }
+        }
+        return null;
+    }
+
     private void showNotificationForPostWithPendingMedia(PostModel post) {
         mPostUploadNotifier.showForegroundNotificationForPost(post, getString(R.string.uploading_post_media));
     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -766,6 +766,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
+    public void onMediaUploadReattached(String localId, float currentProgress) {
+        mUploadingMediaProgressMax.put(localId, currentProgress);
+    }
+
+    @Override
     public void onMediaUploadSucceeded(final String localMediaId, final MediaFile mediaFile) {
         if(!isAdded() || content == null || !mAztecReady) {
             return;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1106,6 +1106,11 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     }
 
     @Override
+    public void onMediaUploadReattached(String localId, float currentProgress) {
+        // no op (no reattachment in Visual Editor)
+    }
+
+    @Override
     public void onMediaUploadSucceeded(final String localMediaId, final MediaFile mediaFile) {
         if(!isAdded()) {
             return;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUploadListener.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUploadListener.java
@@ -3,6 +3,7 @@ package org.wordpress.android.editor;
 import org.wordpress.android.util.helpers.MediaFile;
 
 public interface EditorMediaUploadListener {
+    void onMediaUploadReattached(String localId, float currentProgress);
     void onMediaUploadSucceeded(String localId, MediaFile mediaFile);
     void onMediaUploadProgress(String localId, float progress);
     void onMediaUploadFailed(String localId, EditorFragmentAbstract.MediaType mediaType, String errorMessage);


### PR DESCRIPTION
Fixes #6282 

With the `UploadService` in async media now in place, this PR adds `EditorMediaUploadListener.onMediaUploadReattached` interface and helper methods in `UploadService` to make sure each time the `EditPostActivity` is shown we get the highest latest progress value for each media item known, as reported by the `UploadService`.

Note: reattachment only applies to Aztec.


To test:
1. start a draft
2. include several media items, specially large ones (big images or some videos work too)
3. leave the editor
4. enter the editor again
5. repeat steps 3 and 4 repeatedly and observe the yellow/orange progress bar inside the Editor doesn't make any wild jumps right when you get back into the Editor (this was because every time the editor was opened, we had a progress value of zero, and then all of a sudden we would update to the current real progress).

cc @aforcier 
