### PR TITLE
Set up custom GlideModule using FluxC's RequestQueue

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -118,6 +118,10 @@ dependencies {
         exclude group: 'com.squareup.okhttp3'
     }
 
+    compile 'com.github.bumptech.glide:glide:4.1.1'
+    apt 'com.github.bumptech.glide:compiler:4.1.1'
+    compile 'com.github.bumptech.glide:volley-integration:4.1.1@aar'
+
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.3.2'
     testCompile 'org.robolectric:shadows-multidex:3.3.2'
@@ -154,9 +158,11 @@ dependencies {
     debugCompile project(path:':libs:editor:WordPressEditor', configuration: 'debug')
     releaseCompile (project(path:':libs:login:WordPressLoginFlow', configuration: 'release')) {
         exclude group: "com.github.wordpress-mobile.WordPress-FluxC-Android", module: "fluxc";
+        exclude group: 'com.github.bumptech.glide'
     }
     debugCompile (project(path:':libs:login:WordPressLoginFlow', configuration: 'debug')) {
         exclude group: "com.github.wordpress-mobile.WordPress-FluxC-Android", module: "fluxc";
+        exclude group: 'com.github.bumptech.glide'
     }
 
     // Debug

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -253,6 +253,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(PluginListActivity object);
     void inject(PluginDetailActivity object);
 
+    void inject(WordPressGlideModule object);
+
     // Allows us to inject the application without having to instantiate any modules, and provides the Application
     // in the app graph
     @Component.Builder

--- a/WordPress/src/main/java/org/wordpress/android/modules/WordPressGlideModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/WordPressGlideModule.java
@@ -1,0 +1,36 @@
+package org.wordpress.android.modules;
+
+import android.content.Context;
+
+import com.android.volley.RequestQueue;
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.GlideBuilder;
+import com.bumptech.glide.Registry;
+import com.bumptech.glide.annotation.GlideModule;
+import com.bumptech.glide.integration.volley.VolleyUrlLoader;
+import com.bumptech.glide.load.model.GlideUrl;
+import com.bumptech.glide.module.AppGlideModule;
+
+import org.wordpress.android.WordPress;
+
+import java.io.InputStream;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@GlideModule
+public class WordPressGlideModule extends AppGlideModule {
+    @Inject @Named("custom-ssl") RequestQueue mRequestQueue;
+
+    public WordPressGlideModule() {
+        ((WordPress) WordPress.getContext()).component().inject(this);
+    }
+
+    @Override
+    public void applyOptions(Context context, GlideBuilder builder) {}
+
+    @Override
+    public void registerComponents(Context context, Glide glide, Registry registry) {
+        glide.getRegistry().replace(GlideUrl.class, InputStream.class, new VolleyUrlLoader.Factory(mRequestQueue));
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/modules/WordPressGlideModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/WordPressGlideModule.java
@@ -18,19 +18,19 @@ import java.io.InputStream;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+/**
+ * Custom {@link AppGlideModule} that replaces Glide's default {@link RequestQueue} with FluxC's.
+ */
 @GlideModule
 public class WordPressGlideModule extends AppGlideModule {
     @Inject @Named("custom-ssl") RequestQueue mRequestQueue;
-
-    public WordPressGlideModule() {
-        ((WordPress) WordPress.getContext()).component().inject(this);
-    }
 
     @Override
     public void applyOptions(Context context, GlideBuilder builder) {}
 
     @Override
     public void registerComponents(Context context, Glide glide, Registry registry) {
+        ((WordPress) context).component().inject(this);
         glide.getRegistry().replace(GlideUrl.class, InputStream.class, new VolleyUrlLoader.Factory(mRequestQueue));
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/modules/WordPressGlideModule.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/WordPressGlideModule.java
@@ -29,6 +29,11 @@ public class WordPressGlideModule extends AppGlideModule {
     public void applyOptions(Context context, GlideBuilder builder) {}
 
     @Override
+    public boolean isManifestParsingEnabled() {
+        return false;
+    }
+
+    @Override
     public void registerComponents(Context context, Glide glide, Registry registry) {
         ((WordPress) context).component().inject(this);
         glide.getRegistry().replace(GlideUrl.class, InputStream.class, new VolleyUrlLoader.Factory(mRequestQueue));


### PR DESCRIPTION
Adds the Glide dependency to app's main `build.gradle`, and adds a custom `@GlideModule` which makes Glide use FluxC's `RequestQueue`. This keeps our network requests centrally managed, and allows Glide to share the cache the rest of the app's network requests are using.

Currently this only affects the ~(not yet merged)~ login library (#6935), which uses Glide for gravatar and blavatar requests. ~For this reason, this PR should be merged after #6935 has been reviewed and merged.~

This is also a (small) first step towards Glide everywhere (we have an issue for this: #5738). To actually get there, we'll also have to add private/self-signed ssl/httpauth site support (and replace a bunch of usages of `WPNetworkImageView`, and more...). It looks like we can accomplish that by replacing Glide's `HeaderLoader` with our own (in a similar way to how the `RequestQueue` is replaced in this PR).

I'm opening this PR separately from #6935 to make the change obvious as I'm not completely happy with making this change in the app instead of in the login library (though it's probably the best long-term solution if we're committed to using Glide throughout the app). Whether we want to go ahead with this kind of depends on how soon we want to start introducing Glide into the main app.

(Ideally I would have liked the login library to handle the Glide setup itself. Unfortunately this isn't straightforward since we only get the dependency inverting goodness of dagger-android for Android framework classes like Activities and Fragments, so we need to depend on old-fashioned `((WordPress) WordPress.getContext()).component().inject(this)` for this, or use some somewhat awkward static injection method. On the other hand, defining a `GlideModule` seems to be a [best practice for Glide](http://bumptech.github.io/glide/doc/configuration.html#module-classes-and-annotations), but the documentation is a bit unclear.)

Side note: We're able to add extra configs per-library in the future if we need to, by extending `LibraryGlideModule`, and that will be applied on top of this base config.

To test: Convince yourself that gravatars loaded during login are using FluxC's network stack.

cc @maxme especially, since you opened #5738 