### PR TITLE
Don't allow popupWindow to steal the focus

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -801,7 +801,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
 
         int width = getResources().getDimensionPixelSize(R.dimen.action_bar_spinner_width);
         mAddMediaPopup = new PopupWindow(menuView, width, ViewGroup.LayoutParams.WRAP_CONTENT, false);
-        mAddMediaPopup.setFocusable(true);
+        mAddMediaPopup.setFocusable(false);
+        mAddMediaPopup.setOutsideTouchable(true);
     }
 
     private boolean isAddMediaPopupShowing() {


### PR DESCRIPTION
Fixes #6167 by ensuring the `PopupWindow` doesn't steal the focus.

@daniloercoli Can you give this a quick spin on the device you were seeing the problem on?
