### PR TITLE
Async notifications: media-only success notifications (part IV)

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -519,7 +519,7 @@ public class MySiteFragment extends Fragment
     public void onEventMainThread(UploadService.UploadMediaSuccessEvent event) {
         if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
             UploadUtils.onMediaUploadedSnackbarHandler(getActivity(),
-                    getActivity().findViewById(R.id.coordinator), true,
+                    getActivity().findViewById(R.id.coordinator), false,
                     event.mediaModelList, event.successMessage);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -511,16 +511,17 @@ public class MySiteFragment extends Fragment
         else if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
             UploadUtils.onMediaUploadedSnackbarHandler(getActivity(),
                     getActivity().findViewById(R.id.coordinator), true,
-                    event.mediaModelList, event.errorMessage);
+                    event.mediaModelList, site, event.errorMessage);
         }
     }
 
     @SuppressWarnings("unused")
     public void onEventMainThread(UploadService.UploadMediaSuccessEvent event) {
-        if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
+        SiteModel site = getSelectedSite();
+        if (site != null && event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
             UploadUtils.onMediaUploadedSnackbarHandler(getActivity(),
                     getActivity().findViewById(R.id.coordinator), false,
-                    event.mediaModelList, event.successMessage);
+                    event.mediaModelList, site, event.successMessage);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -515,6 +515,15 @@ public class MySiteFragment extends Fragment
         }
     }
 
+    @SuppressWarnings("unused")
+    public void onEventMainThread(UploadService.UploadMediaSuccessEvent event) {
+        if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
+            UploadUtils.onMediaUploadedSnackbarHandler(getActivity(),
+                    getActivity().findViewById(R.id.coordinator), true,
+                    event.mediaModelList, event.successMessage);
+        }
+    }
+
 
     // FluxC events
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -1085,4 +1085,13 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         }
     }
 
+    @SuppressWarnings("unused")
+    public void onEventMainThread(UploadService.UploadMediaSuccessEvent event) {
+        if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
+            UploadUtils.onMediaUploadedSnackbarHandler(this,
+                    findViewById(R.id.tab_layout), true,
+                    event.mediaModelList, event.successMessage);
+        }
+    }
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -1081,7 +1081,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
             UploadUtils.onMediaUploadedSnackbarHandler(this,
                     findViewById(R.id.tab_layout), true,
-                    event.mediaModelList, event.errorMessage);
+                    event.mediaModelList, mSite, event.errorMessage);
         }
     }
 
@@ -1090,7 +1090,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
             UploadUtils.onMediaUploadedSnackbarHandler(this,
                     findViewById(R.id.tab_layout), false,
-                    event.mediaModelList, event.successMessage);
+                    event.mediaModelList, mSite, event.successMessage);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -1089,7 +1089,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     public void onEventMainThread(UploadService.UploadMediaSuccessEvent event) {
         if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
             UploadUtils.onMediaUploadedSnackbarHandler(this,
-                    findViewById(R.id.tab_layout), true,
+                    findViewById(R.id.tab_layout), false,
                     event.mediaModelList, event.successMessage);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1768,12 +1768,14 @@ public class EditPostActivity extends AppCompatActivity implements
 
         boolean titleChanged = PostUtils.updatePostTitleIfDifferent(mPost, title);
         boolean contentChanged;
-        if (compareCurrentMediaMarkedUploadingToOriginal(content)) {
+        if (mMediaInsertedOnCreation) {
+            mMediaInsertedOnCreation = false;
+            contentChanged = true;
+        } else if (compareCurrentMediaMarkedUploadingToOriginal(content)) {
             contentChanged = true;
         } else if (mEditorFragment instanceof AztecEditorFragment
                 && ((AztecEditorFragment) mEditorFragment).isHistoryEnabled()) {
-            contentChanged = ((AztecEditorFragment) mEditorFragment).hasHistory() || mMediaInsertedOnCreation;
-            mMediaInsertedOnCreation = false;
+            contentChanged = ((AztecEditorFragment) mEditorFragment).hasHistory();
         } else {
             contentChanged = mPost.getContent().compareTo(content) != 0;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2631,6 +2631,8 @@ public class EditPostActivity extends AppCompatActivity implements
         // check whether we have media items to insert from the WRITE POST with media functionality
         if (getIntent().hasExtra(EXTRA_INSERT_MEDIA)) {
             List<MediaModel> mediaList = (List<MediaModel>) getIntent().getSerializableExtra(EXTRA_INSERT_MEDIA);
+            // removing this from the intent so it doesn't insert the media items again on each Acivity re-creation
+            getIntent().removeExtra(EXTRA_INSERT_MEDIA);
             if (mediaList != null && !mediaList.isEmpty()) {
                 shouldFinishInit = false;
                 mMediaInsertedOnCreation = true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -186,6 +186,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private Handler mHandler;
     private boolean mShowAztecEditor;
     private boolean mShowNewEditor;
+    private boolean mMediaInsertedOnCreation;
 
     private List<String> mPendingVideoPressInfoRequests;
     private List<String> mAztecBackspaceDeletedMediaItemIds = new ArrayList<>();
@@ -1771,7 +1772,8 @@ public class EditPostActivity extends AppCompatActivity implements
             contentChanged = true;
         } else if (mEditorFragment instanceof AztecEditorFragment
                 && ((AztecEditorFragment) mEditorFragment).isHistoryEnabled()) {
-            contentChanged = ((AztecEditorFragment) mEditorFragment).hasHistory();
+            contentChanged = ((AztecEditorFragment) mEditorFragment).hasHistory() || mMediaInsertedOnCreation;
+            mMediaInsertedOnCreation = false;
         } else {
             contentChanged = mPost.getContent().compareTo(content) != 0;
         }
@@ -2629,13 +2631,19 @@ public class EditPostActivity extends AppCompatActivity implements
             List<MediaModel> mediaList = (List<MediaModel>) getIntent().getSerializableExtra(EXTRA_INSERT_MEDIA);
             if (mediaList != null && !mediaList.isEmpty()) {
                 shouldFinishInit = false;
+                mMediaInsertedOnCreation = true;
                 for (MediaModel media : mediaList) {
                     addExistingMediaToEditor(media.getMediaId());
                 }
                 savePostAsync(new AfterSavePostListener() {
                     @Override
                     public void onPostSave() {
-                        onEditorFinalTouchesBeforeShowing();
+                        runOnUiThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                onEditorFinalTouchesBeforeShowing();
+                            }
+                        });
                     }
                 });
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -759,7 +759,7 @@ public class PostsListFragment extends Fragment
     public void onEventMainThread(UploadService.UploadMediaSuccessEvent event) {
         if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
             UploadUtils.onMediaUploadedSnackbarHandler(getActivity(),
-                    getActivity().findViewById(R.id.coordinator), true,
+                    getActivity().findViewById(R.id.coordinator), false,
                     event.mediaModelList, event.successMessage);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -754,4 +754,14 @@ public class PostsListFragment extends Fragment
                     event.mediaModelList, event.errorMessage);
         }
     }
+
+    @SuppressWarnings("unused")
+    public void onEventMainThread(UploadService.UploadMediaSuccessEvent event) {
+        if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
+            UploadUtils.onMediaUploadedSnackbarHandler(getActivity(),
+                    getActivity().findViewById(R.id.coordinator), true,
+                    event.mediaModelList, event.successMessage);
+        }
+    }
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -751,7 +751,7 @@ public class PostsListFragment extends Fragment
         else if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
             UploadUtils.onMediaUploadedSnackbarHandler(getActivity(),
                     getActivity().findViewById(R.id.coordinator), true,
-                    event.mediaModelList, event.errorMessage);
+                    event.mediaModelList, mSite, event.errorMessage);
         }
     }
 
@@ -760,7 +760,7 @@ public class PostsListFragment extends Fragment
         if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
             UploadUtils.onMediaUploadedSnackbarHandler(getActivity(),
                     getActivity().findViewById(R.id.coordinator), false,
-                    event.mediaModelList, event.successMessage);
+                    event.mediaModelList, mSite, event.successMessage);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -570,7 +570,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
         } else {
             mPostUploadNotifier.incrementUploadedPostCountFromForegroundNotification(event.post);
             boolean isFirstTimePublish = sFirstPublishPosts.remove(event.post.getId());
-            mPostUploadNotifier.updateNotificationSuccess(event.post, site, isFirstTimePublish);
+            mPostUploadNotifier.updateNotificationSuccessForPost(event.post, site, isFirstTimePublish);
             if (isFirstTimePublish) {
                 if (sCurrentUploadingPostAnalyticsProperties != null){
                     sCurrentUploadingPostAnalyticsProperties.put("post_id", event.post.getRemotePostId());

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -16,8 +16,10 @@ import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.model.PostModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.post.PostStatus;
+import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.notifications.ShareAndDismissNotificationReceiver;
+import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.posts.PostsListActivity;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -234,16 +236,16 @@ class PostUploadNotifier {
         mNotificationManager.cancel((int)getNotificationIdForPost(post));
     }
 
-    void cancelFinalNotificationForMedia() {
-        mNotificationManager.cancel((int)getNotificationIdForMedia());
+    void cancelFinalNotificationForMedia(@NonNull SiteModel site) {
+        mNotificationManager.cancel((int)getNotificationIdForMedia(site));
     }
 
-    void updateNotificationSuccess(@NonNull PostModel post, @NonNull SiteModel site, boolean isFirstTimePublish) {
+    void updateNotificationSuccessForPost(@NonNull PostModel post, @NonNull SiteModel site, boolean isFirstTimePublish) {
         if (!WordPress.sAppIsInTheBackground) {
             // only produce success notifications for the user if the app is in the background
             return;
         }
-        AppLog.d(AppLog.T.POSTS, "updateNotificationSuccess");
+        AppLog.d(AppLog.T.POSTS, "updateNotificationSuccessForPost");
 
         // Get the shareableUrl
         String shareableUrl = WPMeShortlinks.getPostShortlink(site, post);
@@ -320,6 +322,65 @@ class PostUploadNotifier {
         doNotify(notificationId, notificationBuilder.build());
     }
 
+    void updateNotificationSuccessForMedia(@NonNull List<MediaModel> mediaList, @NonNull SiteModel site) {
+        if (!WordPress.sAppIsInTheBackground) {
+            // only produce success notifications for the user if the app is in the background
+            return;
+        }
+        AppLog.d(AppLog.T.MEDIA, "updateNotificationSuccessForMedia");
+
+        NotificationCompat.Builder notificationBuilder =
+                new NotificationCompat.Builder(mContext.getApplicationContext());
+
+        long notificationId = getNotificationIdForMedia(site);
+        // Tap notification intent (open the media browser)
+        Intent notificationIntent = new Intent(mContext, MediaBrowserActivity.class);
+        notificationIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        notificationIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        notificationIntent.putExtra(WordPress.SITE, site);
+        notificationIntent.setAction(String.valueOf(notificationId));
+
+        PendingIntent pendingIntent = PendingIntent.getActivity(mContext,
+                (int)notificationId,
+                notificationIntent, PendingIntent.FLAG_ONE_SHOT);
+
+        notificationBuilder.setSmallIcon(R.drawable.ic_my_sites_24dp);
+        notificationBuilder.setColor(mContext.getResources().getColor(R.color.blue_wordpress));
+
+        String notificationTitle = buildSuccessMessageForMedia(mediaList.size());
+        String notificationMessage = TextUtils.isEmpty(site.getName()) ? mContext.getString(R.string.untitled) : site.getName();
+
+        String snackbarMessage = buildSnackbarSuccessMessageForMedia(mediaList.size());
+
+        notificationBuilder.setContentTitle(notificationTitle);
+        notificationBuilder.setContentText(notificationMessage);
+        //notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(newSuccessMessage));
+        notificationBuilder.setContentIntent(pendingIntent);
+        notificationBuilder.setAutoCancel(true);
+
+        // Add WRITE POST action - only if there is media we can insert in the Post
+        if (mediaList != null && !mediaList.isEmpty()) {
+            ArrayList<MediaModel> mediaToIncludeInPost = new ArrayList<>(mediaList);
+
+            Intent writePostIntent = new Intent(mContext, EditPostActivity.class);
+            writePostIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            writePostIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            writePostIntent.putExtra(WordPress.SITE, site);
+            writePostIntent.putExtra(EditPostActivity.EXTRA_IS_PAGE, false);
+            writePostIntent.putExtra(EditPostActivity.EXTRA_INSERT_MEDIA, mediaToIncludeInPost);
+            writePostIntent.setAction(String.valueOf(notificationId));
+
+            PendingIntent actionPendingIntent = PendingIntent.getActivity(mContext, RequestCodes.EDIT_POST, writePostIntent,
+                    PendingIntent.FLAG_CANCEL_CURRENT);
+            notificationBuilder.addAction(0, mContext.getString(R.string.media_files_uploaded_write_post),
+                    actionPendingIntent);
+
+        }
+
+        EventBus.getDefault().post(new UploadService.UploadMediaSuccessEvent(mediaList, snackbarMessage));
+        doNotify(notificationId, notificationBuilder.build());
+    }
+
     public static long getNotificationIdForPost(PostModel post) {
         long remotePostId = post.getRemotePostId();
         // We can't use the local table post id here because it can change between first post (local draft) to
@@ -327,8 +388,12 @@ class PostUploadNotifier {
         return post.getLocalSiteId() + remotePostId;
     }
 
-    public static long getNotificationIdForMedia() {
-        return BASE_MEDIA_ERROR_NOTIFICATION_ID;
+    public static long getNotificationIdForMedia(SiteModel site) {
+        if (site != null) {
+            return BASE_MEDIA_ERROR_NOTIFICATION_ID + site.getId();
+        } else {
+            return BASE_MEDIA_ERROR_NOTIFICATION_ID;
+        }
     }
 
     void updateNotificationErrorForPost(@NonNull PostModel post, @NonNull SiteModel site, String errorMessage) {
@@ -387,8 +452,8 @@ class PostUploadNotifier {
         NotificationCompat.Builder notificationBuilder =
                 new NotificationCompat.Builder(mContext.getApplicationContext());
 
-        long notificationId = getNotificationIdForMedia();
-        // Tap notification intent (open the post list)
+        long notificationId = getNotificationIdForMedia(site);
+        // Tap notification intent (open the media browser)
         Intent notificationIntent = new Intent(mContext, MediaBrowserActivity.class);
         notificationIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         notificationIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
@@ -479,6 +544,24 @@ class PostUploadNotifier {
         return newErrorMessage;
     }
 
+    private String buildSuccessMessageForMedia(int mediaItemsUploaded) {
+        // all media items were uploaded successfully
+        String successMessage =  String.format(mContext.getString(R.string.media_all_files_uploaded_succcessfully),
+                    mediaItemsUploaded);
+        return successMessage;
+    }
+
+    private String buildSnackbarSuccessMessageForMedia(int mediaItemsUploaded) {
+        String successMessage = "";
+        if (mediaItemsUploaded > 0) {
+            if (mediaItemsUploaded == 1) {
+                successMessage += mContext.getString(R.string.media_file_uploaded);
+            } else {
+                successMessage += String.format(mContext.getString(R.string.media_files_uploaded), mediaItemsUploaded);
+            }
+        }
+        return successMessage;
+    }
 
     private String buildSnackbarErrorMessage(String newErrorMessage, String detailErrorMessage) {
         // now append the detailed error message below

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -323,6 +323,13 @@ class PostUploadNotifier {
     }
 
     void updateNotificationSuccessForMedia(@NonNull List<MediaModel> mediaList, @NonNull SiteModel site) {
+
+        // show the snackbar
+        if (mediaList != null && !mediaList.isEmpty()) {
+            String snackbarMessage = buildSnackbarSuccessMessageForMedia(mediaList.size());
+            EventBus.getDefault().post(new UploadService.UploadMediaSuccessEvent(mediaList, snackbarMessage));
+        }
+
         if (!WordPress.sAppIsInTheBackground) {
             // only produce success notifications for the user if the app is in the background
             return;
@@ -350,8 +357,6 @@ class PostUploadNotifier {
         String notificationTitle = buildSuccessMessageForMedia(mediaList.size());
         String notificationMessage = TextUtils.isEmpty(site.getName()) ? mContext.getString(R.string.untitled) : site.getName();
 
-        String snackbarMessage = buildSnackbarSuccessMessageForMedia(mediaList.size());
-
         notificationBuilder.setContentTitle(notificationTitle);
         notificationBuilder.setContentText(notificationMessage);
         //notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(newSuccessMessage));
@@ -377,7 +382,6 @@ class PostUploadNotifier {
 
         }
 
-        EventBus.getDefault().post(new UploadService.UploadMediaSuccessEvent(mediaList, snackbarMessage));
         doNotify(notificationId, notificationBuilder.build());
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -566,14 +566,16 @@ public class UploadService extends Service {
         if (!mMediaBatchUploaded.isEmpty()) {
             ArrayList<MediaModel> standAloneMediaItems = new ArrayList<>();
             for (MediaModel media: mMediaBatchUploaded) {
-                if (media.getLocalPostId() == 0) {
-                    standAloneMediaItems.add(media);
+                // we need to obtain the latest copy from the Store, as it's got the remote mediaId field
+                MediaModel currentMedia = mMediaStore.getMediaWithLocalId(media.getId());
+                if (currentMedia.getLocalPostId() == 0) {
+                    standAloneMediaItems.add(currentMedia);
                 }
             }
 
             if (!standAloneMediaItems.isEmpty()) {
-                SiteModel site = mSiteStore.getSiteByLocalId(mMediaBatchUploaded.get(0).getLocalSiteId());
-                mPostUploadNotifier.updateNotificationSuccessForMedia(mMediaBatchUploaded, site);
+                SiteModel site = mSiteStore.getSiteByLocalId(standAloneMediaItems.get(0).getLocalSiteId());
+                mPostUploadNotifier.updateNotificationSuccessForMedia(standAloneMediaItems, site);
                 mMediaBatchUploaded.clear();
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -61,6 +61,9 @@ public class UploadService extends Service {
     private PostUploadHandler mPostUploadHandler;
     private PostUploadNotifier mPostUploadNotifier;
 
+    // we hold this reference here for the success notification for Media uploads
+    private List<MediaModel> mMediaBatchUploaded = new ArrayList<>();
+
     @Inject Dispatcher mDispatcher;
     @Inject MediaStore mMediaStore;
     @Inject PostStore mPostStore;
@@ -166,18 +169,22 @@ public class UploadService extends Service {
 //            }
 //        }
 
-        if (!intent.getBooleanExtra(KEY_UPLOAD_MEDIA_FROM_EDITOR, false)) {
-            // only cancel the media error notification if we're triggering a new media pload
-            // either from Media Browser or a RETRY from a notification.
-            // Otherwise, this flag should be true, and we need to keep the error notification as
-            // it might be a separate action (user is editing a Post and including media there)
-            mPostUploadNotifier.cancelFinalNotificationForMedia();
-        }
-
         // add new media
         @SuppressWarnings("unchecked")
         List<MediaModel> mediaList = (List<MediaModel>) intent.getSerializableExtra(KEY_MEDIA_LIST);
-        if (mediaList != null) {
+        if (mediaList != null && !mediaList.isEmpty()) {
+            if (!intent.getBooleanExtra(KEY_UPLOAD_MEDIA_FROM_EDITOR, false)) {
+                // only cancel the media error notification if we're triggering a new media pload
+                // either from Media Browser or a RETRY from a notification.
+                // Otherwise, this flag should be true, and we need to keep the error notification as
+                // it might be a separate action (user is editing a Post and including media there)
+                mPostUploadNotifier.cancelFinalNotificationForMedia(
+                        mSiteStore.getSiteByLocalId(mediaList.get(0).getLocalSiteId()));
+
+                // add these media items so we can use them in WRITE POST once they end up loading successfully
+                mMediaBatchUploaded.addAll(mediaList);
+            }
+
             for (MediaModel media : mediaList) {
                 mMediaUploadHandler.upload(media);
             }
@@ -540,6 +547,8 @@ public class UploadService extends Service {
 
         if (mMediaUploadHandler != null && mMediaUploadHandler.hasInProgressUploads()) {
             return;
+        } else {
+            verifyMediaOnlyUploadsAndNotify();
         }
 
         if (!mUploadStore.getPendingPosts().isEmpty()) {
@@ -550,6 +559,24 @@ public class UploadService extends Service {
 
         AppLog.i(T.MAIN, "UploadService > Completed");
         stopSelf();
+    }
+
+    private void verifyMediaOnlyUploadsAndNotify() {
+        // check if all are successful uploads, then notify the user about it
+        if (!mMediaBatchUploaded.isEmpty()) {
+            ArrayList<MediaModel> standAloneMediaItems = new ArrayList<>();
+            for (MediaModel media: mMediaBatchUploaded) {
+                if (media.getLocalPostId() == 0) {
+                    standAloneMediaItems.add(media);
+                }
+            }
+
+            if (!standAloneMediaItems.isEmpty()) {
+                SiteModel site = mSiteStore.getSiteByLocalId(mMediaBatchUploaded.get(0).getLocalSiteId());
+                mPostUploadNotifier.updateNotificationSuccessForMedia(mMediaBatchUploaded, site);
+                mMediaBatchUploaded.clear();
+            }
+        }
     }
 
     private void updatePostModelsWithCompletedAndFailedUploads(){
@@ -763,4 +790,15 @@ public class UploadService extends Service {
             this.errorMessage = errorMessage;
         }
     }
+
+    public static class UploadMediaSuccessEvent {
+        public final List<MediaModel> mediaModelList;
+        public final String successMessage;
+
+        UploadMediaSuccessEvent(List<MediaModel> mediaModelList, String successMessage) {
+            this.mediaModelList = mediaModelList;
+            this.successMessage = successMessage;
+        }
+    }
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -203,9 +203,9 @@ public class UploadUtils {
                 .show();
     }
 
-    private static void showSnackbarSuccessAction(View view, String messageRes, int buttonTitleRes,
+    private static void showSnackbarSuccessAction(View view, String message, int buttonTitleRes,
                                                   View.OnClickListener onClickListener) {
-        Snackbar.make(view, messageRes, 5000)
+        Snackbar.make(view, message, 5000)
                 .setAction(buttonTitleRes, onClickListener).
                 setActionTextColor(view.getResources().getColor(R.color.blue_medium))
                 .show();

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -31,6 +31,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class UploadUtils {
+
+    private static int K_SNACKBAR_WAIT_TIME_MS = 5000;
     /**
      * Returns a post-type specific error message string.
      */
@@ -181,12 +183,12 @@ public class UploadUtils {
 
     private static void showSnackbarError(View view, String message, int buttonTitleRes,
                                           View.OnClickListener onClickListener) {
-        Snackbar.make(view, message, 5000)
+        Snackbar.make(view, message, K_SNACKBAR_WAIT_TIME_MS)
                 .setAction(buttonTitleRes, onClickListener).show();
     }
 
     private static void showSnackbarError(View view, String message) {
-        Snackbar.make(view, message, 5000).show();
+        Snackbar.make(view, message, K_SNACKBAR_WAIT_TIME_MS).show();
     }
 
     private static void showSnackbar(View view, int messageRes, int buttonTitleRes,
@@ -197,7 +199,7 @@ public class UploadUtils {
 
     private static void showSnackbarSuccessAction(View view, int messageRes, int buttonTitleRes,
                                                   View.OnClickListener onClickListener) {
-        Snackbar.make(view, messageRes, 5000)
+        Snackbar.make(view, messageRes, K_SNACKBAR_WAIT_TIME_MS)
                 .setAction(buttonTitleRes, onClickListener).
                 setActionTextColor(view.getResources().getColor(R.color.blue_medium))
                 .show();
@@ -205,7 +207,7 @@ public class UploadUtils {
 
     private static void showSnackbarSuccessAction(View view, String message, int buttonTitleRes,
                                                   View.OnClickListener onClickListener) {
-        Snackbar.make(view, message, 5000)
+        Snackbar.make(view, message, K_SNACKBAR_WAIT_TIME_MS)
                 .setAction(buttonTitleRes, onClickListener).
                 setActionTextColor(view.getResources().getColor(R.color.blue_medium))
                 .show();

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadUtils.java
@@ -9,6 +9,7 @@ import android.text.TextUtils;
 import android.view.View;
 
 import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.PostActionBuilder;
 import org.wordpress.android.fluxc.model.MediaModel;
@@ -202,6 +203,14 @@ public class UploadUtils {
                 .show();
     }
 
+    private static void showSnackbarSuccessAction(View view, String messageRes, int buttonTitleRes,
+                                                  View.OnClickListener onClickListener) {
+        Snackbar.make(view, messageRes, 5000)
+                .setAction(buttonTitleRes, onClickListener).
+                setActionTextColor(view.getResources().getColor(R.color.blue_medium))
+                .show();
+    }
+
     private static void showSnackbar(View view, int messageRes) {
         Snackbar.make(view,
                 messageRes, Snackbar.LENGTH_LONG).show();
@@ -290,13 +299,13 @@ public class UploadUtils {
 
     public static void onMediaUploadedSnackbarHandler(final Activity activity, View snackbarAttachView,
                                                      boolean isError,
-                                                     final List<MediaModel> mediaList,
-                                                     final String errorMessage) {
+                                                     final List<MediaModel> mediaList, final SiteModel site,
+                                                     final String messageForUser) {
         if (isError) {
-            if (errorMessage != null) {
+            if (messageForUser != null) {
                 // RETRY only available for Aztec
                 if (mediaList != null && !mediaList.isEmpty()) {
-                    UploadUtils.showSnackbarError(snackbarAttachView, errorMessage, R.string.retry, new View.OnClickListener() {
+                    UploadUtils.showSnackbarError(snackbarAttachView, messageForUser, R.string.retry, new View.OnClickListener() {
                         @Override
                         public void onClick(View view) {
                             ArrayList<MediaModel> mediaListToRetry = new ArrayList<>();
@@ -306,22 +315,34 @@ public class UploadUtils {
                         }
                     });
                 } else {
-                    UploadUtils.showSnackbarError(snackbarAttachView, errorMessage);
+                    UploadUtils.showSnackbarError(snackbarAttachView, messageForUser);
                 }
             } else {
                 UploadUtils.showSnackbarError(snackbarAttachView, activity.getString(R.string.error_media_upload));
             }
         } else {
-            // TODO implement success snackbar for media only items (i.e. WRITE POST functtionality)
-//            int messageRes = post.isPage() ? R.string.page_published : R.string.post_published;
-//            UploadUtils.showSnackbarSuccessAction(snackbarAttachView, messageRes,
-//                    R.string.button_view, new View.OnClickListener() {
-//                        @Override
-//                        public void onClick(View view) {
-//                            // jump to Editor Preview mode to show this Post
-//                            ActivityLauncher.browsePostOrPage(activity, site, post);
-//                        }
-//                    });
+            if (mediaList == null || mediaList.isEmpty()) {
+                return;
+            }
+
+            // show success snackbar for media only items and offer the WRITE POST functionality)
+            UploadUtils.showSnackbarSuccessAction(snackbarAttachView, messageForUser,
+                    R.string.media_files_uploaded_write_post, new View.OnClickListener() {
+                        @Override
+                        public void onClick(View view) {
+                            // WRITE POST functionality: show pre-populated Post
+                            ArrayList<MediaModel> mediaListToInsertInPost = new ArrayList<>();
+                            mediaListToInsertInPost.addAll(mediaList);
+
+                            Intent writePostIntent = new Intent(activity, EditPostActivity.class);
+                            writePostIntent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+                            writePostIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                            writePostIntent.putExtra(WordPress.SITE, site);
+                            writePostIntent.putExtra(EditPostActivity.EXTRA_IS_PAGE, false);
+                            writePostIntent.putExtra(EditPostActivity.EXTRA_INSERT_MEDIA, mediaListToInsertInPost);
+                            activity.startActivity(writePostIntent);
+                        }
+                    });
         }
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -288,10 +288,14 @@
     <!-- post uploads -->
     <string name="upload_failed_param">Upload failed for \"%s\"</string>
     <string name="media_files_not_uploaded">%d media files not uploaded</string>
+    <string name="media_files_uploaded">%d media files uploaded</string>
     <string name="media_file_not_uploaded">1 media file not uploaded</string>
+    <string name="media_file_uploaded">1 media file uploaded</string>
     <string name="media_files_uploaded_succcessfully">(%d successfully uploaded)</string>
+    <string name="media_all_files_uploaded_succcessfully">%d files uploaded successfully</string>
     <string name="retry_needs_aztec" translatable="false">Retry only available in the Beta editor</string>
     <string name="media_file_missing_for_retry">Retry not possible - some media files in this Post are missing from your device</string>
+    <string name="media_files_uploaded_write_post">Write Post</string>
 
     <!-- post view -->
     <string name="post_id">Post</string>


### PR DESCRIPTION
This is the last part of async media notifications 🎉 
This PR implements media-only success notifications and snackbars - here's the design excerpt:

<img width="915" alt="screen shot 2017-10-18 at 10 25 56 am" src="https://user-images.githubusercontent.com/6597771/31721090-b2c923c8-b418-11e7-9718-d4218768aa51.png">


To test:

**CASE A: (app in the foreground - snackbars)**
1. go to the media library
2. add a new media item from the device
3. check the progress notification appears

<img width="411" alt="screen shot 2017-10-25 at 4 05 05 pm" src="https://user-images.githubusercontent.com/6597771/32017821-39bfbbbc-b9c8-11e7-927b-b3afcca78092.png">


4. once it’s done uploading:
4.a.) if you have the app on the foreground, you’ll see the snackbar appears, with the `WRITE POST` button on the right. Tapping on `WRITE POST` takes you to the Editor, where a pre-populated Post is shown with the image just uploaded to the Media Library.

<img width="413" alt="screen shot 2017-10-25 at 4 05 48 pm" src="https://user-images.githubusercontent.com/6597771/32017860-53ad200a-b9c8-11e7-9f3d-23b0dc907713.png">

<img width="411" alt="screen shot 2017-10-25 at 4 06 21 pm" src="https://user-images.githubusercontent.com/6597771/32017880-63614634-b9c8-11e7-95dd-9b5bd725bbe0.png">



4.b) repeat steps above, but this time make sure you exit the Media Browser and stay on the app’s home screen before the upload finishes, to check the snackbar appears there as well.


<img width="410" alt="screen shot 2017-10-25 at 4 06 57 pm" src="https://user-images.githubusercontent.com/6597771/32017921-7d67f140-b9c8-11e7-9c21-f55518bbca44.png">


4.c) try once more, but this time while the upload is happening exit the Media Browser and go to the Posts list. Upon finishing the upload, the snackbar should be presented there as well
Note there are no success notifications shown here.

<img width="410" alt="screen shot 2017-10-25 at 4 07 44 pm" src="https://user-images.githubusercontent.com/6597771/32017963-9ea7e68a-b9c8-11e7-9c47-93bba76e23d6.png">


**CASE B: Background app - success notifications**
1. go to the media library
2. add a new media item from the device
3. check the progress notification appears
4. once it’s done uploading, send the app to the background.
5. you can check progress on the progress notification
6. once it’s finished uploading, a new notification is shown with the `WRITE POST` quick action.

<img width="426" alt="screen shot 2017-10-25 at 4 09 34 pm" src="https://user-images.githubusercontent.com/6597771/32018028-daf3f016-b9c8-11e7-9dae-9c0ca68bf12b.png">


7. Tap on `WRITE POST`, that should take you to the Editor, where a pre-populated Post is shown with the image just uploaded to the Media Library


**Notes:**
- as of now, including a new media item in the Media Browser doesn’t allow for multiple selection. I imagine this could be addressed by using the Media Picker already available from within the Editor, as consisting things in a similar way to the one described in https://github.com/wordpress-mobile/WordPress-Android/issues/6719
- please note error notifications are covered in a previous PR #6780

cc @nbradbury 

