### PR TITLE
Better handling of CategoryNode comparisons to handle potential null strings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/CategoryNode.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/CategoryNode.java
@@ -86,14 +86,17 @@ public class CategoryNode {
         }
 
         // Second pass associate nodes to form a tree
-        for(int i = 0; i < categoryMap.size(); i++){
+        for (int i = 0; i < categoryMap.size(); i++){
             CategoryNode category = categoryMap.valueAt(i);
             if (category.getParentId() == 0) { // root node
                 currentRootNode = rootCategory;
             } else {
                 currentRootNode = categoryMap.get(category.getParentId(), rootCategory);
             }
-            currentRootNode.children.put(category.getName(), categoryMap.get(category.getCategoryId()));
+            CategoryNode childNode = categoryMap.get(category.getCategoryId());
+            if (childNode != null) {
+                currentRootNode.children.put(category.getName(), childNode);
+            }
         }
         return rootCategory;
     }

--- a/WordPress/src/main/java/org/wordpress/android/models/CategoryNode.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/CategoryNode.java
@@ -18,6 +18,14 @@ public class CategoryNode {
     private SortedMap<String, CategoryNode> children = new TreeMap<>(new Comparator<String>() {
         @Override
         public int compare(String s, String s2) {
+            if (s == null) {
+                if (s2 == null) {
+                    return 0;
+                }
+                return 1;
+            } else if (s2 == null) {
+                return -1;
+            }
             return s.compareToIgnoreCase(s2);
         }
     });


### PR DESCRIPTION
Fixes #6493 by adding null checks to the `CategoryNode` comparator. Null values are also filtered out in `createCategoryTreeFromList` as an extra preventative measure.