### PR TITLE
Guard for null site url when viewing site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -154,21 +154,17 @@ public class ActivityLauncher {
     }
 
     public static void viewCurrentSite(Context context, SiteModel site, boolean openFromHeader) {
-        if (site == null) {
-            ToastUtils.showToast(context, R.string.blog_not_found, ToastUtils.Duration.SHORT);
-            return;
-        }
-
         AnalyticsTracker.Stat stat = openFromHeader ? AnalyticsTracker.Stat.OPENED_VIEW_SITE_FROM_HEADER
                 : AnalyticsTracker.Stat.OPENED_VIEW_SITE;
         AnalyticsUtils.trackWithSiteDetails(stat, site);
 
-        final String siteUrl = site.getUrl();
-        if (siteUrl == null) {
-            ToastUtils.showToast(context, context.getString(R.string.site_url_null), ToastUtils.Duration.LONG);
+        if (site == null) {
+            ToastUtils.showToast(context, R.string.blog_not_found, ToastUtils.Duration.SHORT);
+        } else if (site.getUrl() == null) {
+            ToastUtils.showToast(context, R.string.blog_not_found, ToastUtils.Duration.SHORT);
             AppLog.w(AppLog.T.UTILS, "Site URL is null. Login URL: " + site.getLoginUrl());
         } else {
-            openUrlExternal(context, siteUrl);
+            openUrlExternal(context, site.getUrl());
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -162,7 +162,14 @@ public class ActivityLauncher {
         AnalyticsTracker.Stat stat = openFromHeader ? AnalyticsTracker.Stat.OPENED_VIEW_SITE_FROM_HEADER
                 : AnalyticsTracker.Stat.OPENED_VIEW_SITE;
         AnalyticsUtils.trackWithSiteDetails(stat, site);
-        openUrlExternal(context, site.getUrl());
+
+        final String siteUrl = site.getUrl();
+        if (siteUrl == null) {
+            ToastUtils.showToast(context, context.getString(R.string.site_url_null), ToastUtils.Duration.LONG);
+            AppLog.w(AppLog.T.UTILS, "Site URL is null. Login URL: " + site.getLoginUrl());
+        } else {
+            openUrlExternal(context, siteUrl);
+        }
     }
 
     public static void viewBlogAdmin(Context context, SiteModel site) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -98,7 +98,6 @@
     <string name="swipe_for_more">Swipe for more</string>
     <string name="confirm">Confirm</string>
     <string name="no_default_app_available_to_open_link">Unable to open the link</string>
-    <string name="site_url_null">Sorry, invalid site URL (null)</string>
     <string name="retry">Retry</string>
 
     <string name="button_skip">Skip</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="swipe_for_more">Swipe for more</string>
     <string name="confirm">Confirm</string>
     <string name="no_default_app_available_to_open_link">Unable to open the link</string>
+    <string name="site_url_null">Sorry, invalid site URL (null)</string>
     <string name="retry">Retry</string>
 
     <string name="button_skip">Skip</string>


### PR DESCRIPTION
Fixes #6586 

There are cases where the site URL can be null in the model so, need to guard for that when trying to open the site (via MySite).

To test:
* No steps known