### PR TITLE
Fix #6986: prevent a crash when a wpcom user sign in via username/password

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginUsernamePasswordFragment.java
@@ -339,7 +339,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         });
     }
 
-    private @Nullable SiteModel detectNewlyAddedSite() {
+    private @Nullable SiteModel detectNewlyAddedXMLRPCSite() {
         List<SiteModel> selfhostedSites = mSiteStore.getSitesAccessedViaXMLRPC();
         for (SiteModel site : selfhostedSites) {
             if (!mOldSitesIDs.contains(site.getId())) {
@@ -429,6 +429,23 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         mLoginListener.loggedInViaPassword(mOldSitesIDs);
     }
 
+    private void finishLogin() {
+        AnalyticsUtils.trackAnalyticsSignIn(mAccountStore, mSiteStore, mIsWpcom);
+
+        startPostLoginServices();
+
+        // mark as finished so any subsequent onSiteChanged (e.g. triggered by WPMainActivity) won't be intercepted
+        mLoginFinished = true;
+
+        if (mLoginListener != null) {
+            if (mIsWpcom) {
+                saveCredentialsInSmartLock(mLoginListener.getSmartLockHelper(), mRequestedUsername, mRequestedPassword);
+            }
+
+            mLoginListener.loggedInViaUsernamePassword(mOldSitesIDs);
+        }
+    }
+
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteChanged(SiteStore.OnSiteChanged event) {
@@ -470,8 +487,13 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
             return;
         }
 
-        SiteModel newlyAddedSite = detectNewlyAddedSite();
-        mDispatcher.dispatch(SiteActionBuilder.newFetchProfileXmlRpcAction(newlyAddedSite));
+        SiteModel newlyAddedXMLRPCSite = detectNewlyAddedXMLRPCSite();
+        // newlyAddedSite will be null if the user sign in with wpcom credentials
+        if (newlyAddedXMLRPCSite != null && !newlyAddedXMLRPCSite.isUsingWpComRestApi()) {
+            mDispatcher.dispatch(SiteActionBuilder.newFetchProfileXmlRpcAction(newlyAddedXMLRPCSite));
+        } else {
+            finishLogin();
+        }
     }
 
     @SuppressWarnings("unused")
@@ -495,20 +517,6 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
             // continue with success, even if the operation was cancelled since the user got logged in regardless. So, go on
             //  with finishing the login process
         }
-
-        AnalyticsUtils.trackAnalyticsSignIn(mAccountStore, mSiteStore, mIsWpcom);
-
-        startPostLoginServices();
-
-        // mark as finished so any subsequent onSiteChanged (e.g. triggered by WPMainActivity) won't be intercepted
-        mLoginFinished = true;
-
-        if (mLoginListener != null) {
-            if (mIsWpcom) {
-                saveCredentialsInSmartLock(mLoginListener.getSmartLockHelper(), mRequestedUsername, mRequestedPassword);
-            }
-
-            mLoginListener.loggedInViaUsernamePassword(mOldSitesIDs);
-        }
+        finishLogin();
     }
 }


### PR DESCRIPTION
Fix #6986: prevent a crash when a wpcom user sign in via username/password.

We should target `release/9.1` if this PR is not merged before 9.1 freeze.

Note: would be great to add a failsafe in FluxC as well.

cc @theck13 