### PR TITLE
Guard against null intent in PostsListFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -319,29 +319,29 @@ public class MySiteFragment extends Fragment
                 }
                 break;
             case RequestCodes.EDIT_POST:
+                if (resultCode != Activity.RESULT_OK || data == null || !isAdded()) {
+                    return;
+                }
                 // if user returned from adding a post via the FAB and it was saved as a local
                 // draft, briefly animate the background of the "Blog posts" view to give the
                 // user a cue as to where to go to return to that post
-                if (resultCode == Activity.RESULT_OK && getView() != null && data != null
-                        && data.getBooleanExtra(EditPostActivity.EXTRA_SAVED_AS_LOCAL_DRAFT, false)) {
+                if (getView() != null && data.getBooleanExtra(EditPostActivity.EXTRA_SAVED_AS_LOCAL_DRAFT, false)) {
                     showAlert(getView().findViewById(R.id.postsGlowBackground));
                 }
 
-                if (isAdded()) {
-                    final PostModel post = mPostStore.
-                            getPostByLocalPostId(data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0));
+                final PostModel post = mPostStore.
+                        getPostByLocalPostId(data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0));
 
-                    if (post != null) {
-                        final SiteModel site = getSelectedSite();
-                        UploadUtils.handleEditPostResultSnackbars(getActivity(),
-                                getActivity().findViewById(R.id.coordinator), resultCode, data, post, site,
-                                new View.OnClickListener() {
-                                    @Override
-                                    public void onClick(View v) {
-                                        UploadUtils.publishPost(getActivity(), post, site, mDispatcher);
-                                    }
-                                });
-                    }
+                if (post != null) {
+                    final SiteModel site = getSelectedSite();
+                    UploadUtils.handleEditPostResultSnackbars(getActivity(),
+                            getActivity().findViewById(R.id.coordinator), resultCode, data, post, site,
+                            new View.OnClickListener() {
+                                @Override
+                                public void onClick(View v) {
+                                    UploadUtils.publishPost(getActivity(), post, site, mDispatcher);
+                                }
+                            });
                 }
                 break;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.posts;
 
+import android.app.Activity;
 import android.app.Fragment;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -207,7 +208,7 @@ public class PostsListFragment extends Fragment
     }
 
     public void handleEditPostResult(int resultCode, Intent data) {
-        if (!isAdded()) {
+        if (resultCode != Activity.RESULT_OK || data == null || !isAdded()) {
             return;
         }
 


### PR DESCRIPTION
Fixes #6537. A check [we used to have](https://github.com/wordpress-mobile/WordPress-Android/pull/6425/files#diff-b77d01da8893da62a4b6bbc5f0b06c3cL193) against `null` intent (which can happen for posts created by a share action) was inadvertently removed - this PR replaces it.

To test:
1. Start a new post
2. Leave the app open, and open a photo gallery app
3. Share a photo to the WordPress app
4. Choose the 'new post' option
5. Press 'Publish'
6. Verify that there's no crash