### PR TITLE
adding snackbar on upload start and finishing in Media Library

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -64,6 +64,7 @@ import org.wordpress.android.ui.media.MediaGridFragment.MediaFilter;
 import org.wordpress.android.ui.media.MediaGridFragment.MediaGridListener;
 import org.wordpress.android.ui.media.services.MediaDeleteService;
 import org.wordpress.android.ui.uploads.UploadService;
+import org.wordpress.android.ui.uploads.UploadUtils;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
@@ -639,6 +640,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                 showMediaToastError(R.string.media_upload_error, event.error.message);
             }
         } else if (event.completed) {
+            UploadUtils.onMediaUploadSnackbarHandler(findViewById(android.R.id.content), false);
             String title = "";
             if (event.media != null) {
                 title = event.media.getTitle();
@@ -956,6 +958,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         addMediaToUploadService(media);
 
         updateMediaGridItem(media, false);
+
+        UploadUtils.onMediaUploadSnackbarHandler(findViewById(android.R.id.content), true);
     }
 
     private void handleSharedMedia() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -223,4 +223,9 @@ public class UploadUtils {
             }
         }
     }
+
+    public static void onMediaUploadSnackbarHandler(View snackbarAttachView, boolean justStarted) {
+        int messageResId = justStarted ? R.string.media_uploading : R.string.media_finished_uploading;
+        UploadUtils.showSnackbar(snackbarAttachView, messageResId);
+    }
 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -134,6 +134,8 @@
     <string name="media_insert_individually">Add individually</string>
     <string name="media_insert_as_gallery">Add as gallery</string>
     <string name="media_downloading">Saving media to this device</string>
+    <string name="media_uploading">Uploading media...</string>
+    <string name="media_finished_uploading">Upload finished!</string>
     <string name="wp_media_title">WordPress media</string>
     <string name="pick_photo">Select photo</string>
     <string name="pick_video">Select video</string>


### PR DESCRIPTION
Adds the snackbar functionality as we have for Posts uploads with Async (see #6445)

To test:
1. go to  Media in the My Sites screen
2. tap on the "+" sign on the top-right corner of the screen to add a media item
3. choose anything (device video or photo, or take a new video / picture)
4. when the item starts uploading, you'll see the snackbar "Uploading media..." appear

![image](https://user-images.githubusercontent.com/6597771/29434552-cd8980a6-8379-11e7-833d-d83f48e7e25c.png)

5. when the item finishes uploading, you'll see the snackbar "Upload finished!"

![image](https://user-images.githubusercontent.com/6597771/29434517-ad8a9c22-8379-11e7-8801-708af8d43479.png)
 

cc @nbradbury 
