### PR TITLE
Rename string values to reflect their new param number

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1213,7 +1213,7 @@ public class EditPostActivity extends AppCompatActivity implements
                     EditPostActivity.this.runOnUiThread(new Runnable() {
                         @Override
                         public void run() {
-                            String message = getString(mIsPage ? R.string.error_publish_empty_page_param : R.string.error_publish_empty_post_param);
+                            String message = getString(mIsPage ? R.string.error_publish_empty_page : R.string.error_publish_empty_post);
                             ToastUtils.showToast(EditPostActivity.this, message, Duration.SHORT);
                         }
                     });

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -33,15 +33,15 @@ public class UploadUtils {
         String baseErrorString;
         if (post.isPage()) {
             if (isMediaError) {
-                baseErrorString = context.getString(R.string.error_upload_page_media_params);
+                baseErrorString = context.getString(R.string.error_upload_page_media_param);
             } else {
-                baseErrorString = context.getString(R.string.error_upload_page_params);
+                baseErrorString = context.getString(R.string.error_upload_page_param);
             }
         } else {
             if (isMediaError) {
-                baseErrorString = context.getString(R.string.error_upload_post_media_params);
+                baseErrorString = context.getString(R.string.error_upload_post_media_param);
             } else {
-                baseErrorString = context.getString(R.string.error_upload_post_params);
+                baseErrorString = context.getString(R.string.error_upload_post_param);
             }
         }
         return String.format(baseErrorString, errorMessage);
@@ -53,7 +53,7 @@ public class UploadUtils {
     public static @NonNull String getErrorMessageFromPostError(Context context, PostModel post, PostError error) {
         switch (error.type) {
             case UNKNOWN_POST:
-                return post.isPage() ? context.getString(R.string.error_unknown_page_param) : context.getString(R.string.error_unknown_post_param);
+                return post.isPage() ? context.getString(R.string.error_unknown_page) : context.getString(R.string.error_unknown_post);
             case UNKNOWN_POST_TYPE:
                 return context.getString(R.string.error_unknown_post_type);
             case UNAUTHORIZED:
@@ -190,7 +190,7 @@ public class UploadUtils {
 
         // If the post is empty, don't publish
         if (!PostUtils.isPublishable(post)) {
-            String message = activity.getString(post.isPage() ? R.string.error_publish_empty_page_param : R.string.error_publish_empty_post_param);
+            String message = activity.getString(post.isPage() ? R.string.error_publish_empty_page : R.string.error_publish_empty_post);
             ToastUtils.showToast(activity, message, ToastUtils.Duration.SHORT);
             return;
         }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1154,13 +1154,13 @@
     <string name="error_generic">An error occurred</string>
     <string name="error_moderate_comment">An error occurred while moderating</string>
     <string name="error_edit_comment">An error occurred while editing the comment</string>
-    <string name="error_publish_empty_post_param">Can\'t publish an empty post</string>
-    <string name="error_publish_empty_page_param">Can\'t publish an empty page</string>
+    <string name="error_publish_empty_post">Can\'t publish an empty post</string>
+    <string name="error_publish_empty_page">Can\'t publish an empty page</string>
     <string name="error_publish_no_network">Device is offline. Changes saved locally.</string>
-    <string name="error_upload_post_params">There was an error uploading this post: %s.</string>
-    <string name="error_upload_post_media_params">There was an error uploading the media in this post: %s.</string>
-    <string name="error_upload_page_params">There was an error uploading this page: %s.</string>
-    <string name="error_upload_page_media_params">There was an error uploading the media in this page: %s.</string>
+    <string name="error_upload_post_param">There was an error uploading this post: %s.</string>
+    <string name="error_upload_page_param">There was an error uploading this page: %s.</string>
+    <string name="error_upload_post_media_param">There was an error uploading the media in this post: %s.</string>
+    <string name="error_upload_page_media_param">There was an error uploading the media in this page: %s.</string>
     <string name="error_media_insufficient_fs_permissions">Read permission denied on device media</string>
     <string name="error_media_not_found">Media could not be found</string>
     <string name="error_media_unauthorized">You don\'t have permission to view or edit media</string>
@@ -1192,8 +1192,8 @@
     <string name="error_fetch_site_after_creation">Site has been created, you might need to refresh your sites in the site picker.</string>
 
     <!-- Post Error -->
-    <string name="error_unknown_post_param">Could not find the post on the server</string>
-    <string name="error_unknown_page_param">Could not find the page on the server</string>
+    <string name="error_unknown_post">Could not find the post on the server</string>
+    <string name="error_unknown_page">Could not find the page on the server</string>
     <string name="error_unknown_post_type">Unknown post format</string>
 
     <!-- Image Descriptions for Accessibility -->


### PR DESCRIPTION
Fixes an string resource issue that was [causing the build to fail due to a lint error](https://travis-ci.org/wordpress-mobile/WordPress-Android/builds/269333087).

The trouble was that [some variable string resources were changed](https://github.com/wordpress-mobile/WordPress-Android/pull/6558) (in `develop`) to take a different number of arguments, which caused a conflict when translated versions of the older version were [merged in](https://github.com/wordpress-mobile/WordPress-Android/commit/edb39ea7872493afec9a7aa9034275bb7276ba3f).

So `strings.xml` had a one-argument version of `error_upload_post_params`, for example, while some of the translated string resources had the old two-argument version, and was caught by the linter.

This PR renames the strings that were modified, eliminating the conflict. (`8.1` is safe since the string resources were changed after that release was cut.)