### PR TITLE
issue/6668 fixed crash in ImageSettingsDialogFragment

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/ImageSettingsDialogFragment.java
@@ -40,6 +40,7 @@ import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.ToastUtils;
 
 import java.util.Arrays;
+import java.util.Locale;
 
 import static org.wordpress.android.editor.EditorFragmentAbstract.ATTR_ALIGN;
 import static org.wordpress.android.editor.EditorFragmentAbstract.ATTR_ALT;
@@ -388,7 +389,7 @@ public class ImageSettingsDialogFragment extends DialogFragment {
             mImageLoader.get(imageUrl, new ImageLoader.ImageListener() {
                 @Override
                 public void onResponse(ImageLoader.ImageContainer response, boolean isImmediate) {
-                    if (!isAdded())  {
+                    if (!isAdded()) {
                         return;
                     }
                     if (response.getBitmap() != null) {
@@ -401,10 +402,11 @@ public class ImageSettingsDialogFragment extends DialogFragment {
                         }
                     }
                 }
+
                 @Override
                 public void onErrorResponse(VolleyError error) {
                     AppLog.e(AppLog.T.MEDIA, error);
-                    if (!isAdded())  {
+                    if (!isAdded()) {
                         return;
                     }
                     showErrorImage();
@@ -431,7 +433,7 @@ public class ImageSettingsDialogFragment extends DialogFragment {
 
         if (imageWidth != 0) {
             widthSeekBar.setProgress(imageWidth / 10);
-            widthText.setText(String.valueOf(imageWidth) + "px");
+            widthText.setText(String.format(Locale.US, getString(R.string.pixel_suffix), imageWidth));
         }
 
         widthSeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
@@ -448,7 +450,7 @@ public class ImageSettingsDialogFragment extends DialogFragment {
                 if (progress == 0) {
                     progress = 1;
                 }
-                widthText.setText(progress * 10 + "px");
+                widthText.setText(String.format(Locale.US, getString(R.string.pixel_suffix), progress * 10));
             }
         });
 
@@ -465,7 +467,16 @@ public class ImageSettingsDialogFragment extends DialogFragment {
             @Override
             public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
                 int width = getEditTextIntegerClamped(widthText, 10, mMaxImageWidth);
-                widthSeekBar.setProgress(width / 10);
+
+                int progress = width / 10;
+
+                //OnSeekBarChangeListener will not be triggered if progress have not changed
+                if (widthSeekBar.getProgress() == progress) {
+                    widthText.setText(String.format(Locale.US, getString(R.string.pixel_suffix), progress * 10));
+                } else {
+                    widthSeekBar.setProgress(progress);
+                }
+
                 widthText.setSelection((String.valueOf(width).length()));
 
                 InputMethodManager imm = (InputMethodManager) getActivity()
@@ -477,6 +488,7 @@ public class ImageSettingsDialogFragment extends DialogFragment {
             }
         });
     }
+
 
     /**
      * Return the integer value of the width EditText, adjusted to be within the given min and max, and stripped of the

--- a/libs/editor/WordPressEditor/src/main/res/values/strings.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/strings.xml
@@ -46,6 +46,8 @@
     <string name="image_settings_dismiss_dialog_title">Discard unsaved changes?</string>
     <string name="image_settings_save_toast">Changes saved</string>
 
+    <string name="pixel_suffix">%dpx</string>
+
     <string name="image_caption">Caption</string>
     <string name="image_alt_text">Alt text</string>
     <string name="image_link_to">Link to</string>


### PR DESCRIPTION
Fixes #6668

The issue was caused because we were trying to select nonexisting text in empty EditText, the value of which was depended on `onProgressChanged` of `widthSeekBar` which was not called when the progress value was not changed (lister is not triggered in this case).

To test:
1. Open image settings dialog in the editor.
2. Tap the Width field.
3. Input 10.
4. Press confirm button on the soft keyboard.
5. The width field should display "10px"
6. Remove focus from the field and then tap on it again and delete the "10px".
7. Press confirm button on the soft keyboard.
8. Notice that nothing is crashing.
