### PR TITLE
Saving remote Post id in EditPostActivity state

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:feature~add-get-post-by-remote-id-SNAPSHOT') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:6603e2cf5c58f764169e842c676b14fb7ff01fdb') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:6422c5020f442bbe42003cb1ae887b8f898e1d2d') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:feature~add-get-post-by-remote-id-SNAPSHOT') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -549,7 +549,9 @@ public class EditPostActivity extends AppCompatActivity implements
         // Saves both post objects so we can restore them in onCreate()
         savePostAsync(null);
         outState.putInt(STATE_KEY_POST_LOCAL_ID, mPost.getId());
-        outState.putLong(STATE_KEY_POST_REMOTE_ID, mPost.getRemotePostId());
+        if (!mPost.isLocalDraft()) {
+            outState.putLong(STATE_KEY_POST_REMOTE_ID, mPost.getRemotePostId());
+        }
         outState.putBoolean(STATE_KEY_IS_NEW_POST, mIsNewPost);
         outState.putSerializable(WordPress.SITE, mSite);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -330,8 +330,7 @@ public class EditPostActivity extends AppCompatActivity implements
             // after FETCH_POSTS
             if (savedInstanceState.containsKey(STATE_KEY_POST_REMOTE_ID)) {
                 initializePostObjectsWithRemoteId(savedInstanceState.getLong(STATE_KEY_POST_REMOTE_ID));
-            }
-            else if (savedInstanceState.containsKey(STATE_KEY_POST_LOCAL_ID)) {
+            } else if (savedInstanceState.containsKey(STATE_KEY_POST_LOCAL_ID)) {
                 initializePostObjectsWithLocalId(savedInstanceState.getInt(STATE_KEY_POST_LOCAL_ID));
             }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -171,6 +171,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private static final String STATE_KEY_EDITOR_FRAGMENT = "editorFragment";
     private static final String STATE_KEY_DROPPED_MEDIA_URIS = "stateKeyDroppedMediaUri";
     private static final String STATE_KEY_POST_LOCAL_ID = "stateKeyPostModelLocalId";
+    private static final String STATE_KEY_POST_REMOTE_ID = "stateKeyPostModelRemoteId";
     private static final String STATE_KEY_IS_NEW_POST = "stateKeyIsNewPost";
 
     private static int PAGE_CONTENT = 0;
@@ -319,14 +320,19 @@ public class EditPostActivity extends AppCompatActivity implements
                 mPost.setStatus(PostStatus.PUBLISHED.toString());
             } else if (extras != null) {
                 // Load post passed in extras
-                initializePostObjects(extras.getInt(EXTRA_POST_LOCAL_ID));
+                initializePostObjectsWithLocalId(extras.getInt(EXTRA_POST_LOCAL_ID));
             }
         } else {
             mDroppedMediaUris = savedInstanceState.getParcelable(STATE_KEY_DROPPED_MEDIA_URIS);
             mIsNewPost = savedInstanceState.getBoolean(STATE_KEY_IS_NEW_POST, false);
 
-            if (savedInstanceState.containsKey(STATE_KEY_POST_LOCAL_ID)) {
-                initializePostObjects(savedInstanceState.getInt(STATE_KEY_POST_LOCAL_ID));
+            // if we have a remote id saved, let's first try with that, as the local Id might have changed
+            // after FETCH_POSTS
+            if (savedInstanceState.containsKey(STATE_KEY_POST_REMOTE_ID)) {
+                initializePostObjectsWithRemoteId(savedInstanceState.getLong(STATE_KEY_POST_REMOTE_ID));
+            }
+            else if (savedInstanceState.containsKey(STATE_KEY_POST_LOCAL_ID)) {
+                initializePostObjectsWithLocalId(savedInstanceState.getInt(STATE_KEY_POST_LOCAL_ID));
             }
 
             mEditorFragment = (EditorFragmentAbstract) fragmentManager.getFragment(savedInstanceState, STATE_KEY_EDITOR_FRAGMENT);
@@ -404,16 +410,27 @@ public class EditPostActivity extends AppCompatActivity implements
         ActivityId.trackLastActivity(ActivityId.POST_EDITOR);
     }
 
-    private void initializePostObjects(int localPostId) {
+    private void initializePostObjectsWithLocalId(int localPostId) {
         mPost = mPostStore.getPostByLocalPostId(localPostId);
         if (mPost != null) {
-            mOriginalPost = mPost.clone();
-            mPost = UploadService.updatePostWithCurrentlyCompletedUploads(mPost);
-            mMediaMarkedUploadingOnStartIds =
-                    AztecEditorFragment.getMediaMarkedUploadingInPostContent(this, mPost.getContent());
-            Collections.sort(mMediaMarkedUploadingOnStartIds);
-            mIsPage = mPost.isPage();
+            initializePostObject();
         }
+    }
+
+    private void initializePostObjectsWithRemoteId(long remotePostId) {
+        mPost = mPostStore.getPostByRemotePostId(remotePostId, mSite);
+        if (mPost != null) {
+            initializePostObject();
+        }
+    }
+
+    private void initializePostObject() {
+        mOriginalPost = mPost.clone();
+        mPost = UploadService.updatePostWithCurrentlyCompletedUploads(mPost);
+        mMediaMarkedUploadingOnStartIds =
+                AztecEditorFragment.getMediaMarkedUploadingInPostContent(this, mPost.getContent());
+        Collections.sort(mMediaMarkedUploadingOnStartIds);
+        mIsPage = mPost.isPage();
     }
 
     // this method aims at recovering the current state of media items if they're inconsistent within the PostModel.
@@ -532,6 +549,7 @@ public class EditPostActivity extends AppCompatActivity implements
         // Saves both post objects so we can restore them in onCreate()
         savePostAsync(null);
         outState.putInt(STATE_KEY_POST_LOCAL_ID, mPost.getId());
+        outState.putLong(STATE_KEY_POST_REMOTE_ID, mPost.getRemotePostId());
         outState.putBoolean(STATE_KEY_IS_NEW_POST, mIsNewPost);
         outState.putSerializable(WordPress.SITE, mSite);
 


### PR DESCRIPTION

Fixes #6808 

Before merging, we need to merge the FluxC branch https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/600 and update the FluxC hash here first.

To test:
These steps have worked consistently for me, and are easier for reproduction:

Using the `release/8.5` branch:
0. set developer options to `Don’t keep activities`
1. go to posts list
2. pull down to refresh
3. while its refreshing, tap on a post
4. while in the editor and once the refresh has finished (check logs or wait a few seconds), tap HOME to kill the a activity
5. go back to the app
6. observe the crash

Switch to this branch `issue/6808-use-remote-post-id-if-available` and repeat steps 1-5 above, observe the app doesn't crash anymore.


