### PR TITLE
Report email check error as "Not registered on WordPress.com"

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
@@ -242,7 +242,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
         if (event.isError()) {
             // report the error but don't bail yet.
             AppLog.e(T.API, "OnAvailabilityChecked has error: " + event.error.type + " - " + event.error.message);
-            showEmailError(R.string.login_error_while_checking_email);
+            showEmailError(R.string.email_not_registered_wpcom);
             return;
         }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1872,7 +1872,6 @@
     <string name="requesting_otp">Requesting a verification code via SMS.</string>
     <string name="email_not_registered_wpcom">This email is not registered on WordPress.com</string>
     <string name="password_incorrect">It looks like this password is incorrect. Please double check your information and try again.</string>
-    <string name="login_error_while_checking_email">An error occurred while checking the email address!</string>
     <string name="login_magic_links_label">We\'ll email you a magic link that\'ll log you in instantly, no password needed. Hunt and peck no more!</string>
     <string name="login_magic_links_sent_label">Your magic link is on its way! Check your email on this device and tap the link in the email you received from WordPress.com.</string>
     <string name="login_magic_links_sent_description">Magic link sent illustration</string>


### PR DESCRIPTION
Fixes #6458 

Report the failed email availability checks to the user as "not registered on WordPress.com".

To test:
* Clean the app data and launch the app
* Tap on "LOG IN" to land on the email input screen
* Input "a@wordpress.com" as the email address and hit "NEXT"
* The error message displayed should now read as "This email is not registered on WordPress.com"