### PR TITLE
Remove assignment of EditPostAcivityHook in onAttach

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -625,7 +625,11 @@ public class EditPostSettingsFragment extends Fragment {
 
     private EditPostActivityHook getHook() {
         Activity activity = getActivity();
-        if (activity != null && activity instanceof EditPostActivityHook) {
+        if (activity == null) {
+            return null;
+        }
+
+        if (activity instanceof EditPostActivityHook) {
             return (EditPostActivityHook) activity;
         } else {
             throw new RuntimeException(activity.toString() + " must implement EditPostActivityHook");

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -174,7 +174,7 @@ public class EditPostSettingsFragment extends Fragment {
                     @Override
                     public void onSettingsUpdated(Exception error) {
                         // EditPostActivityHook will be null if the fragment is detached
-                        if (error == null && getHook() != null) {
+                        if (error == null && getEditPostActivityHook() != null) {
                             updatePostFormat(mSiteSettings.getDefaultPostFormat());
                         }
                     }
@@ -608,22 +608,22 @@ public class EditPostSettingsFragment extends Fragment {
     // Helpers
 
     private PostModel getPost() {
-        if (getHook() == null) {
+        if (getEditPostActivityHook() == null) {
             // This can only happen during a callback while activity is re-created for some reason (config changes etc)
             return null;
         }
-        return getHook().getPost();
+        return getEditPostActivityHook().getPost();
     }
 
     private SiteModel getSite() {
-        if (getHook() == null) {
+        if (getEditPostActivityHook() == null) {
             // This can only happen during a callback while activity is re-created for some reason (config changes etc)
             return null;
         }
-        return getHook().getSite();
+        return getEditPostActivityHook().getSite();
     }
 
-    private EditPostActivityHook getHook() {
+    private EditPostActivityHook getEditPostActivityHook() {
         Activity activity = getActivity();
         if (activity == null) {
             return null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -102,7 +102,6 @@ public class EditPostSettingsFragment extends Fragment {
     private static final int SELECT_LIBRARY_MENU_POSITION = 100;
     private static final int CLEAR_FEATURED_IMAGE_MENU_POSITION = 101;
 
-    private EditPostActivityHook mEditPostActivityHook;
     private SiteSettingsInterface mSiteSettings;
 
     private LinearLayout mCategoriesContainer;
@@ -174,8 +173,8 @@ public class EditPostSettingsFragment extends Fragment {
                 new SiteSettingsListener() {
                     @Override
                     public void onSettingsUpdated(Exception error) {
-                        // mEditPostActivityHook will be null if the fragment is detached
-                        if (error == null && mEditPostActivityHook != null) {
+                        // EditPostActivityHook will be null if the fragment is detached
+                        if (error == null && getHook() != null) {
                             updatePostFormat(mSiteSettings.getDefaultPostFormat());
                         }
                     }
@@ -194,23 +193,6 @@ public class EditPostSettingsFragment extends Fragment {
             // init will fetch remote settings for us
             mSiteSettings.init(true);
         }
-    }
-
-    @SuppressWarnings("deprecation")
-    @Override
-    public void onAttach(Activity activity) {
-        super.onAttach(activity);
-        if (activity instanceof EditPostActivityHook) {
-            mEditPostActivityHook = (EditPostActivityHook) activity;
-        } else {
-            throw new RuntimeException(activity.toString() + " must implement PostSettingsListener");
-        }
-    }
-
-    @Override
-    public void onDetach() {
-        super.onDetach();
-        mEditPostActivityHook = null;
     }
 
     @Override
@@ -626,19 +608,28 @@ public class EditPostSettingsFragment extends Fragment {
     // Helpers
 
     private PostModel getPost() {
-        if (mEditPostActivityHook == null) {
+        if (getHook() == null) {
             // This can only happen during a callback while activity is re-created for some reason (config changes etc)
             return null;
         }
-        return mEditPostActivityHook.getPost();
+        return getHook().getPost();
     }
 
     private SiteModel getSite() {
-        if (mEditPostActivityHook == null) {
+        if (getHook() == null) {
             // This can only happen during a callback while activity is re-created for some reason (config changes etc)
             return null;
         }
-        return mEditPostActivityHook.getSite();
+        return getHook().getSite();
+    }
+
+    private EditPostActivityHook getHook() {
+        Activity activity = getActivity();
+        if (activity != null && activity instanceof EditPostActivityHook) {
+            return (EditPostActivityHook) activity;
+        } else {
+            throw new RuntimeException(activity.toString() + " must implement EditPostActivityHook");
+        }
     }
 
     private void updateSaveButton() {


### PR DESCRIPTION
Fixes #6721  (hopefully)

This PR gets the EditPostActivityHook interface instance through calling `getActivity()`, to get the freshest copy each time, instead of relying on `onAttach` being callled


#### Explanation

Ok so, the only way both `getPost()` and `getSite()` return null is for `mEditPostActivityHook` to be null (see also https://github.com/wordpress-mobile/WordPress-Android/pull/6709). That in turn means that `onAttach` is not executed, because that’s the only place where `mEditPostActivityHook` gets assigned a value.
The `EditPostSettingsFragment` lives behind a `FragmentPagerAdapter`, so this is what is handling their lifecycle (`FragmentManager`)  rather than the Activity (`EditPostActivity`)  in a direct way. 
I’ve been looking into possible problems like having the FragmentPagerAdapter not be calling `onAttach` or so, but didn’t find anything consistent.

As per my local tests running Android 8 `onAttach(Context)` seems to get called every time, and as expected these 3 fragments that live in the adapter when editing a Post are created pretty much right away after instantiating the `EditPostActivity`.

Looking into the Crashlytics session logs I can see the crash happens on healthy (somewhat good memory levels) conditions and EditPost activity is the last activity to be created ofc, and judging from the logs the latest thing to happen is some kind of fetching, specifically `SiteActionBuilder.newFetchPostFormatsAction()` or `TaxonomyActionBuilder.newFetchCategoriesAction(siteModel)`.

I came up with this hypothesis here: 
1) Given the order in which methods are executed should be this (https://developer.android.com/guide/components/fragments.html#Lifecycle):
-onAttach, onCreate, onCreateView, onActivityCreated, onStart, onResume —> onPause, onStop, onDestroyView, onDestroy, onDetach.

2) Also, considered that onAttach seems to not be executed all times as per other people’s findings (URL https://stackoverflow.com/questions/32083053/android-fragment-onattach-deprecated).

3) Furthermore, the NPE happens in `onActivityCreated`, which is supposed to be executed immediately after `onAttach`, therefore, it is clear that `onAttach` is not being executed.
(the other crash that #6709 fixed we had it ocurr in `onCreateView`, which also is supposed to be created after `onAttach` gets called).

4) finally, we know the FluxC calls are happening, so the dispatcher registering (which happens in `onCreate`) is getting executed for sure.


Why is onAttach not being executed here? I don’t have an answer to that yet, but I’ve searched elsewhere in the app and we use the same mechanism in various parts of it, the only difference being that this particular fragment is behind a `FragmentPagerAdapter` and not directly attached to an Activity, as explained at the beginning.

The next possibility that comes to mind is to use `getActivity()` so we always get the freshest copy, and check that it’s not null and is of type `EditPostActivityHook` as well.

Therefore, what we’ll try in this PR is to get the reference to the Activity, each time we need it, by eliminating the class member `mEditPostActivityHook ` and making sure we always get the latest reference to whichever Activity we’re attached to by calling `getActivity()`. 

cc @maxme 
