### PR TITLE
Update Dagger version to 2.11

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -139,7 +139,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:6603e2cf5c58f764169e842c676b14fb7ff01fdb') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:use-dagger-2.11-SNAPSHOT') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -135,8 +135,8 @@ dependencies {
     compile 'org.wordpress:passcodelock:1.5.1'
 
     // Dagger
-    compile 'com.google.dagger:dagger:2.0.2'
-    apt 'com.google.dagger:dagger-compiler:2.0.2'
+    compile 'com.google.dagger:dagger:2.11'
+    apt 'com.google.dagger:dagger-compiler:2.11'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
     compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:use-dagger-2.11-SNAPSHOT') {

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -139,7 +139,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.11'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:use-dagger-2.11-SNAPSHOT') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:a233d19c851c8859f77a1825cee70d9958067089') {
         exclude group: "com.android.volley";
     }
 


### PR DESCRIPTION
Brings in the changes from https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/586, and increases the Dagger version used to match FluxC's.

https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/586 should be merged first, and the FluxC hash updated in this PR.

**To test:**
Nothing should be changed - the app should build and FluxC requests should work.