### PR TITLE
Fix for Android versions that can't add media to the Library

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -791,6 +791,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
         int width = getResources().getDimensionPixelSize(R.dimen.action_bar_spinner_width);
         mAddMediaPopup = new PopupWindow(menuView, width, ViewGroup.LayoutParams.WRAP_CONTENT, false);
+        mAddMediaPopup.setFocusable(true);
     }
 
     private boolean isAddMediaPopupShowing() {


### PR DESCRIPTION
Fixes #6595 by setting the `Add Media` Popup focusable on creation. On some Android versions ListView inside PopupWindow doesn't receive touch events when popup is not focusable.

**To test**
- Start the Android app
- Switch to the first tab
- Select Media
- Then tap on the `+` sign top left and select a picture
- The upload should start

Note: Make sure the search and other functions are still working on the screen :)

#### Tested on Sony Xperia - Android 4.3


cc @theck13 

