### PR TITLE
Don't show error notification for user-cancelled or deleted Posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -17,7 +17,9 @@ import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.generated.UploadActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.PostModel;
+import org.wordpress.android.fluxc.model.PostUploadModel;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.persistence.UploadSqlUtils;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.store.PostStore;
@@ -474,7 +476,10 @@ public class UploadService extends Service {
         SiteModel site = mSiteStore.getSiteByLocalId(postToCancel.getLocalSiteId());
         mPostUploadNotifier.cancelNotification(postToCancel);
 
-        if (!mUploadStore.isPendingPost(postToCancel) && !mUploadStore.isCancelledPost(postToCancel)) {
+        PostUploadModel postUploadModel = UploadSqlUtils.getPostUploadModelForLocalId(postToCancel.getId());
+        if ((postUploadModel != null)
+                && postUploadModel.getUploadState() != PostUploadModel.PENDING
+                && postUploadModel.getUploadState() != PostUploadModel.CANCELLED) {
             // Only show the media upload error notification if the post is NOT registered in the UploadStore
             // - otherwise if it IS registered in the UploadStore and we get a `cancelled` signal it means
             // the user actively cancelled it. No need to show an error then.


### PR DESCRIPTION

Fixes #6750 in a better way than #6751 which didn't take into account the possibility for `PostUploadModel` to be directly null in the `UploadStore`. This PR takes this into account by performing a similar check [as done here](https://github.com/wordpress-mobile/WordPress-Android/pull/6747/files#diff-f2fb34949cc4079ca380e84dfe642d72R209)

To test:
**CASE 1:**
1. start a draft
2. include a media item (large enough)
3. exit the editor (this triggers the Post to be registered in the `UploadStore`)
4. open the editor once more
5. tap on the image
6. observe the `"stop uploading?"` dialog appears
7. tap YES
8. observe no error notification is shown.

**CASE 2:**
1. Start a new post and add several media
2. Publish it!
3. On the posts list select the post and erase it while media is uploading.
4. Observe there is no new error notification coming up.


cc @daniloercoli 

