### PR TITLE
8.5 - Fix NPE MediaPreview

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewFragment.java
@@ -272,7 +272,12 @@ public class MediaPreviewFragment extends Fragment implements MediaController.Me
     /*
      * loads and displays a remote or local image
      */
-    private void loadImage(@NonNull String mediaUri) {
+    private void loadImage(String mediaUri) {
+        if (TextUtils.isEmpty(mediaUri)) {
+            showLoadingError();
+            return;
+        }
+
         mImageView.setVisibility(View.VISIBLE);
 
         int width = DisplayUtils.getDisplayPixelWidth(getActivity());


### PR DESCRIPTION
Fixes #6818 by making sure the media URL is not null before opening it.
For some reason (maybe a plugin or a misconfigured site) the URL field of media details is `null`.

