### PR TITLE
Disallow empty password in username/password login screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -239,7 +239,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         }
 
         if (TextUtils.isEmpty(getCleanedUsername())) {
-            showError(getString(R.string.login_empty_username));
+            showUsernameError(getString(R.string.login_empty_username));
             EditTextUtils.showSoftInput(mUsernameInput.getEditText());
             return;
         }
@@ -290,20 +290,33 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         showError(null);
     }
 
+    private void showUsernameError(String errorMessage) {
+        mUsernameInput.setError(errorMessage);
+        mPasswordInput.setError(null);
+
+        if (errorMessage != null) {
+            requestScrollToView(mUsernameInput);
+        }
+    }
+
     private void showError(String errorMessage) {
         mUsernameInput.setError(errorMessage != null ? " " : null);
         mPasswordInput.setError(errorMessage);
 
         if (errorMessage != null) {
-            mPasswordInput.post(new Runnable() {
-                @Override
-                public void run() {
-                    Rect rect = new Rect(); //coordinates to scroll to
-                    mPasswordInput.getHitRect(rect);
-                    mScrollView.requestChildRectangleOnScreen(mPasswordInput, rect, false);
-                }
-            });
+            requestScrollToView(mPasswordInput);
         }
+    }
+
+    private void requestScrollToView(final View view) {
+        view.post(new Runnable() {
+            @Override
+            public void run() {
+                Rect rect = new Rect(); //coordinates to scroll to
+                view.getHitRect(rect);
+                mScrollView.requestChildRectangleOnScreen(view, rect, false);
+            }
+        });
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -244,10 +244,18 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
             return;
         }
 
+        final String password = mPasswordInput.getEditText().getText().toString();
+
+        if (TextUtils.isEmpty(password)) {
+            showPasswordError(getString(R.string.login_empty_password));
+            EditTextUtils.showSoftInput(mPasswordInput.getEditText());
+            return;
+        }
+
         startProgress();
 
         mRequestedUsername = getCleanedUsername();
-        mRequestedPassword = mPasswordInput.getEditText().getText().toString();
+        mRequestedPassword = password;
 
         // clear up the authentication-failed flag before
         mAuthFailed = false;
@@ -296,6 +304,15 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
 
         if (errorMessage != null) {
             requestScrollToView(mUsernameInput);
+        }
+    }
+
+    private void showPasswordError(String errorMessage) {
+        mUsernameInput.setError(null);
+        mPasswordInput.setError(errorMessage);
+
+        if (errorMessage != null) {
+            requestScrollToView(mPasswordInput);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPLoginInputRow.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPLoginInputRow.java
@@ -202,6 +202,9 @@ public class WPLoginInputRow extends RelativeLayout {
 
     public void setError(@Nullable final CharSequence error) {
         mTextInputLayout.setError(error);
+        if (error == null) {
+            mTextInputLayout.setErrorEnabled(false);
+        }
     }
 
     private static class SavedState extends BaseSavedState {

--- a/WordPress/src/main/res/layout/login_username_password_screen.xml
+++ b/WordPress/src/main/res/layout/login_username_password_screen.xml
@@ -92,6 +92,7 @@
         android:id="@+id/login_password_row"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_extra_large"
         android:layout_marginBottom="@dimen/margin_extra_extra_large"
         android:hint="@string/password"
         android:inputType="textPassword"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1956,6 +1956,7 @@
     <string name="login_log_in_for_share_intent">Log in to WordPress.com to share the content.</string>
     <string name="login_empty_site_url">Please enter a site address</string>
     <string name="login_empty_username">Please enter a username</string>
+    <string name="login_empty_password">Please enter a password</string>
     <string name="login_empty_2fa">Please enter a verification code</string>
     <string name="login_email_client_not_found">Can\'t detect your email client app</string>
     <string name="login_logged_in_as">Logged in as</string>


### PR DESCRIPTION
Fixes #6395 

Prevent continuing with the form and performing the network request if the password is empty.

To test:
* With the app's data cleaned, launch the app
* Hit "Login"
* Hit "Log in to your site by entering your site address instead." secondary action
* Put in your site address and hit "NEXT". Can be a WPCOM site.
* The username+password screen should be visible. Input some username but leave the password empty. Hit "NEXT". The "Please enter a password" error message should come up.