### PR TITLE
Don't log editor content

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/JsCallbackReceiver.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/JsCallbackReceiver.java
@@ -202,7 +202,10 @@ public class JsCallbackReceiver {
                 }
                 break;
             case CALLBACK_RESPONSE_STRING:
-                AppLog.d(AppLog.T.EDITOR, callbackId + ": " + params);
+                // log the params unless they contain the post content
+                if (!params.contains("function=getHTMLForCallback~id=zss_field_content~contents=")) {
+                    AppLog.d(AppLog.T.EDITOR, callbackId + ": " + params);
+                }
                 Set<String> responseDataSet;
                 if (params.startsWith("function=") && params.contains(JS_CALLBACK_DELIMITER)) {
                     String functionName = params.substring("function=".length(), params.indexOf(JS_CALLBACK_DELIMITER));

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/JsCallbackReceiver.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/JsCallbackReceiver.java
@@ -202,8 +202,10 @@ public class JsCallbackReceiver {
                 }
                 break;
             case CALLBACK_RESPONSE_STRING:
-                // log the params unless they contain the post content
-                if (!params.contains("function=getHTMLForCallback~id=zss_field_content~contents=")) {
+                // log the entire params unless they contain the post content
+                if (params.startsWith("function=getHTMLForCallback~id=zss_field_content~contents=")) {
+                    AppLog.d(AppLog.T.EDITOR, callbackId + ": function=getHTMLForCallback~id=zss_field_content~contents=(content not logged)");
+                } else {
                     AppLog.d(AppLog.T.EDITOR, callbackId + ": " + params);
                 }
                 Set<String> responseDataSet;


### PR DESCRIPTION
Changes the visual editor to no longer log the post content, as per our Slack discussion.