### PR TITLE
Async media: Fix NPE in UploadService.onMediaUploaded()

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -652,7 +652,9 @@ public class UploadService extends Service {
                 // now keep track of the error reason so it can be queried
                 UploadError reason = new UploadError(event.error);
                 PostModel failedPost = mPostStore.getPostByLocalPostId(event.media.getLocalPostId());
-                addUploadErrorToFailedPosts(failedPost, reason);
+                if (failedPost != null) {
+                    addUploadErrorToFailedPosts(failedPost, reason);
+                }
             }
             stopServiceIfUploadsComplete();
             return;


### PR DESCRIPTION
Fixes #6529. Under some circumstances, we might get an error for a media item attached to a post that has already been deleted.

Note: This will be handled a bit more neatly with `UploadStore`, which will take care of registering errors for posts in FluxC, and we won't have to manually track it in the `UploadService`.

cc @mzorz