### PR TITLE
Aztec - Image and Video placeholders optimization

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1052,7 +1052,7 @@ public class EditPostActivity extends AppCompatActivity implements
             AztecEditorFragment aztecEditorFragment = (AztecEditorFragment)mEditorFragment;
             aztecEditorFragment.setEditorBetaClickListener(EditPostActivity.this);
             aztecEditorFragment.setAztecImageLoader(new AztecImageLoader(getBaseContext(), loadingDrawable));
-            aztecEditorFragment.setAztecVideoLoader(new AztecVideoLoader(getBaseContext()));
+            aztecEditorFragment.setAztecVideoLoader(new AztecVideoLoader(getBaseContext(), loadingDrawable));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -12,7 +12,6 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
-import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
@@ -1044,15 +1043,10 @@ public class EditPostActivity extends AppCompatActivity implements
     @Override
     public void initializeEditorFragment() {
         if (mEditorFragment instanceof AztecEditorFragment) {
-            Drawable loadingDrawable = getResources().getDrawable(R.drawable.ic_gridicons_image);
-            loadingDrawable.setBounds(0, 0,
-                    AztecEditorFragment.DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP,
-                    AztecEditorFragment.DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP);
-
             AztecEditorFragment aztecEditorFragment = (AztecEditorFragment)mEditorFragment;
             aztecEditorFragment.setEditorBetaClickListener(EditPostActivity.this);
-            aztecEditorFragment.setAztecImageLoader(new AztecImageLoader(getBaseContext(), loadingDrawable));
-            aztecEditorFragment.setAztecVideoLoader(new AztecVideoLoader(getBaseContext(), loadingDrawable));
+            aztecEditorFragment.setAztecImageLoader(new AztecImageLoader(getBaseContext(), aztecEditorFragment.loadingImagePlaceholder));
+            aztecEditorFragment.setAztecVideoLoader(new AztecVideoLoader(getBaseContext(), aztecEditorFragment.loadingVideoPlaceholder));
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -12,6 +12,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
@@ -1045,8 +1046,20 @@ public class EditPostActivity extends AppCompatActivity implements
         if (mEditorFragment instanceof AztecEditorFragment) {
             AztecEditorFragment aztecEditorFragment = (AztecEditorFragment)mEditorFragment;
             aztecEditorFragment.setEditorBetaClickListener(EditPostActivity.this);
-            aztecEditorFragment.setAztecImageLoader(new AztecImageLoader(getBaseContext(), aztecEditorFragment.loadingImagePlaceholder));
-            aztecEditorFragment.setAztecVideoLoader(new AztecVideoLoader(getBaseContext(), aztecEditorFragment.loadingVideoPlaceholder));
+
+            Drawable loadingImagePlaceholder = getResources().getDrawable(org.wordpress.android.editor.R.drawable.ic_gridicons_image);
+            loadingImagePlaceholder.setBounds(0, 0,
+                    AztecEditorFragment.DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP,
+                    AztecEditorFragment.DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP);
+            aztecEditorFragment.setAztecImageLoader(new AztecImageLoader(getBaseContext(), loadingImagePlaceholder));
+            aztecEditorFragment.setLoadingImagePlaceholder(loadingImagePlaceholder);
+
+            Drawable loadingVideoPlaceholder = getResources().getDrawable(org.wordpress.android.editor.R.drawable.ic_gridicons_video_camera);
+            loadingVideoPlaceholder.setBounds(0, 0,
+                    AztecEditorFragment.DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP,
+                    AztecEditorFragment.DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP);
+            aztecEditorFragment.setAztecVideoLoader(new AztecVideoLoader(getBaseContext(), loadingVideoPlaceholder));
+            aztecEditorFragment.setLoadingVideoPlaceholder(loadingVideoPlaceholder);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -12,6 +12,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
@@ -1043,9 +1044,14 @@ public class EditPostActivity extends AppCompatActivity implements
     @Override
     public void initializeEditorFragment() {
         if (mEditorFragment instanceof AztecEditorFragment) {
+            Drawable loadingDrawable = getResources().getDrawable(R.drawable.ic_gridicons_image);
+            loadingDrawable.setBounds(0, 0,
+                    AztecEditorFragment.DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP,
+                    AztecEditorFragment.DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP);
+
             AztecEditorFragment aztecEditorFragment = (AztecEditorFragment)mEditorFragment;
             aztecEditorFragment.setEditorBetaClickListener(EditPostActivity.this);
-            aztecEditorFragment.setAztecImageLoader(new AztecImageLoader(getBaseContext()));
+            aztecEditorFragment.setAztecImageLoader(new AztecImageLoader(getBaseContext(), loadingDrawable));
             aztecEditorFragment.setAztecVideoLoader(new AztecVideoLoader(getBaseContext()));
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
@@ -10,9 +10,7 @@ import android.net.Uri;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.ImageLoader;
 
-import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
-import org.wordpress.android.editor.AztecEditorFragment;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.aztec.Html;
 
@@ -20,16 +18,26 @@ import java.io.File;
 
 public class AztecImageLoader implements Html.ImageGetter {
 
+    private final Drawable loadingInProgess;
     private Context context;
 
-    public AztecImageLoader(Context context) {
+    public AztecImageLoader(Context context, Drawable loadingInProgressDrawable) {
         this.context = context;
+        this.loadingInProgess = loadingInProgressDrawable;
     }
 
     @Override
-    public void loadImage(String url, final Callbacks callbacks, int maxWidth) {
+    public void loadImage(final String url, final Callbacks callbacks, int maxWidth) {
+        // FIXME: Aztec has now the option to set the desired image width. We should respect it
         // Ignore the maxWidth passed from Aztec, since it's the MAX of screen width/height
         final int maxWidthForEditor = ImageUtils.getMaximumThumbnailWidthForEditor(context);
+
+        final String cacheKey = url + maxWidthForEditor;
+        Bitmap cachedBitmap = WordPress.getBitmapCache().get(cacheKey);
+        if (cachedBitmap != null) {
+            callbacks.onImageLoaded(new BitmapDrawable(context.getResources(), cachedBitmap));
+            return;
+        }
 
         if (new File(url).exists()) {
             int orientation = ImageUtils.getImageOrientation(this.context, url);
@@ -37,6 +45,9 @@ public class AztecImageLoader implements Html.ImageGetter {
                    context, Uri.parse(url), maxWidthForEditor, null, orientation);
             if (bytes != null) {
                 Bitmap bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
+                if (bitmap != null) {
+                    WordPress.getBitmapCache().putBitmap(cacheKey, bitmap);
+                }
                 BitmapDrawable bitmapDrawable = new BitmapDrawable(context.getResources(), bitmap);
                 callbacks.onImageLoaded(bitmapDrawable);
             } else {
@@ -45,11 +56,7 @@ public class AztecImageLoader implements Html.ImageGetter {
             return;
         }
 
-        Drawable drawable = context.getResources().getDrawable(R.drawable.ic_gridicons_image);
-        drawable.setBounds(0, 0,
-                AztecEditorFragment.DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP,
-                AztecEditorFragment.DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP);
-        callbacks.onImageLoading(drawable);
+        callbacks.onImageLoading(loadingInProgess);
 
         WordPress.sImageLoader.get(url, new ImageLoader.ImageListener() {
             @Override
@@ -60,6 +67,8 @@ public class AztecImageLoader implements Html.ImageGetter {
                     // isImmediate is true as soon as the request starts.
                     callbacks.onImageFailed();
                 } else if (bitmap != null) {
+                    final String cacheKey = url + maxWidthForEditor;
+                    WordPress.getBitmapCache().putBitmap(cacheKey, bitmap);
                     BitmapDrawable bitmapDrawable = new BitmapDrawable(context.getResources(), bitmap);
                     callbacks.onImageLoaded(bitmapDrawable);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
@@ -18,12 +18,12 @@ import java.io.File;
 
 public class AztecImageLoader implements Html.ImageGetter {
 
-    private final Drawable loadingInProgess;
+    private final Drawable loadingInProgress;
     private Context context;
 
     public AztecImageLoader(Context context, Drawable loadingInProgressDrawable) {
         this.context = context;
-        this.loadingInProgess = loadingInProgressDrawable;
+        this.loadingInProgress = loadingInProgressDrawable;
     }
 
     @Override
@@ -56,7 +56,7 @@ public class AztecImageLoader implements Html.ImageGetter {
             return;
         }
 
-        callbacks.onImageLoading(loadingInProgess);
+        callbacks.onImageLoading(loadingInProgress);
 
         WordPress.sImageLoader.get(url, new ImageLoader.ImageListener() {
             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
@@ -9,8 +9,6 @@ import android.os.AsyncTask;
 import android.provider.MediaStore;
 import android.text.TextUtils;
 
-import org.wordpress.android.R;
-import org.wordpress.android.editor.AztecEditorFragment;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.aztec.Html;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
@@ -19,9 +19,11 @@ import java.io.File;
 public class AztecVideoLoader implements Html.VideoThumbnailGetter {
 
     private Context context;
+    private final Drawable loadingInProgress;
 
-    public AztecVideoLoader(Context context) {
+    public AztecVideoLoader(Context context, Drawable loadingInProgressDrawable) {
         this.context = context;
+        this.loadingInProgress = loadingInProgressDrawable;
     }
 
     public void loadVideoThumbnail(final String url, final Html.VideoThumbnailGetter.Callbacks callbacks, final int maxWidth) {
@@ -32,11 +34,7 @@ public class AztecVideoLoader implements Html.VideoThumbnailGetter {
             return;
         }
 
-        Drawable drawable = context.getResources().getDrawable(R.drawable.ic_gridicons_video_camera);
-        drawable.setBounds(0, 0,
-                AztecEditorFragment.DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP,
-                AztecEditorFragment.DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP);
-        callbacks.onThumbnailLoading(drawable);
+        callbacks.onThumbnailLoading(loadingInProgress);
 
         new AsyncTask<Void, Void, Bitmap>() {
             protected Bitmap doInBackground(Void... params) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -167,9 +167,9 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_aztec_editor, container, false);
 
-        loadingImagePlaceholder = getResources().getDrawable(R.drawable.ic_gridicons_video_camera);
+        loadingImagePlaceholder = getResources().getDrawable(R.drawable.ic_gridicons_image);
         loadingImagePlaceholder.setBounds(0, 0, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP);
-        loadingVideoPlaceholder = getResources().getDrawable(R.drawable.ic_gridicons_image);
+        loadingVideoPlaceholder = getResources().getDrawable(R.drawable.ic_gridicons_video_camera);
         loadingVideoPlaceholder.setBounds(0, 0, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP);
 
         // request dependency injection

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -142,8 +142,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     private EditorBetaClickListener mEditorBetaClickListener;
 
-    public Drawable loadingImagePlaceholder;
-    public Drawable loadingVideoPlaceholder;
+    private Drawable loadingImagePlaceholder;
+    private Drawable loadingVideoPlaceholder;
 
     public static AztecEditorFragment newInstance(String title, String content, boolean isExpanded) {
         mIsToolbarExpanded = isExpanded;
@@ -166,11 +166,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_aztec_editor, container, false);
-
-        loadingImagePlaceholder = getResources().getDrawable(R.drawable.ic_gridicons_image);
-        loadingImagePlaceholder.setBounds(0, 0, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP);
-        loadingVideoPlaceholder = getResources().getDrawable(R.drawable.ic_gridicons_video_camera);
-        loadingVideoPlaceholder.setBounds(0, 0, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP);
 
         // request dependency injection
         if (getActivity() instanceof EditorFragmentActivity) {
@@ -688,10 +683,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             setAttributeValuesIfNotDefault(attributes, mediaFile);
             if(mediaFile.isVideo()) {
                 addVideoUploadingClassIfMissing(attributes);
-                content.insertVideo(loadingVideoPlaceholder, attributes);
+                content.insertVideo(getLoadingVideoPlaceholder(), attributes);
                 overlayVideoIcon(0, new MediaPredicate(mediaUrl, ATTR_SRC));
             } else {
-                content.insertImage(loadingImagePlaceholder, attributes);
+                content.insertImage(getLoadingImagePlaceholder(), attributes);
             }
 
             final String posterURL = mediaFile.isVideo() ? Utils.escapeQuotes(StringUtils.notNullStr(mediaFile.getThumbnailURL())) : mediaUrl;
@@ -1749,5 +1744,35 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         plugins.add(new VideoShortcodePlugin());
         plugins.add(new AudioShortcodePlugin());
         return new AztecParser(plugins);
+    }
+
+    private Drawable getLoadingImagePlaceholder() {
+        if (loadingImagePlaceholder != null) {
+            return  loadingImagePlaceholder;
+        }
+
+        // Use default loading placeholder if none was set by the host activity
+        Drawable defaultLoadingImagePlaceholder = getResources().getDrawable(R.drawable.ic_gridicons_image);
+        defaultLoadingImagePlaceholder.setBounds(0, 0, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP);
+        return defaultLoadingImagePlaceholder;
+    }
+
+    private Drawable getLoadingVideoPlaceholder() {
+        if (loadingVideoPlaceholder != null) {
+            return  loadingVideoPlaceholder;
+        }
+
+        // Use default loading placeholder if none was set by the host activity
+        Drawable defaultLoadingImagePlaceholder = getResources().getDrawable(R.drawable.ic_gridicons_video_camera);
+        defaultLoadingImagePlaceholder.setBounds(0, 0, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP);
+        return defaultLoadingImagePlaceholder;
+    }
+
+    public void setLoadingImagePlaceholder(Drawable loadingImagePlaceholder) {
+        this.loadingImagePlaceholder = loadingImagePlaceholder;
+    }
+
+    public void setLoadingVideoPlaceholder(Drawable loadingVideoPlaceholder) {
+        this.loadingVideoPlaceholder = loadingVideoPlaceholder;
     }
 }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -142,6 +142,9 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     private EditorBetaClickListener mEditorBetaClickListener;
 
+    public Drawable loadingImagePlaceholder;
+    public Drawable loadingVideoPlaceholder;
+
     public static AztecEditorFragment newInstance(String title, String content, boolean isExpanded) {
         mIsToolbarExpanded = isExpanded;
         AztecEditorFragment fragment = new AztecEditorFragment();
@@ -163,6 +166,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_aztec_editor, container, false);
+
+        loadingImagePlaceholder = getResources().getDrawable(R.drawable.ic_gridicons_video_camera);
+        loadingImagePlaceholder.setBounds(0, 0, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP);
+        loadingVideoPlaceholder = getResources().getDrawable(R.drawable.ic_gridicons_image);
+        loadingVideoPlaceholder.setBounds(0, 0, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP);
 
         // request dependency injection
         if (getActivity() instanceof EditorFragmentActivity) {
@@ -673,24 +681,17 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         final int maxWidth = ImageUtils.getMaximumThumbnailWidthForEditor(getActivity());
 
         if (URLUtil.isNetworkUrl(mediaUrl)) {
-            // We're download the image/video from the network. Show the placeholder immediately since it could require time.
-            final Drawable placeholder;
-            if(mediaFile.isVideo()) {
-                placeholder = getResources().getDrawable(R.drawable.ic_gridicons_video_camera);
-            } else {
-                placeholder = getResources().getDrawable(R.drawable.ic_gridicons_image);
-            }
-            placeholder.setBounds(0, 0, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP, DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP);
+
 
             AztecAttributes attributes = new AztecAttributes();
             attributes.setValue(ATTR_SRC, mediaUrl);
             setAttributeValuesIfNotDefault(attributes, mediaFile);
             if(mediaFile.isVideo()) {
                 addVideoUploadingClassIfMissing(attributes);
-                content.insertVideo(placeholder, attributes);
+                content.insertVideo(loadingVideoPlaceholder, attributes);
                 overlayVideoIcon(0, new MediaPredicate(mediaUrl, ATTR_SRC));
             } else {
-                content.insertImage(placeholder, attributes);
+                content.insertImage(loadingImagePlaceholder, attributes);
             }
 
             final String posterURL = mediaFile.isVideo() ? Utils.escapeQuotes(StringUtils.notNullStr(mediaFile.getThumbnailURL())) : mediaUrl;


### PR DESCRIPTION
With this PR we only use 2 placeholders (one for videos and one for pictures) in the editor, when requesting data from the network. 

If you open a remote post with a lot of media there is good amount of memory saved, since we're not creating a new placeholder for each media.

cc @0nko 