### PR TITLE
Login epilogue visual fixes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -23,6 +23,7 @@ import org.wordpress.android.ui.main.SitePickerAdapter;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.GravatarUtils;
 import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.ViewUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.util.ArrayList;
@@ -181,9 +182,13 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
                         if (mSitesList.computeVerticalScrollRange() > mSitesList.getHeight()) {
                             mBottomShadow.setVisibility(View.VISIBLE);
                             mBottomButtonsContainer.setBackgroundResource(R.color.white);
+                            ViewUtils.setButtonBackgroundColor(getContext(), mConnectMore,
+                                    R.style.WordPress_Button_Grey, R.attr.colorButtonNormal);
                         } else {
                             mBottomShadow.setVisibility(View.GONE);
                             mBottomButtonsContainer.setBackground(null);
+                            ViewUtils.setButtonBackgroundColor(getContext(), mConnectMore, R.style.WordPress_Button,
+                                    R.attr.colorButtonNormal);
                         }
                     }
                 });

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -175,13 +175,18 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
 
             @Override
             public void onAfterLoad() {
-                if (mSitesList.computeVerticalScrollRange() > mSitesList.getHeight()) {
-                    mBottomShadow.setVisibility(View.VISIBLE);
-                    mBottomButtonsContainer.setBackgroundResource(R.color.white);
-                } else {
-                    mBottomShadow.setVisibility(View.GONE);
-                    mBottomButtonsContainer.setBackground(null);
-                }
+                mSitesList.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (mSitesList.computeVerticalScrollRange() > mSitesList.getHeight()) {
+                            mBottomShadow.setVisibility(View.VISIBLE);
+                            mBottomButtonsContainer.setBackgroundResource(R.color.white);
+                        } else {
+                            mBottomShadow.setVisibility(View.GONE);
+                            mBottomButtonsContainer.setBackground(null);
+                        }
+                    }
+                });
             }
         }, new SitePickerAdapter.HeaderHandler() {
             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEpilogueFragment.java
@@ -39,6 +39,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
     private RecyclerView mSitesList;
     private View mBottomShadow;
     private View mBottomButtonsContainer;
+    private Button mConnectMore;
 
     @Inject AccountStore mAccountStore;
 
@@ -90,6 +91,7 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
         mBottomShadow = rootView.findViewById(R.id.bottom_shadow);
 
         mBottomButtonsContainer = rootView.findViewById(R.id.bottom_buttons);
+        mConnectMore = (Button) mBottomButtonsContainer.findViewById(R.id.secondary_button);
 
         mSitesList = (RecyclerView) rootView.findViewById(R.id.recycler_view);
         mSitesList.setLayoutManager(new LinearLayoutManager(getActivity()));
@@ -244,12 +246,16 @@ public class LoginEpilogueFragment extends LoginBaseFormFragment<LoginEpilogueLi
 
         if (numberOfSites == 0) {
             holder.mMySitesHeadingTextView.setVisibility(View.GONE);
+
+            mConnectMore.setText(R.string.connect_site);
         } else {
             holder.mMySitesHeadingTextView.setVisibility(View.VISIBLE);
             holder.mMySitesHeadingTextView.setText(
                     StringUtils.getQuantityString(
                             getActivity(), R.string.days_quantity_one, R.string.login_epilogue_mysites_one,
                             R.string.login_epilogue_mysites_other, numberOfSites));
+
+            mConnectMore.setText(R.string.connect_more);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/ViewUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/ViewUtils.java
@@ -1,5 +1,11 @@
 package org.wordpress.android.util;
 
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.content.res.TypedArray;
+import android.support.annotation.AttrRes;
+import android.support.annotation.StyleRes;
+import android.support.v4.view.ViewCompat;
 import android.view.View;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -41,4 +47,11 @@ public class ViewUtils {
         }
     }
 
+    public static void setButtonBackgroundColor(Context context, View button, @StyleRes int styleId,
+            @AttrRes int colorAttribute) {
+        TypedArray a = context.obtainStyledAttributes(styleId, new int[] { colorAttribute } );
+        ColorStateList color = a.getColorStateList(0);
+        a.recycle();
+        ViewCompat.setBackgroundTintList(button, color);
+    }
 }

--- a/WordPress/src/main/res/layout/login_epilogue_header.xml
+++ b/WordPress/src/main/res/layout/login_epilogue_header.xml
@@ -48,7 +48,8 @@
                 android:layout_width="@dimen/avatar_sz_login_epilogue"
                 android:layout_height="@dimen/avatar_sz_login_epilogue"
                 android:layout_marginTop="@dimen/margin_extra_medium_large"
-                android:layout_marginBottom="@dimen/margin_medium"/>
+                android:layout_marginBottom="@dimen/margin_medium"
+                app:wpDefaultImageDrawable="@drawable/ic_gridicons_user_circle_100dp"/>
 
             <org.wordpress.android.widgets.WPTextView
                 style="@style/LoginTheme.Subhead"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1890,6 +1890,7 @@
     <string name="login_magic_link_email_requesting">Requesting log-in email</string>
     <string name="enter_wpcom_password">Enter your WordPress.com password.</string>
     <string name="connect_more">Connect Another Site</string>
+    <string name="connect_site">Connect Site</string>
     <string name="login_continue">Continue</string>
     <string name="login_already_logged_in_wpcom">Already logged in to WordPress.com</string>
     <string name="login_username_at">\@%s</string>


### PR DESCRIPTION
Fixes #6618, #6619, #6635, #6636

To test (scenario A):
* Login normally using a WPCOM account with a big list of sites connected and on the epilogue screen notice:
1. The background of the bottom buttons panel is white
2. The "CONNECT ANOTHER SITE" button color is `grey_light`
3. There is a shadow on the top of the bottom panel

To test (scenario B):
* Login using a WPCOM account that has no Gravatar set and on the epilogue screen notice that the shown avatar is the generic person icon