### PR TITLE
Guard against null RecyclerView

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/PeopleListFragment.java
@@ -275,6 +275,11 @@ public class PeopleListFragment extends Fragment {
 
     // Refresh the role display names after user roles is fetched
     public void refreshUserRoles() {
+        if (mFilteredRecyclerView == null) {
+            // bail when list is not available
+            return;
+        }
+
         PeopleAdapter peopleAdapter = (PeopleAdapter) mFilteredRecyclerView.getAdapter();
         if (peopleAdapter != null) {
             peopleAdapter.refreshUserRoles();


### PR DESCRIPTION
Fixes #6580 

Fixes the crash reported via Fabric by guarding for null RecyclerView.

To test:
Steps are not known.