### PR TITLE
fixed WebView in ReleaseNotesActivity lacks loading sign

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/ReleaseNotesActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/ReleaseNotesActivity.java
@@ -8,6 +8,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.widget.ProgressBar;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
@@ -15,6 +16,7 @@ import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.WebViewActivity;
 import org.wordpress.android.util.HelpshiftHelper;
+import org.wordpress.android.util.helpers.WPWebChromeClient;
 
 import javax.inject.Inject;
 
@@ -52,6 +54,8 @@ public class ReleaseNotesActivity extends WebViewActivity {
                 }
             }
         );
+
+        mWebView.setWebChromeClient(new WPWebChromeClient(this, (ProgressBar) findViewById(R.id.progress_bar)));
     }
 
     @Override


### PR DESCRIPTION
Fixes #6472.  When a web page indicating release notes or more information about a feature is accessed, a "loading..." sign is shown.


## Steps to reproduce the behavior

1. uninstall the app and install it again (or delete all data)
2. start a new draft
3. tap on PUBLISH
4. you should see the promo dialog
5. if you tap on the What's New link, a new screen is opened
6. it now shows "loading" wheel or sign

### After Fix:
![device-2017-12-08-075817](https://user-images.githubusercontent.com/8193385/33754949-e0edbe32-dbee-11e7-9f4c-f03d3ce0aac4.png)
