### PR TITLE
Add analytics to Share to WP

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -291,6 +291,15 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
             }
         }
         analyticsProperties.put("number_of_media_shared", mediaShared);
+
+        String target = "unknown";
+        if (mActionIndex == ADD_TO_NEW_POST) {
+            target = "new_post";
+        } else if (mActionIndex == ADD_TO_MEDIA_LIBRARY) {
+            target = "media_library";
+        }
+        analyticsProperties.put("share_to", target);
+
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.SHARE_TO_WP_SUCCEEDED,
                 mSiteStore.getSiteByLocalId(mSelectedSiteLocalId),
                 analyticsProperties);

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -262,7 +262,7 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
             }
         }
 
-        // bump analytics about usage here. We may wan to track failures in a future iteration.
+        // bump analytics about usage here. We may want to track failures in a future iteration.
         bumpAnalytics();
 
         if (mActionIndex == ADD_TO_NEW_POST) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverActivity.java
@@ -18,12 +18,14 @@ import android.widget.TextView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.accounts.SignInActivity;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.posts.EditPostActivity;
+import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.PermissionUtils;
 import org.wordpress.android.util.SiteUtils;
@@ -31,7 +33,9 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPPermissionUtils;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -258,6 +262,9 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
             }
         }
 
+        // bump analytics about usage here. We may wan to track failures in a future iteration.
+        bumpAnalytics();
+
         if (mActionIndex == ADD_TO_NEW_POST) {
             startActivityAndFinish(new Intent(this, EditPostActivity.class));
         } else if (mActionIndex == ADD_TO_MEDIA_LIBRARY) {
@@ -267,4 +274,27 @@ public class ShareIntentReceiverActivity extends AppCompatActivity implements On
             finish();
         }
     }
+
+    private void bumpAnalytics() {
+        Map<String, Object> analyticsProperties = new HashMap<>();
+        int mediaShared = 0;
+        if (!isSharingText()) {
+            String action = getIntent().getAction();
+            if (Intent.ACTION_SEND_MULTIPLE.equals(action)) {
+                // Multiple pictures share to WP
+                ArrayList<Uri> mediaUrls = getIntent().getParcelableArrayListExtra((Intent.EXTRA_STREAM));
+                if (mediaUrls != null) {
+                    mediaShared = mediaUrls.size();
+                }
+            } else {
+                mediaShared = 1;
+            }
+        }
+        analyticsProperties.put("number_of_media_shared", mediaShared);
+        AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.SHARE_TO_WP_SUCCEEDED,
+                mSiteStore.getSiteByLocalId(mSelectedSiteLocalId),
+                analyticsProperties);
+
+    }
+
 }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -277,7 +277,8 @@ public final class AnalyticsTracker {
         MEDIA_UPLOAD_SUCCESS,
         MEDIA_UPLOAD_CANCELED,
         APP_PERMISSION_GRANTED,
-        APP_PERMISSION_DENIED
+        APP_PERMISSION_DENIED,
+        SHARE_TO_WP_SUCCEEDED
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -854,6 +854,8 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "app_permission_granted";
             case APP_PERMISSION_DENIED:
                 return "app_permission_denied";
+            case SHARE_TO_WP_SUCCEEDED:
+                return "share_to_wp_succeeded";
             default:
                 return null;
         }


### PR DESCRIPTION
This PR adds basic analytics to Share to WP feature.

Number of media shared, and target of the sharing action are tracked in properties.

cc @maxme 

Note: We may want to track permissions failure in a feature iteration.