### PR TITLE
Fix/save post after appending media item

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1824,7 +1824,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // after asking the Editor to append the Media File, save the Post object to the DB
         // as we need to keep the new modifications made to the Post's body (that is, the inserted media)
         if (updatePostObject()) {
-            mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(mPost));
+            savePostToDb();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1823,9 +1823,7 @@ public class EditPostActivity extends AppCompatActivity implements
         mEditorFragment.appendMediaFile(mediaFile, imageUrl, mImageLoader);
         // after asking the Editor to append the Media File, save the Post object to the DB
         // as we need to keep the new modifications made to the Post's body (that is, the inserted media)
-        if (updatePostObject()) {
-            savePostToDb();
-        }
+        savePostAsync(null);
     }
 
     private boolean addMediaLegacyEditor(Uri mediaUri, boolean isVideo) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1458,7 +1458,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             // clear overlay
             content.clearOverlays(predicate);
             content.updateElementAttributes(predicate, attrs);
-            content.resetAttributedMediaSpan(predicate);
             content.refreshText();
 
             // re-set the post content
@@ -1488,7 +1487,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             attributesWithClass.addClass(ATTR_STATUS_FAILED);
 
             content.updateElementAttributes(predicate, attributesWithClass.getAttributes());
-            content.resetAttributedMediaSpan(predicate);
             content.refreshText();
 
             // re-set the post content

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -824,6 +824,9 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 AttributesWithClass attributesWithClass = new AttributesWithClass(
                         content.getElementAttributes(predicate));
                 attributesWithClass.removeClass(ATTR_STATUS_UPLOADING);
+                if (mediaFile.isVideo()) {
+                    attributesWithClass.removeClass(TEMP_VIDEO_UPLOADING_CLASS);
+                }
 
                 // add then new src property with the remoteUrl
                 AztecAttributes attrs = attributesWithClass.getAttributes();
@@ -1455,6 +1458,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             // clear overlay
             content.clearOverlays(predicate);
             content.updateElementAttributes(predicate, attrs);
+            content.resetAttributedMediaSpan(predicate);
             content.refreshText();
 
             // re-set the post content
@@ -1484,6 +1488,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             attributesWithClass.addClass(ATTR_STATUS_FAILED);
 
             content.updateElementAttributes(predicate, attributesWithClass.getAttributes());
+            content.resetAttributedMediaSpan(predicate);
             content.refreshText();
 
             // re-set the post content


### PR DESCRIPTION
This PR saves the post to FluxC right when a new media item is included in it, so to avoid more chances to lose the data while the media is uploaded but the Editor 

To test:
1. start a new draft
2. include some media item (or even a series of items you carefully selected from your phone)
3. stop the app
4. edit the post again
5. observe the media items are still there

cc @nbradbury 
