### PR TITLE
FIX NPE in ImageSettings Fragment

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -366,9 +366,11 @@ public class ImageSettingsDialogFragment extends DialogFragment {
      * Loads the given network image URL into the {@link NetworkImageView}.
      */
     private void loadThumbnail(String imageUrl) {
-        if (imageUrl == null) {
-            AppLog.e(AppLog.T.MEDIA, "Image url is null! Show the default error image.");
+        if (imageUrl == null || mImageLoader == null) {
             showErrorImage();
+            if (imageUrl == null) {
+                AppLog.e(AppLog.T.MEDIA, "Image url is null! Show the default error image.");
+            }
             return;
         }
 


### PR DESCRIPTION
Fixes #6491 by checking that `ImageLoader` is already available to the Fragment before loading the image.

Wasn't able to repro the issue, but used the stack trace reported into the original ticket to track it down.
