### PR TITLE
Consider media upload failed if the remote url is null when user retries to upload

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2444,7 +2444,7 @@ public class EditPostActivity extends AppCompatActivity implements
             return false;
         }
 
-        if (media.getUploadState().equals(MediaUploadState.UPLOADED.toString())) {
+        if (media.getUrl() != null && media.getUploadState().equals(MediaUploadState.UPLOADED.toString())) {
             // Note: we should actually do this when the editor fragment starts instead of waiting for user input.
             // Notify the editor fragment upload was successful and it should replace the local url by the remote url.
             if (mEditorMediaUploadListener != null) {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/AztecEditor-Android/issues/456

This is the same kind of patch as https://github.com/wordpress-mobile/WordPress-Android/pull/6626 

cc @mzorz 