### PR TITLE
Feature/update refresh helper

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -31,6 +31,8 @@ import org.wordpress.android.widgets.RecyclerItemDecoration;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
+
 
 public class FilteredRecyclerView extends RelativeLayout {
 
@@ -133,7 +135,7 @@ public class FilteredRecyclerView extends RelativeLayout {
         mProgressLoadMore = (ProgressBar) findViewById(R.id.progress_loading);
         mProgressLoadMore.setVisibility(View.GONE);
 
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+        mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
             (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
             new SwipeToRefreshHelper.RefreshListener() {
                 @Override
@@ -152,8 +154,7 @@ public class FilteredRecyclerView extends RelativeLayout {
                         }
                     });
                 }
-            },
-            R.color.color_primary, R.color.color_accent
+            }
         );
 
         if (mSpinner == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -133,27 +133,28 @@ public class FilteredRecyclerView extends RelativeLayout {
         mProgressLoadMore = (ProgressBar) findViewById(R.id.progress_loading);
         mProgressLoadMore.setVisibility(View.GONE);
 
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(getContext(),
-                (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
-                new SwipeToRefreshHelper.RefreshListener() {
-                    @Override
-                    public void onRefreshStarted() {
-                        post(new Runnable() {
-                            @Override
-                            public void run() {
-                                if (!NetworkUtils.checkConnection(getContext())) {
-                                    mSwipeToRefreshHelper.setRefreshing(false);
-                                    updateEmptyView(EmptyViewMessageType.NETWORK_ERROR);
-                                    return;
-                                }
-                                if (mFilterListener != null){
-                                    mFilterListener.onLoadData();
-                                }
+        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+            (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
+            new SwipeToRefreshHelper.RefreshListener() {
+                @Override
+                public void onRefreshStarted() {
+                    post(new Runnable() {
+                        @Override
+                        public void run() {
+                            if (!NetworkUtils.checkConnection(getContext())) {
+                                mSwipeToRefreshHelper.setRefreshing(false);
+                                updateEmptyView(EmptyViewMessageType.NETWORK_ERROR);
+                                return;
                             }
-                        });
-                    }
-                });
-
+                            if (mFilterListener != null){
+                                mFilterListener.onLoadData();
+                            }
+                        }
+                    });
+                }
+            },
+            R.color.color_primary, R.color.color_accent
+        );
 
         if (mSpinner == null) {
             mSpinner = (Spinner) findViewById(R.id.filter_spinner);

--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -136,25 +136,25 @@ public class FilteredRecyclerView extends RelativeLayout {
         mProgressLoadMore.setVisibility(View.GONE);
 
         mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
-            (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
-            new SwipeToRefreshHelper.RefreshListener() {
-                @Override
-                public void onRefreshStarted() {
-                    post(new Runnable() {
-                        @Override
-                        public void run() {
-                            if (!NetworkUtils.checkConnection(getContext())) {
-                                mSwipeToRefreshHelper.setRefreshing(false);
-                                updateEmptyView(EmptyViewMessageType.NETWORK_ERROR);
-                                return;
+                (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
+                new SwipeToRefreshHelper.RefreshListener() {
+                    @Override
+                    public void onRefreshStarted() {
+                        post(new Runnable() {
+                            @Override
+                            public void run() {
+                                if (!NetworkUtils.checkConnection(getContext())) {
+                                    mSwipeToRefreshHelper.setRefreshing(false);
+                                    updateEmptyView(EmptyViewMessageType.NETWORK_ERROR);
+                                    return;
+                                }
+                                if (mFilterListener != null){
+                                    mFilterListener.onLoadData();
+                                }
                             }
-                            if (mFilterListener != null){
-                                mFilterListener.onLoadData();
-                            }
-                        }
-                    });
+                        });
+                    }
                 }
-            }
         );
 
         if (mSpinner == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -252,20 +252,20 @@ public class SitePickerActivity extends AppCompatActivity
             return;
         }
         mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
-            (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
-            new SwipeToRefreshHelper.RefreshListener() {
-                @Override
-                public void onRefreshStarted() {
-                    if (isFinishing()) {
-                        return;
+                (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
+                new SwipeToRefreshHelper.RefreshListener() {
+                    @Override
+                    public void onRefreshStarted() {
+                        if (isFinishing()) {
+                            return;
+                        }
+                        if (!NetworkUtils.checkConnection(SitePickerActivity.this)) {
+                            mSwipeToRefreshHelper.setRefreshing(false);
+                            return;
+                        }
+                        mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
                     }
-                    if (!NetworkUtils.checkConnection(SitePickerActivity.this)) {
-                        mSwipeToRefreshHelper.setRefreshing(false);
-                        return;
-                    }
-                    mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
                 }
-            }
         );
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -250,21 +250,22 @@ public class SitePickerActivity extends AppCompatActivity
             return;
         }
         mSwipeToRefreshHelper = new SwipeToRefreshHelper(
-                this,
-                (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
-                new SwipeToRefreshHelper.RefreshListener() {
-                    @Override
-                    public void onRefreshStarted() {
-                        if (isFinishing()) {
-                            return;
-                        }
-                        if (!NetworkUtils.checkConnection(SitePickerActivity.this)) {
-                            mSwipeToRefreshHelper.setRefreshing(false);
-                            return;
-                        }
-                        mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
+            (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
+            new SwipeToRefreshHelper.RefreshListener() {
+                @Override
+                public void onRefreshStarted() {
+                    if (isFinishing()) {
+                        return;
                     }
-                });
+                    if (!NetworkUtils.checkConnection(SitePickerActivity.this)) {
+                        mSwipeToRefreshHelper.setRefreshing(false);
+                        return;
+                    }
+                    mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
+                }
+            },
+            R.color.color_primary, R.color.color_accent
+        );
     }
 
     private void setupRecycleView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -62,6 +62,8 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
+
 public class SitePickerActivity extends AppCompatActivity
         implements SitePickerAdapter.OnSiteClickListener,
         SitePickerAdapter.OnSelectedCountChangedListener,
@@ -249,7 +251,7 @@ public class SitePickerActivity extends AppCompatActivity
         if (view == null) {
             return;
         }
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+        mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
             (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
             new SwipeToRefreshHelper.RefreshListener() {
                 @Override
@@ -263,8 +265,7 @@ public class SitePickerActivity extends AppCompatActivity
                     }
                     mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
                 }
-            },
-            R.color.color_primary, R.color.color_accent
+            }
         );
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -244,20 +244,20 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
 
         // swipe to refresh setup
         mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
-            (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout), new RefreshListener() {
-                @Override
-                public void onRefreshStarted() {
-                    if (!isAdded()) {
-                        return;
+                (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout), new RefreshListener() {
+                    @Override
+                    public void onRefreshStarted() {
+                        if (!isAdded()) {
+                            return;
+                        }
+                        if (!NetworkUtils.checkConnection(getActivity())) {
+                            updateEmptyView(EmptyViewMessageType.NETWORK_ERROR);
+                            setRefreshing(false);
+                            return;
+                        }
+                        fetchMediaList(false);
                     }
-                    if (!NetworkUtils.checkConnection(getActivity())) {
-                        updateEmptyView(EmptyViewMessageType.NETWORK_ERROR);
-                        setRefreshing(false);
-                        return;
-                    }
-                    fetchMediaList(false);
                 }
-            }
         );
 
         if (savedInstanceState != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -242,21 +242,23 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         mEmptyView = (TextView) view.findViewById(R.id.empty_view);
 
         // swipe to refresh setup
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(getActivity(),
-                (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout), new RefreshListener() {
-                    @Override
-                    public void onRefreshStarted() {
-                        if (!isAdded()) {
-                            return;
-                        }
-                        if (!NetworkUtils.checkConnection(getActivity())) {
-                            updateEmptyView(EmptyViewMessageType.NETWORK_ERROR);
-                            setRefreshing(false);
-                            return;
-                        }
-                        fetchMediaList(false);
+        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+            (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout), new RefreshListener() {
+                @Override
+                public void onRefreshStarted() {
+                    if (!isAdded()) {
+                        return;
                     }
-                });
+                    if (!NetworkUtils.checkConnection(getActivity())) {
+                        updateEmptyView(EmptyViewMessageType.NETWORK_ERROR);
+                        setRefreshing(false);
+                        return;
+                    }
+                    fetchMediaList(false);
+                }
+            },
+            R.color.color_primary, R.color.color_accent
+        );
 
         if (savedInstanceState != null) {
             restoreState(savedInstanceState);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -57,6 +57,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 import static android.app.Activity.RESULT_OK;
+import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
 
 /**
  * The grid displaying the media items.
@@ -242,7 +243,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         mEmptyView = (TextView) view.findViewById(R.id.empty_view);
 
         // swipe to refresh setup
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+        mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
             (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout), new RefreshListener() {
                 @Override
                 public void onRefreshStarted() {
@@ -256,8 +257,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
                     }
                     fetchMediaList(false);
                 }
-            },
-            R.color.color_primary, R.color.color_accent
+            }
         );
 
         if (savedInstanceState != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -108,16 +108,15 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
         mRecyclerView.setLayoutManager(mLinearLayoutManager);
 
         mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
-            (CustomSwipeRefreshLayout) view.findViewById(R.id.swipe_refresh_notifications),
-            new SwipeToRefreshHelper.RefreshListener() {
-                @Override
-                public void onRefreshStarted() {
-                    hideNewNotificationsBar();
-                    fetchNotesFromRemote();
+                (CustomSwipeRefreshLayout) view.findViewById(R.id.swipe_refresh_notifications),
+                new SwipeToRefreshHelper.RefreshListener() {
+                    @Override
+                    public void onRefreshStarted() {
+                        hideNewNotificationsBar();
+                        fetchNotesFromRemote();
+                    }
                 }
-            }
         );
-
 
         // bar that appears at bottom after new notes are received and the user is on this screen
         mNewNotificationsBar = view.findViewById(R.id.layout_new_notificatons);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -47,6 +47,7 @@ import javax.inject.Inject;
 import de.greenrobot.event.EventBus;
 
 import static android.app.Activity.RESULT_OK;
+import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
 
 public class NotificationsListFragment extends Fragment implements WPMainActivity.OnScrollToTopListener,
         RadioGroup.OnCheckedChangeListener, NotesAdapter.DataLoadedListener {
@@ -106,7 +107,7 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
         mLinearLayoutManager = new LinearLayoutManager(getActivity());
         mRecyclerView.setLayoutManager(mLinearLayoutManager);
 
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+        mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
             (CustomSwipeRefreshLayout) view.findViewById(R.id.swipe_refresh_notifications),
             new SwipeToRefreshHelper.RefreshListener() {
                 @Override
@@ -114,8 +115,7 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
                     hideNewNotificationsBar();
                     fetchNotesFromRemote();
                 }
-            },
-            R.color.color_primary, R.color.color_accent
+            }
         );
 
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -68,6 +68,8 @@ import javax.inject.Inject;
 
 import de.greenrobot.event.EventBus;
 
+import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
+
 public class PostsListFragment extends Fragment
         implements PostsListAdapter.OnPostsLoadedListener,
         PostsListAdapter.OnLoadMoreListener,
@@ -231,7 +233,7 @@ public class PostsListFragment extends Fragment
     }
 
     private void initSwipeToRefreshHelper(View view) {
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+        mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
             (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
             new RefreshListener() {
                 @Override
@@ -246,8 +248,7 @@ public class PostsListFragment extends Fragment
                     }
                     requestPosts(false);
                 }
-            },
-            R.color.color_primary, R.color.color_accent
+            }
         );
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -232,22 +232,23 @@ public class PostsListFragment extends Fragment
 
     private void initSwipeToRefreshHelper(View view) {
         mSwipeToRefreshHelper = new SwipeToRefreshHelper(
-                getActivity(),
-                (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
-                new RefreshListener() {
-                    @Override
-                    public void onRefreshStarted() {
-                        if (!isAdded()) {
-                            return;
-                        }
-                        if (!NetworkUtils.checkConnection(getActivity())) {
-                            setRefreshing(false);
-                            updateEmptyView(EmptyViewMessageType.NETWORK_ERROR);
-                            return;
-                        }
-                        requestPosts(false);
+            (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
+            new RefreshListener() {
+                @Override
+                public void onRefreshStarted() {
+                    if (!isAdded()) {
+                        return;
                     }
-                });
+                    if (!NetworkUtils.checkConnection(getActivity())) {
+                        setRefreshing(false);
+                        updateEmptyView(EmptyViewMessageType.NETWORK_ERROR);
+                        return;
+                    }
+                    requestPosts(false);
+                }
+            },
+            R.color.color_primary, R.color.color_accent
+        );
     }
 
     private @Nullable PostsListAdapter getPostListAdapter() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -234,21 +234,21 @@ public class PostsListFragment extends Fragment
 
     private void initSwipeToRefreshHelper(View view) {
         mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
-            (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
-            new RefreshListener() {
-                @Override
-                public void onRefreshStarted() {
-                    if (!isAdded()) {
-                        return;
+                (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
+                new RefreshListener() {
+                    @Override
+                    public void onRefreshStarted() {
+                        if (!isAdded()) {
+                            return;
+                        }
+                        if (!NetworkUtils.checkConnection(getActivity())) {
+                            setRefreshing(false);
+                            updateEmptyView(EmptyViewMessageType.NETWORK_ERROR);
+                            return;
+                        }
+                        requestPosts(false);
                     }
-                    if (!NetworkUtils.checkConnection(getActivity())) {
-                        setRefreshing(false);
-                        updateEmptyView(EmptyViewMessageType.NETWORK_ERROR);
-                        return;
-                    }
-                    requestPosts(false);
                 }
-            }
         );
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
@@ -112,17 +112,20 @@ public class SelectCategoriesActivity extends AppCompatActivity {
         }
 
         // swipe to refresh setup
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(this, (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
-                new RefreshListener() {
-                    @Override
-                    public void onRefreshStarted() {
-                        if (!NetworkUtils.checkConnection(getBaseContext())) {
-                            mSwipeToRefreshHelper.setRefreshing(false);
-                            return;
-                        }
-                        refreshCategories();
+        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+            (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
+            new RefreshListener() {
+                @Override
+                public void onRefreshStarted() {
+                    if (!NetworkUtils.checkConnection(getBaseContext())) {
+                        mSwipeToRefreshHelper.setRefreshing(false);
+                        return;
                     }
-                });
+                    refreshCategories();
+                }
+            },
+            R.color.color_primary, R.color.color_accent
+        );
 
         populateCategoryList();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
@@ -44,6 +44,7 @@ import java.util.HashSet;
 import javax.inject.Inject;
 
 import static org.wordpress.android.ui.posts.EditPostActivity.EXTRA_POST_LOCAL_ID;
+import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
 
 public class SelectCategoriesActivity extends AppCompatActivity {
     public static final String KEY_SELECTED_CATEGORY_IDS = "KEY_SELECTED_CATEGORY_IDS";
@@ -112,7 +113,7 @@ public class SelectCategoriesActivity extends AppCompatActivity {
         }
 
         // swipe to refresh setup
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+        mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
             (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
             new RefreshListener() {
                 @Override
@@ -123,8 +124,7 @@ public class SelectCategoriesActivity extends AppCompatActivity {
                     }
                     refreshCategories();
                 }
-            },
-            R.color.color_primary, R.color.color_accent
+            }
         );
 
         populateCategoryList();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/SelectCategoriesActivity.java
@@ -114,17 +114,17 @@ public class SelectCategoriesActivity extends AppCompatActivity {
 
         // swipe to refresh setup
         mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
-            (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
-            new RefreshListener() {
-                @Override
-                public void onRefreshStarted() {
-                    if (!NetworkUtils.checkConnection(getBaseContext())) {
-                        mSwipeToRefreshHelper.setRefreshing(false);
-                        return;
+                (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
+                new RefreshListener() {
+                    @Override
+                    public void onRefreshStarted() {
+                        if (!NetworkUtils.checkConnection(getBaseContext())) {
+                            mSwipeToRefreshHelper.setRefreshing(false);
+                            return;
+                        }
+                        refreshCategories();
                     }
-                    refreshCategories();
                 }
-            }
         );
 
         populateCategoryList();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -129,14 +129,16 @@ public class ReaderCommentListActivity extends AppCompatActivity {
             mInterceptedUri = getIntent().getStringExtra(ReaderConstants.ARG_INTERCEPTED_URI);
         }
 
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(this,
-                (CustomSwipeRefreshLayout) findViewById(R.id.swipe_to_refresh),
-                new SwipeToRefreshHelper.RefreshListener() {
-                    @Override
-                    public void onRefreshStarted() {
-                        updatePostAndComments();
-                    }
-                });
+        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+            (CustomSwipeRefreshLayout) findViewById(R.id.swipe_to_refresh),
+            new SwipeToRefreshHelper.RefreshListener() {
+                @Override
+                public void onRefreshStarted() {
+                    updatePostAndComments();
+                }
+            },
+            R.color.color_primary, R.color.color_accent
+        );
 
         mRecyclerView = (ReaderRecyclerView) findViewById(R.id.recycler_view);
         int spacingHorizontal = 0;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -132,13 +132,13 @@ public class ReaderCommentListActivity extends AppCompatActivity {
         }
 
         mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
-            (CustomSwipeRefreshLayout) findViewById(R.id.swipe_to_refresh),
-            new SwipeToRefreshHelper.RefreshListener() {
-                @Override
-                public void onRefreshStarted() {
-                    updatePostAndComments();
+                (CustomSwipeRefreshLayout) findViewById(R.id.swipe_to_refresh),
+                new SwipeToRefreshHelper.RefreshListener() {
+                    @Override
+                    public void onRefreshStarted() {
+                        updatePostAndComments();
+                    }
                 }
-            }
         );
 
         mRecyclerView = (ReaderRecyclerView) findViewById(R.id.recycler_view);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderCommentListActivity.java
@@ -60,6 +60,8 @@ import javax.inject.Inject;
 
 import de.greenrobot.event.EventBus;
 
+import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
+
 public class ReaderCommentListActivity extends AppCompatActivity {
 
     private static final String KEY_REPLY_TO_COMMENT_ID = "reply_to_comment_id";
@@ -129,15 +131,14 @@ public class ReaderCommentListActivity extends AppCompatActivity {
             mInterceptedUri = getIntent().getStringExtra(ReaderConstants.ARG_INTERCEPTED_URI);
         }
 
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+        mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
             (CustomSwipeRefreshLayout) findViewById(R.id.swipe_to_refresh),
             new SwipeToRefreshHelper.RefreshListener() {
                 @Override
                 public void onRefreshStarted() {
                     updatePostAndComments();
                 }
-            },
-            R.color.color_primary, R.color.color_accent
+            }
         );
 
         mRecyclerView = (ReaderRecyclerView) findViewById(R.id.recycler_view);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -78,6 +78,8 @@ import javax.inject.Inject;
 
 import de.greenrobot.event.EventBus;
 
+import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
+
 public class ReaderPostDetailFragment extends Fragment
         implements WPMainActivity.OnActivityBackPressedListener,
                    ScrollDirectionListener,
@@ -211,7 +213,7 @@ public class ReaderPostDetailFragment extends Fragment
         int swipeToRefreshOffset = getResources().getDimensionPixelSize(R.dimen.toolbar_content_offset);
         swipeRefreshLayout.setProgressViewOffset(false, 0, swipeToRefreshOffset);
 
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+        mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
             swipeRefreshLayout,
             new SwipeToRefreshHelper.RefreshListener() {
                 @Override
@@ -222,8 +224,7 @@ public class ReaderPostDetailFragment extends Fragment
 
                     updatePost();
                 }
-            },
-            R.color.color_primary, R.color.color_accent
+            }
         );
 
         mScrollView = (WPScrollView) view.findViewById(R.id.scroll_view_reader);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -211,16 +211,20 @@ public class ReaderPostDetailFragment extends Fragment
         int swipeToRefreshOffset = getResources().getDimensionPixelSize(R.dimen.toolbar_content_offset);
         swipeRefreshLayout.setProgressViewOffset(false, 0, swipeToRefreshOffset);
 
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(getActivity(), swipeRefreshLayout, new SwipeToRefreshHelper.RefreshListener() {
-            @Override
-            public void onRefreshStarted() {
-                if (!isAdded()) {
-                    return;
-                }
+        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+            swipeRefreshLayout,
+            new SwipeToRefreshHelper.RefreshListener() {
+                @Override
+                public void onRefreshStarted() {
+                    if (!isAdded()) {
+                        return;
+                    }
 
-                updatePost();
-            }
-        });
+                    updatePost();
+                }
+            },
+            R.color.color_primary, R.color.color_accent
+        );
 
         mScrollView = (WPScrollView) view.findViewById(R.id.scroll_view_reader);
         mScrollView.setScrollDirectionListener(this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -214,17 +214,17 @@ public class ReaderPostDetailFragment extends Fragment
         swipeRefreshLayout.setProgressViewOffset(false, 0, swipeToRefreshOffset);
 
         mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
-            swipeRefreshLayout,
-            new SwipeToRefreshHelper.RefreshListener() {
-                @Override
-                public void onRefreshStarted() {
-                    if (!isAdded()) {
-                        return;
-                    }
+                swipeRefreshLayout,
+                new SwipeToRefreshHelper.RefreshListener() {
+                    @Override
+                    public void onRefreshStarted() {
+                        if (!isAdded()) {
+                            return;
+                        }
 
-                    updatePost();
+                        updatePost();
+                    }
                 }
-            }
         );
 
         mScrollView = (WPScrollView) view.findViewById(R.id.scroll_view_reader);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -51,6 +51,8 @@ import javax.inject.Inject;
 
 import de.greenrobot.event.EventBus;
 
+import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
+
 /**
  * The native stats activity
  * <p>
@@ -135,7 +137,7 @@ public class StatsActivity extends AppCompatActivity
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
 
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+        mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
                 (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
                 new RefreshListener() {
                     @Override
@@ -147,8 +149,7 @@ public class StatsActivity extends AppCompatActivity
 
                         refreshStatsFromCurrentDate();
                     }
-                },
-                R.color.color_primary, R.color.color_accent
+                }
         );
 
         setTitle(R.string.stats);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsActivity.java
@@ -135,7 +135,8 @@ public class StatsActivity extends AppCompatActivity
             actionBar.setDisplayHomeAsUpEnabled(true);
         }
 
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(this, (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
+        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+                (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
                 new RefreshListener() {
                     @Override
                     public void onRefreshStarted() {
@@ -146,7 +147,9 @@ public class StatsActivity extends AppCompatActivity
 
                         refreshStatsFromCurrentDate();
                     }
-                });
+                },
+                R.color.color_primary, R.color.color_accent
+        );
 
         setTitle(R.string.stats);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -46,6 +46,8 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 
+import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
+
 
 /**
  *  Single item details activity.
@@ -114,7 +116,7 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
         }
 
         // pull to refresh setup
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+        mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
             (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
             new SwipeToRefreshHelper.RefreshListener() {
                 @Override
@@ -125,8 +127,7 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
                     }
                     refreshStats();
                 }
-            },
-            R.color.color_primary, R.color.color_accent
+            }
         );
 
         TextView mStatsForLabel = (TextView) findViewById(R.id.stats_summary_title);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -117,17 +117,17 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
 
         // pull to refresh setup
         mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
-            (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
-            new SwipeToRefreshHelper.RefreshListener() {
-                @Override
-                public void onRefreshStarted() {
-                    if (!NetworkUtils.checkConnection(getBaseContext())) {
-                        mSwipeToRefreshHelper.setRefreshing(false);
-                        return;
+                (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
+                new SwipeToRefreshHelper.RefreshListener() {
+                    @Override
+                    public void onRefreshStarted() {
+                        if (!NetworkUtils.checkConnection(getBaseContext())) {
+                            mSwipeToRefreshHelper.setRefreshing(false);
+                            return;
+                        }
+                        refreshStats();
                     }
-                    refreshStats();
                 }
-            }
         );
 
         TextView mStatsForLabel = (TextView) findViewById(R.id.stats_summary_title);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -114,17 +114,19 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
         }
 
         // pull to refresh setup
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(this, (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
-                new SwipeToRefreshHelper.RefreshListener() {
-                    @Override
-                    public void onRefreshStarted() {
-                        if (!NetworkUtils.checkConnection(getBaseContext())) {
-                            mSwipeToRefreshHelper.setRefreshing(false);
-                            return;
-                        }
-                        refreshStats();
+        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+            (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
+            new SwipeToRefreshHelper.RefreshListener() {
+                @Override
+                public void onRefreshStarted() {
+                    if (!NetworkUtils.checkConnection(getBaseContext())) {
+                        mSwipeToRefreshHelper.setRefreshing(false);
+                        return;
                     }
+                    refreshStats();
                 }
+            },
+            R.color.color_primary, R.color.color_accent
         );
 
         TextView mStatsForLabel = (TextView) findViewById(R.id.stats_summary_title);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
@@ -69,24 +69,24 @@ public class StatsViewAllActivity extends AppCompatActivity {
 
         // pull to refresh setup
         mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
-            (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
-            new SwipeToRefreshHelper.RefreshListener() {
-                @Override
-                public void onRefreshStarted() {
-                    if (!NetworkUtils.checkConnection(getBaseContext())) {
-                        mSwipeToRefreshHelper.setRefreshing(false);
-                        mIsUpdatingStats = false;
-                        return;
-                    }
+                (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
+                new SwipeToRefreshHelper.RefreshListener() {
+                    @Override
+                    public void onRefreshStarted() {
+                        if (!NetworkUtils.checkConnection(getBaseContext())) {
+                            mSwipeToRefreshHelper.setRefreshing(false);
+                            mIsUpdatingStats = false;
+                            return;
+                        }
 
-                    if (mIsUpdatingStats) {
-                        AppLog.w(AppLog.T.STATS, "stats are already updating, refresh cancelled");
-                        return;
-                    }
+                        if (mIsUpdatingStats) {
+                            AppLog.w(AppLog.T.STATS, "stats are already updating, refresh cancelled");
+                            return;
+                        }
 
-                    refreshStats();
+                        refreshStats();
+                    }
                 }
-            }
         );
 
         if (savedInstanceState != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
@@ -66,24 +66,26 @@ public class StatsViewAllActivity extends AppCompatActivity {
         mOuterScrollView = (ScrollViewExt) findViewById(R.id.scroll_view_stats);
 
         // pull to refresh setup
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(this, (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
-                new SwipeToRefreshHelper.RefreshListener() {
-                    @Override
-                    public void onRefreshStarted() {
-                        if (!NetworkUtils.checkConnection(getBaseContext())) {
-                            mSwipeToRefreshHelper.setRefreshing(false);
-                            mIsUpdatingStats = false;
-                            return;
-                        }
-
-                        if (mIsUpdatingStats) {
-                            AppLog.w(AppLog.T.STATS, "stats are already updating, refresh cancelled");
-                            return;
-                        }
-
-                        refreshStats();
+        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+            (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
+            new SwipeToRefreshHelper.RefreshListener() {
+                @Override
+                public void onRefreshStarted() {
+                    if (!NetworkUtils.checkConnection(getBaseContext())) {
+                        mSwipeToRefreshHelper.setRefreshing(false);
+                        mIsUpdatingStats = false;
+                        return;
                     }
+
+                    if (mIsUpdatingStats) {
+                        AppLog.w(AppLog.T.STATS, "stats are already updating, refresh cancelled");
+                        return;
+                    }
+
+                    refreshStats();
                 }
+            },
+            R.color.color_primary, R.color.color_accent
         );
 
         if (savedInstanceState != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsViewAllActivity.java
@@ -28,6 +28,8 @@ import java.util.Date;
 
 import de.greenrobot.event.EventBus;
 
+import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
+
 /**
  *  Single item details activity.
  */
@@ -66,7 +68,7 @@ public class StatsViewAllActivity extends AppCompatActivity {
         mOuterScrollView = (ScrollViewExt) findViewById(R.id.scroll_view_stats);
 
         // pull to refresh setup
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+        mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
             (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),
             new SwipeToRefreshHelper.RefreshListener() {
                 @Override
@@ -84,8 +86,7 @@ public class StatsViewAllActivity extends AppCompatActivity {
 
                     refreshStats();
                 }
-            },
-            R.color.color_primary, R.color.color_accent
+            }
         );
 
         if (savedInstanceState != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -35,6 +35,8 @@ import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 import org.wordpress.android.widgets.HeaderGridView;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
+import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
+
 /**
  * A fragment display the themes on a grid view.
  */
@@ -187,7 +189,7 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener, 
     }
 
     protected void configureSwipeToRefresh(View view) {
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+        mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
             (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
             new RefreshListener() {
                 @Override
@@ -202,8 +204,7 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener, 
                     }
                     mThemeBrowserActivity.fetchThemes();
                 }
-            },
-            R.color.color_primary, R.color.color_accent
+            }
         );
         mSwipeToRefreshHelper.setRefreshing(mShouldRefreshOnStart);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -190,21 +190,21 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener, 
 
     protected void configureSwipeToRefresh(View view) {
         mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
-            (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
-            new RefreshListener() {
-                @Override
-                public void onRefreshStarted() {
-                    if (!isAdded()) {
-                        return;
+                (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
+                new RefreshListener() {
+                    @Override
+                    public void onRefreshStarted() {
+                        if (!isAdded()) {
+                            return;
+                        }
+                        if (!NetworkUtils.checkConnection(mThemeBrowserActivity)) {
+                            mSwipeToRefreshHelper.setRefreshing(false);
+                            mEmptyTextView.setText(R.string.no_network_title);
+                            return;
+                        }
+                        mThemeBrowserActivity.fetchThemes();
                     }
-                    if (!NetworkUtils.checkConnection(mThemeBrowserActivity)) {
-                        mSwipeToRefreshHelper.setRefreshing(false);
-                        mEmptyTextView.setText(R.string.no_network_title);
-                        return;
-                    }
-                    mThemeBrowserActivity.fetchThemes();
                 }
-            }
         );
         mSwipeToRefreshHelper.setRefreshing(mShouldRefreshOnStart);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -187,21 +187,24 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener, 
     }
 
     protected void configureSwipeToRefresh(View view) {
-        mSwipeToRefreshHelper = new SwipeToRefreshHelper(mThemeBrowserActivity, (CustomSwipeRefreshLayout) view.findViewById(
-                R.id.ptr_layout), new RefreshListener() {
-            @Override
-            public void onRefreshStarted() {
-                if (!isAdded()) {
-                    return;
+        mSwipeToRefreshHelper = new SwipeToRefreshHelper(
+            (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
+            new RefreshListener() {
+                @Override
+                public void onRefreshStarted() {
+                    if (!isAdded()) {
+                        return;
+                    }
+                    if (!NetworkUtils.checkConnection(mThemeBrowserActivity)) {
+                        mSwipeToRefreshHelper.setRefreshing(false);
+                        mEmptyTextView.setText(R.string.no_network_title);
+                        return;
+                    }
+                    mThemeBrowserActivity.fetchThemes();
                 }
-                if (!NetworkUtils.checkConnection(mThemeBrowserActivity)) {
-                    mSwipeToRefreshHelper.setRefreshing(false);
-                    mEmptyTextView.setText(R.string.no_network_title);
-                    return;
-                }
-                mThemeBrowserActivity.fetchThemes();
-            }
-        });
+            },
+            R.color.color_primary, R.color.color_accent
+        );
         mSwipeToRefreshHelper.setRefreshing(mShouldRefreshOnStart);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/util/WPSwipeToRefreshHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPSwipeToRefreshHelper.java
@@ -1,0 +1,21 @@
+package org.wordpress.android.util;
+
+import org.wordpress.android.R;
+import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
+import org.wordpress.android.util.helpers.SwipeToRefreshHelper.RefreshListener;
+import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
+
+public class WPSwipeToRefreshHelper {
+    /**
+     * Builds a {@link org.wordpress.android.util.helpers.SwipeToRefreshHelper} and returns a new
+     * instance with colors designated for the WordPress app.
+     *
+     * @param swipeRefreshLayout    {@link CustomSwipeRefreshLayout} for refreshing the contents
+     *                              of a view via a vertical swipe gesture.
+     * @param listener              {@link RefreshListener} notified when a refresh is triggered
+     *                              via the swipe gesture.
+     */
+    public static SwipeToRefreshHelper buildSwipeToRefreshHelper(CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener) {
+        return new SwipeToRefreshHelper(swipeRefreshLayout, listener, R.color.color_primary, R.color.color_accent);
+    }
+}

--- a/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
+++ b/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.v4.widget.SwipeRefreshLayout
+    <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
         android:id="@+id/swipe_refresh_notifications"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -22,7 +22,7 @@
             android:scrollbars="vertical"
             app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-    </android.support.v4.widget.SwipeRefreshLayout>
+    </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
     <LinearLayout
         android:id="@+id/layout_new_notificatons"

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -30,7 +30,6 @@
         <item name="android:actionBarWidgetTheme">@style/Theme.WordPress.Widget</item>
 
         <item name="windowActionModeOverlay">true</item>
-        <item name="swipeToRefreshStyle">@style/WordPress.SwipeToRefresh</item>
         <item name="searchViewStyle">@style/WordPress.SearchViewStyle</item>
     </style>
 
@@ -374,10 +373,6 @@
 
     <style name="WordPress.BorderedBackground">
         <item name="android:background">@color/white</item>
-    </style>
-
-    <style name="WordPress.SwipeToRefresh">
-        <item name="refreshIndicatorColor">@color/blue_medium</item>
     </style>
 
     <!--My Site Styles-->

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
@@ -17,15 +17,52 @@ public class SwipeToRefreshHelper implements OnRefreshListener {
         public void onRefreshStarted();
     }
 
+    /**
+     * Helps {@link org.wordpress.android.util.widgets.CustomSwipeRefreshLayout} by passing the
+     * {@link android.support.v4.widget.SwipeRefreshLayout}, {@link RefreshListener}, and color.
+     *
+     * @param context               {@link Context} in which this layout is used.
+     * @param swipeRefreshLayout    {@link CustomSwipeRefreshLayout} for refreshing the contents
+     *                              of a view via a vertical swipe gesture.
+     * @param listener              {@link RefreshListener} notified when a refresh is triggered
+     *                              via the swipe gesture.
+     *
+     * @deprecated Use {@link #SwipeToRefreshHelper(CustomSwipeRefreshLayout, RefreshListener, int...)} instead.
+     */
+    @Deprecated
     public SwipeToRefreshHelper(Context context, CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener) {
         init(swipeRefreshLayout, listener, android.R.color.holo_blue_dark);
     }
 
+    /**
+     * Helps {@link org.wordpress.android.util.widgets.CustomSwipeRefreshLayout} by passing the
+     * {@link android.support.v4.widget.SwipeRefreshLayout}, {@link RefreshListener}, and color(s).
+     *
+     * @param swipeRefreshLayout    {@link CustomSwipeRefreshLayout} for refreshing the contents
+     *                              of a view via a vertical swipe gesture.
+     * @param listener              {@link RefreshListener} notified when a refresh is triggered
+     *                              via the swipe gesture.
+     * @param colorResIds           Comma-separated color resource integers used in the progress
+     *                              animation. The first color will also be the color of the bar
+     *                              that grows in response to a user swipe gesture.
+     */
     public SwipeToRefreshHelper(CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener,
                                 @ColorRes int... colorResIds) {
         init(swipeRefreshLayout, listener, colorResIds);
     }
 
+    /**
+     * Initializes {@link org.wordpress.android.util.widgets.CustomSwipeRefreshLayout} by assigning
+     * {@link android.support.v4.widget.SwipeRefreshLayout}, {@link RefreshListener}, and color(s).
+     *
+     * @param swipeRefreshLayout    {@link CustomSwipeRefreshLayout} for refreshing the contents
+     *                              of a view via a vertical swipe gesture.
+     * @param listener              {@link RefreshListener} notified when a refresh is triggered
+     *                              via the swipe gesture.
+     * @param colorResIds           Comma-separated color resource integers used in the progress
+     *                              animation. The first color will also be the color of the bar
+     *                              that grows in response to a user swipe gesture.
+     */
     public void init(CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener,
                      @ColorRes int... colorResIds) {
         mRefreshListener = listener;

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
@@ -2,6 +2,7 @@ package org.wordpress.android.util.helpers;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.support.annotation.ColorRes;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.widget.SwipeRefreshLayout.OnRefreshListener;
 import android.util.TypedValue;
@@ -19,17 +20,18 @@ public class SwipeToRefreshHelper implements OnRefreshListener {
     }
 
     public SwipeToRefreshHelper(Context context, CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener) {
-        init(context, swipeRefreshLayout, listener);
+        init(context, swipeRefreshLayout, listener, android.R.color.holo_blue_dark);
     }
 
-    public void init(Context context, CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener) {
+    public void init(Context context, CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener,
+                     @ColorRes int colorResId) {
         mRefreshListener = listener;
         mSwipeRefreshLayout = swipeRefreshLayout;
         mSwipeRefreshLayout.setOnRefreshListener(this);
         final TypedArray styleAttrs = obtainStyledAttrsFromThemeAttr(context, R.attr.swipeToRefreshStyle,
                 R.styleable.RefreshIndicator);
         int color = styleAttrs.getColor(R.styleable.RefreshIndicator_refreshIndicatorColor, ContextCompat
-                .getColor(context, android.R.color.holo_blue_dark));
+                .getColor(context, colorResId));
         mSwipeRefreshLayout.setColorSchemeColors(color, color, color, color);
     }
 

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
@@ -3,11 +3,9 @@ package org.wordpress.android.util.helpers;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.support.annotation.ColorRes;
-import android.support.v4.content.ContextCompat;
 import android.support.v4.widget.SwipeRefreshLayout.OnRefreshListener;
 import android.util.TypedValue;
 
-import org.wordpress.android.util.R;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 
 public class SwipeToRefreshHelper implements OnRefreshListener {
@@ -20,24 +18,12 @@ public class SwipeToRefreshHelper implements OnRefreshListener {
     }
 
     public SwipeToRefreshHelper(Context context, CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener) {
-        init(context, swipeRefreshLayout, listener, android.R.color.holo_blue_dark);
+        init(swipeRefreshLayout, listener, android.R.color.holo_blue_dark);
     }
 
     public SwipeToRefreshHelper(CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener,
                                 @ColorRes int... colorResIds) {
         init(swipeRefreshLayout, listener, colorResIds);
-    }
-
-    public void init(Context context, CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener,
-                     @ColorRes int colorResId) {
-        mRefreshListener = listener;
-        mSwipeRefreshLayout = swipeRefreshLayout;
-        mSwipeRefreshLayout.setOnRefreshListener(this);
-        final TypedArray styleAttrs = obtainStyledAttrsFromThemeAttr(context, R.attr.swipeToRefreshStyle,
-                R.styleable.RefreshIndicator);
-        int color = styleAttrs.getColor(R.styleable.RefreshIndicator_refreshIndicatorColor, ContextCompat
-                .getColor(context, colorResId));
-        mSwipeRefreshLayout.setColorSchemeColors(color, color, color, color);
     }
 
     public void init(CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener,

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
@@ -23,6 +23,11 @@ public class SwipeToRefreshHelper implements OnRefreshListener {
         init(context, swipeRefreshLayout, listener, android.R.color.holo_blue_dark);
     }
 
+    public SwipeToRefreshHelper(CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener,
+                                @ColorRes int... colorResIds) {
+        init(swipeRefreshLayout, listener, colorResIds);
+    }
+
     public void init(Context context, CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener,
                      @ColorRes int colorResId) {
         mRefreshListener = listener;
@@ -33,6 +38,14 @@ public class SwipeToRefreshHelper implements OnRefreshListener {
         int color = styleAttrs.getColor(R.styleable.RefreshIndicator_refreshIndicatorColor, ContextCompat
                 .getColor(context, colorResId));
         mSwipeRefreshLayout.setColorSchemeColors(color, color, color, color);
+    }
+
+    public void init(CustomSwipeRefreshLayout swipeRefreshLayout, RefreshListener listener,
+                     @ColorRes int... colorResIds) {
+        mRefreshListener = listener;
+        mSwipeRefreshLayout = swipeRefreshLayout;
+        mSwipeRefreshLayout.setOnRefreshListener(this);
+        mSwipeRefreshLayout.setColorSchemeResources(colorResIds);
     }
 
     public void setRefreshing(boolean refreshing) {

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
@@ -1,8 +1,8 @@
 package org.wordpress.android.util.helpers;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.widget.SwipeRefreshLayout.OnRefreshListener;
 import android.util.TypedValue;
 
@@ -28,8 +28,8 @@ public class SwipeToRefreshHelper implements OnRefreshListener {
         mSwipeRefreshLayout.setOnRefreshListener(this);
         final TypedArray styleAttrs = obtainStyledAttrsFromThemeAttr(context, R.attr.swipeToRefreshStyle,
                 R.styleable.RefreshIndicator);
-        int color = styleAttrs.getColor(R.styleable.RefreshIndicator_refreshIndicatorColor, context.getResources()
-                .getColor(android.R.color.holo_blue_dark));
+        int color = styleAttrs.getColor(R.styleable.RefreshIndicator_refreshIndicatorColor, ContextCompat
+                .getColor(context, android.R.color.holo_blue_dark));
         mSwipeRefreshLayout.setColorSchemeColors(color, color, color, color);
     }
 

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java
@@ -1,10 +1,8 @@
 package org.wordpress.android.util.helpers;
 
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.support.annotation.ColorRes;
 import android.support.v4.widget.SwipeRefreshLayout.OnRefreshListener;
-import android.util.TypedValue;
 
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 
@@ -99,12 +97,5 @@ public class SwipeToRefreshHelper implements OnRefreshListener {
 
     public void setEnabled(boolean enabled) {
         mSwipeRefreshLayout.setEnabled(enabled);
-    }
-
-    public static TypedArray obtainStyledAttrsFromThemeAttr(Context context, int themeAttr, int[] styleAttrs) {
-        TypedValue outValue = new TypedValue();
-        context.getTheme().resolveAttribute(themeAttr, outValue, true);
-        int styleResId = outValue.resourceId;
-        return context.obtainStyledAttributes(styleResId, styleAttrs);
     }
 }

--- a/libs/utils/WordPressUtils/src/main/res/values/attrs.xml
+++ b/libs/utils/WordPressUtils/src/main/res/values/attrs.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <attr name="swipeToRefreshStyle" format="reference"/>
-    <declare-styleable name="RefreshIndicator">
-        <attr name="refreshIndicatorColor" format="reference|color"/>
-    </declare-styleable>
-</resources>


### PR DESCRIPTION
### Fix
Update the `SwipeToRefreshHelper` class including:
- Deprecate old [`SwipeToRefreshHelper` constructor and initialization methods](https://github.com/wordpress-mobile/WordPress-Utils-Android/blob/develop/WordPressUtils/src/main/java/org/wordpress/android/util/helpers/SwipeToRefreshHelper.java#L21-L34) 
- Add new [`SwipeToRefreshHelper` constructor and initialization methods](https://github.com/wordpress-mobile/WordPress-Android/commit/e56f1e25a6dee2fc75a341057154780659352d6c).
- Add ability to use custom refresh colors like [SwipeRefreshLayout.setColorSchemeResources](https://developer.android.com/reference/android/support/v4/widget/SwipeRefreshLayout.html#setColorSchemeResources(int...)) method.
- Add `blue_wordpress` (`#0087be`) and `orange_jazzy` (`#f0821e`) colors to `SwipeToRefreshHelper` usages.

### Test
1. Go to any screen with swipe-to-refresh layout (e.g. ***Stats***, ***Reader***, ***Notifications***).
2. Swipe down to refresh content.
3. Notice refresh colors are `blue_wordpress` (`#0087be`) and `orange_jazzy` (`#f0821e`).