### PR TITLE
Feature/6162 Swipe behaviour in comments

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -190,7 +190,7 @@
             android:theme="@style/CalypsoTheme" />
         <activity
             android:name=".ui.comments.CommentsDetailActivity"
-            android:theme="@style/Calypso.NoActionBar" />
+            android:theme="@style/CalypsoTheme" />
 
         <!-- Posts activities -->
         <activity

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -188,6 +188,9 @@
         <activity
             android:name=".ui.comments.EditCommentActivity"
             android:theme="@style/CalypsoTheme" />
+        <activity
+            android:name=".ui.comments.CommentsDetailActivity"
+            android:theme="@style/Calypso.NoActionBar" />
 
         <!-- Posts activities -->
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.modules;
 
+import dagger.Component;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.module.ReleaseBaseModule;
@@ -11,8 +12,8 @@ import org.wordpress.android.push.GCMRegistrationIntentService;
 import org.wordpress.android.push.NotificationsProcessingService;
 import org.wordpress.android.ui.AddQuickPressShortcutActivity;
 import org.wordpress.android.ui.DeepLinkingIntentReceiverActivity;
-import org.wordpress.android.ui.ShareIntentReceiverFragment;
 import org.wordpress.android.ui.ShareIntentReceiverActivity;
+import org.wordpress.android.ui.ShareIntentReceiverFragment;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.LoginActivity;
@@ -34,6 +35,7 @@ import org.wordpress.android.ui.accounts.login.LoginUsernamePasswordFragment;
 import org.wordpress.android.ui.comments.CommentAdapter;
 import org.wordpress.android.ui.comments.CommentDetailFragment;
 import org.wordpress.android.ui.comments.CommentsActivity;
+import org.wordpress.android.ui.comments.CommentsDetailActivity;
 import org.wordpress.android.ui.comments.CommentsListFragment;
 import org.wordpress.android.ui.comments.EditCommentActivity;
 import org.wordpress.android.ui.main.MeFragment;
@@ -109,8 +111,6 @@ import org.wordpress.android.util.WPWebViewClient;
 
 import javax.inject.Singleton;
 
-import dagger.Component;
-
 @Singleton
 @Component(modules = {
         AppContextModule.class,
@@ -167,6 +167,7 @@ public interface AppComponent {
     void inject(CommentAdapter object);
     void inject(CommentsListFragment object);
     void inject(CommentsActivity object);
+    void inject(CommentsDetailActivity object);
 
     void inject(MeFragment object);
     void inject(MyProfileActivity object);

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -1,6 +1,5 @@
 package org.wordpress.android.modules;
 
-import dagger.Component;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.module.AppContextModule;
 import org.wordpress.android.fluxc.module.ReleaseBaseModule;
@@ -12,8 +11,8 @@ import org.wordpress.android.push.GCMRegistrationIntentService;
 import org.wordpress.android.push.NotificationsProcessingService;
 import org.wordpress.android.ui.AddQuickPressShortcutActivity;
 import org.wordpress.android.ui.DeepLinkingIntentReceiverActivity;
-import org.wordpress.android.ui.ShareIntentReceiverActivity;
 import org.wordpress.android.ui.ShareIntentReceiverFragment;
+import org.wordpress.android.ui.ShareIntentReceiverActivity;
 import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.LoginActivity;
@@ -110,6 +109,8 @@ import org.wordpress.android.util.HtmlToSpannedConverter;
 import org.wordpress.android.util.WPWebViewClient;
 
 import javax.inject.Singleton;
+
+import dagger.Component;
 
 @Singleton
 @Component(modules = {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentActions.java
@@ -22,9 +22,6 @@ public class CommentActions {
      * comments (moderated, deleted, added, etc.)
      */
     public enum ChangeType {EDITED, REPLIED}
-    public interface OnCommentChangeListener {
-        void onCommentChanged(ChangeType changeType);
-    }
 
     public interface OnCommentActionListener {
         void onModerateComment(SiteModel site, CommentModel comment, CommentStatus newStatus);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -51,9 +51,7 @@ import org.wordpress.android.models.Note;
 import org.wordpress.android.models.Note.EnabledActions;
 import org.wordpress.android.models.Suggestion;
 import org.wordpress.android.ui.ActivityId;
-import org.wordpress.android.ui.comments.CommentActions.ChangeType;
 import org.wordpress.android.ui.comments.CommentActions.OnCommentActionListener;
-import org.wordpress.android.ui.comments.CommentActions.OnCommentChangeListener;
 import org.wordpress.android.ui.comments.CommentActions.OnNoteCommentActionListener;
 import org.wordpress.android.ui.notifications.NotificationFragment;
 import org.wordpress.android.ui.notifications.NotificationsDetailListFragment;
@@ -144,7 +142,6 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
 
     private boolean mIsSubmittingReply = false;
     private NotificationsDetailListFragment mNotificationsDetailListFragment;
-    private OnCommentChangeListener mOnCommentChangeListener;
     private OnPostClickListener mOnPostClickListener;
     private OnCommentActionListener mOnCommentActionListener;
     private OnNoteCommentActionListener mOnNoteCommentActionListener;
@@ -499,9 +496,6 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     @SuppressWarnings("deprecation") // TODO: Remove when minSdkVersion >= 23
     public void onAttach(Activity activity) {
         super.onAttach(activity);
-        if (activity instanceof OnCommentChangeListener) {
-            mOnCommentChangeListener = (OnCommentChangeListener) activity;
-        }
         if (activity instanceof OnPostClickListener) {
             mOnPostClickListener = (OnPostClickListener) activity;
         }
@@ -548,9 +542,6 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == INTENT_COMMENT_EDITOR && resultCode == Activity.RESULT_OK) {
             reloadComment();
-            // tell the host to reload the comment list
-            if (mOnCommentChangeListener != null)
-                mOnCommentChangeListener.onCommentChanged(ChangeType.EDITED);
         }
     }
 
@@ -1186,9 +1177,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
             return;
         }
 
-        if (mOnCommentChangeListener != null) {
-            mOnCommentChangeListener.onCommentChanged(ChangeType.REPLIED);
-        }
+        reloadComment();
 
         if (isAdded()) {
             ToastUtils.showToast(getActivity(), getString(R.string.note_reply_successful));

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -92,7 +92,7 @@ import de.greenrobot.event.EventBus;
  */
 public class CommentDetailFragment extends Fragment implements NotificationFragment {
     private static final String KEY_MODE = "KEY_MODE";
-    private static final String KEY_SITE_ID = "KEY_SITE_ID";
+    private static final String KEY_SITE_LOCAL_ID = "KEY_SITE_LOCAL_ID";
     private static final String KEY_COMMENT_ID = "KEY_COMMENT_ID";
     private static final String KEY_NOTE_ID = "KEY_NOTE_ID";
     private static final String KEY_REPLY_TEXT = "KEY_REPLY_TEXT";
@@ -160,7 +160,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         CommentDetailFragment fragment = new CommentDetailFragment();
         Bundle args = new Bundle();
         args.putInt(KEY_MODE, FROM_BLOG_COMMENT);
-        args.putLong(KEY_SITE_ID, site.getSiteId());
+        args.putInt(KEY_SITE_LOCAL_ID, site.getId());
         args.putLong(KEY_COMMENT_ID, commentModel.getRemoteCommentId());
         fragment.setArguments(args);
         return fragment;
@@ -188,7 +188,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
 
         switch (getArguments().getInt(KEY_MODE)) {
             case FROM_BLOG_COMMENT:
-                setComment(getArguments().getLong(KEY_COMMENT_ID), getArguments().getLong(KEY_SITE_ID));
+                setComment(getArguments().getLong(KEY_COMMENT_ID), getArguments().getInt(KEY_SITE_LOCAL_ID));
                 break;
             case FROM_NOTE:
                 setNote(getArguments().getString(KEY_NOTE_ID));
@@ -204,7 +204,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
                 // See WordPress.deferredInit()
                 mRestoredNoteId = savedInstanceState.getString(KEY_NOTE_ID);
             } else {
-                long siteId = savedInstanceState.getLong(KEY_SITE_ID);
+                int siteId = savedInstanceState.getInt(KEY_SITE_LOCAL_ID);
                 long commentId = savedInstanceState.getLong(KEY_COMMENT_ID);
                 setComment(commentId, siteId);
             }
@@ -218,7 +218,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         super.onSaveInstanceState(outState);
         if (mComment != null) {
             outState.putLong(KEY_COMMENT_ID, mComment.getRemoteCommentId());
-            outState.putLong(KEY_SITE_ID, mSite.getSiteId());
+            outState.putInt(KEY_SITE_LOCAL_ID, mSite.getId());
         }
 
         if (mNote != null) {
@@ -403,8 +403,8 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         }
     }
 
-    private void setComment(final long commentRemoteId, final long siteId) {
-        final SiteModel site = mSiteStore.getSiteBySiteId(siteId);
+    private void setComment(final long commentRemoteId, final int siteLocalId) {
+        final SiteModel site = mSiteStore.getSiteByLocalId(siteLocalId);
         setComment(mCommentStore.getCommentBySiteAndRemoteId(site, commentRemoteId), site);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
@@ -29,6 +29,12 @@ public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
         return CommentDetailFragment.newInstance(mSite, getComment(position));
     }
 
+    void onNewItems(CommentList commentList) {
+        mComments.clear();
+        mComments.addAll(commentList);
+        notifyDataSetChanged();
+    }
+
     int commentIndex(long commentId) {
         return mComments.indexOfCommentId(commentId);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
@@ -1,27 +1,30 @@
 package org.wordpress.android.ui.comments;
 
-import org.wordpress.android.fluxc.model.CommentModel;
-import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.models.CommentList;
-import org.wordpress.android.util.AppLog;
-
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.v13.app.FragmentStatePagerAdapter;
 
+import org.wordpress.android.fluxc.model.CommentModel;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.models.CommentList;
+import org.wordpress.android.util.AppLog;
+
 public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
 
     private final SiteModel mSite;
-    private final CommentAdapter.OnLoadMoreListener onLoadMoreListener;
-    private final CommentList mComments;
+    private final CommentAdapter.OnLoadMoreListener mOnLoadMoreListener;
+    private final CommentList mCommentList;
 
-    CommentDetailFragmentAdapter(FragmentManager fm, CommentList mComments, SiteModel mSite, CommentAdapter.OnLoadMoreListener onLoadMoreListener) {
+    CommentDetailFragmentAdapter(FragmentManager fm,
+                                 CommentList commentList,
+                                 SiteModel site,
+                                 CommentAdapter.OnLoadMoreListener onLoadMoreListener) {
         super(fm);
-        this.mSite = mSite;
-        this.onLoadMoreListener = onLoadMoreListener;
-        this.mComments = mComments;
+        this.mSite = site;
+        this.mOnLoadMoreListener = onLoadMoreListener;
+        this.mCommentList = commentList;
     }
 
     @Override
@@ -30,29 +33,29 @@ public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
     }
 
     void onNewItems(CommentList commentList) {
-        mComments.clear();
-        mComments.addAll(commentList);
+        mCommentList.clear();
+        mCommentList.addAll(commentList);
         notifyDataSetChanged();
     }
 
     int commentIndex(long commentId) {
-        return mComments.indexOfCommentId(commentId);
+        return mCommentList.indexOfCommentId(commentId);
     }
 
     boolean isEmpty() {
         return getCount() == 0;
     }
 
-    CommentModel getCommentAtPosition(int position){
+    CommentModel getCommentAtPosition(int position) {
         if (isValidPosition(position))
-            return mComments.get(position);
+            return mCommentList.get(position);
         else
             return null;
     }
 
     @Override
     public int getCount() {
-        return mComments.size();
+        return mCommentList.size();
     }
 
     @Override
@@ -83,9 +86,9 @@ public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
 
     private CommentModel getComment(int position) {
         if (position == getCount() - 1) {
-            onLoadMoreListener.onLoadMore();
+            mOnLoadMoreListener.onLoadMore();
         }
-        return mComments.get(position);
+        return mCommentList.get(position);
     }
 
     private boolean isValidPosition(int position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
@@ -41,6 +41,10 @@ public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
         return mComments.indexOfCommentId(commentId);
     }
 
+    public boolean isEmpty() {
+        return getCount() == 0;
+    }
+
     private CommentModel getComment(int position) {
         if (position == mComments.size() - 1) {
             onLoadMoreListener.onLoadMore();

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
@@ -43,11 +43,11 @@ public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
         return getCount() == 0;
     }
 
-    private CommentModel getComment(int position) {
-        if (position == mComments.size() - 1) {
-            onLoadMoreListener.onLoadMore();
-        }
-        return mComments.get(position);
+    CommentModel getCommentAtPosition(int position){
+        if (isValidPosition(position))
+            return mComments.get(position);
+        else
+            return null;
     }
 
     @Override
@@ -81,11 +81,11 @@ public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
         return bundle;
     }
 
-    CommentModel getCommentAtPosition(int position){
-        if (isValidPosition(position))
-            return mComments.get(position);
-        else
-            return null;
+    private CommentModel getComment(int position) {
+        if (position == getCount() - 1) {
+            onLoadMoreListener.onLoadMore();
+        }
+        return mComments.get(position);
     }
 
     private boolean isValidPosition(int position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
@@ -11,6 +11,8 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.models.CommentList;
 import org.wordpress.android.util.AppLog;
 
+import javax.annotation.Nullable;
+
 public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
 
     private final SiteModel mSite;
@@ -20,7 +22,7 @@ public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
     CommentDetailFragmentAdapter(FragmentManager fm,
                                  CommentList commentList,
                                  SiteModel site,
-                                 CommentAdapter.OnLoadMoreListener onLoadMoreListener) {
+                                 @Nullable CommentAdapter.OnLoadMoreListener onLoadMoreListener) {
         super(fm);
         this.mSite = site;
         this.mOnLoadMoreListener = onLoadMoreListener;
@@ -29,7 +31,8 @@ public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
 
     @Override
     public Fragment getItem(int position) {
-        return CommentDetailFragment.newInstance(mSite, getComment(position));
+        final CommentModel comment = getComment(position);
+        return CommentDetailFragment.newInstance(mSite, comment);
     }
 
     void onNewItems(CommentList commentList) {
@@ -38,12 +41,17 @@ public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
         notifyDataSetChanged();
     }
 
-    int commentIndex(long commentId) {
-        return mCommentList.indexOfCommentId(commentId);
+    boolean isAddingNewComments(CommentList newComments) {
+        for (int index = 0; index < mCommentList.size(); index++) {
+            if (newComments.size() <= index || mCommentList.get(index).getRemoteCommentId() != newComments.get(index).getRemoteCommentId()) {
+                return false;
+            }
+        }
+        return true;
     }
 
-    boolean isEmpty() {
-        return getCount() == 0;
+    int commentIndex(long commentId) {
+        return mCommentList.indexOfCommentId(commentId);
     }
 
     CommentModel getCommentAtPosition(int position) {
@@ -85,7 +93,7 @@ public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
     }
 
     private CommentModel getComment(int position) {
-        if (position == getCount() - 1) {
+        if (position == getCount() - 1 && mOnLoadMoreListener != null) {
             mOnLoadMoreListener.onLoadMore();
         }
         return mCommentList.get(position);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
@@ -2,7 +2,6 @@ package org.wordpress.android.ui.comments;
 
 import android.app.Fragment;
 import android.app.FragmentManager;
-import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.v13.app.FragmentStatePagerAdapter;
 
@@ -77,19 +76,6 @@ public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
         } catch (IllegalStateException e) {
             AppLog.e(AppLog.T.COMMENTS, e);
         }
-    }
-
-    @Override
-    public Parcelable saveState() {
-        AppLog.d(AppLog.T.COMMENTS, "comments pager > adapter saveState");
-        Bundle bundle = (Bundle) super.saveState();
-        if (bundle == null) {
-            bundle = new Bundle();
-        }
-        // This is a possible solution to https://github.com/wordpress-mobile/WordPress-Android/issues/5456
-        // See https://issuetracker.google.com/issues/37103380#comment77 for more details
-        bundle.putParcelableArray("states", null);
-        return bundle;
     }
 
     private CommentModel getComment(int position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
@@ -1,0 +1,72 @@
+package org.wordpress.android.ui.comments;
+
+import org.wordpress.android.fluxc.model.CommentModel;
+import org.wordpress.android.fluxc.model.CommentStatus;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.CommentStore;
+import org.wordpress.android.util.AppLog;
+
+import android.app.Fragment;
+import android.app.FragmentManager;
+import android.os.Bundle;
+import android.os.Parcelable;
+import android.support.v13.app.FragmentStatePagerAdapter;
+
+import java.util.List;
+
+public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
+
+    private final CommentStore commentStore;
+    private long mCommentId;
+    private CommentStatus commentStatus;
+    private SiteModel mSite;
+    private List<CommentModel> comments;
+
+    public CommentDetailFragmentAdapter(FragmentManager fm, CommentStore commentStore, long mCommentId, CommentStatus commentStatus, SiteModel mSite) {
+        super(fm);
+        this.commentStore = commentStore;
+        this.mCommentId = mCommentId;
+        this.commentStatus = commentStatus;
+        this.mSite = mSite;
+    }
+
+    @Override
+    public Fragment getItem(int position) {
+        return CommentDetailFragment.newInstance(mSite, getComment(position));
+    }
+
+    private CommentModel getComment(int position) {
+        return comments.get(position);
+    }
+
+    @Override
+    public int getCount() {
+        return comments.size();
+    }
+
+    @Override
+    public void restoreState(Parcelable state, ClassLoader loader) {
+        // work around "Fragment no longer exists for key" Android bug
+        // by catching the IllegalStateException
+        // https://code.google.com/p/android/issues/detail?id=42601
+        try {
+            AppLog.d(AppLog.T.COMMENTS, "comments pager > adapter restoreState");
+            super.restoreState(state, loader);
+        } catch (IllegalStateException e) {
+            AppLog.e(AppLog.T.COMMENTS, e);
+        }
+    }
+
+    @Override
+    public Parcelable saveState() {
+        AppLog.d(AppLog.T.COMMENTS, "comments pager > adapter saveState");
+        Bundle bundle = (Bundle) super.saveState();
+        if (bundle == null) {
+            bundle = new Bundle();
+        }
+        // This is a possible solution to https://github.com/wordpress-mobile/WordPress-Android/issues/5456
+        // See https://issuetracker.google.com/issues/37103380#comment77 for more details
+        bundle.putParcelableArray("states", null);
+        return bundle;
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
@@ -10,8 +10,6 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.models.CommentList;
 import org.wordpress.android.util.AppLog;
 
-import javax.annotation.Nullable;
-
 public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
 
     private final SiteModel mSite;
@@ -21,7 +19,7 @@ public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
     CommentDetailFragmentAdapter(FragmentManager fm,
                                  CommentList commentList,
                                  SiteModel site,
-                                 @Nullable CommentAdapter.OnLoadMoreListener onLoadMoreListener) {
+                                 CommentAdapter.OnLoadMoreListener onLoadMoreListener) {
         super(fm);
         this.mSite = site;
         this.mOnLoadMoreListener = onLoadMoreListener;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
@@ -4,30 +4,43 @@ import org.wordpress.android.fluxc.model.CommentModel;
 import org.wordpress.android.fluxc.model.CommentStatus;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.CommentStore;
+import org.wordpress.android.models.CommentList;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.DateTimeUtils;
 
 import android.app.Fragment;
 import android.app.FragmentManager;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.v13.app.FragmentStatePagerAdapter;
 
-import java.util.List;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
 
 public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
 
-    private final CommentStore commentStore;
-    private long mCommentId;
-    private CommentStatus commentStatus;
-    private SiteModel mSite;
-    private List<CommentModel> comments;
+    private final CommentStore mCommentStore;
+    private final CommentStatus statusFilter;
+    private final SiteModel mSite;
+    private final CommentAdapter.OnDataLoadedListener onDataLoadedListener;
+    private final CommentAdapter.OnLoadMoreListener onLoadMoreListener;
+    private final CommentList mComments = new CommentList();
 
-    public CommentDetailFragmentAdapter(FragmentManager fm, CommentStore commentStore, long mCommentId, CommentStatus commentStatus, SiteModel mSite) {
+    CommentDetailFragmentAdapter(FragmentManager fm,
+                                 CommentStore mCommentStore,
+                                 CommentStatus statusFilter,
+                                 SiteModel mSite,
+                                 CommentAdapter.OnDataLoadedListener onDataLoadedListener,
+                                 CommentAdapter.OnLoadMoreListener onLoadMoreListener) {
         super(fm);
-        this.commentStore = commentStore;
-        this.mCommentId = mCommentId;
-        this.commentStatus = commentStatus;
+        this.mCommentStore = mCommentStore;
+        this.statusFilter = statusFilter;
         this.mSite = mSite;
+        this.onDataLoadedListener = onDataLoadedListener;
+        this.onLoadMoreListener = onLoadMoreListener;
+        loadComments();
     }
 
     @Override
@@ -35,13 +48,20 @@ public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
         return CommentDetailFragment.newInstance(mSite, getComment(position));
     }
 
+    public int commentIndex(long commentId) {
+        return mComments.indexOfCommentId(commentId);
+    }
+
     private CommentModel getComment(int position) {
-        return comments.get(position);
+        if (position == mComments.size() - 1) {
+            onLoadMoreListener.onLoadMore();
+        }
+        return mComments.get(position);
     }
 
     @Override
     public int getCount() {
-        return comments.size();
+        return mComments.size();
     }
 
     @Override
@@ -68,5 +88,61 @@ public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
         // See https://issuetracker.google.com/issues/37103380#comment77 for more details
         bundle.putParcelableArray("states", null);
         return bundle;
+    }
+
+    public CommentModel getCommentAtPosition(int position){
+        if (isValidPosition(position))
+            return mComments.get(position);
+        else
+            return null;
+    }
+
+    private boolean isValidPosition(int position) {
+        return (position >= 0 && position < getCount());
+    }
+
+    /*
+     * load comments using an AsyncTask
+     */
+    private void loadComments() {
+        if (mIsLoadTaskRunning) {
+            AppLog.w(AppLog.T.COMMENTS, "load comments task already active");
+        } else {
+            new LoadCommentsTask(mCommentStore, statusFilter, mSite, new LoadCommentsCallback()).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+        }
+    }
+
+    /*
+     * AsyncTask to load comments from SQLite
+     */
+    private boolean mIsLoadTaskRunning = false;
+
+    private class LoadCommentsCallback implements LoadCommentsTask.LoadingCallback {
+        @Override
+        public void isLoading(boolean loading) {
+            mIsLoadTaskRunning = loading;
+        }
+
+        @Override
+        public void loadingFinished(CommentList commentList) {
+            if (!mComments.isSameList(commentList)) {
+                mComments.clear();
+                mComments.addAll(commentList);
+                // Sort by date
+                Collections.sort(mComments, new Comparator<CommentModel>() {
+                    @Override
+                    public int compare(CommentModel commentModel, CommentModel t1) {
+                        Date d0 = DateTimeUtils.dateFromIso8601(commentModel.getDatePublished());
+                        Date d1 = DateTimeUtils.dateFromIso8601(t1.getDatePublished());
+                        if (d0 == null || d1 == null) {
+                            return 0;
+                        }
+                        return d1.compareTo(d0);
+                    }
+                });
+                notifyDataSetChanged();
+                onDataLoadedListener.onDataLoaded(true);
+            }
+        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragmentAdapter.java
@@ -4,7 +4,6 @@ import org.wordpress.android.fluxc.model.CommentModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.models.CommentList;
 import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.DateTimeUtils;
 
 import android.app.Fragment;
 import android.app.FragmentManager;
@@ -12,20 +11,13 @@ import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.v13.app.FragmentStatePagerAdapter;
 
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-
 public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
 
     private final SiteModel mSite;
     private final CommentAdapter.OnLoadMoreListener onLoadMoreListener;
     private final CommentList mComments;
 
-    CommentDetailFragmentAdapter(FragmentManager fm,
-                                 CommentList mComments,
-                                 SiteModel mSite,
-                                 CommentAdapter.OnLoadMoreListener onLoadMoreListener) {
+    CommentDetailFragmentAdapter(FragmentManager fm, CommentList mComments, SiteModel mSite, CommentAdapter.OnLoadMoreListener onLoadMoreListener) {
         super(fm);
         this.mSite = mSite;
         this.onLoadMoreListener = onLoadMoreListener;
@@ -37,11 +29,11 @@ public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
         return CommentDetailFragment.newInstance(mSite, getComment(position));
     }
 
-    public int commentIndex(long commentId) {
+    int commentIndex(long commentId) {
         return mComments.indexOfCommentId(commentId);
     }
 
-    public boolean isEmpty() {
+    boolean isEmpty() {
         return getCount() == 0;
     }
 
@@ -83,27 +75,7 @@ public class CommentDetailFragmentAdapter extends FragmentStatePagerAdapter {
         return bundle;
     }
 
-    public void onNewComments(CommentList commentList) {
-        if (!mComments.isSameList(commentList)) {
-            mComments.clear();
-            mComments.addAll(commentList);
-            // Sort by date
-            Collections.sort(mComments, new Comparator<CommentModel>() {
-                @Override
-                public int compare(CommentModel commentModel, CommentModel t1) {
-                    Date d0 = DateTimeUtils.dateFromIso8601(commentModel.getDatePublished());
-                    Date d1 = DateTimeUtils.dateFromIso8601(t1.getDatePublished());
-                    if (d0 == null || d1 == null) {
-                        return 0;
-                    }
-                    return d1.compareTo(d0);
-                }
-            });
-            notifyDataSetChanged();
-        }
-    }
-
-    public CommentModel getCommentAtPosition(int position){
+    CommentModel getCommentAtPosition(int position){
         if (isValidPosition(position))
             return mComments.get(position);
         else

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -40,7 +40,6 @@ public class CommentsActivity extends AppCompatActivity
                    NotificationFragment.OnPostClickListener,
                    CommentActions.OnCommentActionListener,
                    CommentActions.OnCommentChangeListener {
-    private static final String KEY_SELECTED_COMMENT = "selected_comment_id";
     static final String KEY_AUTO_REFRESHED = "has_auto_refreshed";
     static final String KEY_EMPTY_VIEW_MESSAGE = "empty_view_message";
     private static final String SAVED_COMMENTS_STATUS_TYPE = "saved_comments_status_type";
@@ -49,7 +48,6 @@ public class CommentsActivity extends AppCompatActivity
     private CommentStatus mCurrentCommentStatusType = CommentStatus.ALL;
 
     private SiteModel mSite;
-    private CommentModel mComment;
 
     @Inject Dispatcher mDispatcher;
     @Inject CommentStore mCommentStore;
@@ -101,7 +99,6 @@ public class CommentsActivity extends AppCompatActivity
         } else {
             getIntent().putExtra(KEY_AUTO_REFRESHED, savedInstanceState.getBoolean(KEY_AUTO_REFRESHED));
             getIntent().putExtra(KEY_EMPTY_VIEW_MESSAGE, savedInstanceState.getString(KEY_EMPTY_VIEW_MESSAGE));
-            mComment = (CommentModel) savedInstanceState.getSerializable(KEY_SELECTED_COMMENT);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -1,5 +1,19 @@
 package org.wordpress.android.ui.comments;
 
+import android.app.Dialog;
+import android.app.Fragment;
+import android.app.FragmentManager;
+import android.app.FragmentTransaction;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.view.MenuItem;
+import android.view.View;
+
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
@@ -18,20 +32,6 @@ import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ToastUtils;
-
-import android.app.Dialog;
-import android.app.Fragment;
-import android.app.FragmentManager;
-import android.app.FragmentTransaction;
-import android.content.Intent;
-import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.design.widget.Snackbar;
-import android.support.v7.app.ActionBar;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
-import android.view.MenuItem;
-import android.view.View;
 
 import javax.inject.Inject;
 
@@ -154,8 +154,8 @@ public class CommentsActivity extends AppCompatActivity
         FragmentTransaction ft = fm.beginTransaction();
         String tagForFragment = getString(R.string.fragment_tag_reader_post_detail);
         ft.add(R.id.layout_fragment_container, fragment, tagForFragment)
-          .addToBackStack(tagForFragment)
-          .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE);
+                .addToBackStack(tagForFragment)
+                .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE);
         ft.commit();
     }
 
@@ -163,10 +163,10 @@ public class CommentsActivity extends AppCompatActivity
      * called from comment list when user taps a comment
      */
     @Override
-    public void onCommentSelected(long commentId, CommentStatus commentStatus) {
+    public void onCommentSelected(long commentId, CommentStatus statusFilter) {
         Intent detailIntent = new Intent(this, CommentsDetailActivity.class);
         detailIntent.putExtra(CommentsDetailActivity.COMMENT_ID_EXTRA, commentId);
-        detailIntent.putExtra(CommentsDetailActivity.COMMENT_STATUS_FILTER_EXTRA, commentStatus);
+        detailIntent.putExtra(CommentsDetailActivity.COMMENT_STATUS_FILTER_EXTRA, statusFilter);
         detailIntent.putExtra(WordPress.SITE, mSite);
         startActivity(detailIntent);
     }
@@ -241,7 +241,7 @@ public class CommentsActivity extends AppCompatActivity
 
             String message = (newStatus == CommentStatus.TRASH ? getString(R.string.comment_trashed) :
                     newStatus == CommentStatus.SPAM ? getString(R.string.comment_spammed) :
-                            getString(R.string.comment_deleted_permanently)  );
+                            getString(R.string.comment_deleted_permanently));
             View.OnClickListener undoListener = new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -1,19 +1,5 @@
 package org.wordpress.android.ui.comments;
 
-import android.app.Dialog;
-import android.app.Fragment;
-import android.app.FragmentManager;
-import android.app.FragmentTransaction;
-import android.content.Intent;
-import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.design.widget.Snackbar;
-import android.support.v7.app.ActionBar;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
-import android.view.MenuItem;
-import android.view.View;
-
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
@@ -32,6 +18,20 @@ import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.reader.ReaderPostDetailFragment;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ToastUtils;
+
+import android.app.Dialog;
+import android.app.Fragment;
+import android.app.FragmentManager;
+import android.app.FragmentTransaction;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.view.MenuItem;
+import android.view.View;
 
 import javax.inject.Inject;
 
@@ -183,25 +183,11 @@ public class CommentsActivity extends AppCompatActivity
      */
     @Override
     public void onCommentSelected(long commentId) {
-        FragmentManager fm = getFragmentManager();
-        if (fm == null) {
-            return;
-        }
-
-        mComment = mCommentStore.getCommentBySiteAndRemoteId(mSite, commentId);
-
-        fm.executePendingTransactions();
-        CommentsListFragment listFragment = getListFragment();
-
-        FragmentTransaction ft = fm.beginTransaction();
-        String tagForFragment = getString(R.string.fragment_tag_comment_detail);
-        CommentDetailFragment detailFragment = CommentDetailFragment.newInstance(mSite, mComment);
-        ft.add(R.id.layout_fragment_container, detailFragment, tagForFragment).addToBackStack(tagForFragment)
-                .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE);
-        if (listFragment != null) {
-            ft.hide(listFragment);
-        }
-        ft.commitAllowingStateLoss();
+        Intent detailIntent = new Intent(this, CommentsDetailActivity.class);
+        detailIntent.putExtra(CommentsDetailActivity.COMMENT_ID_EXTRA, commentId);
+        detailIntent.putExtra(CommentsDetailActivity.COMMENT_STATUS_FILTER_EXTRA, CommentStatus.ALL);
+        detailIntent.putExtra(WordPress.SITE, mSite);
+        startActivity(detailIntent);
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -182,10 +182,10 @@ public class CommentsActivity extends AppCompatActivity
      * called from comment list when user taps a comment
      */
     @Override
-    public void onCommentSelected(long commentId) {
+    public void onCommentSelected(long commentId, CommentStatus commentStatus) {
         Intent detailIntent = new Intent(this, CommentsDetailActivity.class);
         detailIntent.putExtra(CommentsDetailActivity.COMMENT_ID_EXTRA, commentId);
-        detailIntent.putExtra(CommentsDetailActivity.COMMENT_STATUS_FILTER_EXTRA, CommentStatus.ALL);
+        detailIntent.putExtra(CommentsDetailActivity.COMMENT_STATUS_FILTER_EXTRA, commentStatus);
         detailIntent.putExtra(WordPress.SITE, mSite);
         startActivity(detailIntent);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -38,8 +38,7 @@ import javax.inject.Inject;
 
 public class CommentsActivity extends AppCompatActivity
         implements OnCommentSelectedListener,
-        NotificationFragment.OnPostClickListener,
-        CommentActions.OnCommentChangeListener {
+        NotificationFragment.OnPostClickListener {
     static final String KEY_AUTO_REFRESHED = "has_auto_refreshed";
     static final String KEY_EMPTY_VIEW_MESSAGE = "empty_view_message";
     private static final String SAVED_COMMENTS_STATUS_TYPE = "saved_comments_status_type";
@@ -289,18 +288,6 @@ public class CommentsActivity extends AppCompatActivity
             // Actual moderation (push the modified comment).
             comment.setStatus(newStatus.toString());
             mDispatcher.dispatch(CommentActionBuilder.newPushCommentAction(new RemoteCommentPayload(mSite, comment)));
-        }
-    }
-
-    @Override
-    public void onCommentChanged(CommentActions.ChangeType changeType) {
-        switch (changeType) {
-            case EDITED:
-                reloadCommentList();
-                break;
-            case REPLIED:
-                updateCommentList();
-                break;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsActivity.java
@@ -136,20 +136,6 @@ public class CommentsActivity extends AppCompatActivity
         AppLog.d(AppLog.T.COMMENTS, "comment activity new intent");
     }
 
-
-    private CommentDetailFragment getDetailFragment() {
-        Fragment fragment = getFragmentManager().findFragmentByTag(getString(
-                R.string.fragment_tag_comment_detail));
-        if (fragment == null) {
-            return null;
-        }
-        return (CommentDetailFragment) fragment;
-    }
-
-    private boolean hasDetailFragment() {
-        return (getDetailFragment() != null);
-    }
-
     private CommentsListFragment getListFragment() {
         Fragment fragment = getFragmentManager().findFragmentByTag(getString(
                 R.string.fragment_tag_comment_list));
@@ -173,8 +159,6 @@ public class CommentsActivity extends AppCompatActivity
         ft.add(R.id.layout_fragment_container, fragment, tagForFragment)
           .addToBackStack(tagForFragment)
           .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE);
-        if (hasDetailFragment())
-            ft.hide(getDetailFragment());
         ft.commit();
     }
 
@@ -224,11 +208,7 @@ public class CommentsActivity extends AppCompatActivity
     public void onSaveInstanceState(@NonNull Bundle outState) {
         outState.putSerializable(WordPress.SITE, mSite);
 
-        // retain the id of the highlighted and selected comments
-        if (mComment != null && hasDetailFragment()) {
-            outState.putSerializable(KEY_SELECTED_COMMENT, mComment);
-        }
-
+        // retain the id of the highlighted comments
         if (hasListFragment()) {
             outState.putBoolean(KEY_AUTO_REFRESHED, getListFragment().mHasAutoRefreshedComments);
             outState.putString(KEY_EMPTY_VIEW_MESSAGE, getListFragment().getEmptyViewMessage());

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -1,0 +1,90 @@
+package org.wordpress.android.ui.comments;
+
+import org.wordpress.android.R;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.fluxc.model.CommentStatus;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.CommentStore;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.widgets.WPViewPager;
+import org.wordpress.android.widgets.WPViewPagerTransformer;
+
+import android.os.Bundle;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.view.MenuItem;
+
+import javax.inject.Inject;
+
+public class CommentsDetailActivity extends AppCompatActivity {
+    public static final String COMMENT_ID_EXTRA = "commentId";
+    public static final String COMMENT_STATUS_FILTER_EXTRA = "commentStatusFilter";
+
+    @Inject CommentStore mCommentStore;
+
+    private WPViewPager mViewPager;
+
+    private long mCommentId;
+    private CommentStatus commentStatus;
+    private SiteModel mSite;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ((WordPress) getApplication()).component().inject(this);
+        AppLog.i(AppLog.T.COMMENTS, "Creating CommentsDetailActivity");
+
+        setContentView(R.layout.comments_detail_activity);
+
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setElevation(0);
+            actionBar.setTitle(R.string.comments);
+            actionBar.setDisplayShowTitleEnabled(true);
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+
+        if (savedInstanceState == null) {
+            mCommentId = getIntent().getLongExtra(COMMENT_ID_EXTRA, -1);
+            mSite = (SiteModel) getIntent().getSerializableExtra(WordPress.SITE);
+            commentStatus = (CommentStatus) getIntent().getSerializableExtra(COMMENT_STATUS_FILTER_EXTRA);
+
+        } else {
+            mCommentId = savedInstanceState.getLong(COMMENT_ID_EXTRA);
+            mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
+            commentStatus = (CommentStatus) savedInstanceState.getSerializable(COMMENT_STATUS_FILTER_EXTRA);
+        }
+
+        //set up the viewpager and adapter for lateral navigation
+        mViewPager = (WPViewPager) findViewById(R.id.viewpager);
+        mViewPager.setPageTransformer(false,
+                                      new WPViewPagerTransformer(WPViewPagerTransformer.TransformType.SLIDE_OVER));
+        //TODO mCommentStore.getCommentBySiteAndRemoteId(mSite, mCommentId);
+        //TODO updateUI()
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        outState.putLong(COMMENT_ID_EXTRA, mCommentId);
+        outState.putSerializable(WordPress.SITE, mSite);
+        outState.putSerializable(COMMENT_STATUS_FILTER_EXTRA, commentStatus);
+        super.onSaveInstanceState(outState);
+    }
+
+    private void showErrorToastAndFinish() {
+        AppLog.e(AppLog.T.COMMENTS, "Comment could not be found.");
+        ToastUtils.showToast(this, R.string.error_load_comment);
+        finish();
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -179,19 +179,25 @@ public class CommentsDetailActivity extends AppCompatActivity
 
                 @Override
                 public void loadingFinished(CommentList commentList) {
-                    showCommentList(commentList);
+                    if (!commentList.isEmpty()) {
+                        showCommentList(commentList);
+                    }
                 }
             }).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
         }
     }
 
     private void showCommentList(CommentList commentList) {
-        if (mAdapter == null) {
+        final int previousItem = mViewPager.getCurrentItem();
+
+        //Only notify adapter when loading new page
+        if (mAdapter != null && mAdapter.isAddingNewComments(commentList)) {
+            mAdapter.onNewItems(commentList);
+        } else {
+            //If current items change, rebuild the adapter
             mAdapter = new CommentDetailFragmentAdapter(getFragmentManager(), commentList, mSite,
                     CommentsDetailActivity.this);
             mViewPager.setAdapter(mAdapter);
-        } else {
-            mAdapter.onNewItems(commentList);
         }
 
         final int commentIndex = mAdapter.commentIndex(mCommentId);
@@ -212,8 +218,7 @@ public class CommentsDetailActivity extends AppCompatActivity
                 }
             };
         }
-
-        if (commentIndex != mViewPager.getCurrentItem()) {
+        if (commentIndex != previousItem) {
             mViewPager.setCurrentItem(commentIndex);
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -86,6 +86,7 @@ public class CommentsDetailActivity extends AppCompatActivity implements Comment
 
         progressBar = (ProgressBar) findViewById(R.id.progress_loading);
 
+        //Asynchronously loads comments and build the adapter
         loadDataInViewPager();
     }
 
@@ -128,17 +129,20 @@ public class CommentsDetailActivity extends AppCompatActivity implements Comment
 
         mDispatcher.dispatch(CommentActionBuilder.newFetchCommentsAction(new CommentStore.FetchCommentsPayload(mSite, mStatusFilter, COMMENTS_PER_PAGE, mAdapter.getCount())));
         mIsUpdatingComments = true;
+        setLoadingState(true);
     }
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onCommentChanged(CommentStore.OnCommentChanged event) {
         mIsUpdatingComments = false;
+        setLoadingState(false);
         // Don't refresh the list on push, we already updated comments
         if (event.causeOfChange != CommentAction.PUSH_COMMENT) {
             if (event.changedCommentsLocalIds.size() > 0) {
                 loadDataInViewPager();
-            } else if (!event.isError()){
+            } else if (!event.isError()) {
+                //There are no more comments to load
                 mCanLoadMoreComments = false;
             }
         }
@@ -163,7 +167,6 @@ public class CommentsDetailActivity extends AppCompatActivity implements Comment
                 @Override
                 public void loadingFinished(CommentList commentList) {
                     showCommentList(commentList);
-                    setLoadingState(false);
                 }
             }).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
         }
@@ -211,8 +214,7 @@ public class CommentsDetailActivity extends AppCompatActivity implements Comment
 
     private void setLoadingState(boolean visible) {
         if (progressBar != null) {
-            boolean showProgressBar = visible && (mAdapter == null || mAdapter.isEmpty());
-            progressBar.setVisibility(showProgressBar ? View.VISIBLE : View.GONE);
+            progressBar.setVisibility(visible ? View.VISIBLE : View.GONE);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -36,13 +36,14 @@ import static org.wordpress.android.ui.comments.CommentsListFragment.COMMENTS_PE
 
 public class CommentsDetailActivity extends AppCompatActivity
         implements CommentAdapter.OnLoadMoreListener,
-        CommentActions.OnCommentActionListener,
-        CommentActions.OnCommentChangeListener {
+                   CommentActions.OnCommentActionListener {
     public static final String COMMENT_ID_EXTRA = "commentId";
     public static final String COMMENT_STATUS_FILTER_EXTRA = "commentStatusFilter";
 
-    @Inject CommentStore mCommentStore;
-    @Inject Dispatcher mDispatcher;
+    @Inject
+    CommentStore mCommentStore;
+    @Inject
+    Dispatcher mDispatcher;
 
     private WPViewPager mViewPager;
     private ProgressBar mProgressBar;
@@ -121,10 +122,10 @@ public class CommentsDetailActivity extends AppCompatActivity
 
     @Override
     public void onLoadMore() {
-        updateComments(true);
+        updateComments();
     }
 
-    private void updateComments(boolean loadMore) {
+    private void updateComments() {
         if (mIsUpdatingComments) {
             AppLog.w(AppLog.T.COMMENTS, "update comments task already running");
             return;
@@ -136,13 +137,11 @@ public class CommentsDetailActivity extends AppCompatActivity
             return;
         }
 
-        final int offset = loadMore ? mAdapter.getCount() : 0;
+        final int offset = mAdapter.getCount();
         mDispatcher.dispatch(CommentActionBuilder.newFetchCommentsAction(
                 new FetchCommentsPayload(mSite, mStatusFilter, COMMENTS_PER_PAGE, offset)));
-        if (loadMore) {
-            mIsUpdatingComments = true;
-            setLoadingState(true);
-        }
+        mIsUpdatingComments = true;
+        setLoadingState(true);
     }
 
     @SuppressWarnings("unused")
@@ -247,17 +246,5 @@ public class CommentsDetailActivity extends AppCompatActivity
         resultIntent.putExtra(CommentsActivity.COMMENT_MODERATE_STATUS_EXTRA, newStatus.toString());
         setResult(RESULT_OK, resultIntent);
         finish();
-    }
-
-    @Override
-    public void onCommentChanged(CommentActions.ChangeType changeType) {
-        switch (changeType) {
-            case EDITED:
-                loadDataInViewPager();
-                break;
-            case REPLIED:
-                updateComments(false);
-                break;
-        }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -40,10 +40,8 @@ public class CommentsDetailActivity extends AppCompatActivity
     public static final String COMMENT_ID_EXTRA = "commentId";
     public static final String COMMENT_STATUS_FILTER_EXTRA = "commentStatusFilter";
 
-    @Inject
-    CommentStore mCommentStore;
-    @Inject
-    Dispatcher mDispatcher;
+    @Inject CommentStore mCommentStore;
+    @Inject Dispatcher mDispatcher;
 
     private WPViewPager mViewPager;
     private ProgressBar mProgressBar;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -170,8 +170,13 @@ public class CommentsDetailActivity extends AppCompatActivity implements Comment
     }
 
     private void showCommentList(CommentList commentList) {
-        mAdapter = new CommentDetailFragmentAdapter(getFragmentManager(), commentList, mSite, CommentsDetailActivity.this);
-        mViewPager.setAdapter(mAdapter);
+        if (mAdapter == null) {
+            mAdapter = new CommentDetailFragmentAdapter(getFragmentManager(), commentList, mSite, CommentsDetailActivity.this);
+            mViewPager.setAdapter(mAdapter);
+        } else {
+            mAdapter.onNewItems(commentList);
+        }
+
         final int commentIndex = mAdapter.commentIndex(mCommentId);
         if (commentIndex < 0) {
             showErrorToastAndFinish();
@@ -190,7 +195,10 @@ public class CommentsDetailActivity extends AppCompatActivity implements Comment
                 }
             };
         }
-        mViewPager.setCurrentItem(commentIndex);
+
+        if (commentIndex != mViewPager.getCurrentItem()) {
+            mViewPager.setCurrentItem(commentIndex);
+        }
 
         mViewPager.addOnPageChangeListener(mOnPageChangeListener);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsDetailActivity.java
@@ -1,6 +1,14 @@
 package org.wordpress.android.ui.comments;
 
-import static org.wordpress.android.ui.comments.CommentsListFragment.COMMENTS_PER_PAGE;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.support.v4.view.ViewPager;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.text.TextUtils;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.ProgressBar;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -20,17 +28,9 @@ import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.widgets.WPViewPager;
 import org.wordpress.android.widgets.WPViewPagerTransformer;
 
-import android.os.AsyncTask;
-import android.os.Bundle;
-import android.support.v4.view.ViewPager;
-import android.support.v7.app.ActionBar;
-import android.support.v7.app.AppCompatActivity;
-import android.text.TextUtils;
-import android.view.MenuItem;
-import android.view.View;
-import android.widget.ProgressBar;
-
 import javax.inject.Inject;
+
+import static org.wordpress.android.ui.comments.CommentsListFragment.COMMENTS_PER_PAGE;
 
 public class CommentsDetailActivity extends AppCompatActivity implements CommentAdapter.OnLoadMoreListener {
     public static final String COMMENT_ID_EXTRA = "commentId";
@@ -40,7 +40,7 @@ public class CommentsDetailActivity extends AppCompatActivity implements Comment
     @Inject Dispatcher mDispatcher;
 
     private WPViewPager mViewPager;
-    private ProgressBar progressBar;
+    private ProgressBar mProgressBar;
 
     private long mCommentId;
     private CommentStatus mStatusFilter;
@@ -82,9 +82,10 @@ public class CommentsDetailActivity extends AppCompatActivity implements Comment
 
         //set up the viewpager and adapter for lateral navigation
         mViewPager = (WPViewPager) findViewById(R.id.viewpager);
-        mViewPager.setPageTransformer(false, new WPViewPagerTransformer(WPViewPagerTransformer.TransformType.SLIDE_OVER));
+        mViewPager.setPageTransformer(false,
+                new WPViewPagerTransformer(WPViewPagerTransformer.TransformType.SLIDE_OVER));
 
-        progressBar = (ProgressBar) findViewById(R.id.progress_loading);
+        mProgressBar = (ProgressBar) findViewById(R.id.progress_loading);
 
         //Asynchronously loads comments and build the adapter
         loadDataInViewPager();
@@ -110,7 +111,6 @@ public class CommentsDetailActivity extends AppCompatActivity implements Comment
             finish();
             return true;
         }
-
         return super.onOptionsItemSelected(item);
     }
 
@@ -127,7 +127,8 @@ public class CommentsDetailActivity extends AppCompatActivity implements Comment
             return;
         }
 
-        mDispatcher.dispatch(CommentActionBuilder.newFetchCommentsAction(new CommentStore.FetchCommentsPayload(mSite, mStatusFilter, COMMENTS_PER_PAGE, mAdapter.getCount())));
+        mDispatcher.dispatch(CommentActionBuilder.newFetchCommentsAction(
+                new CommentStore.FetchCommentsPayload(mSite, mStatusFilter, COMMENTS_PER_PAGE, mAdapter.getCount())));
         mIsUpdatingComments = true;
         setLoadingState(true);
     }
@@ -174,7 +175,8 @@ public class CommentsDetailActivity extends AppCompatActivity implements Comment
 
     private void showCommentList(CommentList commentList) {
         if (mAdapter == null) {
-            mAdapter = new CommentDetailFragmentAdapter(getFragmentManager(), commentList, mSite, CommentsDetailActivity.this);
+            mAdapter = new CommentDetailFragmentAdapter(getFragmentManager(), commentList, mSite,
+                    CommentsDetailActivity.this);
             mViewPager.setAdapter(mAdapter);
         } else {
             mAdapter.onNewItems(commentList);
@@ -213,8 +215,8 @@ public class CommentsDetailActivity extends AppCompatActivity implements Comment
     }
 
     private void setLoadingState(boolean visible) {
-        if (progressBar != null) {
-            progressBar.setVisibility(visible ? View.VISIBLE : View.GONE);
+        if (mProgressBar != null) {
+            mProgressBar.setVisibility(visible ? View.VISIBLE : View.GONE);
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -1,22 +1,5 @@
 package org.wordpress.android.ui.comments;
 
-import android.app.AlertDialog;
-import android.app.Fragment;
-import android.content.DialogInterface;
-import android.graphics.drawable.Drawable;
-import android.os.Bundle;
-import android.support.annotation.StringRes;
-import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.view.ActionMode;
-import android.text.TextUtils;
-import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup;
-
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.R;
@@ -41,11 +24,27 @@ import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SmartToast;
 import org.wordpress.android.util.ToastUtils;
 
+import android.app.AlertDialog;
+import android.app.Fragment;
+import android.content.DialogInterface;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.support.annotation.StringRes;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.view.ActionMode;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import javax.inject.Inject;
 
 public class CommentsListFragment extends Fragment {
     public static final int COMMENTS_PER_PAGE = 30;

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -1,5 +1,22 @@
 package org.wordpress.android.ui.comments;
 
+import android.app.AlertDialog;
+import android.app.Fragment;
+import android.content.DialogInterface;
+import android.graphics.drawable.Drawable;
+import android.os.Bundle;
+import android.support.annotation.StringRes;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.view.ActionMode;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.R;
@@ -24,27 +41,11 @@ import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SmartToast;
 import org.wordpress.android.util.ToastUtils;
 
-import android.app.AlertDialog;
-import android.app.Fragment;
-import android.content.DialogInterface;
-import android.graphics.drawable.Drawable;
-import android.os.Bundle;
-import android.support.annotation.StringRes;
-import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.view.ActionMode;
-import android.text.TextUtils;
-import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
-import android.view.View;
-import android.view.ViewGroup;
-
-import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import javax.inject.Inject;
 
 public class CommentsListFragment extends Fragment {
     public static final int COMMENTS_PER_PAGE = 30;
@@ -136,7 +137,7 @@ public class CommentsListFragment extends Fragment {
 
     private CommentAdapter getAdapter() {
         if (mAdapter == null) {
-             // called after comments have been loaded
+            // called after comments have been loaded
             CommentAdapter.OnDataLoadedListener dataLoadedListener = new CommentAdapter.OnDataLoadedListener() {
                 @Override
                 public void onDataLoaded(boolean isEmpty) {
@@ -194,6 +195,7 @@ public class CommentsListFragment extends Fragment {
                         getAdapter().toggleItemSelected(position, view);
                     }
                 }
+
                 @Override
                 public void onCommentLongPressed(int position, View view) {
                     // enable CAB if it's not already enabled
@@ -280,7 +282,7 @@ public class CommentsListFragment extends Fragment {
 
             @Override
             public void onLoadFilterCriteriaOptionsAsync(FilteredRecyclerView.FilterCriteriaAsyncLoaderListener listener,
-                                               boolean refresh) {
+                                                         boolean refresh) {
             }
 
             @Override
@@ -363,7 +365,7 @@ public class CommentsListFragment extends Fragment {
         super.onResume();
         if (mFilteredCommentsView.getAdapter() == null) {
             mFilteredCommentsView.setAdapter(getAdapter());
-            if (!NetworkUtils.isNetworkAvailable(getActivity())){
+            if (!NetworkUtils.isNetworkAvailable(getActivity())) {
                 ToastUtils.showToast(getActivity(), getString(R.string.error_refresh_comments_showing_older));
             }
             getAdapter().loadComments(mCommentStatusFilter.toCommentStatus());
@@ -478,7 +480,7 @@ public class CommentsListFragment extends Fragment {
     }
 
     private void moderateComments(CommentList comments, CommentStatus status) {
-        for (CommentModel comment: comments) {
+        for (CommentModel comment : comments) {
             // Preemptive update
             comment.setStatus(status.toString());
             if (shouldRemoveCommentFromList(comment)) {
@@ -503,11 +505,11 @@ public class CommentsListFragment extends Fragment {
         getAdapter().loadComments(mCommentStatusFilter.toCommentStatus());
     }
 
-    void updateEmptyView(){
+    void updateEmptyView() {
         //this is called from CommentsActivity in the case the last moment for a given type has been changed from that
         //status, leaving the list empty, so we need to update the empty view. The method inside FilteredRecyclerView
         //does the handling itself, so we only check for null here.
-        if (mFilteredCommentsView != null){
+        if (mFilteredCommentsView != null) {
             mFilteredCommentsView.updateEmptyView(EmptyViewMessageType.NO_CONTENT);
         }
     }
@@ -530,7 +532,7 @@ public class CommentsListFragment extends Fragment {
         }
 
         //immediately load/refresh whatever we have in our local db as we wait for the API call to get latest results
-        if (!loadMore){
+        if (!loadMore) {
             getAdapter().loadComments(mCommentStatusFilter.toCommentStatus());
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentsListFragment.java
@@ -50,7 +50,7 @@ public class CommentsListFragment extends Fragment {
     public static final int COMMENTS_PER_PAGE = 30;
 
     interface OnCommentSelectedListener {
-        void onCommentSelected(long commentId);
+        void onCommentSelected(long commentId, CommentStatus statusFilter);
     }
 
     public enum CommentStatusCriteria implements FilterCriteria {
@@ -188,7 +188,7 @@ public class CommentsListFragment extends Fragment {
                     if (mActionMode == null) {
                         mFilteredCommentsView.invalidate();
                         if (getActivity() instanceof OnCommentSelectedListener) {
-                            ((OnCommentSelectedListener) getActivity()).onCommentSelected(comment.getRemoteCommentId());
+                            ((OnCommentSelectedListener) getActivity()).onCommentSelected(comment.getRemoteCommentId(), mCommentStatusFilter.toCommentStatus());
                         }
                     } else {
                         getAdapter().toggleItemSelected(position, view);

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/LoadCommentsTask.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/LoadCommentsTask.java
@@ -1,0 +1,64 @@
+package org.wordpress.android.ui.comments;
+
+import org.wordpress.android.fluxc.model.CommentModel;
+import org.wordpress.android.fluxc.model.CommentStatus;
+import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.store.CommentStore;
+import org.wordpress.android.models.CommentList;
+
+import android.os.AsyncTask;
+
+import java.util.List;
+
+class LoadCommentsTask extends AsyncTask<Void, Void, CommentList> {
+    interface LoadingCallback {
+        void isLoading(boolean loading);
+
+        void loadingFinished(CommentList commentList);
+    }
+
+    private final CommentStore mCommentStore;
+    private final CommentStatus mStatusFilter;
+    private final SiteModel mSite;
+    private final LoadingCallback loadingCallback;
+
+    public LoadCommentsTask(CommentStore mCommentStore, CommentStatus statusFilter, SiteModel mSite, LoadingCallback loadingCallback) {
+        this.mCommentStore = mCommentStore;
+        this.mStatusFilter = statusFilter;
+        this.mSite = mSite;
+        this.loadingCallback = loadingCallback;
+    }
+
+    @Override
+    protected void onPreExecute() {
+        loadingCallback.isLoading(true);
+    }
+
+    @Override
+    protected void onCancelled() {
+        loadingCallback.isLoading(false);
+    }
+
+    @Override
+    protected CommentList doInBackground(Void... params) {
+        List<CommentModel> comments;
+        if (mStatusFilter == null || mStatusFilter == CommentStatus.ALL) {
+            // The "all" filter actually means "approved" + "unapproved" (but not "spam", "trash" or "deleted")
+            comments = mCommentStore.getCommentsForSite(mSite, false,
+                                                        CommentStatus.APPROVED, CommentStatus.UNAPPROVED);
+        } else {
+            comments = mCommentStore.getCommentsForSite(mSite, false, mStatusFilter);
+        }
+
+        CommentList tmpComments = new CommentList();
+        tmpComments.addAll(comments);
+
+        return tmpComments;
+    }
+
+    @Override
+    protected void onPostExecute(CommentList result) {
+        loadingCallback.loadingFinished(result);
+        loadingCallback.isLoading(false);
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/LoadCommentsTask.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/LoadCommentsTask.java
@@ -1,12 +1,12 @@
 package org.wordpress.android.ui.comments;
 
+import android.os.AsyncTask;
+
 import org.wordpress.android.fluxc.model.CommentModel;
 import org.wordpress.android.fluxc.model.CommentStatus;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.CommentStore;
 import org.wordpress.android.models.CommentList;
-
-import android.os.AsyncTask;
 
 import java.util.List;
 
@@ -20,23 +20,26 @@ class LoadCommentsTask extends AsyncTask<Void, Void, CommentList> {
     private final CommentStore mCommentStore;
     private final CommentStatus mStatusFilter;
     private final SiteModel mSite;
-    private final LoadingCallback loadingCallback;
+    private final LoadingCallback mLoadingCallback;
 
-    public LoadCommentsTask(CommentStore mCommentStore, CommentStatus statusFilter, SiteModel mSite, LoadingCallback loadingCallback) {
-        this.mCommentStore = mCommentStore;
+    LoadCommentsTask(CommentStore commentStore,
+                     CommentStatus statusFilter,
+                     SiteModel site,
+                     LoadingCallback loadingCallback) {
+        this.mCommentStore = commentStore;
         this.mStatusFilter = statusFilter;
-        this.mSite = mSite;
-        this.loadingCallback = loadingCallback;
+        this.mSite = site;
+        this.mLoadingCallback = loadingCallback;
     }
 
     @Override
     protected void onPreExecute() {
-        loadingCallback.isLoading(true);
+        mLoadingCallback.isLoading(true);
     }
 
     @Override
     protected void onCancelled() {
-        loadingCallback.isLoading(false);
+        mLoadingCallback.isLoading(false);
     }
 
     @Override
@@ -45,7 +48,7 @@ class LoadCommentsTask extends AsyncTask<Void, Void, CommentList> {
         if (mStatusFilter == null || mStatusFilter == CommentStatus.ALL) {
             // The "all" filter actually means "approved" + "unapproved" (but not "spam", "trash" or "deleted")
             comments = mCommentStore.getCommentsForSite(mSite, false,
-                                                        CommentStatus.APPROVED, CommentStatus.UNAPPROVED);
+                    CommentStatus.APPROVED, CommentStatus.UNAPPROVED);
         } else {
             comments = mCommentStore.getCommentsForSite(mSite, false, mStatusFilter);
         }
@@ -57,8 +60,8 @@ class LoadCommentsTask extends AsyncTask<Void, Void, CommentList> {
     }
 
     @Override
-    protected void onPostExecute(CommentList result) {
-        loadingCallback.loadingFinished(result);
-        loadingCallback.isLoading(false);
+    protected void onPostExecute(CommentList loadedCommentList) {
+        mLoadingCallback.loadingFinished(loadedCommentList);
+        mLoadingCallback.isLoading(false);
     }
 }

--- a/WordPress/src/main/res/layout/comments_detail_activity.xml
+++ b/WordPress/src/main/res/layout/comments_detail_activity.xml
@@ -1,0 +1,20 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/comments_detail_container"
+    android:layout_width="match_parent" android:layout_height="match_parent"
+    tools:context="org.wordpress.android.ui.comments.CommentsDetailActivity"
+    tools:ignore="MergeRootFrame" >
+
+    <org.wordpress.android.widgets.WPViewPager
+        android:id="@+id/viewpager"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <ProgressBar
+        android:id="@+id/progress_loading"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:visibility="gone" />
+
+</FrameLayout>


### PR DESCRIPTION
Fixes #6162 
Adds swipe between comments on comment detail page.

To test:
- Go to comment list
- Tap comment
- On the detail screen:
  - it is possible to swipe left and right for previous/following comments
  - swiping to the end of the list (30 items) shows a progress bar 
  - after loading the progress bar disappears and it is possible to swipe further
  - orientation change keeps the current comment visible
- Go back to the comment list
- Select filter
- On the detail screen only the filtered comments are accessible 
- Adding a comment adds a comment to the list but keeps you on the same page.
- Spam/trash click take you back to the comment list which gets updated.

@nbradbury 
