### PR TITLE
Fix NPE in SiteSettingsFragment

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -680,12 +680,18 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     @Override
     public void onSaveError(Exception error) {
+        if (!isAdded()) {
+            return;
+        }
         ToastUtils.showToast(getActivity(), R.string.error_post_remote_site_settings);
         getActivity().finish();
     }
 
     @Override
     public void onFetchError(Exception error) {
+        if (!isAdded()) {
+            return;
+        }
         ToastUtils.showToast(getActivity(), R.string.error_fetch_remote_site_settings);
         getActivity().finish();
     }
@@ -706,6 +712,9 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     @Override
     public void onCredentialsValidated(Exception error) {
+        if (!isAdded()) {
+            return;
+        }
         if (error != null) {
             ToastUtils.showToast(WordPress.getContext(), R.string.username_or_password_incorrect);
         }


### PR DESCRIPTION
Fixes #6888 by making sure the `SiteSettingsFragment` is still attached to its activity before showing any errors.


cc @tonyr59h 