### PR TITLE
Using Aztec with plugins in async media uploads Post processing

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -51,12 +51,12 @@ dependencies {
     compile 'com.android.support:design:25.3.1'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.16.0'
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.0-beta.7')
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.0-beta.7')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:feature~add-headless-factory-method-SNAPSHOT')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:feature~add-headless-factory-method-SNAPSHOT')
             {
                 exclude module: 'aztec'
             }
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:v1.0-beta.7')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:feature~add-headless-factory-method-SNAPSHOT')
             {
                 exclude module: 'aztec'
             }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1650,49 +1650,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     private static AztecText getAztecTextWithPlugins(Context context) {
         AztecText content = new AztecText(context);
-        SourceViewEditText mockSource = new SourceViewEditText(context);
-        AztecToolbar mockFormattingToolbar = new AztecToolbar(context);
-
-        IAztecToolbarClickListener mockListener = new IAztecToolbarClickListener() {
-            @Override
-            public void onToolbarCollapseButtonClicked() {
-                // no op
-            }
-
-            @Override
-            public void onToolbarExpandButtonClicked() {
-                // no op
-            }
-
-            @Override
-            public void onToolbarFormatButtonClicked(ITextFormat iTextFormat, boolean b) {
-                // no op
-            }
-
-            @Override
-            public void onToolbarHeadingButtonClicked() {
-                // no op
-            }
-
-            @Override
-            public void onToolbarHtmlButtonClicked() {
-                // no op
-            }
-
-            @Override
-            public void onToolbarListButtonClicked() {
-                // no op
-            }
-
-            @Override
-            public void onToolbarMediaButtonClicked() {
-                // no op
-            }
-        };
-
-        Aztec.Factory.with(content, mockSource, mockFormattingToolbar, mockListener)
+        Aztec.Factory.with(content)
                 .addPlugin(new WordPressCommentsPlugin(content))
-                .addPlugin(new MoreToolbarButton(content))
                 .addPlugin(new CaptionShortcodePlugin())
                 .addPlugin(new VideoShortcodePlugin())
                 .addPlugin(new AudioShortcodePlugin());

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1474,7 +1474,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         if (mediaFile != null) {
             String remoteUrl = Utils.escapeQuotes(mediaFile.getFileURL());
             // fill in Aztec with the post's content
-            AztecText content = new AztecText(context);
+            AztecText content = getAztecTextWithPlugins(context);
             content.fromHtml(postContent);
 
             MediaPredicate predicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
@@ -1508,7 +1508,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                                                  String localMediaId, MediaFile mediaFile) {
         if (mediaFile != null) {
             // fill in Aztec with the post's content
-            AztecText content = new AztecText(context);
+            AztecText content = getAztecTextWithPlugins(context);
             content.fromHtml(postContent);
 
             MediaPredicate predicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
@@ -1543,7 +1543,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     private static boolean hasMediaItemsMarkedWithTag(Context context, @NonNull String postContent, String tag) {
         // fill in Aztec with the post's content
-        AztecText content = new AztecText(context);
+        AztecText content = getAztecTextWithPlugins(context);
         content.fromHtml(postContent);
 
         // get all items with the class in the "tag" param
@@ -1556,7 +1556,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     public static String resetUploadingMediaToFailed(Context context, @NonNull String postContent) {
         // fill in Aztec with the post's content
-        AztecText content = new AztecText(context);
+        AztecText content = getAztecTextWithPlugins(context);
         content.fromHtml(postContent);
 
         // get all items with "failed" class, and make sure they are still failed
@@ -1574,7 +1574,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     public static List<String> getMediaMarkedUploadingInPostContent(Context context, @NonNull String postContent) {
         ArrayList<String> mediaMarkedUploading = new ArrayList<>();
         // fill in Aztec with the post's content
-        AztecText content = new AztecText(context);
+        AztecText content = getAztecTextWithPlugins(context);
         content.fromHtml(postContent);
         AztecText.AttributePredicate uploadingPredicate = getPredicateWithClass(ATTR_STATUS_UPLOADING);
         for (Attributes attrs : content.getAllElementAttributes(uploadingPredicate)) {
@@ -1646,5 +1646,61 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         }
 
         return attributesWithClass;
+    }
+
+    private static AztecText getAztecTextWithPlugins(Context context) {
+        AztecText content = new AztecText(context);
+        SourceViewEditText mockSource = new SourceViewEditText(context);
+        AztecToolbar mockFormattingToolbar = new AztecToolbar(context);
+
+        IAztecToolbarClickListener mockListener = new IAztecToolbarClickListener() {
+            @Override
+            public void onToolbarCollapseButtonClicked() {
+                // no op
+            }
+
+            @Override
+            public void onToolbarExpandButtonClicked() {
+                // no op
+            }
+
+            @Override
+            public void onToolbarFormatButtonClicked(ITextFormat iTextFormat, boolean b) {
+                // no op
+            }
+
+            @Override
+            public void onToolbarHeadingButtonClicked() {
+                // no op
+            }
+
+            @Override
+            public void onToolbarHtmlButtonClicked() {
+                // no op
+            }
+
+            @Override
+            public void onToolbarListButtonClicked() {
+                // no op
+            }
+
+            @Override
+            public void onToolbarMediaButtonClicked() {
+                // no op
+            }
+        };
+
+        Aztec.Factory.with(content, mockSource, mockFormattingToolbar, mockListener)
+                .addPlugin(new WordPressCommentsPlugin(content))
+                .addPlugin(new MoreToolbarButton(content))
+                .addPlugin(new CaptionShortcodePlugin())
+                .addPlugin(new VideoShortcodePlugin())
+                .addPlugin(new AudioShortcodePlugin());
+
+        new BlockElementWatcher(content)
+                .add(new CaptionHandler())
+                .install(content);
+
+        return content;
     }
 }


### PR DESCRIPTION
Fixes #6531 

Related Aztec PR: https://github.com/wordpress-mobile/AztecEditor-Android/pull/468 (we need to wait for it to be merged and then we'll change the commit hash in this PR)

Video uploads started to work incorrectly in async after upgrading Aztec to beta 7, where the VideoShortcodePlugin was introduced.
We're fixing that by making our background AztecText processing also make use of the necessary plugins to be able to parse Post contents correctly.

To test:
1. start a new draft
2. include a video
3. exit the editor, and observe the posts list show the post upload progressing
4. enter the editor for that post again, observe the upload progress re-attaches seamlessly
5. exit the editor again, as many times as you wish, it should still be working alright
6. confirm the video is uploaded when it finished while you're within the editor
7. make tests again and confirm the video is finished uploading while you're out of the editor.

cc @aforcier 
