### PR TITLE
Issue/6612 aztec release notes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -316,6 +316,9 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
         mLanguagePreference.refreshAdapter();
     }
 
+    /*
+     * only show the editor footer when Aztec is enabled
+     */
     private void toggleEditorFooterPreference() {
         PreferenceCategory editorCategory = (PreferenceCategory) findPreference(getActivity().getString(R.string.pref_key_editor));
         boolean showFooter = AppPrefs.isAztecEditorEnabled();

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -28,6 +28,7 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.LanguageUtils;
+import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.util.WPPrefUtils;
 
@@ -41,8 +42,13 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
     public static final String LANGUAGE_PREF_KEY = "language-pref";
     public static final int LANGUAGE_CHANGED = 1000;
 
+    private static final int IDX_LEGACY_EDITOR = 0;
+    private static final int IDX_VISUAL_EDITOR = 1;
+    private static final int IDX_AZTEC_EDITOR = 2;
+
     private DetailListPreference mLanguagePreference;
     private SharedPreferences mSettings;
+    private Preference mEditorFooterPref;
 
     // This Device settings
     private WPSwitchPreference mOptimizedImage;
@@ -65,6 +71,8 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
 
         mLanguagePreference = (DetailListPreference) findPreference(getString(R.string.pref_key_language));
         mLanguagePreference.setOnPreferenceChangeListener(this);
+
+        mEditorFooterPref = findPreference(getString(R.string.pref_key_editor_footer));
 
         findPreference(getString(R.string.pref_key_language))
                 .setOnPreferenceClickListener(this);
@@ -211,11 +219,11 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
                         editorTypePreference.setSummary(entries[index]);
 
                         switch (index) {
-                            case 1:
+                            case IDX_VISUAL_EDITOR:
                                 AppPrefs.setAztecEditorEnabled(false);
                                 AppPrefs.setVisualEditorEnabled(true);
                                 break;
-                            case 2:
+                            case IDX_AZTEC_EDITOR:
                                 AppPrefs.setAztecEditorEnabled(true);
                                 AppPrefs.setVisualEditorEnabled(false);
                                 break;
@@ -225,6 +233,7 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
                                 break;
                         }
 
+                        toggleEditorFooterPreference();
                         return true;
                     } else {
                         return false;
@@ -239,6 +248,8 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
                 CharSequence[] entries = editorTypePreference.getEntries();
                 editorTypePreference.setSummary(entries[Integer.parseInt(editorTypeSetting)]);
             }
+
+            toggleEditorFooterPreference();
         }
     }
 
@@ -303,6 +314,18 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
         mLanguagePreference.setValue(languageCode);
         mLanguagePreference.setSummary(WPPrefUtils.getLanguageString(languageCode, languageLocale));
         mLanguagePreference.refreshAdapter();
+    }
+
+    private void toggleEditorFooterPreference() {
+        PreferenceCategory editorCategory = (PreferenceCategory) findPreference(getActivity().getString(R.string.pref_key_editor));
+        boolean showFooter = AppPrefs.isAztecEditorEnabled();
+        boolean isFooterShowing = editorCategory.findPreference(getString(R.string.pref_key_editor_footer)) != null;
+
+        if (showFooter && !isFooterShowing) {
+            editorCategory.addPreference(mEditorFooterPref);
+        } else if (!showFooter && isFooterShowing) {
+            editorCategory.removePreference(mEditorFooterPref);
+        }
     }
 
     private boolean handleEditorFooterPreferenceClick() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -28,7 +28,6 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.LanguageUtils;
-import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.util.WPPrefUtils;
 


### PR DESCRIPTION
Fixes #6612 - The "editor release notes" pref in App Settings is now hidden unless Aztec is enabled (since the release notes apply only to Aztec).