### PR TITLE
Update FluxC dependency hash to 2d5ba6a

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -139,7 +139,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.0.2'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:6603e2cf5c58f764169e842c676b14fb7ff01fdb') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:2d5ba6a8475b749ae8cb2248422610e849871caf') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -135,8 +135,8 @@ dependencies {
     compile 'org.wordpress:passcodelock:1.5.1'
 
     // Dagger
-    compile 'com.google.dagger:dagger:2.0.2'
-    apt 'com.google.dagger:dagger-compiler:2.0.2'
+    compile 'com.google.dagger:dagger:2.11'
+    apt 'com.google.dagger:dagger-compiler:2.11'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
     compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:2d5ba6a8475b749ae8cb2248422610e849871caf') {


### PR DESCRIPTION
### Fix
Update the FluxC dependency hash to 2d5ba6a8475b749ae8cb2248422610e849871caf to include changes to the library in order to avoid a `NullPointerException` during Google login as described in https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/618.