### PR TITLE
fixed EditorFragmentListener implementation in MockEditorActivity

### DIFF
--- a/libs/editor/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/MockEditorActivity.java
+++ b/libs/editor/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/MockEditorActivity.java
@@ -55,8 +55,8 @@ public class MockEditorActivity extends AppCompatActivity implements EditorFragm
     }
 
     @Override
-    public void onMediaRetryClicked(String mediaId) {
-
+    public boolean onMediaRetryClicked(String mediaId) {
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Fixes errors when cleaning and building the WPAndroid project 

To test:
- clean
- build

Should build without errors.

cc @theck13 
