### PR TITLE
Refactor/notification events

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -55,6 +55,7 @@ import org.wordpress.android.ui.comments.CommentActions.ChangeType;
 import org.wordpress.android.ui.comments.CommentActions.OnCommentActionListener;
 import org.wordpress.android.ui.comments.CommentActions.OnCommentChangeListener;
 import org.wordpress.android.ui.comments.CommentActions.OnNoteCommentActionListener;
+import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.notifications.NotificationFragment;
 import org.wordpress.android.ui.notifications.NotificationsDetailListFragment;
 import org.wordpress.android.ui.reader.ReaderActivityLauncher;
@@ -1198,6 +1199,11 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     }
 
     private void onCommentLiked(OnCommentChanged event) {
+        // send signal for listeners to perform any needed updates
+        if (mNote != null) {
+            EventBus.getDefault().postSticky(new NotificationEvents.NoteLikeStatusChanged(mNote.getId()));
+        }
+
         if (event.isError()) {
             // Revert button state in case of an error
             toggleLikeButton(!mBtnLikeComment.isActivated());

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -1154,6 +1154,11 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     }
 
     private void onCommentModerated(OnCommentChanged event) {
+        // send signal for listeners to perform any needed updates
+        if (mNote != null) {
+            EventBus.getDefault().postSticky(new NotificationEvents.NoteLikeOrModerationStatusChanged(mNote.getId()));
+        }
+
         if (!isAdded()) return;
 
         if (event.isError()) {
@@ -1201,7 +1206,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     private void onCommentLiked(OnCommentChanged event) {
         // send signal for listeners to perform any needed updates
         if (mNote != null) {
-            EventBus.getDefault().postSticky(new NotificationEvents.NoteLikeStatusChanged(mNote.getId()));
+            EventBus.getDefault().postSticky(new NotificationEvents.NoteLikeOrModerationStatusChanged(mNote.getId()));
         }
 
         if (event.isError()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -134,7 +134,6 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
     private boolean mIsUsersBlog = false;
     private boolean mShouldFocusReplyField;
     private String mPreviousStatus;
-    private long mCommentIdToFetch;
 
     @Inject Dispatcher mDispatcher;
     @Inject AccountStore mAccountStore;
@@ -1247,12 +1246,6 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
                 ToastUtils.showToast(getActivity(), event.error.message);
             }
             return;
-        }
-
-        if (mCommentIdToFetch != 0) {
-            CommentModel comment = mCommentStore.getCommentBySiteAndRemoteId(mSite, mCommentIdToFetch);
-            setComment(comment, mSite);
-            mCommentIdToFetch = 0;
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
@@ -16,14 +16,6 @@ public class NotificationEvents {
             this.hasUnseenNotes = hasUnseenNotes;
         }
     }
-    public static class NoteModerationStatusChanged {
-        final boolean isModerating;
-        final String noteId;
-        public NoteModerationStatusChanged(String noteId, boolean isModerating) {
-            this.noteId = noteId;
-            this.isModerating = isModerating;
-        }
-    }
     public static class NoteLikeStatusChanged {
         final String noteId;
         public NoteLikeStatusChanged(String noteId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
@@ -16,7 +16,6 @@ public class NotificationEvents {
             this.hasUnseenNotes = hasUnseenNotes;
         }
     }
-    public static class NoteModerationFailed {}
     public static class NoteModerationStatusChanged {
         final boolean isModerating;
         final String noteId;

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
@@ -16,9 +16,9 @@ public class NotificationEvents {
             this.hasUnseenNotes = hasUnseenNotes;
         }
     }
-    public static class NoteLikeStatusChanged {
+    public static class NoteLikeOrModerationStatusChanged {
         final String noteId;
-        public NoteLikeStatusChanged(String noteId) {
+        public NoteLikeOrModerationStatusChanged(String noteId) {
             this.noteId = noteId;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationEvents.java
@@ -22,14 +22,6 @@ public class NotificationEvents {
             this.noteId = noteId;
         }
     }
-    public static class NoteVisibilityChanged {
-        final boolean isHidden;
-        final String noteId;
-        public NoteVisibilityChanged(String noteId, boolean isHidden) {
-            this.noteId = noteId;
-            this.isHidden = isHidden;
-        }
-    }
     public static class NotificationsSettingsStatusChanged {
         final String mMessage;
         public NotificationsSettingsStatusChanged(String message) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -37,8 +37,6 @@ import org.wordpress.android.ui.notifications.services.NotificationsUpdateServic
 import org.wordpress.android.ui.notifications.utils.NotificationsActions;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.NetworkUtils;
-import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -602,15 +602,6 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
         EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteVisibilityChanged.class);
     }
 
-    @SuppressWarnings("unused")
-    public void onEventMainThread(NotificationEvents.NoteModerationFailed event) {
-        if (isAdded()) {
-            ToastUtils.showToast(getActivity(), R.string.error_moderate_comment, Duration.LONG);
-        }
-
-        EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteModerationFailed.class);
-    }
-
     public SiteModel getSelectedSite() {
         if (getActivity() instanceof WPMainActivity) {
             WPMainActivity mainActivity = (WPMainActivity) getActivity();

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -292,23 +292,6 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
         activity.startActivityForResult(detailIntent, RequestCodes.NOTE_DETAIL);
     }
 
-    private void setNoteIsHidden(String noteId, boolean isHidden) {
-        if (mNotesAdapter == null) return;
-
-        if (isHidden) {
-            mNotesAdapter.addHiddenNoteId(noteId);
-        } else {
-            // Scroll the row into view if it isn't visible so the animation can be seen
-            int notePosition = mNotesAdapter.getPositionForNote(noteId);
-            if (notePosition != RecyclerView.NO_POSITION &&
-                    mLinearLayoutManager.findFirstCompletelyVisibleItemPosition() > notePosition) {
-                mLinearLayoutManager.scrollToPosition(notePosition);
-            }
-
-            mNotesAdapter.removeHiddenNoteId(noteId);
-        }
-    }
-
     private void showEmptyView(@StringRes int titleResId) {
         showEmptyView(titleResId, 0, 0);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -558,13 +558,6 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
         );
     }
 
-    @SuppressWarnings("unused")
-    public void onEventMainThread(NotificationEvents.NoteVisibilityChanged event) {
-        setNoteIsHidden(event.noteId, event.isHidden);
-
-        EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteVisibilityChanged.class);
-    }
-
     public SiteModel getSelectedSite() {
         if (getActivity() instanceof WPMainActivity) {
             WPMainActivity mainActivity = (WPMainActivity) getActivity();

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -536,13 +536,13 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
     }
 
     @SuppressWarnings("unused")
-    public void onEventMainThread(final NotificationEvents.NoteLikeStatusChanged event) {
+    public void onEventMainThread(final NotificationEvents.NoteLikeOrModerationStatusChanged event) {
         // Like/unlike done -> refresh the note and update db
         NotificationsActions.downloadNoteAndUpdateDB(event.noteId,
                 new RestRequest.Listener() {
                     @Override
                     public void onResponse(JSONObject response) {
-                        EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteLikeStatusChanged.class);
+                        EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteLikeOrModerationStatusChanged.class);
                         //now re-set the object in our list adapter with the note saved in the updated DB
                         Note note = NotificationsTable.getNoteById(event.noteId);
                         if (note != null) {
@@ -552,7 +552,7 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
                 }, new RestRequest.ErrorListener() {
                     @Override
                     public void onErrorResponse(VolleyError error) {
-                        EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteLikeStatusChanged.class);
+                        EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteLikeOrModerationStatusChanged.class);
                     }
                 }
         );

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -311,16 +311,6 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
         }
     }
 
-    private void setNoteIsModerating(String noteId, boolean isModerating) {
-        if (mNotesAdapter == null) return;
-
-        if (isModerating) {
-            mNotesAdapter.addModeratingNoteId(noteId);
-        } else {
-            mNotesAdapter.removeModeratingNoteId(noteId);
-        }
-    }
-
     private void showEmptyView(@StringRes int titleResId) {
         showEmptyView(titleResId, 0, 0);
     }
@@ -545,31 +535,6 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
         }
         mSwipeToRefreshHelper.setRefreshing(false);
         mNotesAdapter.addAll(event.notes, true);
-    }
-
-    @SuppressWarnings("unused")
-    public void onEventMainThread(final NotificationEvents.NoteModerationStatusChanged event) {
-        if (event.isModerating) {
-            setNoteIsModerating(event.noteId, event.isModerating);
-            EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteModerationStatusChanged.class);
-        } else {
-            // Moderation done -> refresh the note before calling the end.
-            NotificationsActions.downloadNoteAndUpdateDB(event.noteId,
-                    new RestRequest.Listener() {
-                        @Override
-                        public void onResponse(JSONObject response) {
-                            setNoteIsModerating(event.noteId, event.isModerating);
-                            EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteModerationStatusChanged.class);
-                        }
-                    }, new RestRequest.ErrorListener() {
-                        @Override
-                        public void onErrorResponse(VolleyError error) {
-                            setNoteIsModerating(event.noteId, event.isModerating);
-                            EventBus.getDefault().removeStickyEvent(NotificationEvents.NoteModerationStatusChanged.class);
-                        }
-                    }
-            );
-        }
     }
 
     @SuppressWarnings("unused")

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -30,7 +30,6 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
     private final int mColorUnread;
     private final int mTextIndentSize;
     private final List<String> mHiddenNoteIds = new ArrayList<>();
-    private final List<String> mModeratingNoteIds = new ArrayList<>();
 
     private final DataLoadedListener mDataLoadedListener;
     private final OnLoadMoreListener mOnLoadMoreListener;
@@ -85,18 +84,6 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
     public void removeHiddenNoteId(String noteId) {
         mHiddenNoteIds.remove(noteId);
         myNotifyDatasetChanged();
-    }
-
-    public void addModeratingNoteId(String noteId) {
-        mModeratingNoteIds.add(noteId);
-        myNotifyDatasetChanged();
-    }
-
-    public void removeModeratingNoteId(String noteId) {
-        mModeratingNoteIds.remove(noteId);
-        // Reload the notifications from DB since the state of at least one of them is changed.
-        // DB already has the fresh value in it.
-        reloadNotesFromDBAsync();
     }
 
     public void addAll(List<Note> notes, boolean clearBeforeAdding) {
@@ -247,12 +234,6 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
             commentStatus = CommentStatus.fromString(note.getLocalStatus());
         }
 
-        if (mModeratingNoteIds.size() > 0 && mModeratingNoteIds.contains(note.getId())) {
-            noteViewHolder.progressBar.setVisibility(View.VISIBLE);
-        } else {
-            noteViewHolder.progressBar.setVisibility(View.GONE);
-        }
-
         // Subject is stored in db as html to preserve text formatting
         CharSequence noteSubjectSpanned = note.getFormattedSubject();
         // Trim the '\n\n' added by Html.fromHtml()
@@ -358,7 +339,6 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
         private final TextView txtDetail;
         private final WPNetworkImageView imgAvatar;
         private final NoticonTextView noteIcon;
-        private final View progressBar;
 
         NoteViewHolder(View view) {
             super(view);
@@ -370,7 +350,6 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
             txtDetail = (TextView) view.findViewById(R.id.note_detail);
             imgAvatar = (WPNetworkImageView) view.findViewById(R.id.note_avatar);
             noteIcon = (NoticonTextView) view.findViewById(R.id.note_icon);
-            progressBar = view.findViewById(R.id.moderate_progress);
 
             itemView.setOnClickListener(mOnClickListener);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -29,7 +29,6 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
     private final int mColorRead;
     private final int mColorUnread;
     private final int mTextIndentSize;
-    private final List<String> mHiddenNoteIds = new ArrayList<>();
 
     private final DataLoadedListener mDataLoadedListener;
     private final OnLoadMoreListener mOnLoadMoreListener;
@@ -74,16 +73,6 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
 
     public FILTERS getCurrentFilter() {
         return mCurrentFilter;
-    }
-
-    public void addHiddenNoteId(String noteId) {
-        mHiddenNoteIds.add(noteId);
-        myNotifyDatasetChanged();
-    }
-
-    public void removeHiddenNoteId(String noteId) {
-        mHiddenNoteIds.remove(noteId);
-        myNotifyDatasetChanged();
     }
 
     public void addAll(List<Note> notes, boolean clearBeforeAdding) {
@@ -216,13 +205,6 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
             }
 
             noteViewHolder.headerView.setVisibility(View.VISIBLE);
-        }
-
-        if (mHiddenNoteIds.size() > 0 && mHiddenNoteIds.contains(note.getId())) {
-            noteViewHolder.contentView.setVisibility(View.GONE);
-            noteViewHolder.headerView.setVisibility(View.GONE);
-        } else {
-            noteViewHolder.contentView.setVisibility(View.VISIBLE);
         }
 
         CommentStatus commentStatus = CommentStatus.ALL;

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -86,24 +86,6 @@
                     android:layout_marginEnd="@dimen/notifications_adjusted_font_margin"
                     android:layout_marginTop="@dimen/margin_small" />
 
-                <LinearLayout
-                    android:id="@+id/moderate_progress"
-                    android:layout_width="@dimen/notifications_avatar_sz"
-                    android:layout_height="@dimen/notifications_avatar_sz"
-                    android:layout_marginTop="@dimen/margin_small"
-                    android:background="@drawable/shape_oval_translucent"
-                    android:gravity="center"
-                    android:padding="@dimen/margin_large"
-                    android:visibility="gone"
-                    tools:visibility="visible">
-
-                    <ProgressBar
-                        style="@android:style/Widget.Holo.ProgressBar"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:indeterminate="true" />
-                </LinearLayout>
-
                 <org.wordpress.android.widgets.NoticonTextView
                     android:id="@+id/note_icon"
                     android:layout_width="@dimen/note_icon_sz"


### PR DESCRIPTION
This PR does some code cleanup on the Notifications list area, as some code that was relying on EventBus events being created was hanging orphan as those events were eventually removed (do a quick search on the event classes in `NotificationEvents.java` to find out there were several listeners registered on EventBus for which no events were actually triggered 😱 ). 
This includes:

- comment like from within the detail view, that need be reflected on the Notifications list screen
- note approval from within the detail view, that needs be reflected on the Notifications list screen
- some other code cleanup

In regards to comment moderation/like I would generally prefer to rely on FluxC’s event mechanism and go ahead and refresh any items on the list, that have been changed elsewhere, but given this is the `CommentStore` we are using (and there is still no implementation for NoteStore, therefore there's also no way to relate one another) we cannot know, given a `commentId`, which `Note` corresponds to it unless we keep a reference to `mNote` as we’re doing in CommentDetailFragment when such a fragment is instantiated from the NotificationsList screen.

Therefore, this PR brings some of the connections back by issuing the EventBus events that were dropped in between migrating to FluxC and now, and drops some unused events / code as well.

cc @maxme @daniloercoli 