### PR TITLE
Aztec v1.0-beta.7

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -56,6 +56,10 @@ dependencies {
             {
                 exclude module: 'aztec'
             }
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:v1.0-beta.7')
+            {
+                exclude module: 'aztec'
+            }
 }
 
 signing {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -51,11 +51,11 @@ dependencies {
     compile 'com.android.support:design:25.3.1'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.16.0'
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:9c5481e04e20cd23b906d5bd766fce1c3f05a21d')
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:9c5481e04e20cd23b906d5bd766fce1c3f05a21d')
-        {
-            exclude module: 'aztec'
-        }
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.0-beta.7')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.0-beta.7')
+            {
+                exclude module: 'aztec'
+            }
 }
 
 signing {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -60,6 +60,10 @@ import org.wordpress.aztec.AztecTextFormat;
 import org.wordpress.aztec.Html;
 import org.wordpress.aztec.IHistoryListener;
 import org.wordpress.aztec.ITextFormat;
+import org.wordpress.aztec.plugins.shortcodes.AudioShortcodePlugin;
+import org.wordpress.aztec.plugins.shortcodes.CaptionShortcodePlugin;
+import org.wordpress.aztec.plugins.shortcodes.VideoShortcodePlugin;
+import org.wordpress.aztec.plugins.shortcodes.handlers.CaptionHandler;
 import org.wordpress.aztec.plugins.wpcomments.CommentsTextFormat;
 import org.wordpress.aztec.plugins.wpcomments.WordPressCommentsPlugin;
 import org.wordpress.aztec.plugins.wpcomments.toolbar.MoreToolbarButton;
@@ -67,6 +71,7 @@ import org.wordpress.aztec.source.SourceViewEditText;
 import org.wordpress.aztec.spans.AztecMediaSpan;
 import org.wordpress.aztec.toolbar.AztecToolbar;
 import org.wordpress.aztec.toolbar.IAztecToolbarClickListener;
+import org.wordpress.aztec.watchers.BlockElementWatcher;
 import org.xml.sax.Attributes;
 
 import java.util.ArrayList;
@@ -218,7 +223,14 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 .setOnVideoTappedListener(this)
                 .setOnMediaDeletedListener(this)
                 .addPlugin(new WordPressCommentsPlugin(content))
-                .addPlugin(new MoreToolbarButton(content));
+                .addPlugin(new MoreToolbarButton(content))
+                .addPlugin(new CaptionShortcodePlugin())
+                .addPlugin(new VideoShortcodePlugin())
+                .addPlugin(new AudioShortcodePlugin());
+
+        new BlockElementWatcher(content)
+                .add(new CaptionHandler())
+                .install(content);
 
         mEditorFragmentListener.onEditorFragmentInitialized();
 


### PR DESCRIPTION
Integrates the new Aztec release version [1.0-beta.7](https://github.com/wordpress-mobile/AztecEditor-Android/releases/tag/v1.0-beta.7).