### PR TITLE
we now make sure an involuntary error is shown to the user

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -469,7 +469,7 @@ public class UploadService extends Service {
         }
     }
 
-    private void cancelPostUploadMatchingMedia(@NonNull MediaModel media, String errorMessage) {
+    private void cancelPostUploadMatchingMedia(@NonNull MediaModel media, String errorMessage, boolean showError) {
         PostModel postToCancel = mPostStore.getPostByLocalPostId(media.getLocalPostId());
         if (postToCancel == null) return;
 
@@ -477,9 +477,9 @@ public class UploadService extends Service {
         mPostUploadNotifier.cancelNotification(postToCancel);
 
         PostUploadModel postUploadModel = UploadSqlUtils.getPostUploadModelForLocalId(postToCancel.getId());
-        if ((postUploadModel != null)
+        if (showError || ((postUploadModel != null)
                 && postUploadModel.getUploadState() != PostUploadModel.PENDING
-                && postUploadModel.getUploadState() != PostUploadModel.CANCELLED) {
+                && postUploadModel.getUploadState() != PostUploadModel.CANCELLED)) {
             // Only show the media upload error notification if the post is NOT registered in the UploadStore
             // - otherwise if it IS registered in the UploadStore and we get a `cancelled` signal it means
             // the user actively cancelled it. No need to show an error then.
@@ -507,7 +507,7 @@ public class UploadService extends Service {
                 AppLog.w(T.MAIN, "UploadService > Media upload failed for post " + event.media.getLocalPostId() + " : "
                         + event.error.type + ": " + event.error.message);
                 String errorMessage = UploadUtils.getErrorMessageFromMediaError(this, event.media, event.error);
-                cancelPostUploadMatchingMedia(event.media, errorMessage);
+                cancelPostUploadMatchingMedia(event.media, errorMessage, true);
             }
             stopServiceIfUploadsComplete();
             return;
@@ -517,7 +517,7 @@ public class UploadService extends Service {
             if (event.media.getLocalPostId() > 0) {
                 AppLog.i(T.MAIN, "UploadService > Upload cancelled for post with id " + event.media.getLocalPostId()
                         + " - a media upload for this post has been cancelled, id: " + event.media.getId());
-                cancelPostUploadMatchingMedia(event.media, getString(R.string.error_media_canceled));
+                cancelPostUploadMatchingMedia(event.media, getString(R.string.error_media_canceled), false);
             }
             stopServiceIfUploadsComplete();
             return;


### PR DESCRIPTION
This PR https://github.com/wordpress-mobile/WordPress-Android/pull/6752  had an error: if a network error caused some upload to stop, this wouldn't generate the proper error notification.

Explanation: ee were missing one case, when `OnMediaUploaded` event `isError() == true` we should show the error message as it was not a voluntary cancellation by the user.

To test:
**CASE 1:**
1. start a draft
2. include a media item (large enough)
3. exit the editor (this triggers the Post to be registered in the `UploadStore`)
4. open the editor once more
5. tap on the image
6. observe the `"stop uploading?"` dialog appears
7. tap YES
8. observe no error notification is shown.

**CASE 2:**
1. Start a new post and add several media
2. Publish it!
3. On the posts list select the post and erase it while media is uploading.
4. Observe there is no new error notification coming up.

**CASE 3: (NEW)**
1. Start a new post and add several media
2. send the app to the background
3. turn airplane mode ON
4. Observe there is a new error notification coming up. (there wasn't one coming up before this PR)

cc @daniloercoli 

