### PR TITLE
i18n: Make error message translatable into languages with gendered post/page names

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1207,8 +1207,7 @@ public class EditPostActivity extends AppCompatActivity implements
                     EditPostActivity.this.runOnUiThread(new Runnable() {
                         @Override
                         public void run() {
-                            String postType = getString(mIsPage ? R.string.page : R.string.post).toLowerCase();
-                            String message = getString(R.string.error_publish_empty_post_param, postType);
+                            String message = getString(mIsPage ? R.string.error_publish_empty_page_param : R.string.error_publish_empty_post_param);
                             ToastUtils.showToast(EditPostActivity.this, message, Duration.SHORT);
                         }
                     });

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -30,10 +30,21 @@ public class UploadUtils {
      * Returns a post-type specific error message string.
      */
     static @NonNull String getErrorMessage(Context context, PostModel post, String errorMessage, boolean isMediaError) {
-        String baseErrorString = context.getString(
-                isMediaError ? R.string.error_upload_post_media_params : R.string.error_upload_post_params);
-        String postType = context.getString(post.isPage() ? R.string.page : R.string.post).toLowerCase();
-        return String.format(baseErrorString, postType, errorMessage);
+        String baseErrorString;
+        if (post.isPage()) {
+            if (isMediaError) {
+                baseErrorString = context.getString(R.string.error_upload_page_media_params);
+            } else {
+                baseErrorString = context.getString(R.string.error_upload_page_params);
+            }
+        } else {
+            if (isMediaError) {
+                baseErrorString = context.getString(R.string.error_upload_post_media_params);
+            } else {
+                baseErrorString = context.getString(R.string.error_upload_post_params);
+            }
+        }
+        return String.format(baseErrorString, errorMessage);
     }
 
     /**
@@ -42,8 +53,7 @@ public class UploadUtils {
     public static @NonNull String getErrorMessageFromPostError(Context context, PostModel post, PostError error) {
         switch (error.type) {
             case UNKNOWN_POST:
-                String postType = context.getString(post.isPage() ? R.string.page : R.string.post).toLowerCase();
-                return context.getString(R.string.error_unknown_post_param, postType);
+                return post.isPage() ? context.getString(R.string.error_unknown_page_param) : context.getString(R.string.error_unknown_post_param);
             case UNKNOWN_POST_TYPE:
                 return context.getString(R.string.error_unknown_post_type);
             case UNAUTHORIZED:
@@ -180,8 +190,7 @@ public class UploadUtils {
 
         // If the post is empty, don't publish
         if (!PostUtils.isPublishable(post)) {
-            String postType = activity.getString(post.isPage() ? R.string.page : R.string.post).toLowerCase();
-            String message = activity.getString(R.string.error_publish_empty_post_param, postType);
+            String message = activity.getString(post.isPage() ? R.string.error_publish_empty_page_param : R.string.error_publish_empty_post_param);
             ToastUtils.showToast(activity, message, ToastUtils.Duration.SHORT);
             return;
         }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1153,10 +1153,13 @@
     <string name="error_generic">An error occurred</string>
     <string name="error_moderate_comment">An error occurred while moderating</string>
     <string name="error_edit_comment">An error occurred while editing the comment</string>
-    <string name="error_publish_empty_post_param">Can\'t publish an empty %s</string>
+    <string name="error_publish_empty_post_param">Can\'t publish an empty post</string>
+    <string name="error_publish_empty_page_param">Can\'t publish an empty page</string>
     <string name="error_publish_no_network">Device is offline. Changes saved locally.</string>
-    <string name="error_upload_post_params">There was an error uploading this %1$s: %2$s.</string>
-    <string name="error_upload_post_media_params">There was an error uploading the media in this %1$s: %2$s.</string>
+    <string name="error_upload_post_params">There was an error uploading this post: %s.</string>
+    <string name="error_upload_post_media_params">There was an error uploading the media in this post: %s.</string>
+    <string name="error_upload_page_params">There was an error uploading this page: %s.</string>
+    <string name="error_upload_page_media_params">There was an error uploading the media in this page: %s.</string>
     <string name="error_media_insufficient_fs_permissions">Read permission denied on device media</string>
     <string name="error_media_not_found">Media could not be found</string>
     <string name="error_media_unauthorized">You don\'t have permission to view or edit media</string>
@@ -1188,7 +1191,8 @@
     <string name="error_fetch_site_after_creation">Site has been created, you might need to refresh your sites in the site picker.</string>
 
     <!-- Post Error -->
-    <string name="error_unknown_post_param">Could not find the %s on the server</string>
+    <string name="error_unknown_post_param">Could not find the post on the server</string>
+    <string name="error_unknown_page_param">Could not find the page on the server</string>
     <string name="error_unknown_post_type">Unknown post format</string>
 
     <!-- Image Descriptions for Accessibility -->


### PR DESCRIPTION
This changes error messages which cannot be translated into languages like French because the word "post" or "page" is inserted into the message as a string concat. This doesn't work for languages that require differently gendered articles for either post type.

@aforcier could you test, review and merge (cc'ing you because you last touched one of the error messages)? I don't have an environment set up for it.