### PR TITLE
Added regex to strip off any wrapping <span> and <progress> tags

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -427,7 +427,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         // as the AztecParser takes care of that, and it would be very difficult to accomplish with a
         // regex (and using a proper XML crawler would be particularly overkill)
         if (originalText != null && originalText.contains("<progress")) {
-            String regex = "<progress.*?><\\/progress>|<span id=\"img_container.*?>";
+            String regex = "<progress.*?><\\/progress>|<span id=\"img_container.*? class=\"img_container\" contenteditable=\"false\">";
             return originalText.replaceAll(regex, "");
         } else {
             return originalText;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -407,7 +407,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             return;
         }
 
-        content.fromHtml(text.toString());
+        content.fromHtml(removeVisualEditorProgressTag(text.toString()));
 
         updateFailedMediaList();
         overlayFailedMedia();
@@ -416,6 +416,14 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         overlayProgressingMedia();
 
         mAztecReady = true;
+    }
+
+    /*
+    * TODO: REMOVE THIS ONCE AZTEC COMPLETELY REPLACES THE VISUAL EDITOR IN WPANDROID APP
+     */
+    private String removeVisualEditorProgressTag(String originalText) {
+        String regex = "<span.*\\/progress>|<\\/span>";
+        return originalText.replaceAll(regex, "");
     }
 
     /**

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -422,6 +422,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     * TODO: REMOVE THIS ONCE AZTEC COMPLETELY REPLACES THE VISUAL EDITOR IN WPANDROID APP
      */
     private String removeVisualEditorProgressTag(String originalText) {
+        // this regex picks any <progress> tags and any opening <span> tags for image containers
+        // as produced by the Visual Editor. Note that we don't care about closing </span> tags
+        // as the AztecParser takes care of that, and it would be very difficult to accomplish with a
+        // regex (and using a proper XML crawler would be particularly overkill)
         String regex = "<progress.*?><\\/progress>|<span id=\"img_container.*?>";
         return originalText.replaceAll(regex, "");
     }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -426,8 +426,12 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         // as produced by the Visual Editor. Note that we don't care about closing </span> tags
         // as the AztecParser takes care of that, and it would be very difficult to accomplish with a
         // regex (and using a proper XML crawler would be particularly overkill)
-        String regex = "<progress.*?><\\/progress>|<span id=\"img_container.*?>";
-        return originalText.replaceAll(regex, "");
+        if (originalText != null && originalText.contains("<progress")) {
+            String regex = "<progress.*?><\\/progress>|<span id=\"img_container.*?>";
+            return originalText.replaceAll(regex, "");
+        } else {
+            return originalText;
+        }
     }
 
     /**

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -422,7 +422,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     * TODO: REMOVE THIS ONCE AZTEC COMPLETELY REPLACES THE VISUAL EDITOR IN WPANDROID APP
      */
     private String removeVisualEditorProgressTag(String originalText) {
-        String regex = "<span.*\\/progress>|<\\/span>";
+        String regex = "<progress.*?><\\/progress>|<span id=\"img_container.*?>";
         return originalText.replaceAll(regex, "");
     }
 


### PR DESCRIPTION
Fixes #6799 

The question marks that  appear when opening in Aztec a failed post originally produced with the Visual Editor are there as Aztec wouldn't know how to parse the `<progress>` tags introduced by the Visual Editor while uploading. If an upload fails (for example due to connectivity loss) the html is still got the wrapping tags as produced by the Visual Editor.

This piece of HTML produced by the Visual Editor contains variants of failed images that I used to come up with a regex that would work:

```
Fud
<span id="img_container_62" class="img_container" contenteditable="false"><progress id="progress_62" value="0.03" class="wp_media_indicator" contenteditable="false"></progress><img data-wpid="62" src="/storage/emulated/0/DCIM/Camera/IMG_20171029_170209.jpg" alt="" class="failed"></span>

<span id="img_container_61" class="img_container" contenteditable="false"><progress id="progress_61" value="0.2" class="wp_media_indicator" contenteditable="false"></progress><img data-wpid="61" src="/storage/emulated/0/WhatsApp/Media/WhatsApp Images/IMG-20171029-WA0022.jpeg" alt="" class="failed"></span>


Fufud <progress id="progress_70" value="0.3" class="wp_media_indicator" contenteditable="false"></progress><img class="failed" data-wpid="70" src="/storage/emulated/0/DCIM/Camera/IMG_20171031_092932.jpg" alt="" /> <progress id="progress_69" value="0.1" class="wp_media_indicator" contenteditable="false"></progress><img class="failed" data-wpid="69" src="/storage/emulated/0/DCIM/Camera/IMG_20171031_093136.jpg" alt="" />

```

It is generally known that using regex-es to parse XML/HTML is not a good idea, but in this case we're in a controlled environment where we know exactly which input to expect, and we can't really afford the overweight of having a full xml parser to strip the unnecessary tags off the original string.
Also, the Visual Editor itself uses regular expressions to produce some of its output.

The applied regex highlights the parts that are of interest here:
<img width="836" alt="screen shot 2017-10-31 at 3 31 30 pm" src="https://user-images.githubusercontent.com/6597771/32242090-8d5b785e-be7a-11e7-8822-8744091b757b.png">


To test:
1. set visual editor
2. start draft and include some media items
3. exit the editor
4. turn airplane mode ON
5. set editor to Beta
6. turn airplane mode OFF
7. go to posts list
8. edit the post
9. confirm there are no more question marks (the post loads seamlessly and shows the failed images with the `Retry` overlay).
12. tap on them and confirm the image uploads is re-started.

cc @nbradbury 

