### PR TITLE
Issue/6680 remove deleted local media

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -334,8 +334,8 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
             // note we count backwards so we can remove from the list
             for (int i = mediaModels.size() - 1 ; i >= 0; i--) {
                 MediaModel media = mediaModels.get(i);
-                if (org.wordpress.android.util.MediaUtils.isLocalFile(media.getUploadState())
-                        && media.getFilePath() != null) {
+                if (media.getFilePath() != null
+                        && org.wordpress.android.util.MediaUtils.isLocalFile(media.getUploadState())) {
                     File file = new File(media.getFilePath());
                     if (!file.exists()) {
                         AppLog.w(AppLog.T.MEDIA, "removing nonexistent local media " + media.getFilePath());

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -338,8 +338,11 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
                         && media.getFilePath() != null) {
                     File file = new File(media.getFilePath());
                     if (!file.exists()) {
+                        AppLog.w(AppLog.T.MEDIA, "removing nonexistent local media " + media.getFilePath());
+                        // remove from the store
+                        mDispatcher.dispatch(MediaActionBuilder.newRemoveMediaAction(media));
+                        // remove from the passed list
                         mediaModels.remove(i);
-                        AppLog.w(AppLog.T.MEDIA, "removed nonexistent local file " + media.getFilePath());
                     }
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -322,14 +322,15 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
      */
     private void ensureCorrectState(List<MediaModel> mediaModels) {
         if (isAdded() && getActivity() instanceof MediaBrowserActivity) {
+            // we only need to check the deletion state if media are currently being deleted
             MediaDeleteService service = ((MediaBrowserActivity)getActivity()).getMediaDeleteService();
-            boolean checkService = service != null && service.isAnyMediaBeingDeleted();
+            boolean checkDeleteState = service != null && service.isAnyMediaBeingDeleted();
 
             // note we count backwards so we can remove from the list
             for (int i = mediaModels.size() - 1 ; i >= 0; i--) {
                 MediaModel media = mediaModels.get(i);
                 // ensure correct upload state for media being deleted
-                if (checkService && service.isMediaBeingDeleted(media)) {
+                if (checkDeleteState && service.isMediaBeingDeleted(media)) {
                     media.setUploadState(MediaUploadState.DELETING);
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -323,17 +323,17 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
     private void ensureCorrectState(List<MediaModel> mediaModels) {
         if (isAdded() && getActivity() instanceof MediaBrowserActivity) {
             MediaDeleteService service = ((MediaBrowserActivity)getActivity()).getMediaDeleteService();
-            if (service != null && service.isAnyMediaBeingDeleted()) {
-                for (MediaModel media : mediaModels) {
-                    if (service.isMediaBeingDeleted(media)) {
-                        media.setUploadState(MediaUploadState.DELETING);
-                    }
-                }
-            }
+            boolean checkService = service != null && service.isAnyMediaBeingDeleted();
 
             // note we count backwards so we can remove from the list
             for (int i = mediaModels.size() - 1 ; i >= 0; i--) {
                 MediaModel media = mediaModels.get(i);
+                // ensure correct upload state for media being deleted
+                if (checkService && service.isMediaBeingDeleted(media)) {
+                    media.setUploadState(MediaUploadState.DELETING);
+                }
+
+                // remove local media that no longer exists
                 if (media.getFilePath() != null
                         && org.wordpress.android.util.MediaUtils.isLocalFile(media.getUploadState())) {
                     File file = new File(media.getFilePath());

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaDeleteService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/services/MediaDeleteService.java
@@ -139,6 +139,10 @@ public class MediaDeleteService extends Service {
         return false;
     }
 
+    public boolean isAnyMediaBeingDeleted() {
+        return mDeleteQueue != null && mDeleteQueue.size() > 0;
+    }
+
     private void handleMediaChangedSuccess(@NonNull OnMediaChanged event) {
         switch (event.cause) {
             case DELETE_MEDIA:


### PR DESCRIPTION
Fixes #6680 by automatically removing local (non-uploaded) media that no longer exists.

To test:

* Put the device in airplane mode (so the media doesn't get uploaded)
* Add a picture from your device to the media library, then close the media library
* Delete the photo from your device (note this may require emptying the trash if you use Google Photos)
* Turn off airplane mode
* Return to the media library, the deleted media should automatically be removed