### PR TITLE
Remove plugin feature

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -115,6 +115,12 @@ public class PluginDetailActivity extends AppCompatActivity {
     }
 
     @Override
+    protected void onDestroy() {
+        mDispatcher.unregister(this);
+        super.onDestroy();
+    }
+
+    @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             onBackPressed();

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -1,8 +1,10 @@
 package org.wordpress.android.ui.plugins;
 
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.ActionBar;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
@@ -33,6 +35,7 @@ import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginPayload;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.ToastUtils.Duration;
 
@@ -175,6 +178,13 @@ public class PluginDetailActivity extends AppCompatActivity {
             }
         });
 
+        findViewById(R.id.plugin_btn_remove).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                removePlugin();
+            }
+        });
+
         refreshViews();
     }
 
@@ -242,6 +252,24 @@ public class PluginDetailActivity extends AppCompatActivity {
         refreshUpdateVersionViews();
         UpdateSitePluginPayload payload = new UpdateSitePluginPayload(mSite, mPlugin);
         mDispatcher.dispatch(PluginActionBuilder.newUpdateSitePluginAction(payload));
+    }
+
+    private void removePlugin() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.Calypso_AlertDialog);
+        builder.setTitle(getResources().getText(R.string.remove_plugin_dialog_title));
+        String confirmationMessage = getString(R.string.remove_plugin_dialog_message,
+                mPlugin.getDisplayName(),
+                SiteUtils.getSiteNameOrHomeURL(mSite));
+        builder.setMessage(confirmationMessage);
+        builder.setPositiveButton(R.string.remove, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialogInterface, int i) {
+            }
+        });
+        builder.setNegativeButton(R.string.cancel, null);
+        builder.setCancelable(true);
+        builder.create();
+        builder.show();
     }
 
     private void showSuccessfulUpdateSnackbar() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -397,7 +397,9 @@ public class PluginDetailActivity extends AppCompatActivity {
         if (event.isError()) {
             AppLog.e(AppLog.T.API, "An error occurred while removing the plugin with type: "
                     + event.error.type);
-            showPluginRemoveFailedSnackbar();
+            String toastMessage = getString(R.string.plugin_updated_failed_detailed,
+                    mPlugin.getDisplayName(), event.error.message);
+            ToastUtils.showToast(this, toastMessage, Duration.LONG);
             return;
         }
         // Plugin removed we need to go back to the plugin list

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -10,6 +10,7 @@ import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.Button;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.LinearLayout;

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -57,8 +57,8 @@ public class PluginDetailActivity extends AppCompatActivity {
     private Switch mSwitchActive;
     private Switch mSwitchAutoupdates;
 
-    private boolean isUpdatingPlugin;
-    private boolean isRemovingPlugin;
+    private boolean mIsUpdatingPlugin;
+    private boolean mIsRemovingPlugin;
 
     @Inject PluginStore mPluginStore;
     @Inject Dispatcher mDispatcher;
@@ -222,13 +222,13 @@ public class PluginDetailActivity extends AppCompatActivity {
 
     private void refreshUpdateVersionViews() {
         boolean isUpdateAvailable = PluginUtils.isUpdateAvailable(mPlugin, mPluginInfo);
-        if (isUpdateAvailable && !isUpdatingPlugin) {
+        if (isUpdateAvailable && !mIsUpdatingPlugin) {
             mUpdateTextView.setVisibility(View.VISIBLE);
         } else {
             mUpdateTextView.setVisibility(View.GONE);
         }
 
-        if (isUpdatingPlugin) {
+        if (mIsUpdatingPlugin) {
             mUpdateProgressBar.setVisibility(View.VISIBLE);
         } else {
             mUpdateProgressBar.setVisibility(View.GONE);
@@ -302,11 +302,11 @@ public class PluginDetailActivity extends AppCompatActivity {
         if (!NetworkUtils.checkConnection(this)) {
             return;
         }
-        if (!PluginUtils.isUpdateAvailable(mPlugin, mPluginInfo) || isUpdatingPlugin) {
+        if (!PluginUtils.isUpdateAvailable(mPlugin, mPluginInfo) || mIsUpdatingPlugin) {
             return;
         }
 
-        isUpdatingPlugin = true;
+        mIsUpdatingPlugin = true;
         refreshUpdateVersionViews();
         UpdateSitePluginPayload payload = new UpdateSitePluginPayload(mSite, mPlugin);
         mDispatcher.dispatch(PluginActionBuilder.newUpdateSitePluginAction(payload));
@@ -322,7 +322,7 @@ public class PluginDetailActivity extends AppCompatActivity {
 
     private void disableAndRemovePlugin() {
         // We need to make sure that plugin is disabled before attempting to remove it
-        isRemovingPlugin = true;
+        mIsRemovingPlugin = true;
         mPlugin.setIsActive(false);
         dispatchConfigurePluginAction();
     }
@@ -334,8 +334,8 @@ public class PluginDetailActivity extends AppCompatActivity {
     public void onSitePluginConfigured(OnSitePluginConfigured event) {
         if (event.isError()) {
             ToastUtils.showToast(this, getString(R.string.plugin_configuration_failed, event.error.message));
-            if (isRemovingPlugin) {
-                isRemovingPlugin = false;
+            if (mIsRemovingPlugin) {
+                mIsRemovingPlugin = false;
                 showPluginRemoveFailedSnackbar();
             }
             return;
@@ -349,7 +349,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         refreshViews();
 
         // Plugin is disabled, we can now remove it
-        if (isRemovingPlugin && !mPlugin.isActive()) {
+        if (mIsRemovingPlugin && !mPlugin.isActive()) {
             dispatchRemovePluginAction();
         }
     }
@@ -371,7 +371,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSitePluginUpdated(OnSitePluginUpdated event) {
-        isUpdatingPlugin = false;
+        mIsUpdatingPlugin = false;
         if (event.isError()) {
             AppLog.e(AppLog.T.API, "An error occurred while updating the plugin with type: "
                     + event.error.type);
@@ -393,7 +393,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSitePluginDeleted(OnSitePluginDeleted event) {
-        isRemovingPlugin = false;
+        mIsRemovingPlugin = false;
         if (event.isError()) {
             AppLog.e(AppLog.T.API, "An error occurred while removing the plugin with type: "
                     + event.error.type);

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -293,7 +293,12 @@ public class PluginDetailActivity extends AppCompatActivity {
         mRemovePluginProgressDialog = new ProgressDialog(this);
         mRemovePluginProgressDialog.setCancelable(false);
         mRemovePluginProgressDialog.setIndeterminate(true);
-        mRemovePluginProgressDialog.setMessage(getString(R.string.plugin_disable_progress_dialog_message));
+        // Even though we are deactivating the plugin to make sure it's disabled on the server side, since the user
+        // sees that the plugin is disabled, it'd be confusing to say we are disabling the plugin
+        String message = mPlugin.isActive()
+                ? getString(R.string.plugin_disable_progress_dialog_message, mPlugin.getDisplayName())
+                : getRemovingPluginMessage();
+        mRemovePluginProgressDialog.setMessage(message);
         mRemovePluginProgressDialog.show();
     }
 
@@ -331,7 +336,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         if (!NetworkUtils.checkConnection(this)) {
             return;
         }
-        mRemovePluginProgressDialog.setMessage(getString(R.string.plugin_remove_progress_dialog_message));
+        mRemovePluginProgressDialog.setMessage(getRemovingPluginMessage());
         DeleteSitePluginPayload payload = new DeleteSitePluginPayload(mSite, mPlugin);
         mDispatcher.dispatch(PluginActionBuilder.newDeleteSitePluginAction(payload));
     }
@@ -435,5 +440,9 @@ public class PluginDetailActivity extends AppCompatActivity {
 
     private String getWpOrgPluginUrl() {
         return "https://wordpress.org/plugins/" + mPlugin.getSlug();
+    }
+
+    private String getRemovingPluginMessage() {
+        return getString(R.string.plugin_remove_progress_dialog_message, mPlugin.getDisplayName());
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -352,7 +352,9 @@ public class PluginDetailActivity extends AppCompatActivity {
             }
             return;
         }
-        mPlugin = mPluginStore.getSitePluginByName(mSite, mPlugin.getName());
+        // Make sure to use a variable for the plugin name to avoid using `mPlugin` on both side of equation
+        String pluginName = mPlugin.getName();
+        mPlugin = mPluginStore.getSitePluginByName(mSite, pluginName);
         if (mPlugin == null) {
             ToastUtils.showToast(this, R.string.plugin_not_found, Duration.SHORT);
             finish();
@@ -391,7 +393,9 @@ public class PluginDetailActivity extends AppCompatActivity {
             showUpdateFailedSnackbar();
             return;
         }
-        mPlugin = mPluginStore.getSitePluginByName(mSite, mPlugin.getName());
+        // Make sure to use a variable for the plugin name to avoid using `mPlugin` on both side of equation
+        String pluginName = mPlugin.getName();
+        mPlugin = mPluginStore.getSitePluginByName(mSite, pluginName);
         if (mPlugin == null) {
             ToastUtils.showToast(this, R.string.plugin_not_found, Duration.SHORT);
             finish();

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -10,7 +10,6 @@ import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.Button;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.LinearLayout;
@@ -58,6 +57,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     private Switch mSwitchAutoupdates;
 
     private boolean isUpdatingPlugin;
+    private boolean isRemovingPlugin;
 
     @Inject PluginStore mPluginStore;
     @Inject Dispatcher mDispatcher;
@@ -182,7 +182,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         findViewById(R.id.plugin_btn_remove).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                removePlugin();
+                confirmRemovePlugin();
             }
         });
 
@@ -234,28 +234,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         }
     }
 
-    // Network Helpers
-
-    private void dispatchConfigurePluginAction() {
-        mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(
-                new ConfigureSitePluginPayload(mSite, mPlugin)));
-    }
-
-    private void dispatchUpdatePluginAction() {
-        if (!NetworkUtils.checkConnection(this)) {
-            return;
-        }
-        if (!PluginUtils.isUpdateAvailable(mPlugin, mPluginInfo) || isUpdatingPlugin) {
-            return;
-        }
-
-        isUpdatingPlugin = true;
-        refreshUpdateVersionViews();
-        UpdateSitePluginPayload payload = new UpdateSitePluginPayload(mSite, mPlugin);
-        mDispatcher.dispatch(PluginActionBuilder.newUpdateSitePluginAction(payload));
-    }
-
-    private void removePlugin() {
+    private void confirmRemovePlugin() {
         AlertDialog.Builder builder = new AlertDialog.Builder(this, R.style.Calypso_AlertDialog);
         builder.setTitle(getResources().getText(R.string.remove_plugin_dialog_title));
         String confirmationMessage = getString(R.string.remove_plugin_dialog_message,
@@ -265,6 +244,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         builder.setPositiveButton(R.string.remove, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialogInterface, int i) {
+                disableAndRemovePlugin();
             }
         });
         builder.setNegativeButton(R.string.cancel, null);
@@ -291,6 +271,31 @@ public class PluginDetailActivity extends AppCompatActivity {
                     }
                 })
                 .show();
+    }
+
+    // Network Helpers
+
+    private void dispatchConfigurePluginAction() {
+        mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(
+                new ConfigureSitePluginPayload(mSite, mPlugin)));
+    }
+
+    private void dispatchUpdatePluginAction() {
+        if (!NetworkUtils.checkConnection(this)) {
+            return;
+        }
+        if (!PluginUtils.isUpdateAvailable(mPlugin, mPluginInfo) || isUpdatingPlugin) {
+            return;
+        }
+
+        isUpdatingPlugin = true;
+        refreshUpdateVersionViews();
+        UpdateSitePluginPayload payload = new UpdateSitePluginPayload(mSite, mPlugin);
+        mDispatcher.dispatch(PluginActionBuilder.newUpdateSitePluginAction(payload));
+    }
+
+    private void disableAndRemovePlugin() {
+        // We need to make sure that plugin is disabled before attempting to remove it
     }
 
     // FluxC callbacks

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -363,9 +363,7 @@ public class PluginDetailActivity extends AppCompatActivity {
             }
             return;
         }
-        // Make sure to use a variable for the plugin name to avoid using `mPlugin` on both side of equation
-        String pluginName = mPlugin.getName();
-        mPlugin = mPluginStore.getSitePluginByName(mSite, pluginName);
+        mPlugin = mPluginStore.getSitePluginByName(mSite, mPlugin.getName());
         if (mPlugin == null) {
             ToastUtils.showToast(this, R.string.plugin_not_found, Duration.SHORT);
             finish();
@@ -404,9 +402,7 @@ public class PluginDetailActivity extends AppCompatActivity {
             showUpdateFailedSnackbar();
             return;
         }
-        // Make sure to use a variable for the plugin name to avoid using `mPlugin` on both side of equation
-        String pluginName = mPlugin.getName();
-        mPlugin = mPluginStore.getSitePluginByName(mSite, pluginName);
+        mPlugin = mPluginStore.getSitePluginByName(mSite, mPlugin.getName());
         if (mPlugin == null) {
             ToastUtils.showToast(this, R.string.plugin_not_found, Duration.SHORT);
             finish();

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
@@ -91,6 +91,12 @@ public class PluginListActivity extends AppCompatActivity {
     }
 
     @Override
+    protected void onDestroy() {
+        mDispatcher.unregister(this);
+        super.onDestroy();
+    }
+
+    @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             onBackPressed();

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
@@ -31,6 +31,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.PluginStore;
 import org.wordpress.android.fluxc.store.PluginStore.OnPluginInfoChanged;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginConfigured;
+import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginDeleted;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginsFetched;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.util.AppLog;
@@ -161,6 +162,12 @@ public class PluginListActivity extends AppCompatActivity {
             // We can ignore the error since the action is taken in `PluginDetailActivity`
             return;
         }
+        refreshPluginList();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onSitePluginDeleted(OnSitePluginDeleted event) {
         refreshPluginList();
     }
 

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -145,6 +145,7 @@
         card_view:cardCornerRadius="@dimen/cardview_default_radius">
 
         <LinearLayout
+            android:id="@+id/plugin_btn_remove"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="?android:attr/selectableItemBackground"
@@ -159,9 +160,7 @@
                 android:tint="@color/alert_red" />
 
             <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
+                style="@style/PluginCardViewPrimaryText"
                 android:layout_marginLeft="@dimen/margin_large"
                 android:layout_marginStart="@dimen/margin_large"
                 android:text="@string/remove"

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -46,7 +46,7 @@
                         android:layout_height="wrap_content"
                         android:background="?android:attr/selectableItemBackground"
                         android:padding="@dimen/margin_large"
-                        android:text="@string/plugin_btn_update"
+                        android:text="@string/update_verb"
                         android:textAllCaps="true"
                         android:textColor="@color/wp_blue_medium"
                         android:textSize="@dimen/text_sz_medium" />
@@ -136,6 +136,37 @@
                     style="@style/PluginCardViewSecondaryElement.ExternalLinkImage"
                     app:srcCompat="@drawable/ic_external_black_24dp"/>
             </RelativeLayout>
+        </LinearLayout>
+    </android.support.v7.widget.CardView>
+
+    <android.support.v7.widget.CardView
+        style="@style/PluginCardView"
+        card_view:cardBackgroundColor="@color/white"
+        card_view:cardCornerRadius="@dimen/cardview_default_radius">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?android:attr/selectableItemBackground"
+            android:orientation="horizontal"
+            android:padding="@dimen/margin_extra_large">
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:src="@drawable/ic_trash_grey_24dp"
+                android:tint="@color/alert_red" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginLeft="@dimen/margin_large"
+                android:layout_marginStart="@dimen/margin_large"
+                android:text="@string/remove"
+                android:textAllCaps="true"
+                android:textColor="@color/alert_red" />
         </LinearLayout>
     </android.support.v7.widget.CardView>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -144,28 +144,16 @@
         card_view:cardBackgroundColor="@color/white"
         card_view:cardCornerRadius="@dimen/cardview_default_radius">
 
-        <LinearLayout
+        <Button
             android:id="@+id/plugin_btn_remove"
+            style="?android:attr/borderlessButtonStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="?android:attr/selectableItemBackground"
-            android:orientation="horizontal"
-            android:padding="@dimen/margin_extra_large">
-
-            <ImageView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:src="@drawable/ic_trash_grey_24dp"
-                android:tint="@color/alert_red" />
-
-            <TextView
-                style="@style/PluginCardViewPrimaryText"
-                android:layout_marginLeft="@dimen/margin_large"
-                android:layout_marginStart="@dimen/margin_large"
-                android:text="@string/remove"
-                android:textAllCaps="true"
-                android:textColor="@color/alert_red" />
-        </LinearLayout>
+            android:gravity="start|center_vertical"
+            android:padding="@dimen/margin_extra_large"
+            android:text="@string/plugin_btn_remove"
+            android:textAllCaps="true"
+            android:textColor="@color/alert_red" />
     </android.support.v7.widget.CardView>
 </LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1799,8 +1799,8 @@
     <string name="plugin_remove_failed">Error removing %s.</string>
     <string name="plugin_configuration_failed">An error occurred while configuring the plugin: %s</string>
     <string name="plugin_btn_remove">Remove Plugin</string>
-    <string name="plugin_disable_progress_dialog_message">Disabling the plugin..</string>
-    <string name="plugin_remove_progress_dialog_message">Removing the plugin..</string>
+    <string name="plugin_disable_progress_dialog_message">Disabling %s..</string>
+    <string name="plugin_remove_progress_dialog_message">Removing %s..</string>
     <string name="plugin_remove_dialog_title">Remove Plugin</string>
     <string name="plugin_remove_dialog_message">Are you sure you want to remove %1$s from %2$s? This will deactivate the plugin and delete all associated files and data.</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1794,6 +1794,8 @@
     <string name="plugin_update_available_icon_content_description">Update available</string>
     <string name="plugin_updated_successfully">Successfully updated %s.</string>
     <string name="plugin_updated_failed">Error updating %s.</string>
+    <string name="plugin_removed_successfully">Successfully removed %s.</string>
+    <string name="plugin_remove_failed">Error removing %s.</string>
     <string name="plugin_configuration_failed">An error occurred while configuring the plugin: %s</string>
     <string name="plugin_btn_remove">Remove Plugin</string>
     <string name="remove_plugin_dialog_title">Remove Plugin</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1793,7 +1793,8 @@
     <string name="plugin_available_version">Version %s is available.</string>
     <string name="plugin_update_available_icon_content_description">Update available</string>
     <string name="plugin_updated_successfully">Successfully updated %s.</string>
-    <string name="plugin_updated_failed">Error updating %s.</string>
+    <string name="plugin_updated_failed">Error removing %s.</string>
+    <string name="plugin_updated_failed_detailed">Error removing %1$s: %2$s</string>
     <string name="plugin_removed_successfully">Successfully removed %s.</string>
     <string name="plugin_remove_failed">Error removing %s.</string>
     <string name="plugin_configuration_failed">An error occurred while configuring the plugin: %s</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1795,6 +1795,7 @@
     <string name="plugin_updated_successfully">Successfully updated %s.</string>
     <string name="plugin_updated_failed">Error updating %s.</string>
     <string name="plugin_configuration_failed">An error occurred while fetching the plugins: %s</string>
+    <string name="plugin_btn_remove">Remove Plugin</string>
     <string name="remove_plugin_dialog_title">Remove Plugin</string>
     <string name="remove_plugin_dialog_message">Are you sure you want to remove %1$s from %2$s? This will deactivate the plugin and delete all associated files and data.</string>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1799,8 +1799,10 @@
     <string name="plugin_remove_failed">Error removing %s.</string>
     <string name="plugin_configuration_failed">An error occurred while configuring the plugin: %s</string>
     <string name="plugin_btn_remove">Remove Plugin</string>
-    <string name="remove_plugin_dialog_title">Remove Plugin</string>
-    <string name="remove_plugin_dialog_message">Are you sure you want to remove %1$s from %2$s? This will deactivate the plugin and delete all associated files and data.</string>
+    <string name="plugin_disable_progress_dialog_message">Disabling the plugin..</string>
+    <string name="plugin_remove_progress_dialog_message">Removing the plugin..</string>
+    <string name="plugin_remove_dialog_title">Remove Plugin</string>
+    <string name="plugin_remove_dialog_message">Are you sure you want to remove %1$s from %2$s? This will deactivate the plugin and delete all associated files and data.</string>
 
     <string name="wordpress_dot_org_plugin_page">WordPress.org Plugin page</string>
     <string name="plugin_home_page">Plugin homepage</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1795,6 +1795,8 @@
     <string name="plugin_updated_successfully">Successfully updated %s.</string>
     <string name="plugin_updated_failed">Error updating %s.</string>
     <string name="plugin_configuration_failed">An error occurred while fetching the plugins: %s</string>
+    <string name="remove_plugin_dialog_title">Remove Plugin</string>
+    <string name="remove_plugin_dialog_message">Are you sure you want to remove %1$s from %2$s? This will deactivate the plugin and delete all associated files and data.</string>
 
     <string name="wordpress_dot_org_plugin_page">WordPress.org Plugin page</string>
     <string name="plugin_home_page">Plugin homepage</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1794,7 +1794,7 @@
     <string name="plugin_update_available_icon_content_description">Update available</string>
     <string name="plugin_updated_successfully">Successfully updated %s.</string>
     <string name="plugin_updated_failed">Error updating %s.</string>
-    <string name="plugin_configuration_failed">An error occurred while fetching the plugins: %s</string>
+    <string name="plugin_configuration_failed">An error occurred while configuring the plugin: %s</string>
     <string name="plugin_btn_remove">Remove Plugin</string>
     <string name="remove_plugin_dialog_title">Remove Plugin</string>
     <string name="remove_plugin_dialog_message">Are you sure you want to remove %1$s from %2$s? This will deactivate the plugin and delete all associated files and data.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1791,7 +1791,6 @@
     <string name="plugin_not_found">An error occurred when accessing this plugin</string>
     <string name="plugin_installed_version">Plugin version %s</string>
     <string name="plugin_available_version">Version %s is available.</string>
-    <string name="plugin_btn_update">Update</string>
     <string name="plugin_update_available_icon_content_description">Update available</string>
     <string name="plugin_updated_successfully">Successfully updated %s.</string>
     <string name="plugin_updated_failed">Error updating %s.</string>


### PR DESCRIPTION
This PR implements the remove plugin feature. It also includes some general fixes for plugins as I've found some issues while testing the remove plugin feature and found that without those fixes it'd be very hard for the reviewer to make sure the feature is working as intended.

A few notes that should help with the review:
* We show a dynamic progress dialog while removing the plugin. We first tell the user that we are disabling the plugin and once the disable goes through, we remove the plugin and update the progress bar with the correct message. However, if the plugin is not active in UI (so, in DB), we only tell the user that we are removing the plugin, but we still go through with the disable network call because we have to make sure the plugin is disabled.
* I forgot about unregistering from the dispatcher in the previous PRs which was leading to a lot of weird issues. I had to fix that to make sure the remove plugin feature would work as expected.
* When a plugin is removed we update the plugin list
* `showSuccessfulUpdateSnackbar` and `showUpdateFailedSnackbar` were only moved to UI section (no actual changes)

There are a few issues left to wrap up plugins which are all being tracked in #6920. Please ignore any issues related to those, however if you find any other issues (even if it's not about this PR) please let me know so I can add that to the list.

A couple videos that shows the feature in action:
https://cloudup.com/cEQE-yYD4X7
https://cloudup.com/cH9n9cOYtBP

/cc @hypest, @kwonye, @nbradbury (if whoever can get to the PR faster can grab it, that'd be great as everything about plugin management needs to be finished until the end of Friday)