### PR TITLE
Aztec - fix for long titles that are not properly rendered

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -198,36 +198,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         content.setOnImeBackListener(this);
         source.setOnImeBackListener(this);
 
-        // We need to intercept the "Enter" key on title. A new space is inserted instead
-        InputFilter noEnterKeyInputFilter = new InputFilter() {
-            @Override
-            public CharSequence filter(CharSequence source, int start, int end,
-                                       Spanned dest, int dstart, int dend) {
-                //  You sometimes get a SpannableStringBuilder, sometimes a plain String in the source parameter
-                if (source instanceof SpannableStringBuilder) {
-                    SpannableStringBuilder sourceAsSpannableBuilder = (SpannableStringBuilder) source;
-                    for (int i = end - 1; i >= start; i--) {
-                        char currentChar = source.charAt(i);
-                        if (currentChar == '\n') {
-                            sourceAsSpannableBuilder.replace(i, i + 1, " ");
-                        }
-                    }
-                    return source;
-                } else {
-                    StringBuilder filteredStringBuilder = new StringBuilder();
-                    for (int i = start; i < end; i++) {
-                        char currentChar = source.charAt(i);
-                        if (currentChar == '\n') {
-                            filteredStringBuilder.append(" ");
-                        } else {
-                            filteredStringBuilder.append(currentChar);
-                        }
-                    }
-                    return filteredStringBuilder.toString();
-                }
-            }
-        };
-        title.setFilters(new InputFilter[]{noEnterKeyInputFilter});
+        // We need to intercept the "Enter" key on the title field, and replace it with a space instead
+        title.setFilters(new InputFilter[]{replaceEnterKeyWithSpaceInputFilter});
 
         source.setHint("<p>" + getString(R.string.editor_content_hint) + "</p>");
 
@@ -308,6 +280,35 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     public void setAztecVideoLoader(Html.VideoThumbnailGetter videoLoader) {
         this.aztecVideoLoader = videoLoader;
     }
+
+    private InputFilter replaceEnterKeyWithSpaceInputFilter = new InputFilter() {
+        @Override
+        public CharSequence filter(CharSequence source, int start, int end,
+                                   Spanned dest, int dstart, int dend) {
+            //  You sometimes get a SpannableStringBuilder, sometimes a plain String in the source parameter
+            if (source instanceof SpannableStringBuilder) {
+                SpannableStringBuilder sourceAsSpannableBuilder = (SpannableStringBuilder) source;
+                for (int i = end - 1; i >= start; i--) {
+                    char currentChar = source.charAt(i);
+                    if (currentChar == '\n') {
+                        sourceAsSpannableBuilder.replace(i, i + 1, " ");
+                    }
+                }
+                return source;
+            } else {
+                StringBuilder filteredStringBuilder = new StringBuilder();
+                for (int i = start; i < end; i++) {
+                    char currentChar = source.charAt(i);
+                    if (currentChar == '\n') {
+                        filteredStringBuilder.append(" ");
+                    } else {
+                        filteredStringBuilder.append(currentChar);
+                    }
+                }
+                return filteredStringBuilder.toString();
+            }
+        }
+    };
 
     @Override
     public void onPause() {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -22,6 +22,8 @@ import android.support.annotation.NonNull;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
+import android.text.InputFilter;
+import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.view.DragEvent;
@@ -195,6 +197,37 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         title.setOnImeBackListener(this);
         content.setOnImeBackListener(this);
         source.setOnImeBackListener(this);
+
+        // We need to intercept the "Enter" key on title. A new space is inserted instead
+        InputFilter noEnterKeyInputFilter = new InputFilter() {
+            @Override
+            public CharSequence filter(CharSequence source, int start, int end,
+                                       Spanned dest, int dstart, int dend) {
+                //  You sometimes get a SpannableStringBuilder, sometimes a plain String in the source parameter
+                if (source instanceof SpannableStringBuilder) {
+                    SpannableStringBuilder sourceAsSpannableBuilder = (SpannableStringBuilder) source;
+                    for (int i = end - 1; i >= start; i--) {
+                        char currentChar = source.charAt(i);
+                        if (currentChar == '\n') {
+                            sourceAsSpannableBuilder.replace(i, i + 1, " ");
+                        }
+                    }
+                    return source;
+                } else {
+                    StringBuilder filteredStringBuilder = new StringBuilder();
+                    for (int i = start; i < end; i++) {
+                        char currentChar = source.charAt(i);
+                        if (currentChar == '\n') {
+                            filteredStringBuilder.append(" ");
+                        } else {
+                            filteredStringBuilder.append(currentChar);
+                        }
+                    }
+                    return filteredStringBuilder.toString();
+                }
+            }
+        };
+        title.setFilters(new InputFilter[]{noEnterKeyInputFilter});
 
         source.setHint("<p>" + getString(R.string.editor_content_hint) + "</p>");
 

--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
@@ -33,7 +33,7 @@
                 <org.wordpress.aztec.AztecText
                     android:id="@+id/title"
                     android:hint="@string/post_title"
-                    android:inputType="textCapSentences"
+                    android:inputType="textCapSentences|textMultiLine"
                     android:layout_height="wrap_content"
                     android:layout_toLeftOf="@+id/title_beta"
                     android:layout_toStartOf="@+id/title_beta"


### PR DESCRIPTION
Fixes #6944 by making sure the title field can be expand on multiple lines, and making sure it doesn't accept "New line" characters in it. When a new line is detected a space character is inserted instead.

To test:
Open the editor and try to write a long title, it must expand on more lines. If you try to insert enter it does insert a space.

cc @mzorz - This PR uses input filter ;)
