### PR TITLE
Enable username, password auto-login for devs

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginBaseFormFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginBaseFormFragment.java
@@ -13,6 +13,7 @@ import android.support.v4.app.Fragment;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -27,7 +28,9 @@ import android.widget.TextView;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.action.AccountAction;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
@@ -283,6 +286,20 @@ public abstract class LoginBaseFormFragment<LoginListenerType> extends Fragment 
             smartLockHelper.saveCredentialsInSmartLock(username, password,
                     HtmlUtils.fastUnescapeHtml(mAccountStore.getAccount().getDisplayName()),
                     Uri.parse(mAccountStore.getAccount().getAvatarUrl()));
+        }
+    }
+
+    /*
+     * auto-fill the username and password from BuildConfig/gradle.properties (developer feature,
+     * only enabled for DEBUG releases)
+     */
+    protected void autoFillFromBuildConfig(String configValueName, TextView textView) {
+        if (!BuildConfig.DEBUG) return;
+
+        String value = (String) WordPress.getBuildConfigValue(getActivity().getApplication(), configValueName);
+        if (!TextUtils.isEmpty(value)) {
+            textView.setText(value);
+            AppLog.d(AppLog.T.NUX, "Auto-filled from build config: " + configValueName);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
@@ -72,11 +72,8 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     @Override
     protected void setupContent(ViewGroup rootView) {
         mEmailInput = (WPLoginInputRow) rootView.findViewById(R.id.login_email_row);
-
-        mEmailInput.addTextChangedListener(this);
-
         autoFillFromBuildConfig("DEBUG_DOTCOM_LOGIN_EMAIL", mEmailInput.getEditText());
-
+        mEmailInput.addTextChangedListener(this);
         mEmailInput.setOnEditorCommitListener(this);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
@@ -4,7 +4,6 @@ import android.os.Bundle;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.Nullable;
 import android.text.Editable;
-import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.Patterns;
 import android.view.View;
@@ -16,7 +15,6 @@ import android.widget.TextView;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -77,7 +75,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
 
         mEmailInput.addTextChangedListener(this);
 
-        autoFillFromBuildConfig();
+        autoFillFromBuildConfig("DEBUG_DOTCOM_LOGIN_EMAIL", mEmailInput.getEditText());
 
         mEmailInput.setOnEditorCommitListener(this);
     }
@@ -155,21 +153,6 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         super.onSaveInstanceState(outState);
 
         outState.putString(KEY_REQUESTED_EMAIL, mRequestedEmail);
-    }
-
-    /*
-     * auto-fill the username and password from BuildConfig/gradle.properties (developer feature,
-     * only enabled for DEBUG releases)
-     */
-    private void autoFillFromBuildConfig() {
-        if (!BuildConfig.DEBUG) return;
-
-        String email = (String) WordPress.getBuildConfigValue(getActivity().getApplication(),
-                "DEBUG_DOTCOM_LOGIN_EMAIL");
-        if (!TextUtils.isEmpty(email)) {
-            mEmailInput.setText(email);
-            AppLog.d(T.NUX, "Auto-filled email from build config");
-        }
     }
 
     protected void next(String email) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
@@ -4,6 +4,7 @@ import android.os.Bundle;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.Nullable;
 import android.text.Editable;
+import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -134,7 +135,11 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
         if (savedInstanceState == null) {
             AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_PASSWORD_FORM_VIEWED);
 
-            mPasswordInput.setText(mPassword);
+            if (!TextUtils.isEmpty(mPassword)) {
+                mPasswordInput.setText(mPassword);
+            } else {
+                autoFillFromBuildConfig("DEBUG_DOTCOM_LOGIN_PASSWORD", mPasswordInput.getEditText());
+            }
         } else {
             mOldSitesIDs = savedInstanceState.getIntegerArrayList(KEY_OLD_SITES_IDS);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -127,6 +127,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
 
         mUsernameInput = (WPLoginInputRow) rootView.findViewById(R.id.login_username_row);
         mUsernameInput.setText(mInputUsername);
+        autoFillFromBuildConfig("DEBUG_DOTCOM_LOGIN_USERNAME", mUsernameInput.getEditText());
         mUsernameInput.addTextChangedListener(this);
         mUsernameInput.setOnEditorCommitListener(new OnEditorCommitListener() {
             @Override
@@ -138,6 +139,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
 
         mPasswordInput = (WPLoginInputRow) rootView.findViewById(R.id.login_password_row);
         mPasswordInput.setText(mInputPassword);
+        autoFillFromBuildConfig("DEBUG_DOTCOM_LOGIN_PASSWORD", mPasswordInput.getEditText());
         mPasswordInput.addTextChangedListener(this);
 
         mPasswordInput.setOnEditorCommitListener(this);


### PR DESCRIPTION
Fixes #6457 

Enable reading the username/password from `gradle.properties`.

To test:
* Set `wp.DEBUG_DOTCOM_LOGIN_EMAIL`, `wp.DEBUG_DOTCOM_LOGIN_USERNAME`, `wp.DEBUG_DOTCOM_LOGIN_PASSWORD` in your gradle.properties file
* Clean the app and launch it
* Go through the "email" input screen. Email should be autofilled with what you set up.
* Fall back to site address mode, input a site address and NEXT
* In the username/password screen the fields should be autofilled as well
