### PR TITLE
Handling deleting uploading media in Aztec - take nbr 2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2346,7 +2346,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // and check for the ones that ARE NOT being uploaded or queued in the UploadService.
         // These are the CANCELED ONES, so mark them FAILED now to retry.
 
-        List <MediaModel> currentlyUploadingMedia = UploadService.getAllInProgressOrQueuedMediaItemsForPost(mPost);
+        List <MediaModel> currentlyUploadingMedia = UploadService.getPendingOrInProgressMediaUploadsForPost(mPost);
         List<String> mediaMarkedUploading  =
                 AztecEditorFragment.getMediaMarkedUploadingInPostContent(EditPostActivity.this, undoedContent);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2362,7 +2362,6 @@ public class EditPostActivity extends AppCompatActivity implements
             }
 
             if (!found) {
-                // 2- Run through loop and set each media to failed
                 if (mEditorFragment instanceof AztecEditorFragment) {
                     ((AztecEditorFragment)mEditorFragment).setMediaToFailed(mediaId);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2346,7 +2346,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // These are the CANCELED ONES, so mark them FAILED now to retry.
 
         List <MediaModel> currentlyUploadingMedia = UploadService.getAllInProgressOrQueuedMediaItemsForPost(mPost);
-        List<String> mediaMarkedUploading  = AztecEditorFragment.getMediaMarkedUploadingInPost(EditPostActivity.this, undoedContent);
+        List<String> mediaMarkedUploading  = AztecEditorFragment.getMediaMarkedUploadingInPostContent(EditPostActivity.this, undoedContent);
 
         // go through the list of items marked UPLOADING within the Post content, and look in the UploadService
         // to see whether they're really being uploaded or not. If an item is not really being uploaded, mark that item failed

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2315,15 +2315,26 @@ public class EditPostActivity extends AppCompatActivity implements
     @Override
     public void onMediaUploadCancelClicked(String localMediaId) {
         if (!TextUtils.isEmpty(localMediaId)) {
-            MediaModel mediaModel = mMediaStore.getMediaWithLocalId(Integer.valueOf(localMediaId));
-            if (mediaModel != null) {
-                CancelMediaPayload payload = new CancelMediaPayload(mSite, mediaModel);
-                mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload));
-            }
+            cancelMediaUpload(StringUtils.stringToInt(localMediaId));
         } else {
             // Passed mediaId is incorrect: cancel all uploads for this post
             ToastUtils.showToast(this, getString(R.string.error_all_media_upload_canceled));
             EventBus.getDefault().post(new PostEvents.PostMediaCanceled(mPost));
+        }
+    }
+
+    @Override
+    public void onMediaDeleted(String localMediaId) {
+        if (!TextUtils.isEmpty(localMediaId)) {
+            cancelMediaUpload(StringUtils.stringToInt(localMediaId));
+        }
+    }
+
+    private void cancelMediaUpload(int localMediaId) {
+        MediaModel mediaModel = mMediaStore.getMediaWithLocalId(Integer.valueOf(localMediaId));
+        if (mediaModel != null) {
+            CancelMediaPayload payload = new CancelMediaPayload(mSite, mediaModel);
+            mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -359,7 +359,7 @@ public class EditPostActivity extends AppCompatActivity implements
         if (mIsNewPost) {
             trackEditorCreatedPost(action, getIntent());
         } else {
-            resetUploadingMediaToFailedIfNotInProgressOrQueued();
+            resetUploadingMediaToFailedIfPostHasNotMediaInProgressOrQueued();
         }
 
         setTitle(StringUtils.unescapeHTML(SiteUtils.getSiteNameOrHomeURL(mSite)));
@@ -409,8 +409,9 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     // this method aims at recovering the current state of media items if they're inconsistent within the PostModel.
-    private void resetUploadingMediaToFailedIfNotInProgressOrQueued() {
+    private void resetUploadingMediaToFailedIfPostHasNotMediaInProgressOrQueued() {
         boolean useAztec = AppPrefs.isAztecEditorEnabled();
+
         if (!useAztec || UploadService.hasPendingOrInProgressMediaUploadsForPost(mPost)) {
             return;
         }
@@ -2336,6 +2337,36 @@ public class EditPostActivity extends AppCompatActivity implements
             CancelMediaPayload payload = new CancelMediaPayload(mSite, mediaModel);
             mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload));
         }
+    }
+
+    @Override
+    public void onUndoMediaCheck(final String undoedContent) {
+        // here we check which elements tagged UPLOADING are there in previousContent,
+        // and check for the ones that ARE NOT being uploaded or queued in the UploadService.
+        // These are the CANCELED ONES, so mark them FAILED now to retry.
+
+        List <MediaModel> currentlyUploadingMedia = UploadService.getAllInProgressOrQueuedMediaItemsForPost(mPost);
+        List<String> mediaMarkedUploading  = AztecEditorFragment.getMediaMarkedUploadingInPost(EditPostActivity.this, undoedContent);
+
+        // go through the list of items marked UPLOADING within the Post content, and look in the UploadService
+        // to see whether they're really being uploaded or not. If an item is not really being uploaded, mark that item failed
+        for (String mediaId : mediaMarkedUploading) {
+            boolean found = false;
+            for (MediaModel media : currentlyUploadingMedia) {
+                if (Integer.valueOf(mediaId) == media.getId()) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found) {
+                // 2- Run through loop and set each media to failed
+                if (mEditorFragment instanceof AztecEditorFragment) {
+                    ((AztecEditorFragment)mEditorFragment).setMediaToFailed(mediaId);
+                }
+            }
+        }
+
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2316,7 +2316,7 @@ public class EditPostActivity extends AppCompatActivity implements
     @Override
     public void onMediaUploadCancelClicked(String localMediaId) {
         if (!TextUtils.isEmpty(localMediaId)) {
-            cancelMediaUpload(StringUtils.stringToInt(localMediaId));
+            cancelMediaUpload(StringUtils.stringToInt(localMediaId), true);
         } else {
             // Passed mediaId is incorrect: cancel all uploads for this post
             ToastUtils.showToast(this, getString(R.string.error_all_media_upload_canceled));
@@ -2327,14 +2327,15 @@ public class EditPostActivity extends AppCompatActivity implements
     @Override
     public void onMediaDeleted(String localMediaId) {
         if (!TextUtils.isEmpty(localMediaId)) {
-            cancelMediaUpload(StringUtils.stringToInt(localMediaId));
+            // passing false here as we need to keep the media item in case the user wants to undo
+            cancelMediaUpload(StringUtils.stringToInt(localMediaId), false);
         }
     }
 
-    private void cancelMediaUpload(int localMediaId) {
+    private void cancelMediaUpload(int localMediaId, boolean delete) {
         MediaModel mediaModel = mMediaStore.getMediaWithLocalId(Integer.valueOf(localMediaId));
         if (mediaModel != null) {
-            CancelMediaPayload payload = new CancelMediaPayload(mSite, mediaModel);
+            CancelMediaPayload payload = new CancelMediaPayload(mSite, mediaModel, delete);
             mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload));
         }
     }
@@ -2346,7 +2347,8 @@ public class EditPostActivity extends AppCompatActivity implements
         // These are the CANCELED ONES, so mark them FAILED now to retry.
 
         List <MediaModel> currentlyUploadingMedia = UploadService.getAllInProgressOrQueuedMediaItemsForPost(mPost);
-        List<String> mediaMarkedUploading  = AztecEditorFragment.getMediaMarkedUploadingInPostContent(EditPostActivity.this, undoedContent);
+        List<String> mediaMarkedUploading  =
+                AztecEditorFragment.getMediaMarkedUploadingInPostContent(EditPostActivity.this, undoedContent);
 
         // go through the list of items marked UPLOADING within the Post content, and look in the UploadService
         // to see whether they're really being uploaded or not. If an item is not really being uploaded, mark that item failed

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2341,7 +2341,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
     @Override
     public void onUndoMediaCheck(final String undoedContent) {
-        // here we check which elements tagged UPLOADING are there in previousContent,
+        // here we check which elements tagged UPLOADING are there in undoedContent,
         // and check for the ones that ARE NOT being uploaded or queued in the UploadService.
         // These are the CANCELED ONES, so mark them FAILED now to retry.
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2355,7 +2355,7 @@ public class EditPostActivity extends AppCompatActivity implements
         for (String mediaId : mediaMarkedUploading) {
             boolean found = false;
             for (MediaModel media : currentlyUploadingMedia) {
-                if (Integer.valueOf(mediaId) == media.getId()) {
+                if (StringUtils.stringToInt(mediaId) == media.getId()) {
                     found = true;
                     break;
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -403,7 +403,7 @@ public class UploadService extends Service {
         return error != null && error.mediaError != null;
     }
 
-    public static List<MediaModel> getAllInProgressOrQueuedMediaItemsForPost(PostModel post){
+    public static List<MediaModel> getPendingOrInProgressMediaUploadsForPost(PostModel post){
         return MediaUploadHandler.getPendingOrInProgressMediaUploadsForPost(post);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -403,6 +403,10 @@ public class UploadService extends Service {
         return error != null && error.mediaError != null;
     }
 
+    public static List<MediaModel> getAllInProgressOrQueuedMediaItemsForPost(PostModel post){
+        return MediaUploadHandler.getPendingOrInProgressMediaUploadsForPost(post);
+    }
+
     public static float getMediaUploadProgressForPost(PostModel postModel) {
         if (postModel == null) {
             return 0;

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -51,8 +51,6 @@ dependencies {
     compile 'com.android.support:design:25.3.1'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.16.0'
-//    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:ce388e4c55e345bb10156329486edd378eb223bb')
-//    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:ce388e4c55e345bb10156329486edd378eb223bb')
     compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:9c5481e04e20cd23b906d5bd766fce1c3f05a21d')
     compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:9c5481e04e20cd23b906d5bd766fce1c3f05a21d')
         {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -51,8 +51,10 @@ dependencies {
     compile 'com.android.support:design:25.3.1'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.16.0'
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:ce388e4c55e345bb10156329486edd378eb223bb')
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:ce388e4c55e345bb10156329486edd378eb223bb')
+//    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:ce388e4c55e345bb10156329486edd378eb223bb')
+//    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:ce388e4c55e345bb10156329486edd378eb223bb')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:9c5481e04e20cd23b906d5bd766fce1c3f05a21d')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:9c5481e04e20cd23b906d5bd766fce1c3f05a21d')
         {
             exclude module: 'aztec'
         }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -81,6 +81,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         AztecText.OnImeBackListener,
         AztecText.OnImageTappedListener,
         AztecText.OnVideoTappedListener,
+        AztecText.OnMediaDeletedListener,
         EditorMediaUploadListener,
         IAztecToolbarClickListener,
         IHistoryListener {
@@ -215,6 +216,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 .setHistoryListener(this)
                 .setOnImageTappedListener(this)
                 .setOnVideoTappedListener(this)
+                .setOnMediaDeletedListener(this)
                 .addPlugin(new WordPressCommentsPlugin(content))
                 .addPlugin(new MoreToolbarButton(content));
 
@@ -852,6 +854,14 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
                 mUploadingMediaProgressMax.remove(localMediaId);
             }
+        }
+    }
+
+    @Override
+    public void onMediaDeleted(AztecAttributes aztecAttributes) {
+        String localMediaId = aztecAttributes.getValue(ATTR_ID_WP);
+        if (!TextUtils.isEmpty(localMediaId)) {
+            mEditorFragmentListener.onMediaDeleted(localMediaId);
         }
     }
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1559,7 +1559,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         return postContent;
     }
 
-    public static List<String> getMediaMarkedUploadingInPost(Context context, @NonNull String postContent) {
+    public static List<String> getMediaMarkedUploadingInPostContent(Context context, @NonNull String postContent) {
         ArrayList<String> mediaMarkedUploading = new ArrayList<>();
         // fill in Aztec with the post's content
         AztecText content = new AztecText(context);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -175,6 +175,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
         void onAddMediaClicked();
         void onMediaRetryClicked(String mediaId);
         void onMediaUploadCancelClicked(String mediaId);
+        void onMediaDeleted(String mediaId);
         void onFeaturedImageChanged(long mediaId);
         void onVideoPressInfoRequested(String videoId);
         String onAuthHeaderRequested(String url);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -176,6 +176,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
         void onMediaRetryClicked(String mediaId);
         void onMediaUploadCancelClicked(String mediaId);
         void onMediaDeleted(String mediaId);
+        void onUndoMediaCheck(String undoedContent);
         void onFeaturedImageChanged(long mediaId);
         void onVideoPressInfoRequested(String videoId);
         String onAuthHeaderRequested(String url);


### PR DESCRIPTION
Superseedes #6513 
This PR is better than #6513 in that it approaches triggering and actions in the same way as `onMediaUploadCancelClicked` by having [both call `cancelMediaUpload`](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/6456-upload-cancel-on-media-deleted-aztec-take-2/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L2317-L2333) 

Thanks @aforcier for bringing my attention to this - tested both the old and the new branch and they behave pretty much the same, while this solution is much simpler and adds less code (and less likely to introduce new bugs)

All the relevant comments from the former PR have bee taken into account and/or cherry-picked in this PR as well @nbradbury 


=========================
Fixes #6456 

This PR takes care of 2 situations:
- when a user deletes one or more media items within Aztec, [now Aztec triggers an event](https://github.com/wordpress-mobile/AztecEditor-Android/pull/461) through the `OnMediaDeletedListener` interface that is being listened to by `AztecEditorFragment` within WPAndroid. This in turn calls the host of such fragment, `EditPostActivity`, which takes care of notifying the `UploadService` of such a thing, which in turn takes care of cancelling the upload as it's not needed anymore.

- this comes with one other situation that can come up from this, and it's the user can go back and `undo` this on Aztec, so you end up having the same media item again, but now the upload for such an item has been stopped (and wiped out from the UploadService altogether). The `EditorFragmentListener` now has a new method, `onUndoMediaCheck()`, where the implementation checks for those media items that are in the new Post content (_undoed_ content) marked with the `UPLOADING` class attribute but are not there in the `UploadService`. These are marked as `FAILED` so they can be retried by the user.

To test:
1. start a new draft
2. insert a media item - preferrably something big so you're able to test an in-progress upload cancelation.
3. while the media item is being uploaded, place the cursor to its right (or after it), and hit backspace to delete it
4. observe the upload is stopped
5. tap on the UNDO button
6. observe the media item appears again, now with the "failed"  overlay
7. Tap on it to start the upload again, as normal

Test this also with variants such as: exiting the editor in the middle of an upload (so the upoading notification is triggered) and coming back in again, or inserting several media items mixed with text, selecting them all and deleting it, check how the Posts list behaves, etc.
Maybe even test we haven't broken anything in the Visual Editor as well (as this should only work with Aztec)

cc @nbradbury  