### PR TITLE
Disable `More` button in the toolbar in Aztec when media picker is showing

### DIFF
--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -52,9 +52,9 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.17.1'
 
-    compile 'com.github.wordpress-mobile.AztecEditor-Android:aztec:v1.0-beta.10'
-    compile 'com.github.wordpress-mobile.AztecEditor-Android:wordpress-comments:v1.0-beta.10'
-    compile 'com.github.wordpress-mobile.AztecEditor-Android:wordpress-shortcodes:v1.0-beta.10'
+    compile 'com.github.wordpress-mobile.AztecEditor-Android:aztec:feature~toolbar-state-signal-SNAPSHOT'
+    compile 'com.github.wordpress-mobile.AztecEditor-Android:wordpress-comments:feature~toolbar-state-signal-SNAPSHOT'
+    compile 'com.github.wordpress-mobile.AztecEditor-Android:wordpress-shortcodes:feature~toolbar-state-signal-SNAPSHOT'
 
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)
     compile "org.jetbrains.kotlin:kotlin-stdlib:1.1.4"


### PR DESCRIPTION
Fixes #6737 

IMPORTANT: do not merge until the related Aztec PR is merged first, and this reference is updated here.

To test:
1. start a draft post
2. tap on the body area of the editor
3. expand the toolbar and check that the `More` option is tappable and works (inserts a More item in the body of the Post)
4. tap on the `+` at the leftmost part of the toolbar to show the mediapicker.
5. once the mediapicker is showing, check in the toolbar that the `More` option is disabled now.
7. exit the media picker (either by pressing back or by actually choosing to insert some media item)
8. observe the `More` item in the toolbar is enabled now again.

cc @0nko 
