### PR TITLE
Comments: Update REST call with parameter that forces Jetpack sites to return i_like field

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:6422c5020f442bbe42003cb1ae887b8f898e1d2d') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:a1d9db60030547224df9dc9ebcd3d1c351da1577') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:a1d9db60030547224df9dc9ebcd3d1c351da1577') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:28698747680c4acc9d9dcc85e26a19d755c9f2f6') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderCommentService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderCommentService.java
@@ -131,6 +131,7 @@ public class ReaderCommentService extends Service {
         String path = "sites/" + blogId + "/posts/" + postId + "/replies/"
                     + "?number=" + Integer.toString(ReaderConstants.READER_MAX_COMMENTS_TO_REQUEST)
                     + "&meta=likes"
+                    + "&force=wpcom"
                     + "&hierarchical=true"
                     + "&order=ASC"
                     + "&page=" + pageNumber;


### PR DESCRIPTION
Fixes a Jetpack site REST issue related to #5618.

To test:
* Set `canShowComments` to `true` in [ReaderPostAdapter](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java#L763)
* Set a breakpoint in the response handler in [ReaderCommentService](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ReaderCommentService.java#L141)
* Select the comment icon in the Reader on a post from a Jetpack site
* Verify the `i_like` field is available in the response object

cc @oguzkocer, ~~wordpress-mobile/WordPress-FluxC-Android#593 needs to be merged first and the FluxC hash needs to be updated in this PR.~~