### PR TITLE
Check change history size to test for content changes in Post

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1740,7 +1740,7 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         if (contentChanged) {
-            contentChanged = PostUtils.updatePostContentIfDifferent(mPost, content);
+            mPost.setContent(content);
         }
 
         if (!mPost.isLocalDraft() && (titleChanged || contentChanged)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1734,13 +1734,19 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         boolean titleChanged = PostUtils.updatePostTitleIfDifferent(mPost, title);
-        boolean contentChanged = true;
+        boolean contentChanged;
         if (mEditorFragment instanceof AztecEditorFragment) {
             contentChanged = ((AztecEditorFragment)mEditorFragment).hasHistory();
-        }
-
-        if (contentChanged) {
-            mPost.setContent(content);
+            if (contentChanged) {
+                mPost.setContent(content);
+            } else if (!((AztecEditorFragment)mEditorFragment).isHistoryEnabled()){
+                // if history is not enabled, then we can only confirm whether there's been a content change
+                // by comparing content
+                contentChanged = PostUtils.updatePostContentIfDifferent(mPost, content);
+            }
+        } else {
+            // not Aztec, compare content to look for changes
+            contentChanged = PostUtils.updatePostContentIfDifferent(mPost, content);
         }
 
         if (!mPost.isLocalDraft() && (titleChanged || contentChanged)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1734,7 +1734,14 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         boolean titleChanged = PostUtils.updatePostTitleIfDifferent(mPost, title);
-        boolean contentChanged = PostUtils.updatePostContentIfDifferent(mPost, content);
+        boolean contentChanged = true;
+        if (mEditorFragment instanceof AztecEditorFragment) {
+            contentChanged = ((AztecEditorFragment)mEditorFragment).hasAnyChanges();
+        }
+
+        if (contentChanged) {
+            contentChanged = PostUtils.updatePostContentIfDifferent(mPost, content);
+        }
 
         if (!mPost.isLocalDraft() && (titleChanged || contentChanged)) {
             mPost.setIsLocallyChanged(true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1736,7 +1736,7 @@ public class EditPostActivity extends AppCompatActivity implements
         boolean titleChanged = PostUtils.updatePostTitleIfDifferent(mPost, title);
         boolean contentChanged = true;
         if (mEditorFragment instanceof AztecEditorFragment) {
-            contentChanged = ((AztecEditorFragment)mEditorFragment).hasAnyChanges();
+            contentChanged = ((AztecEditorFragment)mEditorFragment).hasHistory();
         }
 
         if (contentChanged) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -312,6 +312,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         super.onPrepareOptionsMenu(menu);
     }
 
+    public boolean hasAnyChanges() {
+        return (content.history.getHistoryEnabled() && !content.history.getHistoryList().isEmpty());
+    }
+
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -316,6 +316,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         return (content.history.getHistoryEnabled() && !content.history.getHistoryList().isEmpty());
     }
 
+    public boolean isHistoryEnabled() {
+        return content.history.getHistoryEnabled();
+    }
+
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -312,7 +312,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         super.onPrepareOptionsMenu(menu);
     }
 
-    public boolean hasAnyChanges() {
+    public boolean hasHistory() {
         return (content.history.getHistoryEnabled() && !content.history.getHistoryList().isEmpty());
     }
 


### PR DESCRIPTION
Fixes #6599 partially (on Aztec only).

In investigating this, we realized the problem was that both Aztec and the Visual editors do change the content even if the user doesn't do anything with it, as follows. 

#### Aztec

Using the Aztec editor to open a post that contains 1 media item (at least) and has been written using wp-admin or Calypso, this is how the original Post content looks like:

**Original content**
```
some text
<img src="https://testmzorz2.files.wordpress.com/2017/08/img_20170826_160114_12137624278.jpg?w=300" alt="" width="300" height="169" class="alignnone size-medium wp-image-1957" />
```

When getting this content into Aztec and then exiting the editor, re-creating the html back using `AztecText.toHtml()`, the produced content looks like this:

**Content as rendered by the editor**
```
some text
<img class="alignnone size-medium wp-image-1957" src="https://testmzorz2.files.wordpress.com/2017/08/img_20170826_160114_12137624278.jpg?w=300" alt="" width="300" height="169">
```

Look at the two `img` tags, I'll put them together here:
```
<img class="alignnone size-medium wp-image-1957" src="https://testmzorz2.files.wordpress.com/2017/08/img_20170826_160114_12137624278.jpg?w=300" alt="" width="300" height="169">
<img src="https://testmzorz2.files.wordpress.com/2017/08/img_20170826_160114_12137624278.jpg?w=300" alt="" width="300" height="169" class="alignnone size-medium wp-image-1957" />
```
So two things are different:
1) the placement of the `class` property within the string is different (`wp-admin` places it in the end of the tag, while Aztec places it at the beginning)
2) Aztec is not closing the self-containing tag with `/>`. (BTW don't know whether this is a bug or not, as the Visual Editor behaves the same way as we'll see).


#### Visual Editor

**Original content**
```
some text
<img src="https://testmzorz2.files.wordpress.com/2017/08/wp-image-511380693.jpg?w=225" alt="" width="225" height="300" class="alignnone size-medium wp-image-1941" />
```

**Content rendered by the editor**
```
some text
<img src="https://testmzorz2.files.wordpress.com/2017/08/wp-image-511380693.jpg?w=225" alt="" width="225" height="300" class="alignnone size-medium wp-image-1941">
```

=> Here, the only difference is the wrong closing of the `<img` tag (again without the `/>`).


The way we were using to test if something changed is by means of a [string comparison between the original and new content](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L1763). Because the string actually changes, we [mark the Post as `Locally changed`](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L1766).

#### The proposed solution on Aztec

Now, trying to compare whether two HTML expressions are semantically identical is a difficult thing to achieve, and probably fairly off the scope of this issue in particular. So what this PR does, is it takes advantage of the change history capability placed in Aztec, which keeps track of a change history and makes it possible to undo/redo changes. If the user does anything with the content, it will be tracked in its history tracker. So in order to learn if the content has been edited at all, all we need to do is checking if the change history size is any different than zero.

#### The proposed solution on the Visual Editor
None that I can think of without incurring in a significant effort. I think we could leave it as is, as eventually it will be replaced by Aztec at some point.

To test:
1. on the web admin (wp-admin or Calypso), write a draft that has images and/or videos in it
2. now open the Android app and check for it in the Posts list
3. open it in the editor (Aztec only)
4. exit the editor
5. observe the Post remains unchanged

cc @nbradbury @aforcier