### PR TITLE
Remove shared element transition from media settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -538,7 +538,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
     }
 
     @Override
-    public void onMediaItemSelected(View sourceView, int localMediaId, boolean isLongClick) {
+    public void onMediaItemSelected(int localMediaId, boolean isLongClick) {
         MediaModel media = mMediaStore.getMediaWithLocalId(localMediaId);
         if (media == null) {
             AppLog.w(AppLog.T.MEDIA, "Media browser > unable to load localMediaId = " + localMediaId);
@@ -555,7 +555,7 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         // when long tapped (to mimic native photo picker)
         if (mBrowserType.isBrowser() && !isLongClick
                 || mBrowserType.isPicker() && isLongClick) {
-            showMediaSettings(media, sourceView);
+            showMediaSettings(media);
         } else if (mBrowserType.isSingleImagePicker() && !isLongClick) {
             // if we're picking a single image, we're done
             Intent intent = new Intent();
@@ -584,13 +584,13 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         deleteMedia(ids);
     }
 
-    private void showMediaSettings(@NonNull MediaModel media, View sourceView) {
+    private void showMediaSettings(@NonNull MediaModel media) {
         List<MediaModel> mediaList = mMediaGridFragment.getFilteredMedia();
         ArrayList<String> idList = new ArrayList<>();
         for (MediaModel thisMedia: mediaList) {
             idList.add(Integer.toString(thisMedia.getId()));
         }
-        MediaSettingsActivity.showForResult(this, mSite, media, idList, sourceView);
+        MediaSettingsActivity.showForResult(this, mSite, media, idList);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -69,7 +69,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
 
     public interface MediaGridAdapterCallback {
         void onAdapterFetchMoreData();
-        void onAdapterItemClicked(View sourceView, int position, boolean isLongClick);
+        void onAdapterItemClicked(int position, boolean isLongClick);
         void onAdapterSelectionCountChanged(int count);
         void onAdapterRequestRetry(int position);
         void onAdapterRequestDelete(int position);
@@ -308,7 +308,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                 @Override
                 public void onClick(View v) {
                     int position = getAdapterPosition();
-                    doAdapterItemClicked(v, position, false);
+                    doAdapterItemClicked(position, false);
                 }
             });
 
@@ -316,7 +316,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                 @Override
                 public boolean onLongClick(View v) {
                     int position = getAdapterPosition();
-                    doAdapterItemClicked(v, position, true);
+                    doAdapterItemClicked(position, true);
                     return true;
                 }
             });
@@ -356,7 +356,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
             ViewUtils.addCircularShadowOutline(selectionCountTextView);
         }
 
-        private void doAdapterItemClicked(View sourceView, int position, boolean isLongClick) {
+        private void doAdapterItemClicked(int position, boolean isLongClick) {
             if (!isValidPosition(position)) {
                 return;
             }
@@ -370,7 +370,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                     toggleItemSelected(GridViewHolder.this, position);
                 }
                 if (mCallback != null) {
-                    mCallback.onAdapterItemClicked(sourceView, position, isLongClick);
+                    mCallback.onAdapterItemClicked(position, isLongClick);
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -147,7 +147,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
     private SiteModel mSite;
 
     public interface MediaGridListener {
-        void onMediaItemSelected(View sourceView, int localMediaId, boolean isLongClick);
+        void onMediaItemSelected(int localMediaId, boolean isLongClick);
         void onMediaRequestRetry(int localMediaId);
         void onMediaRequestDelete(int localMediaId);
     }
@@ -419,9 +419,9 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
     }
 
     @Override
-    public void onAdapterItemClicked(View sourceView, int position, boolean isLongPress) {
+    public void onAdapterItemClicked(int position, boolean isLongPress) {
         int localMediaId = getAdapter().getLocalMediaIdAtPosition(position);
-        mListener.onMediaItemSelected(sourceView, localMediaId, isLongPress);
+        mListener.onMediaItemSelected(localMediaId, isLongPress);
     }
 
     @Override

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -35,9 +34,8 @@
                     android:layout_height="wrap_content"
                     android:background="@drawable/media_settings_background"
                     android:scaleType="centerCrop"
-                    android:transitionName="@string/shared_element_media"
                     tools:layout_height="224dp"
-                    tools:src="@drawable/ic_gridicons_audio"/>
+                    tools:src="@drawable/ic_gridicons_audio" />
 
                 <ImageView
                     android:id="@+id/image_gradient_scrim"
@@ -45,7 +43,7 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="top"
                     android:background="@drawable/media_settings_gradient_scrim"
-                    tools:layout_height="74dp"/>
+                    tools:layout_height="74dp" />
 
                 <ImageView
                     android:id="@+id/image_play"
@@ -54,7 +52,7 @@
                     android:layout_gravity="center"
                     android:visibility="gone"
                     app:srcCompat="@drawable/play_video_selector_large"
-                    tools:visibility="visible"/>
+                    tools:visibility="visible" />
             </FrameLayout>
 
             <android.support.v7.widget.Toolbar
@@ -62,7 +60,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
                 app:layout_collapseMode="pin"
-                app:popupTheme="@style/ThemeOverlay.AppCompat.Light"/>
+                app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
 
         </android.support.design.widget.CollapsingToolbarLayout>
 
@@ -109,7 +107,7 @@
                             android:text="@string/media_edit_card_caption"
                             android:textColor="@color/blue_wordpress"
                             android:textSize="@dimen/text_sz_large"
-                            android:textStyle="bold"/>
+                            android:textStyle="bold" />
 
                         <android.support.design.widget.TextInputLayout
                             style="@style/MediaSettings.TextInputStyle"
@@ -123,7 +121,7 @@
                                 android:layout_height="wrap_content"
                                 android:hint="@string/media_edit_title_text"
                                 android:inputType="textCapSentences|textAutoCorrect"
-                                tools:text="edit_title"/>
+                                tools:text="edit_title" />
 
                         </android.support.design.widget.TextInputLayout>
 
@@ -139,7 +137,7 @@
                                 android:layout_height="wrap_content"
                                 android:hint="@string/media_edit_caption_text"
                                 android:inputType="textCapSentences|textAutoCorrect"
-                                tools:text="edit_caption"/>
+                                tools:text="edit_caption" />
 
                         </android.support.design.widget.TextInputLayout>
 
@@ -156,7 +154,7 @@
                                 android:layout_height="wrap_content"
                                 android:hint="@string/media_edit_alttext_text"
                                 android:inputType="textCapSentences|textAutoCorrect"
-                                tools:text="edit_alt_text"/>
+                                tools:text="edit_alt_text" />
 
                         </android.support.design.widget.TextInputLayout>
 
@@ -174,7 +172,7 @@
                                 android:hint="@string/media_edit_description_text"
                                 android:inputType="textCapSentences|textAutoCorrect"
                                 android:lines="3"
-                                tools:text="edit_description"/>
+                                tools:text="edit_description" />
 
                         </android.support.design.widget.TextInputLayout>
                     </LinearLayout>
@@ -204,7 +202,7 @@
                         style="@style/MediaSettings.Label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/media_edit_url_caption"/>
+                        android:text="@string/media_edit_url_caption" />
 
                     <RelativeLayout
                         android:layout_width="match_parent"
@@ -219,7 +217,7 @@
                             android:layout_toLeftOf="@+id/text_copy_url"
                             android:ellipsize="end"
                             android:singleLine="true"
-                            tools:text="text_url"/>
+                            tools:text="text_url" />
 
                         <TextView
                             android:id="@+id/text_copy_url"
@@ -236,51 +234,51 @@
                             android:text="@string/copy"
                             android:textAllCaps="true"
                             android:textColor="@color/grey_dark"
-                            android:textSize="@dimen/text_sz_medium"/>
+                            android:textSize="@dimen/text_sz_medium" />
                     </RelativeLayout>
 
                     <View
                         style="@style/MediaSettings.Divider"
                         android:layout_width="match_parent"
-                        android:layout_height="1dp"/>
+                        android:layout_height="1dp" />
 
                     <!-- filename -->
                     <TextView
                         style="@style/MediaSettings.Label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/media_edit_filename_caption"/>
+                        android:text="@string/media_edit_filename_caption" />
 
                     <TextView
                         android:id="@+id/text_filename"
                         style="@style/MediaSettings.Value"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        tools:text="text_filename"/>
+                        tools:text="text_filename" />
 
                     <View
                         style="@style/MediaSettings.Divider"
                         android:layout_width="match_parent"
-                        android:layout_height="1dp"/>
+                        android:layout_height="1dp" />
 
                     <!-- file type -->
                     <TextView
                         style="@style/MediaSettings.Label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/media_edit_filetype_caption"/>
+                        android:text="@string/media_edit_filetype_caption" />
 
                     <TextView
                         android:id="@+id/text_filetype"
                         style="@style/MediaSettings.Value"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        tools:text="text_filetype"/>
+                        tools:text="text_filetype" />
 
                     <View
                         style="@style/MediaSettings.Divider"
                         android:layout_width="match_parent"
-                        android:layout_height="1dp"/>
+                        android:layout_height="1dp" />
 
                     <!-- dimensions -->
                     <TextView
@@ -288,20 +286,20 @@
                         style="@style/MediaSettings.Label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/media_edit_image_dimensions_caption"/>
+                        android:text="@string/media_edit_image_dimensions_caption" />
 
                     <TextView
                         android:id="@+id/text_image_dimensions"
                         style="@style/MediaSettings.Value"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        tools:text="text_image_dimensions"/>
+                        tools:text="text_image_dimensions" />
 
                     <View
                         android:id="@+id/divider_dimensions"
                         style="@style/MediaSettings.Divider"
                         android:layout_width="match_parent"
-                        android:layout_height="1dp"/>
+                        android:layout_height="1dp" />
 
                     <!-- duration -->
                     <TextView
@@ -309,20 +307,20 @@
                         style="@style/MediaSettings.Label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/media_edit_duration_caption"/>
+                        android:text="@string/media_edit_duration_caption" />
 
                     <TextView
                         android:id="@+id/text_duration"
                         style="@style/MediaSettings.Value"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        tools:text="text_image_dimensions"/>
+                        tools:text="text_image_dimensions" />
 
                     <View
                         android:id="@+id/divider_duration"
                         style="@style/MediaSettings.Divider"
                         android:layout_width="match_parent"
-                        android:layout_height="1dp"/>
+                        android:layout_height="1dp" />
 
                     <!-- upload date -->
                     <TextView
@@ -330,14 +328,14 @@
                         style="@style/MediaSettings.Label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="@string/media_edit_upload_date_caption"/>
+                        android:text="@string/media_edit_upload_date_caption" />
 
                     <TextView
                         android:id="@+id/text_upload_date"
                         style="@style/MediaSettings.Value"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        tools:text="text_upload_date"/>
+                        tools:text="text_upload_date" />
 
                 </LinearLayout>
 
@@ -359,7 +357,7 @@
         app:layout_anchor="@id/app_bar_layout"
         app:layout_anchorGravity="bottom|right|end"
         app:srcCompat="@drawable/ic_fullscreen_white_24dp"
-        tools:visibility="visible"/>
+        tools:visibility="visible" />
 
     <ProgressBar
         android:id="@+id/progress"
@@ -369,11 +367,11 @@
         android:elevation="@dimen/card_elevation"
         android:textAppearance="?android:attr/progressBarStyle"
         android:visibility="gone"
-        tools:visibility="visible"/>
+        tools:visibility="visible" />
 
     <FrameLayout
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent" />
 
 </android.support.design.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1983,7 +1983,4 @@
     <string name="login_error_generic">There was some trouble connecting with the Google account.</string>
     <string name="login_error_suffix">\nMaybe try a different account?</string>
 
-    <!-- shared element names -->
-    <string name="shared_element_media" translatable="false">media</string>
-
 </resources>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -31,8 +31,6 @@
 
         <item name="windowActionModeOverlay">true</item>
         <item name="searchViewStyle">@style/WordPress.SearchViewStyle</item>
-
-        <item name="android:windowContentTransitions">true</item>
     </style>
 
     <!-- http://android-developers.blogspot.com/2014/10/appcompat-v21-material-design-for-pre.html -->


### PR DESCRIPTION
Fixes #6858 and fixes #6864 - both of these issues are related to the shared element transition in the new media settings, and upon researching them I found reports of similar problems from numerous other developers.

Fixing these issues - if it was even possible - appears to require an assortment of hacks, and we already had some hacks in `MediaSettingsActivity` to get the transition to work right.

So I decided to simply ditch the shared element transition. It's nice when it works, but it's not worth having the app crash on users, nor is it worth resorting to hacks that may or may not continue to work down the road.