### PR TITLE
Don't rely on Aztec history to check for content change 

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1798,9 +1798,6 @@ public class EditPostActivity extends AppCompatActivity implements
             contentChanged = true;
         } else if (compareCurrentMediaMarkedUploadingToOriginal(content)) {
             contentChanged = true;
-        } else if (mEditorFragment instanceof AztecEditorFragment
-                && ((AztecEditorFragment) mEditorFragment).isHistoryEnabled()) {
-            contentChanged = ((AztecEditorFragment) mEditorFragment).hasHistory();
         } else {
             contentChanged = mPost.getContent().compareTo(content) != 0;
         }


### PR DESCRIPTION
This patch fixes #6843 and fixes #6946.

Some external events don't change Aztec history so we can't rely on it to check if the post has been modified. 

We should also add new items to Aztec history when these external events happen, but I think this should be done when we drop the old editors.

