### PR TITLE
EditPostSettingsFragment null guard

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -332,7 +332,7 @@ public class EditPostSettingsFragment extends Fragment {
         });
 
 
-        if (getPost().isPage()) { // remove post specific views
+        if (getPost() != null && getPost().isPage()) { // remove post specific views
             final View categoriesTagsContainer = rootView.findViewById(R.id.post_categories_and_tags_card);
             final View formatBottomSeparator = rootView.findViewById(R.id.post_format_bottom_separator);
             categoriesTagsContainer.setVisibility(View.GONE);


### PR DESCRIPTION
Fixes #6708 by adding a null guard. 

From crash reports it seems there's a possibility on configuration change that onCreateView would be called before `mEditPostActivityHook` having been initialized (or, after having it set to null in `onDetach`). In any case I suspect that following this scenario this is some odd behavior happening on an Activity that is about to be destroyed, so it wouldn't really matter what else is going to happen afterwards. Hence, just checking for null here will suffice.


