### PR TITLE
Make sure a Post is not enqueued twice, and replace with latest copy

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -103,6 +103,15 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
     @Override
     public void upload(@NonNull PostModel post) {
         synchronized (sQueuedPostsList) {
+            // first check whether there was an old version of this Post still enqueued waiting
+            // for being uploaded
+            for (PostModel queuedPost : sQueuedPostsList) {
+                if (queuedPost.getId() == post.getId()) {
+                    // we found an older version, so let's remove it and replace it with the newest copy
+                    sQueuedPostsList.remove(queuedPost);
+                    break;
+                }
+            }
             sQueuedPostsList.add(post);
         }
         uploadNextPost();


### PR DESCRIPTION
Fixes #6739 

To test:
- There's no "easy" way to test this except by calling `upload()` on the same Post repeatedly in an artificial way (i.e. adding lines of code with duplicate calls).
- Another way to test is to create an artificially slow connection environment and enter/exit the Post Editor multiple times. Each time the editor is exited, a new copy of the Draft post will be sent to the upload queue by calling `upload()`.