### PR TITLE
Theme browser crash fixed for pre API 23

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -109,6 +109,8 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener {
     public void onAttach(Activity activity) {
         super.onAttach(activity);
 
+        // This version of onAttach will be called for all Android versions but it's deprecated, so we only want to
+        // use it when we have to. https://github.com/wordpress-mobile/WordPress-Android/issues/6937
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             attachActivity((ThemeBrowserActivity) activity);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -1,11 +1,13 @@
 package org.wordpress.android.ui.themes;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.app.Fragment;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.MatrixCursor;
 import android.database.MergeCursor;
+import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -100,11 +102,24 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener {
     public void onAttach(Context context) {
         super.onAttach(context);
 
+        attachActivity((ThemeBrowserActivity) context);
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            attachActivity((ThemeBrowserActivity) activity);
+        }
+    }
+
+    private void attachActivity(ThemeBrowserActivity activity) {
         try {
-            mCallback = (ThemeBrowserFragmentCallback) context;
-            mThemeBrowserActivity = (ThemeBrowserActivity) context;
+            mCallback = activity;
+            mThemeBrowserActivity = activity;
         } catch (ClassCastException e) {
-            throw new ClassCastException(context.toString() + " must implement ThemeBrowserFragmentCallback");
+            throw new ClassCastException(activity.toString() + " must implement ThemeBrowserFragmentCallback");
         }
     }
 


### PR DESCRIPTION
Fixes #6906. I have explained this issue in detail in #6937 and as mentioned there, I don't think this is the best way to fix the issue. However, the proposed solution in that issue requires one too many changes than I am comfortable making on a release branch, so the "right?" solution has to wait.

To test:
1. Switch to `release/8.9` branch (so these changes are not applied yet)
2. Create an emulator with API 22 or below and go into Themes page which should crash
3. Switch to this branch and verify that crash is not happening anymore.

Bonus steps: You can put some breakpoints to the double `onAttach` methods and verify that the right ones are called for different API versions.

/cc @maxme @mzorz