### PR TITLE
moved method mediaModelFromLocalUri from WPMediaUtils to FluxCUtils

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -69,6 +69,7 @@ import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.CrashlyticsUtils;
 import org.wordpress.android.util.DisplayUtils;
+import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.ListUtils;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.NetworkUtils;
@@ -950,7 +951,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     }
 
     private void queueFileForUpload(Uri uri, String mimeType) {
-        MediaModel media = WPMediaUtils.mediaModelFromLocalUri(this, uri, mimeType, mMediaStore, mSite.getId());
+        MediaModel media = FluxCUtils.mediaModelFromLocalUri(this, uri, mimeType, mMediaStore, mSite.getId());
         if (media == null) {
             ToastUtils.showToast(this, R.string.file_not_found, ToastUtils.Duration.SHORT);
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -31,6 +31,7 @@ import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.media.MediaBrowserType;
 import org.wordpress.android.ui.uploads.UploadService;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.FluxCUtils;
 import org.wordpress.android.util.ListUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -289,7 +290,7 @@ public class PhotoPickerActivity extends AppCompatActivity
 
         showUploadProgressDialog();
 
-        MediaModel media = WPMediaUtils.mediaModelFromLocalUri(this, mediaUri, null, mMediaStore, mSite.getId());
+        MediaModel media = FluxCUtils.mediaModelFromLocalUri(this, mediaUri, null, mMediaStore, mSite.getId());
         mDispatcher.dispatch(MediaActionBuilder.newUpdateMediaAction(media));
         ArrayList<MediaModel> mediaList = new ArrayList<>();
         mediaList.add(media);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2341,42 +2341,14 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private MediaModel buildMediaModel(Uri uri, String mimeType, MediaUploadState startingState) {
-        String path = MediaUtils.getRealPathFromURI(this, uri);
 
-        MediaModel media = mMediaStore.instantiateMediaModel();
-        AppLog.i(T.MEDIA, "New media instantiated localId=" + media.getId());
-        String filename = org.wordpress.android.fluxc.utils.MediaUtils.getFileName(path);
-        String fileExtension = org.wordpress.android.fluxc.utils.MediaUtils.getExtension(path);
-
-        // Try to get mimetype if none was passed to this method
-        if (mimeType == null) {
-            mimeType = getContentResolver().getType(uri);
-            if (mimeType == null) {
-                mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExtension);
-            }
-            if (mimeType == null) {
-                // Default to image jpeg
-                mimeType = "image/jpeg";
-            }
-        }
-        // If file extension is null, upload won't work on wordpress.com
-        if (fileExtension == null) {
-            fileExtension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
-            filename += "." + fileExtension;
-        }
-
-        if (org.wordpress.android.fluxc.utils.MediaUtils.isVideoMimeType(mimeType)) {
+        MediaModel media = FluxCUtils.mediaModelFromLocalUri(this, uri, mimeType, mMediaStore, mSite.getId());
+        if (org.wordpress.android.fluxc.utils.MediaUtils.isVideoMimeType(media.getMimeType())) {
+            String path = MediaUtils.getRealPathFromURI(this, uri);
             media.setThumbnailUrl(getVideoThumbnail(path));
         }
 
-        media.setFileName(filename);
-        media.setTitle(filename);
-        media.setFilePath(path);
-        media.setLocalSiteId(mSite.getId());
-        media.setFileExtension(fileExtension);
-        media.setMimeType(mimeType);
         media.setUploadState(startingState);
-        media.setUploadDate(DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000));
         if (!mPost.isLocalDraft()) {
             media.setPostId(mPost.getRemotePostId());
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -1,9 +1,18 @@
 package org.wordpress.android.util;
 
+import android.content.Context;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+import android.webkit.MimeTypeMap;
+
 import org.wordpress.android.fluxc.model.MediaModel;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.util.helpers.MediaFile;
+
+import java.io.File;
 
 public class FluxCUtils {
     /**
@@ -61,4 +70,63 @@ public class FluxCUtils {
         mediaFile.setWidth(media.getWidth());
         return mediaFile;
     }
+
+    /*
+     * returns a MediaModel from a device media URI
+     */
+    public static MediaModel mediaModelFromLocalUri(@NonNull Context context,
+                                                    @NonNull Uri uri,
+                                                    @Nullable String mimeType,
+                                                    @NonNull org.wordpress.android.fluxc.store.MediaStore mediaStore,
+                                                    int localSiteId) {
+        String path = MediaUtils.getRealPathFromURI(context, uri);
+
+        if (TextUtils.isEmpty(path)) {
+            return null;
+        }
+
+        File file = new File(path);
+        if (!file.exists()) {
+            return null;
+        }
+
+        MediaModel media = mediaStore.instantiateMediaModel();
+        String filename = org.wordpress.android.fluxc.utils.MediaUtils.getFileName(path);
+        String fileExtension = org.wordpress.android.fluxc.utils.MediaUtils.getExtension(path);
+
+        if (TextUtils.isEmpty(mimeType)) {
+            mimeType = context.getContentResolver().getType(uri);
+            if (mimeType == null) {
+                mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExtension);
+                if (mimeType == null) {
+                    mimeType = context.getContentResolver().getType(uri);
+                    if (mimeType == null) {
+                        mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExtension);
+                    }
+                    if (mimeType == null) {
+                        // Default to image jpeg
+                        mimeType = "image/jpeg";
+                    }
+                }
+            }
+        }
+
+        // If file extension is null, upload won't work on wordpress.com
+        if (fileExtension == null) {
+            fileExtension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
+            filename += "." + fileExtension;
+        }
+
+        media.setFileName(filename);
+        media.setTitle(filename);
+        media.setFilePath(path);
+        media.setLocalSiteId(localSiteId);
+        media.setFileExtension(fileExtension);
+        media.setMimeType(mimeType);
+        media.setUploadState(MediaModel.MediaUploadState.QUEUED);
+        media.setUploadDate(DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000));
+
+        return media;
+    }
+
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/FluxCUtils.java
@@ -99,14 +99,8 @@ public class FluxCUtils {
             if (mimeType == null) {
                 mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExtension);
                 if (mimeType == null) {
-                    mimeType = context.getContentResolver().getType(uri);
-                    if (mimeType == null) {
-                        mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExtension);
-                    }
-                    if (mimeType == null) {
-                        // Default to image jpeg
-                        mimeType = "image/jpeg";
-                    }
+                    // Default to image jpeg
+                    mimeType = "image/jpeg";
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -15,9 +15,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.content.FileProvider;
-import android.text.TextUtils;
 import android.view.ViewConfiguration;
-import android.webkit.MimeTypeMap;
 
 import com.android.volley.toolbox.NetworkImageView;
 
@@ -444,61 +442,4 @@ public class WPMediaUtils {
         return ViewConfiguration.get(context).getScaledMaximumFlingVelocity() / 2;
     }
 
-    /*
-     * returns a MediaModel from a device media URI
-     */
-    public static MediaModel mediaModelFromLocalUri(@NonNull Context context,
-                                                    @NonNull Uri uri,
-                                                    @Nullable String mimeType,
-                                                    @NonNull org.wordpress.android.fluxc.store.MediaStore mediaStore,
-                                                    int localSiteId) {
-        String path = MediaUtils.getRealPathFromURI(context, uri);
-
-        if (TextUtils.isEmpty(path)) {
-            return null;
-        }
-
-        File file = new File(path);
-        if (!file.exists()) {
-            return null;
-        }
-
-        MediaModel media = mediaStore.instantiateMediaModel();
-        String filename = org.wordpress.android.fluxc.utils.MediaUtils.getFileName(path);
-        String fileExtension = org.wordpress.android.fluxc.utils.MediaUtils.getExtension(path);
-
-        if (TextUtils.isEmpty(mimeType)) {
-            mimeType = context.getContentResolver().getType(uri);
-            if (mimeType == null) {
-                mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExtension);
-                if (mimeType == null) {
-                    mimeType = context.getContentResolver().getType(uri);
-                    if (mimeType == null) {
-                        mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(fileExtension);
-                    }
-                    if (mimeType == null) {
-                        // Default to image jpeg
-                        mimeType = "image/jpeg";
-                    }
-                }
-            }
-        }
-
-        // If file extension is null, upload won't work on wordpress.com
-        if (fileExtension == null) {
-            fileExtension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
-            filename += "." + fileExtension;
-        }
-
-        media.setFileName(filename);
-        media.setTitle(filename);
-        media.setFilePath(path);
-        media.setLocalSiteId(localSiteId);
-        media.setFileExtension(fileExtension);
-        media.setMimeType(mimeType);
-        media.setUploadState(MediaModel.MediaUploadState.QUEUED);
-        media.setUploadDate(DateTimeUtils.iso8601UTCFromTimestamp(System.currentTimeMillis() / 1000));
-
-        return media;
-    }
 }


### PR DESCRIPTION
Comes from https://github.com/wordpress-mobile/WordPress-Android/pull/6792#discussion_r147407846

Moves method `mediaModelFromLocalUri` from `WPMediaUtils` to `FluxCUtils`.

To test: 
Make sure #6792 works as expected as per the steps described in issue #6719
cc @nbradbury

