### PR TITLE
Check for failed Post before showing progress bar in Posts list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -418,7 +418,8 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     }
 
     private void updatePostUploadProgressBar(ProgressBar view, PostModel post) {
-        if (UploadService.isPostUploadingOrQueued(post) || UploadService.hasInProgressMediaUploadsForPost(post)) {
+        if (mUploadStore.isFailedPost(post) &&
+                (UploadService.isPostUploadingOrQueued(post) || UploadService.hasInProgressMediaUploadsForPost(post))) {
             view.setVisibility(View.VISIBLE);
             int overallProgress = Math.round(UploadService.getMediaUploadProgressForPost(post) * 100);
             // Sometimes the progress bar can be stuck at 100% for a long time while further processing happens

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -418,7 +418,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     }
 
     private void updatePostUploadProgressBar(ProgressBar view, PostModel post) {
-        if (mUploadStore.isFailedPost(post) &&
+        if (!mUploadStore.isFailedPost(post) &&
                 (UploadService.isPostUploadingOrQueued(post) || UploadService.hasInProgressMediaUploadsForPost(post))) {
             view.setVisibility(View.VISIBLE);
             int overallProgress = Math.round(UploadService.getMediaUploadProgressForPost(post) * 100);


### PR DESCRIPTION
Fixes #6781 

In FluxC, the order of events is not guaranteed, thus it can happen that after getting a signal that 
 a Post upload has failed we still receive "older" progress events for the attached media upload. This PR adds a `isFailed` check to make sure we don't show a progress bar when the `UploadStore` knows this is Post is failed already.


To test:
1. draft a post with several files in it
2. exit the editor
3. turn airplane mode off (you might have to do this several times)
4. eventually you'll get to this situation in `develop`, and should not see that happen on this branch.

cc @nbradbury 
