### PR TITLE
added null check to avoid NPE

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -605,7 +605,7 @@ public class UploadService extends Service {
             for (MediaModel media: mMediaBatchUploaded) {
                 // we need to obtain the latest copy from the Store, as it's got the remote mediaId field
                 MediaModel currentMedia = mMediaStore.getMediaWithLocalId(media.getId());
-                if (currentMedia.getLocalPostId() == 0
+                if (currentMedia != null && currentMedia.getLocalPostId() == 0
                         && MediaUploadState.fromString(currentMedia.getUploadState())
                         == MediaUploadState.UPLOADED) {
                     standAloneMediaItems.add(currentMedia);


### PR DESCRIPTION
Fixes #6974 

To test:
1.  go to the Media browser in the app
2. start uploading one big media item by using the + icon and choosing to take a new picture
3. while that first one is uploading, please start another upload for a much smaller media item (maybe something that's already on the device)
4. wait until the second item is finished uploading (the first one should still keep uploading as it should be larger enough) - and please tap on that new item and tap on the trash icon to delete it (the dialog appears, tap DELETE there as well). All of this should be done while the first image is still uploading.
5. wait until the first item is finished uploading
6. this is the moment when the crash was produced - confirm it doesn't crash anymore.

cc @maxme 