### PR TITLE
Check for upload changes to determine need to update Post content

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1780,23 +1780,17 @@ public class EditPostActivity extends AppCompatActivity implements
         }
 
         boolean titleChanged = PostUtils.updatePostTitleIfDifferent(mPost, title);
-        boolean contentChanged = compareCurrentMediaMarkedUploadingToOriginal(content);
+        boolean contentChanged;
+        if (compareCurrentMediaMarkedUploadingToOriginal(content)) {
+            contentChanged = true;
+        } else if (mEditorFragment instanceof AztecEditorFragment
+                && ((AztecEditorFragment) mEditorFragment).isHistoryEnabled()) {
+            contentChanged = ((AztecEditorFragment) mEditorFragment).hasHistory();
+        } else {
+            contentChanged = mPost.getContent().compareTo(content) != 0;
+        }
         if (contentChanged) {
             mPost.setContent(content);
-        } else {
-            if (mEditorFragment instanceof AztecEditorFragment) {
-                contentChanged = ((AztecEditorFragment)mEditorFragment).hasHistory();
-                if (contentChanged) {
-                    mPost.setContent(content);
-                } else if (!((AztecEditorFragment)mEditorFragment).isHistoryEnabled()){
-                    // if history is not enabled, then we can only confirm whether there's been a content change
-                    // by comparing content
-                    contentChanged = PostUtils.updatePostContentIfDifferent(mPost, content);
-                }
-            } else {
-                // not Aztec, compare content to look for changes
-                contentChanged = PostUtils.updatePostContentIfDifferent(mPost, content);
-            }
         }
 
         if (!mPost.isLocalDraft() && (titleChanged || contentChanged)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1073,6 +1073,10 @@ public class EditPostActivity extends AppCompatActivity implements
 
         // update the original post object, so we'll know of new changes
         mOriginalPost = mPost.clone();
+
+        // update the list of uploading ids
+        mMediaMarkedUploadingOnStartIds =
+                AztecEditorFragment.getMediaMarkedUploadingInPostContent(this, mPost.getContent());
     }
 
     @Override


### PR DESCRIPTION
Fixes #6654 

The reason it was failing as described in #6654 is because we look for changes only by checking whether the Aztec editor has a Change History (change introduced in https://github.com/wordpress-mobile/WordPress-Android/pull/6610). Given the completed uploads actually do change the URL but they do so in the background, thus not affecting Aztec’s Change History, we think there’s nothing new and thus we don’t save the latest Post content (with the updated remote URLS for media that have been uploaded).

It is not trivial to understand which changes need to be saved, given a dumb string comparison can return different strings for semantically identical HTML content (for instance, the order in which a div class appears makes the string different but the HTML piece is no different from each other).

So, this PR tackles this by relying on what we _do_ know: when the Editor is opened, we know which media items in the Post content are marked as being uploaded. Same thing when the Editor is closed: when the user exits the editor, and we have any change in uploads for this Post (i.e. the existing uploads when we opened the Editor have now completed when we try to exit the Editor), then we need to save the Post content as a change in the media items URL has happened.


To test:

FOR IMAGES:
1. start a new draft
2. insert an image
3. while the image is uploading, exit the editor
4. enter the editor again
5. confirm the progress gets re-attached
6. wait until the image is finished uploading
7. tap on the image, confirm the image settings screen is displayed
8. exit the editor
9. enter the editor for that post again
10. tap on the image, observe the image settings screen is displayed

FOR VIDEOS:
1. start a new draft
2. insert a video
3. while the video is uploading, exit the editor
4. enter the editor again
5. confirm the progress gets re-attached
6. wait until the video is finished uploading
7. tap on the video, confirm the player is executed
8. exit the editor
9. enter the editor for that post again
10. observe it's there and can be played - also observe the URL to it is the remote one.

cc @nbradbury 

