### PR TITLE
Issue/google json warning

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -219,6 +219,11 @@ android.buildTypes.all { buildType ->
             tasks.copyGoogleServicesBuddybuildFile.execute()
         }
     }
+
+    // Print warning message if example Google services file is used.
+    if ((new File('WordPress/google-services.json').text) == (new File('WordPress/google-services.json-example').text)) {
+        println("WARNING: You're using the example google-services.json file. Google login will fail.")
+    }
 }
 
 def checkGradlePropertiesFile() {


### PR DESCRIPTION
### Fix
Add a warning message at build time when the example Google services configuration file, `WordPress/google-services.json-example`, is used.

### Test
1. Copy valid `google-services.json` file to `WordPress/` directory.
2. Run `./gradlew assembleWasabiDebug | grep WARNING` command.
3. Notice `WARNING: You're using the example google-services.json file. Google login will fail.` message is ***not*** shown.
4. Delete `WordPress/google-services.json` file.
5. Run `./gradlew assembleWasabiDebug | grep WARNING` command.
6. Notice `WARNING: You're using the example google-services.json file. Google login will fail.` message is shown.