### PR TITLE
Match ReaderWebView's width directly

### DIFF
--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -40,7 +40,7 @@
 
                     <include
                         layout="@layout/reader_include_post_detail_content"
-                        android:layout_width="wrap_content"
+                        android:layout_width="@dimen/reader_webview_width"
                         android:layout_height="wrap_content"
                         android:layout_below="@+id/header_view"
                         android:layout_centerHorizontal="true"

--- a/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
@@ -6,11 +6,10 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:tools="http://schemas.android.com/tools"
               android:id="@+id/layout_post_detail_content"
-              android:layout_width="wrap_content"
+              android:layout_width="@dimen/reader_webview_width"
               android:layout_height="match_parent"
               android:orientation="vertical"
-              android:paddingTop="@dimen/margin_medium"
-              tools:layout_width="match_parent">
+              android:paddingTop="@dimen/margin_medium">
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/text_title"


### PR DESCRIPTION
Fixes #6591 

`LinearLayout` has apparently a different behaviour than `RelativeLayout` in regards to determining its final relative width so, directly define `<include>`s and `LinearLayout`s width to be `reader_webview_width`.

To test:
* Using your _mobile_ web browser, tap on this link: https://wordpress.com/read/blogs/15154162/posts/18737. That should open or prompt to open the app. Choose the app if prompted.
* Observe the margins on the screen. Should be "normal" and not big as in the ticket.