### PR TITLE
Do not force media optimization

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -48,6 +48,9 @@ public class WPMediaUtils {
         if (isVideo) {
             return null;
         }
+        if (!AppPrefs.isImageOptimize()) {
+            return null;
+        }
         int resizeWidth = AppPrefs.getImageOptimizeWidth() > 1 ? AppPrefs.getImageOptimizeWidth() : Integer.MAX_VALUE;
         int quality = AppPrefs.getImageOptimizeQuality();
         // do not optimize if original-size and 100% quality are set.


### PR DESCRIPTION
Fixes #6559 by checking `AppPrefs.isImageOptimize` before returning the optimized picture.

To test:
- On a clean installation
- Start a new post
- Add a picture
- Publish the post
- (The picture should be upload "as-is", not being optimized).

(Redo the steps above, but enable picture optimizations in app->settings. Pictures should be resized accordingly to settings.)


