### PR TITLE
Issue/global notification setting

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -693,7 +693,7 @@ public class GCMMessageService extends GcmListenerService {
             resultIntent.putExtra(NotificationsListFragment.NOTE_ID_EXTRA, wpcomNoteID);
 
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-            boolean shouldReceiveNotifications = prefs.getBoolean(context.getString(R.string.wp_pref_notification_receive), true);
+            boolean shouldReceiveNotifications = prefs.getBoolean(context.getString(R.string.wp_pref_notifications_master), true);
 
             if (shouldReceiveNotifications) {
                 if (notifyUser) {

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -95,7 +95,6 @@
 
     <string name="wp_pref_notifications_root" translatable="false">wp_pref_notifications_root</string>
     <string name="wp_pref_notifications_master" translatable="false">wp_pref_notifications_master</string>
-    <string name="wp_pref_notification_receive" translatable="false">wp_pref_notification_receive</string>
     <string name="wp_pref_custom_notification_sound" translatable="false">wp_pref_custom_notification_sound</string>
     <string name="wp_pref_notification_vibrate" translatable="false">wp_pref_notification_vibrate</string>
     <string name="wp_pref_notification_light" translatable="false">wp_pref_notification_light</string>


### PR DESCRIPTION
### Fix
Update the global notification shared preference key to the correct reference, `wp_pref_notifications_master`.

### Test
1. Go to ***Me*** tab.
2. Tap ***Notification Settings*** option.
3. Notice global notification switch in toolbar.
4. Notice global notification switch is on.
5. Notice notification settings are enabled.
6. Like a post from another account.
7. Notice notification is received.
8. Tap global notification switch.
9. Notice global notification switch is off.
10. Notice notification settings are disabled.
11. Like a post from another account.
12. Notice notification is not received.