### PR TITLE
Async media: Use FluxC UploadStore

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:156b375bd13409f7fca092c39c7e35a9272022ff') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:add-upload-store-SNAPSHOT') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:add-upload-store-SNAPSHOT') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:407c7a41d8cb4706874b65327838fa13edab7fac') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -54,7 +54,6 @@ import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.MediaActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.MediaModel.MediaUploadState;
-import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaChanged;
@@ -83,10 +82,8 @@ import org.wordpress.android.util.WPPermissionUtils;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -682,14 +679,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             if (UploadService.isPendingOrInProgressMediaUpload(mediaModel)) {
                 MediaStore.CancelMediaPayload payload = new MediaStore.CancelMediaPayload(mSite, mediaModel, false);
                 mDispatcher.dispatch(MediaActionBuilder.newCancelMediaUploadAction(payload));
-
-                // check if media item was inserted into a Post - if that is the case, then
-                // mark it in the error list so it can be shown properly in the  Posts list, and
-                // also can be accessible from the Error Notification that will be shown.
-                PostModel post = UploadService.isMediaBeingUploadedForAPost(mediaModel);
-                if (post != null) {
-                    UploadService.markPostAsError(post);
-                }
             }
 
             if (mediaModel.getUploadState() != null &&

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -98,7 +98,6 @@ import org.wordpress.android.ui.posts.services.AztecVideoLoader;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.ReleaseNotesActivity;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
-import org.wordpress.android.ui.uploads.MediaUploadHandler;
 import org.wordpress.android.ui.uploads.PostEvents;
 import org.wordpress.android.ui.uploads.UploadService;
 import org.wordpress.android.ui.uploads.VideoOptimizer;
@@ -471,12 +470,12 @@ public class EditPostActivity extends AppCompatActivity implements
             // UploadService.getPendingMediaForPost will be populated only when the user exits the editor
             // But if the user doesn't exit the editor and sends the app to the background, a reattachment
             // for the media within this Post is needed as soon as the app comes back to foreground,
-            // so we get the list of progressing media for this Post from the MediaUploadHandler
+            // so we get the list of progressing media for this Post from the UploadService
             List<MediaModel> allUploadingMediaInPost = new ArrayList<>();
             Set<MediaModel> uploadingMediaInPost = UploadService.getPendingMediaForPost(mPost);
             allUploadingMediaInPost.addAll(uploadingMediaInPost);
             // add them to the array only if they are not in there yet
-            for (MediaModel media1 : MediaUploadHandler.getPendingOrInProgressMediaUploadsForPost(mPost)) {
+            for (MediaModel media1 : UploadService.getPendingOrInProgressMediaUploadsForPost(mPost)) {
                 boolean found = false;
                 for (MediaModel media2 : uploadingMediaInPost) {
                     if (media1.getId() == media2.getId()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -444,12 +444,13 @@ public class EditPostActivity extends AppCompatActivity implements
 
     private void updateUploadServiceErrorForPost(String postContent) {
         if (AztecEditorFragment.hasMediaItemsMarkedFailed(this, postContent)) {
+            // TODO This should be unnecessary if we correctly mirror media errors in the UploadStore
+            // If the error came through a OnMediaUploaded event, the UploadStore should be updated already
+            // If we manually flagged the media as errored (e.g. on app restart), we should reflect that new state
+            // in the background in FluxC
             UploadService.markPostAsError(mPost);
-        } else {
-            UploadService.removeUploadErrorForPost(mPost);
         }
     }
-
 
     private Runnable mAutoSave = new Runnable() {
         @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -427,11 +427,6 @@ public class EditPostActivity extends AppCompatActivity implements
 
         String newContent = AztecEditorFragment.resetUploadingMediaToFailed(this, oldContent);
 
-        // now check if the newcontent still has items marked as failed. If it does,
-        // then hook this post up to our error list, so it can be queried by the Posts List later
-        // and be shown properly to the user
-        updateUploadServiceErrorForPost(newContent);
-
         if (!TextUtils.isEmpty(oldContent) && newContent != null && oldContent.compareTo(newContent) != 0) {
             mPost.setContent(newContent);
 
@@ -440,16 +435,6 @@ public class EditPostActivity extends AppCompatActivity implements
                 mPost.setIsLocallyChanged(true);
             }
             mPost.setDateLocallyChanged(DateTimeUtils.iso8601FromTimestamp(System.currentTimeMillis() / 1000));
-        }
-    }
-
-    private void updateUploadServiceErrorForPost(String postContent) {
-        if (AztecEditorFragment.hasMediaItemsMarkedFailed(this, postContent)) {
-            // TODO This should be unnecessary if we correctly mirror media errors in the UploadStore
-            // If the error came through a OnMediaUploaded event, the UploadStore should be updated already
-            // If we manually flagged the media as errored (e.g. on app restart), we should reflect that new state
-            // in the background in FluxC
-            UploadService.markPostAsError(mPost);
         }
     }
 
@@ -1294,7 +1279,6 @@ public class EditPostActivity extends AppCompatActivity implements
                 saveResult(shouldSave && shouldSync, false);
 
                 definitelyDeleteBackspaceDeletedMediaItems();
-                updateUploadServiceErrorForPost(mPost.getContent());
 
                 if (shouldSave) {
                     if (isNewPost()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -140,6 +140,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -487,7 +488,7 @@ public class EditPostActivity extends AppCompatActivity implements
             // for the media within this Post is needed as soon as the app comes back to foreground,
             // so we get the list of progressing media for this Post from the MediaUploadHandler
             List<MediaModel> allUploadingMediaInPost = new ArrayList<>();
-            List<MediaModel> uploadingMediaInPost = UploadService.getPendingMediaForPost(mPost);
+            Set<MediaModel> uploadingMediaInPost = UploadService.getPendingMediaForPost(mPost);
             allUploadingMediaInPost.addAll(uploadingMediaInPost);
             // add them to the array only if they are not in there yet
             for (MediaModel media1 : MediaUploadHandler.getPendingOrInProgressMediaUploadsForPost(mPost)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -208,7 +208,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         // TODO remove the hasMediaErrorForPost(post) check when we get a proper retry mechanism in place,
         // that retried to upload any failed media along with the post
         return post != null && !UploadService.isPostUploadingOrQueued(post) &&
-                !UploadService.hasMediaErrorForPost(post, mUploadStore) &&
+                !UploadUtils.isMediaError(mUploadStore.getUploadErrorForPost(post)) &&
                 (post.isLocallyChanged() || post.isLocalDraft() || PostStatus.fromPost(post) == PostStatus.DRAFT);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -418,7 +418,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     }
 
     private void updatePostUploadProgressBar(ProgressBar view, PostModel post) {
-        if (UploadService.isPostUploadingOrQueued(post)) {
+        if (UploadService.hasInProgressMediaUploadsForPost(post)) {
             view.setVisibility(View.VISIBLE);
             int overallProgress = Math.round(UploadService.getMediaUploadProgressForPost(post) * 100);
             // Sometimes the progress bar can be stuck at 100% for a long time while further processing happens

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -441,7 +441,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             int statusColorResId = R.color.grey_darken_10;
             String errorMessage = null;
 
-            UploadError reason = UploadService.getUploadErrorForPost(post, mUploadStore);
+            UploadError reason = mUploadStore.getUploadErrorForPost(post);
             if (reason != null) {
                 if (reason.mediaError != null) {
                     errorMessage = context.getString(post.isPage() ? R.string.error_media_recover_page
@@ -527,7 +527,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             holder.btnView.setButtonType(PostListButton.BUTTON_VIEW);
         }
 
-        if (UploadService.getUploadErrorForPost(post, mUploadStore) != null) {
+        if (mUploadStore.getUploadErrorForPost(post) != null) {
             holder.btnPublish.setButtonType(PostListButton.BUTTON_RETRY);
         } else {
             if (PostStatus.fromPost(post) == PostStatus.SCHEDULED && post.isLocallyChanged()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -418,7 +418,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     }
 
     private void updatePostUploadProgressBar(ProgressBar view, PostModel post) {
-        if (UploadService.hasInProgressMediaUploadsForPost(post)) {
+        if (UploadService.isPostUploadingOrQueued(post) || UploadService.hasInProgressMediaUploadsForPost(post)) {
             view.setVisibility(View.VISIBLE);
             int overallProgress = Math.round(UploadService.getMediaUploadProgressForPost(post) * 100);
             // Sometimes the progress bar can be stuck at 100% for a long time while further processing happens

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -15,7 +15,6 @@ import org.wordpress.android.fluxc.store.MediaStore.CancelMediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.MediaPayload;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.store.SiteStore;
-import org.wordpress.android.fluxc.store.UploadStore;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -156,25 +155,16 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
         return false;
     }
 
-    // TODO Update to avoid the UploadStore dependency, either passing in the raw progress or moving this logic to
-    // the UploadService and only returning the optimizationProgress from here
     /**
-     * Returns the last recorded progress value for the given {@param media}. If there is no record for that media,
-     * it's assumed to be a completed upload.
+     * Returns an overall progress for the given {@param video}, including the video optimization progress. If there is
+     * no record for that video, it's assumed to be a completed upload.
      */
-    static float getProgressForMedia(MediaModel media, UploadStore uploadStore) {
-        float uploadProgress = uploadStore.getUploadProgressForMedia(media);
-
-        // if this is a video and video optimization is enabled, include the optimization progress in the outcome
-        if (media.isVideo() && WPMediaUtils.isVideoOptimizationEnabled()) {
-            if (sOptimizationProgressByMediaId.containsKey(media.getId())) {
-                float optimizationProgress = sOptimizationProgressByMediaId.get(media.getId());
-                return optimizationProgress * 0.5F;
-            }
-            return 0.5F + (uploadProgress * 0.5F);
+    static float getOverallProgressForVideo(MediaModel video, float uploadProgress) {
+        if (sOptimizationProgressByMediaId.containsKey(video.getId())) {
+            float optimizationProgress = sOptimizationProgressByMediaId.get(video.getId());
+            return optimizationProgress * 0.5F;
         }
-
-        return uploadProgress;
+        return 0.5F + (uploadProgress * 0.5F);
     }
 
     private void handleOnMediaUploadedSuccess(@NonNull OnMediaUploaded event) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -85,6 +85,10 @@ public class UploadService extends Service {
         // Update posts with any completed AND failed uploads in our post->media map
         updatePostModelWithCompletedAndFailedUploads();
 
+        for (PostModel pendingPost : mUploadStore.getPendingPosts()) {
+            cancelQueuedPostUpload(pendingPost);
+        }
+
         mDispatcher.unregister(this);
         sInstance = null;
         AppLog.i(T.MAIN, "UploadService > Destroyed");

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -31,6 +31,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.FluxCUtils;
+import org.wordpress.android.util.WPMediaUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -354,7 +355,14 @@ public class UploadService extends Service {
             return 0;
         }
 
-        return MediaUploadHandler.getProgressForMedia(mediaModel, sInstance.mUploadStore);
+        float uploadProgress = sInstance.mUploadStore.getUploadProgressForMedia(mediaModel);
+
+        // If this is a video and video optimization is enabled, include the optimization progress in the outcome
+        if (mediaModel.isVideo() && WPMediaUtils.isVideoOptimizationEnabled()) {
+            return MediaUploadHandler.getOverallProgressForVideo(mediaModel, uploadProgress);
+        }
+
+        return uploadProgress;
     }
 
     public static @NonNull Set<MediaModel> getPendingMediaForPost(PostModel postModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -44,6 +45,8 @@ public class UploadService extends Service {
     private static final String KEY_MEDIA_LIST = "mediaList";
     private static final String KEY_LOCAL_POST_ID = "localPostId";
     private static final String KEY_SHOULD_TRACK_ANALYTICS = "shouldTrackPostAnalytics";
+
+    private static @Nullable UploadService sInstance;
 
     private MediaUploadHandler mMediaUploadHandler;
     private PostUploadHandler mPostUploadHandler;
@@ -101,6 +104,7 @@ public class UploadService extends Service {
         ((WordPress) getApplication()).component().inject(this);
         AppLog.i(T.MAIN, "UploadService > Created");
         mDispatcher.register(this);
+        sInstance = this;
         // TODO: Recover any posts/media uploads that were interrupted by the service being stopped
     }
 
@@ -120,6 +124,7 @@ public class UploadService extends Service {
         updatePostModelWithCompletedAndFailedUploads();
 
         mDispatcher.unregister(this);
+        sInstance = null;
         AppLog.i(T.MAIN, "UploadService > Destroyed");
         super.onDestroy();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -316,12 +316,8 @@ public class UploadService extends Service {
     }
 
     public static boolean hasMediaErrorForPost(PostModel post, UploadStore uploadStore) {
-        UploadError error  = getUploadErrorForPost(post, uploadStore);
+        UploadError error  = uploadStore.getUploadErrorForPost(post);
         return error != null && error.mediaError != null;
-    }
-
-    public static UploadError getUploadErrorForPost(PostModel post, UploadStore uploadStore) {
-        return uploadStore.getUploadErrorForPost(post);
     }
 
     public static List<MediaModel> getPendingOrInProgressMediaUploadsForPost(PostModel post){

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -25,7 +25,6 @@ import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.UploadStore;
 import org.wordpress.android.fluxc.store.UploadStore.ClearMediaPayload;
-import org.wordpress.android.fluxc.store.UploadStore.UploadError;
 import org.wordpress.android.ui.media.services.MediaUploadReadyListener;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -313,11 +312,6 @@ public class UploadService extends Service {
 
     public static boolean hasPendingOrInProgressMediaUploadsForPost(PostModel postModel) {
         return postModel != null && MediaUploadHandler.hasPendingOrInProgressMediaUploadsForPost(postModel);
-    }
-
-    public static boolean hasMediaErrorForPost(PostModel post, UploadStore uploadStore) {
-        UploadError error  = uploadStore.getUploadErrorForPost(post);
-        return error != null && error.mediaError != null;
     }
 
     public static List<MediaModel> getPendingOrInProgressMediaUploadsForPost(PostModel post){

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -19,8 +19,6 @@ import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.MediaStore;
-import org.wordpress.android.fluxc.store.MediaStore.MediaError;
-import org.wordpress.android.fluxc.store.MediaStore.MediaErrorType;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
@@ -302,13 +300,6 @@ public class UploadService extends Service {
             // Unlike completed media, we won't remove the failed media references, so we can look up their errors later
         }
         return post;
-    }
-
-    public static void markPostAsError(PostModel post) {
-        // now keep track of the error reason so it can be queried
-        UploadError reason = new UploadError(new MediaError(MediaErrorType.GENERIC_ERROR));
-        // TODO
-//        addUploadErrorToFailedPosts(post, reason);
     }
 
     public static boolean hasInProgressMediaUploadsForPost(PostModel postModel) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -243,12 +243,8 @@ public class UploadService extends Service {
     }
 
     public static boolean isPostQueued(PostModel post) {
-        if (post == null) {
-            return false;
-        }
-
         // Check for posts queued inside the PostUploadManager
-        return PostUploadHandler.isPostQueued(post);
+        return sInstance != null && post != null && PostUploadHandler.isPostQueued(post);
     }
 
     /**
@@ -257,7 +253,7 @@ public class UploadService extends Service {
      * waiting for media to finish uploading counts as 'waiting to be uploaded' until the media uploads complete.
      */
     public static boolean isPostUploading(PostModel post) {
-        return post != null && PostUploadHandler.isPostUploading(post);
+        return sInstance != null && post != null && PostUploadHandler.isPostUploading(post);
     }
 
     public static void cancelQueuedPostUploadAndRelatedMedia(PostModel post) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -21,6 +21,7 @@ import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.OnPostUploaded;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.UploadStore;
 import org.wordpress.android.ui.media.services.MediaUploadReadyListener;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -68,6 +69,7 @@ public class UploadService extends Service {
     @Inject MediaStore mMediaStore;
     @Inject PostStore mPostStore;
     @Inject SiteStore mSiteStore;
+    @Inject UploadStore mUploadStore;
 
     public static class UploadError {
         public PostStore.PostError postError;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -283,7 +283,7 @@ public class UploadService extends Service {
             }
             // finally remove all completed uploads for this post, as they've been taken care of
             ClearMediaPayload clearMediaPayload = new ClearMediaPayload(post, completedMedia);
-            sInstance.mDispatcher.dispatch(UploadActionBuilder.newClearMediaAction(clearMediaPayload));
+            sInstance.mDispatcher.dispatch(UploadActionBuilder.newClearMediaForPostAction(clearMediaPayload));
         }
         return post;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -18,6 +18,7 @@ import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.fluxc.store.MediaStore.MediaError;
 import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.PostStore.PostError;
+import org.wordpress.android.fluxc.store.UploadStore.UploadError;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.PostUtils;
@@ -76,6 +77,10 @@ public class UploadUtils {
         }
 
         return errorMessage;
+    }
+
+    public static boolean isMediaError(UploadError uploadError) {
+        return uploadError != null && uploadError.mediaError != null;
     }
 
     public static void handleEditPostResultSnackbars(final Activity activity, View snackbarAttachView,

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -868,7 +868,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
         if (mediaFile != null) {
             String remoteUrl = Utils.escapeQuotes(mediaFile.getFileURL());
-            AppLog.e(T.MEDIA, "onMediaUploadSucceeded - Remote URL: " + remoteUrl + ", Filename: "
+            AppLog.i(T.MEDIA, "onMediaUploadSucceeded - Remote URL: " + remoteUrl + ", Filename: "
                     + mediaFile.getFileName());
 
             // we still need to refresh the screen visually, no matter whether the service already


### PR DESCRIPTION
Addresses #6352, dropping the various lists/maps used in the `UploadService` and its helper classes to keep track of media progress, completed/failed/pending media uploads for posts, and post upload errors. Those are instead tracked inside FluxC's new `UploadStore`, which shadows media and post upload-related events and maintains a separate state for them.

https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/533 should be reviewed and merged first.

This PR is mostly complete, but some testing and cleanup remains. Marking 'Not Ready for Review' for now.