### PR TITLE
Update Aztec to latest version and update the image and video loaders

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -37,8 +37,8 @@ android {
 
     defaultConfig {
         applicationId "org.wordpress.android"
-        versionName "9.0-rc-1"
-        versionCode 497
+        versionName "alpha-87"
+        versionCode 498
         minSdkVersion 16
         targetSdkVersion 25
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
@@ -28,6 +28,11 @@ public class AztecImageLoader implements Html.ImageGetter {
 
     @Override
     public void loadImage(final String url, final Callbacks callbacks, int maxWidth) {
+        loadImage(url, callbacks, maxWidth, 0);
+    }
+
+    @Override
+    public void loadImage(final String url, final Callbacks callbacks, int maxWidth, int minWidth) {
         // FIXME: Aztec has now the option to set the desired image width. We should respect it
         // Ignore the maxWidth passed from Aztec, since it's the MAX of screen width/height
         final int maxWidthForEditor = ImageUtils.getMaximumThumbnailWidthForEditor(context);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
@@ -24,7 +24,13 @@ public class AztecVideoLoader implements Html.VideoThumbnailGetter {
         this.loadingInProgress = loadingInProgressDrawable;
     }
 
-    public void loadVideoThumbnail(final String url, final Html.VideoThumbnailGetter.Callbacks callbacks, final int maxWidth) {
+    public void loadVideoThumbnail(final String url, final Html.VideoThumbnailGetter.Callbacks callbacks,
+                                   final int maxWidth) {
+        loadVideoThumbnail(url, callbacks, maxWidth, 0);
+    }
+
+    public void loadVideoThumbnail(final String url, final Html.VideoThumbnailGetter.Callbacks callbacks,
+                                   final int maxWidth, final int minWidth) {
         // Ignore the maxWidth passed from Aztec, since it's the MAX of screen width/height
         final int maxWidthForEditor = ImageUtils.getMaximumThumbnailWidthForEditor(context);
         if (TextUtils.isEmpty(url) || maxWidthForEditor <= 0) {

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -53,9 +53,9 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.18.1'
 
-    compile 'com.github.wordpress-mobile.AztecEditor-Android:aztec:v1.0-beta.11'
-    compile 'com.github.wordpress-mobile.AztecEditor-Android:wordpress-comments:v1.0-beta.11'
-    compile 'com.github.wordpress-mobile.AztecEditor-Android:wordpress-shortcodes:v1.0-beta.11'
+    compile 'com.github.wordpress-mobile.AztecEditor-Android:aztec:fc0bab7105a2be65061b56d66b4cd752bdb92901'
+    compile 'com.github.wordpress-mobile.AztecEditor-Android:wordpress-comments:fc0bab7105a2be65061b56d66b4cd752bdb92901'
+    compile 'com.github.wordpress-mobile.AztecEditor-Android:wordpress-shortcodes:fc0bab7105a2be65061b56d66b4cd752bdb92901'
 
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)
     compile "org.jetbrains.kotlin:kotlin-stdlib:1.1.4"

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -53,9 +53,9 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.18.1'
 
-    compile 'com.github.wordpress-mobile.AztecEditor-Android:aztec:fc0bab7105a2be65061b56d66b4cd752bdb92901'
-    compile 'com.github.wordpress-mobile.AztecEditor-Android:wordpress-comments:fc0bab7105a2be65061b56d66b4cd752bdb92901'
-    compile 'com.github.wordpress-mobile.AztecEditor-Android:wordpress-shortcodes:fc0bab7105a2be65061b56d66b4cd752bdb92901'
+    compile 'com.github.wordpress-mobile.AztecEditor-Android:aztec:2b1944336a508c3bd15da5e91b1f5ab5d782c3a4'
+    compile 'com.github.wordpress-mobile.AztecEditor-Android:wordpress-comments:2b1944336a508c3bd15da5e91b1f5ab5d782c3a4'
+    compile 'com.github.wordpress-mobile.AztecEditor-Android:wordpress-shortcodes:2b1944336a508c3bd15da5e91b1f5ab5d782c3a4'
 
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)
     compile "org.jetbrains.kotlin:kotlin-stdlib:1.1.4"


### PR DESCRIPTION
We'll release a version `1.0-beta-12` of aztec and update the dependency here before merging that one.