### PR TITLE
Retry failed posts from post list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -509,9 +509,14 @@ public class PostsListFragment extends Fragment
                 }
                 ActivityLauncher.editPostOrPageForResult(getActivity(), mSite, post);
                 break;
+            case PostListButton.BUTTON_RETRY:
+                // restart the UploadService with retry parameters
+                Intent intent = UploadService.getUploadPostServiceIntent(
+                        getActivity(), post, PostUtils.isFirstTimePublish(post), false, true);
+                getActivity().startService(intent);
+                break;
             case PostListButton.BUTTON_SUBMIT:
             case PostListButton.BUTTON_SYNC:
-            case PostListButton.BUTTON_RETRY:
             case PostListButton.BUTTON_PUBLISH:
                 UploadUtils.publishPost(getActivity(), post, mSite, mDispatcher);
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -543,7 +543,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
         // edit / view are always visible
         holder.btnEdit.setVisibility(View.VISIBLE);
-        holder.btnView.setVisibility(View.VISIBLE);
+        holder.btnPublish.setVisibility(View.VISIBLE);
 
         // if we have enough room to show all buttons, hide the back/more buttons and show stats/trash/publish
         if (mAlwaysShowAllButtons || numVisibleButtons <= 3) {
@@ -561,7 +561,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             holder.btnBack.setVisibility(View.GONE);
             holder.btnTrash.setVisibility(View.GONE);
             holder.btnStats.setVisibility(View.GONE);
-            holder.btnPublish.setVisibility(View.GONE);
+            holder.btnView.setVisibility(View.GONE);
         }
 
         View.OnClickListener btnClickListener = new View.OnClickListener() {
@@ -615,11 +615,11 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
                 // row 1
                 holder.btnEdit.setVisibility(showRow1 ? View.VISIBLE : View.GONE);
-                holder.btnView.setVisibility(showRow1 ? View.VISIBLE : View.GONE);
+                holder.btnPublish.setVisibility(showRow1 && canPublishPost(post) ? View.VISIBLE : View.GONE);
                 holder.btnMore.setVisibility(showRow1 ? View.VISIBLE : View.GONE);
                 // row 2
+                holder.btnView.setVisibility(!showRow1 ? View.VISIBLE : View.GONE);
                 holder.btnStats.setVisibility(!showRow1 && canShowStatsForPost(post) ? View.VISIBLE : View.GONE);
-                holder.btnPublish.setVisibility(!showRow1 && canPublishPost(post) ? View.VISIBLE : View.GONE);
                 holder.btnTrash.setVisibility(!showRow1 ? View.VISIBLE : View.GONE);
                 holder.btnBack.setVisibility(!showRow1 ? View.VISIBLE : View.GONE);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -205,10 +205,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
     }
 
     private boolean canPublishPost(PostModel post) {
-        // TODO remove the hasMediaErrorForPost(post) check when we get a proper retry mechanism in place,
-        // that retried to upload any failed media along with the post
         return post != null && !UploadService.isPostUploadingOrQueued(post) &&
-                !UploadUtils.isMediaError(mUploadStore.getUploadErrorForPost(post)) &&
                 (post.isLocallyChanged() || post.isLocalDraft() || PostStatus.fromPost(post) == PostStatus.DRAFT);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -543,7 +543,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
         // edit / view are always visible
         holder.btnEdit.setVisibility(View.VISIBLE);
-        holder.btnPublish.setVisibility(View.VISIBLE);
+        holder.btnView.setVisibility(View.VISIBLE);
 
         // if we have enough room to show all buttons, hide the back/more buttons and show stats/trash/publish
         if (mAlwaysShowAllButtons || numVisibleButtons <= 3) {
@@ -561,7 +561,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             holder.btnBack.setVisibility(View.GONE);
             holder.btnTrash.setVisibility(View.GONE);
             holder.btnStats.setVisibility(View.GONE);
-            holder.btnView.setVisibility(View.GONE);
+            holder.btnPublish.setVisibility(View.GONE);
         }
 
         View.OnClickListener btnClickListener = new View.OnClickListener() {
@@ -615,11 +615,11 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
                 // row 1
                 holder.btnEdit.setVisibility(showRow1 ? View.VISIBLE : View.GONE);
-                holder.btnPublish.setVisibility(showRow1 && canPublishPost(post) ? View.VISIBLE : View.GONE);
+                holder.btnView.setVisibility(showRow1 ? View.VISIBLE : View.GONE);
                 holder.btnMore.setVisibility(showRow1 ? View.VISIBLE : View.GONE);
                 // row 2
-                holder.btnView.setVisibility(!showRow1 ? View.VISIBLE : View.GONE);
                 holder.btnStats.setVisibility(!showRow1 && canShowStatsForPost(post) ? View.VISIBLE : View.GONE);
+                holder.btnPublish.setVisibility(!showRow1 && canPublishPost(post) ? View.VISIBLE : View.GONE);
                 holder.btnTrash.setVisibility(!showRow1 ? View.VISIBLE : View.GONE);
                 holder.btnBack.setVisibility(!showRow1 ? View.VISIBLE : View.GONE);
 

--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButton.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButton.java
@@ -2,6 +2,9 @@ package org.wordpress.android.widgets;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.support.annotation.ColorRes;
+import android.support.annotation.DrawableRes;
+import android.support.annotation.StringRes;
 import android.util.AttributeSet;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -86,7 +89,7 @@ public class PostListButton extends LinearLayout {
         mTextView.setTextColor(getContext().getResources().getColor(getTextColorResId(buttonType)));
     }
 
-    public static int getButtonTextResId(int buttonType) {
+    public static @StringRes int getButtonTextResId(int buttonType) {
         switch (buttonType) {
             case BUTTON_EDIT:
                 return R.string.button_edit;
@@ -117,7 +120,7 @@ public class PostListButton extends LinearLayout {
         }
     }
 
-    public static int getButtonIconResId(int buttonType) {
+    public static @DrawableRes int getButtonIconResId(int buttonType) {
         switch (buttonType) {
             case BUTTON_EDIT:
                 return R.drawable.ic_pencil_blue_wordpress_18dp;
@@ -146,7 +149,7 @@ public class PostListButton extends LinearLayout {
         }
     }
 
-    public static int getTextColorResId(int buttonType) {
+    public static @ColorRes int getTextColorResId(int buttonType) {
         switch (buttonType) {
             case BUTTON_RETRY:
                 return R.color.alert_red;

--- a/WordPress/src/main/java/org/wordpress/android/widgets/PostListButton.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/PostListButton.java
@@ -83,6 +83,7 @@ public class PostListButton extends LinearLayout {
         mButtonType = buttonType;
         mTextView.setText(getButtonTextResId(buttonType));
         mImageView.setImageResource(getButtonIconResId(buttonType));
+        mTextView.setTextColor(getContext().getResources().getColor(getTextColorResId(buttonType)));
     }
 
     public static int getButtonTextResId(int buttonType) {
@@ -139,9 +140,18 @@ public class PostListButton extends LinearLayout {
             case BUTTON_BACK:
                 return R.drawable.ic_chevron_left_blue_wordpress_18dp;
             case BUTTON_RETRY:
-                return R.drawable.ic_refresh_blue_wordpress_18dp;
+                return R.drawable.ic_refresh_red_18dp;
             default:
                 return 0;
+        }
+    }
+
+    public static int getTextColorResId(int buttonType) {
+        switch (buttonType) {
+            case BUTTON_RETRY:
+                return R.color.alert_red;
+            default:
+                return R.color.blue_wordpress;
         }
     }
 }

--- a/WordPress/src/main/res/drawable/ic_refresh_red_18dp.xml
+++ b/WordPress/src/main/res/drawable/ic_refresh_red_18dp.xml
@@ -9,7 +9,7 @@
         android:pathData="M 0 0 H 24 V 24 H 0 V 0 Z" >
     </path>
     <path
-        android:fillColor="@color/blue_wordpress"
+        android:fillColor="@color/alert_red"
         android:pathData="M17.91 14c-.478 2.833-2.943 5-5.91 5-3.308 0-6-2.692-6-6s2.692-6
 6-6h2.172l-2.086 2.086L13.5 10.5 18 6l-4.5-4.5-1.414 1.414L14.172 5H12c-4.418
 0-8 3.582-8 8s3.582 8 8 8c4.08 0 7.438-3.055 7.93-7h-2.02z" >

--- a/WordPress/src/main/res/layout/post_cardview.xml
+++ b/WordPress/src/main/res/layout/post_cardview.xml
@@ -116,20 +116,20 @@
                     wp:wpPostButtonType="edit" />
 
                 <org.wordpress.android.widgets.PostListButton
-                    android:id="@+id/btn_view"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    wp:wpPostButtonType="view" />
-
-                <org.wordpress.android.widgets.PostListButton
                     android:id="@+id/btn_publish"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:gravity="center"
                     wp:wpPostButtonType="publish" />
+
+                <org.wordpress.android.widgets.PostListButton
+                    android:id="@+id/btn_view"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    wp:wpPostButtonType="view" />
 
                 <org.wordpress.android.widgets.PostListButton
                     android:id="@+id/btn_stats"

--- a/WordPress/src/main/res/layout/post_cardview.xml
+++ b/WordPress/src/main/res/layout/post_cardview.xml
@@ -116,20 +116,20 @@
                     wp:wpPostButtonType="edit" />
 
                 <org.wordpress.android.widgets.PostListButton
-                    android:id="@+id/btn_publish"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    wp:wpPostButtonType="publish" />
-
-                <org.wordpress.android.widgets.PostListButton
                     android:id="@+id/btn_view"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:gravity="center"
                     wp:wpPostButtonType="view" />
+
+                <org.wordpress.android.widgets.PostListButton
+                    android:id="@+id/btn_publish"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="center"
+                    wp:wpPostButtonType="publish" />
 
                 <org.wordpress.android.widgets.PostListButton
                     android:id="@+id/btn_stats"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1225,8 +1225,8 @@
     <string name="error_media_load">Unable to load media</string>
     <string name="error_media_save">Unable to save media</string>
     <string name="error_media_canceled">Uploading media were canceled</string>
-    <string name="error_media_recover_post">We were unable to upload this post\'s media. Please tap retry or edit the post to try again.</string>
-    <string name="error_media_recover_page">We were unable to upload this page\'s media. Please tap retry or edit the page to try again.</string>
+    <string name="error_media_recover_post">Unable to upload this post\'s media.</string>
+    <string name="error_media_recover_page">Unable to upload this page\'s media.</string>
     <string name="error_post_does_not_exist">This post no longer exists</string>
     <string name="error_page_does_not_exist">This page no longer exists</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1225,8 +1225,8 @@
     <string name="error_media_load">Unable to load media</string>
     <string name="error_media_save">Unable to save media</string>
     <string name="error_media_canceled">Uploading media were canceled</string>
-    <string name="error_media_recover_post">We were unable to upload this post\'s media. Please edit the post to try again.</string>
-    <string name="error_media_recover_page">We were unable to upload this page\'s media. Please edit the page to try again.</string>
+    <string name="error_media_recover_post">We were unable to upload this post\'s media. Please tap retry or edit the post to try again.</string>
+    <string name="error_media_recover_page">We were unable to upload this page\'s media. Please tap retry or edit the page to try again.</string>
     <string name="error_post_does_not_exist">This post no longer exists</string>
     <string name="error_page_does_not_exist">This page no longer exists</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1225,8 +1225,8 @@
     <string name="error_media_load">Unable to load media</string>
     <string name="error_media_save">Unable to save media</string>
     <string name="error_media_canceled">Uploading media were canceled</string>
-    <string name="error_media_recover_post">Unable to upload this post\'s media.</string>
-    <string name="error_media_recover_page">Unable to upload this page\'s media.</string>
+    <string name="error_media_recover_post">Unable to upload this post\'s media</string>
+    <string name="error_media_recover_page">Unable to upload this page\'s media</string>
     <string name="error_post_does_not_exist">This post no longer exists</string>
     <string name="error_page_does_not_exist">This page no longer exists</string>
     <string name="error_blog_hidden">This blog is hidden and couldn\'t be loaded. Enable it again in settings and try again.</string>


### PR DESCRIPTION
Fixes #6407 

Unhides and implements the `Retry` button in Posts List, by making use of the implementation of `UploadService`.

<img width="413" alt="screen shot 2017-10-25 at 7 36 04 pm" src="https://user-images.githubusercontent.com/6597771/32026696-b9bd9c68-b9e5-11e7-8b35-2a4638f9e5d3.png">


To test:
1. start a draft
2. include several media items in it
3. as the media started uploading, exit the editor
4. see the progress notification show something like “1 post, xxxx media files”
5. turn airplane mode ON
6. observe the error is shown in the Posts list, in red, and the `RETRY` button becomes visible on that Post item, along with the snackbar and corresponding notification.
7. turn airplane mode OFF
8. once connectivity is recovered, tap on RETRY
9. see the progress notification appear, the error disappears from the posts list, and the progress is shown.

cc @nbradbury 