### PR TITLE
Aztec upload stop finds null predicate crash

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -876,6 +876,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     @Override
     public void onMediaDeleted(AztecAttributes aztecAttributes) {
         String localMediaId = aztecAttributes.getValue(ATTR_ID_WP);
+        mUploadingMediaProgressMax.remove(localMediaId);
         if (!TextUtils.isEmpty(localMediaId)) {
             mEditorFragmentListener.onMediaDeleted(localMediaId);
         }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1655,13 +1655,13 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     private static void resetMediaWithStatus(Spanned content, String status) {
-        // get all items with "uploading" class
-        AztecText.AttributePredicate uploadingPredicate = getPredicateWithClass(status);
+        // get all items with class defined by the "status" variable
+        AztecText.AttributePredicate statusPredicate = getPredicateWithClass(status);
 
         // update all items to failed, unless they already have a remote URL, in which case
         // it means the upload completed, but the item remained inconsistently marked as uploading
         // (for example after an app crash)
-        for (IAztecAttributedSpan span : getSpansForPredicate(content, uploadingPredicate, false)) {
+        for (IAztecAttributedSpan span : getSpansForPredicate(content, statusPredicate, false)) {
             clearMediaUploadingAndSetToFailedIfLocal(span);
         }
     }


### PR DESCRIPTION
This PR has a couple of interesting updates:
https://github.com/wordpress-mobile/WordPress-Android/commit/36ca40f583c9efd247751ca710482737c54a37ca  is the actual fix to the crash, checking for `null` and adding nonnull annotations for safety

https://github.com/wordpress-mobile/WordPress-Android/commit/f9d145d91c34e650e54ddafb2decfaf050a4e526 introduces an optimisation to how we were looking into content to find items with specific attributes, now relying on spans to have one less level of indirection (as opposed to looking for a predicate with a media id, and _then_ look for items with a specific `uploading` class)


Fixes #6557

To test: 
Case A: cancelling from the editor 
1. start a draft
2. try uploading several images / videos
3. get out of the editor
4. get back into the editor
5. tap on images / videos to cancel upload, or delete by positioning the cursor to the right of a media item then pressing the delete key on the keyboard
6. verify images / videos are cancelled (look into the logs)

Case B: provoking cancelation
1. start a draft
2. try uploading several images / videos
3. get out of the editor
4. turn airplane mode ON
5. get back into the editor to make the cleaning code run
6. check that media that was uploading is all marked failed and able to retry

Verify it doesn't crash

cc @daniloercoli 
