### PR TITLE
Fix for Aztec resulting enabled after logout/login

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PromoDialogEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PromoDialogEditor.java
@@ -138,8 +138,7 @@ public class PromoDialogEditor extends PromoDialogAdvanced {
                         AnalyticsTracker.track(AnalyticsTracker.Stat.EDITOR_AZTEC_PROMO_POSITIVE);
                         AppPrefs.setAztecEditorEnabled(true);
                         AppPrefs.setVisualEditorEnabled(false);
-                        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
-                        preferences.edit().putString(getString(R.string.pref_key_editor_type), "2").apply();
+                        AppPrefs.setNewEditorPromoRequired(false);
                     }
 
                     ActivityLauncher.addNewPostOrPageForResult(getActivity(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PromoDialogEditor.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PromoDialogEditor.java
@@ -1,9 +1,7 @@
 package org.wordpress.android.ui.posts;
 
 import android.app.Dialog;
-import android.content.SharedPreferences;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppPrefs.java
@@ -63,15 +63,6 @@ public class AppPrefs {
         // last data stored for the Stats Widgets
         STATS_WIDGET_DATA,
 
-        // aztec editor enabled
-        AZTEC_EDITOR_ENABLED,
-
-        // aztec editor toolbar expanded state
-        AZTEC_EDITOR_TOOLBAR_EXPANDED,
-
-        // visual editor enabled
-        VISUAL_EDITOR_ENABLED,
-
         // Store the number of times Stats are loaded without errors. It's used to show the Widget promo dialog.
         STATS_WIDGET_PROMO_ANALYTICS,
 
@@ -118,6 +109,15 @@ public class AppPrefs {
 
         // visual editor available
         VISUAL_EDITOR_AVAILABLE,
+
+        // visual editor enabled
+        VISUAL_EDITOR_ENABLED,
+
+        // aztec editor enabled
+        AZTEC_EDITOR_ENABLED,
+
+        // aztec editor toolbar expanded state
+        AZTEC_EDITOR_TOOLBAR_EXPANDED,
 
         // When we need to show the new editor beta snackbar
         AZTEC_EDITOR_BETA_REQUIRED,
@@ -430,25 +430,25 @@ public class AppPrefs {
 
     // Aztec Editor
     public static void setAztecEditorEnabled(boolean isEnabled) {
-        setBoolean(DeletablePrefKey.AZTEC_EDITOR_ENABLED, isEnabled);
+        setBoolean(UndeletablePrefKey.AZTEC_EDITOR_ENABLED, isEnabled);
         AnalyticsTracker.track(isEnabled ? Stat.EDITOR_AZTEC_TOGGLED_ON : Stat.EDITOR_AZTEC_TOGGLED_OFF);
     }
 
     public static boolean isAztecEditorEnabled() {
-        return getBoolean(DeletablePrefKey.AZTEC_EDITOR_ENABLED, false);
+        return getBoolean(UndeletablePrefKey.AZTEC_EDITOR_ENABLED, false);
     }
 
     public static boolean isAztecEditorToolbarExpanded() {
-        return getBoolean(DeletablePrefKey.AZTEC_EDITOR_TOOLBAR_EXPANDED, false);
+        return getBoolean(UndeletablePrefKey.AZTEC_EDITOR_TOOLBAR_EXPANDED, false);
     }
 
     public static void setAztecEditorToolbarExpanded(boolean isExpanded) {
-        setBoolean(DeletablePrefKey.AZTEC_EDITOR_TOOLBAR_EXPANDED, isExpanded);
+        setBoolean(UndeletablePrefKey.AZTEC_EDITOR_TOOLBAR_EXPANDED, isExpanded);
     }
 
     // Visual Editor
     public static void setVisualEditorEnabled(boolean visualEditorEnabled) {
-        setBoolean(DeletablePrefKey.VISUAL_EDITOR_ENABLED, visualEditorEnabled);
+        setBoolean(UndeletablePrefKey.VISUAL_EDITOR_ENABLED, visualEditorEnabled);
         AnalyticsTracker.track(visualEditorEnabled ? Stat.EDITOR_HYBRID_TOGGLED_ON : Stat.EDITOR_HYBRID_TOGGLED_OFF);
     }
 
@@ -464,7 +464,7 @@ public class AppPrefs {
     }
 
     public static boolean isVisualEditorEnabled() {
-        return isVisualEditorAvailable() && getBoolean(DeletablePrefKey.VISUAL_EDITOR_ENABLED, !isAztecEditorEnabled());
+        return isVisualEditorAvailable() && getBoolean(UndeletablePrefKey.VISUAL_EDITOR_ENABLED, !isAztecEditorEnabled());
     }
 
     public static boolean isNewEditorBetaRequired() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -241,13 +241,18 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
                 }
             });
 
-            String editorTypeKey = getString(R.string.pref_key_editor_type);
-            String editorTypeSetting = mSettings.getString(editorTypeKey, "");
-
-            if (!editorTypeSetting.equalsIgnoreCase("")) {
-                CharSequence[] entries = editorTypePreference.getEntries();
-                editorTypePreference.setSummary(entries[Integer.parseInt(editorTypeSetting)]);
+            final int editorTypeSetting;
+            if (AppPrefs.isAztecEditorEnabled()) {
+                editorTypeSetting = IDX_AZTEC_EDITOR;
+            } else if(AppPrefs.isVisualEditorEnabled()) {
+                editorTypeSetting = IDX_VISUAL_EDITOR;
+            } else{
+                editorTypeSetting = IDX_LEGACY_EDITOR;
             }
+
+            CharSequence[] entries = editorTypePreference.getEntries();
+            editorTypePreference.setSummary(entries[editorTypeSetting]);
+            editorTypePreference.setValueIndex(editorTypeSetting);
 
             toggleEditorFooterPreference();
         }


### PR DESCRIPTION
This is a fix for #6932 where Aztec seems enabled in App preferences screen instead it was not when you start writing a new post. This issue happens only if you tap "enable the beta editor" in the Promo Dialog.

This was because the PromoDialog accessed Preferences directly without using utils methods, and was storing the value in a different key, that was not erased on logout. Not sure if it was done on purpose or not.

Note that "on logout" the preference that stores the value about which editor to use is erased, so on new logins the visual editor is the default one, even if you had previously selected Aztec.


cc @0nko 
