### PR TITLE
Return default category ID that is consistent with WP Uncategorized

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -152,7 +152,7 @@ public abstract class SiteSettingsInterface {
      * Gets the default category value stored in {@link SharedPreferences}, 0 by default.
      */
     public static int getDefaultCategory(Context context) {
-        return siteSettingsPreferences(context).getInt(DEF_CATEGORY_PREF_KEY, 0);
+        return siteSettingsPreferences(context).getInt(DEF_CATEGORY_PREF_KEY, 1);
     }
 
     /**


### PR DESCRIPTION
Something in the 7.9 release causes a post upload error on self-hosted sites. For some reason posts always have a `0` category ID which is unrecognized by WordPress so it kicks back an error.

To test:
* Sign into self-hosted site with self-hosted credentials
* Create a new post and publish it
* Make sure .com works as well

cc @mzorz 