### PR TITLE
Fix #6919: Update currency/price usage in Themes

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -137,7 +137,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.11'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:2d5ba6a8475b749ae8cb2248422610e849871caf') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:44658ef54b05df49eee38ea3b779b786319f5cea') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserAdapter.java
@@ -43,12 +43,12 @@ class ThemeBrowserAdapter extends CursorAdapter {
 
     static final String[] THEME_COLUMNS = new String[] {
             ThemeModelTable.ID, ThemeModelTable.THEME_ID, ThemeModelTable.NAME, ThemeModelTable.SCREENSHOT_URL,
-            ThemeModelTable.CURRENCY, ThemeModelTable.PRICE, ThemeModelTable.ACTIVE
+            ThemeModelTable.PRICE_TEXT, ThemeModelTable.ACTIVE, ThemeModelTable.FREE
     };
     static String[] createThemeCursorRow(@NonNull ThemeModel theme) {
         return new String[] {
                 String.valueOf(theme.getId()), theme.getThemeId(), theme.getName(), theme.getScreenshotUrl(),
-                theme.getCurrency(), String.valueOf(theme.getPrice()), String.valueOf(theme.getActive())
+                theme.getPriceText(), String.valueOf(theme.getActive()), String.valueOf(theme.getFree())
         };
     }
 
@@ -126,15 +126,14 @@ class ThemeBrowserAdapter extends CursorAdapter {
         final ThemeViewHolder themeViewHolder = (ThemeViewHolder) view.getTag();
         final String name = cursor.getString(cursor.getColumnIndex(ThemeModelTable.NAME));
         final String themeId = cursor.getString(cursor.getColumnIndex(ThemeModelTable.THEME_ID));
-        final String currency = cursor.getString(cursor.getColumnIndex(ThemeModelTable.CURRENCY));
-        final float price = cursor.getFloat(cursor.getColumnIndex(ThemeModelTable.PRICE));
-        final boolean isPremium = price > 0.f;
+        final String priceText = cursor.getString(cursor.getColumnIndex(ThemeModelTable.PRICE_TEXT));
+        final boolean isPremium =
+                StringUtils.equals("false", cursor.getString(cursor.getColumnIndex(ThemeModelTable.FREE)));
         final boolean isCurrent =
                 StringUtils.equals("true", cursor.getString(cursor.getColumnIndex(ThemeModelTable.ACTIVE)));
 
         themeViewHolder.nameView.setText(name);
         if (isPremium) {
-            String priceText = currency + String.valueOf((int) price);
             themeViewHolder.priceView.setText(priceText);
             themeViewHolder.priceView.setVisibility(View.VISIBLE);
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -411,7 +411,7 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener {
         Iterator<ThemeModel> iterator = themes.iterator();
         while (iterator.hasNext()) {
             ThemeModel theme = iterator.next();
-            if (theme.getPrice() > 0.f && !theme.getActive()) {
+            if (!theme.isFree() && !theme.getActive()) {
                 iterator.remove();
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
@@ -72,7 +72,7 @@ public class ThemeWebActivity extends WPWebViewActivity {
         intent.putExtra(WPWebViewActivity.AUTHENTICATION_URL, authURL);
         intent.putExtra(WPWebViewActivity.LOCAL_BLOG_ID, site.getId());
         intent.putExtra(WPWebViewActivity.USE_GLOBAL_WPCOM_USER, true);
-        intent.putExtra(IS_PREMIUM_THEME, theme.getPrice() > 0.f);
+        intent.putExtra(IS_PREMIUM_THEME, !theme.isFree());
         intent.putExtra(IS_CURRENT_THEME, theme.getActive());
         intent.putExtra(THEME_NAME, theme.getName());
         intent.putExtra(ThemeBrowserActivity.THEME_ID, theme.getThemeId());


### PR DESCRIPTION
Fix #6919: Update currency/price usage in Themes

Related to https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/634

cc @oguzkocer @tonyr59h 