### PR TITLE
Making sanitizeMediaUploadStateForSite run on first run

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -291,9 +291,14 @@ public class WordPress extends MultiDexApplication {
 
     private void sanitizeMediaUploadStateForSite() {
         int siteLocalId = AppPrefs.getSelectedSite();
-        SiteModel selectedSite = mSiteStore.getSiteByLocalId(siteLocalId);
+        final SiteModel selectedSite = mSiteStore.getSiteByLocalId(siteLocalId);
         if (selectedSite != null) {
-            UploadService.sanitizeMediaUploadStateForSite(mMediaStore, mDispatcher, selectedSite);
+            new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    UploadService.sanitizeMediaUploadStateForSite(mMediaStore, mDispatcher, selectedSite);
+                }
+            }).start();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -275,6 +275,9 @@ public class WordPress extends MultiDexApplication {
         // Note: if removed, this will cause crashes on Android < 21
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
 
+        // verify media is sanitized
+        sanitizeMediaUploadStateForSite();
+
         // setup the Credentials Client so we can clean it up on wpcom logout
         mCredentialsClient = new GoogleApiClient.Builder(this)
                 .addConnectionCallbacks(new GoogleApiClient.ConnectionCallbacks() {
@@ -284,6 +287,14 @@ public class WordPress extends MultiDexApplication {
                 .addApi(Auth.CREDENTIALS_API)
                 .build();
         mCredentialsClient.connect();
+    }
+
+    private void sanitizeMediaUploadStateForSite() {
+        int siteLocalId = AppPrefs.getSelectedSite();
+        SiteModel selectedSite = mSiteStore.getSiteByLocalId(siteLocalId);
+        if (selectedSite != null) {
+            UploadService.sanitizeMediaUploadStateForSite(mMediaStore, mDispatcher, selectedSite);
+        }
     }
 
     private void initAnalytics(final long elapsedTimeOnCreate) {
@@ -665,14 +676,6 @@ public class WordPress extends MultiDexApplication {
             if (isPushNotificationPingNeeded() && mAccountStore.hasAccessToken()) {
                 // Register for Cloud messaging
                 startService(new Intent(getContext(), GCMRegistrationIntentService.class));
-            }
-        }
-
-        private void sanitizeMediaUploadStateForSite() {
-            int siteLocalId = AppPrefs.getSelectedSite();
-            SiteModel selectedSite = mSiteStore.getSiteByLocalId(siteLocalId);
-            if (selectedSite != null) {
-                UploadService.sanitizeMediaUploadStateForSite(mMediaStore, mDispatcher, selectedSite);
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -492,6 +492,11 @@ public class UploadService extends Service {
                 mediaStore.getSiteMediaWithState(site, MediaModel.MediaUploadState.UPLOADING);
         List<MediaModel> queuedMedia =
                 mediaStore.getSiteMediaWithState(site, MediaModel.MediaUploadState.QUEUED);
+
+        if (uploadingMedia.isEmpty() && queuedMedia.isEmpty()) {
+            return;
+        }
+
         List<MediaModel> uploadingOrQueuedMedia = new ArrayList<>();
         uploadingOrQueuedMedia.addAll(uploadingMedia);
         uploadingOrQueuedMedia.addAll(queuedMedia);


### PR DESCRIPTION
Fixes #6794 

The code to sanitize the state was already there, but when you run the app for the first time the code for  the lifecycle listener `appComesFromBackground` is not executed. If OTOH you open the app, send it to the background, and then bring it to the foreground again, the code would be executed, thus showing the right information in the Posts list screen.

With this PR, having the app be force-stopped and then launched again will make the errors visible right away on the first run.

To test:
1. open the app and start a new draft
2. include some media in it
3. exit the editor
4. while uploads are still happening, go to Settings->Apps->WordPress-> tap FORCE STOP and answer "OK"  to the confirm dialog.
5. launch the app again
6. go to the Posts list screen
7. observe the Post that was uploading shows an error in the Posts list.

cc @daniloercoli 
