### PR TITLE
Allow editing with Aztec in landscape orientation

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1046,9 +1046,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public boolean onTouch(View view, MotionEvent event) {
-        if (event.getAction() == MotionEvent.ACTION_UP) {
-            // If the WebView or EditText has received a touch event, the keyboard will be displayed and the action bar
-            // should hide
+        // In landscape mode, if the title or content view has received a touch event, the keyboard will be
+        // displayed and the action bar should hide
+        if (event.getAction() == MotionEvent.ACTION_UP
+                && getResources().getConfiguration().orientation == Configuration.ORIENTATION_LANDSCAPE) {
             mHideActionBarOnSoftKeyboardUp = true;
             hideActionBarIfNeeded();
         }

--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
@@ -38,14 +38,14 @@
                     android:layout_toLeftOf="@+id/title_beta"
                     android:layout_toStartOf="@+id/title_beta"
                     android:layout_width="match_parent"
-                    android:padding="16dp"
+                    android:padding="@dimen/margin_extra_large"
                     android:fontFamily="serif"
                     android:textStyle="bold"
                     android:textSize="@dimen/aztec_title_size"
                     android:imeOptions="flagNoExtractUi"
                     aztec:lineSpacingExtra="@dimen/spacing_extra_title"
                     aztec:textColor="@color/grey_dark"
-                    aztec:textColorHint="@color/hint_text" >
+                    aztec:textColorHint="@color/hint_text">
                 </org.wordpress.aztec.AztecText>
 
                 <ImageButton
@@ -55,10 +55,10 @@
                     android:layout_alignParentEnd="true"
                     android:layout_alignParentRight="true"
                     android:layout_centerVertical="true"
-                    android:padding="@dimen/sourceview_side_margin"
-                    android:src="@drawable/ic_gridicons_help"
                     android:background="?android:attr/selectableItemBackground"
-                    android:contentDescription="@string/editor_title_beta">
+                    android:contentDescription="@string/editor_title_beta"
+                    android:padding="@dimen/margin_extra_large"
+                    android:src="@drawable/ic_gridicons_help">
                 </ImageButton>
 
             </RelativeLayout>

--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
@@ -42,6 +42,7 @@
                     android:fontFamily="serif"
                     android:textStyle="bold"
                     android:textSize="@dimen/aztec_title_size"
+                    android:imeOptions="flagNoExtractUi"
                     aztec:lineSpacingExtra="@dimen/spacing_extra_title"
                     aztec:textColor="@color/grey_dark"
                     aztec:textColorHint="@color/hint_text" >
@@ -88,6 +89,7 @@
                     android:paddingTop="16dp"
                     android:scrollbars="vertical"
                     android:fontFamily="serif"
+                    android:imeOptions="flagNoExtractUi"
                     aztec:bulletColor="@color/bullet"
                     aztec:bulletMargin="@dimen/bullet_margin"
                     aztec:bulletPadding="@dimen/bullet_padding"
@@ -125,8 +127,8 @@
                     android:background="@null"
                     android:textSize="14sp"
                     android:visibility="gone"
-                    android:fontFamily="monospace">
-                </org.wordpress.aztec.source.SourceViewEditText>
+                    android:fontFamily="monospace"
+                    android:imeOptions="flagNoExtractUi" />
 
             </FrameLayout>
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/AztecEditor-Android/issues/412

To test: Edit a post in portrait and switch to landscape, make sure the action bar is hidden when the software keyboard is visible and make sure the action bar is visible when the software keyboard is dismissed.

Note: it's very similar to https://github.com/wordpress-mobile/WordPress-Android/pull/5073
