### PR TITLE
checks for currently queued deleting media items after refresh

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -200,6 +200,13 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         }
     }
 
+    public MediaDeleteService getMediaDeleteService() {
+        if (mDeleteService == null) {
+            return null;
+        }
+        return mDeleteService.getService();
+    }
+
     /*
      * only show tabs when being used as a media browser rather than a media picker
      */

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaDeleteService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaDeleteService.java
@@ -128,6 +128,17 @@ public class MediaDeleteService extends Service {
         return mCompletedItems;
     }
 
+    public boolean isMediaBeingDeleted(@NonNull MediaModel media) {
+        if (mDeleteQueue != null) {
+            for (MediaModel deletingMedia : mDeleteQueue) {
+                if (deletingMedia.getId() == media.getId()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     private void handleMediaChangedSuccess(@NonNull OnMediaChanged event) {
         switch (event.cause) {
             case DELETE_MEDIA:


### PR DESCRIPTION
Fixes #6632

To test:
1. go to media library
2. pick several (more than 6 items) to delete (long press)
3. tap on delete (trash icon)
4. tap OK on the confirm dialog
5. immediately pull down to refresh
6. observe that items that are being removed correctly showing the "DELETING" overlay

cc @nbradbury 
