### PR TITLE
Stop using parameters for post types in error messages

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
@@ -95,8 +95,9 @@ public class PostsListActivity extends AppCompatActivity {
         if (targetPostId > 0) {
             targetPost = mPostStore.getPostByLocalPostId(intent.getIntExtra(EXTRA_TARGET_POST_LOCAL_ID, 0));
             if (targetPost == null) {
-                String postType = getString(mIsPage ? R.string.page : R.string.post).toLowerCase();
-                ToastUtils.showToast(this, getString(R.string.error_post_does_not_exist_param, postType));
+                String errorMessage = getString(mIsPage ? R.string.error_page_does_not_exist
+                        : R.string.error_post_does_not_exist);
+                ToastUtils.showToast(this, errorMessage);
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -665,8 +665,7 @@ public class PostsListFragment extends Fragment
                 break;
             case DELETE_POST:
                 if (event.isError()) {
-                    String postType = getString(mIsPage ? R.string.page : R.string.post).toLowerCase();
-                    String message = getString(R.string.error_delete_post, postType);
+                    String message = getString(mIsPage ? R.string.error_deleting_page : R.string.error_deleting_post);
                     ToastUtils.showToast(getActivity(), message, ToastUtils.Duration.SHORT);
                     loadPosts(LoadMode.IF_CHANGED);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -441,8 +441,8 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             UploadService.UploadError reason = UploadService.getUploadErrorForPost(post);
             if (reason != null) {
                 if (reason.mediaError != null) {
-                    String postType = context.getString(post.isPage() ? R.string.page : R.string.post).toLowerCase();
-                    errorMessage = context.getString(R.string.error_media_recover_params, postType);
+                    errorMessage = context.getString(post.isPage() ? R.string.error_media_recover_page
+                            : R.string.error_media_recover_post);
                 } else if (reason.postError != null) {
                     errorMessage = UploadUtils.getErrorMessageFromPostError(context, post, reason.postError);
                 }

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1133,7 +1133,6 @@
     <string name="wordpress_dot_com_capitalized" translatable="false">WordPress.com</string>
 
     <!-- Error Messages -->
-    <string name="error_delete_post">An error occurred while deleting the %s</string>
     <!-- The following messages can\'t be factorized due to i18n -->
     <string name="error_refresh_posts">Posts couldn\'t be refreshed at this time</string>
     <string name="error_refresh_pages">Pages couldn\'t be refreshed at this time</string>
@@ -1142,6 +1141,8 @@
     <string name="error_refresh_comments_showing_older">Comments couldn\'t be refreshed at this time - showing older comments</string>
     <string name="error_refresh_stats">Stats couldn\'t be refreshed at this time</string>
     <string name="error_refresh_media">Media couldn\'t be refreshed at this time</string>
+    <string name="error_deleting_post">An error occurred while deleting the post</string>
+    <string name="error_deleting_page">An error occurred while deleting the page</string>
 
     <string name="error_refresh_unauthorized_comments">You don\'t have permission to view or edit comments</string>
     <string name="error_refresh_unauthorized_pages">You don\'t have permission to view or edit pages</string>
@@ -1170,8 +1171,10 @@
     <string name="error_media_load">Unable to load media</string>
     <string name="error_media_save">Unable to save media</string>
     <string name="error_media_canceled">Uploading media were canceled</string>
-    <string name="error_media_recover_params">We were unable to upload this %1$s\'s media. Please edit the %1$s to try again.</string>
-    <string name="error_post_does_not_exist_param">This %s no longer exists</string>
+    <string name="error_media_recover_post">We were unable to upload this post\'s media. Please edit the post to try again.</string>
+    <string name="error_media_recover_page">We were unable to upload this page\'s media. Please edit the page to try again.</string>
+    <string name="error_post_does_not_exist">This post no longer exists</string>
+    <string name="error_page_does_not_exist">This page no longer exists</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>
     <string name="fatal_db_error">An error occurred while creating the app database. Try reinstalling the app.</string>
     <string name="error_copy_to_clipboard">An error occurred while copying text to clipboard</string>


### PR DESCRIPTION
Fixes a few post/page error strings that can cause translation issues in other languages. Instead of using parameterizable strings, we should just use a separate resource for each post type. (We had a few more that were fixed in https://github.com/wordpress-mobile/WordPress-Android/pull/6558.)

@mzorz, two of these (`error_media_recover_params` and `error_post_does_not_exist_param`) were introduced in 8.1 (the third has been there since 2012). I'm not sure what the process is for translations and existing releases - if it would be better to target a `8.1` hotfix branch please let me know and I'll make the changes.