### PR TITLE
Fallback to correct default values when reading REST response

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -181,8 +181,8 @@ class DotComSiteSettings extends SiteSettingsInterface {
         mRemoteSettings.tagline = response.optString(GET_DESC_KEY, "");
         mRemoteSettings.languageId = settingsObject.optInt(LANGUAGE_ID_KEY, -1);
         mRemoteSettings.privacy = settingsObject.optInt(PRIVACY_KEY, -2);
-        mRemoteSettings.defaultCategory = settingsObject.optInt(DEF_CATEGORY_KEY, 0);
-        mRemoteSettings.defaultPostFormat = settingsObject.optString(DEF_POST_FORMAT_KEY, "0");
+        mRemoteSettings.defaultCategory = settingsObject.optInt(DEF_CATEGORY_KEY, 1);
+        mRemoteSettings.defaultPostFormat = settingsObject.optString(DEF_POST_FORMAT_KEY, STANDARD_POST_FORMAT_KEY);
         mRemoteSettings.language = languageIdToLanguageCode(Integer.toString(mRemoteSettings.languageId));
         mRemoteSettings.allowComments = settingsObject.optBoolean(ALLOW_COMMENTS_KEY, true);
         mRemoteSettings.sendPingbacks = settingsObject.optBoolean(SEND_PINGBACKS_KEY, false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -113,7 +113,7 @@ public abstract class SiteSettingsInterface {
     /**
      * Key for the Standard post format. Used as default if post format is not set/known.
      */
-    private static final String STANDARD_POST_FORMAT_KEY = "standard";
+    static final String STANDARD_POST_FORMAT_KEY = "standard";
 
     /**
      * Standard sharing button style value. Used as default value if button style is unknown.


### PR DESCRIPTION
From a Mobile Requests post. If the default post format key is not included in the REST response map WPAndroid currently defaults to `0` when it should use `standard`.