### PR TITLE
Show post title in upload error notifications

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -196,7 +196,11 @@ class PostUploadNotifier {
                 notificationIntent, PendingIntent.FLAG_ONE_SHOT);
 
         notificationBuilder.setSmallIcon(android.R.drawable.stat_notify_error);
-        notificationBuilder.setContentTitle(mContext.getString(R.string.upload_failed));
+
+        String postTitle = TextUtils.isEmpty(post.getTitle()) ? mContext.getString(R.string.untitled) : post.getTitle();
+        String notificationTitle = String.format(mContext.getString(R.string.upload_failed_param), postTitle);
+        notificationBuilder.setContentTitle(notificationTitle);
+
         notificationBuilder.setContentText(errorMessage);
         notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(errorMessage));
         notificationBuilder.setContentIntent(pendingIntent);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -273,6 +273,7 @@
     <string name="post_updated_param">\"%s\" has been updated!</string>
     <string name="post_scheduled_param">\"%s\" has been scheduled!</string>
     <string name="post_draft_param">\"%s\" has been saved as a draft!</string>
+    <string name="upload_failed_param">Upload failed for \"%s\"</string>
 
     <!-- post view -->
     <string name="post_id">Post</string>


### PR DESCRIPTION
Addresses #6533, adding the title of the failed post to upload error notifications:

![error-notifs-compare](https://user-images.githubusercontent.com/9613966/29405231-a1a05280-833d-11e7-890e-3cdfd8a8c674.png)