### PR TITLE
Update fluxc hash and reflect social payload changes

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -137,7 +137,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.11'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:304a7f68117ea030a50ef9b9c8a17a111b78110c') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:b44adaf240a73acc630e9a201b63038c6a53b9f1') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/Login2FaFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/Login2FaFragment.java
@@ -415,7 +415,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
         AppLog.i(T.NUX, "onAuthenticationChanged: " + event.toString());
 
         if (isSocialLoginConnect) {
-            AccountStore.PushSocialLoginPayload payload = new AccountStore.PushSocialLoginPayload(mIdToken, mService);
+            AccountStore.PushSocialPayload payload = new AccountStore.PushSocialPayload(mIdToken, mService);
             mDispatcher.dispatch(AccountActionBuilder.newPushSocialConnectAction(payload));
         } else {
             doFinishLogin();

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginGoogleFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginGoogleFragment.java
@@ -31,7 +31,7 @@ import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnSocialChanged;
-import org.wordpress.android.fluxc.store.AccountStore.PushSocialLoginPayload;
+import org.wordpress.android.fluxc.store.AccountStore.PushSocialPayload;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -234,7 +234,7 @@ public class LoginGoogleFragment extends Fragment implements ConnectionCallbacks
                             mGoogleEmail = account.getEmail();
                             mGoogleLoginListener.onGoogleEmailSelected(mGoogleEmail);
                             mIdToken = account.getIdToken();
-                            PushSocialLoginPayload payload = new PushSocialLoginPayload(mIdToken, SERVICE_TYPE_GOOGLE);
+                            PushSocialPayload payload = new PushSocialPayload(mIdToken, SERVICE_TYPE_GOOGLE);
                             mDispatcher.dispatch(AccountActionBuilder.newPushSocialLoginAction(payload));
                         } catch (NullPointerException exception) {
                             disconnectGoogleClient();

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginWpcomService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginWpcomService.java
@@ -306,7 +306,7 @@ public class LoginWpcomService extends AutoForeground<OnLoginStateUpdated> {
 
         if (isSocialLogin) {
             setState(LoginPhase.SOCIAL_LOGIN);
-            AccountStore.PushSocialLoginPayload payload = new AccountStore.PushSocialLoginPayload(mIdToken, mService);
+            AccountStore.PushSocialPayload payload = new AccountStore.PushSocialPayload(mIdToken, mService);
             mDispatcher.dispatch(AccountActionBuilder.newPushSocialConnectAction(payload));
         } else {
             signalCredentialsOK();


### PR DESCRIPTION
This PR updates the FluxC hash to the latest `develop` and reflects the payload changes made in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/639.

As I don't have any background into these changes, I simply assumed that it's a naming change and nothing else. Please let me know if we need to make any further changes due to that FluxC PR.

@theck13 I've also noticed a few warnings about possible NPEs in the files I've updated, you might want to look into those as they seem to be marked as `@NonNull` in FluxC.

/cc @aforcier 

P.S: This is a blocking change and should be reviewed as soon as possible. Thanks!