### PR TITLE
Jetpack disconnect - development only implementation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteDeleted;
+import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
 import org.wordpress.android.networking.ConnectionChangeReceiver;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -109,6 +110,15 @@ public class BlogPreferencesActivity extends AppCompatActivity {
             //https://github.com/wordpress-mobile/WordPress-Android/commit/6a90e3fe46e24ee40abdc4a7f8f0db06f157900c
             // Checks for stats widgets that were synched with a blog that could be gone now.
             //            StatsWidgetProvider.updateWidgetsOnLogout(this);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onSiteRemoved(OnSiteRemoved event) {
+        if (!event.isError()) {
+            setResult(SiteSettingsFragment.RESULT_BLOG_REMOVED);
+            finish();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/BlogPreferencesActivity.java
@@ -28,8 +28,6 @@ import de.greenrobot.event.EventBus;
  * Activity for configuring blog specific settings.
  */
 public class BlogPreferencesActivity extends AppCompatActivity {
-    public static final int RESULT_BLOG_REMOVED = RESULT_FIRST_USER;
-
     private static final String KEY_SETTINGS_FRAGMENT = "settings-fragment";
 
     @Inject AccountStore mAccountStore;
@@ -125,7 +123,7 @@ public class BlogPreferencesActivity extends AppCompatActivity {
             }
 
             siteSettingsFragment.handleSiteDeleted();
-            setResult(RESULT_BLOG_REMOVED);
+            setResult(SiteSettingsFragment.RESULT_BLOG_REMOVED);
             finish();
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -491,6 +491,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                                 AppLog.v(AppLog.T.API, "Successfully disconnected Jetpack site");
                                 ToastUtils.showToast(getActivity(), R.string.jetpack_disconnect_success_toast);
                                 mDispatcher.dispatch(SiteActionBuilder.newRemoveSiteAction(mSite));
+                                mSite = null;
                             }
                         }, new RestRequest.ErrorListener() {
                             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -98,7 +98,6 @@ public class SiteSettingsFragment extends PreferenceFragment
      */
     public static final int RESULT_BLOG_REMOVED = Activity.RESULT_FIRST_USER;
 
-
     /**
      * Provides the regex to identify domain HTTP(S) protocol and/or 'www' sub-domain.
      *
@@ -491,7 +490,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                             public void onResponse(JSONObject response) {
                                 AppLog.v(AppLog.T.API, "Successfully disconnected Jetpack site");
                                 ToastUtils.showToast(getActivity(), R.string.jetpack_disconnect_success_toast);
-                                getActivity().finish();
+                                mDispatcher.dispatch(SiteActionBuilder.newRemoveSiteAction(mSite));
                             }
                         }, new RestRequest.ErrorListener() {
                             @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -477,21 +477,30 @@ public class SiteSettingsFragment extends PreferenceFragment
     }
 
     private void disconnectFromJetpack() {
-        String url = String.format(Locale.US, "jetpack-blogs/%d/mine/delete", mSite.getSiteId());
-        WordPress.getRestClientUtilsV1_1().post(url, new RestRequest.Listener() {
-            @Override
-            public void onResponse(JSONObject response) {
-                AppLog.v(AppLog.T.API, "Successfully disconnected Jetpack site");
-                ToastUtils.showToast(getActivity(), "Site disconnected");
-                getActivity().finish();
-            }
-        }, new RestRequest.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError error) {
-                AppLog.e(AppLog.T.API, "Error disconnecting Jetpack site");
-                ToastUtils.showToast(getActivity(), "Error disconnecting site");
-            }
-        });
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setMessage("Are you sure you want to disconnect Jetpack from the site?");
+        builder.setPositiveButton("Disconnect", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        String url = String.format(Locale.US, "jetpack-blogs/%d/mine/delete", mSite.getSiteId());
+                        WordPress.getRestClientUtilsV1_1().post(url, new RestRequest.Listener() {
+                            @Override
+                            public void onResponse(JSONObject response) {
+                                AppLog.v(AppLog.T.API, "Successfully disconnected Jetpack site");
+                                ToastUtils.showToast(getActivity(), "Site disconnected");
+                                getActivity().finish();
+                            }
+                        }, new RestRequest.ErrorListener() {
+                            @Override
+                            public void onErrorResponse(VolleyError error) {
+                                AppLog.e(AppLog.T.API, "Error disconnecting Jetpack site");
+                                ToastUtils.showToast(getActivity(), "Error disconnecting site");
+                            }
+                        });
+                    }
+                });
+        builder.setNegativeButton("Cancel", null);
+        builder.show();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -255,7 +255,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (BuildConfig.DEBUG && mSite.isJetpackConnected() && mSite.isUsingWpComRestApi()) {
             PreferenceCategory parent = (PreferenceCategory) findPreference(getString(R.string.pref_key_site_discussion));
             Preference disconnectPref = new Preference(getActivity());
-            disconnectPref.setTitle("Disconnect from WordPress.com");
+            disconnectPref.setTitle(getString(R.string.jetpack_disconnect_pref_title));
             disconnectPref.setKey(getString(R.string.pref_key_site_disconnect));
             disconnectPref.setOnPreferenceClickListener(this);
             parent.addPreference(disconnectPref);
@@ -478,8 +478,8 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private void disconnectFromJetpack() {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        builder.setMessage("Are you sure you want to disconnect Jetpack from the site?");
-        builder.setPositiveButton("Disconnect", new DialogInterface.OnClickListener() {
+        builder.setMessage(R.string.jetpack_disconnect_confirmation_message);
+        builder.setPositiveButton(R.string.jetpack_disconnect_confirm, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         String url = String.format(Locale.US, "jetpack-blogs/%d/mine/delete", mSite.getSiteId());
@@ -487,19 +487,19 @@ public class SiteSettingsFragment extends PreferenceFragment
                             @Override
                             public void onResponse(JSONObject response) {
                                 AppLog.v(AppLog.T.API, "Successfully disconnected Jetpack site");
-                                ToastUtils.showToast(getActivity(), "Site disconnected");
+                                ToastUtils.showToast(getActivity(), R.string.jetpack_disconnect_success_toast);
                                 getActivity().finish();
                             }
                         }, new RestRequest.ErrorListener() {
                             @Override
                             public void onErrorResponse(VolleyError error) {
                                 AppLog.e(AppLog.T.API, "Error disconnecting Jetpack site");
-                                ToastUtils.showToast(getActivity(), "Error disconnecting site");
+                                ToastUtils.showToast(getActivity(), R.string.jetpack_disconnect_error_toast);
                             }
                         });
                     }
                 });
-        builder.setNegativeButton("Cancel", null);
+        builder.setNegativeButton(android.R.string.cancel, null);
         builder.show();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -252,12 +252,19 @@ public class SiteSettingsFragment extends PreferenceFragment
     public void addPreferencesFromResource() {
         addPreferencesFromResource(R.xml.site_settings);
 
-        if (BuildConfig.DEBUG && mSite.isJetpackConnected() && mSite.isUsingWpComRestApi()) {
+        // add Disconnect option for Jetpack sites when running a debug build
+        if (shouldShowDisconnect()) {
             PreferenceCategory parent = (PreferenceCategory) findPreference(getString(R.string.pref_key_site_discussion));
             Preference disconnectPref = new Preference(getActivity());
             disconnectPref.setTitle(getString(R.string.jetpack_disconnect_pref_title));
             disconnectPref.setKey(getString(R.string.pref_key_site_disconnect));
-            disconnectPref.setOnPreferenceClickListener(this);
+            disconnectPref.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                @Override
+                public boolean onPreferenceClick(Preference preference) {
+                    disconnectFromJetpack();
+                    return true;
+                }
+            });
             parent.addPreference(disconnectPref);
         }
     }
@@ -465,10 +472,6 @@ public class SiteSettingsFragment extends PreferenceFragment
         } else if (preference == mDeleteSitePref) {
             AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.SITE_SETTINGS_DELETE_SITE_ACCESSED, mSite);
             requestPurchasesForDeletionCheck();
-        } else if (BuildConfig.DEBUG && mSite.isJetpackConnected() && mSite.isUsingWpComRestApi()) {
-            if (getString(R.string.pref_key_site_disconnect).equals(preference.getKey())) {
-                disconnectFromJetpack();
-            }
         } else {
             return false;
         }
@@ -1483,5 +1486,10 @@ public class SiteSettingsFragment extends PreferenceFragment
             );
             return true;
         }
+    }
+
+    /** Show Disconnect button for development purposes. Only available in debug builds on Jetpack sites. */
+    private boolean shouldShowDisconnect() {
+        return BuildConfig.DEBUG && mSite.isJetpackConnected() && mSite.isUsingWpComRestApi();
     }
 }

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -76,6 +76,7 @@
     <string name="pref_key_site_blacklist" translatable="false">wp_pref_site_blacklist</string>
     <string name="pref_key_site_danger" translatable="false">wp_pref_site_danger</string>
     <string name="pref_key_site_advanced" translatable="false">wp_pref_site_advanced</string>
+    <string name="pref_key_site_disconnect" translatable="false">wp_pref_site_disconnect</string>
     <string name="pref_key_site_start_over" translatable="false">wp_pref_site_start_over</string>
     <string name="pref_key_site_export_site" translatable="false">pref_key_site_export_site</string>
     <string name="pref_key_site_delete_site" translatable="false">wp_pref_site_delete_site</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1258,6 +1258,11 @@
     <string name="jetpack_different_com_account">Jetpack sites belonging to different WordPress.com accounts are not supported</string>
     <string name="jetpack_stats_module_disabled_message">The Jetpack plugin is connected, but the Stats module is not active. Do you want to activate Stats?</string>
     <string name="jetpack_stats_module_disabled_message_not_admin">The Jetpack plugin is connected, but the Stats module is not active. Contact the site administrator.</string>
+    <string name="jetpack_disconnect_pref_title">"Disconnect from WordPress.com"</string>
+    <string name="jetpack_disconnect_confirmation_message">Are you sure you want to disconnect Jetpack from the site?</string>
+    <string name="jetpack_disconnect_confirm">Disconnect</string>
+    <string name="jetpack_disconnect_success_toast">Site disconnected</string>
+    <string name="jetpack_disconnect_error_toast">Error disconnecting site</string>
 
     <!--
       reader strings


### PR DESCRIPTION
Implements #6195 for development purposes only. We'll ship it in release builds once the UX flow is finalized.

[Sibling PR on WP-iOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/7827)

**To test:**
* Select a Jetpack site
* Go to Site Settings
* Disconnect from WordPress.com is added at the bottom of the list
* Verify on the web that Jetpack was disconnected