### PR TITLE
Async error gathering

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/adapters/PostsListAdapter.java
@@ -440,7 +440,7 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
             String errorMessage = null;
 
             UploadError reason = mUploadStore.getUploadErrorForPost(post);
-            if (reason != null) {
+            if (reason != null && !UploadService.hasInProgressMediaUploadsForPost(post)) {
                 if (reason.mediaError != null) {
                     errorMessage = context.getString(post.isPage() ? R.string.error_media_recover_page
                             : R.string.error_media_recover_post);
@@ -518,7 +518,8 @@ public class PostsListAdapter extends RecyclerView.Adapter<RecyclerView.ViewHold
 
     private void configurePostButtons(final PostViewHolder holder,
                                       final PostModel post) {
-        boolean canRetry = mUploadStore.getUploadErrorForPost(post) != null;
+        boolean canRetry = mUploadStore.getUploadErrorForPost(post) != null
+                && !UploadService.hasInProgressMediaUploadsForPost(post);
         boolean canShowViewButton = !canRetry;
         boolean canShowStatsButton = canShowStatsForPost(post);
         boolean canShowPublishButton = canRetry || canPublishPost(post);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -199,7 +199,8 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
                 // This block only runs if the PUSH_POST action was never dispatched - if it was dispatched, any error
                 // will be handled in OnPostChanged instead of here
                 mPostUploadNotifier.incrementUploadedPostCountFromForegroundNotification(mPost);
-                mPostUploadNotifier.updateNotificationErrorForPost(mPost, mSite, mErrorMessage);
+                mPostUploadNotifier.updateNotificationErrorForPost(mPost, mSite, mErrorMessage,
+                        PostUploadNotifier.K_DONT_OVERRIDE_MEDIA_COUNT);
                 finishUpload();
             }
         }
@@ -544,7 +545,8 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
             String errorMessage = UploadUtils.getErrorMessageFromPostError(context, event.post, event.error);
             String notificationMessage = UploadUtils.getErrorMessage(context, event.post, errorMessage, false);
             mPostUploadNotifier.incrementUploadedPostCountFromForegroundNotification(event.post);
-            mPostUploadNotifier.updateNotificationErrorForPost(event.post, site, notificationMessage);
+            mPostUploadNotifier.updateNotificationErrorForPost(event.post, site, notificationMessage,
+                    PostUploadNotifier.K_DONT_OVERRIDE_MEDIA_COUNT);
             sFirstPublishPosts.remove(event.post.getId());
         } else {
             mPostUploadNotifier.incrementUploadedPostCountFromForegroundNotification(event.post);
@@ -595,7 +597,8 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
             String notificationMessage =
                     UploadUtils.getErrorMessage(context, sCurrentUploadingPost, errorMessage, true);
             mPostUploadNotifier.incrementUploadedPostCountFromForegroundNotification(sCurrentUploadingPost);
-            mPostUploadNotifier.updateNotificationErrorForPost(sCurrentUploadingPost, site, notificationMessage);
+            mPostUploadNotifier.updateNotificationErrorForPost(sCurrentUploadingPost, site, notificationMessage,
+                    PostUploadNotifier.K_DONT_OVERRIDE_MEDIA_COUNT);
             sFirstPublishPosts.remove(sCurrentUploadingPost.getId());
             finishUpload();
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -199,8 +199,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
                 // This block only runs if the PUSH_POST action was never dispatched - if it was dispatched, any error
                 // will be handled in OnPostChanged instead of here
                 mPostUploadNotifier.incrementUploadedPostCountFromForegroundNotification(mPost);
-                mPostUploadNotifier.updateNotificationErrorForPost(mPost, mSite, mErrorMessage,
-                        PostUploadNotifier.K_DONT_OVERRIDE_MEDIA_COUNT);
+                mPostUploadNotifier.updateNotificationErrorForPost(mPost, mSite, mErrorMessage, 0);
                 finishUpload();
             }
         }
@@ -545,8 +544,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
             String errorMessage = UploadUtils.getErrorMessageFromPostError(context, event.post, event.error);
             String notificationMessage = UploadUtils.getErrorMessage(context, event.post, errorMessage, false);
             mPostUploadNotifier.incrementUploadedPostCountFromForegroundNotification(event.post);
-            mPostUploadNotifier.updateNotificationErrorForPost(event.post, site, notificationMessage,
-                    PostUploadNotifier.K_DONT_OVERRIDE_MEDIA_COUNT);
+            mPostUploadNotifier.updateNotificationErrorForPost(event.post, site, notificationMessage, 0);
             sFirstPublishPosts.remove(event.post.getId());
         } else {
             mPostUploadNotifier.incrementUploadedPostCountFromForegroundNotification(event.post);
@@ -597,8 +595,7 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
             String notificationMessage =
                     UploadUtils.getErrorMessage(context, sCurrentUploadingPost, errorMessage, true);
             mPostUploadNotifier.incrementUploadedPostCountFromForegroundNotification(sCurrentUploadingPost);
-            mPostUploadNotifier.updateNotificationErrorForPost(sCurrentUploadingPost, site, notificationMessage,
-                    PostUploadNotifier.K_DONT_OVERRIDE_MEDIA_COUNT);
+            mPostUploadNotifier.updateNotificationErrorForPost(sCurrentUploadingPost, site, notificationMessage, 0);
             sFirstPublishPosts.remove(sCurrentUploadingPost.getId());
             finishUpload();
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -2,8 +2,6 @@ package org.wordpress.android.ui.uploads;
 
 import android.content.Context;
 import android.database.Cursor;
-import android.graphics.Bitmap;
-import android.media.ThumbnailUtils;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.provider.MediaStore.Images;
@@ -36,9 +34,7 @@ import org.wordpress.android.ui.uploads.PostEvents.PostUploadStarted;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
-import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.FluxCUtils;
-import org.wordpress.android.util.ImageUtils;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.SqlUtils;
 import org.wordpress.android.util.helpers.MediaFile;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -424,7 +424,7 @@ class PostUploadNotifier {
      * for this  Post (i.e. how many media items have been uploaded successfully and how many failed, as well
      * as the information for the Post itself if we couldn't upload it).
      *
-     * In order to give the user a description of the *current state* of failed media items, youn can pass a value
+     * In order to give the user a description of the *current state* of failed media items, you can pass a value
      * other than zero (0) in overrideMediaNotUploadedCount and this value will be shown instead.
      */
     void updateNotificationErrorForPost(@NonNull PostModel post, @NonNull SiteModel site, String errorMessage,

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -37,7 +37,6 @@ import java.util.Random;
 import de.greenrobot.event.EventBus;
 
 class PostUploadNotifier {
-    public static final int K_DONT_OVERRIDE_MEDIA_COUNT = 0;
     private final Context mContext;
     private final UploadService mService;
 
@@ -420,6 +419,14 @@ class PostUploadNotifier {
         }
     }
 
+    /*
+     * This method will create an error notification with the description of the *final state* of the queue
+     * for this  Post (i.e. how many media items have been uploaded successfully and how many failed, as well
+     * as the information for the Post itself if we couldn't upload it).
+     *
+     * In order to give the user a description of the *current state* of failed media items, youn can pass a value
+     * other than zero (0) in overrideMediaNotUploadedCount and this value will be shown instead.
+     */
     void updateNotificationErrorForPost(@NonNull PostModel post, @NonNull SiteModel site, String errorMessage,
                                         int overrideMediaNotUploadedCount) {
         AppLog.d(AppLog.T.POSTS, "updateNotificationErrorForPost: " + errorMessage);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -819,6 +819,25 @@ public class UploadService extends Service {
         }
     }
 
+    /*
+     * This method will make sure to keep the bodies of all Posts registered (*) in the UploadStore
+     * up-to-date with their corresponding media item upload statuses (i.e. marking them failed or
+     * successfully uploaded in the actual Post content to reflect what the UploadStore says).
+     *
+     * Finally, it will either cancel the Post upload from the queue and create an error notification
+     * for the user if there are any failed media items for such a Post, or upload the Post if it's
+     * in good shape.
+     *
+     * This method returns:
+     * - `false` if all registered posts have no in-progress items, and at least one or more retriable
+     *      (failed) items are found in them (this, in other words, means all registered posts are found
+     *      in a `finalized` state other than "UPLOADED").
+     * - `true` if at least one registered Post is found that is in good conditions to be uploaded.
+     *
+     *
+     * (*)`Registered` posts are posts that had media in them and are waiting to be uploaded once
+     * their corresponding associated media is uploaded first.
+    */
     private boolean doFinalProcessingOfPosts() {
         // If this was the last media upload a post was waiting for, update the post content
         // This done for pending as well as cancelled and failed posts

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -633,13 +633,7 @@ public class UploadService extends Service {
 
     private boolean mediaBelongsToAPost(MediaModel media) {
         PostModel postToCancel = mPostStore.getPostByLocalPostId(media.getLocalPostId());
-        if (postToCancel == null) return false;
-
-        if (!mUploadStore.isRegisteredPostModel(postToCancel)) {
-            return false;
-        }
-
-        return true;
+        return (postToCancel != null && mUploadStore.isRegisteredPostModel(postToCancel));
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -670,7 +670,7 @@ public class UploadService extends Service {
         Set<MediaModel> failedMedia = mUploadStore.getFailedMediaForPost(post);
         mPostUploadNotifier.setTotalMediaItems(post, failedMedia.size());
         mPostUploadNotifier.updateNotificationErrorForPost(post,
-                mSiteStore.getSiteByLocalId(post.getLocalSiteId()), errorMessage, PostUploadNotifier.K_DONT_OVERRIDE_MEDIA_COUNT);
+                mSiteStore.getSiteByLocalId(post.getLocalSiteId()), errorMessage, 0);
 
     }
 
@@ -837,8 +837,7 @@ public class UploadService extends Service {
                         // update error notification for Post
                         SiteModel site = mSiteStore.getSiteByLocalId(postModel.getLocalSiteId());
                         String message = UploadUtils.getErrorMessage(this, postModel, getString(R.string.error_generic_error), true);
-                        mPostUploadNotifier.updateNotificationErrorForPost(postModel, site, message,
-                                PostUploadNotifier.K_DONT_OVERRIDE_MEDIA_COUNT);
+                        mPostUploadNotifier.updateNotificationErrorForPost(postModel, site, message, 0);
 
                         mPostUploadHandler.unregisterPostForAnalyticsTracking(postModel);
                         EventBus.getDefault().post(


### PR DESCRIPTION
Fixes #6835  by providing a way to update the error notification as errors occur, but not stop the progress notification (that is, letting all other uploads still happen and inform of their progresses while there are things being uploaded still).

This PR comprises the following changes:
- bb8a7444a324f16438672fa78919bbed160b2c87 this prevents any error from showing up in the Posts list if such a Post still has in-progress items (otherwise, if a Post with 5 items fails to upload the first one, it would show as failed while in reality the other items were still uploading).
- 483785aa554f29ef7b8e198dfb26b095e8597547 does a final processing of posts only when the queue seems to be empty (it was being done right after receiving a media error event from FluxC, which made it unnecessary as some other uploads might be still in progress as well)
- a7351ec88b146a59b724c3fc0169f3066a8cc2a7 repurposes the `updateNotificationErrorForPost()` method in `UploadNotifier` to allow for media failed count to be overriden. This is particularly handy to keep the user informed about what's going on with a specific Post for which some items might have failed but some other items are still in progress.

For example, this is how the notifications change before the following screenshot, which captures moment number 3 below:
1. 4 items have been included in a Post, and the user exited the editor. The progress notification shows "1 post, 4 of 4 media files remaining"
2. (not seen in the picture), 1 media file has been uploaded successfully, so the progress notification changes to "1 post, 3 of 4 media files remaining"
3. 1 media file has been uploaded sucessfully already, but another one failed. The error notification appears, saying "1 post, 1 media file not uploaded (1 successfully uploaded).", and the progress notification will show "1 post, 2 of 4 media files remaining".
<img width="371" alt="screen shot 2017-11-08 at 11 50 32 am" src="https://user-images.githubusercontent.com/6597771/32559454-da1fed56-c4af-11e7-9752-a479921efa78.png">


Find some live video captures here below. Not shown in the captures, I purposedly cancel some of the requests on Charles, to trigger errors in different situations.

![async_errors](https://user-images.githubusercontent.com/6597771/32556635-9eb83f5e-c4a8-11e7-8413-f27f718ee5f3.gif)

![async_errors_retry](https://user-images.githubusercontent.com/6597771/32556634-9e9462b4-c4a8-11e7-830a-3f1f275382f5.gif)


![async_errors_retry_last](https://user-images.githubusercontent.com/6597771/32556633-9e6c42e8-c4a8-11e7-99a5-0ac13df6f961.gif)


To test:

### TEST CASE H: multiple media upload & selective error & recover, outside the Editor (fully async)
For this one you’ll need to go through Charles proxy as I want to intentionally abort specific uploads.
1. go to the Posts list and start a new draft
2. open the media picker to include several media items
3. see the foreground progress notification starts and remains there for as long as it takes for the media item to upload. If you drag the drawer down, you should see the Notification shows title “Uploading…” and subtext “x of x media files remaining”. (with x being the number of items you included in the Post)
4. exit the editor.
5. you should see the progress notification there, and now it reads “1 post, x of x media files remaining”.
6. before the upload finishes, cancel one of the uploads. You can do so by setting a breakpoint in Charles for the endpoint `https://public-api.wordpress.com/rest/v1.1/sites/<site_id>/media/new/`
7. an error notification is shown for that specific item, and the foreground notiification keeps informing you of other remaining items. Note as well that the sum of items make for the complete items initially in the Post, for example if you inserted 5 items, the foreground notification will read "5 of 5 media files remaining", make one of them fail, you'll have an error notification saying 1 media file could not be uploaded, and the progress notification will read "4 of 5 media files remaining", etc.


cc @nbradbury 
