### PR TITLE
Fixing state restoration of publicize button settings fragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
@@ -73,6 +73,8 @@ public class PublicizeButtonPrefsFragment extends Fragment implements
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
+        setRetainInstance(true);
+
         if (!NetworkUtils.checkConnection(getActivity())) {
             getActivity().finish();
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
@@ -98,7 +98,7 @@ public class PublicizeButtonPrefsFragment extends Fragment implements
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putSerializable(WordPress.SITE,mSite);
+        outState.putSerializable(WordPress.SITE, mSite);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
@@ -73,8 +73,6 @@ public class PublicizeButtonPrefsFragment extends Fragment implements
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
-        setRetainInstance(true);
-
         if (!NetworkUtils.checkConnection(getActivity())) {
             getActivity().finish();
             return;
@@ -95,6 +93,12 @@ public class PublicizeButtonPrefsFragment extends Fragment implements
         // this creates a default site settings interface - the actual settings will
         // be retrieved when getSiteSettings() is called
         mSiteSettings = SiteSettingsInterface.getInterface(getActivity(), mSite, this);
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putSerializable(WordPress.SITE,mSite);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPPrefView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPPrefView.java
@@ -177,7 +177,7 @@ public class WPPrefView extends LinearLayout implements
             return mList;
         }
 
-         PrefListItemsWrapper(PrefListItems mList) {
+        PrefListItemsWrapper(PrefListItems mList) {
             this.mList = mList;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPPrefView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPPrefView.java
@@ -167,6 +167,21 @@ public class WPPrefView extends LinearLayout implements
         }
     }
 
+   /*
+   * Wrapper that will allow us to preserve type of PrefListItems when serializing it
+   */
+    public static class PrefListItemsWrapper implements Serializable {
+        private PrefListItems mList;
+
+        public PrefListItems getList() {
+            return mList;
+        }
+
+         PrefListItemsWrapper(PrefListItems mList) {
+            this.mList = mList;
+        }
+    }
+
     public WPPrefView(Context context) {
         super(context);
         initView(context, null);
@@ -229,7 +244,7 @@ public class WPPrefView extends LinearLayout implements
     @Override
     public Parcelable onSaveInstanceState() {
         Bundle bundle = new Bundle();
-        bundle.putSerializable(KEY_LIST_ITEMS, mListItems);
+        bundle.putSerializable(KEY_LIST_ITEMS, new PrefListItemsWrapper(mListItems));
         bundle.putParcelable(KEY_SUPER_STATE, super.onSaveInstanceState());
         return bundle;
     }
@@ -238,8 +253,11 @@ public class WPPrefView extends LinearLayout implements
     public void onRestoreInstanceState(Parcelable state) {
         if (state instanceof Bundle) {
             Bundle bundle = (Bundle) state;
-            PrefListItems items = (PrefListItems) bundle.getSerializable(KEY_LIST_ITEMS);
-            setListItems(items);
+            PrefListItemsWrapper listWrapper = (PrefListItemsWrapper) bundle.getSerializable(KEY_LIST_ITEMS);
+            if(listWrapper != null){
+                PrefListItems items = listWrapper.getList();
+                setListItems(items);
+            }
             state = bundle.getParcelable(KEY_SUPER_STATE);
         }
         super.onRestoreInstanceState(state);


### PR DESCRIPTION
Fixes #6660 
Fixes #6661 

To test:

1. Turn on "Do not keep activities"
2. Navigate to publicize button preferences screen - My Site -> Sharing -> Manage (Under "Sharing buttons").
3. Press the home button to collapse the app, and then navigate back to it.
4. Confirm that fragment state was restored correctly.

#6660 happens because we have `setRetainInstance(true)` which retains `mSite`, that is later replaced by `null` from `savedInstanceState` (where we never put it).

#6661 caused by the way android packs extras. `PrefListItems` was packed as `ArrayList` and not as serializable. More info [here](https://stackoverflow.com/questions/25623099/arraylist-cannot-be-cast-to-custom-class-extending-arraylist/25626637#25626637).
