### PR TITLE
Feature/site media image settings

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -266,7 +266,7 @@
         <activity
             android:name=".ui.media.MediaSettingsActivity"
             android:windowSoftInputMode="stateHidden|adjustPan"
-            android:theme="@style/Theme.AppCompat.Light.DarkActionBar" />
+            android:theme="@style/MediaSettings.Theme" />
 
         <!-- Theme Activities -->
         <activity

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -265,6 +265,7 @@
             android:theme="@style/Theme.AppCompat.NoActionBar" />
         <activity
             android:name=".ui.media.MediaSettingsActivity"
+            android:windowSoftInputMode="stateHidden"
             android:theme="@style/MediaSettingsTheme" />
 
         <!-- Theme Activities -->

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -265,7 +265,7 @@
             android:theme="@style/Theme.AppCompat.NoActionBar" />
         <activity
             android:name=".ui.media.MediaSettingsActivity"
-            android:windowSoftInputMode="stateHidden"
+            android:windowSoftInputMode="stateHidden|adjustPan"
             android:theme="@style/MediaSettingsTheme" />
 
         <!-- Theme Activities -->

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -266,7 +266,7 @@
         <activity
             android:name=".ui.media.MediaSettingsActivity"
             android:windowSoftInputMode="stateHidden|adjustPan"
-            android:theme="@style/MediaSettings.Theme" />
+            android:theme="@style/MediaSettings.ActivityTheme" />
 
         <!-- Theme Activities -->
         <activity

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -266,7 +266,7 @@
         <activity
             android:name=".ui.media.MediaSettingsActivity"
             android:windowSoftInputMode="stateHidden|adjustPan"
-            android:theme="@style/MediaSettings.ActivityTheme" />
+            android:theme="@style/Theme.AppCompat.Light.DarkActionBar" />
 
         <!-- Theme Activities -->
         <activity

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -266,7 +266,7 @@
         <activity
             android:name=".ui.media.MediaSettingsActivity"
             android:windowSoftInputMode="stateHidden|adjustPan"
-            android:theme="@style/MediaSettingsTheme" />
+            android:theme="@style/MediaSettings.Theme" />
 
         <!-- Theme Activities -->
         <activity

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -265,7 +265,7 @@
             android:theme="@style/Theme.AppCompat.NoActionBar" />
         <activity
             android:name=".ui.media.MediaSettingsActivity"
-            android:theme="@style/Calypso.NoActionBar" />
+            android:theme="@style/MediaSettingsTheme" />
 
         <!-- Theme Activities -->
         <activity

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -263,6 +263,9 @@
             android:name=".ui.media.MediaPreviewActivity"
             android:windowSoftInputMode="adjustNothing"
             android:theme="@style/Theme.AppCompat.NoActionBar" />
+        <activity
+            android:name=".ui.media.MediaSettingsActivity"
+            android:theme="@style/Calypso.NoActionBar" />
 
         <!-- Theme Activities -->
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -44,6 +44,7 @@ import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.media.MediaEditFragment;
 import org.wordpress.android.ui.media.MediaGridFragment;
 import org.wordpress.android.ui.media.MediaPreviewActivity;
+import org.wordpress.android.ui.media.MediaSettingsActivity;
 import org.wordpress.android.ui.media.services.MediaDeleteService;
 import org.wordpress.android.ui.notifications.NotificationsDetailActivity;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
@@ -185,6 +186,7 @@ public interface AppComponent {
     void inject(MediaGridFragment object);
     void inject(MediaEditFragment object);
     void inject(MediaPreviewActivity object);
+    void inject(MediaSettingsActivity object);
 
     void inject(PublicizeListActivity object);
     void inject(PublicizeWebViewFragment object);

--- a/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
@@ -28,6 +28,7 @@ public class RequestCodes {
     public static final int PICTURE_LIBRARY_OR_CAPTURE = 2500;
     public static final int MULTI_SELECT_MEDIA_PICKER = 2600;
     public static final int SINGLE_SELECT_MEDIA_PICKER = 2601;
+    public static final int MEDIA_SETTINGS = 2700;
 
     // Jetpack
     public static final int REQUEST_JETPACK = 3000;

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -83,10 +83,8 @@ import org.wordpress.android.util.WPPermissionUtils;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -557,19 +555,25 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             setResult(RESULT_OK, intent);
             finish();
         } else {
-            // TODO: right now only images & videos are supported
-            String mimeType = StringUtils.notNullStr(media.getMimeType()).toLowerCase();
-            if (mimeType.startsWith("image") || mimeType.startsWith("video")) {
-                if (media.getUploadState() != null &&
-                        MediaUtils.isLocalFile(media.getUploadState().toLowerCase())) {
-                    // Show the simple preview in case of uploading items. i.e: No metadata info, and other options only available
-                    // for files already on the remote site.
-                    MediaPreviewActivity.showPreview(this, sourceView, media.getFilePath(), mimeType.startsWith("video"));
-                } else {
-                    MediaPreviewActivity.showPreview(this, sourceView, mSite, localMediaId);
-                }
-            }
+            showMediaSettings(media);
         }
+    }
+
+    private void showMediaSettings(@NonNull MediaModel media) {
+        // TODO: right now only images & videos are supported
+        String mimeType = StringUtils.notNullStr(media.getMimeType()).toLowerCase();
+        if (!mimeType.startsWith("image") && !mimeType.startsWith("video")) {
+            return;
+        }
+
+        // Show the simple preview in case of uploading items. i.e: No metadata info, and other options only available
+        // for files already on the remote site.
+        if (media.getUploadState() != null && MediaUtils.isLocalFile(media.getUploadState())) {
+            MediaPreviewActivity.showPreview(this, null, media.getFilePath(), mimeType.startsWith("video"));
+            return;
+        }
+
+        MediaSettingsActivity.show(this, mSite, media.getId());
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -392,6 +392,11 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
                     trackAddMediaFromDeviceEvents(true, true, uri);
                 }
                 break;
+            case RequestCodes.MEDIA_SETTINGS:
+                if (resultCode == MediaSettingsActivity.RESULT_MEDIA_DELETED) {
+                    reloadMediaGrid();
+                }
+                break;
         }
     }
 
@@ -575,12 +580,13 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
         // Show the simple preview in case of uploading items. i.e: No metadata info, and other options only available
         // for files already on the remote site.
+        // TODO: this should be handled by MediaSettingsActivity
         if (media.getUploadState() != null && MediaUtils.isLocalFile(media.getUploadState())) {
             MediaPreviewActivity.showPreview(this, null, media.getFilePath(), mimeType.startsWith("video"));
             return;
         }
 
-        MediaSettingsActivity.show(this, mSite, media.getId());
+        MediaSettingsActivity.showForResult(this, mSite, media.getId());
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -493,7 +493,7 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
                 query.setFilterById(mDownloadId);
                 DownloadManager dm = (DownloadManager) getSystemService(DOWNLOAD_SERVICE);
                 Cursor cursor = dm.query(query);
-                if (cursor.moveToFirst()) {
+                if (cursor != null && cursor.moveToFirst()) {
                     int reason = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_REASON));
                     if (reason == DownloadManager.STATUS_FAILED) {
                         ToastUtils.showToast(MediaSettingsActivity.this, R.string.error_media_save);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -10,7 +10,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.res.Resources;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -24,6 +23,7 @@ import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
+import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v4.content.ContextCompat;
@@ -53,6 +53,7 @@ import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
+import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DateTimeUtils;
 import org.wordpress.android.util.DisplayUtils;
@@ -85,6 +86,7 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
     private EditText mCaptionView;
     private EditText mAltTextView;
     private EditText mDescriptionView;
+    private FloatingActionButton mFabView;
 
     private ProgressDialog mProgressDialog;
 
@@ -135,6 +137,7 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         mCaptionView = (EditText) findViewById(R.id.edit_caption);
         mAltTextView = (EditText) findViewById(R.id.edit_alt_text);
         mDescriptionView = (EditText) findViewById(R.id.edit_description);
+        mFabView = (FloatingActionButton) findViewById(R.id.fab_button);
 
         int mediaId;
         if (savedInstanceState != null) {
@@ -156,6 +159,19 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
 
         showMediaMetaData();
         loadImage();
+
+        if (shouldShowFab()) {
+            mFabView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    notImplemented();
+                }
+            });
+        }
+    }
+
+    private void notImplemented() {
+        ToastUtils.showToast(this, "Not implemented yet!");
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
@@ -167,6 +183,39 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
             window.setStatusBarColor(statusColor);
         }
     }
+
+    private boolean shouldShowFab() {
+        if (mMedia == null) {
+            return false;
+        }
+        String mimeType = StringUtils.notNullStr(mMedia.getMimeType());
+        return mimeType.startsWith("image/");
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        if (shouldShowFab()) {
+            AniUtils.scaleOut(mFabView, AniUtils.Duration.SHORT);
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        long delayMs = getResources().getInteger(R.integer.fab_animation_delay);
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                if (!isFinishing() && shouldShowFab() && mFabView.getVisibility() != View.VISIBLE) {
+                    AniUtils.scaleIn(mFabView, AniUtils.Duration.SHORT);
+                }
+            }
+        }, delayMs);
+    }
+
+
 
     @Override
     protected void onSaveInstanceState(Bundle outState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -164,15 +164,11 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         View.OnClickListener listener = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                showFullScreenPreview();
+                ToastUtils.showToast(v.getContext(), "Full-screen preview now implemented yet!");
             }
         };
         mFabView.setOnClickListener(listener);
         mImageView.setOnClickListener(listener);
-    }
-
-    private void showFullScreenPreview() {
-        ToastUtils.showToast(this, "Not implemented yet!");
     }
 
     private boolean shouldShowFab() {
@@ -201,8 +197,6 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
             }
         }, delayMs);
     }
-
-
 
     @Override
     protected void onSaveInstanceState(Bundle outState) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -9,6 +9,7 @@ import android.content.IntentFilter;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.drawable.ColorDrawable;
 import android.media.MediaPlayer;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -19,6 +20,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.ActivityOptionsCompat;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -170,12 +172,13 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
             return;
         }
 
-        setSupportActionBar(mToolbar);
+        //setSupportActionBar(mToolbar);
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             actionBar.setDisplayShowTitleEnabled(true);
             actionBar.setDisplayHomeAsUpEnabled(true);
             actionBar.setTitle(R.string.media);
+            actionBar.setBackgroundDrawable(new ColorDrawable(ContextCompat.getColor(this, R.color.transparent)));
         }
 
         mImageView.setVisibility(mIsVideo ? View.GONE : View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -77,6 +77,7 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
     private ImageView mImageView;
     private EditText mTitleView;
     private EditText mCaptionView;
+    private EditText mAltTextView;
     private EditText mDescriptionView;
 
     private ProgressDialog mProgressDialog;
@@ -126,6 +127,7 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         mImageView = (ImageView) findViewById(R.id.image_preview);
         mTitleView = (EditText) findViewById(R.id.edit_title);
         mCaptionView = (EditText) findViewById(R.id.edit_caption);
+        mAltTextView = (EditText) findViewById(R.id.edit_alt_text);
         mDescriptionView = (EditText) findViewById(R.id.edit_description);
 
         int mediaId;
@@ -261,6 +263,7 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
     private void showMediaMetaData() {
         mTitleView.setText(mMedia.getTitle());
         mCaptionView.setText(mMedia.getCaption());
+        mAltTextView.setText(mMedia.getAlt());
         mDescriptionView.setText(mMedia.getDescription());
 
         mTitleView.requestFocus();
@@ -404,15 +407,18 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
 
         String thisTitle = EditTextUtils.getText(mTitleView);
         String thisCaption = EditTextUtils.getText(mCaptionView);
+        String thisAltText = EditTextUtils.getText(mAltTextView);
         String thisDescription = EditTextUtils.getText(mDescriptionView);
 
         boolean hasChanged = !StringUtils.equals(media.getTitle(), thisTitle)
                 || !StringUtils.equals(media.getCaption(), thisCaption)
+                || !StringUtils.equals(media.getAlt(), thisAltText)
                 || !StringUtils.equals(media.getDescription(), thisDescription);
         if (hasChanged) {
             AppLog.d(AppLog.T.MEDIA, "MediaSettingsActivity > Saving changes");
             media.setTitle(thisTitle);
             media.setCaption(thisCaption);
+            media.setAlt(thisAltText);
             media.setDescription(thisDescription);
             mDispatcher.dispatch(MediaActionBuilder.newPushMediaAction(new MediaStore.MediaPayload(mSite, media)));
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -403,7 +403,7 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
                 public void onResponse(ImageLoader.ImageContainer response, boolean isImmediate) {
                     if (!isFinishing() && response.getBitmap() != null) {
                         showProgress(false);
-                        mImageView.setImageBitmap(response.getBitmap());
+                        fadeInBitmap(response.getBitmap());
                     }
                 }
 
@@ -447,11 +447,16 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
                 return;
             }
             if (bitmap != null) {
-                mImageView.setImageBitmap(bitmap);
+                fadeInBitmap(bitmap);
             } else {
                 delayedFinishWithError();
             }
         }
+    }
+
+    private void fadeInBitmap(@NonNull Bitmap bitmap) {
+        mImageView.setImageBitmap(bitmap);
+        AniUtils.fadeIn(mImageView, AniUtils.Duration.LONG);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -155,25 +155,28 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
             return;
         }
 
+        // make image 40% of screen height
         int displayHeight = DisplayUtils.getDisplayPixelHeight(this);
         int imageHeight = (int) (displayHeight * 0.4);
         mImageView.getLayoutParams().height = imageHeight;
 
-        int fabHeight = DisplayUtils.dpToPx(this, 56);
-        ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) mFabView.getLayoutParams();
-        int topMargin = imageHeight - (fabHeight / 2);
-        int rightMargin = getResources().getDimensionPixelSize(R.dimen.fab_margin);
-        params.setMargins(0, topMargin, rightMargin, 0);
+        // position the fab so it overlaps the image
+        if (shouldShowFab()) {
+            int fabHeight = DisplayUtils.dpToPx(this, 56);
+            ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) mFabView.getLayoutParams();
+            int topMargin = imageHeight - (fabHeight / 2);
+            int rightMargin = getResources().getDimensionPixelSize(R.dimen.fab_margin);
+            params.setMargins(0, topMargin, rightMargin, 0);
+        }
 
+        // set the height of the gradient scrim that appears atop the image
         int toolbarHeight = DisplayUtils.getActionBarHeight(this);
         ImageView imgGradient = (ImageView) findViewById(R.id.image_gradient);
         imgGradient.getLayoutParams().height = toolbarHeight * 3;
 
-        showMediaMetaData();
-        loadImage();
-
         ImageView imgPlayVideo = (ImageView) findViewById(R.id.image_play_video);
         imgPlayVideo.setVisibility(mMedia.isVideo() ? View.VISIBLE : View.GONE);
+        findViewById(R.id.edit_alt_text_layout).setVisibility(mMedia.isVideo() ? View.GONE : View.VISIBLE);
 
         View.OnClickListener listener = new View.OnClickListener() {
             @Override
@@ -184,6 +187,9 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         mFabView.setOnClickListener(listener);
         mImageView.setOnClickListener(listener);
         imgPlayVideo.setOnClickListener(listener);
+
+        showMediaMetaData();
+        loadImage();
     }
 
     @Override
@@ -258,6 +264,7 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
     }
 
     private boolean shouldShowFab() {
+        // fab only shows for images
         return mMedia != null && StringUtils.notNullStr(mMedia.getMimeType()).startsWith("image/");
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -1,0 +1,564 @@
+package org.wordpress.android.ui.media;
+
+import android.Manifest;
+import android.app.DownloadManager;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.database.Cursor;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.media.MediaPlayer;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.os.Environment;
+import android.os.Handler;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.app.ActivityOptionsCompat;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.text.TextUtils;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.ImageView;
+import android.widget.MediaController;
+import android.widget.VideoView;
+
+import com.android.volley.VolleyError;
+import com.android.volley.toolbox.ImageLoader;
+import com.android.volley.toolbox.NetworkImageView;
+
+import org.greenrobot.eventbus.Subscribe;
+import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.generated.MediaActionBuilder;
+import org.wordpress.android.fluxc.model.MediaModel;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.MediaStore;
+import org.wordpress.android.fluxc.tools.FluxCImageLoader;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.DateTimeUtils;
+import org.wordpress.android.util.DisplayUtils;
+import org.wordpress.android.util.EditTextUtils;
+import org.wordpress.android.util.ImageUtils;
+import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.PermissionUtils;
+import org.wordpress.android.util.PhotonUtils;
+import org.wordpress.android.util.SiteUtils;
+import org.wordpress.android.util.StringUtils;
+import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.WPPermissionUtils;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import javax.inject.Inject;
+
+import uk.co.senab.photoview.PhotoViewAttacher;
+
+public class MediaSettingsActivity extends AppCompatActivity implements ActivityCompat.OnRequestPermissionsResultCallback {
+
+    private static final String ARG_MEDIA_CONTENT_URI = "content_uri";
+    private static final String ARG_MEDIA_LOCAL_ID = "media_local_id";
+    private static final String ARG_IS_VIDEO = "is_video";
+
+    private String mContentUri;
+    private int mMediaId;
+    private long mDownloadId;
+    private boolean mIsVideo;
+    private boolean mEnableMetadata;
+    private boolean mIsClosable;
+
+    private SiteModel mSite;
+
+    private ImageView mImageView;
+    private VideoView mVideoView;
+    private EditText mTitleView;
+    private EditText mCaptionView;
+    private EditText mDescriptionView;
+    private Toolbar mToolbar;
+
+    @Inject
+    MediaStore mMediaStore;
+    @Inject
+    FluxCImageLoader mImageLoader;
+    @Inject
+    Dispatcher mDispatcher;
+
+    /**
+     * @param context    self explanatory
+     * @param contentUri local content:// uri of media
+     * @param isVideo    whether the passed media is a video - assumed to be an image otherwise
+     */
+    public static void show(Context context,
+                            String contentUri,
+                            boolean isVideo) {
+        Intent intent = new Intent(context, MediaSettingsActivity.class);
+        intent.putExtra(ARG_MEDIA_CONTENT_URI, contentUri);
+        intent.putExtra(ARG_IS_VIDEO, isVideo);
+        showSettingsIntent(context, intent);
+    }
+
+    /**
+     * @param context self explanatory
+     * @param site    site which contains this media item
+     * @param mediaId local ID in site's media library
+     */
+    public static void show(Context context,
+                            SiteModel site,
+                            int mediaId) {
+        Intent intent = new Intent(context, MediaSettingsActivity.class);
+        intent.putExtra(ARG_MEDIA_LOCAL_ID, mediaId);
+        intent.putExtra(WordPress.SITE, site);
+        showSettingsIntent(context, intent);
+    }
+
+    private static void showSettingsIntent(Context context, Intent intent) {
+        ActivityOptionsCompat options = ActivityOptionsCompat.makeCustomAnimation(
+                context,
+                R.anim.activity_slide_up_from_bottom,
+                R.anim.do_nothing);
+        ActivityCompat.startActivity(context, intent, options.toBundle());
+    }
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ((WordPress) getApplication()).component().inject(this);
+
+        setContentView(R.layout.media_settings_activity);
+
+        mImageView = (ImageView) findViewById(R.id.image_preview);
+        mVideoView = (VideoView) findViewById(R.id.video_preview);
+
+        mTitleView = (EditText) findViewById(R.id.edit_title);
+        mCaptionView = (EditText) findViewById(R.id.edit_caption);
+        mDescriptionView = (EditText) findViewById(R.id.edit_description);
+        mToolbar = (Toolbar) findViewById(R.id.toolbar);
+
+        if (savedInstanceState != null) {
+            mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
+            mContentUri = savedInstanceState.getString(ARG_MEDIA_CONTENT_URI);
+            mMediaId = savedInstanceState.getInt(ARG_MEDIA_LOCAL_ID);
+            mIsVideo = savedInstanceState.getBoolean(ARG_IS_VIDEO);
+        } else {
+            mSite = (SiteModel) getIntent().getSerializableExtra(WordPress.SITE);
+            mContentUri = getIntent().getStringExtra(ARG_MEDIA_CONTENT_URI);
+            mMediaId = getIntent().getIntExtra(ARG_MEDIA_LOCAL_ID, 0);
+            mIsVideo = getIntent().getBooleanExtra(ARG_IS_VIDEO, false);
+        }
+
+        setLookClosable(true);
+
+        String mediaUri = null;
+        if (!TextUtils.isEmpty(mContentUri)) {
+            mediaUri = mContentUri;
+        } else if (mMediaId != 0) {
+            MediaModel media = mMediaStore.getMediaWithLocalId(mMediaId);
+            if (media == null) {
+                delayedFinish(true);
+                return;
+            }
+            mIsVideo = media.isVideo();
+            mEnableMetadata = true;
+            mediaUri = media.getUrl();
+        }
+
+        if (TextUtils.isEmpty(mediaUri)) {
+            delayedFinish(true);
+            return;
+        }
+
+        if (mEnableMetadata) {
+            setSupportActionBar(mToolbar);
+            ActionBar actionBar = getSupportActionBar();
+            if (actionBar != null) {
+                actionBar.setDisplayShowTitleEnabled(true);
+                actionBar.setDisplayHomeAsUpEnabled(true);
+                actionBar.setTitle(R.string.media);
+            }
+        } else {
+            mToolbar.setVisibility(View.GONE);
+        }
+
+        mImageView.setVisibility(mIsVideo ? View.GONE : View.VISIBLE);
+        findViewById(R.id.frame_video).setVisibility(mIsVideo ? View.VISIBLE : View.GONE);
+        loadMediaMetaData();
+
+        if (mIsVideo) {
+            playVideo(mediaUri);
+        } else {
+            loadImage(mediaUri);
+        }
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString(ARG_MEDIA_CONTENT_URI, mContentUri);
+        outState.putInt(ARG_MEDIA_LOCAL_ID, mMediaId);
+        outState.putBoolean(ARG_IS_VIDEO, mIsVideo);
+        if (mSite != null) {
+            outState.putSerializable(WordPress.SITE, mSite);
+        }
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        registerReceiver(mDownloadReceiver, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
+        mDispatcher.register(this);
+    }
+
+    @Override
+    public void onStop() {
+        unregisterReceiver(mDownloadReceiver);
+        mDispatcher.unregister(this);
+        super.onStop();
+    }
+
+    private void delayedFinish(boolean showError) {
+        if (showError) {
+            ToastUtils.showToast(this, R.string.error_media_not_found);
+        }
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                finish();
+            }
+        }, 1500);
+    }
+
+    private void showProgress(boolean show) {
+        findViewById(R.id.progress).setVisibility(show ? View.VISIBLE : View.GONE);
+    }
+
+    @Override
+    public void onBackPressed() {
+        saveChanges();
+        setLookClosable(false);
+        invalidateOptionsMenu();
+
+        super.onBackPressed();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.media_settings, menu);
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        boolean showSaveMenu = mMediaId != 0 && mSite != null && !mSite.isPrivate();
+        boolean showShareMenu = mMediaId != 0 && mSite != null && !mSite.isPrivate();
+
+        MenuItem mnuSave = menu.findItem(R.id.menu_save);
+        mnuSave.setVisible(showSaveMenu);
+        mnuSave.setEnabled(mDownloadId == 0);
+
+        MenuItem mnuShare = menu.findItem(R.id.menu_share);
+        mnuShare.setVisible(showShareMenu);
+
+        return super.onPrepareOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            onBackPressed();
+            return true;
+        } else if (item.getItemId() == R.id.menu_save) {
+            saveMediaToDevice();
+            return true;
+        } else if (item.getItemId() == R.id.menu_share) {
+            shareMedia();
+            return true;
+        }
+
+        return super.onOptionsItemSelected(item);
+    }
+
+    void loadMediaMetaData() {
+        MediaModel media = mMediaStore.getMediaWithLocalId(mMediaId);
+        if (media != null) {
+            mTitleView.setText(media.getTitle());
+            mCaptionView.setText(media.getCaption());
+            mDescriptionView.setText(media.getDescription());
+
+            mTitleView.requestFocus();
+            mTitleView.setSelection(mTitleView.getText().length());
+        } else {
+            ToastUtils.showToast(this, R.string.error_media_load);
+        }
+    }
+
+    /*
+     * loads and displays a remote or local image
+     */
+    private void loadImage(@NonNull String mediaUri) {
+        int width = DisplayUtils.getDisplayPixelWidth(this);
+        int height = DisplayUtils.getDisplayPixelHeight(this);
+        int size = Math.max(width, height);
+
+        if (mediaUri.startsWith("http")) {
+            showProgress(true);
+            String imageUrl = mediaUri;
+            if (SiteUtils.isPhotonCapable(mSite)) {
+                imageUrl = PhotonUtils.getPhotonImageUrl(mediaUri, size, 0);
+            }
+            mImageLoader.get(imageUrl, new ImageLoader.ImageListener() {
+                @Override
+                public void onResponse(ImageLoader.ImageContainer response, boolean isImmediate) {
+                    if (!isFinishing() && response.getBitmap() != null) {
+                        showProgress(false);
+                        setBitmap(response.getBitmap());
+                    }
+                }
+
+                @Override
+                public void onErrorResponse(VolleyError error) {
+                    AppLog.e(AppLog.T.MEDIA, error);
+                    if (!isFinishing()) {
+                        showProgress(false);
+                        delayedFinish(true);
+                    }
+                }
+            }, size, 0);
+        } else {
+            new LocalImageTask(mediaUri, size).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        }
+    }
+
+    private class LocalImageTask extends AsyncTask<Void, Void, Bitmap> {
+        private final String mMediaUri;
+        private final int mSize;
+
+        LocalImageTask(@NonNull String mediaUri, int size) {
+            mMediaUri = mediaUri;
+            mSize = size;
+        }
+
+        @Override
+        protected Bitmap doInBackground(Void... params) {
+            int orientation = ImageUtils.getImageOrientation(MediaSettingsActivity.this, mMediaUri);
+            byte[] bytes = ImageUtils.createThumbnailFromUri(
+                    MediaSettingsActivity.this, Uri.parse(mMediaUri), mSize, null, orientation);
+            if (bytes != null) {
+                return BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
+            }
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(Bitmap bitmap) {
+            if (isFinishing()) {
+                return;
+            }
+            if (bitmap != null) {
+                setBitmap(bitmap);
+            } else {
+                delayedFinish(true);
+            }
+        }
+    }
+
+    private void setBitmap(@NonNull Bitmap bmp) {
+        // assign the photo attacher to enable pinch/zoom - must come before setImageBitmap
+        // for it to be correctly resized upon loading
+        PhotoViewAttacher attacher = new PhotoViewAttacher(mImageView);
+        mImageView.setImageBitmap(bmp);
+        invalidateOptionsMenu();
+    }
+
+    /*
+     * loads and plays a remote or local video
+     */
+    private void playVideo(@NonNull String mediaUri) {
+        final MediaController controls = new MediaController(this);
+        mVideoView.setMediaController(controls);
+
+        mVideoView.setOnErrorListener(new MediaPlayer.OnErrorListener() {
+            @Override
+            public boolean onError(MediaPlayer mp, int what, int extra) {
+                delayedFinish(false);
+                return false;
+            }
+        });
+
+        showProgress(true);
+        mVideoView.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
+            @Override
+            public void onPrepared(MediaPlayer mp) {
+                showProgress(false);
+                controls.show();
+                mp.start();
+            }
+        });
+
+        mVideoView.setVideoURI(Uri.parse(mediaUri));
+        mVideoView.requestFocus();
+    }
+
+
+    /*
+     * returns the passed string formatted as a short date if it's valid ISO 8601 date,
+     * otherwise returns the passed string
+     */
+    private String getDisplayDate(String dateString) {
+        if (dateString != null) {
+            Date date = DateTimeUtils.dateFromIso8601(dateString);
+            if (date != null) {
+                return SimpleDateFormat.getDateInstance().format(date);
+            }
+        }
+        return dateString;
+    }
+
+    private void setLookClosable(boolean lookClosable) {
+        mIsClosable = lookClosable;
+        if (mToolbar != null) {
+            mToolbar.setNavigationIcon(lookClosable ? R.drawable.ic_close_white_24dp : R.drawable.ic_arrow_left_white_24dp);
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode,
+                                           @NonNull String permissions[],
+                                           @NonNull int[] grantResults) {
+        boolean allGranted = WPPermissionUtils.setPermissionListAsked(
+                this, requestCode, permissions, grantResults, true);
+        if (allGranted && requestCode == WPPermissionUtils.MEDIA_PREVIEW_PERMISSION_REQUEST_CODE) {
+            saveMediaToDevice();
+        }
+    }
+
+    /*
+     * receives download completion broadcasts from the DownloadManager
+     */
+    private final BroadcastReceiver mDownloadReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            long thisId = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1);
+            if (thisId == mDownloadId) {
+                DownloadManager.Query query = new DownloadManager.Query();
+                query.setFilterById(mDownloadId);
+                DownloadManager dm = (DownloadManager) getSystemService(DOWNLOAD_SERVICE);
+                Cursor cursor = dm.query(query);
+                if (cursor.moveToFirst()) {
+                    int reason = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_REASON));
+                    if (reason == DownloadManager.STATUS_FAILED) {
+                        ToastUtils.showToast(MediaSettingsActivity.this, R.string.error_media_save);
+                    }
+                }
+                mDownloadId = 0;
+                invalidateOptionsMenu();
+            }
+        }
+    };
+
+    public void saveChanges() {
+        if (isFinishing()) return;
+
+        MediaModel media = mMediaStore.getMediaWithLocalId(mMediaId);
+        if (media == null) {
+            AppLog.w(AppLog.T.MEDIA, "MediaSettingsActivity > Cannot save null media");
+            ToastUtils.showToast(this, R.string.media_edit_failure);
+            return;
+        }
+
+        String thisTitle = EditTextUtils.getText(mTitleView);
+        String thisCaption = EditTextUtils.getText(mCaptionView);
+        String thisDescription = EditTextUtils.getText(mDescriptionView);
+
+        boolean hasChanged = !StringUtils.equals(media.getTitle(), thisTitle)
+                || !StringUtils.equals(media.getCaption(), thisCaption)
+                || !StringUtils.equals(media.getDescription(), thisDescription);
+        if (hasChanged) {
+            AppLog.d(AppLog.T.MEDIA, "MediaSettingsActivity > Saving changes");
+            media.setTitle(thisTitle);
+            media.setCaption(thisCaption);
+            media.setDescription(thisDescription);
+            mDispatcher.dispatch(MediaActionBuilder.newPushMediaAction(new MediaStore.MediaPayload(mSite, media)));
+        }
+    }
+
+    /*
+     * saves the media to the local device using the Android DownloadManager
+     */
+    private void saveMediaToDevice() {
+        // must request permissions even though they're already defined in the manifest
+        String[] permissionList = {
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+        };
+        if (!PermissionUtils.checkAndRequestPermissions(this, WPPermissionUtils.MEDIA_PREVIEW_PERMISSION_REQUEST_CODE, permissionList)) {
+            return;
+        }
+
+        if (!NetworkUtils.checkConnection(this)) {
+            return;
+        }
+
+        MediaModel media = mMediaStore.getMediaWithLocalId(mMediaId);
+        if (media == null) {
+            ToastUtils.showToast(this, R.string.error_media_not_found);
+            return;
+        }
+
+        DownloadManager dm = (DownloadManager) getSystemService(DOWNLOAD_SERVICE);
+        DownloadManager.Request request = new DownloadManager.Request(Uri.parse(media.getUrl()));
+        try {
+            request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, media.getFileName());
+        } catch (IllegalStateException error) {
+            AppLog.e(AppLog.T.MEDIA, error);
+            ToastUtils.showToast(MediaSettingsActivity.this, R.string.error_media_save);
+            return;
+        }
+        request.allowScanningByMediaScanner();
+        request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE);
+
+        mDownloadId = dm.enqueue(request);
+        invalidateOptionsMenu();
+        ToastUtils.showToast(this, R.string.media_downloading);
+    }
+
+    private void shareMedia() {
+        MediaModel media = mMediaStore.getMediaWithLocalId(mMediaId);
+        if (media == null) {
+            ToastUtils.showToast(this, R.string.error_media_not_found);
+            return;
+        }
+
+        Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.setType("text/plain");
+        intent.putExtra(Intent.EXTRA_TEXT, media.getUrl());
+        if (!TextUtils.isEmpty(media.getTitle())) {
+            intent.putExtra(Intent.EXTRA_SUBJECT, media.getTitle());
+        } else if (!TextUtils.isEmpty(media.getDescription())) {
+            intent.putExtra(Intent.EXTRA_SUBJECT, media.getDescription());
+        }
+        try {
+            startActivity(Intent.createChooser(intent, getString(R.string.share_link)));
+        } catch (android.content.ActivityNotFoundException ex) {
+            ToastUtils.showToast(this, R.string.reader_toast_err_share_intent);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onMediaChanged(MediaStore.OnMediaChanged event) {
+        if (!event.isError()) {
+            loadMediaMetaData();
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.media;
 
 import android.Manifest;
-import android.annotation.TargetApi;
 import android.app.AlertDialog;
 import android.app.DownloadManager;
 import android.app.ProgressDialog;
@@ -18,7 +17,6 @@ import android.graphics.BitmapFactory;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
@@ -35,8 +33,6 @@ import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.Window;
-import android.view.WindowManager;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -123,9 +119,8 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         ((WordPress) getApplication()).component().inject(this);
 
         setContentView(R.layout.media_settings_activity);
-        makeStatusBarTransparent();
 
-        int toolbarColor = ContextCompat.getColor(this, R.color.grey_dark_translucent_50);
+        int toolbarColor = ContextCompat.getColor(this, R.color.transparent);
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             actionBar.setDisplayShowTitleEnabled(true);
@@ -157,7 +152,13 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         }
 
         int displayHeight = DisplayUtils.getDisplayPixelHeight(this);
-        mImageView.getLayoutParams().height = (int) (displayHeight * 0.4);
+        int imageHeight = (int) (displayHeight * 0.4);
+        mImageView.getLayoutParams().height = imageHeight;
+
+        int toolbarHeight = DisplayUtils.getActionBarHeight(this);
+        int gradientHeight = toolbarHeight * 3;
+        ImageView imgGradient = (ImageView) findViewById(R.id.image_gradient);
+        imgGradient.getLayoutParams().height = gradientHeight;
 
         showMediaMetaData();
         loadImage();
@@ -174,16 +175,6 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
 
     private void notImplemented() {
         ToastUtils.showToast(this, "Not implemented yet!");
-    }
-
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    private void makeStatusBarTransparent() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            Window window = getWindow();
-            window.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-            int statusColor = ContextCompat.getColor(this, R.color.grey_dark_translucent_70);
-            window.setStatusBarColor(statusColor);
-        }
     }
 
     private boolean shouldShowFab() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -11,11 +11,9 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.res.ColorStateList;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -163,29 +161,22 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         showMediaMetaData();
         loadImage();
 
-        if (mMedia.isVideo()) {
-            mFabView.setImageResource(R.drawable.ic_play_video);
-            mFabView.setBackgroundTintList(ColorStateList.valueOf(Color.WHITE));
-        }
-
-        if (shouldShowFab()) {
-            mFabView.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    notImplemented();
-                }
-            });
-        }
+        View.OnClickListener listener = new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                showFullScreenPreview();
+            }
+        };
+        mFabView.setOnClickListener(listener);
+        mImageView.setOnClickListener(listener);
     }
 
-    private void notImplemented() {
+    private void showFullScreenPreview() {
         ToastUtils.showToast(this, "Not implemented yet!");
     }
 
     private boolean shouldShowFab() {
-        return mMedia != null
-                && (mMedia.isVideo()
-                || StringUtils.notNullStr(mMedia.getMimeType()).startsWith("image/"));
+        return mMedia != null && StringUtils.notNullStr(mMedia.getMimeType()).startsWith("image/");
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -11,9 +11,11 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.res.ColorStateList;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -152,16 +154,19 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         }
 
         int displayHeight = DisplayUtils.getDisplayPixelHeight(this);
-        int imageHeight = (int) (displayHeight * 0.4);
-        mImageView.getLayoutParams().height = imageHeight;
+        mImageView.getLayoutParams().height = (int) (displayHeight * 0.4);
 
         int toolbarHeight = DisplayUtils.getActionBarHeight(this);
-        int gradientHeight = toolbarHeight * 3;
         ImageView imgGradient = (ImageView) findViewById(R.id.image_gradient);
-        imgGradient.getLayoutParams().height = gradientHeight;
+        imgGradient.getLayoutParams().height = toolbarHeight * 3;
 
         showMediaMetaData();
         loadImage();
+
+        if (mMedia.isVideo()) {
+            mFabView.setImageResource(R.drawable.ic_play_video);
+            mFabView.setBackgroundTintList(ColorStateList.valueOf(Color.WHITE));
+        }
 
         if (shouldShowFab()) {
             mFabView.setOnClickListener(new View.OnClickListener() {
@@ -178,11 +183,9 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
     }
 
     private boolean shouldShowFab() {
-        if (mMedia == null) {
-            return false;
-        }
-        String mimeType = StringUtils.notNullStr(mMedia.getMimeType());
-        return mimeType.startsWith("image/");
+        return mMedia != null
+                && (mMedia.isVideo()
+                || StringUtils.notNullStr(mMedia.getMimeType()).startsWith("image/"));
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.media;
 
 import android.Manifest;
+import android.annotation.TargetApi;
 import android.app.AlertDialog;
 import android.app.DownloadManager;
 import android.app.ProgressDialog;
@@ -16,6 +17,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.media.MediaPlayer;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
@@ -27,11 +29,12 @@ import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.MediaController;
@@ -83,7 +86,6 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
     private EditText mTitleView;
     private EditText mCaptionView;
     private EditText mDescriptionView;
-    private Toolbar mToolbar;
 
     private ProgressDialog mProgressDialog;
 
@@ -118,6 +120,16 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         ((WordPress) getApplication()).component().inject(this);
 
         setContentView(R.layout.media_settings_activity);
+        setupStatusBar();
+
+        int toolbarColor = ContextCompat.getColor(this, R.color.grey_dark_translucent_50);
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayShowTitleEnabled(true);
+            actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setTitle(R.string.media);
+            actionBar.setBackgroundDrawable(new ColorDrawable(toolbarColor));
+        }
 
         mImageView = (ImageView) findViewById(R.id.image_preview);
         mVideoView = (VideoView) findViewById(R.id.video_preview);
@@ -125,7 +137,6 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         mTitleView = (EditText) findViewById(R.id.edit_title);
         mCaptionView = (EditText) findViewById(R.id.edit_caption);
         mDescriptionView = (EditText) findViewById(R.id.edit_description);
-        mToolbar = (Toolbar) findViewById(R.id.toolbar);
 
         int mediaId;
         if (savedInstanceState != null) {
@@ -142,14 +153,6 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
             return;
         }
 
-        ActionBar actionBar = getSupportActionBar();
-        if (actionBar != null) {
-            actionBar.setDisplayShowTitleEnabled(true);
-            actionBar.setDisplayHomeAsUpEnabled(true);
-            actionBar.setTitle(R.string.media);
-            actionBar.setBackgroundDrawable(new ColorDrawable(ContextCompat.getColor(this, R.color.transparent)));
-        }
-
         int height = DisplayUtils.getDisplayPixelHeight(this) / 3;
         mImageView.getLayoutParams().height = height;
 
@@ -161,6 +164,17 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
             playVideo();
         } else {
             loadImage();
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private void setupStatusBar() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            Window window = getWindow();
+            window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+            window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+            int statusColor = ContextCompat.getColor(this, R.color.grey_dark_translucent_50);
+            window.setStatusBarColor(statusColor);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -6,6 +6,8 @@ import android.app.AlertDialog;
 import android.app.DownloadManager;
 import android.app.ProgressDialog;
 import android.content.BroadcastReceiver;
+import android.content.ClipData;
+import android.content.ClipboardManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -357,6 +359,18 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
             txtUploadDate.setVisibility(View.GONE);
             txtUploadDateLabel.setVisibility(View.GONE);
         }
+
+        boolean hasUrl = !TextUtils.isEmpty(mMedia.getUrl());
+        View btnCopy = findViewById(R.id.button_copy_url);
+        btnCopy.setVisibility(hasUrl ? View.VISIBLE : View.GONE);
+        if (hasUrl) {
+            btnCopy.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    copyMediaUrlToClipboard();
+                }
+            });
+        }
     }
 
     /*
@@ -601,6 +615,17 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
                 mMedia = media;
                 showMediaMetaData();
             }
+        }
+    }
+
+    private void copyMediaUrlToClipboard() {
+        try {
+            ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+            clipboard.setPrimaryClip(ClipData.newPlainText(getString(R.string.app_name), mMedia.getUrl()));
+            ToastUtils.showToast(this, R.string.media_edit_copy_url_toast);
+        } catch (Exception e) {
+            AppLog.e(AppLog.T.UTILS, e);
+            ToastUtils.showToast(this, R.string.error_copy_to_clipboard);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -150,6 +150,9 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
             actionBar.setBackgroundDrawable(new ColorDrawable(ContextCompat.getColor(this, R.color.transparent)));
         }
 
+        int height = DisplayUtils.getDisplayPixelHeight(this) / 3;
+        mImageView.getLayoutParams().height = height;
+
         mImageView.setVisibility(mMedia.isVideo() ? View.GONE : View.VISIBLE);
         findViewById(R.id.frame_video).setVisibility(mMedia.isVideo() ? View.VISIBLE : View.GONE);
         showMediaMetaData();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -33,7 +33,6 @@ import android.widget.VideoView;
 
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.ImageLoader;
-import com.android.volley.toolbox.NetworkImageView;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -63,8 +62,6 @@ import java.util.Date;
 
 import javax.inject.Inject;
 
-import uk.co.senab.photoview.PhotoViewAttacher;
-
 public class MediaSettingsActivity extends AppCompatActivity implements ActivityCompat.OnRequestPermissionsResultCallback {
 
     private static final String ARG_MEDIA_CONTENT_URI = "content_uri";
@@ -75,8 +72,6 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
     private int mMediaId;
     private long mDownloadId;
     private boolean mIsVideo;
-    private boolean mEnableMetadata;
-    private boolean mIsClosable;
 
     private SiteModel mSite;
 
@@ -157,8 +152,6 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
             mIsVideo = getIntent().getBooleanExtra(ARG_IS_VIDEO, false);
         }
 
-        setLookClosable(true);
-
         String mediaUri = null;
         if (!TextUtils.isEmpty(mContentUri)) {
             mediaUri = mContentUri;
@@ -169,7 +162,6 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
                 return;
             }
             mIsVideo = media.isVideo();
-            mEnableMetadata = true;
             mediaUri = media.getUrl();
         }
 
@@ -178,16 +170,12 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
             return;
         }
 
-        if (mEnableMetadata) {
-            setSupportActionBar(mToolbar);
-            ActionBar actionBar = getSupportActionBar();
-            if (actionBar != null) {
-                actionBar.setDisplayShowTitleEnabled(true);
-                actionBar.setDisplayHomeAsUpEnabled(true);
-                actionBar.setTitle(R.string.media);
-            }
-        } else {
-            mToolbar.setVisibility(View.GONE);
+        setSupportActionBar(mToolbar);
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayShowTitleEnabled(true);
+            actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setTitle(R.string.media);
         }
 
         mImageView.setVisibility(mIsVideo ? View.GONE : View.VISIBLE);
@@ -226,6 +214,12 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         super.onStop();
     }
 
+    @Override
+    public void finish() {
+        super.finish();
+        overridePendingTransition(R.anim.do_nothing, R.anim.activity_slide_out_to_bottom);
+    }
+
     private void delayedFinish(boolean showError) {
         if (showError) {
             ToastUtils.showToast(this, R.string.error_media_not_found);
@@ -245,9 +239,7 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
     @Override
     public void onBackPressed() {
         saveChanges();
-        setLookClosable(false);
         invalidateOptionsMenu();
-
         super.onBackPressed();
     }
 
@@ -375,7 +367,7 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
     private void setBitmap(@NonNull Bitmap bmp) {
         // assign the photo attacher to enable pinch/zoom - must come before setImageBitmap
         // for it to be correctly resized upon loading
-        PhotoViewAttacher attacher = new PhotoViewAttacher(mImageView);
+        //PhotoViewAttacher attacher = new PhotoViewAttacher(mImageView);
         mImageView.setImageBitmap(bmp);
         invalidateOptionsMenu();
     }
@@ -422,13 +414,6 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
             }
         }
         return dateString;
-    }
-
-    private void setLookClosable(boolean lookClosable) {
-        mIsClosable = lookClosable;
-        if (mToolbar != null) {
-            mToolbar.setNavigationIcon(lookClosable ? R.drawable.ic_close_white_24dp : R.drawable.ic_arrow_left_white_24dp);
-        }
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -33,6 +33,7 @@ import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -152,7 +153,14 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         }
 
         int displayHeight = DisplayUtils.getDisplayPixelHeight(this);
-        mImageView.getLayoutParams().height = (int) (displayHeight * 0.4);
+        int imageHeight = (int) (displayHeight * 0.4);
+        mImageView.getLayoutParams().height = imageHeight;
+
+        int fabHeight = DisplayUtils.dpToPx(this, 56);
+        ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) mFabView.getLayoutParams();
+        int topMargin = imageHeight - (fabHeight / 2);
+        int rightMargin = getResources().getDimensionPixelSize(R.dimen.fab_margin);
+        params.setMargins(0, topMargin, rightMargin, 0);
 
         int toolbarHeight = DisplayUtils.getActionBarHeight(this);
         ImageView imgGradient = (ImageView) findViewById(R.id.image_gradient);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -172,6 +172,9 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         showMediaMetaData();
         loadImage();
 
+        ImageView imgPlayVideo = (ImageView) findViewById(R.id.image_play_video);
+        imgPlayVideo.setVisibility(mMedia.isVideo() ? View.VISIBLE : View.GONE);
+
         View.OnClickListener listener = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -180,6 +183,7 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         };
         mFabView.setOnClickListener(listener);
         mImageView.setOnClickListener(listener);
+        imgPlayVideo.setOnClickListener(listener);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -340,10 +340,10 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         }
 
         boolean hasUrl = !TextUtils.isEmpty(mMedia.getUrl());
-        View btnCopy = findViewById(R.id.button_copy_url);
-        btnCopy.setVisibility(hasUrl ? View.VISIBLE : View.GONE);
+        View txtCopyUrl = findViewById(R.id.text_copy_url);
+        txtCopyUrl.setVisibility(hasUrl ? View.VISIBLE : View.GONE);
         if (hasUrl) {
-            btnCopy.setOnClickListener(new View.OnClickListener() {
+            txtCopyUrl.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     copyMediaUrlToClipboard();

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -119,7 +119,7 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         ((WordPress) getApplication()).component().inject(this);
 
         setContentView(R.layout.media_settings_activity);
-        setupStatusBar();
+        makeStatusBarTransparent();
 
         int toolbarColor = ContextCompat.getColor(this, R.color.grey_dark_translucent_50);
         ActionBar actionBar = getSupportActionBar();
@@ -159,19 +159,12 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-    private void setupStatusBar() {
+    private void makeStatusBarTransparent() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             Window window = getWindow();
             window.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
-
             int statusColor = ContextCompat.getColor(this, R.color.grey_dark_translucent_70);
             window.setStatusBarColor(statusColor);
-
-            Resources resources = getResources();
-            int resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
-            if (resourceId > 0) {
-                int margin = resources.getDimensionPixelSize(resourceId);
-            }
         }
     }
 
@@ -348,7 +341,7 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
                 public void onResponse(ImageLoader.ImageContainer response, boolean isImmediate) {
                     if (!isFinishing() && response.getBitmap() != null) {
                         showProgress(false);
-                        setBitmap(response.getBitmap());
+                        mImageView.setImageBitmap(response.getBitmap());
                     }
                 }
 
@@ -392,19 +385,11 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
                 return;
             }
             if (bitmap != null) {
-                setBitmap(bitmap);
+                mImageView.setImageBitmap(bitmap);
             } else {
                 delayedFinishWithError();
             }
         }
-    }
-
-    private void setBitmap(@NonNull Bitmap bmp) {
-        // assign the photo attacher to enable pinch/zoom - must come before setImageBitmap
-        // for it to be correctly resized upon loading
-        //PhotoViewAttacher attacher = new PhotoViewAttacher(mImageView);
-        mImageView.setImageBitmap(bmp);
-        invalidateOptionsMenu();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.media;
 
 import android.Manifest;
+import android.annotation.TargetApi;
 import android.app.AlertDialog;
 import android.app.DownloadManager;
 import android.app.ProgressDialog;
@@ -17,6 +18,7 @@ import android.graphics.BitmapFactory;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
@@ -34,6 +36,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -121,13 +124,13 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
 
         setContentView(R.layout.media_settings_activity);
 
-        int toolbarColor = ContextCompat.getColor(this, R.color.transparent);
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             actionBar.setDisplayShowTitleEnabled(true);
             actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setHomeAsUpIndicator(R.drawable.ic_close_white_24dp);
             actionBar.setTitle(R.string.media);
-            actionBar.setBackgroundDrawable(new ColorDrawable(toolbarColor));
+            makeStatusAndToolbarTransparent();
         }
 
         mImageView = (ImageView) findViewById(R.id.image_preview);
@@ -177,10 +180,6 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         };
         mFabView.setOnClickListener(listener);
         mImageView.setOnClickListener(listener);
-    }
-
-    private boolean shouldShowFab() {
-        return mMedia != null && StringUtils.notNullStr(mMedia.getMimeType()).startsWith("image/");
     }
 
     @Override
@@ -243,6 +242,19 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
                 finish();
             }
         }, 1500);
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private void makeStatusAndToolbarTransparent() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            int toolbarColor = ContextCompat.getColor(this, R.color.transparent);
+            getSupportActionBar().setBackgroundDrawable(new ColorDrawable(toolbarColor));
+            getWindow().addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
+        }
+    }
+
+    private boolean shouldShowFab() {
+        return mMedia != null && StringUtils.notNullStr(mMedia.getMimeType()).startsWith("image/");
     }
 
     private void showProgress(boolean show) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -153,8 +153,9 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
             return;
         }
 
-        int height = DisplayUtils.getDisplayPixelHeight(this) / 3;
-        mImageView.getLayoutParams().height = height;
+        int displayHeight = DisplayUtils.getDisplayPixelHeight(this);
+        int imageHeight = (int) (displayHeight * 0.4);
+        mImageView.getLayoutParams().height = imageHeight;
 
         mImageView.setVisibility(mMedia.isVideo() ? View.GONE : View.VISIBLE);
         findViewById(R.id.frame_video).setVisibility(mMedia.isVideo() ? View.VISIBLE : View.GONE);
@@ -173,7 +174,7 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
             Window window = getWindow();
             window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
             window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-            int statusColor = ContextCompat.getColor(this, R.color.grey_dark_translucent_50);
+            int statusColor = ContextCompat.getColor(this, R.color.grey_dark_translucent_70);
             window.setStatusBarColor(statusColor);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -164,7 +164,7 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
         View.OnClickListener listener = new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                ToastUtils.showToast(v.getContext(), "Full-screen preview now implemented yet!");
+                ToastUtils.showToast(v.getContext(), "Full-screen preview isn't implemented yet");
             }
         };
         mFabView.setOnClickListener(listener);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaSettingsActivity.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.media;
 
 import android.Manifest;
 import android.annotation.TargetApi;
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.DownloadManager;
 import android.app.ProgressDialog;
@@ -55,6 +56,7 @@ import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.tools.FluxCImageLoader;
+import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DateTimeUtils;
@@ -77,6 +79,7 @@ import javax.inject.Inject;
 public class MediaSettingsActivity extends AppCompatActivity implements ActivityCompat.OnRequestPermissionsResultCallback {
 
     private static final String ARG_MEDIA_LOCAL_ID = "media_local_id";
+    public static final int RESULT_MEDIA_DELETED = RESULT_FIRST_USER;
 
     private long mDownloadId;
 
@@ -100,21 +103,21 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
     Dispatcher mDispatcher;
 
     /**
-     * @param context self explanatory
-     * @param site    site which contains this media item
-     * @param mediaId local ID in site's media library
+     * @param activity self explanatory
+     * @param site     site which contains this media item
+     * @param mediaId  local ID in site's media library
      */
-    public static void show(Context context,
-                            SiteModel site,
-                            int mediaId) {
-        Intent intent = new Intent(context, MediaSettingsActivity.class);
+    public static void showForResult(Activity activity,
+                                     SiteModel site,
+                                     int mediaId) {
+        Intent intent = new Intent(activity, MediaSettingsActivity.class);
         intent.putExtra(ARG_MEDIA_LOCAL_ID, mediaId);
         intent.putExtra(WordPress.SITE, site);
         ActivityOptionsCompat options = ActivityOptionsCompat.makeCustomAnimation(
-                context,
+                activity,
                 R.anim.activity_slide_up_from_bottom,
                 R.anim.do_nothing);
-        ActivityCompat.startActivity(context, intent, options.toBundle());
+        ActivityCompat.startActivityForResult(activity, intent, RequestCodes.MEDIA_SETTINGS, options.toBundle());
     }
 
     @Override
@@ -257,8 +260,10 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private void makeStatusAndToolbarTransparent() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            int toolbarColor = ContextCompat.getColor(this, R.color.transparent);
-            getSupportActionBar().setBackgroundDrawable(new ColorDrawable(toolbarColor));
+            if (getSupportActionBar() != null) {
+                int toolbarColor = ContextCompat.getColor(this, R.color.transparent);
+                getSupportActionBar().setBackgroundDrawable(new ColorDrawable(toolbarColor));
+            }
             getWindow().addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS);
         }
     }
@@ -622,6 +627,7 @@ public class MediaSettingsActivity extends AppCompatActivity implements Activity
             if (event.isError()) {
                 ToastUtils.showToast(this, R.string.error_generic);
             } else {
+                setResult(RESULT_MEDIA_DELETED);
                 finish();
             }
         } else if (!event.isError()) {

--- a/WordPress/src/main/res/anim/activity_slide_out_to_bottom.xml
+++ b/WordPress/src/main/res/anim/activity_slide_out_to_bottom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+     android:duration="@android:integer/config_shortAnimTime"
+     android:interpolator="@android:anim/accelerate_interpolator">
+
+    <translate
+        android:fromYDelta="0"
+        android:toYDelta="100%p"/>
+
+</set>

--- a/WordPress/src/main/res/anim/activity_slide_up_from_bottom.xml
+++ b/WordPress/src/main/res/anim/activity_slide_up_from_bottom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+     android:duration="@android:integer/config_mediumAnimTime"
+     android:interpolator="@android:anim/decelerate_interpolator">
+
+    <translate
+        android:fromYDelta="100%p"
+        android:toYDelta="0"/>
+
+</set>

--- a/WordPress/src/main/res/anim/activity_slide_up_from_bottom.xml
+++ b/WordPress/src/main/res/anim/activity_slide_up_from_bottom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <set xmlns:android="http://schemas.android.com/apk/res/android"
-     android:duration="@android:integer/config_mediumAnimTime"
+     android:duration="@android:integer/config_shortAnimTime"
      android:interpolator="@android:anim/decelerate_interpolator">
 
     <translate

--- a/WordPress/src/main/res/drawable/button_frame.xml
+++ b/WordPress/src/main/res/drawable/button_frame.xml
@@ -14,6 +14,7 @@
             <stroke
                 android:width="1dp"
                 android:color="@color/grey_lighten_20"/>
+            <solid android:color="@color/white"/>
             <corners android:radius="@dimen/margin_small"/>
         </shape>
     </item>

--- a/WordPress/src/main/res/drawable/button_frame.xml
+++ b/WordPress/src/main/res/drawable/button_frame.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true">
+        <shape android:shape="rectangle">
+            <stroke
+                android:width="1dp"
+                android:color="@color/grey"/>
+            <solid android:color="@color/grey_lighten_20"/>
+            <corners android:radius="@dimen/margin_small"/>
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <stroke
+                android:width="1dp"
+                android:color="@color/grey_lighten_20"/>
+            <corners android:radius="@dimen/margin_small"/>
+        </shape>
+    </item>
+</selector>

--- a/WordPress/src/main/res/drawable/media_settings_gradient.xml
+++ b/WordPress/src/main/res/drawable/media_settings_gradient.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:angle="90"
+        android:centerY="75%"
+        android:endColor="@color/black_translucent_50"
+        android:startColor="@color/transparent"
+        android:type="linear"/>
+</shape>

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -1,274 +1,288 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:app="http://schemas.android.com/apk/res-auto"
-            xmlns:tools="http://schemas.android.com/tools"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             xmlns:app="http://schemas.android.com/apk/res-auto"
+             xmlns:tools="http://schemas.android.com/tools"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent">
 
-    <RelativeLayout
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent">
 
-        <android.support.v7.widget.CardView
-            android:id="@+id/card1"
+        <RelativeLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:cardBackgroundColor="@color/white"
-            app:cardCornerRadius="@dimen/cardview_default_radius"
-            app:cardElevation="@dimen/card_elevation">
+            android:layout_height="wrap_content">
 
-            <LinearLayout
+            <android.support.v7.widget.CardView
+                android:id="@+id/card1"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                app:cardBackgroundColor="@color/white"
+                app:cardCornerRadius="@dimen/cardview_default_radius"
+                app:cardElevation="@dimen/card_elevation">
 
-                <FrameLayout
+                <LinearLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
 
-                    <ImageView
-                        android:id="@+id/image_preview"
+                    <FrameLayout
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:background="@color/grey"
-                        android:scaleType="centerCrop"
-                        tools:layout_height="224dp"
-                        tools:src="@drawable/drake_empty_results_400dp"/>
+                        android:layout_height="wrap_content">
 
-                    <android.support.design.widget.FloatingActionButton
-                        android:id="@+id/fab_button"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="end|bottom"
-                        android:layout_marginBottom="@dimen/fab_margin"
-                        android:layout_marginRight="@dimen/fab_margin"
-                        android:contentDescription="@string/fab_content_description_write"
-                        android:visibility="gone"
-                        app:borderWidth="0dp"
-                        app:srcCompat="@drawable/ic_fullscreen_white_24dp"
-                        tools:visibility="visible"/>
-                </FrameLayout>
+                        <ImageView
+                            android:id="@+id/image_preview"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:background="@color/grey"
+                            android:scaleType="centerCrop"
+                            tools:layout_height="224dp"
+                            tools:src="@drawable/drake_empty_results_400dp"/>
 
+                        <android.support.design.widget.FloatingActionButton
+                            android:id="@+id/fab_button"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="end|bottom"
+                            android:layout_marginBottom="@dimen/fab_margin"
+                            android:layout_marginRight="@dimen/fab_margin"
+                            android:contentDescription="@string/fab_content_description_write"
+                            android:visibility="gone"
+                            app:borderWidth="0dp"
+                            app:srcCompat="@drawable/ic_fullscreen_white_24dp"
+                            tools:visibility="visible"/>
+                    </FrameLayout>
+
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:orientation="vertical"
+                        android:padding="@dimen/margin_extra_large">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginLeft="@dimen/margin_small"
+                            android:text="@string/media_edit_card_caption"
+                            android:textColor="@color/color_primary"
+                            android:textSize="@dimen/text_sz_large"
+                            android:textStyle="bold"/>
+
+                        <android.support.design.widget.TextInputLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/margin_extra_large">
+
+                            <android.support.design.widget.TextInputEditText
+                                android:id="@+id/edit_title"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:hint="@string/media_edit_title_text"
+                                android:inputType="textCapSentences|textAutoCorrect"
+                                tools:text="edit_title"/>
+
+                        </android.support.design.widget.TextInputLayout>
+
+                        <android.support.design.widget.TextInputLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/margin_small">
+
+                            <android.support.design.widget.TextInputEditText
+                                android:id="@+id/edit_caption"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:hint="@string/media_edit_caption_text"
+                                android:inputType="textCapSentences|textAutoCorrect"
+                                tools:text="edit_caption"/>
+
+                        </android.support.design.widget.TextInputLayout>
+
+                        <android.support.design.widget.TextInputLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/margin_small">
+
+                            <android.support.design.widget.TextInputEditText
+                                android:id="@+id/edit_alt_text"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:hint="@string/media_edit_alttext_text"
+                                android:inputType="textCapSentences|textAutoCorrect"
+                                tools:text="edit_alt_text"/>
+
+                        </android.support.design.widget.TextInputLayout>
+
+                        <android.support.design.widget.TextInputLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="@dimen/margin_small">
+
+                            <android.support.design.widget.TextInputEditText
+                                android:id="@+id/edit_description"
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content"
+                                android:gravity="top|start"
+                                android:hint="@string/media_edit_description_text"
+                                android:inputType="textCapSentences|textAutoCorrect"
+                                android:lines="3"
+                                tools:text="edit_description"/>
+
+                        </android.support.design.widget.TextInputLayout>
+                    </LinearLayout>
+                </LinearLayout>
+            </android.support.v7.widget.CardView>
+
+            <android.support.v7.widget.CardView
+                android:id="@+id/card2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/card1"
+                android:layout_marginTop="@dimen/margin_extra_large"
+                app:cardBackgroundColor="@color/white"
+                app:cardCornerRadius="@dimen/cardview_default_radius"
+                app:cardElevation="@dimen/card_elevation">
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
+                    android:layout_marginLeft="@dimen/margin_small"
                     android:orientation="vertical"
                     android:padding="@dimen/margin_extra_large">
 
+                    <!-- url -->
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginLeft="@dimen/margin_small"
-                        android:text="@string/media_edit_card_caption"
-                        android:textColor="@color/color_primary"
-                        android:textSize="@dimen/text_sz_large"
-                        android:textStyle="bold"/>
+                        android:text="@string/media_edit_url_caption"
+                        android:textColor="@color/grey_dark"
+                        android:textSize="@dimen/text_sz_large"/>
 
-                    <android.support.design.widget.TextInputLayout
+                    <RelativeLayout
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_extra_large">
+                        android:layout_height="wrap_content">
 
-                        <android.support.design.widget.TextInputEditText
-                            android:id="@+id/edit_title"
+                        <TextView
+                            android:id="@+id/text_url"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:hint="@string/media_edit_title_text"
-                            android:inputType="textCapSentences|textAutoCorrect"
-                            tools:text="edit_title"/>
+                            android:layout_centerVertical="true"
+                            android:layout_marginTop="@dimen/margin_small"
+                            android:layout_toLeftOf="@+id/button_copy_url"
+                            android:ellipsize="end"
+                            android:maxLines="1"
+                            android:textColor="@color/grey"
+                            android:textSize="@dimen/text_sz_medium"
+                            tools:text="text_url"/>
 
-                    </android.support.design.widget.TextInputLayout>
-
-                    <android.support.design.widget.TextInputLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_small">
-
-                        <android.support.design.widget.TextInputEditText
-                            android:id="@+id/edit_caption"
-                            android:layout_width="match_parent"
+                        <Button
+                            android:id="@+id/button_copy_url"
+                            android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:hint="@string/media_edit_caption_text"
-                            android:inputType="textCapSentences|textAutoCorrect"
-                            tools:text="edit_caption"/>
+                            android:layout_alignParentRight="true"
+                            android:layout_centerVertical="true"
+                            android:layout_marginLeft="@dimen/margin_large"
+                            android:text="@string/copy"/>
+                    </RelativeLayout>
 
-                    </android.support.design.widget.TextInputLayout>
-
-                    <android.support.design.widget.TextInputLayout
-                        android:layout_width="match_parent"
+                    <!-- filename -->
+                    <TextView
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_small">
-
-                        <android.support.design.widget.TextInputEditText
-                            android:id="@+id/edit_alt_text"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:hint="@string/media_edit_alttext_text"
-                            android:inputType="textCapSentences|textAutoCorrect"
-                            tools:text="edit_alt_text"/>
-
-                    </android.support.design.widget.TextInputLayout>
-
-                    <android.support.design.widget.TextInputLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_small">
-
-                        <android.support.design.widget.TextInputEditText
-                            android:id="@+id/edit_description"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:gravity="top|start"
-                            android:hint="@string/media_edit_description_text"
-                            android:inputType="textCapSentences|textAutoCorrect"
-                            android:lines="3"
-                            tools:text="edit_description"/>
-
-                    </android.support.design.widget.TextInputLayout>
-                </LinearLayout>
-            </LinearLayout>
-        </android.support.v7.widget.CardView>
-
-        <android.support.v7.widget.CardView
-            android:id="@+id/card2"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_below="@+id/card1"
-            android:layout_marginTop="@dimen/margin_extra_large"
-            app:cardBackgroundColor="@color/white"
-            app:cardCornerRadius="@dimen/cardview_default_radius"
-            app:cardElevation="@dimen/card_elevation">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginLeft="@dimen/margin_small"
-                android:orientation="vertical"
-                android:padding="@dimen/margin_extra_large">
-
-                <!-- url -->
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/media_edit_url_caption"
-                    android:textColor="@color/grey_dark"
-                    android:textSize="@dimen/text_sz_large"/>
-
-                <RelativeLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                        android:layout_marginTop="@dimen/margin_extra_large"
+                        android:text="@string/media_edit_filename_caption"
+                        android:textColor="@color/grey_dark"
+                        android:textSize="@dimen/text_sz_large"/>
 
                     <TextView
-                        android:id="@+id/text_url"
-                        android:layout_width="match_parent"
+                        android:id="@+id/text_filename"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_centerVertical="true"
                         android:layout_marginTop="@dimen/margin_small"
-                        android:layout_toLeftOf="@+id/button_copy_url"
-                        android:ellipsize="end"
-                        android:maxLines="1"
                         android:textColor="@color/grey"
                         android:textSize="@dimen/text_sz_medium"
-                        tools:text="text_url"/>
+                        tools:text="text_filename"/>
 
-                    <Button
-                        android:id="@+id/button_copy_url"
+                    <!-- file type -->
+                    <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_alignParentRight="true"
-                        android:layout_centerVertical="true"
-                        android:layout_marginLeft="@dimen/margin_large"
-                        android:text="@string/copy"/>
-                </RelativeLayout>
+                        android:layout_marginTop="@dimen/margin_extra_large"
+                        android:text="@string/media_edit_filetype_caption"
+                        android:textColor="@color/grey_dark"
+                        android:textSize="@dimen/text_sz_large"/>
 
-                <!-- filename -->
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_extra_large"
-                    android:text="@string/media_edit_filename_caption"
-                    android:textColor="@color/grey_dark"
-                    android:textSize="@dimen/text_sz_large"/>
+                    <TextView
+                        android:id="@+id/text_filetype"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_small"
+                        android:textColor="@color/grey"
+                        android:textSize="@dimen/text_sz_medium"
+                        tools:text="text_filetype"/>
 
-                <TextView
-                    android:id="@+id/text_filename"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_small"
-                    android:textColor="@color/grey"
-                    android:textSize="@dimen/text_sz_medium"
-                    tools:text="text_filename"/>
+                    <!-- dimensions -->
+                    <TextView
+                        android:id="@+id/text_image_dimensions_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_extra_large"
+                        android:text="@string/media_edit_image_dimensions_caption"
+                        android:textColor="@color/grey_dark"
+                        android:textSize="@dimen/text_sz_large"/>
 
-                <!-- file type -->
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_extra_large"
-                    android:text="@string/media_edit_filetype_caption"
-                    android:textColor="@color/grey_dark"
-                    android:textSize="@dimen/text_sz_large"/>
+                    <TextView
+                        android:id="@+id/text_image_dimensions"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_small"
+                        android:textColor="@color/grey"
+                        android:textSize="@dimen/text_sz_medium"
+                        tools:text="text_image_dimensions"/>
 
-                <TextView
-                    android:id="@+id/text_filetype"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_small"
-                    android:textColor="@color/grey"
-                    android:textSize="@dimen/text_sz_medium"
-                    tools:text="text_filetype"/>
+                    <!-- upload date -->
+                    <TextView
+                        android:id="@+id/text_upload_date_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_extra_large"
+                        android:text="@string/media_edit_upload_date_caption"
+                        android:textColor="@color/grey_dark"
+                        android:textSize="@dimen/text_sz_large"/>
 
-                <!-- dimensions -->
-                <TextView
-                    android:id="@+id/text_image_dimensions_label"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_extra_large"
-                    android:text="@string/media_edit_image_dimensions_caption"
-                    android:textColor="@color/grey_dark"
-                    android:textSize="@dimen/text_sz_large"/>
+                    <TextView
+                        android:id="@+id/text_upload_date"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_small"
+                        android:textColor="@color/grey"
+                        android:textSize="@dimen/text_sz_medium"
+                        tools:text="text_upload_date"/>
 
-                <TextView
-                    android:id="@+id/text_image_dimensions"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_small"
-                    android:textColor="@color/grey"
-                    android:textSize="@dimen/text_sz_medium"
-                    tools:text="text_image_dimensions"/>
+                </LinearLayout>
 
-                <!-- upload date -->
-                <TextView
-                    android:id="@+id/text_upload_date_label"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_extra_large"
-                    android:text="@string/media_edit_upload_date_caption"
-                    android:textColor="@color/grey_dark"
-                    android:textSize="@dimen/text_sz_large"/>
+            </android.support.v7.widget.CardView>
 
-                <TextView
-                    android:id="@+id/text_upload_date"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_small"
-                    android:textColor="@color/grey"
-                    android:textSize="@dimen/text_sz_medium"
-                    tools:text="text_upload_date"/>
+            <ProgressBar
+                android:id="@+id/progress"
+                style="?android:attr/progressBarStyle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:elevation="@dimen/card_elevation"
+                android:visibility="gone"
+                tools:visibility="visible"/>
 
-            </LinearLayout>
+        </RelativeLayout>
+    </ScrollView>
 
-        </android.support.v7.widget.CardView>
+    <ImageView
+        android:id="@+id/image_gradient"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top"
+        android:background="@drawable/media_settings_gradient"
+        tools:layout_height="74dp"/>
 
-        <ProgressBar
-            android:id="@+id/progress"
-            style="?android:attr/progressBarStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:elevation="@dimen/card_elevation"
-            android:visibility="gone"
-            tools:visibility="visible"/>
-
-    </RelativeLayout>
-</ScrollView>
+</FrameLayout>

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -10,10 +10,9 @@
     <ImageView
         android:id="@+id/image_preview"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:adjustViewBounds="true"
-        android:background="@color/grey_lighten_10"
-        tools:layout_height="64dp"/>
+        android:layout_height="224dp"
+        android:background="@color/grey"
+        android:scaleType="centerCrop"/>
 
     <FrameLayout
         android:id="@+id/frame_video"
@@ -43,7 +42,7 @@
         android:id="@+id/layout_metadata"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="224dp"
+        android:layout_below="@+id/image_preview"
         android:background="@color/white"
         android:orientation="vertical"
         android:padding="@dimen/margin_extra_large">

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -22,14 +22,34 @@
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
 
-                <ImageView
-                    android:id="@+id/image_preview"
+                <FrameLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:background="@color/grey"
-                    android:scaleType="centerCrop"
-                    tools:layout_height="224dp"
-                    tools:src="@drawable/drake_empty_results_400dp"/>
+                    android:layout_height="wrap_content">
+
+                    <ImageView
+                        android:id="@+id/image_preview"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@color/grey"
+                        android:scaleType="centerCrop"
+                        tools:layout_height="224dp"
+                        tools:src="@drawable/drake_empty_results_400dp"/>
+
+                    <android.support.design.widget.FloatingActionButton
+                        android:id="@+id/fab_button"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="end|bottom"
+                        android:layout_marginBottom="@dimen/fab_margin"
+                        android:layout_marginRight="@dimen/fab_margin"
+                        android:contentDescription="@string/fab_content_description_write"
+                        android:visibility="gone"
+                        app:borderWidth="0dp"
+                        app:rippleColor="@color/fab_pressed"
+                        app:srcCompat="@drawable/ic_fullscreen_white_24dp"
+                        tools:visibility="visible"/>
+                </FrameLayout>
+
 
                 <LinearLayout
                     android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -21,10 +21,10 @@
                 android:layout_gravity="end|bottom"
                 android:layout_marginBottom="@dimen/fab_margin"
                 android:layout_marginRight="@dimen/fab_margin"
-                android:contentDescription="@string/fab_content_description_write"
+                android:contentDescription="@string/fab_content_description_preview"
                 android:visibility="gone"
                 app:borderWidth="0dp"
-                app:elevation="4dp"
+                app:elevation="8dp"
                 app:fabSize="normal"
                 app:srcCompat="@drawable/ic_fullscreen_white_24dp"
                 tools:visibility="visible"/>

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -5,14 +5,6 @@
              android:layout_width="match_parent"
              android:layout_height="match_parent">
 
-    <ImageView
-        android:id="@+id/image_gradient"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="top"
-        android:background="@drawable/media_settings_gradient"
-        tools:layout_height="74dp"/>
-
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -20,6 +12,22 @@
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
+
+            <android.support.design.widget.FloatingActionButton
+                android:id="@+id/fab_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:layout_gravity="end|bottom"
+                android:layout_marginBottom="@dimen/fab_margin"
+                android:layout_marginRight="@dimen/fab_margin"
+                android:contentDescription="@string/fab_content_description_write"
+                android:visibility="gone"
+                app:borderWidth="0dp"
+                app:elevation="4dp"
+                app:fabSize="normal"
+                app:srcCompat="@drawable/ic_fullscreen_white_24dp"
+                tools:visibility="visible"/>
 
             <android.support.v7.widget.CardView
                 android:id="@+id/card1"
@@ -34,35 +42,14 @@
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
 
-                    <FrameLayout
+                    <ImageView
+                        android:id="@+id/image_preview"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content">
-
-                        <ImageView
-                            android:id="@+id/image_preview"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:background="@color/grey_darken_10"
-                            android:scaleType="centerCrop"
-                            tools:layout_height="224dp"
-                            tools:src="@drawable/drake_empty_results_400dp"/>
-
-                        <android.support.design.widget.FloatingActionButton
-                            android:id="@+id/fab_button"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="end|bottom"
-                            android:layout_marginBottom="@dimen/fab_margin"
-                            android:layout_marginRight="@dimen/fab_margin"
-                            android:contentDescription="@string/fab_content_description_write"
-                            android:visibility="gone"
-                            app:borderWidth="0dp"
-                            app:elevation="4dp"
-                            app:fabSize="normal"
-                            app:srcCompat="@drawable/ic_fullscreen_white_24dp"
-                            tools:visibility="visible"/>
-                    </FrameLayout>
-
+                        android:layout_height="wrap_content"
+                        android:background="@color/grey_darken_10"
+                        android:scaleType="centerCrop"
+                        tools:layout_height="224dp"
+                        tools:src="@drawable/drake_empty_results_400dp"/>
 
                     <LinearLayout
                         android:layout_width="match_parent"
@@ -298,5 +285,13 @@
 
         </RelativeLayout>
     </ScrollView>
+
+    <ImageView
+        android:id="@+id/image_gradient"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top"
+        android:background="@drawable/media_settings_gradient"
+        tools:layout_height="74dp"/>
 
 </FrameLayout>

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -5,6 +5,14 @@
              android:layout_width="match_parent"
              android:layout_height="match_parent">
 
+    <ImageView
+        android:id="@+id/image_gradient"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top"
+        android:background="@drawable/media_settings_gradient"
+        tools:layout_height="74dp"/>
+
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -175,22 +183,29 @@
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_centerVertical="true"
-                            android:layout_marginTop="@dimen/margin_small"
-                            android:layout_toLeftOf="@+id/button_copy_url"
+                            android:layout_toLeftOf="@+id/text_copy_url"
                             android:ellipsize="end"
                             android:maxLines="1"
                             android:textColor="@color/grey"
                             android:textSize="@dimen/text_sz_medium"
                             tools:text="text_url"/>
 
-                        <Button
-                            android:id="@+id/button_copy_url"
+                        <TextView
+                            android:id="@+id/text_copy_url"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_alignParentRight="true"
                             android:layout_centerVertical="true"
                             android:layout_marginLeft="@dimen/margin_large"
-                            android:text="@string/copy"/>
+                            android:background="@drawable/button_frame"
+                            android:paddingBottom="@dimen/margin_small"
+                            android:paddingLeft="@dimen/margin_extra_large"
+                            android:paddingRight="@dimen/margin_extra_large"
+                            android:paddingTop="@dimen/margin_small"
+                            android:text="@string/copy"
+                            android:textAllCaps="true"
+                            android:textColor="@color/grey_dark"
+                            android:textSize="@dimen/text_sz_medium"/>
                     </RelativeLayout>
 
                     <!-- filename -->
@@ -283,13 +298,5 @@
 
         </RelativeLayout>
     </ScrollView>
-
-    <ImageView
-        android:id="@+id/image_gradient"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="top"
-        android:background="@drawable/media_settings_gradient"
-        tools:layout_height="74dp"/>
 
 </FrameLayout>

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -42,14 +42,28 @@
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
 
-                    <ImageView
-                        android:id="@+id/image_preview"
+                    <FrameLayout
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:background="@color/grey_light"
-                        android:scaleType="centerCrop"
-                        tools:layout_height="224dp"
-                        tools:src="@drawable/drake_empty_results_400dp"/>
+                        android:layout_height="wrap_content">
+
+                        <ImageView
+                            android:id="@+id/image_preview"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:background="@color/grey_light"
+                            android:scaleType="centerCrop"
+                            tools:layout_height="224dp"
+                            tools:src="@drawable/drake_empty_results_400dp"/>
+
+                        <ImageView
+                            android:id="@+id/image_play_video"
+                            android:layout_width="56dp"
+                            android:layout_height="56dp"
+                            android:layout_gravity="center"
+                            android:visibility="gone"
+                            app:srcCompat="@drawable/ic_play_video"
+                            tools:visibility="visible"/>
+                    </FrameLayout>
 
                     <LinearLayout
                         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -15,21 +15,6 @@
         android:scaleType="centerCrop"
         tools:layout_height="224dp"/>
 
-    <FrameLayout
-        android:id="@+id/frame_video"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_below="@+id/toolbar"
-        android:visibility="gone"
-        tools:visibility="visible">
-
-        <VideoView
-            android:id="@+id/video_preview"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_gravity="center"/>
-    </FrameLayout>
-
     <ProgressBar
         android:id="@+id/progress"
         style="?android:attr/progressBarStyle"

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -46,7 +46,7 @@
                         android:id="@+id/image_preview"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:background="@color/grey_darken_10"
+                        android:background="@color/grey_light"
                         android:scaleType="centerCrop"
                         tools:layout_height="224dp"
                         tools:src="@drawable/drake_empty_results_400dp"/>

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -10,9 +10,10 @@
     <ImageView
         android:id="@+id/image_preview"
         android:layout_width="match_parent"
-        android:layout_height="224dp"
+        android:layout_height="wrap_content"
         android:background="@color/grey"
-        android:scaleType="centerCrop"/>
+        android:scaleType="centerCrop"
+        tools:layout_height="224dp"/>
 
     <FrameLayout
         android:id="@+id/frame_video"

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -117,6 +117,7 @@
                         </android.support.design.widget.TextInputLayout>
 
                         <android.support.design.widget.TextInputLayout
+                            android:id="@+id/edit_alt_text_layout"
                             style="@style/MediaSettings.TextInputStyle"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -65,17 +65,18 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:layout_marginBottom="@dimen/margin_large"
                             android:layout_marginLeft="@dimen/margin_small"
                             android:text="@string/media_edit_card_caption"
-                            android:textColor="@color/color_primary"
+                            android:textColor="@color/blue_wordpress"
                             android:textSize="@dimen/text_sz_large"
                             android:textStyle="bold"/>
 
                         <android.support.design.widget.TextInputLayout
+                            style="@style/MediaSettings.TextInputStyle"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/margin_extra_large"
-                            android:textColorHint="@color/grey_500">
+                            app:theme="@style/MediaSettings.TextInputTheme">
 
                             <android.support.design.widget.TextInputEditText
                                 android:id="@+id/edit_title"
@@ -88,10 +89,10 @@
                         </android.support.design.widget.TextInputLayout>
 
                         <android.support.design.widget.TextInputLayout
+                            style="@style/MediaSettings.TextInputStyle"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/margin_small"
-                            android:textColorHint="@color/grey_500">
+                            app:theme="@style/MediaSettings.TextInputTheme">
 
                             <android.support.design.widget.TextInputEditText
                                 android:id="@+id/edit_caption"
@@ -104,10 +105,10 @@
                         </android.support.design.widget.TextInputLayout>
 
                         <android.support.design.widget.TextInputLayout
+                            style="@style/MediaSettings.TextInputStyle"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/margin_small"
-                            android:textColorHint="@color/grey_500">
+                            app:theme="@style/MediaSettings.TextInputTheme">
 
                             <android.support.design.widget.TextInputEditText
                                 android:id="@+id/edit_alt_text"
@@ -120,10 +121,10 @@
                         </android.support.design.widget.TextInputLayout>
 
                         <android.support.design.widget.TextInputLayout
+                            style="@style/MediaSettings.TextInputStyle"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/margin_small"
-                            android:textColorHint="@color/grey_500">
+                            app:theme="@style/MediaSettings.TextInputTheme">
 
                             <android.support.design.widget.TextInputEditText
                                 android:id="@+id/edit_description"
@@ -272,11 +273,11 @@
 
             <ProgressBar
                 android:id="@+id/progress"
-                style="?android:attr/progressBarStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_centerInParent="true"
                 android:elevation="@dimen/card_elevation"
+                android:textAppearance="?android:attr/progressBarStyle"
                 android:visibility="gone"
                 tools:visibility="visible"/>
 

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -55,7 +55,10 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:orientation="vertical"
-                        android:padding="@dimen/margin_extra_large">
+                        android:paddingBottom="@dimen/margin_extra_large"
+                        android:paddingLeft="@dimen/media_settings_margin"
+                        android:paddingRight="@dimen/media_settings_margin"
+                        android:paddingTop="@dimen/margin_extra_large">
 
                         <TextView
                             android:layout_width="wrap_content"

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:app="http://schemas.android.com/apk/res-auto"
                 xmlns:tools="http://schemas.android.com/tools"
@@ -7,13 +6,127 @@
                 android:layout_height="match_parent"
                 android:fitsSystemWindows="false">
 
-    <ImageView
-        android:id="@+id/image_preview"
+
+    <android.support.v7.widget.CardView
+        android:id="@+id/card1"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/grey"
-        android:scaleType="centerCrop"
-        tools:layout_height="224dp"/>
+        app:cardBackgroundColor="@color/white"
+        app:cardCornerRadius="@dimen/cardview_default_radius"
+        app:cardElevation="@dimen/card_elevation">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <ImageView
+                android:id="@+id/image_preview"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/grey"
+                android:scaleType="centerCrop"
+                tools:layout_height="224dp"
+                tools:src="@drawable/drake_empty_results_400dp"/>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                android:padding="@dimen/margin_extra_large">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="@dimen/margin_small"
+                    android:text="@string/media_settings_card_caption"
+                    android:textColor="@color/color_primary"
+                    android:textStyle="bold"/>
+
+                <android.support.design.widget.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_extra_large">
+
+                    <android.support.design.widget.TextInputEditText
+                        android:id="@+id/edit_title"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/media_edit_title_text"
+                        android:inputType="textCapSentences|textAutoCorrect"
+                        tools:text="edit_title"/>
+
+                </android.support.design.widget.TextInputLayout>
+
+                <android.support.design.widget.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_small">
+
+                    <android.support.design.widget.TextInputEditText
+                        android:id="@+id/edit_caption"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/media_edit_caption_text"
+                        android:inputType="textCapSentences|textAutoCorrect"
+                        tools:text="edit_caption"/>
+
+                </android.support.design.widget.TextInputLayout>
+
+                <android.support.design.widget.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_small">
+
+                    <android.support.design.widget.TextInputEditText
+                        android:id="@+id/edit_alt_text"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/media_edit_alttext_text"
+                        android:inputType="textCapSentences|textAutoCorrect"
+                        tools:text="edit_alt_text"/>
+
+                </android.support.design.widget.TextInputLayout>
+
+                <android.support.design.widget.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_small">
+
+                    <android.support.design.widget.TextInputEditText
+                        android:id="@+id/edit_description"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="top|start"
+                        android:hint="@string/media_edit_description_text"
+                        android:inputType="textCapSentences|textAutoCorrect"
+                        android:lines="3"
+                        tools:text="edit_description"/>
+
+                </android.support.design.widget.TextInputLayout>
+            </LinearLayout>
+        </LinearLayout>
+    </android.support.v7.widget.CardView>
+
+    <android.support.v7.widget.CardView
+        android:id="@+id/card2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/card1"
+        android:layout_marginTop="@dimen/margin_extra_large"
+        app:cardBackgroundColor="@color/white"
+        app:cardCornerRadius="@dimen/cardview_default_radius"
+        app:cardElevation="@dimen/card_elevation">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:padding="@dimen/margin_extra_large">
+
+        </LinearLayout>
+
+    </android.support.v7.widget.CardView>
 
     <ProgressBar
         android:id="@+id/progress"
@@ -21,63 +134,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
+        android:elevation="@dimen/card_elevation"
         android:visibility="gone"
         tools:visibility="visible"/>
-
-    <LinearLayout
-        android:id="@+id/layout_metadata"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_below="@+id/image_preview"
-        android:background="@color/white"
-        android:orientation="vertical"
-        android:padding="@dimen/margin_extra_large">
-
-        <android.support.design.widget.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <android.support.design.widget.TextInputEditText
-                android:id="@+id/edit_title"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/media_edit_title_text"
-                android:inputType="textCapSentences|textAutoCorrect"
-                tools:text="edit_title"/>
-
-        </android.support.design.widget.TextInputLayout>
-
-        <android.support.design.widget.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_small">
-
-            <android.support.design.widget.TextInputEditText
-                android:id="@+id/edit_caption"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/media_edit_caption_text"
-                android:inputType="textCapSentences|textAutoCorrect"
-                tools:text="edit_caption"/>
-
-        </android.support.design.widget.TextInputLayout>
-
-        <android.support.design.widget.TextInputLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_small">
-
-            <android.support.design.widget.TextInputEditText
-                android:id="@+id/edit_description"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="top|start"
-                android:hint="@string/media_edit_description_text"
-                android:inputType="textCapSentences|textAutoCorrect"
-                android:lines="3"
-                tools:text="edit_description"/>
-
-        </android.support.design.widget.TextInputLayout>
-    </LinearLayout>
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+    <include
+        android:id="@+id/toolbar"
+        layout="@layout/toolbar"/>
+
+    <ImageView
+        android:id="@+id/image_preview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@+id/toolbar"/>
+
+    <FrameLayout
+        android:id="@+id/frame_video"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@+id/toolbar"
+        android:visibility="gone"
+        tools:visibility="visible">
+
+        <VideoView
+            android:id="@+id/video_preview"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center"/>
+    </FrameLayout>
+
+    <ProgressBar
+        android:id="@+id/progress"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:visibility="gone"
+        tools:visibility="visible"/>
+
+    <LinearLayout
+        android:id="@+id/layout_metadata"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="128dp"
+        android:orientation="vertical"
+        android:padding="@dimen/margin_extra_large">
+
+        <android.support.design.widget.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/edit_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/media_edit_title_text"
+                android:inputType="textCapSentences|textAutoCorrect"
+                tools:text="edit_title"/>
+
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_small">
+
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/edit_caption"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/media_edit_caption_text"
+                android:inputType="textCapSentences|textAutoCorrect"
+                tools:text="edit_caption"/>
+
+        </android.support.design.widget.TextInputLayout>
+
+        <android.support.design.widget.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_small">
+
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/edit_description"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="top|start"
+                android:hint="@string/media_edit_description_text"
+                android:inputType="textCapSentences|textAutoCorrect"
+                android:lines="3"
+                tools:text="edit_description"/>
+
+        </android.support.design.widget.TextInputLayout>
+    </LinearLayout>
+
+</RelativeLayout>

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -11,7 +11,9 @@
         android:id="@+id/image_preview"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:adjustViewBounds="true"/>
+        android:adjustViewBounds="true"
+        android:background="@color/grey_lighten_10"
+        tools:layout_height="64dp"/>
 
     <FrameLayout
         android:id="@+id/frame_video"
@@ -41,7 +43,7 @@
         android:id="@+id/layout_metadata"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="196dp"
+        android:layout_marginTop="224dp"
         android:background="@color/white"
         android:orientation="vertical"
         android:padding="@dimen/margin_extra_large">

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -13,22 +13,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-            <android.support.design.widget.FloatingActionButton
-                android:id="@+id/fab_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                android:layout_gravity="end|bottom"
-                android:layout_marginBottom="@dimen/fab_margin"
-                android:layout_marginRight="@dimen/fab_margin"
-                android:contentDescription="@string/fab_content_description_preview"
-                android:visibility="gone"
-                app:borderWidth="0dp"
-                app:elevation="8dp"
-                app:fabSize="normal"
-                app:srcCompat="@drawable/ic_fullscreen_white_24dp"
-                tools:visibility="visible"/>
-
             <android.support.v7.widget.CardView
                 android:id="@+id/card1"
                 android:layout_width="match_parent"
@@ -153,6 +137,20 @@
                     </LinearLayout>
                 </LinearLayout>
             </android.support.v7.widget.CardView>
+
+            <android.support.design.widget.FloatingActionButton
+                android:id="@+id/fab_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:layout_marginBottom="@dimen/fab_margin"
+                android:layout_marginRight="@dimen/fab_margin"
+                android:contentDescription="@string/fab_content_description_preview"
+                android:visibility="gone"
+                app:elevation="8dp"
+                app:fabSize="normal"
+                app:srcCompat="@drawable/ic_fullscreen_white_24dp"
+                tools:visibility="visible"/>
 
             <android.support.v7.widget.CardView
                 android:id="@+id/card2"

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -1,19 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:app="http://schemas.android.com/apk/res-auto"
                 xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
-    <include
+    <android.support.v7.widget.Toolbar
         android:id="@+id/toolbar"
-        layout="@layout/toolbar"/>
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="@color/transparent"
+        android:elevation="0dp"
+        app:contentInsetLeft="@dimen/toolbar_content_offset"
+        app:contentInsetStart="@dimen/toolbar_content_offset"
+        app:navigationIcon="@drawable/ic_close_white_24dp"/>
 
     <ImageView
         android:id="@+id/image_preview"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_below="@+id/toolbar"/>
+        android:layout_height="wrap_content"
+        android:adjustViewBounds="true"/>
 
     <FrameLayout
         android:id="@+id/frame_video"
@@ -43,7 +50,8 @@
         android:id="@+id/layout_metadata"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="128dp"
+        android:layout_marginTop="196dp"
+        android:background="@color/white"
         android:orientation="vertical"
         android:padding="@dimen/margin_extra_large">
 

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -195,11 +195,16 @@
                             android:textSize="@dimen/text_sz_medium"/>
                     </RelativeLayout>
 
+                    <View
+                        style="@style/MediaSettings.Divider"
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"/>
+
                     <!-- filename -->
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_extra_large"
+                        android:layout_marginTop="@dimen/margin_medium"
                         android:text="@string/media_edit_filename_caption"
                         android:textColor="@color/grey_dark"
                         android:textSize="@dimen/text_sz_large"/>
@@ -213,11 +218,16 @@
                         android:textSize="@dimen/text_sz_medium"
                         tools:text="text_filename"/>
 
+                    <View
+                        style="@style/MediaSettings.Divider"
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"/>
+
                     <!-- file type -->
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_extra_large"
+                        android:layout_marginTop="@dimen/margin_medium"
                         android:text="@string/media_edit_filetype_caption"
                         android:textColor="@color/grey_dark"
                         android:textSize="@dimen/text_sz_large"/>
@@ -231,12 +241,17 @@
                         android:textSize="@dimen/text_sz_medium"
                         tools:text="text_filetype"/>
 
+                    <View
+                        style="@style/MediaSettings.Divider"
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"/>
+
                     <!-- dimensions -->
                     <TextView
                         android:id="@+id/text_image_dimensions_label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_extra_large"
+                        android:layout_marginTop="@dimen/margin_medium"
                         android:text="@string/media_edit_image_dimensions_caption"
                         android:textColor="@color/grey_dark"
                         android:textSize="@dimen/text_sz_large"/>
@@ -250,12 +265,17 @@
                         android:textSize="@dimen/text_sz_medium"
                         tools:text="text_image_dimensions"/>
 
+                    <View
+                        style="@style/MediaSettings.Divider"
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"/>
+
                     <!-- upload date -->
                     <TextView
                         android:id="@+id/text_upload_date_label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_extra_large"
+                        android:layout_marginTop="@dimen/margin_medium"
                         android:text="@string/media_edit_upload_date_caption"
                         android:textColor="@color/grey_dark"
                         android:textSize="@dimen/text_sz_large"/>

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -45,7 +45,6 @@
                         android:contentDescription="@string/fab_content_description_write"
                         android:visibility="gone"
                         app:borderWidth="0dp"
-                        app:rippleColor="@color/fab_pressed"
                         app:srcCompat="@drawable/ic_fullscreen_white_24dp"
                         tools:visibility="visible"/>
                 </FrameLayout>
@@ -156,14 +155,32 @@
                     android:textColor="@color/grey_dark"
                     android:textSize="@dimen/text_sz_large"/>
 
-                <TextView
-                    android:id="@+id/text_url"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_small"
-                    android:textColor="@color/grey"
-                    android:textSize="@dimen/text_sz_medium"
-                    tools:text="text_url"/>
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <TextView
+                        android:id="@+id/text_url"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_centerVertical="true"
+                        android:layout_marginTop="@dimen/margin_small"
+                        android:layout_toLeftOf="@+id/button_copy_url"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:textColor="@color/grey"
+                        android:textSize="@dimen/text_sz_medium"
+                        tools:text="text_url"/>
+
+                    <Button
+                        android:id="@+id/button_copy_url"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentRight="true"
+                        android:layout_centerVertical="true"
+                        android:layout_marginLeft="@dimen/margin_large"
+                        android:text="@string/copy"/>
+                </RelativeLayout>
 
                 <!-- filename -->
                 <TextView

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -1,141 +1,237 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
-                xmlns:tools="http://schemas.android.com/tools"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:fitsSystemWindows="false">
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            xmlns:tools="http://schemas.android.com/tools"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
-
-    <android.support.v7.widget.CardView
-        android:id="@+id/card1"
+    <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:cardBackgroundColor="@color/white"
-        app:cardCornerRadius="@dimen/cardview_default_radius"
-        app:cardElevation="@dimen/card_elevation">
+        android:layout_height="wrap_content">
 
-        <LinearLayout
+        <android.support.v7.widget.CardView
+            android:id="@+id/card1"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            app:cardBackgroundColor="@color/white"
+            app:cardCornerRadius="@dimen/cardview_default_radius"
+            app:cardElevation="@dimen/card_elevation">
 
-            <ImageView
-                android:id="@+id/image_preview"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@color/grey"
-                android:scaleType="centerCrop"
-                tools:layout_height="224dp"
-                tools:src="@drawable/drake_empty_results_400dp"/>
+                android:orientation="vertical">
+
+                <ImageView
+                    android:id="@+id/image_preview"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@color/grey"
+                    android:scaleType="centerCrop"
+                    tools:layout_height="224dp"
+                    tools:src="@drawable/drake_empty_results_400dp"/>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical"
+                    android:padding="@dimen/margin_extra_large">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="@dimen/margin_small"
+                        android:text="@string/media_edit_card_caption"
+                        android:textColor="@color/color_primary"
+                        android:textSize="@dimen/text_sz_large"
+                        android:textStyle="bold"/>
+
+                    <android.support.design.widget.TextInputLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_extra_large">
+
+                        <android.support.design.widget.TextInputEditText
+                            android:id="@+id/edit_title"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:hint="@string/media_edit_title_text"
+                            android:inputType="textCapSentences|textAutoCorrect"
+                            tools:text="edit_title"/>
+
+                    </android.support.design.widget.TextInputLayout>
+
+                    <android.support.design.widget.TextInputLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_small">
+
+                        <android.support.design.widget.TextInputEditText
+                            android:id="@+id/edit_caption"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:hint="@string/media_edit_caption_text"
+                            android:inputType="textCapSentences|textAutoCorrect"
+                            tools:text="edit_caption"/>
+
+                    </android.support.design.widget.TextInputLayout>
+
+                    <android.support.design.widget.TextInputLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_small">
+
+                        <android.support.design.widget.TextInputEditText
+                            android:id="@+id/edit_alt_text"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:hint="@string/media_edit_alttext_text"
+                            android:inputType="textCapSentences|textAutoCorrect"
+                            tools:text="edit_alt_text"/>
+
+                    </android.support.design.widget.TextInputLayout>
+
+                    <android.support.design.widget.TextInputLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_small">
+
+                        <android.support.design.widget.TextInputEditText
+                            android:id="@+id/edit_description"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:gravity="top|start"
+                            android:hint="@string/media_edit_description_text"
+                            android:inputType="textCapSentences|textAutoCorrect"
+                            android:lines="3"
+                            tools:text="edit_description"/>
+
+                    </android.support.design.widget.TextInputLayout>
+                </LinearLayout>
+            </LinearLayout>
+        </android.support.v7.widget.CardView>
+
+        <android.support.v7.widget.CardView
+            android:id="@+id/card2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/card1"
+            android:layout_marginTop="@dimen/margin_extra_large"
+            app:cardBackgroundColor="@color/white"
+            app:cardCornerRadius="@dimen/cardview_default_radius"
+            app:cardElevation="@dimen/card_elevation">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:layout_marginLeft="@dimen/margin_small"
                 android:orientation="vertical"
                 android:padding="@dimen/margin_extra_large">
 
+                <!-- url -->
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginLeft="@dimen/margin_small"
-                    android:text="@string/media_settings_card_caption"
-                    android:textColor="@color/color_primary"
-                    android:textStyle="bold"/>
+                    android:text="@string/media_edit_url_caption"
+                    android:textColor="@color/grey_dark"
+                    android:textSize="@dimen/text_sz_large"/>
 
-                <android.support.design.widget.TextInputLayout
-                    android:layout_width="match_parent"
+                <TextView
+                    android:id="@+id/text_url"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_extra_large">
+                    android:layout_marginTop="@dimen/margin_small"
+                    android:textColor="@color/grey"
+                    android:textSize="@dimen/text_sz_medium"
+                    tools:text="text_url"/>
 
-                    <android.support.design.widget.TextInputEditText
-                        android:id="@+id/edit_title"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:hint="@string/media_edit_title_text"
-                        android:inputType="textCapSentences|textAutoCorrect"
-                        tools:text="edit_title"/>
-
-                </android.support.design.widget.TextInputLayout>
-
-                <android.support.design.widget.TextInputLayout
-                    android:layout_width="match_parent"
+                <!-- filename -->
+                <TextView
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_small">
+                    android:layout_marginTop="@dimen/margin_extra_large"
+                    android:text="@string/media_edit_filename_caption"
+                    android:textColor="@color/grey_dark"
+                    android:textSize="@dimen/text_sz_large"/>
 
-                    <android.support.design.widget.TextInputEditText
-                        android:id="@+id/edit_caption"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:hint="@string/media_edit_caption_text"
-                        android:inputType="textCapSentences|textAutoCorrect"
-                        tools:text="edit_caption"/>
-
-                </android.support.design.widget.TextInputLayout>
-
-                <android.support.design.widget.TextInputLayout
-                    android:layout_width="match_parent"
+                <TextView
+                    android:id="@+id/text_filename"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_small">
+                    android:layout_marginTop="@dimen/margin_small"
+                    android:textColor="@color/grey"
+                    android:textSize="@dimen/text_sz_medium"
+                    tools:text="text_filename"/>
 
-                    <android.support.design.widget.TextInputEditText
-                        android:id="@+id/edit_alt_text"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:hint="@string/media_edit_alttext_text"
-                        android:inputType="textCapSentences|textAutoCorrect"
-                        tools:text="edit_alt_text"/>
-
-                </android.support.design.widget.TextInputLayout>
-
-                <android.support.design.widget.TextInputLayout
-                    android:layout_width="match_parent"
+                <!-- file type -->
+                <TextView
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="@dimen/margin_small">
+                    android:layout_marginTop="@dimen/margin_extra_large"
+                    android:text="@string/media_edit_filetype_caption"
+                    android:textColor="@color/grey_dark"
+                    android:textSize="@dimen/text_sz_large"/>
 
-                    <android.support.design.widget.TextInputEditText
-                        android:id="@+id/edit_description"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="top|start"
-                        android:hint="@string/media_edit_description_text"
-                        android:inputType="textCapSentences|textAutoCorrect"
-                        android:lines="3"
-                        tools:text="edit_description"/>
+                <TextView
+                    android:id="@+id/text_filetype"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_small"
+                    android:textColor="@color/grey"
+                    android:textSize="@dimen/text_sz_medium"
+                    tools:text="text_filetype"/>
 
-                </android.support.design.widget.TextInputLayout>
+                <!-- dimensions -->
+                <TextView
+                    android:id="@+id/text_image_dimensions_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_extra_large"
+                    android:text="@string/media_edit_image_dimensions_caption"
+                    android:textColor="@color/grey_dark"
+                    android:textSize="@dimen/text_sz_large"/>
+
+                <TextView
+                    android:id="@+id/text_image_dimensions"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_small"
+                    android:textColor="@color/grey"
+                    android:textSize="@dimen/text_sz_medium"
+                    tools:text="text_image_dimensions"/>
+
+                <!-- upload date -->
+                <TextView
+                    android:id="@+id/text_upload_date_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_extra_large"
+                    android:text="@string/media_edit_upload_date_caption"
+                    android:textColor="@color/grey_dark"
+                    android:textSize="@dimen/text_sz_large"/>
+
+                <TextView
+                    android:id="@+id/text_upload_date"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_small"
+                    android:textColor="@color/grey"
+                    android:textSize="@dimen/text_sz_medium"
+                    tools:text="text_upload_date"/>
+
             </LinearLayout>
-        </LinearLayout>
-    </android.support.v7.widget.CardView>
 
-    <android.support.v7.widget.CardView
-        android:id="@+id/card2"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/card1"
-        android:layout_marginTop="@dimen/margin_extra_large"
-        app:cardBackgroundColor="@color/white"
-        app:cardCornerRadius="@dimen/cardview_default_radius"
-        app:cardElevation="@dimen/card_elevation">
+        </android.support.v7.widget.CardView>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical"
-            android:padding="@dimen/margin_extra_large">
+        <ProgressBar
+            android:id="@+id/progress"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:elevation="@dimen/card_elevation"
+            android:visibility="gone"
+            tools:visibility="visible"/>
 
-        </LinearLayout>
-
-    </android.support.v7.widget.CardView>
-
-    <ProgressBar
-        android:id="@+id/progress"
-        style="?android:attr/progressBarStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:elevation="@dimen/card_elevation"
-        android:visibility="gone"
-        tools:visibility="visible"/>
-
-</RelativeLayout>
+    </RelativeLayout>
+</ScrollView>

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -151,15 +151,15 @@
                     android:layout_height="match_parent"
                     android:layout_marginLeft="@dimen/margin_small"
                     android:orientation="vertical"
-                    android:padding="@dimen/margin_extra_large">
+                    android:paddingBottom="@dimen/margin_extra_large"
+                    android:paddingTop="@dimen/margin_extra_large">
 
                     <!-- url -->
                     <TextView
+                        style="@style/MediaSettings.Label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/media_edit_url_caption"
-                        android:textColor="@color/grey_dark"
-                        android:textSize="@dimen/text_sz_large"/>
+                        android:text="@string/media_edit_url_caption"/>
 
                     <RelativeLayout
                         android:layout_width="match_parent"
@@ -167,14 +167,13 @@
 
                         <TextView
                             android:id="@+id/text_url"
+                            style="@style/MediaSettings.Value"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_centerVertical="true"
                             android:layout_toLeftOf="@+id/text_copy_url"
                             android:ellipsize="end"
                             android:maxLines="1"
-                            android:textColor="@color/grey"
-                            android:textSize="@dimen/text_sz_medium"
                             tools:text="text_url"/>
 
                         <TextView
@@ -183,7 +182,7 @@
                             android:layout_height="wrap_content"
                             android:layout_alignParentRight="true"
                             android:layout_centerVertical="true"
-                            android:layout_marginLeft="@dimen/margin_large"
+                            android:layout_marginRight="@dimen/margin_extra_large"
                             android:background="@drawable/button_frame"
                             android:paddingBottom="@dimen/margin_small"
                             android:paddingLeft="@dimen/margin_extra_large"
@@ -202,20 +201,16 @@
 
                     <!-- filename -->
                     <TextView
+                        style="@style/MediaSettings.Label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_medium"
-                        android:text="@string/media_edit_filename_caption"
-                        android:textColor="@color/grey_dark"
-                        android:textSize="@dimen/text_sz_large"/>
+                        android:text="@string/media_edit_filename_caption"/>
 
                     <TextView
                         android:id="@+id/text_filename"
+                        style="@style/MediaSettings.Value"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_small"
-                        android:textColor="@color/grey"
-                        android:textSize="@dimen/text_sz_medium"
                         tools:text="text_filename"/>
 
                     <View
@@ -225,20 +220,16 @@
 
                     <!-- file type -->
                     <TextView
+                        style="@style/MediaSettings.Label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_medium"
-                        android:text="@string/media_edit_filetype_caption"
-                        android:textColor="@color/grey_dark"
-                        android:textSize="@dimen/text_sz_large"/>
+                        android:text="@string/media_edit_filetype_caption"/>
 
                     <TextView
                         android:id="@+id/text_filetype"
+                        style="@style/MediaSettings.Value"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_small"
-                        android:textColor="@color/grey"
-                        android:textSize="@dimen/text_sz_medium"
                         tools:text="text_filetype"/>
 
                     <View
@@ -249,20 +240,16 @@
                     <!-- dimensions -->
                     <TextView
                         android:id="@+id/text_image_dimensions_label"
+                        style="@style/MediaSettings.Label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_medium"
-                        android:text="@string/media_edit_image_dimensions_caption"
-                        android:textColor="@color/grey_dark"
-                        android:textSize="@dimen/text_sz_large"/>
+                        android:text="@string/media_edit_image_dimensions_caption"/>
 
                     <TextView
                         android:id="@+id/text_image_dimensions"
+                        style="@style/MediaSettings.Value"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_small"
-                        android:textColor="@color/grey"
-                        android:textSize="@dimen/text_sz_medium"
                         tools:text="text_image_dimensions"/>
 
                     <View
@@ -273,20 +260,16 @@
                     <!-- upload date -->
                     <TextView
                         android:id="@+id/text_upload_date_label"
+                        style="@style/MediaSettings.Label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_medium"
-                        android:text="@string/media_edit_upload_date_caption"
-                        android:textColor="@color/grey_dark"
-                        android:textSize="@dimen/text_sz_large"/>
+                        android:text="@string/media_edit_upload_date_caption"/>
 
                     <TextView
                         android:id="@+id/text_upload_date"
+                        style="@style/MediaSettings.Value"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/margin_small"
-                        android:textColor="@color/grey"
-                        android:textSize="@dimen/text_sz_medium"
                         tools:text="text_upload_date"/>
 
                 </LinearLayout>

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -4,17 +4,8 @@
                 xmlns:app="http://schemas.android.com/apk/res-auto"
                 xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
-
-    <android.support.v7.widget.Toolbar
-        android:id="@+id/toolbar"
-        android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:background="@color/transparent"
-        android:elevation="0dp"
-        app:contentInsetLeft="@dimen/toolbar_content_offset"
-        app:contentInsetStart="@dimen/toolbar_content_offset"
-        app:navigationIcon="@drawable/ic_close_white_24dp"/>
+                android:layout_height="match_parent"
+                android:fitsSystemWindows="false">
 
     <ImageView
         android:id="@+id/image_preview"

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -34,7 +34,7 @@
                             android:id="@+id/image_preview"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:background="@color/grey"
+                            android:background="@color/grey_darken_10"
                             android:scaleType="centerCrop"
                             tools:layout_height="224dp"
                             tools:src="@drawable/drake_empty_results_400dp"/>
@@ -48,6 +48,9 @@
                             android:layout_marginRight="@dimen/fab_margin"
                             android:contentDescription="@string/fab_content_description_write"
                             android:visibility="gone"
+                            app:borderWidth="0dp"
+                            app:elevation="4dp"
+                            app:fabSize="normal"
                             app:srcCompat="@drawable/ic_fullscreen_white_24dp"
                             tools:visibility="visible"/>
                     </FrameLayout>
@@ -71,7 +74,8 @@
                         <android.support.design.widget.TextInputLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/margin_extra_large">
+                            android:layout_marginTop="@dimen/margin_extra_large"
+                            android:textColorHint="@color/grey_500">
 
                             <android.support.design.widget.TextInputEditText
                                 android:id="@+id/edit_title"
@@ -86,7 +90,8 @@
                         <android.support.design.widget.TextInputLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/margin_small">
+                            android:layout_marginTop="@dimen/margin_small"
+                            android:textColorHint="@color/grey_500">
 
                             <android.support.design.widget.TextInputEditText
                                 android:id="@+id/edit_caption"
@@ -101,7 +106,8 @@
                         <android.support.design.widget.TextInputLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/margin_small">
+                            android:layout_marginTop="@dimen/margin_small"
+                            android:textColorHint="@color/grey_500">
 
                             <android.support.design.widget.TextInputEditText
                                 android:id="@+id/edit_alt_text"
@@ -116,7 +122,8 @@
                         <android.support.design.widget.TextInputLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginTop="@dimen/margin_small">
+                            android:layout_marginTop="@dimen/margin_small"
+                            android:textColorHint="@color/grey_500">
 
                             <android.support.design.widget.TextInputEditText
                                 android:id="@+id/edit_description"

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -48,7 +48,6 @@
                             android:layout_marginRight="@dimen/fab_margin"
                             android:contentDescription="@string/fab_content_description_write"
                             android:visibility="gone"
-                            app:borderWidth="0dp"
                             app:srcCompat="@drawable/ic_fullscreen_white_24dp"
                             tools:visibility="visible"/>
                     </FrameLayout>

--- a/WordPress/src/main/res/menu/media_settings.xml
+++ b/WordPress/src/main/res/menu/media_settings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menu_save"
+        android:icon="@drawable/ic_download_white_24dp"
+        android:title="@string/save"
+        app:showAsAction="ifRoom"/>
+
+    <item
+        android:id="@+id/menu_share"
+        android:icon="@drawable/ic_share_24dp"
+        android:title="@string/share_link"
+        app:showAsAction="ifRoom"/>
+</menu>

--- a/WordPress/src/main/res/menu/media_settings.xml
+++ b/WordPress/src/main/res/menu/media_settings.xml
@@ -3,6 +3,12 @@
       xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
+        android:id="@+id/menu_trash"
+        android:icon="@drawable/ic_trash_white_24dp"
+        android:title="@string/trash"
+        app:showAsAction="ifRoom"/>
+
+    <item
         android:id="@+id/menu_save"
         android:icon="@drawable/ic_download_white_24dp"
         android:title="@string/save"

--- a/WordPress/src/main/res/values-sw600dp/dimens.xml
+++ b/WordPress/src/main/res/values-sw600dp/dimens.xml
@@ -7,4 +7,5 @@
     <dimen name="notifications_list_margin">48dp</dimen>
     <dimen name="fab_margin">@dimen/fab_margin_tablet</dimen>
     <dimen name="menu_item_margin">@dimen/menu_item_margin_tablet</dimen>
+    <dimen name="media_settings_margin">@dimen/media_settings_margin_tablet</dimen>
 </resources>

--- a/WordPress/src/main/res/values-sw720dp/dimens.xml
+++ b/WordPress/src/main/res/values-sw720dp/dimens.xml
@@ -7,4 +7,5 @@
     <dimen name="reader_featured_image_height">@dimen/reader_featured_image_height_tablet_large</dimen>
     <dimen name="stats_barchart_height">200dp</dimen>
     <dimen name="postlist_featured_image_height">@dimen/postlist_featured_image_height_tablet_large</dimen>
+    <dimen name="media_settings_margin">@dimen/media_settings_margin_tablet_large</dimen>
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -26,6 +26,10 @@
     <dimen name="tabs_elevation">4dp</dimen>
 
     <dimen name="media_grid_progress_height">24dp</dimen>
+    <dimen name="media_settings_margin_normal">@dimen/margin_extra_large</dimen>
+    <dimen name="media_settings_margin_tablet">48dp</dimen>
+    <dimen name="media_settings_margin_tablet_large">96dp</dimen>
+    <dimen name="media_settings_margin">@dimen/media_settings_margin_normal</dimen>
 
     <dimen name="theme_details_fragment_width">650dp</dimen>
     <dimen name="theme_details_fragment_height">450dp</dimen>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -135,6 +135,7 @@
     <string name="media_insert_individually">Add individually</string>
     <string name="media_insert_as_gallery">Add as gallery</string>
     <string name="media_downloading">Saving media to this device</string>
+    <string name="media_settings_card_caption">File Details</string>
     <string name="wp_media_title">WordPress media</string>
     <string name="pick_photo">Select photo</string>
     <string name="pick_video">Select video</string>
@@ -177,6 +178,7 @@
     <!-- Edit Media -->
     <string name="media_edit_title_text">Title</string>
     <string name="media_edit_caption_text">Caption</string>
+    <string name="media_edit_alttext_text">Alt text</string>
     <string name="media_edit_description_text">Description</string>
     <string name="media_edit_title_hint">Enter a title here</string>
     <string name="media_edit_caption_hint">Enter a caption here</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -194,6 +194,7 @@
     <string name="media_edit_image_dimensions_caption">Image Dimensions</string>
     <string name="media_edit_upload_date_caption">Upload Date</string>
     <string name="media_edit_copy_url_toast">URL copied to clipboard</string>
+    <string name="fab_content_description_preview">Preview</string>
 
     <!-- Delete Media -->
     <string name="confirm_delete_multi_media">Delete selected items?</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -187,7 +187,6 @@
     <string name="confirm_discard_changes">Discard unsaved changes?</string>
 
     <!-- Delete Media -->
-    <string name="confirm_delete_media">Delete selected item?</string>
     <string name="confirm_delete_multi_media">Delete selected items?</string>
     <string name="cannot_delete_multi_media_items">Some media can\'t be deleted at this time. Try again later.</string>
     <string name="cannot_retry_deleted_media_item">Media has been removed. Delete it from this post?</string>
@@ -197,6 +196,9 @@
     <string name="media_empty_documents_list">You don\'t have any documents</string>
     <string name="media_empty_audio_list">You don\'t have any audio</string>
     <string name="delete">Delete</string>
+    <string name="confirm_delete_media_image">Delete this image?</string>
+    <string name="confirm_delete_media_video">Delete this video?</string>
+    <string name="deleting_media_dlg">Deleting</string>
 
     <!-- Media details -->
     <string name="media_details_label_date_added">Added</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -135,7 +135,6 @@
     <string name="media_insert_individually">Add individually</string>
     <string name="media_insert_as_gallery">Add as gallery</string>
     <string name="media_downloading">Saving media to this device</string>
-    <string name="media_settings_card_caption">File Details</string>
     <string name="wp_media_title">WordPress media</string>
     <string name="pick_photo">Select photo</string>
     <string name="pick_video">Select video</string>
@@ -187,6 +186,12 @@
     <string name="media_edit_failure">Failed to update</string>
     <string name="saving">Saving…</string>
     <string name="confirm_discard_changes">Discard unsaved changes?</string>
+    <string name="media_edit_card_caption">File Details</string>
+    <string name="media_edit_url_caption">URL</string>
+    <string name="media_edit_filename_caption">File Name</string>
+    <string name="media_edit_filetype_caption">File Type</string>
+    <string name="media_edit_image_dimensions_caption">Image Dimensions</string>
+    <string name="media_edit_upload_date_caption">Upload Date</string>
 
     <!-- Delete Media -->
     <string name="confirm_delete_multi_media">Delete selected items?</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -99,6 +99,7 @@
     <string name="confirm">Confirm</string>
     <string name="cant_open_url">Unable to open the link</string>
     <string name="retry">Retry</string>
+    <string name="copy">Copy</string>
     <string name="error_please_choose_browser">Error opening the default web browser. Please choose another app:</string>
 
     <string name="button_skip">Skip</string>
@@ -192,6 +193,7 @@
     <string name="media_edit_filetype_caption">File Type</string>
     <string name="media_edit_image_dimensions_caption">Image Dimensions</string>
     <string name="media_edit_upload_date_caption">Upload Date</string>
+    <string name="media_edit_copy_url_toast">URL copied to clipboard</string>
 
     <!-- Delete Media -->
     <string name="confirm_delete_multi_media">Delete selected items?</string>
@@ -212,8 +214,6 @@
     <string name="media_details_label_date_uploaded">Uploaded</string>
     <string name="media_details_label_file_name">File name</string>
     <string name="media_details_label_file_type">File type</string>
-    <string name="media_details_copy_url">Copy URL</string>
-    <string name="media_details_copy_url_toast">URL copied to clipboard</string>
 
     <!-- themes -->
     <string name="themes_live_preview">Live preview</string>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -242,6 +242,8 @@
     </style>
 
     <style name="MediaSettingsTheme" parent="WordPress">
+        <item name="android:windowTranslucentStatus">true</item>
+
         <item name="colorAccent">@color/blue_medium</item>
         <item name="android:homeAsUpIndicator">@drawable/ic_close_white_24dp</item>
     </style>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -242,6 +242,7 @@
     </style>
 
     <style name="MediaSettingsTheme" parent="WordPress">
+        <item name="colorAccent">@color/blue_medium</item>
         <item name="android:homeAsUpIndicator">@drawable/ic_close_white_24dp</item>
     </style>
 

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -243,8 +243,6 @@
 
     <style name="MediaSettingsTheme" parent="WordPress">
         <item name="android:windowTranslucentStatus">true</item>
-
-        <item name="colorAccent">@color/blue_medium</item>
         <item name="android:homeAsUpIndicator">@drawable/ic_close_white_24dp</item>
     </style>
 

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -241,7 +241,7 @@
         <item name="android:gravity">center</item>
     </style>
 
-    <style name="MediaSettingsTheme" parent="Theme.AppCompat.Light">
+    <style name="MediaSettingsTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <item name="android:windowTranslucentStatus">true</item>
         <item name="android:windowTranslucentNavigation">true</item>
         <item name="android:homeAsUpIndicator">@drawable/ic_close_white_24dp</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -242,7 +242,7 @@
     </style>
 
     <style name="MediaSettings" />
-    <style name="MediaSettings.Theme" parent="WordPress">
+    <style name="MediaSettings.ActivityTheme" parent="WordPress">
         <item name="android:windowTranslucentStatus">true</item>
         <item name="android:homeAsUpIndicator">@drawable/ic_close_white_24dp</item>
     </style>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -242,8 +242,6 @@
     </style>
 
     <style name="MediaSettingsTheme" parent="WordPress">
-        <item name="android:windowTranslucentStatus">true</item>
-        <item name="android:windowTranslucentNavigation">true</item>
         <item name="android:homeAsUpIndicator">@drawable/ic_close_white_24dp</item>
     </style>
 

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -255,6 +255,11 @@
         <item name="colorControlNormal">@color/grey_500</item>
         <item name="colorControlActivated">@color/blue_wordpress</item>
     </style>
+    <style name="MediaSettings.Divider">
+        <item name="android:background">@color/divider_grey</item>
+        <item name="android:layout_marginTop">@dimen/margin_medium</item>
+        <item name="android:layout_marginBottom">@dimen/margin_medium</item>
+    </style>
 
     <style name="EmptyListText">
         <item name="android:layout_width">fill_parent</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -241,6 +241,12 @@
         <item name="android:gravity">center</item>
     </style>
 
+    <style name="MediaSettingsTheme" parent="Theme.AppCompat.Light">
+        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowTranslucentNavigation">true</item>
+        <item name="android:homeAsUpIndicator">@drawable/ic_close_white_24dp</item>
+    </style>
+
     <style name="EmptyListText">
         <item name="android:layout_width">fill_parent</item>
         <item name="android:layout_height">fill_parent</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -241,9 +241,20 @@
         <item name="android:gravity">center</item>
     </style>
 
-    <style name="MediaSettingsTheme" parent="WordPress">
+    <style name="MediaSettings" />
+    <style name="MediaSettings.Theme" parent="WordPress">
         <item name="android:windowTranslucentStatus">true</item>
         <item name="android:homeAsUpIndicator">@drawable/ic_close_white_24dp</item>
+    </style>
+    <style name="MediaSettings.TextInputStyle">
+        <item name="android:layout_marginTop">@dimen/margin_medium</item>
+    </style>
+    <style name="MediaSettings.TextInputTheme" parent="TextAppearance.AppCompat">
+        <!-- Hint color and label color in FALSE state -->
+        <item name="android:textColorHint">@color/grey_500</item>
+        <!-- Label color in TRUE state and bar color FALSE and TRUE State -->
+        <item name="colorControlNormal">@color/grey_500</item>
+        <item name="colorControlActivated">@color/blue_wordpress</item>
     </style>
 
     <style name="EmptyListText">

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -261,14 +261,14 @@
         <item name="android:layout_marginBottom">@dimen/margin_extra_large</item>
     </style>
     <style name="MediaSettings.Label">
-        <item name="android:layout_marginLeft">@dimen/margin_extra_large</item>
-        <item name="android:layout_marginRight">@dimen/margin_extra_large</item>
+        <item name="android:layout_marginLeft">@dimen/media_settings_margin</item>
+        <item name="android:layout_marginRight">@dimen/media_settings_margin</item>
         <item name="android:textColor">@color/grey_dark</item>
         <item name="android:textSize">@dimen/text_sz_large</item>
     </style>
     <style name="MediaSettings.Value">
-        <item name="android:layout_marginLeft">@dimen/margin_extra_large</item>
-        <item name="android:layout_marginRight">@dimen/margin_extra_large</item>
+        <item name="android:layout_marginLeft">@dimen/media_settings_margin</item>
+        <item name="android:layout_marginRight">@dimen/media_settings_margin</item>
         <item name="android:textColor">@color/grey</item>
         <item name="android:textSize">@dimen/text_sz_medium</item>
     </style>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -257,8 +257,20 @@
     </style>
     <style name="MediaSettings.Divider">
         <item name="android:background">@color/divider_grey</item>
-        <item name="android:layout_marginTop">@dimen/margin_medium</item>
-        <item name="android:layout_marginBottom">@dimen/margin_medium</item>
+        <item name="android:layout_marginTop">@dimen/margin_extra_large</item>
+        <item name="android:layout_marginBottom">@dimen/margin_extra_large</item>
+    </style>
+    <style name="MediaSettings.Label">
+        <item name="android:layout_marginLeft">@dimen/margin_extra_large</item>
+        <item name="android:layout_marginRight">@dimen/margin_extra_large</item>
+        <item name="android:textColor">@color/grey_dark</item>
+        <item name="android:textSize">@dimen/text_sz_large</item>
+    </style>
+    <style name="MediaSettings.Value">
+        <item name="android:layout_marginLeft">@dimen/margin_extra_large</item>
+        <item name="android:layout_marginRight">@dimen/margin_extra_large</item>
+        <item name="android:textColor">@color/grey</item>
+        <item name="android:textSize">@dimen/text_sz_medium</item>
     </style>
 
     <style name="EmptyListText">

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -242,10 +242,6 @@
     </style>
 
     <style name="MediaSettings" />
-    <style name="MediaSettings.ActivityTheme" parent="WordPress">
-        <item name="android:windowTranslucentStatus">true</item>
-        <item name="android:homeAsUpIndicator">@drawable/ic_close_white_24dp</item>
-    </style>
     <style name="MediaSettings.TextInputStyle">
         <item name="android:layout_marginTop">@dimen/margin_medium</item>
     </style>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -242,6 +242,9 @@
     </style>
 
     <style name="MediaSettings" />
+    <style name="MediaSettings.Theme" parent="WordPress">
+        <item name="colorAccent">@color/blue_wordpress</item>
+    </style>
     <style name="MediaSettings.TextInputStyle">
         <item name="android:layout_marginTop">@dimen/margin_medium</item>
     </style>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -241,7 +241,7 @@
         <item name="android:gravity">center</item>
     </style>
 
-    <style name="MediaSettingsTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="MediaSettingsTheme" parent="WordPress">
         <item name="android:windowTranslucentStatus">true</item>
         <item name="android:windowTranslucentNavigation">true</item>
         <item name="android:homeAsUpIndicator">@drawable/ic_close_white_24dp</item>


### PR DESCRIPTION
This is the first of several PRs which will implement the media settings redesign. In this PR, the new settings screen has been implemented for images and videos. Full-screen preview and settings for audio & documents will be implemented in subsequent PRs (as per #6606).

Note that a design review will come after all the PRs have been merged into the feature branch. That said, feel free to comment on any obvious design issues.

To test
* Open the site media browser
* Tap an image
* Notice the snazzy new screen :)

![screenshot_1505326975](https://user-images.githubusercontent.com/3903757/30393896-7d762b66-988f-11e7-813e-c1745fd7a4ba.png)

