### PR TITLE
Issue/6793 post list buttons per row

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -522,7 +522,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         boolean canShowStatsButton = canShowStatsForPost(post);
         boolean canShowPublishButton = canRetry || canPublishPost(post);
 
-        // publish button is repurposed depending on the situation
+        // publish button is re-purposed depending on the situation
         if (canShowPublishButton) {
             if (!mSite.getHasCapabilityPublishPosts()) {
                 holder.btnPublish.setButtonType(PostListButton.BUTTON_SUBMIT);
@@ -842,9 +842,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             }
 
             // Make sure we don't return any hidden posts
-            for (PostModel hiddenPost : mHiddenPosts) {
-                tmpPosts.remove(hiddenPost);
-            }
+            tmpPosts.removeAll(mHiddenPosts);
 
             // Go no further if existing post list is the same
             if (mLoadMode == LoadMode.IF_CHANGED && PostUtils.postListsAreEqual(mPosts, tmpPosts)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -842,7 +842,9 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             }
 
             // Make sure we don't return any hidden posts
-            tmpPosts.removeAll(mHiddenPosts);
+            if (mHiddenPosts.size() > 0) {
+                tmpPosts.removeAll(mHiddenPosts);
+            }
 
             // Go no further if existing post list is the same
             if (mLoadMode == LoadMode.IF_CHANGED && PostUtils.postListsAreEqual(mPosts, tmpPosts)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -517,20 +517,10 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
     private void configurePostButtons(final PostViewHolder holder,
                                       final PostModel post) {
-        // posts with local changes have preview rather than view button
-        if (post.isLocalDraft() || post.isLocallyChanged()) {
-            holder.btnView.setButtonType(PostListButton.BUTTON_PREVIEW);
-        } else {
-            holder.btnView.setButtonType(PostListButton.BUTTON_VIEW);
-        }
-
         boolean canRetry = mUploadStore.getUploadErrorForPost(post) != null;
+        boolean canShowViewButton = !canRetry;
         boolean canShowStatsButton = canShowStatsForPost(post);
         boolean canShowPublishButton = canRetry || canPublishPost(post);
-
-        int numVisibleButtons = 3;
-        if (canShowPublishButton) numVisibleButtons++;
-        if (canShowStatsButton) numVisibleButtons++;
 
         // publish button is repurposed depending on the situation
         if (canShowPublishButton) {
@@ -545,9 +535,23 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             }
         }
 
-        // edit / view are always visible
+        // posts with local changes have preview rather than view button
+        if (canShowViewButton) {
+            if (post.isLocalDraft() || post.isLocallyChanged()) {
+                holder.btnView.setButtonType(PostListButton.BUTTON_PREVIEW);
+            } else {
+                holder.btnView.setButtonType(PostListButton.BUTTON_VIEW);
+            }
+        }
+
+        // edit is always visible
         holder.btnEdit.setVisibility(View.VISIBLE);
-        holder.btnView.setVisibility(View.VISIBLE);
+        holder.btnView.setVisibility(canShowViewButton ? View.VISIBLE : View.GONE);
+
+        int numVisibleButtons = 2;
+        if (canShowViewButton) numVisibleButtons++;
+        if (canShowPublishButton) numVisibleButtons++;
+        if (canShowStatsButton) numVisibleButtons++;
 
         // if there's enough room to show all buttons then hide back/more and show stats/trash/publish,
         // otherwise show the more button and hide stats/trash/publish

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -95,7 +95,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
     private final boolean mIsPage;
     private final boolean mIsStatsSupported;
-    private final boolean mAlwaysShowAllButtons;
+    private final int mMaxButtonsPerRow;
 
     private boolean mIsLoadingPosts;
 
@@ -128,8 +128,13 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         // endlist indicator height is hard-coded here so that its horz line is in the middle of the fab
         mEndlistIndicatorHeight = DisplayUtils.dpToPx(context, mIsPage ? 82 : 74);
 
-        // on larger displays we can always show all buttons
-        mAlwaysShowAllButtons = (displayWidth >= 1080);
+        if (displayWidth >= 1080) {
+            mMaxButtonsPerRow = 6;
+        } else if (displayWidth >= 768) {
+            mMaxButtonsPerRow = 4;
+        } else {
+            mMaxButtonsPerRow = 3;
+        }
     }
 
     public void setOnLoadMoreListener(OnLoadMoreListener listener) {
@@ -545,8 +550,8 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         holder.btnEdit.setVisibility(View.VISIBLE);
         holder.btnView.setVisibility(View.VISIBLE);
 
-        // if we have enough room to show all buttons, hide the back/more buttons and show stats/trash/publish
-        if (mAlwaysShowAllButtons || numVisibleButtons <= 3) {
+        // if there's enough room to show all buttons, hide the back/more buttons and show stats/trash/publish
+        if (numVisibleButtons <= mMaxButtonsPerRow) {
             holder.btnMore.setVisibility(View.GONE);
             holder.btnBack.setVisibility(View.GONE);
             holder.btnTrash.setVisibility(View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -128,8 +128,8 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
         // endlist indicator height is hard-coded here so that its horz line is in the middle of the fab
         mEndlistIndicatorHeight = DisplayUtils.dpToPx(context, mIsPage ? 82 : 74);
 
-        // show all buttons if screen is wide enough
-        mShowAllButtons = displayWidth >= 780;
+        // on larger displays we can always show all buttons
+        mShowAllButtons = displayWidth >= 1080;
     }
 
     public void setOnLoadMoreListener(OnLoadMoreListener listener) {


### PR DESCRIPTION
Fixes #6793 - hides the Preview button when post failed to upload, which enables the Retry button to appear in the first button row. Also cleaned up some of the logic in the adapter while I was at it.

cc: @mzorz 