### PR TITLE
Update FluxC hash and drop ReleaseStoreModule

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:407c7a41d8cb4706874b65327838fa13edab7fac') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:f68900cba331c0cb2a911885749b4160c496488d') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -5,7 +5,6 @@ import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.module.ReleaseBaseModule;
 import org.wordpress.android.fluxc.module.ReleaseNetworkModule;
 import org.wordpress.android.fluxc.module.ReleaseOkHttpClientModule;
-import org.wordpress.android.fluxc.module.ReleaseStoreModule;
 import org.wordpress.android.fluxc.module.ReleaseToolsModule;
 import org.wordpress.android.push.GCMMessageService;
 import org.wordpress.android.push.GCMRegistrationIntentService;
@@ -115,7 +114,6 @@ import dagger.Component;
         ReleaseBaseModule.class,
         ReleaseOkHttpClientModule.class,
         ReleaseNetworkModule.class,
-        ReleaseStoreModule.class,
         LegacyModule.class,
         ReleaseToolsModule.class
 })


### PR DESCRIPTION
Brings in the changes from https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/562, which eliminated the `ReleaseStoreModule` (relying instead on `@Inject`-annotated constructors for the stores).

cc @maxme