### PR TITLE
Recover from inconsistent QUEUED/UPLOADING states - take 2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -47,6 +47,7 @@ import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.persistence.WellSqlConfig;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.OnAccountChanged;
+import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
 import org.wordpress.android.fluxc.utils.ErrorUtils.OnUnexpectedError;
@@ -64,6 +65,7 @@ import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.stats.StatsWidgetProvider;
 import org.wordpress.android.ui.stats.datasets.StatsDatabaseHelper;
 import org.wordpress.android.ui.stats.datasets.StatsTable;
+import org.wordpress.android.ui.uploads.UploadService;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.AppLogListener;
@@ -121,6 +123,8 @@ public class WordPress extends MultiDexApplication {
     @Inject Dispatcher mDispatcher;
     @Inject AccountStore mAccountStore;
     @Inject SiteStore mSiteStore;
+    @Inject MediaStore mMediaStore;
+
 
     @Inject @Named("custom-ssl") RequestQueue mRequestQueue;
     public static RequestQueue sRequestQueue;
@@ -664,6 +668,14 @@ public class WordPress extends MultiDexApplication {
             }
         }
 
+        private void sanitizeMediaUploadStateForSite() {
+            int siteLocalId = AppPrefs.getSelectedSite();
+            SiteModel selectedSite = mSiteStore.getSiteByLocalId(siteLocalId);
+            if (selectedSite != null) {
+                UploadService.sanitizeMediaUploadStateForSite(mMediaStore, mDispatcher, selectedSite);
+            }
+        }
+
         /**
          * The two methods below (startActivityTransitionTimer and stopActivityTransitionTimer)
          * are used to track when the app goes to background.
@@ -759,6 +771,9 @@ public class WordPress extends MultiDexApplication {
                         NotificationsUpdateService.startService(getContext());
                     }
                 }
+
+                // verify media is sanitized
+                sanitizeMediaUploadStateForSite();
 
                 // Rate limited PN Token Update
                 updatePushNotificationTokenIfNotLimited();

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -141,6 +141,25 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
         return mediaList;
     }
 
+    static boolean isPendingOrInProgressMediaUpload(MediaModel media) {
+        synchronized (sInProgressUploads) {
+            for (MediaModel uploadingMedia : sInProgressUploads) {
+                if (uploadingMedia.getId() == media.getId()) {
+                    return true;
+                }
+            }
+        }
+
+        synchronized (sPendingUploads) {
+            for (MediaModel queuedMedia : sPendingUploads) {
+                if (queuedMedia.getId() == media.getId()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     /**
      * Returns the last recorded progress value for the given {@param media}. If there is no record for that media,
      * it's assumed to be a completed upload.

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -141,7 +141,7 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
         return mediaList;
     }
 
-    static boolean isPendingOrInProgressMediaUpload(MediaModel media) {
+    static boolean isPendingOrInProgressMediaUpload(@NonNull MediaModel media) {
         synchronized (sInProgressUploads) {
             for (MediaModel uploadingMedia : sInProgressUploads) {
                 if (uploadingMedia.getId() == media.getId()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -435,7 +435,7 @@ public class UploadService extends Service {
         return Collections.emptyList();
     }
 
-    public static boolean isPendingOrInProgressMediaUpload(MediaModel media) {
+    public static boolean isPendingOrInProgressMediaUpload(@NonNull MediaModel media) {
         return MediaUploadHandler.isPendingOrInProgressMediaUpload(media);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -439,10 +439,11 @@ public class UploadService extends Service {
         return MediaUploadHandler.isPendingOrInProgressMediaUpload(media);
     }
 
-    /*
-        rechecks all media in the MediaStore marked UPLOADING/QUEUED against the UploadingService to see
-        if it's actually uploading or queued and change it accordingly, to recover from an inconsistent state
-    */
+
+    /**
+     * Rechecks all media in the MediaStore marked UPLOADING/QUEUED against the UploadingService to see
+     * if it's actually uploading or queued and change it accordingly, to recover from an inconsistent state
+     */
     public static void sanitizeMediaUploadStateForSite(@NonNull MediaStore mediaStore, @NonNull Dispatcher dispatcher,
                                                        @NonNull SiteModel site) {
         List<MediaModel> uploadingMedia =

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -11,6 +11,7 @@ import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.PostModel;
@@ -432,6 +433,33 @@ public class UploadService extends Service {
             }
         }
         return Collections.emptyList();
+    }
+
+    public static boolean isPendingOrInProgressMediaUpload(MediaModel media) {
+        return MediaUploadHandler.isPendingOrInProgressMediaUpload(media);
+    }
+
+    /*
+        rechecks all media in the MediaStore marked UPLOADING/QUEUED against the UploadingService to see
+        if it's actually uploading or queued and change it accordingly, to recover from an inconsistent state
+    */
+    public static void sanitizeMediaUploadStateForSite(@NonNull MediaStore mediaStore, @NonNull Dispatcher dispatcher,
+                                                       @NonNull SiteModel site) {
+        List<MediaModel> uploadingMedia =
+                mediaStore.getSiteMediaWithState(site, MediaModel.MediaUploadState.UPLOADING);
+        List<MediaModel> queuedMedia =
+                mediaStore.getSiteMediaWithState(site, MediaModel.MediaUploadState.QUEUED);
+        List<MediaModel> uploadingOrQueuedMedia = new ArrayList<>();
+        uploadingOrQueuedMedia.addAll(uploadingMedia);
+        uploadingOrQueuedMedia.addAll(queuedMedia);
+
+        for (final MediaModel media : uploadingOrQueuedMedia) {
+            if (!UploadService.isPendingOrInProgressMediaUpload(media)) {
+                // it is NOT being uploaded or queued in the actual UploadService, mark it failed
+                media.setUploadState(MediaModel.MediaUploadState.FAILED);
+                dispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));
+            }
+        }
     }
 
     private void showNotificationForPostWithPendingMedia(PostModel post) {


### PR DESCRIPTION
Fixes #6516 by checking which media items have a `QUEUED` or `UPLOADING` state in FluxC's MediaStore, but are not being tracked by the UploadService (i.e. they're no really being queued to upload or uploading).

To test:
1. start uploading something (either by including media in a draft or by going to the media library  and adding a new item
2. stop the app (settings-> apps -> WordPress -> force stop)
3. open the app again
4. verify the item shows "RETRY" in the Media library

cc @aforcier  
