### PR TITLE
Move media settings to app settings - Fix rare migration glitches

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/SiteSettingsTable.java
@@ -125,25 +125,33 @@ public final class SiteSettingsTable {
             if (cursor == null || cursor.getCount() == 0 || !cursor.moveToFirst()) {
                 return false;
             }
-            int columnIndex = cursor.getColumnIndex("optimizedImage");
-            if (columnIndex == -1) {
+            if (cursor.getColumnIndex("optimizedImage") == -1) {
                 // No old columns for media optimization settings
                 return false;
             }
-            // we're safe to read all the settings now since all the columns must be there
-            int optimizeImageOldSettings = cursor.getInt(columnIndex);
-            AppPrefs.setImageOptimize(optimizeImageOldSettings == 1);
-            AppPrefs.setImageOptimizeWidth(
-                    cursor.getInt(cursor.getColumnIndex("maxImageWidth")));
-            AppPrefs.setImageOptimizeQuality(
-                    cursor.getInt(cursor.getColumnIndex("imageEncoderQuality")));
-            AppPrefs.setVideoOptimize(
-                    cursor.getInt(cursor.getColumnIndex("optimizedVideo")) == 1
-            );
-            AppPrefs.setVideoOptimizeWidth(
-                    cursor.getInt(cursor.getColumnIndex("maxVideoWidth")));
-            AppPrefs.setVideoOptimizeQuality(
-                    cursor.getInt(cursor.getColumnIndex("videoEncoderBitrate")));
+            AppPrefs.setImageOptimize(cursor.getInt(cursor.getColumnIndex("optimizedImage")) == 1);
+
+            if (cursor.getColumnIndex("maxImageWidth") != -1) {
+                AppPrefs.setImageOptimizeWidth(
+                        cursor.getInt(cursor.getColumnIndex("maxImageWidth")));
+            }
+            if (cursor.getColumnIndex("imageEncoderQuality") != -1) {
+                AppPrefs.setImageOptimizeQuality(
+                        cursor.getInt(cursor.getColumnIndex("imageEncoderQuality")));
+            }
+            if (cursor.getColumnIndex("optimizedVideo") != -1) {
+                AppPrefs.setVideoOptimize(
+                        cursor.getInt(cursor.getColumnIndex("optimizedVideo")) == 1
+                );
+            }
+            if (cursor.getColumnIndex("maxVideoWidth") != -1) {
+                AppPrefs.setVideoOptimizeWidth(
+                        cursor.getInt(cursor.getColumnIndex("maxVideoWidth")));
+            }
+            if (cursor.getColumnIndex("videoEncoderBitrate") != -1) {
+                AppPrefs.setVideoOptimizeQuality(
+                        cursor.getInt(cursor.getColumnIndex("videoEncoderBitrate")));
+            }
 
             // Delete the old columns? --> cannot drop a specific column in SQLite 3 ;(
 


### PR DESCRIPTION
This PR fixes migration issues for media settings for those users that upgrade to the last app version coming from a version that uses DB version 51 (or above) but lower that 57.

Note, that the app was not crashing since there was a try/catch around the code that read old values. Just old settings were not migrated.
The app could crash if you downgrade the code in AS. 
 
Thanks to @mzorz that brought up this to my attention. 
cc @kwonye 