### PR TITLE
fixed password field misaligned with icons overlapping text

### DIFF
--- a/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
+++ b/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
@@ -129,7 +129,7 @@
                     android:hint="@string/password"
                     android:maxLength="@integer/max_length_password"
                     android:layout_marginRight="38dp"
-                    android:layout_marginEnd="38dp"/>
+                    android:layout_marginStart="38dp"/>
 
                 <ImageView
                     android:layout_width="wrap_content"
@@ -153,8 +153,8 @@
                     android:layout_gravity="center_horizontal"
                     android:layout_alignParentLeft="false"
                     android:layout_alignParentStart="false"
-                    android:layout_alignParentRight="false"
-                    android:layout_alignParentEnd="false"
+                    android:layout_alignParentRight="true"
+                    android:layout_alignParentEnd="true"
                     app:srcCompat="@drawable/ic_visible_off_black_24dp"
                     android:layout_centerVertical="true"
                     android:layout_marginRight="16dp"


### PR DESCRIPTION
Fixes #6917.  Icons (padlock and eye) now aligned on the left and right of the password text field respectively.

## To test:
1. Open Login/Sign up screen.
2. Click on Create A Wordpress Site.

### Before Fix:
![device-2017-12-04-221802](https://user-images.githubusercontent.com/8193385/33754154-31e58648-dbeb-11e7-9394-e39c013e7cf7.png)

### After Fix:
![device-2017-12-04-214122](https://user-images.githubusercontent.com/8193385/33754181-5b19330c-dbeb-11e7-92b4-246b7890c1c9.png)

