### PR TITLE
Media: async upload media library grid item update

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -578,6 +578,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     public void onRetryUpload(int localMediaId) {
         MediaModel media = mMediaStore.getMediaWithLocalId(localMediaId);
         if (media == null) {
+            ToastUtils.showToast(this, R.string.file_not_found, ToastUtils.Duration.SHORT);
             return;
         }
         addMediaToUploadService(media);
@@ -900,7 +901,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         // Start the upload service if it's not started and fill the media queue
         if (!NetworkUtils.isNetworkAvailable(this)) {
             AppLog.v(AppLog.T.MEDIA, "Unable to start UploadService, internet connection required.");
-            return;
+            ToastUtils.showToast(this, R.string.no_network_message, ToastUtils.Duration.SHORT);
         }
 
         ArrayList<MediaModel> mediaList = new ArrayList<>();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -902,6 +902,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         if (!NetworkUtils.isNetworkAvailable(this)) {
             AppLog.v(AppLog.T.MEDIA, "Unable to start UploadService, internet connection required.");
             ToastUtils.showToast(this, R.string.no_network_message, ToastUtils.Duration.SHORT);
+            return;
         }
 
         ArrayList<MediaModel> mediaList = new ArrayList<>();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -619,7 +619,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         }
 
         if (event.mediaList != null && event.mediaList.size() == 1) {
-            updateMediaGridItem(event.mediaList.get(0));
+            updateMediaGridItem(event.mediaList.get(0), true);
         } else {
             reloadMediaGrid();
         }
@@ -646,7 +646,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         }
 
         if (event.media != null) {
-            updateMediaGridItem(event.media);
+            updateMediaGridItem(event.media, event.isError());
         } else {
             reloadMediaGrid();
         }
@@ -953,7 +953,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));
         addMediaToUploadService(media);
 
-        updateMediaGridItem(media);
+        updateMediaGridItem(media, false);
     }
 
     private void handleSharedMedia() {
@@ -1000,10 +1000,10 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         }
     }
 
-    private void updateMediaGridItem(@NonNull MediaModel media) {
+    private void updateMediaGridItem(@NonNull MediaModel media, boolean forceUpdate) {
         if (mMediaGridFragment != null) {
             if (mMediaStore.getMediaWithLocalId(media.getId()) != null) {
-                mMediaGridFragment.updateMediaItem(media);
+                mMediaGridFragment.updateMediaItem(media, forceUpdate);
             } else {
                 mMediaGridFragment.removeMediaItem(media);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -578,9 +578,9 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         return "";
     }
 
-    void updateMediaItem(@NonNull MediaModel media) {
+    void updateMediaItem(@NonNull MediaModel media, boolean forceUpdate) {
         int index = indexOfMedia(media);
-        if (index > -1 && !media.equals(mMediaList.get(index))) {
+        if (index > -1 && (forceUpdate || !media.equals(mMediaList.get(index)))) {
             mMediaList.set(index, media);
             notifyItemChanged(index);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -365,8 +365,6 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                         MediaModel media = mMediaList.get(position);
                         MediaUploadState state = MediaUploadState.fromString(media.getUploadState());
                         if (state == MediaUploadState.FAILED) {
-                            stateTextView.setText(R.string.media_upload_state_queued);
-                            stateTextView.setCompoundDrawables(null, null, null, null);
                             if (mCallback != null) {
                                 mCallback.onAdapterRetryUpload(media.getId());
                             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -430,11 +430,11 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
      * update just the passed media item - if it doesn't exist it may be because
      * it was just added, so reload the adapter
      */
-    void updateMediaItem(@NonNull MediaModel media) {
+    void updateMediaItem(@NonNull MediaModel media, boolean forceUpdate) {
         if (!isAdded() || !hasAdapter()) return;
 
         if (getAdapter().mediaExists(media)) {
-            getAdapter().updateMediaItem(media);
+            getAdapter().updateMediaItem(media, forceUpdate);
         } else {
             reload();
         }


### PR DESCRIPTION
Fixes #6518 

The problem is that in `MediaGridAdapter` we check for item equality before actually attempting to update an item in the list. That happens in `updateMediaItem`  through the `equals` method implemented in FluxC for a given `MediaModel`, which checks for 2 items being equal by means of being the very same object or having all the same property values.
When an upload is in progress, FluxC reuses the same media object with each new `onMediaUploaded` event, thus it changes the status but the object reference remains the same, and so it doesn’t end up refreshing the item in the adapter (because comparing an object to itself returns `true` for the `equals()`  implementation).

That specifically is addressed by commit 5b1de02, by adding a flag to force an item update in the grid adapter, so when we have an error event in `onMediaUploaded` or we have a change in a `MediaModel` as reported by `OnMediaChanged`, we force the item to be updated.

I decided to add this flag instead of [removing the `==` equality in FluxC ](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/develop/fluxc/src/main/java/org/wordpress/android/fluxc/model/MediaModel.java#L93)because a) it is true this is only an exception to the general rule that "if an item doesn't change we don't need to update it" and b) the `equals` implementation in FluxC seems right to me, and it is only in this particular context where we need to make sure changes to the _same_  object are reflected on the screen.

In commit f0aa65a we also add a couple of Toasts to signal the user _why_  we can't retry if they tap on retry while they still lack a a connection in place.


To test:

1. go to the media library
2. start uploading a media item
3. turn airplane mode ON
4. see it shows a toast “connectivity lost”
5. also observe with this PR the item says "RETRY" instead of being  stuck at “UPLOADING”.

cc @aforcier 