### PR TITLE
Show the multiselect "smart toast" when the photo picker is shown

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerFragment.java
@@ -186,10 +186,6 @@ public class PhotoPickerFragment extends Fragment {
             });
         }
 
-        if (savedInstanceState == null && mAllowMultiSelect && hasStoragePermission()) {
-            SmartToast.show(getActivity(), SmartToast.SmartToastType.MEDIA_LONG_PRESS);
-        }
-
         return view;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -672,6 +672,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
         // make sure we initialized the photo picker
         if (mPhotoPickerFragment == null) {
+            //SmartToast.reset();
             initPhotoPicker();
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.posts;
 
+import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Fragment;
@@ -8,6 +9,7 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.net.Uri;
@@ -22,6 +24,7 @@ import android.support.design.widget.Snackbar;
 import android.support.v13.app.FragmentPagerAdapter;
 import android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
@@ -118,6 +121,7 @@ import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.SiteUtils;
+import org.wordpress.android.util.SmartToast;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
@@ -664,6 +668,8 @@ public class EditPostActivity extends AppCompatActivity implements
      * user has requested to show the photo picker
      */
     private void showPhotoPicker() {
+        boolean isAlreadyShowing = isPhotoPickerShowing();
+
         // make sure we initialized the photo picker
         if (mPhotoPickerFragment == null) {
             initPhotoPicker();
@@ -677,7 +683,7 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         // slide in the photo picker
-        if (!isPhotoPickerShowing()) {
+        if (!isAlreadyShowing) {
             AniUtils.animateBottomBar(mPhotoPickerContainer, true, AniUtils.Duration.MEDIUM);
             mPhotoPickerFragment.refresh();
             mPhotoPickerFragment.setPhotoPickerListener(this);
@@ -688,6 +694,13 @@ public class EditPostActivity extends AppCompatActivity implements
 
         if (mEditorFragment instanceof AztecEditorFragment) {
             ((AztecEditorFragment)mEditorFragment).enableMediaMode(true);
+        }
+
+        // let the user know about long-press to multiselect, but only if the user has already granted
+        // storage permission - otherwise the toast will appear above the "soft ask" view
+        if (!isAlreadyShowing && ContextCompat.checkSelfPermission(
+                    this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+            SmartToast.show(this, SmartToast.SmartToastType.MEDIA_LONG_PRESS);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/SmartToast.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SmartToast.java
@@ -39,6 +39,13 @@ public class SmartToast {
     private static final int MIN_TIMES_TO_USE_FEATURE = 3;
     private static final int MAX_TIMES_TO_SHOW_TOAST = 2;
 
+    public static void reset() {
+        for (SmartToastType type: SmartToastType.values()) {
+            AppPrefs.setInt(type.shownKey, 0);
+            AppPrefs.setInt(type.usageKey, 0);
+        }
+    }
+
     public static boolean show(@NonNull Context context, @NonNull SmartToastType type) {
         // limit the number of times to show the toast
         int numTimesShown = AppPrefs.getInt(type.shownKey);
@@ -50,7 +57,7 @@ public class SmartToast {
         int numTypesFeatureUsed = AppPrefs.getInt(type.usageKey);
         numTypesFeatureUsed++;
         AppPrefs.setInt(type.usageKey, numTypesFeatureUsed);
-        if (numTypesFeatureUsed <= MIN_TIMES_TO_USE_FEATURE) {
+        if (numTypesFeatureUsed < MIN_TIMES_TO_USE_FEATURE) {
             return false;
         }
 


### PR DESCRIPTION
Fixes #6628 - The "Tap and hold to select multiple photos" toast we show in the photo picker only appears after the third time the picker is created. Since the picker is kept in memory until the editor is closed, the toast won't appear until after you access the picker in three different editor sessions.

This PR corrects this by having the toast appear after the third time the picker is accessed.

cc: @mzorz 
