### PR TITLE
Editor: refresh PostModel when recovering Activity state

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -328,6 +328,11 @@ public class EditPostActivity extends AppCompatActivity implements
             if (mEditorFragment instanceof EditorMediaUploadListener) {
                 mEditorMediaUploadListener = (EditorMediaUploadListener) mEditorFragment;
             }
+
+            if (mEditorFragment != null) {
+                mEditorFragment.setContent(mPost.getContent());
+                mEditorFragment.setTitle(mPost.getTitle());
+            }
         }
 
         if (mSite == null) {
@@ -1394,6 +1399,11 @@ public class EditPostActivity extends AppCompatActivity implements
                 case 0:
                     mEditorFragment = (EditorFragmentAbstract) fragment;
                     mEditorFragment.setImageLoader(mImageLoader);
+
+                    if (mEditorFragment != null) {
+                        mEditorFragment.setContent(mPost.getContent());
+                        mEditorFragment.setTitle(mPost.getTitle());
+                    }
 
                     if (mEditorFragment instanceof EditorMediaUploadListener) {
                         mEditorMediaUploadListener = (EditorMediaUploadListener) mEditorFragment;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -331,11 +331,6 @@ public class EditPostActivity extends AppCompatActivity implements
             if (mEditorFragment instanceof EditorMediaUploadListener) {
                 mEditorMediaUploadListener = (EditorMediaUploadListener) mEditorFragment;
             }
-
-            if (mEditorFragment != null) {
-                mEditorFragment.setContent(mPost.getContent());
-                mEditorFragment.setTitle(mPost.getTitle());
-            }
         }
 
         if (mSite == null) {
@@ -352,6 +347,11 @@ public class EditPostActivity extends AppCompatActivity implements
         if (mPost == null) {
             showErrorAndFinish(R.string.post_not_found);
             return;
+        }
+
+        if (mEditorFragment != null) {
+            mEditorFragment.setContent(mPost.getContent());
+            mEditorFragment.setTitle(mPost.getTitle());
         }
 
         if (mIsNewPost) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -169,6 +169,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private static final String STATE_KEY_EDITOR_FRAGMENT = "editorFragment";
     private static final String STATE_KEY_DROPPED_MEDIA_URIS = "stateKeyDroppedMediaUri";
     private static final String STATE_KEY_POST_LOCAL_ID = "stateKeyPostModelLocalId";
+    private static final String STATE_KEY_IS_NEW_POST = "stateKeyIsNewPost";
 
     private static int PAGE_CONTENT = 0;
     private static int PAGE_SETTINGS = 1;
@@ -319,10 +320,12 @@ public class EditPostActivity extends AppCompatActivity implements
             }
         } else {
             mDroppedMediaUris = savedInstanceState.getParcelable(STATE_KEY_DROPPED_MEDIA_URIS);
+            mIsNewPost = savedInstanceState.getBoolean(STATE_KEY_IS_NEW_POST, false);
 
             if (savedInstanceState.containsKey(STATE_KEY_POST_LOCAL_ID)) {
                 initializePostObjects(savedInstanceState.getInt(STATE_KEY_POST_LOCAL_ID));
             }
+
             mEditorFragment = (EditorFragmentAbstract) fragmentManager.getFragment(savedInstanceState, STATE_KEY_EDITOR_FRAGMENT);
 
             if (mEditorFragment instanceof EditorMediaUploadListener) {
@@ -517,6 +520,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // Saves both post objects so we can restore them in onCreate()
         savePostAsync(null);
         outState.putInt(STATE_KEY_POST_LOCAL_ID, mPost.getId());
+        outState.putBoolean(STATE_KEY_IS_NEW_POST, mIsNewPost);
         outState.putSerializable(WordPress.SITE, mSite);
 
         outState.putParcelableArrayList(STATE_KEY_DROPPED_MEDIA_URIS, mDroppedMediaUris);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -349,11 +349,6 @@ public class EditPostActivity extends AppCompatActivity implements
             return;
         }
 
-        if (mEditorFragment != null) {
-            mEditorFragment.setContent(mPost.getContent());
-            mEditorFragment.setTitle(mPost.getTitle());
-        }
-
         if (mIsNewPost) {
             trackEditorCreatedPost(action, getIntent());
         } else {
@@ -1403,11 +1398,6 @@ public class EditPostActivity extends AppCompatActivity implements
                 case 0:
                     mEditorFragment = (EditorFragmentAbstract) fragment;
                     mEditorFragment.setImageLoader(mImageLoader);
-
-                    if (mEditorFragment != null) {
-                        mEditorFragment.setContent(mPost.getContent());
-                        mEditorFragment.setTitle(mPost.getTitle());
-                    }
 
                     if (mEditorFragment instanceof EditorMediaUploadListener) {
                         mEditorMediaUploadListener = (EditorMediaUploadListener) mEditorFragment;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -117,7 +117,7 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
         return hasInProgressMediaUploadsForPost(postModel) || hasPendingMediaUploadsForPost(postModel);
     }
 
-    static List<MediaModel> getPendingOrInProgressMediaUploadsForPost(PostModel postModel) {
+    public static List<MediaModel> getPendingOrInProgressMediaUploadsForPost(PostModel postModel) {
         if (postModel == null) {
             return Collections.emptyList();
         }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -385,6 +385,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void setTitle(CharSequence text) {
+        if (text == null) {
+            text = "";
+        }
+
         if (title == null) {
             mLateInit = true;
             mLateInitTitle = text;
@@ -395,6 +399,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void setContent(CharSequence text) {
+        if (text == null) {
+            text = "";
+        }
+
         if (content == null) {
             mLateInit = true;
             mLateInitContent = text;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -19,6 +19,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
@@ -125,6 +126,9 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     private AztecText title;
     private AztecText content;
     private boolean mAztecReady;
+    protected boolean mLateInit;
+    protected CharSequence mLateInitContent;
+    protected CharSequence mLateInitTitle;
     private SourceViewEditText source;
     private AztecToolbar formattingToolbar;
     private Html.ImageGetter aztecImageLoader;
@@ -238,6 +242,16 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         mEditorFragmentListener.onEditorFragmentInitialized();
 
         return view;
+    }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        if (mLateInit) {
+            setTitle(mLateInitTitle);
+            setContent(mLateInitContent);
+            mLateInit = false;
+        }
     }
 
     public void setEditorBetaClickListener(EditorBetaClickListener listener) {
@@ -371,11 +385,22 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void setTitle(CharSequence text) {
+        if (title == null) {
+            mLateInit = true;
+            mLateInitTitle = text;
+            return;
+        }
         title.setText(text);
     }
 
     @Override
     public void setContent(CharSequence text) {
+        if (content == null) {
+            mLateInit = true;
+            mLateInitContent = text;
+            return;
+        }
+
         content.fromHtml(text.toString());
 
         updateFailedMediaList();

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -19,7 +19,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
@@ -586,17 +585,22 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     private void overlayProgressingMedia() {
         for (String localMediaId : mUploadingMediaProgressMax.keySet()) {
-            MediaPredicate predicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
-            overlayProgressingMedia(predicate);
-            // here check if this is a video uploading in progress or not; if it is, show the video play icon
-            for (Attributes attrs : content.getAllElementAttributes(predicate)) {
-                AttributesWithClass attributesWithClass = getAttributesWithClass(attrs);
-                if (attributesWithClass.hasClass(TEMP_VIDEO_UPLOADING_CLASS)) {
-                    overlayVideoIcon(2, predicate);
-                }
+            overlayProgressingMediaForMediaId(localMediaId);
+        }
+    }
+
+    private void overlayProgressingMediaForMediaId(String localMediaId) {
+        MediaPredicate predicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
+        overlayProgressingMedia(predicate);
+        // here check if this is a video uploading in progress or not; if it is, show the video play icon
+        for (Attributes attrs : content.getAllElementAttributes(predicate)) {
+            AttributesWithClass attributesWithClass = getAttributesWithClass(attrs);
+            if (attributesWithClass.hasClass(TEMP_VIDEO_UPLOADING_CLASS)) {
+                overlayVideoIcon(2, predicate);
             }
         }
     }
+
 
     private void overlayVideoIcon(int overlayLevel, AztecText.AttributePredicate predicate) {
         Drawable videoDrawable = getResources().getDrawable(R.drawable.ic_overlay_video);
@@ -840,6 +844,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     @Override
     public void onMediaUploadReattached(String localId, float currentProgress) {
         mUploadingMediaProgressMax.put(localId, currentProgress);
+        overlayProgressingMediaForMediaId(localId);
     }
 
     @Override

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -126,9 +126,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     private AztecText title;
     private AztecText content;
     private boolean mAztecReady;
-    protected boolean mLateInit;
-    protected CharSequence mLateInitContent;
-    protected CharSequence mLateInitTitle;
     private SourceViewEditText source;
     private AztecToolbar formattingToolbar;
     private Html.ImageGetter aztecImageLoader;
@@ -242,16 +239,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         mEditorFragmentListener.onEditorFragmentInitialized();
 
         return view;
-    }
-
-    @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-        if (mLateInit) {
-            setTitle(mLateInitTitle);
-            setContent(mLateInitContent);
-            mLateInit = false;
-        }
     }
 
     public void setEditorBetaClickListener(EditorBetaClickListener listener) {
@@ -390,8 +377,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         }
 
         if (title == null) {
-            mLateInit = true;
-            mLateInitTitle = text;
             return;
         }
         title.setText(text);
@@ -404,8 +389,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         }
 
         if (content == null) {
-            mLateInit = true;
-            mLateInitContent = text;
             return;
         }
 


### PR DESCRIPTION
Fixes #5863 by making `EditPostActivity` try and fetch the latest copy from the `PostStore` if it's restoring a post from saved state.

To test:
1. Enable 'don't keep activities'
2. Start new post, upload media
3. While media is uploading, background the app (don't leave the editor)
4. Wait for upload to complete
5. The post is updated asynchronously, and the store copy of the store is updated
6. Re-open the app
7. The editor is recreated, confirm it obtains the latest `PostModel` (i.e. the picture is retrieved from the remote URL

cc @aforcier @nbradbury 
