### PR TITLE
Issue/6812 update email error

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1930,7 +1930,7 @@
     <string name="enter_verification_code">Almost there! Please enter the verification code from your Authenticator app.</string>
     <string name="login_text_otp">Text me a code instead.</string>
     <string name="requesting_otp">Requesting a verification code via SMS.</string>
-    <string name="email_not_registered_wpcom">This email is not registered on WordPress.com</string>
+    <string name="email_not_registered_wpcom">Hmm, this email address isn\'t registered with WordPress.com.\nAre you trying to access a self-hosted site? Log in using the link at the bottom of this screen.</string>
     <string name="password_incorrect">It looks like this password is incorrect. Please double check your information and try again.</string>
     <string name="login_magic_links_label">We\'ll email you a magic link that\'ll log you in instantly, no password needed. Hunt and peck no more!</string>
     <string name="login_magic_links_sent_label">Your magic link is on its way! Check your email on this device and tap the link in the email you received from WordPress.com.</string>


### PR DESCRIPTION
### Fix
Update the error message on the login email screen as described in https://github.com/wordpress-mobile/WordPress-Android/issues/6812.

### Test
0. Clear app data.
1. Tap ***Log In*** button.
2. Enter ***pamela.nguyen@gmail.com*** email address.
3. Tap ***Next*** button.
4. Notice updated error message as shown below.

<img src="https://user-images.githubusercontent.com/3827611/32612904-af2215a8-c526-11e7-9bda-eba382d0918d.png" width="320">