### PR TITLE
Issue/unused help method

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginGoogleFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginGoogleFragment.java
@@ -169,13 +169,6 @@ public class LoginGoogleFragment extends Fragment implements ConnectionCallbacks
         Log.w(LoginGoogleFragment.class.getSimpleName(), "onConnectionSuspended: " + i);
     }
 
-    public void onHelp() {
-        if (mLoginListener != null) {
-            // Send last email chosen from Google login if available.
-            mLoginListener.helpSocialEmailScreen(mGoogleEmail);
-        }
-    }
-
     public void connectGoogleClient() {
         if (!mGoogleApiClient.isConnecting() && !mGoogleApiClient.isConnected()) {
             shouldResolveError = true;


### PR DESCRIPTION
### Fix
Remove the unused `onHelp` method from the `LoginGoogleFragment` class.  This was overlooked in the [technical debt changes](https://github.com/wordpress-mobile/WordPress-Android/pull/6764).  The `LoginGoogleFragment.onHelp` method functionality is now handled with the `LoginGoogleFragment.GoogleLoginListener.onGoogleEmailSelected` and `LoginEmailFragment.setGoogleEmail` methods due to the code refactor from the technical debt changes.

### Test
0. Set breakpoint on [this](https://github.com/wordpress-mobile/WordPress-Android/blob/issue/unused-help-method/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java#L163) line.
1. Tap ***Log In*** button.
2. Tap ***Log in with Google*** button.
3. Tap email address *not* associated with WordPress.com account.
4. Notice error message.
5. Tap ***Help*** action.
6. Notice breakpoint is hit and `mGoogleEmail` is what was selected in Step 3.