### PR TITLE
Issue/6961 crash login email

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
@@ -6,9 +6,11 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v7.app.AlertDialog;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.Patterns;
+import android.view.ContextThemeWrapper;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
@@ -108,6 +110,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener>
                         addGoogleFragment();
                     } else {
                         AppLog.e(T.NUX, "Google login could not be started.  LoginEmailFragment was not attached.");
+                        showErrorDialog(getString(R.string.login_error_generic_start));
                     }
                 }
             }
@@ -269,6 +272,14 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener>
 
     private void showEmailError(int messageId) {
         mEmailInput.setError(getString(messageId));
+    }
+
+    private void showErrorDialog(String message) {
+        AlertDialog dialog = new AlertDialog.Builder(new ContextThemeWrapper(getActivity(), R.style.LoginTheme))
+                .setMessage(message)
+                .setPositiveButton(R.string.login_error_button, null)
+                .create();
+        dialog.show();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
@@ -101,7 +101,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener>
                 AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_SOCIAL_BUTTON_CLICK);
                 ActivityUtils.hideKeyboardForced(getActivity().getCurrentFocus());
 
-                if (NetworkUtils.checkConnection(getActivity())) {
+                if (NetworkUtils.checkConnection(getActivity()) && isAdded()) {
                     mOldSitesIDs = SiteUtils.getCurrentSiteIds(mSiteStore, false);
                     isSocialLogin = true;
                     addGoogleFragment();

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginEmailFragment.java
@@ -101,10 +101,14 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener>
                 AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_SOCIAL_BUTTON_CLICK);
                 ActivityUtils.hideKeyboardForced(getActivity().getCurrentFocus());
 
-                if (NetworkUtils.checkConnection(getActivity()) && isAdded()) {
-                    mOldSitesIDs = SiteUtils.getCurrentSiteIds(mSiteStore, false);
-                    isSocialLogin = true;
-                    addGoogleFragment();
+                if (NetworkUtils.checkConnection(getActivity())) {
+                    if (isAdded()) {
+                        mOldSitesIDs = SiteUtils.getCurrentSiteIds(mSiteStore, false);
+                        isSocialLogin = true;
+                        addGoogleFragment();
+                    } else {
+                        AppLog.e(T.NUX, "Google login could not be started.  LoginEmailFragment was not attached.");
+                    }
                 }
             }
         });

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2008,6 +2008,7 @@
     <string name="login_error_button">Close</string>
     <string name="login_error_email_not_found">The Google account \'%s\' doesn\'t match any existing account on WordPress.com.</string>
     <string name="login_error_generic">There was some trouble connecting with the Google account.</string>
+    <string name="login_error_generic_start">Google login could not be started.</string>
     <string name="login_error_suffix">\nMaybe try a different account?</string>
 
     <string name="notification_login_title_success">Logged in!</string>


### PR DESCRIPTION
### Fix
Add a guard to add the `LoginGoogleFragment` only if the calling `LoginEmailFragment` is attached to avoid the `IllegalStateException` as described in https://github.com/wordpress-mobile/WordPress-Android/issues/6961.