### PR TITLE
Fix #6724: guard against a null site name in SiteUtils

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -11,6 +11,9 @@ import java.util.List;
 public class SiteUtils {
     public static String getSiteNameOrHomeURL(SiteModel site) {
         String siteName = site.getName();
+        if (siteName == null) {
+            return "";
+        }
         if (siteName.trim().length() == 0) {
             siteName = getHomeURLOrHostName(site);
         }


### PR DESCRIPTION
Fix #6724: guard against a null site name in SiteUtils
