### PR TITLE
Remove the configChanges attribute for the EditPostActivity

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -197,7 +197,6 @@
             android:windowSoftInputMode="stateVisible" />
         <activity
             android:name=".ui.posts.EditPostActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize"
             android:theme="@style/Calypso.ActionMode.Dark"
             android:windowSoftInputMode="stateHidden|adjustResize">
             <meta-data


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/AztecEditor-Android/issues/410

This was used a long time ago to maintain the state of an AsyncTask that was used to upload posts. This AsyncTask has been replaced by a service a while ago but the attribute was not removed. It was causing problem in Aztec because the view was not recreated on screen re-orientation.

cc @daniloercoli @mzorz @rachelmcr @0nko 