### PR TITLE
Remove active plugin section for jetpack

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -252,7 +252,9 @@ public class PluginDetailActivity extends AppCompatActivity {
         // Handle specific cases for Jetpack, Akismet and VaultPress
         boolean canPluginBeDisabledOrRemoved = canPluginBeDisabledOrRemoved();
         removeBtn.setVisibility(canPluginBeDisabledOrRemoved ? View.VISIBLE : View.GONE);
-        mSwitchActive.setClickable(canPluginBeDisabledOrRemoved);
+        if (!canPluginBeDisabledOrRemoved) {
+            findViewById(R.id.plugin_state_active_container).setVisibility(View.GONE);
+        }
 
         refreshViews();
     }

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -71,7 +71,9 @@
 
             <LinearLayout style="@style/PluginCardViewVerticalContainer">
 
-                <RelativeLayout style="@style/PluginCardViewHorizontalContainer">
+                <RelativeLayout
+                    android:id="@+id/plugin_state_active_container"
+                    style="@style/PluginCardViewHorizontalContainer">
 
                     <TextView
                         style="@style/PluginCardViewPrimaryText"


### PR DESCRIPTION
This PR fixes the issue discussed [here](https://github.com/wordpress-mobile/WordPress-Android/pull/6973#commitcomment-26200524) by using the proposal by @mattmiklic [here](https://github.com/wordpress-mobile/WordPress-Android/issues/6981#issuecomment-351529400).

/cc @nbradbury 

![screenshot_1513201125](https://user-images.githubusercontent.com/662023/33963889-a0989dae-e024-11e7-826f-04c659ea2bc5.png)

