### PR TITLE
Issue/6975 crash login activity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPLoginInputRow.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPLoginInputRow.java
@@ -80,6 +80,14 @@ public class WPLoginInputRow extends RelativeLayout {
                     mIcon.setVisibility(View.GONE);
                 }
 
+                if (a.hasValue(R.styleable.wpLoginInputRow_android_inputType)) {
+                    mEditText.setInputType(a.getInteger(R.styleable.wpLoginInputRow_android_inputType, 0));
+                }
+
+                if (a.hasValue(R.styleable.wpLoginInputRow_android_imeOptions)) {
+                    mEditText.setImeOptions(a.getInteger(R.styleable.wpLoginInputRow_android_imeOptions, 0));
+                }
+
                 if (a.hasValue(R.styleable.wpLoginInputRow_android_hint)) {
                     mTextInputLayout.setHint(a.getString(R.styleable.wpLoginInputRow_android_hint));
                 }
@@ -93,14 +101,6 @@ public class WPLoginInputRow extends RelativeLayout {
                 if (a.hasValue(R.styleable.wpLoginInputRow_passwordToggleTint)) {
                     mTextInputLayout.setPasswordVisibilityToggleTintList(
                             a.getColorStateList(R.styleable.wpLoginInputRow_passwordToggleTint));
-                }
-
-                if (a.hasValue(R.styleable.wpLoginInputRow_android_inputType)) {
-                    mEditText.setInputType(a.getInteger(R.styleable.wpLoginInputRow_android_inputType, 0));
-                }
-
-                if (a.hasValue(R.styleable.wpLoginInputRow_android_imeOptions)) {
-                    mEditText.setImeOptions(a.getInteger(R.styleable.wpLoginInputRow_android_imeOptions, 0));
                 }
             } finally {
                 a.recycle();


### PR DESCRIPTION
### Fix
Move the attribute assignments for `EditText` before `TextInputLayout` in `WPLoginInputRow` to avoid the `NullPionterException` as described in https://github.com/wordpress-mobile/WordPress-Android/issues/6975.  The `EditText` view in a `TextInputLayout` view must have the `android:inputType` attribute for password fields set prior to the [`TextInputLayout.setPasswordVisibilityToggleEnabled` call](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/widgets/WPLoginInputRow.java#L88-L89) in order for the [`TextInputLayout.updatePasswordToggleView` method](https://android.googlesource.com/platform/frameworks/support.git/+/master/design/src/android/support/design/widget/TextInputLayout.java#1288) to [initialize `mPasswordToggleView`](https://android.googlesource.com/platform/frameworks/support.git/+/master/design/src/android/support/design/widget/TextInputLayout.java#1103).

Since this behavior occurs everywhere the `WPLoginInputRow` view is used *as a password field*, both the ***Email/Password*** and ***Username/Password*** login screens are affected.

### Test
***Email/Password***

0. Clear app data.
1. Tap ***Log In*** button.
2. Enter WordPress.com email address into ***Email address** field.
3. Tap ***Next*** button.
4. Tap ***Enter your password instead*** button.
5. Tap visibility toggle button in ***Password*** field.
6. Rotate device.

***Username/Password***

0. Clear app data.
1. Tap ***Log In*** button.
2. Tap ***Log in to your site by entering your site address instead.*** button.
3. Enter self-hosted site address into ***Site address*** field.
4. Tap ***Next*** button.
5. Tap visibility toggle button in ***Password*** field.
6. Rotate device.

#### Note
This may fix https://github.com/wordpress-mobile/WordPress-Android/issues/6963 as well since it has a similar stack trace, but I'm unable to reproduce that crash so I'm not sure.