### PR TITLE
Issue/remove comment divider

### DIFF
--- a/WordPress/src/main/res/layout/comment_detail_fragment.xml
+++ b/WordPress/src/main/res/layout/comment_detail_fragment.xml
@@ -111,10 +111,8 @@
                 android:fontFamily="serif"
                 tools:text="text_content" />
 
-            <View android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="@drawable/notifications_list_divider_full_width" />
         </LinearLayout>
+
     </ScrollView>
 
     <LinearLayout


### PR DESCRIPTION
### Fix
Remove unnecessary divider view from comment detail screen.  The view can be hard to see since it's a `1dp` line just below the toolbar.  See the zoomed in screenshots below for illustration.

![divider](https://user-images.githubusercontent.com/3827611/31056422-8fcaa230-a68e-11e7-8c46-74c7eabdffa3.png)

### Test
1. Go to ***Notifications*** tab.
2. Tap comment notification from list.
3. Notice no line is shown below toolbar.
4. Swipe through multiple notifications.
5. Notice no line is shown below toolbar.