### PR TITLE
Polishing update plugin feature

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -233,6 +233,8 @@ public class PluginDetailActivity extends AppCompatActivity {
             return;
         }
 
+        isUpdatingVersion = true;
+        refreshUpdateVersionViews();
         UpdateSitePluginVersionPayload payload = new UpdateSitePluginVersionPayload(mSite, mPlugin);
         mDispatcher.dispatch(PluginActionBuilder.newUpdateSitePluginVersionAction(payload));
     }
@@ -278,9 +280,11 @@ public class PluginDetailActivity extends AppCompatActivity {
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSitePluginVersionUpdated(PluginStore.OnSitePluginVersionUpdated event) {
+        isUpdatingVersion = false;
         if (event.isError()) {
             AppLog.e(AppLog.T.API, "An error occurred while updating the plugin version with type: "
                     + event.error.type);
+            refreshPluginVersionViews();
             return;
         }
         mPlugin = mPluginStore.getSitePluginByName(mSite, mPlugin.getName());
@@ -289,6 +293,7 @@ public class PluginDetailActivity extends AppCompatActivity {
             finish();
             return;
         }
+
         refreshViews();
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -274,8 +274,7 @@ public class PluginDetailActivity extends AppCompatActivity {
                 // these errors are thrown when the plugin is already active and we try to activate it and vice versa.
                 return;
             }
-            ToastUtils.showToast(this, "An error occurred while fetching the plugins: "
-                    + event.error.message);
+            ToastUtils.showToast(this, getString(R.string.plugin_configuration_failed, event.error.message));
             return;
         }
         mPlugin = mPluginStore.getSitePluginByName(mSite, mPlugin.getName());

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -192,7 +192,7 @@ public class PluginDetailActivity extends AppCompatActivity {
                     mPlugin.getVersion()));
         }
 
-        if (!isUpdateAvailable()) {
+        if (!PluginUtils.isUpdateAvailable(mPlugin, mPluginInfo)) {
             mAvailableVersionTextView.setVisibility(View.GONE);
         } else {
             mAvailableVersionTextView.setVisibility(View.VISIBLE);
@@ -204,7 +204,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     }
 
     private void refreshUpdateVersionViews() {
-        boolean isUpdateAvailable = isUpdateAvailable();
+        boolean isUpdateAvailable = PluginUtils.isUpdateAvailable(mPlugin, mPluginInfo);
         if (isUpdateAvailable && !isUpdatingVersion) {
             mUpdateVersionTextView.setVisibility(View.VISIBLE);
         } else {
@@ -229,7 +229,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         if (!NetworkUtils.checkConnection(this)) {
             return;
         }
-        if (!isUpdateAvailable() || isUpdatingVersion) {
+        if (!PluginUtils.isUpdateAvailable(mPlugin, mPluginInfo) || isUpdatingVersion) {
             return;
         }
 
@@ -301,10 +301,5 @@ public class PluginDetailActivity extends AppCompatActivity {
 
     private String getWpOrgPluginUrl() {
         return "https://wordpress.org/plugins/" + mPlugin.getSlug();
-    }
-
-    private boolean isUpdateAvailable() {
-        return mPluginInfo != null && !TextUtils.isEmpty(mPluginInfo.getVersion())
-                && !mPlugin.getVersion().equals(mPluginInfo.getVersion());
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.plugins;
 
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -9,6 +10,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
+import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.Switch;
 import android.widget.TextView;
@@ -42,6 +44,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     private PluginModel mPlugin;
     private PluginInfoModel mPluginInfo;
 
+    private LinearLayout mContainer;
     private TextView mInstalledVersionTextView;
     private TextView mAvailableVersionTextView;
     private TextView mUpdateVersionTextView;
@@ -122,6 +125,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     // UI Helpers
 
     private void setupViews() {
+        mContainer = findViewById(R.id.plugin_detail_container);
         mInstalledVersionTextView = findViewById(R.id.plugin_installed_version);
         mAvailableVersionTextView = findViewById(R.id.plugin_available_version);
         mUpdateVersionTextView = findViewById(R.id.plugin_btn_update);
@@ -239,6 +243,26 @@ public class PluginDetailActivity extends AppCompatActivity {
         mDispatcher.dispatch(PluginActionBuilder.newUpdateSitePluginVersionAction(payload));
     }
 
+    private void showSuccessfulUpdateSnackbar() {
+        Snackbar.make(mContainer,
+                getString(R.string.plugin_updated_successfully, mPlugin.getDisplayName()),
+                Snackbar.LENGTH_LONG)
+                .show();
+    }
+
+    private void showUpdateFailedSnackbar() {
+        Snackbar.make(mContainer,
+                getString(R.string.plugin_updated_failed, mPlugin.getDisplayName()),
+                Snackbar.LENGTH_LONG)
+                .setAction(R.string.retry, new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        updatePluginVersion();
+                    }
+                })
+                .show();
+    }
+
     // FluxC callbacks
 
     @SuppressWarnings("unused")
@@ -285,6 +309,7 @@ public class PluginDetailActivity extends AppCompatActivity {
             AppLog.e(AppLog.T.API, "An error occurred while updating the plugin version with type: "
                     + event.error.type);
             refreshPluginVersionViews();
+            showUpdateFailedSnackbar();
             return;
         }
         mPlugin = mPluginStore.getSitePluginByName(mSite, mPlugin.getName());
@@ -295,6 +320,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         }
 
         refreshViews();
+        showSuccessfulUpdateSnackbar();
     }
 
     // Utils

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -9,6 +9,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
+import android.widget.ProgressBar;
 import android.widget.Switch;
 import android.widget.TextView;
 
@@ -44,8 +45,11 @@ public class PluginDetailActivity extends AppCompatActivity {
     private TextView mInstalledVersionTextView;
     private TextView mAvailableVersionTextView;
     private TextView mUpdateVersionTextView;
+    private ProgressBar mUpdateVersionProgressBar;
     private Switch mSwitchActive;
     private Switch mSwitchAutoupdates;
+
+    private boolean isUpdatingVersion;
 
     @Inject PluginStore mPluginStore;
     @Inject Dispatcher mDispatcher;
@@ -119,6 +123,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         mInstalledVersionTextView = findViewById(R.id.plugin_installed_version);
         mAvailableVersionTextView = findViewById(R.id.plugin_available_version);
         mUpdateVersionTextView = findViewById(R.id.plugin_btn_update);
+        mUpdateVersionProgressBar = findViewById(R.id.plugin_update_progress_bar);
         mSwitchActive = findViewById(R.id.plugin_state_active);
         mSwitchAutoupdates = findViewById(R.id.plugin_state_autoupdates);
 
@@ -190,12 +195,27 @@ public class PluginDetailActivity extends AppCompatActivity {
 
         if (!isUpdateAvailable()) {
             mAvailableVersionTextView.setVisibility(View.GONE);
-            mUpdateVersionTextView.setVisibility(View.GONE);
         } else {
             mAvailableVersionTextView.setVisibility(View.VISIBLE);
             mAvailableVersionTextView.setText(getString(R.string.plugin_available_version,
                     mPluginInfo.getVersion()));
+        }
+
+        refreshUpdateVersionViews();
+    }
+
+    private void refreshUpdateVersionViews() {
+        boolean isUpdateAvailable = !isUpdateAvailable();
+        if (isUpdateAvailable && !isUpdatingVersion) {
             mUpdateVersionTextView.setVisibility(View.VISIBLE);
+        } else {
+            mUpdateVersionTextView.setVisibility(View.GONE);
+        }
+
+        if (isUpdatingVersion) {
+            mUpdateVersionProgressBar.setVisibility(View.VISIBLE);
+        } else {
+            mUpdateVersionProgressBar.setVisibility(View.GONE);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -204,7 +204,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     }
 
     private void refreshUpdateVersionViews() {
-        boolean isUpdateAvailable = !isUpdateAvailable();
+        boolean isUpdateAvailable = isUpdateAvailable();
         if (isUpdateAvailable && !isUpdatingVersion) {
             mUpdateVersionTextView.setVisibility(View.VISIBLE);
         } else {
@@ -226,7 +226,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     }
 
     private void updatePluginVersion() {
-        if (NetworkUtils.checkConnection(this)) {
+        if (!NetworkUtils.checkConnection(this)) {
             return;
         }
         if (!isUpdateAvailable() || isUpdatingVersion) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -119,6 +119,8 @@ public class PluginDetailActivity extends AppCompatActivity {
         outState.putString(KEY_PLUGIN_NAME, mPlugin.getName());
     }
 
+    // UI Helpers
+
     private void setupViews() {
         mInstalledVersionTextView = findViewById(R.id.plugin_installed_version);
         mAvailableVersionTextView = findViewById(R.id.plugin_available_version);
@@ -150,10 +152,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         mUpdateVersionTextView.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                if (NetworkUtils.checkConnection(PluginDetailActivity.this) && isUpdateAvailable()) {
-                    UpdateSitePluginVersionPayload payload = new UpdateSitePluginVersionPayload(mSite, mPlugin);
-                    mDispatcher.dispatch(PluginActionBuilder.newUpdateSitePluginVersionAction(payload));
-                }
+                updatePluginVersion();
             }
         });
 
@@ -219,10 +218,26 @@ public class PluginDetailActivity extends AppCompatActivity {
         }
     }
 
+    // Network Helpers
+
     private void dispatchUpdateAction() {
         mDispatcher.dispatch(PluginActionBuilder.newUpdateSitePluginAction(
                 new UpdateSitePluginPayload(mSite, mPlugin)));
     }
+
+    private void updatePluginVersion() {
+        if (NetworkUtils.checkConnection(this)) {
+            return;
+        }
+        if (!isUpdateAvailable() || isUpdatingVersion) {
+            return;
+        }
+
+        UpdateSitePluginVersionPayload payload = new UpdateSitePluginVersionPayload(mSite, mPlugin);
+        mDispatcher.dispatch(PluginActionBuilder.newUpdateSitePluginVersionAction(payload));
+    }
+
+    // FluxC callbacks
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
@@ -277,7 +292,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         refreshViews();
     }
 
-    // Helpers
+    // Utils
 
     private String getWpOrgPluginUrl() {
         return "https://wordpress.org/plugins/" + mPlugin.getSlug();

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
@@ -15,6 +15,7 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
@@ -233,12 +234,14 @@ public class PluginListActivity extends AppCompatActivity {
             TextView name;
             TextView status;
             WPNetworkImageView icon;
+            ImageView updateAvailableIcon;
 
             PluginViewHolder(View view) {
                 super(view);
                 name = view.findViewById(R.id.plugin_name);
                 status = view.findViewById(R.id.plugin_status);
                 icon = view.findViewById(R.id.plugin_icon);
+                updateAvailableIcon = view.findViewById(R.id.plugin_update_available_icon);
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
@@ -204,6 +204,12 @@ public class PluginListActivity extends AppCompatActivity {
                 }
                 String iconUrl = pluginInfo != null ? pluginInfo.getIcon() : "";
                 pluginHolder.icon.setImageUrl(iconUrl, ImageType.PLUGIN_ICON);
+
+                if (pluginInfo != null && PluginUtils.isUpdateAvailable(pluginModel, pluginInfo)) {
+                    pluginHolder.updateAvailableIcon.setVisibility(View.VISIBLE);
+                } else {
+                    pluginHolder.updateAvailableIcon.setVisibility(View.GONE);
+                }
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
@@ -15,4 +15,9 @@ class PluginUtils {
         }
         return pluginStore.getPluginInfoBySlug(slug);
     }
+
+    static boolean isUpdateAvailable(PluginModel pluginModel, PluginInfoModel pluginInfoModel) {
+        return pluginInfoModel != null && !TextUtils.isEmpty(pluginInfoModel.getVersion())
+                && !pluginModel.getVersion().equals(pluginInfoModel.getVersion());
+    }
 }

--- a/WordPress/src/main/res/drawable/ic_gridicons_sync.xml
+++ b/WordPress/src/main/res/drawable/ic_gridicons_sync.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/white"
+        android:pathData="M23.5 13.5l-3.086 3.086L19 18l-4.5-4.5 1.414-1.414L18 14.172V12c0-3.308-2.692-6-6-6V4c4.418 0 8 3.582 8 8v2.172l2.086-2.086L23.5 13.5zM6 12V9.828l2.086 2.086L9.5 10.5 5 6 3.586 7.414.5 10.5l1.414 1.414L4 9.828V12c0 4.418 3.582 8 8 8v-2c-3.308 0-6-2.692-6-6z"/>
+</vector>

--- a/WordPress/src/main/res/drawable/plugin_update_available_icon.xml
+++ b/WordPress/src/main/res/drawable/plugin_update_available_icon.xml
@@ -1,0 +1,16 @@
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="@color/orange_jazzy" />
+            <size
+                android:width="@dimen/margin_extra_medium_large"
+                android:height="@dimen/margin_extra_medium_large" />
+            <padding
+                android:top="@dimen/margin_medium"
+                android:right="@dimen/margin_medium"
+                android:left="@dimen/margin_medium"
+                android:bottom="@dimen/margin_medium" />
+        </shape>
+    </item>
+    <item android:drawable="@drawable/ic_gridicons_sync"/>
+</layer-list>

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -32,19 +32,31 @@
                     android:layout_below="@id/plugin_installed_version"
                     android:textColor="@color/grey_darken_10"/>
 
-                <TextView
-                    android:id="@+id/plugin_btn_update"
-                    android:padding="@dimen/margin_large"
+                <FrameLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_alignParentEnd="true"
                     android:layout_alignParentRight="true"
-                    android:layout_centerVertical="true"
-                    android:background="?android:attr/selectableItemBackground"
-                    android:text="@string/plugin_btn_update"
-                    android:textAllCaps="true"
-                    android:textColor="@color/wp_blue_medium"
-                    android:textSize="@dimen/text_sz_medium"/>
+                    android:layout_centerVertical="true">
+
+                    <TextView
+                        android:id="@+id/plugin_btn_update"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="?android:attr/selectableItemBackground"
+                        android:padding="@dimen/margin_large"
+                        android:text="@string/plugin_btn_update"
+                        android:textAllCaps="true"
+                        android:textColor="@color/wp_blue_medium"
+                        android:textSize="@dimen/text_sz_medium" />
+
+                    <ProgressBar
+                        android:id="@+id/plugin_update_progress_bar"
+                        style="?android:attr/progressBarStyle"
+                        android:layout_width="@dimen/margin_extra_extra_medium_large"
+                        android:layout_height="@dimen/margin_extra_extra_medium_large"
+                        android:layout_gravity="center" />
+                </FrameLayout>
             </RelativeLayout>
         </LinearLayout>
 

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/plugin_detail_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">

--- a/WordPress/src/main/res/layout/plugin_list_row.xml
+++ b/WordPress/src/main/res/layout/plugin_list_row.xml
@@ -52,6 +52,7 @@
         android:layout_alignParentEnd="true"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
+        android:contentDescription="@string/plugin_update_available_icon_content_description"
         app:srcCompat="@drawable/plugin_update_available_icon" />
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/plugin_list_row.xml
+++ b/WordPress/src/main/res/layout/plugin_list_row.xml
@@ -53,6 +53,7 @@
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
         android:contentDescription="@string/plugin_update_available_icon_content_description"
+        android:visibility="gone"
         app:srcCompat="@drawable/plugin_update_available_icon" />
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/plugin_list_row.xml
+++ b/WordPress/src/main/res/layout/plugin_list_row.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/white"
@@ -43,7 +43,15 @@
             android:layout_height="wrap_content"
             android:textColor="@color/grey_darken_10"
             android:textSize="@dimen/text_sz_medium"/>
-
     </LinearLayout>
+
+    <ImageView
+        android:id="@+id/plugin_update_available_icon"
+        android:layout_width="@dimen/margin_extra_medium_large"
+        android:layout_height="@dimen/margin_extra_medium_large"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentRight="true"
+        android:layout_centerVertical="true"
+        app:srcCompat="@drawable/plugin_update_available_icon" />
 
 </RelativeLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1792,6 +1792,7 @@
     <string name="plugin_installed_version">Plugin version %s</string>
     <string name="plugin_available_version">Version %s is available.</string>
     <string name="plugin_btn_update">Update</string>
+    <string name="plugin_update_available_icon_content_description">Update available</string>
 
     <string name="wordpress_dot_org_plugin_page">WordPress.org Plugin page</string>
     <string name="plugin_home_page">Plugin homepage</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1795,6 +1795,7 @@
     <string name="plugin_update_available_icon_content_description">Update available</string>
     <string name="plugin_updated_successfully">Successfully updated %s.</string>
     <string name="plugin_updated_failed">Error updating %s.</string>
+    <string name="plugin_configuration_failed">An error occurred while fetching the plugins: %s</string>
 
     <string name="wordpress_dot_org_plugin_page">WordPress.org Plugin page</string>
     <string name="plugin_home_page">Plugin homepage</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1793,6 +1793,8 @@
     <string name="plugin_available_version">Version %s is available.</string>
     <string name="plugin_btn_update">Update</string>
     <string name="plugin_update_available_icon_content_description">Update available</string>
+    <string name="plugin_updated_successfully">Successfully updated %s.</string>
+    <string name="plugin_updated_failed">Error updating %s.</string>
 
     <string name="wordpress_dot_org_plugin_page">WordPress.org Plugin page</string>
     <string name="plugin_home_page">Plugin homepage</string>


### PR DESCRIPTION
This PR polishes the update plugin version feature. Here are the important changes:
* Added an update available icon to the plugin list
* While plugin is updating we now show a progress bar
* We now show a snackbar when a plugin is updated
* If plugin update fails, we show a snackbar with a retry button

There are also some other minor improvements overall. This PR should cover everything we are going to do for v1 of the "update plugin feature" however the plugin feature overall is not yet finished (or completely polished).

![screenshot_1512274839](https://user-images.githubusercontent.com/662023/33522309-768e86ec-d7b7-11e7-82e9-6e99e0d864ce.png)
![screenshot_1512274792](https://user-images.githubusercontent.com/662023/33522310-76a171e4-d7b7-11e7-82a2-9cc554cfdcd3.png)
![screenshot_1512274713](https://user-images.githubusercontent.com/662023/33522311-76b31a70-d7b7-11e7-8ea5-5bc4db2c632b.png)
![screenshot_1512274717](https://user-images.githubusercontent.com/662023/33522312-76bf386e-d7b7-11e7-90f9-5011ad6c62ea.png)
