### PR TITLE
Check that a Postmodel exists before attempting to update it

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -562,11 +562,16 @@ public class UploadService extends Service {
                 // For each post with completed media uploads, update the content with the new remote URLs
                 // This is done in a batch when all media is complete to prevent conflicts by updating separate images
                 // at a time simultaneously for the same post
-                PostModel updatedPost = updatePostWithCurrentlyCompletedUploads(mPostStore.getPostByLocalPostId(postId));
-                // also do the same now with failed uploads
-                updatedPost = updatePostWithCurrentlyFailedUploads(updatedPost);
-                // finally, save the PostModel
-                mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(updatedPost));
+                PostModel post  = mPostStore.getPostByLocalPostId(postId);
+                if (post != null) {
+                    PostModel updatedPost = updatePostWithCurrentlyCompletedUploads(post);
+                    // also do the same now with failed uploads
+                    updatedPost = updatePostWithCurrentlyFailedUploads(updatedPost);
+                    // finally, save the PostModel
+                    if (updatedPost != null) {
+                        mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(updatedPost));
+                    }
+                }
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -705,17 +705,22 @@ public class UploadService extends Service {
                                 // Fetch latest version of the post, in case it has been modified elsewhere
                                 PostModel latestPost = mPostStore.getPostByLocalPostId(uploadingPost.postModel.getId());
 
-                                // Replace local with remote media in the post content
-                                PostModel updatedPost = updatePostWithCurrentlyCompletedUploads(latestPost);
-                                // also do the same now with failed uploads
-                                updatedPost = updatePostWithCurrentlyFailedUploads(updatedPost);
-                                // finally, save the PostModel
-                                mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(updatedPost));
+                                if (latestPost != null) {
+                                    // Replace local with remote media in the post content
+                                    PostModel updatedPost = updatePostWithCurrentlyCompletedUploads(latestPost);
+                                    // also do the same now with failed uploads
+                                    updatedPost = updatePostWithCurrentlyFailedUploads(updatedPost);
+                                    // finally, save the PostModel
+                                    if (updatedPost != null) {
+                                        mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(updatedPost));
+                                        mPostUploadHandler.upload(updatedPost);
+                                    }
+                                }
+
 
                                 // TODO Should do some extra validation here
                                 // e.g. what if the post has local media URLs but no pending media uploads?
                                 iterator.remove();
-                                mPostUploadHandler.upload(updatedPost);
                             }
                         }
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -713,13 +713,11 @@ public class UploadService extends Service {
                                     // finally, save the PostModel
                                     if (updatedPost != null) {
                                         mDispatcher.dispatch(PostActionBuilder.newUpdatePostAction(updatedPost));
+                                        // TODO Should do some extra validation here
+                                        // e.g. what if the post has local media URLs but no pending media uploads?
                                         mPostUploadHandler.upload(updatedPost);
                                     }
                                 }
-
-
-                                // TODO Should do some extra validation here
-                                // e.g. what if the post has local media URLs but no pending media uploads?
                                 iterator.remove();
                             }
                         }


### PR DESCRIPTION
Fixes #6530 

To test:
1. start a new draft, put lots of images in there (big, 2mb images, at lest 6 or 8 of them) by using the multiple selector in the media picker
2. exit the editor
3. in the posts list, tap on `DELETE/TRASH` button
4. see the snackbar appear, wait until it disappears: if the app doesn't crash, it means this worked :)

cc @aforcier 