### PR TITLE
Issue/global notification setting analytics

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsActivity.java
@@ -105,6 +105,7 @@ public class NotificationsSettingsActivity extends AppCompatActivity {
 
         // Set secondary toolbar title and master switch state from shared preferences.
         boolean isMasterChecked = mSharedPreferences.getBoolean(getString(R.string.wp_pref_notifications_master), true);
+        hideDisabledView(isMasterChecked);
 
         mToolbarSwitch = (Toolbar) findViewById(R.id.toolbar_with_switch);
         mToolbarSwitch.inflateMenu(R.menu.notifications_settings_secondary);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsActivity.java
@@ -103,11 +103,18 @@ public class NotificationsSettingsActivity extends AppCompatActivity {
             actionBar.setDisplayShowTitleEnabled(true);
         }
 
+        // Set secondary toolbar title and master switch state from shared preferences.
+        boolean isMasterChecked = mSharedPreferences.getBoolean(getString(R.string.wp_pref_notifications_master), true);
+
         mToolbarSwitch = (Toolbar) findViewById(R.id.toolbar_with_switch);
-        mToolbarSwitch.setTitle("Off");
         mToolbarSwitch.inflateMenu(R.menu.notifications_settings_secondary);
+        mToolbarSwitch.setTitle(isMasterChecked ?
+                getString(R.string.notification_settings_master_status_on) :
+                getString(R.string.notification_settings_master_status_off));
+
         MenuItem menuItem = mToolbarSwitch.getMenu().findItem(R.id.master_switch);
         mMasterSwitch = (SwitchCompat) menuItem.getActionView();
+        mMasterSwitch.setChecked(isMasterChecked);
         mMasterSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
@@ -134,14 +141,6 @@ public class NotificationsSettingsActivity extends AppCompatActivity {
                 return true;
             }
         });
-
-        // Set secondary toolbar title and master switch state from shared preferences.
-        boolean isMasterChecked = mSharedPreferences.getBoolean(getString(R.string.wp_pref_notifications_master), true);
-        mToolbarSwitch.setTitle(isMasterChecked ?
-                getString(R.string.notification_settings_master_status_on) :
-                getString(R.string.notification_settings_master_status_off));
-        mMasterSwitch.setChecked(isMasterChecked);
-
     }
 
     /**


### PR DESCRIPTION
### Fix
Update the order of the global notification preference view initialization and setting to avoid corrupting analytics.  When the `mMasterSwitch.setChecked` statement was being called after the `mMasterSwitch.setOnCheckedChangeListener` statement, the analytics tracker was triggered which means analytics were being counted every time the view was created.  Now the switch value is set before the listener is initialized and the analytics will only be tracked when the switch state is changed.