### PR TITLE
Async media / editing: Garbage collect backspace-deleted media items

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -429,11 +429,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // now check if the newcontent still has items marked as failed. If it does,
         // then hook this post up to our error list, so it can be queried by the Posts List later
         // and be shown properly to the user
-        if (AztecEditorFragment.hasMediaItemsMarkedFailed(this, newContent)) {
-            UploadService.markPostAsError(mPost);
-        } else {
-            UploadService.removeUploadErrorForPost(mPost);
-        }
+        updateUploadServiceErrorForPost(newContent);
 
         if (!TextUtils.isEmpty(oldContent) && newContent != null && oldContent.compareTo(newContent) != 0) {
             mPost.setContent(newContent);
@@ -445,6 +441,15 @@ public class EditPostActivity extends AppCompatActivity implements
             mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
         }
     }
+
+    private void updateUploadServiceErrorForPost(String postContent) {
+        if (AztecEditorFragment.hasMediaItemsMarkedFailed(this, postContent)) {
+            UploadService.markPostAsError(mPost);
+        } else {
+            UploadService.removeUploadErrorForPost(mPost);
+        }
+    }
+
 
     private Runnable mAutoSave = new Runnable() {
         @Override
@@ -1262,6 +1267,9 @@ public class EditPostActivity extends AppCompatActivity implements
 
                 saveResult(shouldSave && shouldSync, false);
 
+                definitelyDeleteBackspaceDeletedMediaItems();
+                updateUploadServiceErrorForPost(mPost.getContent());
+
                 if (shouldSave) {
                     if (isNewPost()) {
                         // new post - user just left the editor without publishing, they probably want
@@ -1290,9 +1298,6 @@ public class EditPostActivity extends AppCompatActivity implements
                     }
                     finish();
                 }
-
-                definitelyDeleteBackspaceDeletedMediaItems();
-
             }
         }).start();
     }


### PR DESCRIPTION
Comes from https://github.com/wordpress-mobile/WordPress-Android/pull/6567#issuecomment-324243208

This PR addresses this case by keeping track of "backspace-deleted" media items in Aztec, and making sure these are deleted when exiting the editor. The list needs to be kept (along with the media items) because you can always delete one or several media items/ text and then `undo` in Aztec - (i.e. if we removed physically right away, the `undo` would not be possible at all).

To test:
- Open the editor
- Add 3 videos
- Use the back key to remove a video
- Go out to posts list 
- Go to Media Library
- The video deleted should not appear in the Media Library

Also, when you delete one progressing video and the other 2 are already done uploading, it should not show an error in the Posts list (it was being shown because of UploadService's Post error not being updated). - this one addressed in https://github.com/wordpress-mobile/WordPress-Android/commit/7f1043d4f339071c7ff0b30c45fe7b14d978db25

cc @daniloercoli 