### PR TITLE
Use correct post type in messaging

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1208,7 +1208,9 @@ public class EditPostActivity extends AppCompatActivity implements
                     EditPostActivity.this.runOnUiThread(new Runnable() {
                         @Override
                         public void run() {
-                            ToastUtils.showToast(EditPostActivity.this, R.string.error_publish_empty_post, Duration.SHORT);
+                            String postType = getString(mIsPage ? R.string.page : R.string.post).toLowerCase();
+                            String message = getString(R.string.error_publish_empty_post_param, postType);
+                            ToastUtils.showToast(EditPostActivity.this, message, Duration.SHORT);
                         }
                     });
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
@@ -95,7 +95,8 @@ public class PostsListActivity extends AppCompatActivity {
         if (targetPostId > 0) {
             targetPost = mPostStore.getPostByLocalPostId(intent.getIntExtra(EXTRA_TARGET_POST_LOCAL_ID, 0));
             if (targetPost == null) {
-                ToastUtils.showToast(this, R.string.error_post_does_not_exist);
+                String postType = getString(mIsPage ? R.string.page : R.string.post).toLowerCase();
+                ToastUtils.showToast(this, getString(R.string.error_post_does_not_exist_param, postType));
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -659,8 +659,8 @@ public class PostsListFragment extends Fragment
                 break;
             case DELETE_POST:
                 if (event.isError()) {
-                    String message = String.format(getText(R.string.error_delete_post).toString(),
-                            mIsPage ? "page" : "post");
+                    String postType = getString(mIsPage ? R.string.page : R.string.post).toLowerCase();
+                    String message = getString(R.string.error_delete_post, postType);
                     ToastUtils.showToast(getActivity(), message, ToastUtils.Duration.SHORT);
                     loadPosts(LoadMode.IF_CHANGED);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -427,6 +427,8 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     }
 
     private void updateStatusTextAndImage(TextView txtStatus, ImageView imgStatus, PostModel post) {
+        Context context = txtStatus.getContext();
+
         if ((PostStatus.fromPost(post) == PostStatus.PUBLISHED) && !post.isLocalDraft() && !post.isLocallyChanged()) {
             txtStatus.setVisibility(View.GONE);
             imgStatus.setVisibility(View.GONE);
@@ -439,10 +441,10 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             UploadService.UploadError reason = UploadService.getUploadErrorForPost(post);
             if (reason != null) {
                 if (reason.mediaError != null) {
-                    errorMessage = txtStatus.getContext().getString(R.string.error_media_recover);
+                    String postType = context.getString(post.isPage() ? R.string.page : R.string.post).toLowerCase();
+                    errorMessage = context.getString(R.string.error_media_recover_params, postType);
                 } else if (reason.postError != null) {
-                    errorMessage = UploadUtils.getErrorMessageFromPostError(
-                            txtStatus.getContext(), post, reason.postError);
+                    errorMessage = UploadUtils.getErrorMessageFromPostError(context, post, reason.postError);
                 }
                 statusIconResId = R.drawable.ic_notice_48dp;
                 statusColorResId = R.color.alert_red;
@@ -492,7 +494,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
                 }
             }
 
-            Resources resources = txtStatus.getContext().getResources();
+            Resources resources = context.getResources();
             txtStatus.setTextColor(resources.getColor(statusColorResId));
             if (!TextUtils.isEmpty(errorMessage)) {
                 txtStatus.setText(errorMessage);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -179,7 +179,9 @@ public class UploadUtils {
 
         // If the post is empty, don't publish
         if (!PostUtils.isPublishable(post)) {
-            ToastUtils.showToast(activity, R.string.error_publish_empty_post, ToastUtils.Duration.SHORT);
+            String postType = activity.getString(post.isPage() ? R.string.page : R.string.post).toLowerCase();
+            String message = activity.getString(R.string.error_publish_empty_post_param, postType);
+            ToastUtils.showToast(activity, message, ToastUtils.Duration.SHORT);
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -42,7 +42,8 @@ public class UploadUtils {
     public static @NonNull String getErrorMessageFromPostError(Context context, PostModel post, PostError error) {
         switch (error.type) {
             case UNKNOWN_POST:
-                return context.getString(R.string.error_unknown_post);
+                String postType = context.getString(post.isPage() ? R.string.page : R.string.post).toLowerCase();
+                return context.getString(R.string.error_unknown_post_param, postType);
             case UNKNOWN_POST_TYPE:
                 return context.getString(R.string.error_unknown_post_type);
             case UNAUTHORIZED:

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1165,7 +1165,7 @@
     <string name="error_media_load">Unable to load media</string>
     <string name="error_media_save">Unable to save media</string>
     <string name="error_media_canceled">Uploading media were canceled</string>
-    <string name="error_media_recover">We were unable to upload this post\'s media. Please edit the post to try again.</string>
+    <string name="error_media_recover_params">We were unable to upload this %1$s\'s media. Please edit the %1$s to try again.</string>
     <string name="error_post_does_not_exist">This post no longer exists</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>
     <string name="fatal_db_error">An error occurred while creating the app database. Try reinstalling the app.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1152,7 +1152,7 @@
     <string name="error_generic">An error occurred</string>
     <string name="error_moderate_comment">An error occurred while moderating</string>
     <string name="error_edit_comment">An error occurred while editing the comment</string>
-    <string name="error_publish_empty_post">Can\'t publish an empty post</string>
+    <string name="error_publish_empty_post_param">Can\'t publish an empty %s</string>
     <string name="error_publish_no_network">Device is offline. Changes saved locally.</string>
     <string name="error_upload_post_params">There was an error uploading this %1$s: %2$s.</string>
     <string name="error_upload_post_media_params">There was an error uploading the media in this %1$s: %2$s.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1166,7 +1166,7 @@
     <string name="error_media_save">Unable to save media</string>
     <string name="error_media_canceled">Uploading media were canceled</string>
     <string name="error_media_recover_params">We were unable to upload this %1$s\'s media. Please edit the %1$s to try again.</string>
-    <string name="error_post_does_not_exist">This post no longer exists</string>
+    <string name="error_post_does_not_exist_param">This %s no longer exists</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>
     <string name="fatal_db_error">An error occurred while creating the app database. Try reinstalling the app.</string>
     <string name="error_copy_to_clipboard">An error occurred while copying text to clipboard</string>
@@ -1187,7 +1187,7 @@
     <string name="error_fetch_site_after_creation">Site has been created, you might need to refresh your sites in the site picker.</string>
 
     <!-- Post Error -->
-    <string name="error_unknown_post">Could not find the post on the server</string>
+    <string name="error_unknown_post_param">Could not find the %s on the server</string>
     <string name="error_unknown_post_type">Unknown post format</string>
 
     <!-- Image Descriptions for Accessibility -->


### PR DESCRIPTION
Fixes #6541, using 'post' or 'page' appropriately in the media error message shown in the post list.

Also corrected a few other instances where we should be using 'page' in the post list/editing flow.