### PR TITLE
Keep original filename for optimizated pictures

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -946,6 +946,10 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         }
 
         media.setFileName(filename);
+        String title = MediaUtils.getFileNameFromPath(filename);
+        if (title != null) {
+            media.setTitle(title);
+        }
         media.setFilePath(path);
         media.setLocalSiteId(mSite.getId());
         media.setFileExtension(fileExtension);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -946,10 +946,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         }
 
         media.setFileName(filename);
-        String title = MediaUtils.getFileNameFromPath(filename);
-        if (title != null) {
-            media.setTitle(title);
-        }
+        media.setTitle(filename);
         media.setFilePath(path);
         media.setLocalSiteId(mSite.getId());
         media.setFileExtension(fileExtension);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2337,6 +2337,10 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         media.setFileName(filename);
+        String title = MediaUtils.getFileNameFromPath(filename);
+        if (title != null) {
+            media.setTitle(title);
+        }
         media.setFilePath(path);
         media.setLocalSiteId(mSite.getId());
         media.setFileExtension(fileExtension);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2337,10 +2337,7 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         media.setFileName(filename);
-        String title = MediaUtils.getFileNameFromPath(filename);
-        if (title != null) {
-            media.setTitle(title);
-        }
+        media.setTitle(filename);
         media.setFilePath(path);
         media.setLocalSiteId(mSite.getId());
         media.setFileExtension(fileExtension);

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/FileUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/FileUtils.java
@@ -1,5 +1,7 @@
 package org.wordpress.android.util;
 
+import android.text.TextUtils;
+
 import java.io.File;
 
 public class FileUtils {
@@ -27,5 +29,32 @@ public class FileUtils {
             AppLog.e(AppLog.T.MEDIA, "Can't access the file.", e);
             return -1L;
         }
+    }
+
+    /**
+     * Given the full file path, or the filename with extension (i.e. my-picture.jpg), returns the filename part only (my-picture).
+     *
+     * @param filePath The path to the file or the full filename
+     * @return filename part only or null
+     */
+    public static String getFileNameFromPath(String filePath) {
+        if (TextUtils.isEmpty(filePath)) {
+            return null;
+        }
+        if (filePath.contains("/")) {
+            if (filePath.lastIndexOf("/") + 1 >= filePath.length()) {
+                filePath = filePath.substring(0, filePath.length() - 1);
+            }
+            filePath = filePath.substring(filePath.lastIndexOf("/") + 1);
+        }
+
+        String filename;
+        int dotPos = filePath.indexOf('.');
+        if (dotPos > 0) {
+            filename = filePath.substring(0, dotPos);
+        } else {
+            filename = filePath;
+        }
+        return filename;
     }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -551,7 +551,21 @@ public class ImageUtils {
         FileOutputStream out;
 
         try {
-            resizedImageFile = File.createTempFile("wp-image-", "." + fileExtension);
+            // try to re-use the same name as prefix of the temp file
+            String prefix;
+            int dotPos = fileName.indexOf('.');
+            if (dotPos > 0) {
+                prefix = fileName.substring(0, dotPos);
+            } else {
+                prefix = fileName;
+            }
+
+            if (prefix.length() < 3) {
+                // prefix must be at least 3 characters
+                prefix = "wp-image";
+            }
+
+            resizedImageFile = File.createTempFile(prefix, "." + fileExtension);
             out = new FileOutputStream(resizedImageFile);
         } catch (IOException e) {
             AppLog.e(AppLog.T.MEDIA, "Failed to create the temp file on storage. Use the original picture instead.");
@@ -791,7 +805,12 @@ public class ImageUtils {
                 prefix = fileName;
             }
 
-            rotatedImageFile = File.createTempFile(prefix + "-rot", "." + fileExtension);
+            if (prefix.length() < 3) {
+                // prefix must be at least 3 characters
+                prefix = "wp-image";
+            }
+
+            rotatedImageFile = File.createTempFile(prefix, "." + fileExtension);
             out = new FileOutputStream(rotatedImageFile);
         } catch (IOException e) {
             AppLog.e(AppLog.T.MEDIA, "Failed to create the temp file on storage.");

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -552,7 +552,7 @@ public class ImageUtils {
 
         try {
             // try to re-use the same name as prefix of the temp file
-            String prefix = MediaUtils.getFileNameFromPath(fileName);
+            String prefix = FileUtils.getFileNameFromPath(fileName);
 
             if (TextUtils.isEmpty(prefix) || prefix.length() < 3) {
                 // prefix must be at least 3 characters
@@ -791,7 +791,7 @@ public class ImageUtils {
 
         try {
             // try to re-use the same name as prefix of the temp file
-            String prefix = MediaUtils.getFileNameFromPath(fileName);
+            String prefix = FileUtils.getFileNameFromPath(fileName);
 
             if (TextUtils.isEmpty(prefix) || prefix.length() < 3) {
                 // prefix must be at least 3 characters

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -791,12 +791,7 @@ public class ImageUtils {
                 prefix = fileName;
             }
 
-            if (prefix.length() < 3) {
-                // prefix must be at least 3 characters
-                prefix = "wp-image";
-            }
-
-            rotatedImageFile = File.createTempFile(prefix, "." + fileExtension);
+            rotatedImageFile = File.createTempFile(prefix + "-rot", "." + fileExtension);
             out = new FileOutputStream(rotatedImageFile);
         } catch (IOException e) {
             AppLog.e(AppLog.T.MEDIA, "Failed to create the temp file on storage.");

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -552,15 +552,9 @@ public class ImageUtils {
 
         try {
             // try to re-use the same name as prefix of the temp file
-            String prefix;
-            int dotPos = fileName.indexOf('.');
-            if (dotPos > 0) {
-                prefix = fileName.substring(0, dotPos);
-            } else {
-                prefix = fileName;
-            }
+            String prefix = MediaUtils.getFileNameFromPath(fileName);
 
-            if (prefix.length() < 3) {
+            if (TextUtils.isEmpty(prefix) || prefix.length() < 3) {
                 // prefix must be at least 3 characters
                 prefix = "wp-image";
             }
@@ -797,15 +791,9 @@ public class ImageUtils {
 
         try {
             // try to re-use the same name as prefix of the temp file
-            String prefix;
-            int dotPos = fileName.indexOf('.');
-            if (dotPos > 0) {
-                prefix = fileName.substring(0, dotPos);
-            } else {
-                prefix = fileName;
-            }
+            String prefix = MediaUtils.getFileNameFromPath(fileName);
 
-            if (prefix.length() < 3) {
+            if (TextUtils.isEmpty(prefix) || prefix.length() < 3) {
                 // prefix must be at least 3 characters
                 prefix = "wp-image";
             }
@@ -851,7 +839,6 @@ public class ImageUtils {
 
         return null;
     }
-
 
     /**
      * This is a wrapper around MediaStore.Images.Thumbnails.getThumbnail that takes in consideration

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -379,33 +379,6 @@ public class MediaUtils {
         return originalFileName;
     }
 
-    /**
-     * Given the full file path, or the filename with extension (i.e. my-picture.jpg), returns the filename part only (my-picture).
-     *
-     * @param filePath The path to the file or the full filename
-     * @return filename part only or null
-     */
-    public static String getFileNameFromPath(String filePath) {
-        if (TextUtils.isEmpty(filePath)) {
-            return null;
-        }
-        if (filePath.contains("/")) {
-            if (filePath.lastIndexOf("/") + 1 >= filePath.length()) {
-                filePath = filePath.substring(0, filePath.length() - 1);
-            }
-            filePath = filePath.substring(filePath.lastIndexOf("/") + 1);
-        }
-
-        String filename;
-        int dotPos = filePath.indexOf('.');
-        if (dotPos > 0) {
-            filename = filePath.substring(0, dotPos);
-        } else {
-            filename = filePath;
-        }
-        return filename;
-    }
-
     public static String getExtensionForMimeType(String mimeType) {
         if (TextUtils.isEmpty(mimeType))
             return "";

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/MediaUtils.java
@@ -379,6 +379,33 @@ public class MediaUtils {
         return originalFileName;
     }
 
+    /**
+     * Given the full file path, or the filename with extension (i.e. my-picture.jpg), returns the filename part only (my-picture).
+     *
+     * @param filePath The path to the file or the full filename
+     * @return filename part only or null
+     */
+    public static String getFileNameFromPath(String filePath) {
+        if (TextUtils.isEmpty(filePath)) {
+            return null;
+        }
+        if (filePath.contains("/")) {
+            if (filePath.lastIndexOf("/") + 1 >= filePath.length()) {
+                filePath = filePath.substring(0, filePath.length() - 1);
+            }
+            filePath = filePath.substring(filePath.lastIndexOf("/") + 1);
+        }
+
+        String filename;
+        int dotPos = filePath.indexOf('.');
+        if (dotPos > 0) {
+            filename = filePath.substring(0, dotPos);
+        } else {
+            filename = filePath;
+        }
+        return filename;
+    }
+
     public static String getExtensionForMimeType(String mimeType) {
         if (TextUtils.isEmpty(mimeType))
             return "";


### PR DESCRIPTION
Fixes #6560 by trying to reuse the original filename as prefix for the temporary optimized file.

Ex: `my-picture_20170606.jpg`, when optimized, will become `my-picture_20170606-<timestamp>.jpg`. The timestamp part is not controlled by us.


Also try to set the `Title` property of the media on uploading. The Title property is set by reusing the filename part of the file. Matching Calypso.
