### PR TITLE
Issue/6488 forgot password link

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -33,7 +33,6 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.HelpshiftHelper;
 import org.wordpress.android.util.HelpshiftHelper.Tag;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPActivityUtils;
 
 import java.util.ArrayList;
@@ -43,14 +42,11 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     private static final String KEY_SMARTLOCK_COMPLETED = "KEY_SMARTLOCK_COMPLETED";
 
     private static final String FORGOT_PASSWORD_URL = "https://wordpress.com/wp-login.php?action=lostpassword";
-    private static final String FORGOT_PASSWORD_URL_SUFFIX = "wp-login.php?action=lostpassword";
 
     private SmartLockHelper mSmartLockHelper;
     private boolean mSmartLockCompleted;
 
     private LoginMode mLoginMode;
-
-    private String mSelfHostedSiteAddress;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -292,13 +288,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     @Override
     public void forgotPassword() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_FORGOT_PASSWORD_CLICKED);
-
-        // Use self-hosted site address if applicable
-        if ((mLoginMode == LoginMode.FULL || mLoginMode == LoginMode.SELFHOSTED_ONLY) && mSelfHostedSiteAddress != null) {
-            ActivityLauncher.openUrlExternal(this, mSelfHostedSiteAddress + FORGOT_PASSWORD_URL_SUFFIX);
-        } else {
-            ActivityLauncher.openUrlExternal(this, FORGOT_PASSWORD_URL);
-        }
+        ActivityLauncher.openUrlExternal(this, FORGOT_PASSWORD_URL);
     }
 
     @Override
@@ -322,7 +312,6 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
         LoginUsernamePasswordFragment loginUsernamePasswordFragment = LoginUsernamePasswordFragment.newInstance(
                 siteAddress, siteAddress, siteName, siteIconUrl, null, null, true);
         slideInFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG);
-        mSelfHostedSiteAddress = null;
     }
 
     @Override
@@ -330,7 +319,6 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
         LoginUsernamePasswordFragment loginUsernamePasswordFragment = LoginUsernamePasswordFragment.newInstance(
                 inputSiteAddress, endpointAddress, null, null, null, null, false);
         slideInFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG);
-        mSelfHostedSiteAddress = UrlUtils.removeXmlrpcSuffix(endpointAddress);
     }
 
     private void launchHelpshift(String url, String username, boolean isWpcom, Tag origin) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -33,6 +33,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.HelpshiftHelper;
 import org.wordpress.android.util.HelpshiftHelper.Tag;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.UrlUtils;
 import org.wordpress.android.util.WPActivityUtils;
 
 import java.util.ArrayList;
@@ -42,11 +43,14 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     private static final String KEY_SMARTLOCK_COMPLETED = "KEY_SMARTLOCK_COMPLETED";
 
     private static final String FORGOT_PASSWORD_URL = "https://wordpress.com/wp-login.php?action=lostpassword";
+    private static final String FORGOT_PASSWORD_URL_SUFFIX = "wp-login.php?action=lostpassword";
 
     private SmartLockHelper mSmartLockHelper;
     private boolean mSmartLockCompleted;
 
     private LoginMode mLoginMode;
+
+    private String mSelfHostedSiteAddress;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -288,7 +292,13 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     @Override
     public void forgotPassword() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_FORGOT_PASSWORD_CLICKED);
-        ActivityLauncher.openUrlExternal(this, FORGOT_PASSWORD_URL);
+
+        // Use self-hosted site address if applicable
+        if ((mLoginMode == LoginMode.FULL || mLoginMode == LoginMode.SELFHOSTED_ONLY) && mSelfHostedSiteAddress != null) {
+            ActivityLauncher.openUrlExternal(this, mSelfHostedSiteAddress + FORGOT_PASSWORD_URL_SUFFIX);
+        } else {
+            ActivityLauncher.openUrlExternal(this, FORGOT_PASSWORD_URL);
+        }
     }
 
     @Override
@@ -319,6 +329,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
         LoginUsernamePasswordFragment loginUsernamePasswordFragment = LoginUsernamePasswordFragment.newInstance(
                 inputSiteAddress, endpointAddress, null, null, null, null, false);
         slideInFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG);
+        mSelfHostedSiteAddress = UrlUtils.removeXmlrpcSuffix(endpointAddress);
     }
 
     private void launchHelpshift(String url, String username, boolean isWpcom, Tag origin) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -234,7 +234,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     }
 
     @Override
-    public void loggedInViaSigUp(ArrayList<Integer> oldSitesIds) {
+    public void loggedInViaSignup(ArrayList<Integer> oldSitesIds) {
         loggedInAndFinish(oldSitesIds);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -322,6 +322,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
         LoginUsernamePasswordFragment loginUsernamePasswordFragment = LoginUsernamePasswordFragment.newInstance(
                 siteAddress, siteAddress, siteName, siteIconUrl, null, null, true);
         slideInFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG);
+        mSelfHostedSiteAddress = null;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -41,7 +41,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
         Callback, LoginListener {
     private static final String KEY_SMARTLOCK_COMPLETED = "KEY_SMARTLOCK_COMPLETED";
 
-    private static final String FORGOT_PASSWORD_URL = "https://wordpress.com/wp-login.php?action=lostpassword";
+    private static final String FORGOT_PASSWORD_URL_SUFFIX = "wp-login.php?action=lostpassword";
 
     private SmartLockHelper mSmartLockHelper;
     private boolean mSmartLockCompleted;
@@ -286,9 +286,9 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     }
 
     @Override
-    public void forgotPassword() {
+    public void forgotPassword(String url) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_FORGOT_PASSWORD_CLICKED);
-        ActivityLauncher.openUrlExternal(this, FORGOT_PASSWORD_URL);
+        ActivityLauncher.openUrlExternal(this, url + FORGOT_PASSWORD_URL_SUFFIX);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/NewUserFragment.java
@@ -421,7 +421,7 @@ public class NewUserFragment extends AbstractFragment {
         if (mUnderLoginWizard) {
             if (mLoginListener != null) {
                 ArrayList<Integer> oldSitesIDs = SiteUtils.getCurrentSiteIds(mSiteStore, false);
-                mLoginListener.loggedInViaSigUp(oldSitesIDs);
+                mLoginListener.loggedInViaSignup(oldSitesIDs);
             }
         } else {
             getActivity().setResult(Activity.RESULT_OK);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
@@ -40,6 +40,8 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
     private static final String ARG_EMAIL_ADDRESS = "ARG_EMAIL_ADDRESS";
     private static final String ARG_PASSWORD = "ARG_PASSWORD";
 
+    private static final String FORGOT_PASSWORD_URL_WPCOM = "https://wordpress.com/";
+
     public static final String TAG = "login_email_password_fragment_tag";
 
     private WPLoginInputRow mPasswordInput;
@@ -104,7 +106,7 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
             @Override
             public void onClick(View v) {
                 if (mLoginListener != null) {
-                    mLoginListener.forgotPassword("");
+                    mLoginListener.forgotPassword(FORGOT_PASSWORD_URL_WPCOM);
                 }
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailPasswordFragment.java
@@ -104,7 +104,7 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
             @Override
             public void onClick(View v) {
                 if (mLoginListener != null) {
-                    mLoginListener.forgotPassword();
+                    mLoginListener.forgotPassword("");
                 }
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
@@ -23,7 +23,7 @@ public interface LoginListener {
     // Login Request Magic Link callbacks
     void showMagicLinkSentScreen(String email);
     void usePasswordInstead(String email);
-    void forgotPassword();
+    void forgotPassword(String url);
     void helpMagicLinkRequest(String email);
 
     // Login Magic Link Sent callbacks

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginListener.java
@@ -11,7 +11,7 @@ public interface LoginListener {
     // Login Prologue callbacks
     void showEmailLoginScreen();
     void doStartSignup();
-    void loggedInViaSigUp(ArrayList<Integer> oldSitesIds);
+    void loggedInViaSignup(ArrayList<Integer> oldSitesIds);
     void newUserCreatedButErrored(String email, String password);
 
     // Login Email input callbacks

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -53,6 +53,8 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
     private static final String ARG_INPUT_PASSWORD = "ARG_INPUT_PASSWORD";
     private static final String ARG_IS_WPCOM = "ARG_IS_WPCOM";
 
+    private static final String FORGOT_PASSWORD_URL_WPCOM = "https://wordpress.com/";
+
     public static final String TAG = "login_username_password_fragment_tag";
 
     private ScrollView mScrollView;
@@ -67,6 +69,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
     ArrayList<Integer> mOldSitesIDs;
 
     private String mInputSiteAddress;
+    private String mInputSiteAddressWithoutSuffix;
     private String mEndpointAddress;
     private String mSiteName;
     private String mSiteIconUrl;
@@ -125,6 +128,8 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         siteAddressView.setText(UrlUtils.removeScheme(UrlUtils.removeXmlrpcSuffix(mInputSiteAddress)));
         siteAddressView.setVisibility(mInputSiteAddress != null ? View.VISIBLE : View.GONE);
 
+        mInputSiteAddressWithoutSuffix = UrlUtils.removeXmlrpcSuffix(mEndpointAddress);
+
         mUsernameInput = (WPLoginInputRow) rootView.findViewById(R.id.login_username_row);
         mUsernameInput.setText(mInputUsername);
         mUsernameInput.addTextChangedListener(this);
@@ -150,7 +155,11 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
             @Override
             public void onClick(View v) {
                 if (mLoginListener != null) {
-                    mLoginListener.forgotPassword("");
+                    if (mIsWpcom) {
+                        mLoginListener.forgotPassword(FORGOT_PASSWORD_URL_WPCOM);
+                    } else {
+                        mLoginListener.forgotPassword(mInputSiteAddressWithoutSuffix);
+                    }
                 }
             }
         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -150,7 +150,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
             @Override
             public void onClick(View v) {
                 if (mLoginListener != null) {
-                    mLoginListener.forgotPassword();
+                    mLoginListener.forgotPassword("");
                 }
             }
         });


### PR DESCRIPTION
### Fix
Added self-hosted site condition such that the lost password link directs to `[self-hosted site]wp-login.php?action=lostpassword` rather than `https://wordpress.com/wp-login.php?action=lostpassword` when applicable as described in
 https://github.com/wordpress-mobile/WordPress-Android/issues/6488.

### Test
0. Clear app data.
1. Tap ***Log In*** button.
2. Tap ***Log in to your site by entering your site address instead.*** link.
3. Enter self-hosted site address.
4. Tap ***Next*** button.
5. Tap ***Lost your password?*** link.
6. Notice `[self-hosted site]wp-login.php?action=lostpassword` site displayed.
7. Tap back button twice.
8. Enter WordPress.com site address.
9. Tap ***Next*** button.
10. Tap ***Lost your password?*** link.
11. Notice `https://wordpress.com/wp-login.php?action=lostpassword` site displayed.