### PR TITLE
Upload foreground notification wording

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -446,22 +446,36 @@ class PostUploadNotifier {
     }
 
     private String buildNotificationSubtitleForMedia(){
-        String uploadingMessage = String.format(
-                mContext.getString(R.string.uploading_subtitle_media_only),
-                sNotificationData.totalMediaItems - getCurrentMediaItem(),
-                sNotificationData.totalMediaItems
-        );
+        String uploadingMessage;
+        if (sNotificationData.totalMediaItems == 1) {
+            uploadingMessage = mContext.getString(R.string.uploading_subtitle_media_only_one);
+        } else {
+            uploadingMessage = String.format(
+                    mContext.getString(R.string.uploading_subtitle_media_only),
+                    sNotificationData.totalMediaItems - getCurrentMediaItem(),
+                    sNotificationData.totalMediaItems
+            );
+        }
         return uploadingMessage;
     }
 
     private String buildNotificationSubtitleForMixedContent(){
-        String uploadingMessage = String.format(
-                mContext.getString(R.string.uploading_subtitle_mixed),
-                sNotificationData.totalPostItems - getCurrentPostItem(),
-                getPagesAndOrPostsString(),
-                sNotificationData.totalMediaItems - getCurrentMediaItem(),
-                sNotificationData.totalMediaItems
-        );
+        String uploadingMessage;
+        if (sNotificationData.totalMediaItems == 1) {
+            uploadingMessage = String.format(
+                    mContext.getString(R.string.uploading_subtitle_mixed_one),
+                    sNotificationData.totalPostItems - getCurrentPostItem(),
+                    getPagesAndOrPostsString()
+            );
+        } else {
+            uploadingMessage = String.format(
+                    mContext.getString(R.string.uploading_subtitle_mixed),
+                    sNotificationData.totalPostItems - getCurrentPostItem(),
+                    getPagesAndOrPostsString(),
+                    sNotificationData.totalMediaItems - getCurrentMediaItem(),
+                    sNotificationData.totalMediaItems
+            );
+        }
         return uploadingMessage;
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -400,8 +400,7 @@ class PostUploadNotifier {
     private String buildNotificationSubtitleForPost(PostModel post){
         String uploadingMessage = String.format(
                 mContext.getString(R.string.uploading_subtitle_posts_only),
-                getCurrentPostItem() + 1,
-                sNotificationData.totalPostItems,
+                sNotificationData.totalPostItems - getCurrentPostItem(),
                 (post != null && post.isPage()) ? mContext.getString(R.string.page).toLowerCase()
                         : mContext.getString(R.string.post).toLowerCase()
         );
@@ -412,8 +411,7 @@ class PostUploadNotifier {
         String pagesAndOrPosts = getPagesAndOrPostsString();
         String uploadingMessage = String.format(
                 mContext.getString(R.string.uploading_subtitle_posts_only),
-                getCurrentPostItem() + 1,
-                sNotificationData.totalPostItems,
+                sNotificationData.totalPostItems - getCurrentPostItem(),
                 pagesAndOrPosts
         );
         return uploadingMessage;
@@ -424,14 +422,24 @@ class PostUploadNotifier {
         if (sNotificationData.totalPageItemsIncludedInPostCount > 0 && sNotificationData.totalPostItems > 0
                 && sNotificationData.totalPostItems > sNotificationData.totalPageItemsIncludedInPostCount) {
             // we have both pages and posts
-            pagesAndOrPosts = mContext.getString(R.string.post).toLowerCase() + "/" +
-                    mContext.getString(R.string.page).toLowerCase();
+            pagesAndOrPosts = mContext.getString(R.string.posts).toLowerCase() + "/" +
+                    mContext.getString(R.string.pages).toLowerCase();
         } else if (sNotificationData.totalPageItemsIncludedInPostCount > 0) {
             // we have only pages
-            pagesAndOrPosts = mContext.getString(R.string.page).toLowerCase();
+            if (sNotificationData.totalPageItemsIncludedInPostCount == 1) {
+                // only one page
+                pagesAndOrPosts = mContext.getString(R.string.page).toLowerCase();
+            } else {
+                pagesAndOrPosts = mContext.getString(R.string.pages).toLowerCase();
+            }
         } else {
             // we have only posts
-            pagesAndOrPosts = mContext.getString(R.string.post).toLowerCase();
+            if (sNotificationData.totalPostItems == 1) {
+                // only one post
+                pagesAndOrPosts = mContext.getString(R.string.post).toLowerCase();
+            } else {
+                pagesAndOrPosts = mContext.getString(R.string.posts).toLowerCase();
+            }
         }
         return pagesAndOrPosts;
     }
@@ -439,7 +447,7 @@ class PostUploadNotifier {
     private String buildNotificationSubtitleForMedia(){
         String uploadingMessage = String.format(
                 mContext.getString(R.string.uploading_subtitle_media_only),
-                getCurrentMediaItem() + 1,
+                sNotificationData.totalMediaItems - getCurrentMediaItem(),
                 sNotificationData.totalMediaItems
         );
         return uploadingMessage;
@@ -448,10 +456,9 @@ class PostUploadNotifier {
     private String buildNotificationSubtitleForMixedContent(){
         String uploadingMessage = String.format(
                 mContext.getString(R.string.uploading_subtitle_mixed),
-                getCurrentPostItem() + 1,
-                sNotificationData.totalPostItems,
+                sNotificationData.totalPostItems - getCurrentPostItem(),
                 getPagesAndOrPostsString(),
-                getCurrentMediaItem() + 1,
+                sNotificationData.totalMediaItems - getCurrentMediaItem(),
                 sNotificationData.totalMediaItems
         );
         return uploadingMessage;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -36,7 +36,7 @@ class PostUploadNotifier {
     private final UploadService mService;
 
     private final NotificationManager mNotificationManager;
-    private final Notification.Builder mNotificationBuilder;
+    private final NotificationCompat.Builder mNotificationBuilder;
 
     // error notifications will remain visible until the user discards or acts upon them,
     // so we need to be able to map them to the Post that failed
@@ -63,8 +63,9 @@ class PostUploadNotifier {
         sNotificationData = new NotificationData();
         mNotificationManager = (NotificationManager) SystemServiceFactory.get(mContext,
                 Context.NOTIFICATION_SERVICE);
-        mNotificationBuilder = new Notification.Builder(mContext.getApplicationContext());
-        mNotificationBuilder.setSmallIcon(android.R.drawable.stat_sys_upload);
+        mNotificationBuilder = new NotificationCompat.Builder(mContext.getApplicationContext());
+        mNotificationBuilder.setSmallIcon(R.drawable.ic_my_sites_24dp)
+                .setColor(context.getResources().getColor(R.color.blue_wordpress));
     }
 
     private void updateForegroundNotification(@Nullable PostModel post) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -156,9 +156,6 @@ class PostUploadNotifier {
 
     void incrementUploadedPostCountFromForegroundNotification(@NonNull PostModel post) {
         sNotificationData.currentPostItem++;
-        if (post.isPage()) {
-            sNotificationData.totalPageItemsIncludedInPostCount--;
-        }
 
         // update Notification now
         if (!removeNotificationAndStopForegroundServiceIfNoItemsInQueue()) {
@@ -409,16 +406,17 @@ class PostUploadNotifier {
     }
 
     private String buildNotificationSubtitleForPosts(){
-        String pagesAndOrPosts = getPagesAndOrPostsString();
+        int remaining = sNotificationData.totalPostItems - getCurrentPostItem();
+        String pagesAndOrPosts = getPagesAndOrPostsString(remaining);
         String uploadingMessage = String.format(
                 mContext.getString(R.string.uploading_subtitle_posts_only),
-                sNotificationData.totalPostItems - getCurrentPostItem(),
+                remaining,
                 pagesAndOrPosts
         );
         return uploadingMessage;
     }
 
-    private String getPagesAndOrPostsString() {
+    private String getPagesAndOrPostsString(int remaining) {
         String pagesAndOrPosts;
         if (sNotificationData.totalPageItemsIncludedInPostCount > 0 && sNotificationData.totalPostItems > 0
                 && sNotificationData.totalPostItems > sNotificationData.totalPageItemsIncludedInPostCount) {
@@ -427,7 +425,7 @@ class PostUploadNotifier {
                     mContext.getString(R.string.pages).toLowerCase();
         } else if (sNotificationData.totalPageItemsIncludedInPostCount > 0) {
             // we have only pages
-            if (sNotificationData.totalPageItemsIncludedInPostCount == 1) {
+            if (remaining == 1) {
                 // only one page
                 pagesAndOrPosts = mContext.getString(R.string.page).toLowerCase();
             } else {
@@ -435,7 +433,7 @@ class PostUploadNotifier {
             }
         } else {
             // we have only posts
-            if (sNotificationData.totalPostItems == 1) {
+            if (remaining == 1) {
                 // only one post
                 pagesAndOrPosts = mContext.getString(R.string.post).toLowerCase();
             } else {
@@ -460,18 +458,19 @@ class PostUploadNotifier {
     }
 
     private String buildNotificationSubtitleForMixedContent(){
+        int remaining = sNotificationData.totalPostItems - getCurrentPostItem();
         String uploadingMessage;
         if (sNotificationData.totalMediaItems == 1) {
             uploadingMessage = String.format(
                     mContext.getString(R.string.uploading_subtitle_mixed_one),
-                    sNotificationData.totalPostItems - getCurrentPostItem(),
-                    getPagesAndOrPostsString()
+                    remaining,
+                    getPagesAndOrPostsString(remaining)
             );
         } else {
             uploadingMessage = String.format(
                     mContext.getString(R.string.uploading_subtitle_mixed),
                     sNotificationData.totalPostItems - getCurrentPostItem(),
-                    getPagesAndOrPostsString(),
+                    getPagesAndOrPostsString(remaining),
                     sNotificationData.totalMediaItems - getCurrentMediaItem(),
                     sNotificationData.totalMediaItems
             );

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -430,8 +430,10 @@
     <string name="sending_content">Uploading %s content…</string>
     <string name="uploading_title">Uploading…</string>
     <string name="uploading_subtitle_mixed">%1$d %2$s, %3$d of %4$d media files remaining</string>
+    <string name="uploading_subtitle_mixed_one">%1$d %2$s, 1 media file remaining</string>
     <string name="uploading_subtitle_posts_only">%1$d %2$s remaining</string>
     <string name="uploading_subtitle_media_only">%1$d of %2$d media files remaining</string>
+    <string name="uploading_subtitle_media_only_one">1 media file remaining</string>
     <string name="uploading_total">Uploading %1$d of %2$d</string>
     <string name="uploading_post_media">Uploading media…</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -429,9 +429,9 @@
     <string name="update_verb">Update</string>
     <string name="sending_content">Uploading %s content…</string>
     <string name="uploading_title">Uploading…</string>
-    <string name="uploading_subtitle_mixed">%1$d/%2$d %3$s, %4$d/%5$d media items</string>
-    <string name="uploading_subtitle_posts_only">%1$d/%2$d %3$s</string>
-    <string name="uploading_subtitle_media_only">%1$d/%2$d media items</string>
+    <string name="uploading_subtitle_mixed">%1$d %2$s, %3$d of %4$d media files remaining</string>
+    <string name="uploading_subtitle_posts_only">%1$d %2$s remaining</string>
+    <string name="uploading_subtitle_media_only">%1$d of %2$d media files remaining</string>
     <string name="uploading_total">Uploading %1$d of %2$d</string>
     <string name="uploading_post_media">Uploading media…</string>
 


### PR DESCRIPTION
Brings the notification wording and L&F as per the designs in #6735 and discussed in https://github.com/wordpress-mobile/WordPress-Android/pull/6713#issuecomment-337594615 :

<img width="421" alt="screen shot 2017-10-18 at 6 23 26 pm" src="https://user-images.githubusercontent.com/6597771/31743631-08b0a44e-b45c-11e7-915c-dcfc6b0be16f.png">

Unique post case (majority of cases):
- `1 post, 3 of 12 media files remaining`

Unique post case, no media:
- `1 post`

Mixed case (pages and posts):
- `2 posts/pages, 3 of 12 media files remaining`
Note that for this case I decided to keep the `posts/pages` abbreviation instead of showing `1 post, 1 page` format as it takes too much of the screen width and would make the full description not read clearly.

Media only:
- `3 of 12 media files remaining`

Also note the Title reads "Uploading..." instead of using the full site domain for the same reasons noted above

cc @nbradbury 