### PR TITLE
Prevent showing error notification for user-cancelled media uploads

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -474,8 +474,10 @@ public class UploadService extends Service {
         SiteModel site = mSiteStore.getSiteByLocalId(postToCancel.getLocalSiteId());
         mPostUploadNotifier.cancelNotification(postToCancel);
 
-        if (mUploadStore.isPendingPost(postToCancel) || mUploadStore.isCancelledPost(postToCancel)) {
-            // Only show the media upload error notification if the post is registered in the UploadStore
+        if (!mUploadStore.isPendingPost(postToCancel) && !mUploadStore.isCancelledPost(postToCancel)) {
+            // Only show the media upload error notification if the post is NOT registered in the UploadStore
+            // - otherwise if it IS registered in the UploadStore and we get a `cancelled` signal it means
+            // the user actively cancelled it. No need to show an error then.
             String message = UploadUtils.getErrorMessage(this, postToCancel, errorMessage, true);
             mPostUploadNotifier.updateNotificationError(postToCancel, site, message);
         }


### PR DESCRIPTION

Fixes #6750 

To test:
1. start a draft
2. include a media item (large enough)
3. exit the editor (this triggers the Post to be registered in the `UploadStore`)
4. open the editor once more
5. tap on the image
6. observe the `"stop uploading?"` dialog appears
7. tap YES
8. observe no error notification is shown.

cc @daniloercoli 

PS this was most probably a mis-translation [from old code](https://github.com/wordpress-mobile/WordPress-Android/blob/bfc8584d990350e960bfae33c28cb8059fdd87be/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java#L656-L665)  to the new code with the introduction of the `UploadStore` in FluxC.