### PR TITLE
Makes sure to download external media before uploading to Media library

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MeFragment.java
@@ -55,6 +55,7 @@ import org.wordpress.android.util.HelpshiftHelper.Tag;
 import org.wordpress.android.util.MediaUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
+import org.wordpress.android.util.WPMediaUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.io.DataInputStream;
@@ -449,17 +450,18 @@ public class MeFragment extends Fragment {
                                     : AnalyticsTracker.Stat.ME_GRAVATAR_GALLERY_PICKED;
                     AnalyticsTracker.track(stat);
                     Uri imageUri = Uri.parse(strMediaUri);
-                    if (!MediaUtils.isInMediaStore(imageUri)) {
-                        // Download the picture. See https://github.com/wordpress-mobile/WordPress-Android/issues/5818
-                        Uri downloadedUri = MediaUtils.downloadExternalMedia(getActivity(), imageUri);
-                        if (downloadedUri != null) {
-                            startCropActivity(downloadedUri);
-                        } else {
-                            ToastUtils.showToast(getActivity(), R.string.error_downloading_image, Duration.SHORT);
+                    if (imageUri != null) {
+                        boolean didGoWell = WPMediaUtils.fetchMediaAndDoNext(getActivity(), imageUri,
+                                new WPMediaUtils.MediaFetchDoNext() {
+                                    @Override
+                                    public void doNext(Uri uri) {
+                                        startCropActivity(uri);
+                                    }
+                                });
+
+                        if (!didGoWell) {
                             AppLog.e(AppLog.T.UTILS, "Can't download picked or captured image");
                         }
-                    } else {
-                        startCropActivity(imageUri);
                     }
                 }
                 break;
@@ -467,7 +469,14 @@ public class MeFragment extends Fragment {
                 AnalyticsTracker.track(AnalyticsTracker.Stat.ME_GRAVATAR_CROPPED);
 
                 if (resultCode == Activity.RESULT_OK) {
-                    fetchMedia(UCrop.getOutput(data));
+                    WPMediaUtils.fetchMediaAndDoNext(getActivity(), UCrop.getOutput(data),
+                            new WPMediaUtils.MediaFetchDoNext() {
+                                @Override
+                                public void doNext(Uri uri) {
+                                    startGravatarUpload(MediaUtils.getRealPathFromURI(getActivity(), uri));
+                                }
+                            });
+
                 } else if (resultCode == UCrop.RESULT_ERROR) {
                     AppLog.e(AppLog.T.MAIN, "Image cropping failed!", UCrop.getError(data));
                     ToastUtils.showToast(getActivity(), R.string.error_cropping_image, Duration.SHORT);
@@ -498,21 +507,6 @@ public class MeFragment extends Fragment {
                 .withAspectRatio(1, 1)
                 .withOptions(options)
                 .start(getActivity(), this);
-    }
-
-    private void fetchMedia(Uri mediaUri) {
-        if (!MediaUtils.isInMediaStore(mediaUri)) {
-            // Do not download the file in async task. See https://github.com/wordpress-mobile/WordPress-Android/issues/5818
-            Uri downloadedUri = MediaUtils.downloadExternalMedia(getActivity(), mediaUri);
-            if (downloadedUri != null) {
-                startGravatarUpload(MediaUtils.getRealPathFromURI(getActivity(), downloadedUri));
-            } else {
-                ToastUtils.showToast(getActivity(), R.string.error_downloading_image, ToastUtils.Duration.SHORT);
-            }
-        } else {
-            // It is a regular local media file
-            startGravatarUpload(MediaUtils.getRealPathFromURI(getActivity(), mediaUri));
-        }
     }
 
     private void startGravatarUpload(final String filePath) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/photopicker/PhotoPickerActivity.java
@@ -240,7 +240,14 @@ public class PhotoPickerActivity extends AppCompatActivity
     private void doMediaUriSelected(@NonNull Uri mediaUri, @NonNull PhotoPickerMediaSource source) {
         // if user chose a featured image, we need to upload it and return the uploaded media object
         if (mBrowserType == MediaBrowserType.FEATURED_IMAGE_PICKER) {
-            uploadMedia(mediaUri);
+            WPMediaUtils.fetchMediaAndDoNext(this, mediaUri,
+                    new WPMediaUtils.MediaFetchDoNext() {
+                        @Override
+                        public void doNext(Uri uri) {
+                            uploadMedia(uri);
+                        }
+                    });
+
         } else {
             Intent intent = new Intent()
                     .putExtra(EXTRA_MEDIA_URI, mediaUri.toString())

--- a/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPMediaUtils.java
@@ -442,4 +442,34 @@ public class WPMediaUtils {
         return ViewConfiguration.get(context).getScaledMaximumFlingVelocity() / 2;
     }
 
+
+    public interface MediaFetchDoNext {
+        void doNext(Uri uri);
+    }
+
+    public static boolean fetchMediaAndDoNext(Context context, Uri mediaUri, MediaFetchDoNext listener) {
+        if (!MediaUtils.isInMediaStore(mediaUri)) {
+            // Do not download the file in async task. See https://github.com/wordpress-mobile/WordPress-Android/issues/5818
+            Uri downloadedUri = null;
+            try {
+                downloadedUri = MediaUtils.downloadExternalMedia(context, mediaUri);
+            } catch (IllegalStateException e) {
+                // Ref: https://github.com/wordpress-mobile/WordPress-Android/issues/5823
+                AppLog.e(AppLog.T.UTILS, "Can't download the image at: " + mediaUri.toString(), e);
+                CrashlyticsUtils.logException(e, AppLog.T.MEDIA, "Can't download the image at: " + mediaUri.toString() +
+                        " See issue #5823");
+            }
+            if (downloadedUri != null) {
+                listener.doNext(downloadedUri);
+            } else {
+                ToastUtils.showToast(context, R.string.error_downloading_image,
+                        ToastUtils.Duration.SHORT);
+                return false;
+            }
+        } else {
+            listener.doNext(mediaUri);
+        }
+        return true;
+    }
+
 }


### PR DESCRIPTION

Fixes #6866 

This PR refactors some places where the user might pick a picture from the device and external sources such as google drive, and use them in WPAndroid:
- MeFragment (avatar)
- Post Featured Image
- Uploading to a Post
- Uploading to Media Library

To test:
1. start a draft
2. go to post settings
3. tap on "set featured image"
4. make sure to tap on the device picker (lower-left icon in the media picker)
5. try to choose a picture that is not local to the device (for example, something in google drive).
6. It should first download to the device, then upload to the WP media library / set as featured image.

All other paths (avatar, uploading to a Post, and uploading to media library) when picking an image that is not local but is hosted somewhere else should continue to work as expected.

cc @maxme 