### PR TITLE
Add missing interface method implementations

### DIFF
--- a/libs/editor/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/MockEditorActivity.java
+++ b/libs/editor/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/MockEditorActivity.java
@@ -65,6 +65,16 @@ public class MockEditorActivity extends AppCompatActivity implements EditorFragm
     }
 
     @Override
+    public void onMediaDeleted(String mediaId) {
+
+    }
+
+    @Override
+    public void onUndoMediaCheck(String undoedContent) {
+
+    }
+
+    @Override
     public void onFeaturedImageChanged(long mediaId) {
 
     }


### PR DESCRIPTION
Adds missing interface methods implementations missing from `MockEditorActivity`, which were causing errors on project rebuilding.