### PR TITLE
Issue/google login canceled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginGoogleFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginGoogleFragment.java
@@ -282,7 +282,7 @@ public class LoginGoogleFragment extends Fragment implements ConnectionCallbacks
                     }
                 } else if (result == RESULT_CANCELED) {
                     AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_SOCIAL_BUTTON_FAILURE);
-                    AppLog.e(T.NUX, "Google Sign-in Failed: cancelled by user.");
+                    AppLog.e(T.NUX, "Google Sign-in Failed: result was CANCELED.");
                 } else {
                     AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_SOCIAL_BUTTON_FAILURE);
                     AppLog.e(T.NUX, "Google Sign-in Failed: result was not OK or CANCELED.");


### PR DESCRIPTION
### Fix
Update application logging text from `Google Sign-in Failed: cancelled by user.` to `Google Sign-in Failed: result was CANCELED.` when Google login returns with the result `RESULT_CANCELED`.  This case can occur not only when Google login is canceled by the user, but also when an incorrect configuration is used during the build process or when an incorrect Google account is chosen.  This text change will help differentiate between those occurrences and the [internal Google login cancelation](https://github.com/wordpress-mobile/WordPress-Android/blob/fe68c315ad6ff89ab1fd717ba65dfeb9da2048cd/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginGoogleFragment.java#L264).

### Test
1. Clear app data.
2. Keep `google-services.json-example` file.
3. Remove all `google-services.json` files.
4. Set breakpoint [here](https://github.com/wordpress-mobile/WordPress-Android/blob/fe68c315ad6ff89ab1fd717ba65dfeb9da2048cd/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginGoogleFragment.java#L285).
5. Tap ***Log In*** button.
6. Tap ***Log In with Google*** button.
7. Tap back button.
8. Notice breakpoint is hit.
9. Tap ***Log In with Google*** button.
10. Choose any Google account.
11. Notice breakpoint is hit.