### PR TITLE
Issue/6704 media items multiple enqueueing

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2279,7 +2279,7 @@ public class EditPostActivity extends AppCompatActivity implements
      * Starts the upload service to upload selected media.
      */
     private void startUploadService(MediaModel media) {
-        // make sure we only pass items with the QUEUED state to thee UploadService
+        // make sure we only pass items with the QUEUED state to the UploadService
         if (!MediaUploadState.QUEUED.toString().equals(media.getUploadState())) {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -944,12 +944,7 @@ public class EditPostActivity extends AppCompatActivity implements
         if (mediaToClear == null) {
             return;
         }
-        for (MediaModel pendingUpload : mPendingUploads) {
-            if (pendingUpload.getId() == mediaToClear.getId()) {
-                mPendingUploads.remove(pendingUpload);
-                break;
-            }
-        }
+        mPendingUploads.remove(mediaToClear.getId());
     }
 
     private void launchPictureLibrary() {
@@ -2142,7 +2137,7 @@ public class EditPostActivity extends AppCompatActivity implements
         }
     }
 
-    private ArrayList<MediaModel> mPendingUploads = new ArrayList<>();
+    private HashMap<Integer, MediaModel> mPendingUploads = new HashMap<>();
 
     /*
      * called before we add media to make sure we have access to any media shared from another app (Google Photos, etc.)
@@ -2302,7 +2297,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private void startUploadService() {
         if (mPendingUploads != null && !mPendingUploads.isEmpty()) {
             final ArrayList<MediaModel> mediaList = new ArrayList<>();
-            for (MediaModel media : mPendingUploads) {
+            for (MediaModel media : mPendingUploads.values()) {
                 if (MediaUploadState.QUEUED.toString().equals(media.getUploadState())) {
                     mediaList.add(media);
                 }
@@ -2371,7 +2366,7 @@ public class EditPostActivity extends AppCompatActivity implements
         mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));
 
         // add this item to the queue - we keep it for visual aid atm
-        mPendingUploads.add(media);
+        mPendingUploads.put(media.getId(), media);
 
         startUploadService();
 
@@ -2508,7 +2503,7 @@ public class EditPostActivity extends AppCompatActivity implements
         } else {
             media.setUploadState(MediaUploadState.QUEUED);
             mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));
-            mPendingUploads.add(media);
+            mPendingUploads.put(media.getId(), media);
             startUploadService();
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2279,22 +2279,21 @@ public class EditPostActivity extends AppCompatActivity implements
      * Starts the upload service to upload selected media.
      */
     private void startUploadService(MediaModel media) {
+        // make sure we only pass items with the QUEUED state to thee UploadService
+        if (!MediaUploadState.QUEUED.toString().equals(media.getUploadState())) {
+            return;
+        }
+
         final ArrayList<MediaModel> mediaList = new ArrayList<>();
-        if (MediaUploadState.QUEUED.toString().equals(media.getUploadState())) {
-            mediaList.add(media);
-        }
-
-        if (!mediaList.isEmpty()) {
-            // before starting the service, we need to update the posts' contents so we are sure the service
-            // can retrieve it from there on
-            savePostAsync(new AfterSavePostListener() {
-                @Override
-                public void onPostSave() {
-                    UploadService.uploadMedia(EditPostActivity.this, mediaList);
-                }
-            });
-
-        }
+        mediaList.add(media);
+        // before starting the service, we need to update the posts' contents so we are sure the service
+        // can retrieve it from there on
+        savePostAsync(new AfterSavePostListener() {
+            @Override
+            public void onPostSave() {
+                UploadService.uploadMedia(EditPostActivity.this, mediaList);
+            }
+        });
     }
 
     private String getVideoThumbnail(String videoPath) {


### PR DESCRIPTION
Fixes #6704 

Removes the `mPendingUploads` artifact as it was being kept for visual purposes previous to the `UploadStore` introduction in https://github.com/wordpress-mobile/WordPress-Android/pull/6613

To test:

1. Place a breakpoint on this line https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java#L163
2. start a new draft
3. tap on the media picker icon
4. select two items using long press
5. observe the `unpackIntent` method gets called twice, first time with a `mediaList` containing 1 item (size=1) and second time with a `mediaList` containing 1 item (size=1)

cc @nbradbury @aforcier 
