### PR TITLE
Offering other url handlers on SecurityException

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -400,6 +400,7 @@ public class ActivityLauncher {
             } else {
                 Intent chooser = Intent.createChooser(intent, context.getString(R.string.error_please_choose_browser));
                 context.startActivity(chooser);
+                AppLockManager.getInstance().setExtendedTimeout();
             }
         } finally {
             // re-enable deeplinking

--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -387,7 +387,7 @@ public class ActivityLauncher {
             AppLockManager.getInstance().setExtendedTimeout();
 
         } catch (ActivityNotFoundException e) {
-            ToastUtils.showToast(context, context.getString(R.string.no_default_app_available_to_open_link), ToastUtils.Duration.LONG);
+            ToastUtils.showToast(context, context.getString(R.string.cant_open_url), ToastUtils.Duration.LONG);
             AppLog.e(AppLog.T.UTILS, "No default app available on the device to open the link: " + url, e);
         } catch (SecurityException se) {
             AppLog.e(AppLog.T.UTILS, "Error opening url in default browser. Url: " + url, se);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -97,10 +97,9 @@
     <string name="send">Send</string>
     <string name="swipe_for_more">Swipe for more</string>
     <string name="confirm">Confirm</string>
-    <string name="no_default_app_available_to_open_link">Unable to open the link</string>
+    <string name="cant_open_url">Unable to open the link</string>
     <string name="retry">Retry</string>
     <string name="error_please_choose_browser">Error opening the default web browser. Please choose another app:</string>
-    <string name="cant_open_url">Error occurred while opening link</string>
 
     <string name="button_skip">Skip</string>
     <string name="button_next">Next</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -99,6 +99,8 @@
     <string name="confirm">Confirm</string>
     <string name="no_default_app_available_to_open_link">Unable to open the link</string>
     <string name="retry">Retry</string>
+    <string name="error_please_choose_browser">Error opening the default web browser. Please choose another app:</string>
+    <string name="cant_open_url">Error occurred while opening link</string>
 
     <string name="button_skip">Skip</string>
     <string name="button_next">Next</string>


### PR DESCRIPTION
Fixes #6001 

The Alibaba B2B still causes problems (probably older versions of the app still in circulation) so, let's guard against the SecurityException and offer the user the list of available URL handlers (web browsers usually) to chose from.

Unfortunately, there are no steps to reproduce here. A way to test this is to manually modify the code to throw a SecurityException right after the call to `WPActivityUtils.disableComponent()`.

To test:
* no steps available