### PR TITLE
Prevent crash in trashed posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -610,7 +610,7 @@ public class PostsListFragment extends Fragment
                 mTrashedPosts.remove(post);
 
                 // here cancel all media uploads related to this Post
-                UploadService.cancelQueuedPostUploadAndRelatedMedia(getActivity(), post);
+                UploadService.cancelQueuedPostUploadAndRelatedMedia(WordPress.getContext(), post);
 
                 if (post.isLocalDraft()) {
                     mDispatcher.dispatch(PostActionBuilder.newRemovePostAction(post));

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -618,7 +618,7 @@ public class PostsListFragment extends Fragment
                     // delete the pending draft notification if available
                     mShouldCancelPendingDraftNotification = false;
                     int pushId = PendingDraftsNotificationsUtils.makePendingDraftNotificationId(post.getId());
-                    NativeNotificationsUtils.dismissNotification(pushId, getActivity());
+                    NativeNotificationsUtils.dismissNotification(pushId, WordPress.getContext());
                 } else {
                     mDispatcher.dispatch(PostActionBuilder.newDeletePostAction(new RemotePostPayload(post, mSite)));
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -234,9 +234,11 @@ class PostUploadNotifier {
     // cancels the error or success notification (only one of these exist per Post at any given
     // time
     public static void cancelFinalNotification(Context context, @NonNull PostModel post) {
-        NotificationManager notificationManager = (NotificationManager) SystemServiceFactory.get(context,
-                Context.NOTIFICATION_SERVICE);
-        notificationManager.cancel((int)getNotificationIdForPost(post));
+        if (context != null) {
+            NotificationManager notificationManager = (NotificationManager) SystemServiceFactory.get(context,
+                    Context.NOTIFICATION_SERVICE);
+            notificationManager.cancel((int)getNotificationIdForPost(post));
+        }
     }
 
     void cancelFinalNotificationForMedia(@NonNull SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -368,10 +368,12 @@ public class UploadService extends Service {
 
     public static void cancelQueuedPostUploadAndRelatedMedia(Context context, PostModel post) {
         if (post != null) {
-            PostUploadNotifier.cancelFinalNotification(context, post);
             if (sInstance != null) {
+                PostUploadNotifier.cancelFinalNotification(sInstance, post);
                 sInstance.mPostUploadNotifier.removePostInfoFromForegroundNotification(
                         post, sInstance.mMediaStore.getMediaForPost(post));
+            } else {
+                PostUploadNotifier.cancelFinalNotification(context, post);
             }
             cancelQueuedPostUpload(post);
             EventBus.getDefault().post(new PostEvents.PostMediaCanceled(post));


### PR DESCRIPTION
Fixes #6804 

Adds null check for context before trying to get notification service instance in `cancelFinalNotification`, and tries to use the `UploadService` as a context if present in order to cancel one of their notifications in `cancelQueuedPostUploadAndRelatedMedia`.


To test:
1. start a draft, include some media
2. exit the editor, quickly tap on `Trash/delete` in the Posts List
3. quickly exit the Post list

The app shouldn't crash

cc @nbradbury 
