### PR TITLE
Fix NPE with VideoPress embedded from another site

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2612,6 +2612,12 @@ public class EditPostActivity extends AppCompatActivity implements
         String videoUrl = mMediaStore.
                 getUrlForSiteVideoWithVideoPressGuid(mSite, videoId);
 
+        if (videoUrl == null) {
+            AppLog.w(T.EDITOR, "The editor wants more info about the following VideoPress code: " + videoId
+                    + " but it's not available in the current site " + mSite.getUrl() + " Maybe it's from another site?" );
+            return;
+        }
+
         if (videoUrl.isEmpty()) {
             if (PermissionUtils.checkAndRequestCameraAndStoragePermissions(this, WPPermissionUtils.EDITOR_MEDIA_PERMISSION_REQUEST_CODE)) {
                 runOnUiThread(new Runnable() {


### PR DESCRIPTION
This PR fixes an issue where embedding a VideoPress file from another site will crash the app. 

It's a rare case, but worth to fix it.


To test it, just create a new post and embed the following code:
- `[wpvideo OcobLTqC]`. 
- Save it as draft or publish.
- Re-open the post from post lists. 
- The app should not crash.
