### PR TITLE
Move hideKeyboard method to utils library

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/AbstractFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/AbstractFragment.java
@@ -15,7 +15,7 @@ import android.widget.EditText;
 import android.widget.ImageView;
 
 import org.wordpress.android.R;
-import org.wordpress.android.util.WPActivityUtils;
+import org.wordpress.android.util.ActivityUtils;
 
 /**
  * A fragment representing a single step in a wizard. The fragment shows a dummy title indicating
@@ -53,7 +53,7 @@ public abstract class AbstractFragment extends Fragment {
 
             // hide keyboard before calling the done action
             if (getActivity() != null) {
-                WPActivityUtils.hideKeyboard(getActivity().getCurrentFocus());
+                ActivityUtils.hideKeyboardForced(getActivity().getCurrentFocus());
             }
 
             // call child action

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
@@ -25,13 +25,13 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore.OnAvailabilityChecked;
 import org.wordpress.android.ui.accounts.LoginMode;
+import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SiteUtils;
-import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.widgets.WPLoginInputRow;
 import org.wordpress.android.widgets.WPLoginInputRow.OnEditorCommitListener;
 
@@ -99,7 +99,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener>
             @Override
             public void onClick(View view) {
                 AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_SOCIAL_BUTTON_CLICK);
-                WPActivityUtils.hideKeyboard(getActivity().getCurrentFocus());
+                ActivityUtils.hideKeyboardForced(getActivity().getCurrentFocus());
 
                 if (NetworkUtils.checkConnection(getActivity())) {
                     mOldSitesIDs = SiteUtils.getCurrentSiteIds(mSiteStore, false);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -46,10 +46,10 @@ import org.wordpress.android.ui.main.SitePickerAdapter.SiteList;
 import org.wordpress.android.ui.main.SitePickerAdapter.SiteRecord;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.stats.datasets.StatsTable;
+import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.WPActivityUtils;
 import org.wordpress.android.util.helpers.Debouncer;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
@@ -462,7 +462,7 @@ public class SitePickerActivity extends AppCompatActivity
 
     private void hideSoftKeyboard() {
         if (!hasHardwareKeyboard()) {
-            WPActivityUtils.hideKeyboard(mSearchView);
+            ActivityUtils.hideKeyboardForced(mSearchView);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsTagsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsTagsActivity.java
@@ -30,8 +30,8 @@ import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.store.TaxonomyStore;
+import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.util.WPActivityUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -131,7 +131,7 @@ public class PostSettingsTagsActivity extends AppCompatActivity implements TextW
     }
 
     private void saveAndFinish() {
-        WPActivityUtils.hideKeyboard(mTagsEditText);
+        ActivityUtils.hideKeyboardForced(mTagsEditText);
 
         Bundle bundle = new Bundle();
         bundle.putString(KEY_SELECTED_TAGS, mTagsEditText.getText().toString());

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -13,7 +13,6 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
 import android.preference.PreferenceManager;
-import android.support.annotation.Nullable;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -23,7 +22,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
 import android.view.WindowManager;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
@@ -97,13 +95,6 @@ public class WPActivityUtils {
             //noinspection deprecation
             window.setStatusBarColor(window.getContext().getResources().getColor(color));
         }
-    }
-
-    public static void hideKeyboard(@Nullable final View view) {
-        if (view == null) return;
-        InputMethodManager inputMethodManager = (InputMethodManager) view.getContext()
-                .getSystemService(Context.INPUT_METHOD_SERVICE);
-        inputMethodManager.hideSoftInputFromWindow(view.getWindowToken(), 0);
     }
 
     public static void applyLocale(Context context) {

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ActivityUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ActivityUtils.java
@@ -2,6 +2,8 @@ package org.wordpress.android.util;
 
 import android.app.Activity;
 import android.content.Context;
+import android.support.annotation.Nullable;
+import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 
 public class ActivityUtils {
@@ -12,5 +14,12 @@ public class ActivityUtils {
             inputManager.hideSoftInputFromWindow(activity.getCurrentFocus().getWindowToken(),
                     InputMethodManager.HIDE_NOT_ALWAYS);
         }
+    }
+
+    public static void hideKeyboardForced(@Nullable final View view) {
+        if (view == null) return;
+        InputMethodManager inputMethodManager = (InputMethodManager) view.getContext()
+                .getSystemService(Context.INPUT_METHOD_SERVICE);
+        inputMethodManager.hideSoftInputFromWindow(view.getWindowToken(), 0);
     }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ActivityUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ActivityUtils.java
@@ -7,6 +7,11 @@ import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 
 public class ActivityUtils {
+    /**
+     * Hides the keyboard in the given {@link Activity}'s current focus using the
+     * {@link InputMethodManager#HIDE_NOT_ALWAYS} flag, which will hide the keyboard unless it was originally shown
+     * with {@link InputMethodManager#SHOW_FORCED}.
+     */
     public static void hideKeyboard(Activity activity) {
         if (activity != null && activity.getCurrentFocus() != null) {
             InputMethodManager inputManager = (InputMethodManager) activity.getSystemService(
@@ -16,6 +21,10 @@ public class ActivityUtils {
         }
     }
 
+    /**
+     * Hides the keyboard for the given {@link View}. No {@link InputMethodManager} flag is used, therefore the
+     * keyboard is forcibly hidden regardless of the circumstances.
+     */
     public static void hideKeyboardForced(@Nullable final View view) {
         if (view == null) return;
         InputMethodManager inputMethodManager = (InputMethodManager) view.getContext()


### PR DESCRIPTION
Moves a method from our WordPress app-internal `WPActivityUtils` class to the utils library, so it can be re-used. We have a similar method there already, but it expects an `Activity` and uses the `HIDE_NOT_ALWAYS` flag, while the one I moved uses the default (forced) flag.

The motivation for this change is that the method is used in `LoginEmailFragment`, which is being moved to a stand-alone login library (and so won't have access to `WPActivityUtils` anymore).

(I'll be pushing the changes to the utils repo and cutting a new version once this has been merged.)