### PR TITLE
Update plugin

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -137,7 +137,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.11'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:9a0aa939ff9273630c551b085c73d281f8c609ed') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:defe57c3d76acef184918215d00101ce0214b197') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -137,7 +137,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.11'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:defe57c3d76acef184918215d00101ce0214b197') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:a6ff8356ad7be8d7a00e94b0934cc827a6213c84') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -26,6 +26,7 @@ import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginUpdated;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginPayload;
 import org.wordpress.android.ui.ActivityLauncher;
+import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 
@@ -195,6 +196,19 @@ public class PluginDetailActivity extends AppCompatActivity {
         if (event.plugin != null) {
             mPlugin = event.plugin;
             refreshViews();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onPluginInfoChanged(PluginStore.OnPluginInfoChanged event) {
+        if (event.isError()) {
+            AppLog.e(AppLog.T.API, "An error occurred while fetching the plugin info with type: "
+                    + event.error.type);
+            return;
+        }
+        if (event.pluginInfo != null) {
+            refreshPluginVersionViews();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -90,6 +90,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         setSupportActionBar(toolbar);
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
+            actionBar.setTitle(mPlugin.getDisplayName());
             actionBar.setHomeButtonEnabled(true);
             actionBar.setDisplayHomeAsUpEnabled(true);
             actionBar.setElevation(0);

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -18,6 +18,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.PluginActionBuilder;
+import org.wordpress.android.fluxc.model.PluginInfoModel;
 import org.wordpress.android.fluxc.model.PluginModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.PluginStore;
@@ -37,6 +38,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     private PluginModel mPlugin;
 
     private TextView mInstalledPluginVersionTextView;
+    private TextView mAvailablePluginVersionTextView;
     private Switch mSwitchActive;
     private Switch mSwitchAutoupdates;
 
@@ -105,7 +107,7 @@ public class PluginDetailActivity extends AppCompatActivity {
 
     private void setupViews() {
         mInstalledPluginVersionTextView = findViewById(R.id.plugin_installed_version);
-
+        mAvailablePluginVersionTextView = findViewById(R.id.plugin_available_version);
         mSwitchActive = findViewById(R.id.plugin_state_active);
         mSwitchAutoupdates = findViewById(R.id.plugin_state_autoupdates);
 
@@ -147,14 +149,29 @@ public class PluginDetailActivity extends AppCompatActivity {
     }
 
     private void refreshViews() {
+        mSwitchActive.setChecked(mPlugin.isActive());
+        mSwitchAutoupdates.setChecked(mPlugin.isAutoUpdateEnabled());
+
+        refreshPluginVersionViews();
+    }
+
+    private void refreshPluginVersionViews() {
         if (TextUtils.isEmpty(mPlugin.getVersion())) {
             mInstalledPluginVersionTextView.setVisibility(View.GONE);
         } else {
             mInstalledPluginVersionTextView.setVisibility(View.VISIBLE);
-            mInstalledPluginVersionTextView.setText(getString(R.string.plugin_installed_version, mPlugin.getVersion()));
+            mInstalledPluginVersionTextView.setText(getString(R.string.plugin_installed_version,
+                    mPlugin.getVersion()));
         }
-        mSwitchActive.setChecked(mPlugin.isActive());
-        mSwitchAutoupdates.setChecked(mPlugin.isAutoUpdateEnabled());
+
+        PluginInfoModel pluginInfoModel = PluginUtils.getOrFetchPluginInfo(mDispatcher, mPluginStore, mPlugin);
+        if (pluginInfoModel == null || TextUtils.isEmpty(pluginInfoModel.getVersion())) {
+            mAvailablePluginVersionTextView.setVisibility(View.GONE);
+        } else {
+            mAvailablePluginVersionTextView.setVisibility(View.VISIBLE);
+            mAvailablePluginVersionTextView.setText(getString(R.string.plugin_available_version,
+                    pluginInfoModel.getVersion()));
+        }
     }
 
     private void dispatchUpdateAction() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -213,10 +213,8 @@ public class PluginDetailActivity extends AppCompatActivity {
                     + event.error.message);
             return;
         }
-        if (event.plugin != null) {
-            mPlugin = event.plugin;
-            refreshViews();
-        }
+        mPlugin = mPluginStore.getSitePluginByName(mSite, mPlugin.getName());
+        refreshViews();
     }
 
     @SuppressWarnings("unused")
@@ -241,7 +239,8 @@ public class PluginDetailActivity extends AppCompatActivity {
                     + event.error.type);
             return;
         }
-        refreshPluginVersionViews();
+        mPlugin = mPluginStore.getSitePluginByName(mSite, mPlugin.getName());
+        refreshViews();
     }
 
     // Helpers

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -171,7 +171,7 @@ public class PluginDetailActivity extends AppCompatActivity {
                     mPlugin.getVersion()));
         }
 
-        if (mPluginInfo == null || TextUtils.isEmpty(mPluginInfo.getVersion())) {
+        if (!isUpdateAvailable()) {
             mAvailablePluginVersionTextView.setVisibility(View.GONE);
         } else {
             mAvailablePluginVersionTextView.setVisibility(View.VISIBLE);
@@ -222,5 +222,10 @@ public class PluginDetailActivity extends AppCompatActivity {
 
     private String getWpOrgPluginUrl() {
         return "https://wordpress.org/plugins/" + mPlugin.getSlug();
+    }
+
+    private boolean isUpdateAvailable() {
+        return mPluginInfo != null && !TextUtils.isEmpty(mPluginInfo.getVersion())
+                && !mPlugin.getVersion().equals(mPluginInfo.getVersion());
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -28,6 +28,7 @@ import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginPayload;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginVersionPayload;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 
@@ -145,7 +146,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         mUpdateVersionTextView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                if (isUpdateAvailable()) {
+                if (NetworkUtils.checkConnection(PluginDetailActivity.this) && isUpdateAvailable()) {
                     UpdateSitePluginVersionPayload payload = new UpdateSitePluginVersionPayload(mSite, mPlugin);
                     mDispatcher.dispatch(PluginActionBuilder.newUpdateSitePluginVersionAction(payload));
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.store.PluginStore;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginUpdated;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginErrorType;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginPayload;
+import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginVersionPayload;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.ToastUtils;
@@ -143,7 +144,10 @@ public class PluginDetailActivity extends AppCompatActivity {
         mUpdateVersionTextView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-
+                if (isUpdateAvailable()) {
+                    UpdateSitePluginVersionPayload payload = new UpdateSitePluginVersionPayload(mSite, mPlugin);
+                    mDispatcher.dispatch(PluginActionBuilder.newUpdateSitePluginVersionAction(payload));
+                }
             }
         });
 
@@ -182,10 +186,12 @@ public class PluginDetailActivity extends AppCompatActivity {
 
         if (!isUpdateAvailable()) {
             mAvailableVersionTextView.setVisibility(View.GONE);
+            mUpdateVersionTextView.setVisibility(View.GONE);
         } else {
             mAvailableVersionTextView.setVisibility(View.VISIBLE);
             mAvailableVersionTextView.setText(getString(R.string.plugin_available_version,
                     mPluginInfo.getVersion()));
+            mUpdateVersionTextView.setVisibility(View.VISIBLE);
         }
     }
 
@@ -225,6 +231,17 @@ public class PluginDetailActivity extends AppCompatActivity {
             mPluginInfo = event.pluginInfo;
             refreshPluginVersionViews();
         }
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onSitePluginVersionUpdated(PluginStore.OnSitePluginVersionUpdated event) {
+        if (event.isError()) {
+            AppLog.e(AppLog.T.API, "An error occurred while updating the plugin version with type: "
+                    + event.error.type);
+            return;
+        }
+        refreshPluginVersionViews();
     }
 
     // Helpers

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -73,7 +73,11 @@ public class PluginDetailActivity extends AppCompatActivity {
         }
 
         mPlugin = mPluginStore.getSitePluginByName(mSite, pluginName);
-        checkIfPluginIsNull();
+        if (mPlugin == null) {
+            ToastUtils.showToast(this, R.string.plugin_not_found, Duration.SHORT);
+            finish();
+            return;
+        }
 
         mPluginInfo = PluginUtils.getPluginInfo(mPluginStore, mPlugin);
         if (mPluginInfo == null) {
@@ -214,7 +218,11 @@ public class PluginDetailActivity extends AppCompatActivity {
             return;
         }
         mPlugin = mPluginStore.getSitePluginByName(mSite, mPlugin.getName());
-        checkIfPluginIsNull();
+        if (mPlugin == null) {
+            ToastUtils.showToast(this, R.string.plugin_not_found, Duration.SHORT);
+            finish();
+            return;
+        }
         refreshViews();
     }
 
@@ -241,18 +249,15 @@ public class PluginDetailActivity extends AppCompatActivity {
             return;
         }
         mPlugin = mPluginStore.getSitePluginByName(mSite, mPlugin.getName());
-        checkIfPluginIsNull();
+        if (mPlugin == null) {
+            ToastUtils.showToast(this, R.string.plugin_not_found, Duration.SHORT);
+            finish();
+            return;
+        }
         refreshViews();
     }
 
     // Helpers
-
-    private void checkIfPluginIsNull() {
-        if (mPlugin == null) {
-            ToastUtils.showToast(this, R.string.plugin_not_found, Duration.SHORT);
-            finish();
-        }
-    }
 
     private String getWpOrgPluginUrl() {
         return "https://wordpress.org/plugins/" + mPlugin.getSlug();

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -73,12 +73,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         }
 
         mPlugin = mPluginStore.getSitePluginByName(mSite, pluginName);
-
-        if (mPlugin == null) {
-            ToastUtils.showToast(this, R.string.plugin_not_found, Duration.SHORT);
-            finish();
-            return;
-        }
+        checkIfPluginIsNull();
 
         mPluginInfo = PluginUtils.getPluginInfo(mPluginStore, mPlugin);
         if (mPluginInfo == null) {
@@ -219,6 +214,7 @@ public class PluginDetailActivity extends AppCompatActivity {
             return;
         }
         mPlugin = mPluginStore.getSitePluginByName(mSite, mPlugin.getName());
+        checkIfPluginIsNull();
         refreshViews();
     }
 
@@ -245,10 +241,18 @@ public class PluginDetailActivity extends AppCompatActivity {
             return;
         }
         mPlugin = mPluginStore.getSitePluginByName(mSite, mPlugin.getName());
+        checkIfPluginIsNull();
         refreshViews();
     }
 
     // Helpers
+
+    private void checkIfPluginIsNull() {
+        if (mPlugin == null) {
+            ToastUtils.showToast(this, R.string.plugin_not_found, Duration.SHORT);
+            finish();
+        }
+    }
 
     private String getWpOrgPluginUrl() {
         return "https://wordpress.org/plugins/" + mPlugin.getSlug();

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -55,8 +55,6 @@ public class PluginDetailActivity extends AppCompatActivity {
         ((WordPress) getApplication()).component().inject(this);
         mDispatcher.register(this);
 
-        setContentView(R.layout.plugin_detail_activity);
-
         String pluginName;
 
         if (savedInstanceState == null) {
@@ -67,14 +65,13 @@ public class PluginDetailActivity extends AppCompatActivity {
             pluginName = savedInstanceState.getString(KEY_PLUGIN_NAME);
         }
 
-        mPlugin = mPluginStore.getSitePluginByName(mSite, pluginName);
-        mPluginInfo = PluginUtils.getPluginInfo(mPluginStore, mPlugin);
-
         if (mSite == null) {
             ToastUtils.showToast(this, R.string.blog_not_found, Duration.SHORT);
             finish();
             return;
         }
+
+        mPlugin = mPluginStore.getSitePluginByName(mSite, pluginName);
 
         if (mPlugin == null) {
             ToastUtils.showToast(this, R.string.plugin_not_found, Duration.SHORT);
@@ -82,9 +79,12 @@ public class PluginDetailActivity extends AppCompatActivity {
             return;
         }
 
+        mPluginInfo = PluginUtils.getPluginInfo(mPluginStore, mPlugin);
         if (mPluginInfo == null) {
             mDispatcher.dispatch(PluginActionBuilder.newFetchPluginInfoAction(mPlugin.getSlug()));
         }
+
+        setContentView(R.layout.plugin_detail_activity);
 
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -4,11 +4,13 @@ import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.text.TextUtils;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.Switch;
+import android.widget.TextView;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -34,6 +36,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     private SiteModel mSite;
     private PluginModel mPlugin;
 
+    private TextView mInstalledPluginVersionTextView;
     private Switch mSwitchActive;
     private Switch mSwitchAutoupdates;
 
@@ -101,6 +104,8 @@ public class PluginDetailActivity extends AppCompatActivity {
     }
 
     private void setupViews() {
+        mInstalledPluginVersionTextView = findViewById(R.id.plugin_installed_version);
+
         mSwitchActive = findViewById(R.id.plugin_state_active);
         mSwitchAutoupdates = findViewById(R.id.plugin_state_autoupdates);
 
@@ -138,10 +143,16 @@ public class PluginDetailActivity extends AppCompatActivity {
             }
         });
 
-        refreshStates();
+        refreshViews();
     }
 
-    private void refreshStates() {
+    private void refreshViews() {
+        if (TextUtils.isEmpty(mPlugin.getVersion())) {
+            mInstalledPluginVersionTextView.setVisibility(View.GONE);
+        } else {
+            mInstalledPluginVersionTextView.setVisibility(View.VISIBLE);
+            mInstalledPluginVersionTextView.setText(getString(R.string.plugin_installed_version, mPlugin.getVersion()));
+        }
         mSwitchActive.setChecked(mPlugin.isActive());
         mSwitchAutoupdates.setChecked(mPlugin.isAutoUpdateEnabled());
     }
@@ -166,7 +177,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         }
         if (event.plugin != null) {
             mPlugin = event.plugin;
-            refreshStates();
+            refreshViews();
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -39,9 +39,9 @@ public class PluginDetailActivity extends AppCompatActivity {
     private PluginModel mPlugin;
     private PluginInfoModel mPluginInfo;
 
-    private TextView mInstalledPluginVersionTextView;
-    private TextView mAvailablePluginVersionTextView;
-    private TextView mUpdatePluginVersionTextView;
+    private TextView mInstalledVersionTextView;
+    private TextView mAvailableVersionTextView;
+    private TextView mUpdateVersionTextView;
     private Switch mSwitchActive;
     private Switch mSwitchAutoupdates;
 
@@ -114,9 +114,9 @@ public class PluginDetailActivity extends AppCompatActivity {
     }
 
     private void setupViews() {
-        mInstalledPluginVersionTextView = findViewById(R.id.plugin_installed_version);
-        mAvailablePluginVersionTextView = findViewById(R.id.plugin_available_version);
-        mUpdatePluginVersionTextView = findViewById(R.id.plugin_btn_update);
+        mInstalledVersionTextView = findViewById(R.id.plugin_installed_version);
+        mAvailableVersionTextView = findViewById(R.id.plugin_available_version);
+        mUpdateVersionTextView = findViewById(R.id.plugin_btn_update);
         mSwitchActive = findViewById(R.id.plugin_state_active);
         mSwitchAutoupdates = findViewById(R.id.plugin_state_autoupdates);
 
@@ -140,7 +140,7 @@ public class PluginDetailActivity extends AppCompatActivity {
             }
         });
 
-        mUpdatePluginVersionTextView.setOnClickListener(new View.OnClickListener() {
+        mUpdateVersionTextView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
 
@@ -173,18 +173,18 @@ public class PluginDetailActivity extends AppCompatActivity {
 
     private void refreshPluginVersionViews() {
         if (TextUtils.isEmpty(mPlugin.getVersion())) {
-            mInstalledPluginVersionTextView.setVisibility(View.GONE);
+            mInstalledVersionTextView.setVisibility(View.GONE);
         } else {
-            mInstalledPluginVersionTextView.setVisibility(View.VISIBLE);
-            mInstalledPluginVersionTextView.setText(getString(R.string.plugin_installed_version,
+            mInstalledVersionTextView.setVisibility(View.VISIBLE);
+            mInstalledVersionTextView.setText(getString(R.string.plugin_installed_version,
                     mPlugin.getVersion()));
         }
 
         if (!isUpdateAvailable()) {
-            mAvailablePluginVersionTextView.setVisibility(View.GONE);
+            mAvailableVersionTextView.setVisibility(View.GONE);
         } else {
-            mAvailablePluginVersionTextView.setVisibility(View.VISIBLE);
-            mAvailablePluginVersionTextView.setText(getString(R.string.plugin_available_version,
+            mAvailableVersionTextView.setVisibility(View.VISIBLE);
+            mAvailableVersionTextView.setText(getString(R.string.plugin_available_version,
                     mPluginInfo.getVersion()));
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -41,6 +41,7 @@ public class PluginDetailActivity extends AppCompatActivity {
 
     private TextView mInstalledPluginVersionTextView;
     private TextView mAvailablePluginVersionTextView;
+    private TextView mUpdatePluginVersionTextView;
     private Switch mSwitchActive;
     private Switch mSwitchAutoupdates;
 
@@ -115,6 +116,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     private void setupViews() {
         mInstalledPluginVersionTextView = findViewById(R.id.plugin_installed_version);
         mAvailablePluginVersionTextView = findViewById(R.id.plugin_available_version);
+        mUpdatePluginVersionTextView = findViewById(R.id.plugin_btn_update);
         mSwitchActive = findViewById(R.id.plugin_state_active);
         mSwitchAutoupdates = findViewById(R.id.plugin_state_autoupdates);
 
@@ -135,6 +137,13 @@ public class PluginDetailActivity extends AppCompatActivity {
                     mPlugin.setIsAutoUpdateEnabled(b);
                     dispatchUpdateAction();
                 }
+            }
+        });
+
+        mUpdatePluginVersionTextView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+
             }
         });
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
@@ -197,7 +197,7 @@ public class PluginListActivity extends AppCompatActivity {
                 PluginViewHolder pluginHolder = (PluginViewHolder) holder;
                 pluginHolder.name.setText(pluginModel.getDisplayName());
                 pluginHolder.status.setText(getPluginStatusText(pluginModel));
-                PluginInfoModel pluginInfo = getOrFetchPluginInfo(pluginModel);
+                PluginInfoModel pluginInfo = PluginUtils.getOrFetchPluginInfo(mDispatcher, mPluginStore, pluginModel);
                 String iconUrl = pluginInfo != null ? pluginInfo.getIcon() : "";
                 pluginHolder.icon.setImageUrl(iconUrl, ImageType.PLUGIN_ICON);
             }
@@ -246,17 +246,5 @@ public class PluginListActivity extends AppCompatActivity {
         String autoUpdateStatus = plugin.isAutoUpdateEnabled() ? getString(R.string.plugin_autoupdates_on)
                 : getString(R.string.plugin_autoupdates_off);
         return activeStatus + ", " + autoUpdateStatus;
-    }
-
-    private PluginInfoModel getOrFetchPluginInfo(@NonNull PluginModel plugin) {
-        String slug = plugin.getSlug();
-        if (TextUtils.isEmpty(slug)) {
-            return null;
-        }
-        PluginInfoModel pluginInfo = mPluginStore.getPluginInfoBySlug(slug);
-        if (pluginInfo == null) {
-            mDispatcher.dispatch(PluginActionBuilder.newFetchPluginInfoAction(slug));
-        }
-        return pluginInfo;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
@@ -197,7 +197,10 @@ public class PluginListActivity extends AppCompatActivity {
                 PluginViewHolder pluginHolder = (PluginViewHolder) holder;
                 pluginHolder.name.setText(pluginModel.getDisplayName());
                 pluginHolder.status.setText(getPluginStatusText(pluginModel));
-                PluginInfoModel pluginInfo = PluginUtils.getOrFetchPluginInfo(mDispatcher, mPluginStore, pluginModel);
+                PluginInfoModel pluginInfo = PluginUtils.getPluginInfo(mPluginStore, pluginModel);
+                if (pluginInfo == null) {
+                    mDispatcher.dispatch(PluginActionBuilder.newFetchPluginInfoAction(pluginModel.getSlug()));
+                }
                 String iconUrl = pluginInfo != null ? pluginInfo.getIcon() : "";
                 pluginHolder.icon.setImageUrl(iconUrl, ImageType.PLUGIN_ICON);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
@@ -1,0 +1,25 @@
+package org.wordpress.android.ui.plugins;
+
+import android.support.annotation.NonNull;
+import android.text.TextUtils;
+
+import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.generated.PluginActionBuilder;
+import org.wordpress.android.fluxc.model.PluginInfoModel;
+import org.wordpress.android.fluxc.model.PluginModel;
+import org.wordpress.android.fluxc.store.PluginStore;
+
+public class PluginUtils {
+    public static PluginInfoModel getOrFetchPluginInfo(@NonNull Dispatcher dispatcher, @NonNull PluginStore pluginStore,
+                                                 @NonNull PluginModel plugin) {
+        String slug = plugin.getSlug();
+        if (TextUtils.isEmpty(slug)) {
+            return null;
+        }
+        PluginInfoModel pluginInfo = pluginStore.getPluginInfoBySlug(slug);
+        if (pluginInfo == null) {
+            dispatcher.dispatch(PluginActionBuilder.newFetchPluginInfoAction(slug));
+        }
+        return pluginInfo;
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
@@ -3,23 +3,16 @@ package org.wordpress.android.ui.plugins;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
-import org.wordpress.android.fluxc.Dispatcher;
-import org.wordpress.android.fluxc.generated.PluginActionBuilder;
 import org.wordpress.android.fluxc.model.PluginInfoModel;
 import org.wordpress.android.fluxc.model.PluginModel;
 import org.wordpress.android.fluxc.store.PluginStore;
 
-public class PluginUtils {
-    public static PluginInfoModel getOrFetchPluginInfo(@NonNull Dispatcher dispatcher, @NonNull PluginStore pluginStore,
-                                                 @NonNull PluginModel plugin) {
+class PluginUtils {
+    static PluginInfoModel getPluginInfo(@NonNull PluginStore pluginStore, @NonNull PluginModel plugin) {
         String slug = plugin.getSlug();
         if (TextUtils.isEmpty(slug)) {
             return null;
         }
-        PluginInfoModel pluginInfo = pluginStore.getPluginInfoBySlug(slug);
-        if (pluginInfo == null) {
-            dispatcher.dispatch(PluginActionBuilder.newFetchPluginInfoAction(slug));
-        }
-        return pluginInfo;
+        return pluginStore.getPluginInfoBySlug(slug);
     }
 }

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -25,6 +25,12 @@
                 <TextView
                     android:id="@+id/plugin_installed_version"
                     style="@style/PluginCardViewPrimaryText"/>
+
+                <TextView
+                    android:id="@+id/plugin_available_version"
+                    style="@style/PluginCardViewPrimaryText"
+                    android:layout_below="@id/plugin_installed_version"
+                    android:textColor="@color/grey_darken_10"/>
             </RelativeLayout>
         </LinearLayout>
 

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -34,6 +34,7 @@
 
                 <TextView
                     android:id="@+id/plugin_btn_update"
+                    android:padding="@dimen/margin_large"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_alignParentEnd="true"

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -31,6 +31,19 @@
                     style="@style/PluginCardViewPrimaryText"
                     android:layout_below="@id/plugin_installed_version"
                     android:textColor="@color/grey_darken_10"/>
+
+                <TextView
+                    android:id="@+id/plugin_btn_update"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentEnd="true"
+                    android:layout_alignParentRight="true"
+                    android:layout_centerVertical="true"
+                    android:background="?android:attr/selectableItemBackground"
+                    android:text="@string/plugin_btn_update"
+                    android:textAllCaps="true"
+                    android:textColor="@color/wp_blue_medium"
+                    android:textSize="@dimen/text_sz_medium"/>
             </RelativeLayout>
         </LinearLayout>
 

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -23,6 +23,25 @@
                 style="@style/PluginCardViewHorizontalContainer">
 
                 <TextView
+                    android:id="@+id/plugin_installed_version"
+                    style="@style/PluginCardViewPrimaryText"/>
+            </RelativeLayout>
+        </LinearLayout>
+
+    </android.support.v7.widget.CardView>
+
+    <android.support.v7.widget.CardView
+        style="@style/PluginCardView"
+        card_view:cardBackgroundColor="@color/white"
+        card_view:cardCornerRadius="@dimen/cardview_default_radius">
+
+        <LinearLayout
+            style="@style/PluginCardViewVerticalContainer">
+
+            <RelativeLayout
+                style="@style/PluginCardViewHorizontalContainer">
+
+                <TextView
                     style="@style/PluginCardViewPrimaryText"
                     android:text="@string/plugin_detail_label_state_active"/>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1789,6 +1789,7 @@
     <string name="plugin_detail_label_state_active">Active</string>
     <string name="plugin_detail_label_state_autoupdates">Autoupdates</string>
     <string name="plugin_not_found">An error occurred when accessing this plugin</string>
+    <string name="plugin_installed_version">Plugin version %s</string>
 
     <string name="wordpress_dot_org_plugin_page">WordPress.org Plugin page</string>
     <string name="plugin_home_page">Plugin homepage</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1790,6 +1790,7 @@
     <string name="plugin_detail_label_state_autoupdates">Autoupdates</string>
     <string name="plugin_not_found">An error occurred when accessing this plugin</string>
     <string name="plugin_installed_version">Plugin version %s</string>
+    <string name="plugin_available_version">Version %s is available.</string>
 
     <string name="wordpress_dot_org_plugin_page">WordPress.org Plugin page</string>
     <string name="plugin_home_page">Plugin homepage</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1791,6 +1791,7 @@
     <string name="plugin_not_found">An error occurred when accessing this plugin</string>
     <string name="plugin_installed_version">Plugin version %s</string>
     <string name="plugin_available_version">Version %s is available.</string>
+    <string name="plugin_btn_update">Update</string>
 
     <string name="wordpress_dot_org_plugin_page">WordPress.org Plugin page</string>
     <string name="plugin_home_page">Plugin homepage</string>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -715,7 +715,7 @@
     <style name="PluginCardViewPrimaryText">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_centerVertical">true</item>
+        <item name="android:gravity">center_vertical</item>
         <item name="android:textColor">@color/grey_dark</item>
         <item name="android:textSize">@dimen/text_sz_large</item>
     </style>


### PR DESCRIPTION
This PR adds the ability to update a plugin from the plugin details page. There is currently an issue with the fetch request for plugins and it'll return the cached data. So, for example, if the user were to update the plugin, even though the update will complete and will be reflected on the UI, if another fetch happen (for example in the plugins page), it'll override the updated plugin model and instead will show the cached version. This bug should be fixed in 5.6 version of Jetpack.

Another PR is incoming to polish the update feature a bit with Activity indicator and a snackbar to let the user know what's happening.