### PR TITLE
correctly handling media delete actions in the media browser

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -689,8 +689,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                     mDispatcher.dispatch(MediaActionBuilder.newRemoveMediaAction(mediaModel));
                 } else {
                     mediaToDelete.add(mediaModel);
-                    mediaModel.setUploadState(MediaUploadState.DELETING);
-                    mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(mediaModel));
                 }
                 processedItemCount++;
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2296,10 +2296,10 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void onMediaRetryClicked(final String mediaId) {
+    public boolean onMediaRetryClicked(final String mediaId) {
         if (TextUtils.isEmpty(mediaId)) {
             AppLog.e(T.MEDIA, "Invalid media id passed to onMediaRetryClicked");
-            return;
+            return false;
         }
         MediaModel media = mMediaStore.getMediaWithLocalId(StringUtils.stringToInt(mediaId));
         if (media == null) {
@@ -2308,7 +2308,12 @@ public class EditPostActivity extends AppCompatActivity implements
             builder.setTitle(getString(R.string.cannot_retry_deleted_media_item));
             builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
                 public void onClick(DialogInterface dialog, int id) {
-                    mEditorFragment.removeMedia(mediaId);
+                    runOnUiThread(new Runnable() {
+                        @Override
+                        public void run() {
+                            mEditorFragment.removeMedia(mediaId);
+                        }
+                    });
                     dialog.dismiss();
                 }
             });
@@ -2322,7 +2327,7 @@ public class EditPostActivity extends AppCompatActivity implements
             AlertDialog dialog = builder.create();
             dialog.show();
 
-            return;
+            return false;
         }
 
         if (media.getUploadState().equals(MediaUploadState.UPLOADED.toString())) {
@@ -2340,6 +2345,7 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         AnalyticsTracker.track(Stat.EDITOR_UPLOAD_MEDIA_RETRIED);
+        return true;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2296,7 +2296,7 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     @Override
-    public void onMediaRetryClicked(String mediaId) {
+    public void onMediaRetryClicked(final String mediaId) {
         if (TextUtils.isEmpty(mediaId)) {
             AppLog.e(T.MEDIA, "Invalid media id passed to onMediaRetryClicked");
             return;
@@ -2304,7 +2304,24 @@ public class EditPostActivity extends AppCompatActivity implements
         MediaModel media = mMediaStore.getMediaWithLocalId(StringUtils.stringToInt(mediaId));
         if (media == null) {
             AppLog.e(T.MEDIA, "Can't find media with local id: " + mediaId);
-            ToastUtils.showToast(this, getString(R.string.cannot_retry_deleted_media_item));
+            AlertDialog.Builder builder = new AlertDialog.Builder(this);
+            builder.setTitle(getString(R.string.cannot_retry_deleted_media_item));
+            builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int id) {
+                    mEditorFragment.removeMedia(mediaId);
+                    dialog.dismiss();
+                }
+            });
+
+            builder.setNegativeButton(getString(R.string.no), new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int id) {
+                    dialog.dismiss();
+                }
+            });
+
+            AlertDialog dialog = builder.create();
+            dialog.show();
+
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2304,6 +2304,7 @@ public class EditPostActivity extends AppCompatActivity implements
         MediaModel media = mMediaStore.getMediaWithLocalId(StringUtils.stringToInt(mediaId));
         if (media == null) {
             AppLog.e(T.MEDIA, "Can't find media with local id: " + mediaId);
+            ToastUtils.showToast(this, getString(R.string.cannot_retry_deleted_media_item));
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -439,6 +439,16 @@ public class UploadService extends Service {
         return MediaUploadHandler.isPendingOrInProgressMediaUpload(media);
     }
 
+    public static boolean isMediaBeingUploadedForAPost(@NonNull MediaModel mediaToCheck) {
+        for (UploadingPost uploadingPost : sPostsWithPendingMedia) {
+            for (MediaModel media : uploadingPost.pendingMedia) {
+                if (media.getId() == mediaToCheck.getId()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 
     /**
      * Rechecks all media in the MediaStore marked UPLOADING/QUEUED against the UploadingService to see

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -439,15 +439,15 @@ public class UploadService extends Service {
         return MediaUploadHandler.isPendingOrInProgressMediaUpload(media);
     }
 
-    public static boolean isMediaBeingUploadedForAPost(@NonNull MediaModel mediaToCheck) {
+    public static PostModel isMediaBeingUploadedForAPost(@NonNull MediaModel mediaToCheck) {
         for (UploadingPost uploadingPost : sPostsWithPendingMedia) {
             for (MediaModel media : uploadingPost.pendingMedia) {
                 if (media.getId() == mediaToCheck.getId()) {
-                    return true;
+                    return uploadingPost.postModel;
                 }
             }
         }
-        return false;
+        return null;
     }
 
     /**

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -188,8 +188,7 @@
     <!-- Delete Media -->
     <string name="confirm_delete_media">Delete selected item?</string>
     <string name="confirm_delete_multi_media">Delete selected items?</string>
-    <string name="wait_until_upload_completes">Wait until upload completes</string>
-    <string name="cannot_delete_multi_media_items">Some media can\'t be deleted at this time. Try again later.</string>
+    <string name="cannot_delete_some_multi_media_items">Some media can\'t be deleted at this time. Wait until upload completes, or try deleting it from within the associated Post.</string>
     <string name="media_empty_list">No media</string>
     <string name="media_empty_image_list">You don\'t have any images</string>
     <string name="media_empty_videos_list">You don\'t have any videos</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -188,7 +188,7 @@
     <!-- Delete Media -->
     <string name="confirm_delete_media">Delete selected item?</string>
     <string name="confirm_delete_multi_media">Delete selected items?</string>
-    <string name="cannot_delete_some_multi_media_items">Some media can\'t be deleted at this time. Wait until upload completes, or try deleting it from within the associated Post.</string>
+    <string name="cannot_delete_multi_media_items">Some media can\'t be deleted at this time. Try again later.</string>
     <string name="media_empty_list">No media</string>
     <string name="media_empty_image_list">You don\'t have any images</string>
     <string name="media_empty_videos_list">You don\'t have any videos</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -189,6 +189,7 @@
     <string name="confirm_delete_media">Delete selected item?</string>
     <string name="confirm_delete_multi_media">Delete selected items?</string>
     <string name="cannot_delete_multi_media_items">Some media can\'t be deleted at this time. Try again later.</string>
+    <string name="cannot_retry_deleted_media_item">Media item has been removed from the device and can\'t  be retried. Try inserting it again.</string>
     <string name="media_empty_list">No media</string>
     <string name="media_empty_image_list">You don\'t have any images</string>
     <string name="media_empty_videos_list">You don\'t have any videos</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -189,7 +189,7 @@
     <string name="confirm_delete_media">Delete selected item?</string>
     <string name="confirm_delete_multi_media">Delete selected items?</string>
     <string name="cannot_delete_multi_media_items">Some media can\'t be deleted at this time. Try again later.</string>
-    <string name="cannot_retry_deleted_media_item">Media item has been removed from the device and can\'t  be retried. Try inserting it again.</string>
+    <string name="cannot_retry_deleted_media_item">Media has been removed. Delete it from this post?</string>
     <string name="media_empty_list">No media</string>
     <string name="media_empty_image_list">You don\'t have any images</string>
     <string name="media_empty_videos_list">You don\'t have any videos</string>

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1214,7 +1214,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 // Display 'cancel upload' dialog
                 AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
                 builder.setTitle(getString(R.string.stop_upload_dialog_title));
-                builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
 
                         if (mUploadingMediaProgressMax.containsKey(localMediaId)) {
@@ -1236,7 +1236,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                     }
                 });
 
-                builder.setNegativeButton(getString(R.string.cancel), new DialogInterface.OnClickListener() {
+                builder.setNegativeButton(getString(R.string.no), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         dialog.dismiss();
                     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -809,6 +809,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     }
 
     @Override
+    public void removeMedia(String mediaId) {
+        content.removeMedia(MediaPredicate.getLocalMediaIdPredicate(mediaId));
+    }
+
+    @Override
     public Spanned getSpannedContent() {
         return null;
     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1214,7 +1214,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 // Display 'cancel upload' dialog
                 AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
                 builder.setTitle(getString(R.string.stop_upload_dialog_title));
-                builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+                builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
 
                         if (mUploadingMediaProgressMax.containsKey(localMediaId)) {
@@ -1236,7 +1236,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                     }
                 });
 
-                builder.setNegativeButton(getString(R.string.no), new DialogInterface.OnClickListener() {
+                builder.setNegativeButton(getString(R.string.cancel), new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
                         dialog.dismiss();
                     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1247,50 +1247,53 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 break;
             case ATTR_STATUS_FAILED:
                 // Retry media upload
+                boolean successfullyRetried = true;
                 if (mFailedMediaIds.contains(localMediaId)) {
-                    mEditorFragmentListener.onMediaRetryClicked(localMediaId);
+                    successfullyRetried = mEditorFragmentListener.onMediaRetryClicked(localMediaId);
                 }
-                switch (mediaType) {
-                    case IMAGE:
-                    case VIDEO:
-                        AttributesWithClass attributesWithClass = getAttributesWithClass(
-                                content.getElementAttributes(mTappedMediaPredicate));
+                if (successfullyRetried) {
+                    switch (mediaType) {
+                        case IMAGE:
+                        case VIDEO:
+                            AttributesWithClass attributesWithClass = getAttributesWithClass(
+                                    content.getElementAttributes(mTappedMediaPredicate));
 
-                        // remove the failed class
-                        attributesWithClass = addFailedStatusToMediaIfLocalSrcPresent(attributesWithClass);
+                            // remove the failed class
+                            attributesWithClass = addFailedStatusToMediaIfLocalSrcPresent(attributesWithClass);
 
-                        if (!attributesWithClass.hasClass(ATTR_STATUS_FAILED)) {
-                            // just save the item and leave
-                            content.clearOverlays(mTappedMediaPredicate);
+                            if (!attributesWithClass.hasClass(ATTR_STATUS_FAILED)) {
+                                // just save the item and leave
+                                content.clearOverlays(mTappedMediaPredicate);
+                                content.resetAttributedMediaSpan(mTappedMediaPredicate);
+                                return;
+                            }
+
+                            attributesWithClass.addClass(ATTR_STATUS_UPLOADING);
+                            if (mediaType.equals(MediaType.VIDEO)) {
+                                attributesWithClass.addClass(TEMP_VIDEO_UPLOADING_CLASS);
+                            }
+
+                            // set intermediate shade overlay
+                            content.setOverlay(mTappedMediaPredicate, 0,
+                                    new ColorDrawable(getResources().getColor(R.color.media_shade_overlay_color)), Gravity.FILL);
+
+                            Drawable progressDrawable = getResources().getDrawable(android.R.drawable.progress_horizontal);
+                            // set the height of the progress bar to 2 (it's in dp since the drawable will be adjusted by the span)
+                            progressDrawable.setBounds(0, 0, 0, 4);
+
+                            content.setOverlay(mTappedMediaPredicate, 1, progressDrawable, Gravity.FILL_HORIZONTAL | Gravity.TOP);
+                            content.updateElementAttributes(mTappedMediaPredicate, attributesWithClass.getAttributes());
+
+                            if (mediaType.equals(MediaType.VIDEO)) {
+                                overlayVideoIcon(2, mTappedMediaPredicate);
+                            }
+
                             content.resetAttributedMediaSpan(mTappedMediaPredicate);
-                            return;
-                        }
-
-                        attributesWithClass.addClass(ATTR_STATUS_UPLOADING);
-                        if (mediaType.equals(MediaType.VIDEO)) {
-                            attributesWithClass.addClass(TEMP_VIDEO_UPLOADING_CLASS);
-                        }
-
-                        // set intermediate shade overlay
-                        content.setOverlay(mTappedMediaPredicate, 0,
-                                new ColorDrawable(getResources().getColor(R.color.media_shade_overlay_color)), Gravity.FILL);
-
-                        Drawable progressDrawable = getResources().getDrawable(android.R.drawable.progress_horizontal);
-                        // set the height of the progress bar to 2 (it's in dp since the drawable will be adjusted by the span)
-                        progressDrawable.setBounds(0, 0, 0, 4);
-
-                        content.setOverlay(mTappedMediaPredicate, 1, progressDrawable, Gravity.FILL_HORIZONTAL | Gravity.TOP);
-                        content.updateElementAttributes(mTappedMediaPredicate, attributesWithClass.getAttributes());
-
-                        if (mediaType.equals(MediaType.VIDEO)) {
-                            overlayVideoIcon(2, mTappedMediaPredicate);
-                        }
-
-                        content.resetAttributedMediaSpan(mTappedMediaPredicate);
-                        break;
+                            break;
+                    }
+                    mFailedMediaIds.remove(localMediaId);
+                    mUploadingMediaProgressMax.put(localMediaId, 0f);
                 }
-                mFailedMediaIds.remove(localMediaId);
-                mUploadingMediaProgressMax.put(localMediaId, 0f);
                 break;
             default:
                 if (mediaType.equals(MediaType.VIDEO)) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1380,24 +1380,25 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                 }
 
                 // Retry media upload
-                mEditorFragmentListener.onMediaRetryClicked(mediaId);
-
-                mWebView.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        switch (mediaType) {
-                            case IMAGE:
-                                mWebView.execJavaScriptFromString("ZSSEditor.unmarkImageUploadFailed(" + mediaId
-                                        + ");");
-                                break;
-                            case VIDEO:
-                                mWebView.execJavaScriptFromString("ZSSEditor.unmarkVideoUploadFailed(" + mediaId
-                                        + ");");
+                boolean successfullyRetried = mEditorFragmentListener.onMediaRetryClicked(mediaId);
+                if (successfullyRetried) {
+                    mWebView.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            switch (mediaType) {
+                                case IMAGE:
+                                    mWebView.execJavaScriptFromString("ZSSEditor.unmarkImageUploadFailed(" + mediaId
+                                            + ");");
+                                    break;
+                                case VIDEO:
+                                    mWebView.execJavaScriptFromString("ZSSEditor.unmarkVideoUploadFailed(" + mediaId
+                                            + ");");
+                            }
+                            mFailedMediaIds.remove(mediaId);
+                            mUploadingMedia.put(mediaId, mediaType);
                         }
-                        mFailedMediaIds.remove(mediaId);
-                        mUploadingMedia.put(mediaId, mediaType);
-                    }
-                });
+                    });
+                }
                 break;
             default:
                 if (!mediaType.equals(MediaType.IMAGE)) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -1091,6 +1091,11 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
     }
 
     @Override
+    public void removeMedia(String mediaId) {
+        mWebView.execJavaScriptFromString("ZSSEditor.removeMedia('" + mediaId + "');");
+    }
+
+    @Override
     public Spanned getSpannedContent() {
         return null;
     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -28,6 +28,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
     public abstract boolean isActionInProgress();
     public abstract boolean hasFailedMediaUploads();
     public abstract void removeAllFailedMediaUploads();
+    public abstract void removeMedia(String mediaId);
     public abstract void setTitlePlaceholder(CharSequence text);
     public abstract void setContentPlaceholder(CharSequence text);
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -174,7 +174,7 @@ public abstract class EditorFragmentAbstract extends Fragment {
         void onEditorFragmentInitialized();
         void onSettingsClicked();
         void onAddMediaClicked();
-        void onMediaRetryClicked(String mediaId);
+        boolean onMediaRetryClicked(String mediaId);
         void onMediaUploadCancelClicked(String mediaId);
         void onMediaDeleted(String mediaId);
         void onUndoMediaCheck(String undoedContent);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/LegacyEditorFragment.java
@@ -1169,6 +1169,9 @@ public class LegacyEditorFragment extends EditorFragmentAbstract implements Text
     public void removeAllFailedMediaUploads() {}
 
     @Override
+    public void removeMedia(String mediaId) {}
+
+    @Override
     public void setTitlePlaceholder(CharSequence text) {
     }
 

--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -19,6 +19,8 @@
 
     <string name="stop_upload_dialog_title">Stop uploading?</string>
     <string name="upload_finished_toast">Can\'t stop the upload because it\'s already finished</string>
+    <string name="yes">Yes</string>
+    <string name="no">No</string>
 
     <string name="format_bar_tag_bold" translatable="false">bold</string>
     <string name="format_bar_tag_italic" translatable="false">italic</string>

--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -19,8 +19,6 @@
 
     <string name="stop_upload_dialog_title">Stop uploading?</string>
     <string name="upload_finished_toast">Can\'t stop the upload because it\'s already finished</string>
-    <string name="yes">Yes</string>
-    <string name="no">No</string>
 
     <string name="format_bar_tag_bold" translatable="false">bold</string>
     <string name="format_bar_tag_italic" translatable="false">italic</string>

--- a/libs/editor/example/src/test/java/org/wordpress/android/editor/EditorFragmentAbstractTest.java
+++ b/libs/editor/example/src/test/java/org/wordpress/android/editor/EditorFragmentAbstractTest.java
@@ -95,6 +95,11 @@ public class EditorFragmentAbstractTest {
         }
 
         @Override
+        public void removeMedia(String mediaId) {
+
+        }
+
+        @Override
         public void setTitlePlaceholder(CharSequence text) {
 
         }


### PR DESCRIPTION
Fixes #6576 

**To test:** 
**CASE A**: uploading media item in Post can't be deleted/stopped from the Media Browser
1. start a new draft
2. include a media item (something large, like a video, so it's easier to test)
3. exit the editor, the upload will continue in the background
4. go to the Media Browser
5. you'll see the media item being uploaded
6. long press on it to select it
7. tap on the trash icon
8. when prompted to confirm deletion, tap OK
9. a Toast is shown `Some media can\'t be deleted at this time. Wait until upload completes, or try deleting it from within the associated Post.`.
10. Confirm this happens each time you try, successfully preventing the user from deleting a media item that is being uploaded as part of a Post.

**CASE B:** upload a media item from the Media Browser and delete it
1. go to the media browser
2. include a media item by tapping on the `+` button on the top-right corner of the screen
3. while the item is uploading, long press on it
4. tap on the trash icon
5. when prompted to confirm deletion, tap OK
6. verify the item is deleted and the upload is canceled (check upload progress logs for that).

Please note this doesn't cover the case of deleting media that has already been uploaded to the server and is included / referenced in some Post content, which is a separate case.
This only covers the case of being able to delete solo items, or hinting the user on what to do if they want to cancel an upload for an item that is included in a Post currently being uploaded.

cc @nbradbury @daniloercoli 



