### PR TITLE
Add WP gallery shortcode support

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -808,7 +808,17 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void appendGallery(MediaGallery mediaGallery) {
-        ToastUtils.showToast(getActivity(), R.string.media_insert_unimplemented);
+        String shortcode = "[gallery %s=\"%s\" ids=\"%s\"]";
+        if (TextUtils.isEmpty(mediaGallery.getType())) {
+            shortcode = String.format(shortcode, "columns",
+                    mediaGallery.getNumColumns(),
+                    mediaGallery.getIdsStr());
+        } else {
+            shortcode = String.format(shortcode, "type",
+                    mediaGallery.getType(),
+                    mediaGallery.getIdsStr());
+        }
+        content.getText().insert(content.getSelectionEnd(), shortcode);
     }
 
     @Override


### PR DESCRIPTION
Fixes #5749.

This adds the same gallery support that already exists in the hybrid editor (i.e. generates a `[gallery]` tag).
