### PR TITLE
Using AztecParser + Plugins to do background async media operation on Post content

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -51,12 +51,12 @@ dependencies {
     compile 'com.android.support:design:25.3.1'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.16.0'
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:feature~add-headless-factory-method-SNAPSHOT')
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:feature~add-headless-factory-method-SNAPSHOT')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.0-beta.7')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.0-beta.7')
             {
                 exclude module: 'aztec'
             }
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:feature~add-headless-factory-method-SNAPSHOT')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:v1.0-beta.7')
             {
                 exclude module: 'aztec'
             }

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -51,12 +51,12 @@ dependencies {
     compile 'com.android.support:design:25.3.1'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.16.0'
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.0-beta.7')
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.0-beta.7')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:feature~add-headless-factory-method-SNAPSHOT')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:feature~add-headless-factory-method-SNAPSHOT')
             {
                 exclude module: 'aztec'
             }
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:v1.0-beta.7')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:feature~add-headless-factory-method-SNAPSHOT')
             {
                 exclude module: 'aztec'
             }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -55,11 +55,13 @@ import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 import org.wordpress.aztec.Aztec;
 import org.wordpress.aztec.AztecAttributes;
+import org.wordpress.aztec.AztecParser;
 import org.wordpress.aztec.AztecText;
 import org.wordpress.aztec.AztecTextFormat;
 import org.wordpress.aztec.Html;
 import org.wordpress.aztec.IHistoryListener;
 import org.wordpress.aztec.ITextFormat;
+import org.wordpress.aztec.plugins.IAztecPlugin;
 import org.wordpress.aztec.plugins.shortcodes.AudioShortcodePlugin;
 import org.wordpress.aztec.plugins.shortcodes.CaptionShortcodePlugin;
 import org.wordpress.aztec.plugins.shortcodes.VideoShortcodePlugin;
@@ -69,6 +71,7 @@ import org.wordpress.aztec.plugins.wpcomments.WordPressCommentsPlugin;
 import org.wordpress.aztec.plugins.wpcomments.toolbar.MoreToolbarButton;
 import org.wordpress.aztec.source.SourceViewEditText;
 import org.wordpress.aztec.spans.AztecMediaSpan;
+import org.wordpress.aztec.spans.IAztecAttributedSpan;
 import org.wordpress.aztec.toolbar.AztecToolbar;
 import org.wordpress.aztec.toolbar.IAztecToolbarClickListener;
 import org.wordpress.aztec.watchers.BlockElementWatcher;
@@ -1469,19 +1472,52 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         attributes.setValue(ATTR_CLASS, attrs.getAttributes().getValue(ATTR_CLASS));
     }
 
+    private static Attributes getElementAttributes(Spanned content, AztecText.AttributePredicate predicate) {
+        IAztecAttributedSpan[] spans = content.getSpans(0, content.length(), IAztecAttributedSpan.class);
+         for (IAztecAttributedSpan span : spans) {
+            if (predicate.matches(span.getAttributes())) {
+                return span.getAttributes();
+            }
+         }
+         return null;
+    }
+
+    private static List<Attributes> getAllElementAttributes(Spanned content, AztecText.AttributePredicate predicate) {
+        IAztecAttributedSpan[] spans = content.getSpans(0, content.length(), IAztecAttributedSpan.class);
+        List<Attributes> allAttrs = new ArrayList<>();
+        for (IAztecAttributedSpan span : spans) {
+            if (predicate.matches(span.getAttributes())) {
+                allAttrs.add(span.getAttributes());
+            }
+        }
+        return allAttrs;
+    }
+
+    private static void updateElementAttributes(Spanned content,
+                                                AztecText.AttributePredicate predicate,
+                                                AztecAttributes attrs) {
+        IAztecAttributedSpan[] spans = content.getSpans(0, content.length(), IAztecAttributedSpan.class);
+        for (IAztecAttributedSpan span : spans) {
+            if (predicate.matches(span.getAttributes())) {
+                span.setAttributes(attrs);
+                return;
+            }
+        }
+    }
+
     public static String replaceMediaFileWithUrl(Context context, @NonNull String postContent,
                                                  String localMediaId, MediaFile mediaFile) {
         if (mediaFile != null) {
             String remoteUrl = Utils.escapeQuotes(mediaFile.getFileURL());
             // fill in Aztec with the post's content
-            AztecText content = getAztecTextWithPlugins(context);
-            content.fromHtml(postContent);
+            AztecParser parser = getAztecParserWithPlugins();
+            Spanned content = parser.fromHtml(postContent, context);
 
             MediaPredicate predicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
 
             // remove the uploading class
             AttributesWithClass attributesWithClass = new AttributesWithClass(
-                    content.getElementAttributes(predicate));
+                    getElementAttributes(content, predicate));
             attributesWithClass.removeClass(ATTR_STATUS_UPLOADING);
             if (mediaFile.isVideo()) {
                 attributesWithClass.removeClass(TEMP_VIDEO_UPLOADING_CLASS);
@@ -1494,12 +1530,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             addDefaultSizeClassIfMissing(attrs);
 
             // clear overlay
-            content.clearOverlays(predicate);
-            content.updateElementAttributes(predicate, attrs);
-            content.refreshText();
+            // content.clearOverlays(predicate);
+            updateElementAttributes(content, predicate, attrs);
 
             // re-set the post content
-            postContent = content.toHtml(false);
+            postContent = parser.toHtml(content, false);
         }
         return postContent;
     }
@@ -1508,14 +1543,14 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                                                  String localMediaId, MediaFile mediaFile) {
         if (mediaFile != null) {
             // fill in Aztec with the post's content
-            AztecText content = getAztecTextWithPlugins(context);
-            content.fromHtml(postContent);
+            AztecParser parser = getAztecParserWithPlugins();
+            Spanned content = parser.fromHtml(postContent, context);
 
             MediaPredicate predicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
 
             // remove the uploading class
             AttributesWithClass attributesWithClass = new AttributesWithClass(
-                    content.getElementAttributes(predicate));
+                    getElementAttributes(content, predicate));
             attributesWithClass.removeClass(ATTR_STATUS_UPLOADING);
             if (mediaFile.isVideo()) {
                 attributesWithClass.removeClass(TEMP_VIDEO_UPLOADING_CLASS);
@@ -1524,11 +1559,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             // mark failed
             attributesWithClass.addClass(ATTR_STATUS_FAILED);
 
-            content.updateElementAttributes(predicate, attributesWithClass.getAttributes());
-            content.refreshText();
+            updateElementAttributes(content, predicate, attributesWithClass.getAttributes());
 
             // re-set the post content
-            postContent = content.toHtml(false);
+            postContent = parser.toHtml(content, false);
         }
         return postContent;
     }
@@ -1543,21 +1577,20 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     private static boolean hasMediaItemsMarkedWithTag(Context context, @NonNull String postContent, String tag) {
         // fill in Aztec with the post's content
-        AztecText content = getAztecTextWithPlugins(context);
-        content.fromHtml(postContent);
+        AztecParser parser = getAztecParserWithPlugins();
+        Spanned content = parser.fromHtml(postContent, context);
 
         // get all items with the class in the "tag" param
         AztecText.AttributePredicate uploadingPredicate = getPredicateWithClass(tag);
 
-        List<AztecAttributes> attrs = content.getAllElementAttributes(uploadingPredicate);
 
-        return (attrs != null && !attrs.isEmpty());
+        return getElementAttributes(content, uploadingPredicate) != null;
     }
 
     public static String resetUploadingMediaToFailed(Context context, @NonNull String postContent) {
         // fill in Aztec with the post's content
-        AztecText content = getAztecTextWithPlugins(context);
-        content.fromHtml(postContent);
+        AztecParser parser = getAztecParserWithPlugins();
+        Spanned content = parser.fromHtml(postContent, context);
 
         // get all items with "failed" class, and make sure they are still failed
         // i.e. if they have a local src, then they are failed.
@@ -1567,17 +1600,17 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         resetMediaWithStatus(content, ATTR_STATUS_UPLOADING);
 
         // re-set the post content
-        postContent = content.toHtml(false);
+        postContent = parser.toHtml(content, false);
         return postContent;
     }
 
     public static List<String> getMediaMarkedUploadingInPostContent(Context context, @NonNull String postContent) {
         ArrayList<String> mediaMarkedUploading = new ArrayList<>();
         // fill in Aztec with the post's content
-        AztecText content = getAztecTextWithPlugins(context);
-        content.fromHtml(postContent);
+        AztecParser parser = getAztecParserWithPlugins();
+        Spanned content = parser.fromHtml(postContent, context);
         AztecText.AttributePredicate uploadingPredicate = getPredicateWithClass(ATTR_STATUS_UPLOADING);
-        for (Attributes attrs : content.getAllElementAttributes(uploadingPredicate)) {
+        for (Attributes attrs : getAllElementAttributes(content, uploadingPredicate)) {
             String itemId = attrs.getValue(ATTR_ID_WP);
             if (!TextUtils.isEmpty(itemId)) {
                 mediaMarkedUploading.add(itemId);
@@ -1588,21 +1621,21 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     public void setMediaToFailed(@NonNull String mediaId) {
         AztecText.AttributePredicate localMediaIdPredicate = MediaPredicate.getLocalMediaIdPredicate(mediaId);
-        clearMediaUploadingAndSetToFailedIfLocal(content, localMediaIdPredicate);
+        clearMediaUploadingAndSetToFailedIfLocal(content.getText(), localMediaIdPredicate);
         content.clearOverlays(localMediaIdPredicate);
         overlayFailedMedia(mediaId, content.getElementAttributes(localMediaIdPredicate));
         safeAddMediaIdToSet(mFailedMediaIds, mediaId);
         content.resetAttributedMediaSpan(localMediaIdPredicate);
     }
 
-    private static void resetMediaWithStatus(AztecText content, String status) {
+    private static void resetMediaWithStatus(Spanned content, String status) {
         // get all items with "uploading" class
         AztecText.AttributePredicate uploadingPredicate = getPredicateWithClass(status);
 
         // update all items to failed, unless they already have a remote URL, in which case
         // it means the upload completed, but the item remained inconsistently marked as uploading
         // (for example after an app crash)
-        for (Attributes attrs : content.getAllElementAttributes(uploadingPredicate)) {
+        for (Attributes attrs : getAllElementAttributes(content, uploadingPredicate)) {
             clearMediaUploadingAndSetToFailedIfLocal(content, getPredicateForMedia(attrs));
         }
     }
@@ -1621,16 +1654,15 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         return predicate;
     }
 
-    private static void clearMediaUploadingAndSetToFailedIfLocal(AztecText content, AztecText.AttributePredicate predicate) {
+    private static void clearMediaUploadingAndSetToFailedIfLocal(Spanned content, AztecText.AttributePredicate predicate) {
         // remove the uploading class
         AttributesWithClass attributesWithClass = new AttributesWithClass(
-                content.getElementAttributes(predicate));
+                getElementAttributes(content,predicate));
         attributesWithClass.removeClass(ATTR_STATUS_UPLOADING);
 
         attributesWithClass = addFailedStatusToMediaIfLocalSrcPresent(attributesWithClass);
 
-        content.updateElementAttributes(predicate, attributesWithClass.getAttributes());
-        content.refreshText();
+        updateElementAttributes(content, predicate, attributesWithClass.getAttributes());
     }
 
 
@@ -1648,18 +1680,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         return attributesWithClass;
     }
 
-    private static AztecText getAztecTextWithPlugins(Context context) {
-        AztecText content = new AztecText(context);
-        Aztec.Factory.with(content)
-                .addPlugin(new WordPressCommentsPlugin(content))
-                .addPlugin(new CaptionShortcodePlugin())
-                .addPlugin(new VideoShortcodePlugin())
-                .addPlugin(new AudioShortcodePlugin());
-
-        new BlockElementWatcher(content)
-                .add(new CaptionHandler())
-                .install(content);
-
-        return content;
+    private static AztecParser getAztecParserWithPlugins() {
+        List<IAztecPlugin> plugins = new ArrayList<>();
+        plugins.add(new CaptionShortcodePlugin());
+        plugins.add(new VideoShortcodePlugin());
+        plugins.add(new AudioShortcodePlugin());
+        return new AztecParser(plugins);
     }
 }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1650,49 +1650,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     private static AztecText getAztecTextWithPlugins(Context context) {
         AztecText content = new AztecText(context);
-        SourceViewEditText mockSource = new SourceViewEditText(context);
-        AztecToolbar mockFormattingToolbar = new AztecToolbar(context);
-
-        IAztecToolbarClickListener mockListener = new IAztecToolbarClickListener() {
-            @Override
-            public void onToolbarCollapseButtonClicked() {
-                // no op
-            }
-
-            @Override
-            public void onToolbarExpandButtonClicked() {
-                // no op
-            }
-
-            @Override
-            public void onToolbarFormatButtonClicked(ITextFormat iTextFormat, boolean b) {
-                // no op
-            }
-
-            @Override
-            public void onToolbarHeadingButtonClicked() {
-                // no op
-            }
-
-            @Override
-            public void onToolbarHtmlButtonClicked() {
-                // no op
-            }
-
-            @Override
-            public void onToolbarListButtonClicked() {
-                // no op
-            }
-
-            @Override
-            public void onToolbarMediaButtonClicked() {
-                // no op
-            }
-        };
-
-        Aztec.Factory.with(content, mockSource, mockFormattingToolbar, mockListener)
+        Aztec.Factory.with(content)
                 .addPlugin(new WordPressCommentsPlugin(content))
-                .addPlugin(new MoreToolbarButton(content))
                 .addPlugin(new CaptionShortcodePlugin())
                 .addPlugin(new VideoShortcodePlugin())
                 .addPlugin(new AudioShortcodePlugin());

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1472,22 +1472,30 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         attributes.setValue(ATTR_CLASS, attrs.getAttributes().getValue(ATTR_CLASS));
     }
 
-    private static Attributes getElementAttributes(Spanned content, AztecText.AttributePredicate predicate) {
-        IAztecAttributedSpan[] spans = content.getSpans(0, content.length(), IAztecAttributedSpan.class);
-         for (IAztecAttributedSpan span : spans) {
-            if (predicate.matches(span.getAttributes())) {
-                return span.getAttributes();
-            }
-         }
-         return null;
+    private static Attributes getFirstElementAttributes(Spanned content, AztecText.AttributePredicate predicate) {
+        List<Attributes> firstAttrs = getElementAttributes(content, predicate, true);
+        if (firstAttrs.size() == 1) {
+            return firstAttrs.get(0);
+        }
+        else {
+            return null;
+        }
     }
 
-    private static List<Attributes> getAllElementAttributes(Spanned content, AztecText.AttributePredicate predicate) {
+    private static @NonNull List<Attributes> getAllElementAttributes(Spanned content,
+                                                                  AztecText.AttributePredicate predicate) {
+        return getElementAttributes(content, predicate, false);
+    }
+
+    private static @NonNull List<Attributes> getElementAttributes(Spanned content,
+                                                                  AztecText.AttributePredicate predicate,
+                                                                  boolean returnFirstFoundOnly) {
         IAztecAttributedSpan[] spans = content.getSpans(0, content.length(), IAztecAttributedSpan.class);
         List<Attributes> allAttrs = new ArrayList<>();
         for (IAztecAttributedSpan span : spans) {
             if (predicate.matches(span.getAttributes())) {
                 allAttrs.add(span.getAttributes());
+                if (returnFirstFoundOnly) return allAttrs;
             }
         }
         return allAttrs;
@@ -1517,7 +1525,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
             // remove the uploading class
             AttributesWithClass attributesWithClass = new AttributesWithClass(
-                    getElementAttributes(content, predicate));
+                    getFirstElementAttributes(content, predicate));
             attributesWithClass.removeClass(ATTR_STATUS_UPLOADING);
             if (mediaFile.isVideo()) {
                 attributesWithClass.removeClass(TEMP_VIDEO_UPLOADING_CLASS);
@@ -1550,7 +1558,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
             // remove the uploading class
             AttributesWithClass attributesWithClass = new AttributesWithClass(
-                    getElementAttributes(content, predicate));
+                    getFirstElementAttributes(content, predicate));
             attributesWithClass.removeClass(ATTR_STATUS_UPLOADING);
             if (mediaFile.isVideo()) {
                 attributesWithClass.removeClass(TEMP_VIDEO_UPLOADING_CLASS);
@@ -1584,7 +1592,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         AztecText.AttributePredicate uploadingPredicate = getPredicateWithClass(tag);
 
 
-        return getElementAttributes(content, uploadingPredicate) != null;
+        return getFirstElementAttributes(content, uploadingPredicate) != null;
     }
 
     public static String resetUploadingMediaToFailed(Context context, @NonNull String postContent) {
@@ -1657,7 +1665,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     private static void clearMediaUploadingAndSetToFailedIfLocal(Spanned content, AztecText.AttributePredicate predicate) {
         // remove the uploading class
         AttributesWithClass attributesWithClass = new AttributesWithClass(
-                getElementAttributes(content,predicate));
+                getFirstElementAttributes(content,predicate));
         attributesWithClass.removeClass(ATTR_STATUS_UPLOADING);
 
         attributesWithClass = addFailedStatusToMediaIfLocalSrcPresent(attributesWithClass);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1474,7 +1474,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         if (mediaFile != null) {
             String remoteUrl = Utils.escapeQuotes(mediaFile.getFileURL());
             // fill in Aztec with the post's content
-            AztecText content = new AztecText(context);
+            AztecText content = getAztecTextWithPlugins(context);
             content.fromHtml(postContent);
 
             MediaPredicate predicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
@@ -1508,7 +1508,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                                                  String localMediaId, MediaFile mediaFile) {
         if (mediaFile != null) {
             // fill in Aztec with the post's content
-            AztecText content = new AztecText(context);
+            AztecText content = getAztecTextWithPlugins(context);
             content.fromHtml(postContent);
 
             MediaPredicate predicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
@@ -1543,7 +1543,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     private static boolean hasMediaItemsMarkedWithTag(Context context, @NonNull String postContent, String tag) {
         // fill in Aztec with the post's content
-        AztecText content = new AztecText(context);
+        AztecText content = getAztecTextWithPlugins(context);
         content.fromHtml(postContent);
 
         // get all items with the class in the "tag" param
@@ -1556,7 +1556,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     public static String resetUploadingMediaToFailed(Context context, @NonNull String postContent) {
         // fill in Aztec with the post's content
-        AztecText content = new AztecText(context);
+        AztecText content = getAztecTextWithPlugins(context);
         content.fromHtml(postContent);
 
         // get all items with "failed" class, and make sure they are still failed
@@ -1574,7 +1574,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     public static List<String> getMediaMarkedUploadingInPostContent(Context context, @NonNull String postContent) {
         ArrayList<String> mediaMarkedUploading = new ArrayList<>();
         // fill in Aztec with the post's content
-        AztecText content = new AztecText(context);
+        AztecText content = getAztecTextWithPlugins(context);
         content.fromHtml(postContent);
         AztecText.AttributePredicate uploadingPredicate = getPredicateWithClass(ATTR_STATUS_UPLOADING);
         for (Attributes attrs : content.getAllElementAttributes(uploadingPredicate)) {
@@ -1646,5 +1646,61 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         }
 
         return attributesWithClass;
+    }
+
+    private static AztecText getAztecTextWithPlugins(Context context) {
+        AztecText content = new AztecText(context);
+        SourceViewEditText mockSource = new SourceViewEditText(context);
+        AztecToolbar mockFormattingToolbar = new AztecToolbar(context);
+
+        IAztecToolbarClickListener mockListener = new IAztecToolbarClickListener() {
+            @Override
+            public void onToolbarCollapseButtonClicked() {
+                // no op
+            }
+
+            @Override
+            public void onToolbarExpandButtonClicked() {
+                // no op
+            }
+
+            @Override
+            public void onToolbarFormatButtonClicked(ITextFormat iTextFormat, boolean b) {
+                // no op
+            }
+
+            @Override
+            public void onToolbarHeadingButtonClicked() {
+                // no op
+            }
+
+            @Override
+            public void onToolbarHtmlButtonClicked() {
+                // no op
+            }
+
+            @Override
+            public void onToolbarListButtonClicked() {
+                // no op
+            }
+
+            @Override
+            public void onToolbarMediaButtonClicked() {
+                // no op
+            }
+        };
+
+        Aztec.Factory.with(content, mockSource, mockFormattingToolbar, mockListener)
+                .addPlugin(new WordPressCommentsPlugin(content))
+                .addPlugin(new MoreToolbarButton(content))
+                .addPlugin(new CaptionShortcodePlugin())
+                .addPlugin(new VideoShortcodePlugin())
+                .addPlugin(new AudioShortcodePlugin());
+
+        new BlockElementWatcher(content)
+                .add(new CaptionHandler())
+                .install(content);
+
+        return content;
     }
 }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1537,8 +1537,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
             addDefaultSizeClassIfMissing(attrs);
 
-            // clear overlay
-            // content.clearOverlays(predicate);
             updateElementAttributes(content, predicate, attrs);
 
             // re-set the post content


### PR DESCRIPTION
Fixes #6531, supersedes #6536 

Video uploads started to work incorrectly in async after upgrading Aztec to beta 7, where the `VideoShortcodePlugin` was introduced.
We're fixing that by making our background processing also make use of the necessary plugins to be able to parse Post contents correctly.
Also, we're now only using `AztecParser` for any non-UI (i.e. background) operations  on Posts while async media operations are happening.

To test videos:
1. start a new draft
2. include a video
3. exit the editor, and observe the posts list show the post upload progressing
4. enter the editor for that post again, observe the upload progress re-attaches seamlessly
5. exit the editor again, as many times as you wish, it should still be working alright
6. confirm the video is uploaded when it finished while you're within the editor
7. make tests again and confirm the video is finished uploading while you're out of the editor.

Also, given this PR touches a bit of how all processing is done, pelase test uploading images and going back and forth the editor, specially letting uploads finish while you're outside the editor.

cc @aforcier 


