### PR TITLE
Issue/6889 ise google login

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginGoogleFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginGoogleFragment.java
@@ -108,6 +108,11 @@ public class LoginGoogleFragment extends Fragment implements ConnectionCallbacks
         } catch (ClassCastException exception) {
             throw new ClassCastException(context.toString() + " must implement OnGoogleLoginFinishedListener");
         }
+
+        // Show account dialog when Google API onConnected callback returns before fragment is attached.
+        if (mGoogleApiClient != null && mGoogleApiClient.isConnected() && !isResolvingError && !shouldResolveError) {
+            showAccountDialog();
+        }
     }
 
     @Override
@@ -135,7 +140,10 @@ public class LoginGoogleFragment extends Fragment implements ConnectionCallbacks
         // connection to Google Play services has been established.
         if (shouldResolveError) {
             shouldResolveError = false;
-            showAccountDialog();
+
+            if (isAdded()) {
+                showAccountDialog();
+            }
         }
     }
 


### PR DESCRIPTION
### Fix
Add a guard to show the Google account dialog only when the `LoginGoogleFragment` is attached to avoid the `IllegalStateException` as described in https://github.com/wordpress-mobile/WordPress-Android/issues/6889.