### PR TITLE
Fix auto-reset pending PNs on the `badge-reset` notification

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -831,8 +831,7 @@ public class GCMMessageService extends GcmListenerService {
 
         // Clear all notifications
         private void handleBadgeResetPN(Context context, Bundle data) {
-            if (data == null || !data.containsKey(PUSH_ARG_NOTE_ID))  {
-                // ignore the reset-badge PN if it's a global one
+            if (data == null)  {
                 return;
             }
 
@@ -844,12 +843,15 @@ public class GCMMessageService extends GcmListenerService {
                     note.setRead();
                     NotificationsTable.saveNote(note);
                 }
-            }
 
-            removeNotificationWithNoteIdFromSystemBar(context, noteID);
-            //now that we cleared the specific notif, we can check and make any visual updates
-            if (sActiveNotificationsMap.size() > 0) {
-                rebuildAndUpdateNotificationsOnSystemBar(context, data);
+
+                removeNotificationWithNoteIdFromSystemBar(context, noteID);
+                //now that we cleared the specific notif, we can check and make any visual updates
+                if (sActiveNotificationsMap.size() > 0) {
+                    rebuildAndUpdateNotificationsOnSystemBar(context, data);
+                }
+            } else {
+                removeAllNotifications(context);
             }
 
             EventBus.getDefault().post(new NotificationEvents.NotificationsChanged(sActiveNotificationsMap.size() > 0));


### PR DESCRIPTION
Fixes #6701 by making sure PNs are reset when badge-reset PN is received on the device.

I'm not sure why we were checking for the `note_id` field in the payload before resetting them, since the badge reset could have no `note_id` in it, for i.e. when you open the drawer on the web.

To test scenario 1:
- Make sure your browser is open on wordpress.com, but put the tab on the background. 
- on another account/browser comment in one of your posts
- you should receive PNs on your mobile devices
- Quick approve the comment on one of your device, from the system notifications center
- The badge reset pn is sent and notifications are cleared on all of your device

To test scenario 1bis:
- Make sure your browser is open on wordpress.com, but put the tab on the background. 
- On another account/browser comment in one of your posts
- You should receive PNs on your mobile devices
- Tap on the push notification in system notifications center
- The app is started
- The badge reset pn is sent and notifications are cleared on all of your device



To test scenario 2:
- Make sure your browser is open on wordpress.com, but put the tab on the background. 
- On another account/browser comment in one of your posts
- You should receive PNs on your mobile devices
- On the web, switch the wpcom tab in foreground and open the notifications sidebar
- The badge reset pn is sent and notifications are cleared on all of your device

To test scenario 3:
- Make sure your browser is open on wordpress.com, keep the tab on Foreground
- On another account/browser comment in one of your posts
- You should receive PNs on your mobile devices
- Wait a bit on the wpcom web page without opening the sidebar
- You should see your bell changing color to orange
- No reset PNs are sent to the device till this point
- Open the notifications sidebar on the web
- The badge reset pn is sent and notifications are cleared on all of your device
(*) sometimes I see web wordpress.com leaking on my browser with tons of badge reset PNs sent on my devices.

cc @mzorz - Do you remember the old good times? 🛴 

