### PR TITLE
Recover from inconsistent QUEUED/UPLOADING states

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -141,6 +141,25 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
         return mediaList;
     }
 
+    static boolean isPendingOrInProgressMediaUpload(MediaModel media) {
+        synchronized (sInProgressUploads) {
+            for (MediaModel uploadingMedia : sInProgressUploads) {
+                if (uploadingMedia.getId() == media.getId()) {
+                    return true;
+                }
+            }
+        }
+
+        synchronized (sPendingUploads) {
+            for (MediaModel queuedMedia : sPendingUploads) {
+                if (queuedMedia.getId() == media.getId()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     /**
      * Returns the last recorded progress value for the given {@param media}. If there is no record for that media,
      * it's assumed to be a completed upload.

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -430,6 +430,10 @@ public class UploadService extends Service {
         return Collections.emptyList();
     }
 
+    public static boolean isPendingOrInProgressMediaUpload(MediaModel media) {
+        return MediaUploadHandler.isPendingOrInProgressMediaUpload(media);
+    }
+
     private void showNotificationForPostWithPendingMedia(PostModel post) {
         mPostUploadNotifier.showForegroundNotificationForPost(post, getString(R.string.uploading_post_media));
     }


### PR DESCRIPTION
Fixes #6516 by checking (only when needed) which media items have a `QUEUED` or `UPLOADING` state in FluxC's MediaStore, but are not being tracked by the UploadService (i.e. they're no really being queued to upload or uploading).

To test:
1. start uploading something (either by including media in a draft or by going to the media library  and adding a new item
2. stop the app (settings-> apps -> WordPress -> force stop)
3. open the app again
4. verify the item shows "RETRY" in the Media library

cc @nbradbury 
