### PR TITLE
Mark login input box icon is decorative

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPLoginInputRow.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPLoginInputRow.java
@@ -73,10 +73,6 @@ public class WPLoginInputRow extends RelativeLayout {
             TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable.wpLoginInputRow, 0, 0);
 
             try {
-                if (a.hasValue(R.styleable.wpLoginInputRow_wpIconContentDescription)) {
-                    mIcon.setContentDescription(a.getString(R.styleable.wpLoginInputRow_wpIconContentDescription));
-                }
-
                 if (a.hasValue(R.styleable.wpLoginInputRow_wpIconDrawable)) {
                     mIcon.setImageResource(a.getResourceId(R.styleable.wpLoginInputRow_wpIconDrawable, 0));
                     mIcon.setVisibility(View.VISIBLE);

--- a/WordPress/src/main/res/layout/login_email_password_screen.xml
+++ b/WordPress/src/main/res/layout/login_email_password_screen.xml
@@ -30,7 +30,7 @@
             android:id="@+id/login_email_icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:contentDescription="@string/login_email_image"
+            android:importantForAccessibility="no"
             android:tint="@color/grey_lighten_10"
             app:srcCompat="@drawable/ic_user_grey_24dp"/>
 
@@ -67,6 +67,5 @@
         android:inputType="textPassword"
         app:passwordToggleEnabled="true"
         app:passwordToggleTint="@color/wp_grey"
-        app:wpIconContentDescription="@string/login_password_image"
         app:wpIconDrawable="@drawable/ic_lock_grey_24dp"/>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/login_email_screen.xml
+++ b/WordPress/src/main/res/layout/login_email_screen.xml
@@ -27,6 +27,5 @@
         android:hint="@string/email_address"
         android:inputType="textEmailAddress"
         android:imeOptions="actionNext"
-        app:wpIconContentDescription="@string/login_email_image"
         app:wpIconDrawable="@drawable/ic_user_grey_24dp"/>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/login_input_row.xml
+++ b/WordPress/src/main/res/layout/login_input_row.xml
@@ -11,7 +11,7 @@
         android:layout_alignBaseline="@+id/input_layout"
         android:layout_marginRight="@dimen/margin_extra_large"
         android:layout_marginEnd="@dimen/margin_extra_large"
-        android:contentDescription="@string/login_email_image"
+        android:importantForAccessibility="no"
         android:tint="@color/grey_lighten_10"
         app:srcCompat="@drawable/ic_user_grey_24dp"/>
 

--- a/WordPress/src/main/res/layout/login_site_address_screen.xml
+++ b/WordPress/src/main/res/layout/login_site_address_screen.xml
@@ -27,6 +27,5 @@
         android:hint="@string/login_site_address"
         android:inputType="textUri"
         android:imeOptions="actionNext"
-        app:wpIconContentDescription="@string/login_globe_icon"
         app:wpIconDrawable="@drawable/ic_globe_grey_24dp"/>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/login_username_password_screen.xml
+++ b/WordPress/src/main/res/layout/login_username_password_screen.xml
@@ -86,7 +86,6 @@
         android:hint="@string/username"
         android:inputType="textPersonName"
         android:imeOptions="actionNext"
-        app:wpIconContentDescription="@string/login_username_image"
         app:wpIconDrawable="@drawable/ic_user_grey_24dp"/>
 
     <org.wordpress.android.widgets.WPLoginInputRow
@@ -98,6 +97,5 @@
         android:inputType="textPassword"
         app:passwordToggleEnabled="true"
         app:passwordToggleTint="@color/wp_grey"
-        app:wpIconContentDescription="@string/login_password_image"
         app:wpIconDrawable="@drawable/ic_lock_grey_24dp"/>
 </LinearLayout>

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -120,7 +120,6 @@
     -->
     <declare-styleable name="wpLoginInputRow">
         <attr name="wpIconDrawable" format="reference"/>
-        <attr name="wpIconContentDescription" format="string"/>
         <attr name="android:inputType" />
         <attr name="android:hint" />
         <attr name="android:imeOptions" />

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1191,11 +1191,7 @@
     <string name="error_load_comment">Couldn\'t load the comment</string>
     <string name="error_downloading_image">Error downloading image</string>
     <string name="cd_related_post_preview_image">Related post preview image</string>
-    <string name="login_email_image">Login email icon</string>
-    <string name="login_globe_icon">Site address globe icon</string>
     <string name="login_site_address_help_image">Site address positioning image</string>
-    <string name="login_username_image">Login username icon</string>
-    <string name="login_password_image">Login password icon</string>
 
     <!-- Passcode lock -->
     <string name="passcode_manage">Manage PIN lock</string>


### PR DESCRIPTION
Fixes #6463 

The icon next to the login input boxes is only for decorative purposes so, this PR marks it as not important for accessibility. That also makes the linter happy that `contentDescription` is missing.

To test:
* Open `login_input_row.xml` in AndroidStudio and observe that the `ImageView` is not highlighted by the linter