### PR TITLE
remove media count from progress notification when media canceled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -150,6 +150,16 @@ class PostUploadNotifier {
     void removeMediaInfoFromForegroundNotification(@NonNull List<MediaModel> mediaList) {
         if (sNotificationData.totalMediaItems >= mediaList.size()) {
             sNotificationData.totalMediaItems -= mediaList.size();
+            // update Notification now
+            updateForegroundNotification(null);
+        }
+    }
+
+    void removeOneMediaItemInfoFromForegroundNotification() {
+        if (sNotificationData.totalMediaItems >= 1) {
+            sNotificationData.totalMediaItems --;
+            // update Notification now
+            updateForegroundNotification(null);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -157,7 +157,7 @@ class PostUploadNotifier {
 
     void removeOneMediaItemInfoFromForegroundNotification() {
         if (sNotificationData.totalMediaItems >= 1) {
-            sNotificationData.totalMediaItems --;
+            sNotificationData.totalMediaItems--;
             // update Notification now
             updateForegroundNotification(null);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -714,6 +714,10 @@ public class UploadService extends Service {
         }
 
         if (event.canceled) {
+            // remove this media item from the progress notification
+            if (sInstance != null) {
+                sInstance.mPostUploadNotifier.removeOneMediaItemInfoFromForegroundNotification();
+            }
             if (event.media.getLocalPostId() > 0) {
                 AppLog.i(T.MAIN, "UploadService > Upload cancelled for post with id " + event.media.getLocalPostId()
                         + " - a media upload for this post has been cancelled, id: " + event.media.getId());


### PR DESCRIPTION
Fixes #6800 

(keeps the right count of media files being uploaded when media items are deleted from Aztec)

To test:
1. start a new draft on Aztec
2. insert some media in it. Preferrably, large files (such as videos) to let you perceive the changes. Please add at least 3 of them.
3. as upload start for all 3, you should see the progress notification appears, reading "3 of 3 media files remaining"
4. place the cursor to the right of one of the videos (because of some strange Aztec behavior, it's very difficult to place the cursor right after any media item except the last one - tracked in https://github.com/wordpress-mobile/AztecEditor-Android/issues/492).
5. press backspace to delete the media item
6. observe the progress notification (if you did this before any 3 items completed uploading), reads now "2 of 2 media files remaining"
7. repeat steps 4 and 5, and observe the progress notification now reads "1 media file remaining"
8. repeat steps 4 and 5, and observe the progress notification is now gone.

cc @nbradbury 
