### PR TITLE
Update support and utils library versions

### DIFF
--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -12,18 +12,19 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 repositories {
+    google()
     jcenter()
 }
 
 dependencies {
     compile 'com.automattic:tracks:1.1.2'
-    compile 'org.wordpress:utils:1.+'
+    compile 'org.wordpress:utils:1.18.1'
 }
 
 android {
     publishNonDefault true
 
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion "25.0.3"
 
     defaultConfig {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile 'com.android.support:support-v4:26.1.0'
     compile 'com.android.support:design:26.1.0'
     compile 'org.apache.commons:commons-lang3:3.5'
-    compile 'org.wordpress:utils:1.17.1'
+    compile 'org.wordpress:utils:1.18.1'
 
     compile 'com.github.wordpress-mobile.AztecEditor-Android:aztec:develop-SNAPSHOT'
     compile 'com.github.wordpress-mobile.AztecEditor-Android:wordpress-comments:develop-SNAPSHOT'

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -12,6 +12,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 repositories {
+    google()
     jcenter()
     maven { url "https://jitpack.io" }
 }
@@ -19,7 +20,7 @@ repositories {
 android {
     publishNonDefault true
 
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion "25.0.3"
 
     defaultConfig {
@@ -46,9 +47,9 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:support-v4:25.3.1'
-    compile 'com.android.support:design:25.3.1'
+    compile 'com.android.support:appcompat-v7:26.1.0'
+    compile 'com.android.support:support-v4:26.1.0'
+    compile 'com.android.support:design:26.1.0'
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.17.1'
 

--- a/libs/networking/WordPressNetworking/build.gradle
+++ b/libs/networking/WordPressNetworking/build.gradle
@@ -8,6 +8,7 @@ buildscript {
 }
 
 repositories {
+    google()
     jcenter()
     maven { url 'http://wordpress-mobile.github.io/WordPress-Android' }
 }
@@ -18,7 +19,7 @@ apply plugin: 'maven'
 android {
     publishNonDefault true
 
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion "25.0.3"
 
     defaultConfig {
@@ -29,7 +30,7 @@ android {
 }
 
 dependencies {
-    compile 'org.wordpress:utils:1.+'
+    compile 'org.wordpress:utils:1.18.1'
     compile 'com.automattic:rest:1.0.7'
 }
 


### PR DESCRIPTION
This change should fix the `Failed to resolve: com.android.support:support-v4:26.1.0` issue in the editor library. The project builds now, but for some reason there is still a warning for me in `compile 'com.android.support:appcompat-v7:26.1.0'` line. AS is claiming that we are mixing `25.3.1` with `26.1.0`, but I can not find any reference to `25.3.1` in the code. It seems like a caching issue but invalidating the cache or cleaning the project did not help. It'd be great if the reviewer can check if it's happening for them too in which case we should look into this a little further.