### PR TITLE
Issue/6609 delay aztec promo

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -301,20 +301,18 @@ public class WPMainActivity extends AppCompatActivity {
         }
     }
 
-    private void showNewEditorPromoDialogIfNeeded() {
-        if (AppPrefs.isNewEditorPromoRequired()) {
-            AppCompatDialogFragment newFragment = new PromoDialogEditor.Builder(
-                    R.drawable.img_promo_editor,
-                    R.string.new_editor_promo_title,
-                    R.string.new_editor_promo_description,
-                    R.string.new_editor_promo_button_positive)
-                    .setLinkText(R.string.new_editor_promo_link)
-                    .setNegativeButtonText(R.string.new_editor_promo_button_negative)
-                    .setTitleBetaText(R.string.new_editor_promo_title_beta)
-                    .build();
-            newFragment.show(getSupportFragmentManager(), "new-editor-promo");
-            AppPrefs.setNewEditorPromoRequired(false);
-        }
+    private void showNewEditorPromoDialog() {
+        AppCompatDialogFragment newFragment = new PromoDialogEditor.Builder(
+                R.drawable.img_promo_editor,
+                R.string.new_editor_promo_title,
+                R.string.new_editor_promo_description,
+                R.string.new_editor_promo_button_positive)
+                .setLinkText(R.string.new_editor_promo_link)
+                .setNegativeButtonText(R.string.new_editor_promo_button_negative)
+                .setTitleBetaText(R.string.new_editor_promo_title_beta)
+                .build();
+        newFragment.show(getSupportFragmentManager(), "new-editor-promo");
+        AppPrefs.setNewEditorPromoRequired(false);
     }
 
     @Override
@@ -499,13 +497,18 @@ public class WPMainActivity extends AppCompatActivity {
     }
 
     private void trackLastVisibleTab(int position, boolean trackAnalytics) {
-        if (FluxCUtils.isSignedInWPComOrHasWPOrgSite(mAccountStore, mSiteStore)
-                && position == WPMainTabAdapter.TAB_MY_SITE) {
-            showNewEditorPromoDialogIfNeeded();
-        }
-
         switch (position) {
             case WPMainTabAdapter.TAB_MY_SITE:
+                // show the new editor promo if the user is logged in and this is at least the third time
+                // the my site tab has been visited
+                if (AppPrefs.isNewEditorPromoRequired()
+                        && !AppPrefs.isAztecEditorEnabled()
+                        && FluxCUtils.isSignedInWPComOrHasWPOrgSite(mAccountStore, mSiteStore)) {
+                    int count = AppPrefs.bumpAndReturnAztecPromoCounter();
+                    if (count >= 3)  {
+                        showNewEditorPromoDialog();
+                    }
+                }
                 ActivityId.trackLastActivity(ActivityId.MY_SITE);
                 if (trackAnalytics) {
                     AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.MY_SITE_ACCESSED,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -499,13 +499,13 @@ public class WPMainActivity extends AppCompatActivity {
     private void trackLastVisibleTab(int position, boolean trackAnalytics) {
         switch (position) {
             case WPMainTabAdapter.TAB_MY_SITE:
-                // show the new editor promo if the user is logged in and this is at least the third time
+                // show the new editor promo if the user is logged in and this is at least the second time
                 // the my site tab has been visited
                 if (AppPrefs.isNewEditorPromoRequired()
                         && !AppPrefs.isAztecEditorEnabled()
                         && FluxCUtils.isSignedInWPComOrHasWPOrgSite(mAccountStore, mSiteStore)) {
                     int count = AppPrefs.bumpAndReturnAztecPromoCounter();
-                    if (count >= 3)  {
+                    if (count >= 2)  {
                         showNewEditorPromoDialog();
                     }
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -122,6 +122,9 @@ public class AppPrefs {
         // When we need to show the new editor promo dialog
         AZTEC_EDITOR_PROMO_REQUIRED,
 
+        // counter which determines whether it's time to show the above promo
+        AZTEC_EDITOR_PROMO_COUNTER,
+
         // When we need to show the async promo dialog
         ASYNC_PROMO_REQUIRED,
 
@@ -465,7 +468,7 @@ public class AppPrefs {
     }
 
     public static boolean isNewEditorPromoRequired() {
-       return getBoolean(UndeletablePrefKey.AZTEC_EDITOR_PROMO_REQUIRED, true);
+       return true; // TODO: getBoolean(UndeletablePrefKey.AZTEC_EDITOR_PROMO_REQUIRED, true);
    }
 
     public static boolean isAsyncPromoRequired() {
@@ -508,6 +511,12 @@ public class AppPrefs {
 
     public static int getAnalyticsForStatsWidgetPromo() {
         return getInt(DeletablePrefKey.STATS_WIDGET_PROMO_ANALYTICS);
+    }
+
+    public static int bumpAndReturnAztecPromoCounter() {
+        int count = getInt(UndeletablePrefKey.AZTEC_EDITOR_PROMO_COUNTER) + 1;
+        setInt(UndeletablePrefKey.AZTEC_EDITOR_PROMO_COUNTER, count);
+        return count;
     }
 
     public static void setGlobalPlansFeatures(String jsonOfFeatures) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -143,9 +143,6 @@ public class AppPrefs {
         // Same as above but for the reader
         SWIPE_TO_NAVIGATE_READER,
 
-        // aztec editor available
-        AZTEC_EDITOR_AVAILABLE,
-
         // smart toast counters
         SMART_TOAST_MEDIA_LONG_PRESS_USAGE_COUNTER,
         SMART_TOAST_MEDIA_LONG_PRESS_TOAST_COUNTER,

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -468,7 +468,7 @@ public class AppPrefs {
     }
 
     public static boolean isNewEditorPromoRequired() {
-       return true; // TODO: getBoolean(UndeletablePrefKey.AZTEC_EDITOR_PROMO_REQUIRED, true);
+       return getBoolean(UndeletablePrefKey.AZTEC_EDITOR_PROMO_REQUIRED, true);
    }
 
     public static boolean isAsyncPromoRequired() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -218,6 +218,7 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
                             case 2:
                                 AppPrefs.setAztecEditorEnabled(true);
                                 AppPrefs.setVisualEditorEnabled(false);
+                                AppPrefs.setNewEditorPromoRequired(false);
                                 break;
                             default:
                                 AppPrefs.setAztecEditorEnabled(false);


### PR DESCRIPTION
Fixes #6609 - delays the Aztec promo dialog until the second time the user hits the My Site tab. 

Note that [the issue](https://github.com/wordpress-mobile/WordPress-Android/issues/6609) states we should also show the promo the first time the editor is shown, but I chose not to implement this. The problem is the user can enable Aztec from that promo dialog, and if they do that while the editor is showing we have to destroy the existing editor and replace it with Aztec. That *is* solvable, but given Aztec will became the default in October I didn't think it was worth the effort.