### PR TITLE
Instance data update closer to notifyDataSetChanged

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -472,7 +472,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
      * AsyncTask which loads sites from database and populates the adapter
      */
     private boolean mIsTaskRunning;
-    private class LoadSitesTask extends AsyncTask<Void, Void, Void> {
+    private class LoadSitesTask extends AsyncTask<Void, Void, SiteList[]> {
         @Override
         protected void onPreExecute() {
             super.onPreExecute();
@@ -490,7 +490,7 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         }
 
         @Override
-        protected Void doInBackground(Void... params) {
+        protected SiteList[] doInBackground(Void... params) {
             List<SiteModel> siteModels;
             if (mIsInSearchMode) {
                 siteModels = mSiteStore.getSites();
@@ -541,16 +541,22 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             }
 
             if (mSites == null || !mSites.isSameList(sites)) {
-                mAllSites = (SiteList) sites.clone();
-                mSites = filteredSitesByTextIfInSearchMode(sites);
+                SiteList allSites = (SiteList) sites.clone();
+                SiteList filteredSites = filteredSitesByTextIfInSearchMode(sites);
+
+                return new SiteList[]{allSites, filteredSites};
             }
 
             return null;
         }
 
         @Override
-        protected void onPostExecute(Void results) {
-            notifyDataSetChanged();
+        protected void onPostExecute(SiteList[] updatedSiteLists) {
+            if (updatedSiteLists != null) {
+                mAllSites = updatedSiteLists[0];
+                mSites = updatedSiteLists[1];
+                notifyDataSetChanged();
+            }
             mIsTaskRunning = false;
             if (mDataLoadedListener != null) {
                 mDataLoadedListener.onAfterLoad();

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerAdapter.java
@@ -471,12 +471,10 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
     /*
      * AsyncTask which loads sites from database and populates the adapter
      */
-    private boolean mIsTaskRunning;
     private class LoadSitesTask extends AsyncTask<Void, Void, SiteList[]> {
         @Override
         protected void onPreExecute() {
             super.onPreExecute();
-            mIsTaskRunning = true;
             if (mDataLoadedListener != null) {
                 boolean isEmpty = mSites == null || mSites.size() == 0;
                 mDataLoadedListener.onBeforeLoad(isEmpty);
@@ -486,7 +484,6 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
         @Override
         protected void onCancelled() {
             super.onCancelled();
-            mIsTaskRunning = false;
         }
 
         @Override
@@ -557,7 +554,6 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
                 mSites = updatedSiteLists[1];
                 notifyDataSetChanged();
             }
-            mIsTaskRunning = false;
             if (mDataLoadedListener != null) {
                 mDataLoadedListener.onAfterLoad();
             }
@@ -658,12 +654,5 @@ public class SitePickerAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             }
             return -1;
         }
-    }
-
-    /*
-     * same as Long.compare() which wasn't added until API 19
-     */
-    private static int compareTimestamps(long timestamp1, long timestamp2) {
-        return timestamp1 < timestamp2 ? -1 : (timestamp1 == timestamp2 ? 0 : 1);
     }
 }


### PR DESCRIPTION
Fixes #5660 (and possibly #5969 )

The issue cannot reliably be reproduced but based on info gathered (example: https://issuetracker.google.com/issues/37007605) it can be caused when the RecyclerView's adapter reports a wrong item count while its updated.

The fix tries to put the instance data (`mSites`) change closer to the `notifyDataSetChanged()` call so the adapter has consistent data as soon as possible. Previously, `mSites` was changed in the background (`doInBackground`) but the notifyDataSetChanged happened on the main thread (`onPostExecute`).

To test:
* While in "My Site", open the site picker by tapping on "SWITCH SITE"
* Pull to refresh
* The app should normally finish the list update
