### PR TITLE
issue/6527-post-list-wrong-featured-image

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -347,6 +347,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             Bitmap bmp = ImageUtils.getWPImageSpanThumbnailFromFilePath(
                     imgFeatured.getContext(), imageUrl, mPhotonWidth);
             if (bmp != null) {
+                imgFeatured.setImageUrl(null, WPNetworkImageView.ImageType.NONE);
                 imgFeatured.setVisibility(View.VISIBLE);
                 imgFeatured.setImageBitmap(bmp);
             } else {


### PR DESCRIPTION
Fixes #6527 - the original problem was caused by the way WPNetworkImageView works. It's designed to show network images, but in this situation we were calling `setImageBitmap()` to set the image to a local bitmap. When we do this, we must first nullify the WPNetworkImageView's URL and set the imageType to `ImageType.NONE` to prevent it from loading the previously set image URL.
