### PR TITLE
issue/6572-local-video-thumb

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -4,8 +4,10 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
+import android.media.ThumbnailUtils;
 import android.os.AsyncTask;
 import android.os.Handler;
+import android.provider.MediaStore;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
@@ -174,10 +176,17 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             } else {
                 holder.imageView.setImageUrl(getBestImageUrl(media), WPNetworkImageView.ImageType.PHOTO);
             }
-        } else if (media.isVideo() && !TextUtils.isEmpty(media.getThumbnailUrl())) {
+        } else if (media.isVideo()) {
             holder.fileContainer.setVisibility(View.GONE);
             holder.videoOverlayContainer.setVisibility(View.VISIBLE);
-            holder.imageView.setImageUrl(media.getThumbnailUrl(), WPNetworkImageView.ImageType.VIDEO);
+            if (isLocalFile) {
+                Bitmap thumb = ThumbnailUtils.createVideoThumbnail(media.getFilePath(),
+                        MediaStore.Images.Thumbnails.MINI_KIND);
+                holder.imageView.setImageUrl(null, WPNetworkImageView.ImageType.NONE);
+                holder.imageView.setImageBitmap(thumb);
+            } else {
+                holder.imageView.setImageUrl(media.getThumbnailUrl(), WPNetworkImageView.ImageType.VIDEO);
+            }
         } else {
             // not an image or video, so show file name and file type
             holder.videoOverlayContainer.setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -469,6 +469,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         }
 
         imageView.setImageUrl(null, WPNetworkImageView.ImageType.NONE);
+        imageView.setImageBitmap(null);
         imageView.setTag(filePath);
 
         if (TextUtils.isEmpty(filePath)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -475,7 +475,6 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                             WordPress.getBitmapCache().put(filePath, thumb);
                             if (imageView.getTag() instanceof String
                                     && ((String) imageView.getTag()).equalsIgnoreCase(filePath)) {
-
                                 imageView.setImageBitmap(thumb);
                             }
                         }


### PR DESCRIPTION
Fixes #6572 - the media browser now shows a thumbnail for local videos (ie: videos that are still uploading).

Note that this fix uncovers a separate issue: after the video is uploaded, we don't immediately have the thumbnail URL from the backend, so it shows as blank in the media browser after the upload completes.

cc: @daniloercoli 

