### PR TITLE
Post information only added to notification for new Posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -180,9 +180,10 @@ public class UploadService extends Service {
 
             mPostUploadNotifier.cancelErrorNotification(post);
 
-            // is this a new post? only add count to the notification when the post is new
+            // is this a new post? only add count to the notification when the post is totally new
             // i.e. it still doesn't have any tracked state in the UploadStore
-            if (isThisPostTotallyNew(post)) {
+            // or it's a failed one the user is activley retrying.
+            if (isThisPostTotallyNewOrFailed(post)) {
                 mPostUploadNotifier.addPostInfoToForegroundNotification(post, null);
             }
 
@@ -197,7 +198,7 @@ public class UploadService extends Service {
         }
     }
 
-    private boolean isThisPostTotallyNew(PostModel post){
+    private boolean isThisPostTotallyNewOrFailed(PostModel post){
         // if we have any tracks for this Post's UploadState, this means this Post is not new.
         // Conditions under which the UploadStore would contain traces of this Post's UploadState are:
         // - it's been cancelled by entering/exiting/entering the editor thus cancelling the queued post upload
@@ -206,7 +207,7 @@ public class UploadService extends Service {
         // - it's a pending upload (it is currently registered for upload once the associated media finishes
         // uploading).
         PostUploadModel postUploadModel = UploadSqlUtils.getPostUploadModelForLocalId(post.getId());
-        return (postUploadModel == null);
+        return (postUploadModel == null) || (postUploadModel.getUploadState() == PostUploadModel.FAILED);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -17,7 +17,9 @@ import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.generated.UploadActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.model.PostUploadModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.persistence.UploadSqlUtils;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.store.PostStore;
@@ -178,17 +180,33 @@ public class UploadService extends Service {
 
             mPostUploadNotifier.cancelErrorNotification(post);
 
+            // is this a new post? only add count to the notification when the post is new
+            // i.e. it still doesn't have any tracked state in the UploadStore
+            if (isThisPostTotallyNew(post)) {
+                mPostUploadNotifier.addPostInfoToForegroundNotification(post, null);
+            }
+
             if (!hasPendingOrInProgressMediaUploadsForPost(post)) {
                 mPostUploadHandler.upload(post);
-                mPostUploadNotifier.addPostInfoToForegroundNotification(post, null);
             } else {
                 // Register the post (as PENDING) in the UploadStore, along with all media currently in progress for it
                 // If the post is already registered, the new media will be added to its list
                 List<MediaModel> activeMedia = MediaUploadHandler.getPendingOrInProgressMediaUploadsForPost(post);
                 mUploadStore.registerPostModel(post, activeMedia);
-                mPostUploadNotifier.addPostInfoToForegroundNotification(post, null);
             }
         }
+    }
+
+    private boolean isThisPostTotallyNew(PostModel post){
+        // if we have any tracks for this Post's UploadState, this means this Post is not new.
+        // Conditions under which the UploadStore would contain traces of this Post's UploadState are:
+        // - it's been cancelled by entering/exiting/entering the editor thus cancelling the queued post upload
+        // to allow for the user to keep editing it before sending to the server
+        // - it's a failed upload (due to some network issue, for example)
+        // - it's a pending upload (it is currently registered for upload once the associated media finishes
+        // uploading).
+        PostUploadModel postUploadModel = UploadSqlUtils.getPostUploadModelForLocalId(post.getId());
+        return (postUploadModel == null);
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -182,7 +182,7 @@ public class UploadService extends Service {
 
             // is this a new post? only add count to the notification when the post is totally new
             // i.e. it still doesn't have any tracked state in the UploadStore
-            // or it's a failed one the user is activley retrying.
+            // or it's a failed one the user is actively retrying.
             if (isThisPostTotallyNewOrFailed(post)) {
                 mPostUploadNotifier.addPostInfoToForegroundNotification(post, null);
             }


### PR DESCRIPTION
Fixes a count problem with the foreground progress notification. When starting a draft then exiting the editor, entering again, exiting again (repeat the cycle as many times you want) each time the total Posts count in the foreground notifications would increase, and it would read "Uploading 1/1 Posts", "Uploading 1/2 Posts", "Uploading 1/3 Posts", etc.

Now we're only counting new Posts that are sent to the UploadService.

To test:
**CASE A: no media**
1. start a draft 
2. write something
3. exit the editor
4. check the foreground notification appears and reads "Uploading 1/1 Post" (_please note wording will change to match the designs later_)

**CASE B: including media**
1. start a draft 
2. write something and include some media, perferably something that will take some time to upload, so it gives you time to exit and enter the editor repeatedly while some uploads are progressing
3. exit the editor
4. check the foreground notification appears and reads "Uploading 1/1 Post, 1/x media" (_please note wording will change to match the designs later_)
5. repeat steps 3 and 4 above repeatedly, check that the total amount of Posts doesn't get incremented each time.

**CASE C: no media, failed upload state**
Make sure you have connectivity but don't have access to the WordPress site. For example, by setting up a Proxy on the emulator/device but not making the proxy work, or by selectively aborting the connection to the `/posts/new` API endpoint using the proxy.
1. start a draft 
2. write something
3. exit the editor - here the app will try to upload the draft
4. check the foreground notification appears and reads "Uploading 1/1 Post" (_please note wording will change to match the designs later_)
5. Immediately after, this ends up in a error notification with the "GENERIC_ERROR" description.
6. Open the Post in the Editor again, and exit the editor once more
7. At this point, the Post would have been marked with a `FAILED` Upload State, and we want to make sure that foreground notifications for this kind of Post states also are shown. Therefore: please observe the notification appears.
8. Repeat steps 6 and 7 a couple of times, it should be the same every time.


cc @nbradbury 



