### PR TITLE
Show progress while device image loads

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -317,6 +317,12 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
         }
 
         @Override
+        protected void onPreExecute() {
+            super.onPreExecute();
+            showProgress(true);
+        }
+
+        @Override
         protected Bitmap doInBackground(Void... params) {
             int orientation = ImageUtils.getImageOrientation(getActivity(), mMediaUri);
             byte[] bytes = ImageUtils.createThumbnailFromUri(
@@ -335,6 +341,7 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
                 } else {
                     showLoadingError();
                 }
+                showProgress(false);
             }
         }
     }


### PR DESCRIPTION
Fixes #6742 - a progress spinner is now shown while loading device images in the media preview.

To test:
* Open the editor
* Tap to add media
* Long press on a photo
* A progress bar now appears on the fullscreen preview while it loads

cc: @daniloercoli 
