### PR TITLE
Fix Media Library crash when downloading local media

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -564,7 +564,14 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             // TODO: right now only images & videos are supported
             String mimeType = StringUtils.notNullStr(media.getMimeType()).toLowerCase();
             if (mimeType.startsWith("image") || mimeType.startsWith("video")) {
-                MediaPreviewActivity.showPreview(this, sourceView, mSite, localMediaId);
+                if (media.getUploadState() != null &&
+                        MediaUtils.isLocalFile(media.getUploadState().toLowerCase())) {
+                    // Show the simple preview in case of uploading items. i.e: No metadata info, and other options only available
+                    // for files already on the remote site.
+                    MediaPreviewActivity.showPreview(this, sourceView, media.getFilePath(), mimeType.startsWith("video"));
+                } else {
+                    MediaPreviewActivity.showPreview(this, sourceView, mSite, localMediaId);
+                }
             }
         }
     }


### PR DESCRIPTION
Fix #6573 and part of #6572 by making sure the file is already on the remote site before showing edit screen. Show the simple preview if the file is in uploading or queued.

cc @nbradbury 