### PR TITLE
Jetpack: Enable reader comments for Jetpack sites

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -45,7 +45,6 @@ android {
         vectorDrawables.useSupportLibrary = true
 
         buildConfigField "boolean", "LOGIN_WIZARD_STYLE_ACTIVE", "true"
-        buildConfigField "boolean", "ENABLE_READER_COMMENTS_FOR_JETPACK_SITES", "false"
     }
 
     productFlavors {
@@ -54,14 +53,12 @@ android {
 
         zalpha { // alpha version - enable experimental features
             applicationId "org.wordpress.android"
-            buildConfigField "boolean", "ENABLE_READER_COMMENTS_FOR_JETPACK_SITES", "true"
             buildConfigField "boolean", "VIDEO_OPTIMIZATION_AVAILABLE", "true"
         }
 
         wasabi { // "hot" version, can be installed along release, alpha or beta versions
             applicationId "org.wordpress.android.beta"
             minSdkVersion 21 // to take advantage of "fast" multi dex (pre-dex each module)
-            buildConfigField "boolean", "ENABLE_READER_COMMENTS_FOR_JETPACK_SITES", "true"
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -24,7 +24,6 @@ import android.webkit.WebView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -1293,10 +1292,6 @@ public class ReaderPostDetailFragment extends Fragment
         }
         if (!mAccountStore.hasAccessToken()) {
             return mPost.numReplies > 0;
-        }
-        // On Jetpack sites, if the feature flag is not enabled, we don't want to show the comment count
-        if (mPost.isJetpack && !BuildConfig.ENABLE_READER_COMMENTS_FOR_JETPACK_SITES) {
-            return false;
         }
         return mPost.isWP()
                 && !mPost.isDiscoverPost()

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java
@@ -11,7 +11,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
@@ -789,10 +788,6 @@ public class ReaderPostAdapter extends RecyclerView.Adapter<RecyclerView.ViewHol
             canShowComments = post.numReplies > 0;
         } else {
             canShowComments = post.isWP() && (post.isCommentsOpen || post.numReplies > 0);
-        }
-        // On Jetpack sites, if the feature flag is not enabled, we don't want to show comments
-        if (post.isJetpack && !BuildConfig.ENABLE_READER_COMMENTS_FOR_JETPACK_SITES) {
-            canShowComments = false;
         }
 
         if (canShowComments) {


### PR DESCRIPTION
Fixes #6483, related to #6486.

This PR removes the `ENABLE_READER_COMMENTS_FOR_JETPACK_SITES` feature flag to enable comments in the reader for Jetpack sites.

To test:
* Sign into Jetpack site
* Go to Reader and verify posts have comment icon + count
* Click a post with comments enabled and verify details screen has comment icon + count

cc @maxme, @elibud, @oguzkocer