### PR TITLE
Simplify check for a failed Post

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:185cb8bc887f90dc5ae4cfeea2ec4d2d52f195ed') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:6422c5020f442bbe42003cb1ae887b8f898e1d2d') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:6422c5020f442bbe42003cb1ae887b8f898e1d2d') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:185cb8bc887f90dc5ae4cfeea2ec4d2d52f195ed') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -17,7 +17,6 @@ import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.generated.UploadActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.PostModel;
-import org.wordpress.android.fluxc.model.PostUploadModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -19,7 +19,6 @@ import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.PostUploadModel;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.persistence.UploadSqlUtils;
 import org.wordpress.android.fluxc.store.MediaStore;
 import org.wordpress.android.fluxc.store.MediaStore.OnMediaUploaded;
 import org.wordpress.android.fluxc.store.PostStore;
@@ -476,10 +475,7 @@ public class UploadService extends Service {
         SiteModel site = mSiteStore.getSiteByLocalId(postToCancel.getLocalSiteId());
         mPostUploadNotifier.cancelNotification(postToCancel);
 
-        PostUploadModel postUploadModel = UploadSqlUtils.getPostUploadModelForLocalId(postToCancel.getId());
-        if (showError || ((postUploadModel != null)
-                && postUploadModel.getUploadState() != PostUploadModel.PENDING
-                && postUploadModel.getUploadState() != PostUploadModel.CANCELLED)) {
+        if (showError || mUploadStore.isFailedPost(postToCancel)) {
             // Only show the media upload error notification if the post is NOT registered in the UploadStore
             // - otherwise if it IS registered in the UploadStore and we get a `cancelled` signal it means
             // the user actively cancelled it. No need to show an error then.


### PR DESCRIPTION
Re-work for the change introduced in https://github.com/wordpress-mobile/WordPress-Android/pull/6752  with a simplified expression as suggested by @aforcier 

To test:
**CASE 1:**
1. start a draft
2. include a media item (large enough)
3. exit the editor (this triggers the Post to be registered in the `UploadStore`)
4. open the editor once more
5. tap on the image
6. observe the `"stop uploading?"` dialog appears
7. tap YES
8. observe no error notification is shown.

**CASE 2:**
1. Start a new post and add several media
2. Publish it!
3. On the posts list select the post and erase it while media is uploading.
4. Observe there is no new error notification coming up.

cc @aforcier 