### PR TITLE
Remove final notification and update notification count when Post deleted

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -361,7 +361,7 @@ public class EditPostActivity extends AppCompatActivity implements
             // if we are opening a Post for which an error notification exists, we need to remove
             // it from the dashboard to prevent the user from tapping RETRY on a Post that is
             // being currently edited
-            UploadService.cancelFinalNotification(mPost);
+            UploadService.cancelFinalNotification(this, mPost);
             resetUploadingMediaToFailedIfPostHasNotMediaInProgressOrQueued();
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -605,7 +605,7 @@ public class PostsListFragment extends Fragment
                 mTrashedPosts.remove(post);
 
                 // here cancel all media uploads related to this Post
-                UploadService.cancelQueuedPostUploadAndRelatedMedia(post);
+                UploadService.cancelQueuedPostUploadAndRelatedMedia(getActivity(), post);
 
                 if (post.isLocalDraft()) {
                     mDispatcher.dispatch(PostActionBuilder.newRemovePostAction(post));

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -146,6 +146,17 @@ class PostUploadNotifier {
         startOrUpdateForegroundNotification(post);
     }
 
+    void removePostInfoFromForegroundNotification(@NonNull PostModel post, @Nullable List<MediaModel> media) {
+        sNotificationData.totalPostItems--;
+        if (post.isPage()) {
+            sNotificationData.totalPageItemsIncludedInPostCount--;
+        }
+        if (media != null) {
+            removeMediaInfoFromForegroundNotification(media);
+        }
+        startOrUpdateForegroundNotification(post);
+    }
+
     void removeMediaInfoFromForegroundNotification(@NonNull List<MediaModel> mediaList) {
         if (sNotificationData.totalMediaItems >= mediaList.size()) {
             sNotificationData.totalMediaItems -= mediaList.size();
@@ -232,8 +243,10 @@ class PostUploadNotifier {
 
     // cancels the error or success notification (only one of these exist per Post at any given
     // time
-    void cancelFinalNotification(@NonNull PostModel post) {
-        mNotificationManager.cancel((int)getNotificationIdForPost(post));
+    public static void cancelFinalNotification(Context context, @NonNull PostModel post) {
+        NotificationManager notificationManager = (NotificationManager) SystemServiceFactory.get(context,
+                Context.NOTIFICATION_SERVICE);
+        notificationManager.cancel((int)getNotificationIdForPost(post));
     }
 
     void cancelFinalNotificationForMedia(@NonNull SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -118,11 +118,7 @@ class PostUploadNotifier {
         }
     }
 
-    void prepareForegroundNotificationForRetry(@NonNull PostModel post, @Nullable List<MediaModel> media) {
-        removePostInfoFromForegroundNotificationData(post, media);
-    }
-
-    private void removePostInfoFromForegroundNotificationData(@NonNull PostModel post, @Nullable List<MediaModel> media) {
+    void removePostInfoFromForegroundNotificationData(@NonNull PostModel post, @Nullable List<MediaModel> media) {
         if (sNotificationData.totalPostItems > 0) {
             sNotificationData.totalPostItems--;
             if (post.isPage()) {
@@ -147,13 +143,7 @@ class PostUploadNotifier {
     }
 
     void removePostInfoFromForegroundNotification(@NonNull PostModel post, @Nullable List<MediaModel> media) {
-        sNotificationData.totalPostItems--;
-        if (post.isPage()) {
-            sNotificationData.totalPageItemsIncludedInPostCount--;
-        }
-        if (media != null) {
-            removeMediaInfoFromForegroundNotification(media);
-        }
+        removePostInfoFromForegroundNotificationData(post, media);
         startOrUpdateForegroundNotification(post);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -202,7 +202,7 @@ public class UploadService extends Service {
 
             // cancel any outstanding "end" notification for this Post before we start processing it again
             // i.e. dismiss success or error notification for the post.
-            mPostUploadNotifier.cancelFinalNotification(post);
+            mPostUploadNotifier.cancelFinalNotification(this, post);
 
             // if the user tapped on the PUBLISH quick action, make this Post publishable and track
             // analytics before starting the upload process.
@@ -242,11 +242,11 @@ public class UploadService extends Service {
         }
     }
 
-    public static void cancelFinalNotification(PostModel post){
+    public static void cancelFinalNotification(Context context, PostModel post){
         // cancel any outstanding "end" notification for this Post before we start processing it again
         // i.e. dismiss success or error notification for the post.
         if (sInstance != null && sInstance.mPostUploadNotifier != null) {
-            sInstance.mPostUploadNotifier.cancelFinalNotification(post);
+            sInstance.mPostUploadNotifier.cancelFinalNotification(context, post);
         }
     }
 
@@ -366,8 +366,13 @@ public class UploadService extends Service {
         return sInstance != null && post != null && PostUploadHandler.isPostUploading(post);
     }
 
-    public static void cancelQueuedPostUploadAndRelatedMedia(PostModel post) {
+    public static void cancelQueuedPostUploadAndRelatedMedia(Context context, PostModel post) {
         if (post != null) {
+            PostUploadNotifier.cancelFinalNotification(context, post);
+            if (sInstance != null) {
+                sInstance.mPostUploadNotifier.removePostInfoFromForegroundNotification(
+                        post, sInstance.mMediaStore.getMediaForPost(post));
+            }
             cancelQueuedPostUpload(post);
             EventBus.getDefault().post(new PostEvents.PostMediaCanceled(post));
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -637,7 +637,7 @@ public class UploadService extends Service {
     private void aztecRetryUpload(PostModel post) {
         Set<MediaModel> failedMedia = mUploadStore.getFailedMediaForPost(post);
         ArrayList<MediaModel> mediaToRetry = new ArrayList<>(failedMedia);
-        mPostUploadNotifier.prepareForegroundNotificationForRetry(post, mediaToRetry);
+        mPostUploadNotifier.removePostInfoFromForegroundNotificationData(post, mediaToRetry);
         if (!failedMedia.isEmpty()) {
             // reset these media items to QUEUED
             for (MediaModel media : failedMedia) {


### PR DESCRIPTION
Fixes #6651 

To test:

**CASE A: remove success Post notification**
1. start a draft
2. include several media items in the Post
3. exit the editor
4. you should see the progress notification read “1 post, xxx media files remaining"
5. send the app to the background so the success notification can be created
6. wait until it all uploads, and see the success notification is shown
7. open the app again, go to the Posts list and tap “Delete” or “Trash” on the post you just uploaded.
8. once the UNDO snackbar appears, let it disappear
9. observe the final success notification for such a Post is gone.


**CASE B: remove error Post notification**
1. start a draft
2. include several media items in the Post
3. exit the editor
4. you should see the progress notification read “1 post, xxx media files remaining"
5. turn airplane mode ON
6. wait a bit and the progress notification disappears, and an error notification appears.
7. open the app again, go to the Posts list and tap “Delete” or “Trash” on the post you just uploaded.
8. once the UNDO snackbar appears, let it disappear
9. observe the final error notification for such a Post is gone.


**CASE C: decrement count from progress notification on the go**
1. start a draft
2. include several media items in the Post (the more the better so we can have 2 Posts simultaneously uploaded)
3. exit the editor
4. you should see the progress notification read “1 post, xxx media files remaining"
5. repeat steps 1 through 3, you should see the progress notification read “2 posts, xxx media files remaining”
6. before the first Post finishes uploading, go to the Posts list and tap “Delete” or “Trash” on the post.
8. once the UNDO snackbar appears, let it disappear
9. observe the progress notification shows now “1 post, xxx media files remaining”
10. let it finish and observe the success notification for the remaining Post (if you send the app to the background before it finishes)

cc @nbradbury 
