### PR TITLE
Add Learn More to Jetpack SSO settings category

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
@@ -28,8 +28,7 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.util.ToastUtils;
 
-public class LearnMorePreference extends Preference
-        implements PreferenceHint, View.OnClickListener {
+public class LearnMorePreference extends Preference implements View.OnClickListener {
     private static final String SUPPORT_CONTENT_JS = "javascript:(function(){" +
             "var mobileSupport = document.getElementById('mobile-only-usage');" +
             "mobileSupport.style.display = 'inline';" +
@@ -43,7 +42,6 @@ public class LearnMorePreference extends Preference
             "document.getElementById('actionbar').style.display = 'none';" +
             "})();";
 
-    private String mHint;
     private Dialog mDialog;
     private String mUrl;
     private String mCaption;
@@ -108,21 +106,6 @@ public class LearnMorePreference extends Preference
         if (mDialog != null) return;
         AnalyticsTracker.track(Stat.SITE_SETTINGS_LEARN_MORE_CLICKED);
         showDialog();
-    }
-
-    @Override
-    public boolean hasHint() {
-        return !TextUtils.isEmpty(mHint);
-    }
-
-    @Override
-    public String getHint() {
-        return mHint;
-    }
-
-    @Override
-    public void setHint(String hint) {
-        mHint = hint;
     }
 
     private void showDialog() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
@@ -92,8 +92,8 @@ public class LearnMorePreference extends Preference implements View.OnClickListe
     }
 
     @Override
-    public void onRestoreInstanceState(Parcelable state) {
-        if (!(state instanceof SavedState)) {// per documentation, state is always non-null
+    public void onRestoreInstanceState(@NonNull Parcelable state) {
+        if (!(state instanceof SavedState)) {
             super.onRestoreInstanceState(state);
         } else {
             super.onRestoreInstanceState(((SavedState) state).getSuperState());

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
@@ -142,15 +142,23 @@ public class LearnMorePreference extends Preference implements View.OnClickListe
     }
 
     private static class SavedState extends BaseSavedState {
-        public SavedState(Parcel source) { super(source); }
+        SavedState(Parcel source) {
+            super(source);
+        }
 
-        public SavedState(Parcelable superState) { super(superState); }
+        SavedState(Parcelable superState) {
+            super(superState);
+        }
 
         public static final Parcelable.Creator<SavedState> CREATOR =
                 new Parcelable.Creator<SavedState>() {
-                    public SavedState createFromParcel(Parcel in) { return new SavedState(in); }
+                    public SavedState createFromParcel(Parcel in) {
+                        return new SavedState(in);
+                    }
 
-                    public SavedState[] newArray(int size) { return new SavedState[size]; }
+                    public SavedState[] newArray(int size) {
+                        return new SavedState[size];
+                    }
                 };
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/LearnMorePreference.java
@@ -30,13 +30,17 @@ import org.wordpress.android.util.ToastUtils;
 
 public class LearnMorePreference extends Preference
         implements PreferenceHint, View.OnClickListener {
-    private static final String SUPPORT_MOBILE_ID = "mobile-only-usage";
     private static final String SUPPORT_CONTENT_JS = "javascript:(function(){" +
-            "var mobileSupport = document.getElementById('" + SUPPORT_MOBILE_ID + "');" +
+            "var mobileSupport = document.getElementById('mobile-only-usage');" +
             "mobileSupport.style.display = 'inline';" +
             "var newHtml = '<' + mobileSupport.tagName + '>' + mobileSupport.innerHTML + '</' + mobileSupport.tagName + '>';" +
             "document.body.innerHTML = newHtml;" +
             "document.body.setAttribute('style', 'padding:24px 24px 0px 24px !important');" +
+            "})();";
+    private static final String CONTENT_PADDING_JS = "javascript:(function(){" +
+            "document.body.setAttribute('style', 'padding:24px 24px 0px 24px !important');" +
+            "document.getElementById('mobilenav-toggle').style.display = 'none';" +
+            "document.getElementById('actionbar').style.display = 'none';" +
             "})();";
 
     private String mHint;
@@ -170,7 +174,8 @@ public class LearnMorePreference extends Preference
     private class LearnMoreClient extends WebViewClient {
         @Override
         public boolean shouldOverrideUrlLoading(WebView webView, String url) {
-            return !WP_SUPPORT_URL.equals(url) && !SUPPORT_CONTENT_JS.equals(url);
+            // prevent loading clicked links
+            return !mUrl.equals(url) && !SUPPORT_CONTENT_JS.equals(url) && !CONTENT_PADDING_JS.equals(url);
         }
 
         @Override

--- a/WordPress/src/main/res/layout/learn_more_pref.xml
+++ b/WordPress/src/main/res/layout/learn_more_pref.xml
@@ -15,7 +15,7 @@
         android:id="@+id/learn_more_caption"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/site_settings_learn_more_caption"
+        android:visibility="gone"
         android:textSize="@dimen/text_sz_small"
         android:textColor="@color/grey_darken_10" />
 

--- a/WordPress/src/main/res/values/attrs.xml
+++ b/WordPress/src/main/res/values/attrs.xml
@@ -26,6 +26,12 @@
         <attr name="buttonTextAllCaps" format="boolean" />
     </declare-styleable>
 
+    <declare-styleable name="LearnMorePreference">
+        <attr name="url" format="string" />
+        <attr name="caption" format="string" />
+        <attr name="useCustomJsFormatting" format="boolean" />
+    </declare-styleable>
+
     <declare-styleable name="FlowLayout">
         <attr name="horizontalSpacing" format="dimension" />
         <attr name="verticalSpacing" format="dimension" />

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -104,6 +104,7 @@
     <string name="pref_key_jetpack_allow_wpcom_sign_in" translatable="false">wp_pref_jetpack_allow_wpcom_sign_in</string>
     <string name="pref_key_jetpack_match_via_email" translatable="false">wp_pref_jetpack_match_via_email</string>
     <string name="pref_key_jetpack_require_two_factor" translatable="false">wp_pref_jetpack_require_two_factor</string>
+    <string name="pref_key_jetpack_learn_more" translatable="false">wp_pref_jetpack_learn_more</string>
 
     <!-- Notifications -->
     <string-array name="notifications_blog_settings_values" translatable="false">

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -326,6 +326,11 @@
                     android:title="@string/jetpack_require_two_factor_title"
                     android:dependency="@string/pref_key_jetpack_allow_wpcom_sign_in" />
 
+                <org.wordpress.android.ui.prefs.LearnMorePreference
+                    android:id="@+id/pref_jetpack_learn_more"
+                    android:key="@string/pref_key_jetpack_learn_more"
+                    android:title="@string/site_settings_learn_more_header" />
+
             </PreferenceCategory>
         </PreferenceScreen>
     </PreferenceCategory>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -167,6 +167,9 @@
                     app:longClickHint="@string/site_settings_receive_pingbacks_hint" />
 
                 <org.wordpress.android.ui.prefs.LearnMorePreference
+                    app:url="https://en.support.wordpress.com/settings/discussion-settings/#default-article-settings"
+                    app:useCustomJsFormatting="true"
+                    app:caption="@string/site_settings_learn_more_caption"
                     android:id="@+id/pref_learn_more"
                     android:key="@string/pref_key_site_learn_more"
                     android:title="@string/site_settings_learn_more_header" />
@@ -327,6 +330,8 @@
                     android:dependency="@string/pref_key_jetpack_allow_wpcom_sign_in" />
 
                 <org.wordpress.android.ui.prefs.LearnMorePreference
+                    app:url="https://jetpack.com/support/sso/"
+                    app:useCustomJsFormatting="false"
                     android:id="@+id/pref_jetpack_learn_more"
                     android:key="@string/pref_key_jetpack_learn_more"
                     android:title="@string/site_settings_learn_more_header" />


### PR DESCRIPTION
Another PR to move #6194 along. This one makes some significant changes to `LearnMorePreference` in order to use it in both `Discussion` and `Jetpack` settings.

Some existing JS was modified and some new JS was added to strip certain web elements for a better mobile experience.

cc @oguzkocer