### PR TITLE
Issue/6647 reader cutoff 8.2

### DIFF
--- a/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
+++ b/WordPress/src/main/res/layout/reader_fragment_post_detail.xml
@@ -40,7 +40,7 @@
 
                     <include
                         layout="@layout/reader_include_post_detail_content"
-                        android:layout_width="@dimen/reader_webview_width"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_below="@+id/header_view"
                         android:layout_centerHorizontal="true"

--- a/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
@@ -6,7 +6,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:tools="http://schemas.android.com/tools"
               android:id="@+id/layout_post_detail_content"
-              android:layout_width="@dimen/reader_webview_width"
+              android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:orientation="vertical"
               android:paddingTop="@dimen/margin_medium">
@@ -45,7 +45,7 @@
 
     <org.wordpress.android.ui.reader.views.ReaderWebView
         android:id="@+id/reader_webview"
-        android:layout_width="@dimen/reader_webview_width"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_extra_large"
         android:scrollbars="none"/>
@@ -74,7 +74,7 @@
 
     <View
         android:id="@+id/layout_liking_users_divider"
-        android:layout_width="@dimen/reader_webview_width"
+        android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_marginTop="@dimen/margin_medium"
         android:background="@color/reader_divider_grey"
@@ -98,7 +98,7 @@
     <!-- liking avatars are inserted into this view at runtime -->
     <org.wordpress.android.ui.reader.views.ReaderLikingUsersView
         android:id="@+id/layout_liking_users_view"
-        android:layout_width="@dimen/reader_webview_width"
+        android:layout_width="match_parent"
         android:layout_height="@dimen/avatar_sz_small"
         android:layout_below="@id/text_liking_users_label"
         android:layout_marginBottom="@dimen/margin_medium"

--- a/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_footer.xml
@@ -19,7 +19,7 @@
         android:background="@color/reader_divider_grey" />
 
     <RelativeLayout
-        android:layout_width="@dimen/reader_webview_width"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true"
         android:layout_marginLeft="@dimen/reader_detail_margin"

--- a/WordPress/src/main/res/values-sw600dp-land/dimens.xml
+++ b/WordPress/src/main/res/values-sw600dp-land/dimens.xml
@@ -1,3 +1,4 @@
 <resources>
     <dimen name="notifications_list_margin">192dp</dimen>
+    <dimen name="reader_detail_margin">@dimen/reader_detail_margin_tablet_landscape</dimen>
 </resources>

--- a/WordPress/src/main/res/values-w720dp-land/dimens.xml
+++ b/WordPress/src/main/res/values-w720dp-land/dimens.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="reader_detail_margin">@dimen/reader_detail_margin_tablet_big_landscape</dimen>
+</resources>

--- a/WordPress/src/main/res/values-w720dp/dimens.xml
+++ b/WordPress/src/main/res/values-w720dp/dimens.xml
@@ -3,6 +3,5 @@
     <dimen name="content_margin">@dimen/content_margin_tablet_big</dimen>
     <dimen name="reader_card_margin">@dimen/reader_card_margin_tablet_big</dimen>
     <dimen name="reader_detail_margin">@dimen/reader_detail_margin_tablet_big</dimen>
-    <dimen name="reader_webview_width">680dp</dimen>
     <dimen name="notifications_content_margin">@dimen/content_margin_tablet_big</dimen>
 </resources>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -78,9 +78,6 @@
     <dimen name="margin_extra_extra_large">48dp</dimen>
     <dimen name="margin_filter_spinner">64dp</dimen>
 
-    <item name="wp_match_parent" type="dimen">-1</item>
-    <dimen name="reader_webview_width">@dimen/wp_match_parent</dimen>
-
     <!-- left/right margin for reader cards -->
     <dimen name="reader_card_margin_normal">0dp</dimen>
     <dimen name="reader_card_margin_tablet">48dp</dimen>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -87,7 +87,9 @@
     <!-- left/right margin for reader detail -->
     <dimen name="reader_detail_margin_normal">24dp</dimen>
     <dimen name="reader_detail_margin_tablet">48dp</dimen>
+    <dimen name="reader_detail_margin_tablet_landscape">96dp</dimen>
     <dimen name="reader_detail_margin_tablet_big">96dp</dimen>
+    <dimen name="reader_detail_margin_tablet_big_landscape">160dp</dimen>
     <dimen name="reader_detail_margin">@dimen/reader_detail_margin_normal</dimen>
 
     <dimen name="reader_detail_header_avatar">48dp</dimen>


### PR DESCRIPTION
Fixes #6647 - the problem was triggered by using a fixed-width for reader content on tablets, which in addition to the large left/right margins caused the content to be clipped.

This PR resolves this by dropping the fixed-width content and relying solely on the margins to limit the size of the content. In addition, it adds increased margins for landscape tablets.