### PR TITLE
Getting notification alert and progress small icons back in place

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -68,7 +68,7 @@ class PostUploadNotifier {
         mNotificationManager = (NotificationManager) SystemServiceFactory.get(mContext,
                 Context.NOTIFICATION_SERVICE);
         mNotificationBuilder = new NotificationCompat.Builder(mContext.getApplicationContext());
-        mNotificationBuilder.setSmallIcon(R.drawable.ic_my_sites_24dp)
+        mNotificationBuilder.setSmallIcon(android.R.drawable.stat_sys_upload)
                 .setColor(context.getResources().getColor(R.color.blue_wordpress));
     }
 
@@ -420,8 +420,7 @@ class PostUploadNotifier {
                 (int)notificationId,
                 notificationIntent, PendingIntent.FLAG_ONE_SHOT);
 
-        notificationBuilder.setSmallIcon(R.drawable.ic_my_sites_24dp);
-        notificationBuilder.setColor(mContext.getResources().getColor(R.color.blue_wordpress));
+        notificationBuilder.setSmallIcon(android.R.drawable.stat_notify_error);
 
         String postTitle = TextUtils.isEmpty(post.getTitle()) ? mContext.getString(R.string.untitled) : post.getTitle();
         String notificationTitle = String.format(mContext.getString(R.string.upload_failed_param), postTitle);
@@ -468,8 +467,7 @@ class PostUploadNotifier {
                 (int)notificationId,
                 notificationIntent, PendingIntent.FLAG_ONE_SHOT);
 
-        notificationBuilder.setSmallIcon(R.drawable.ic_my_sites_24dp);
-        notificationBuilder.setColor(mContext.getResources().getColor(R.color.blue_wordpress));
+        notificationBuilder.setSmallIcon(android.R.drawable.stat_notify_error);
 
         String siteName = TextUtils.isEmpty(site.getName()) ? mContext.getString(R.string.untitled) : site.getName();
         String notificationTitle = String.format(mContext.getString(R.string.upload_failed_param), siteName);


### PR DESCRIPTION
Brings the alert and progress small icons back in place for async media notifications, as discussed elsewhere.

Progress:
<img width="413" alt="screen shot 2017-10-25 at 4 56 42 pm" src="https://user-images.githubusercontent.com/6597771/32020196-aa27f660-b9cf-11e7-90f4-3f8b24d8bd2a.png">


Progress (status bar view):
<img width="261" alt="screen shot 2017-10-25 at 4 58 57 pm" src="https://user-images.githubusercontent.com/6597771/32020218-bd4f6c5a-b9cf-11e7-808d-1238c54aa719.png">


Success:
<img width="419" alt="screen shot 2017-10-25 at 4 59 25 pm" src="https://user-images.githubusercontent.com/6597771/32020232-cc23d4dc-b9cf-11e7-9148-711d85a121e6.png">

Failure:

<img width="429" alt="screen shot 2017-10-25 at 4 59 43 pm" src="https://user-images.githubusercontent.com/6597771/32020238-dbf7e83a-b9cf-11e7-8c78-78b4872a903b.png">


cc @nbradbury 
