### PR TITLE
Theme activation issues

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -137,7 +137,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.11'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:b44adaf240a73acc630e9a201b63038c6a53b9f1') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:f9650f35ad65d36aae3e7d45b6c64801b5ad6085') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -137,7 +137,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.11'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:304a7f68117ea030a50ef9b9c8a17a111b78110c') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:b44adaf240a73acc630e9a201b63038c6a53b9f1') {
         exclude group: "com.android.volley";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/Login2FaFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/Login2FaFragment.java
@@ -415,7 +415,7 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
         AppLog.i(T.NUX, "onAuthenticationChanged: " + event.toString());
 
         if (isSocialLoginConnect) {
-            AccountStore.PushSocialLoginPayload payload = new AccountStore.PushSocialLoginPayload(mIdToken, mService);
+            AccountStore.PushSocialPayload payload = new AccountStore.PushSocialPayload(mIdToken, mService);
             mDispatcher.dispatch(AccountActionBuilder.newPushSocialConnectAction(payload));
         } else {
             doFinishLogin();

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginGoogleFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginGoogleFragment.java
@@ -31,7 +31,7 @@ import org.wordpress.android.fluxc.generated.AccountActionBuilder;
 import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.OnAuthenticationChanged;
 import org.wordpress.android.fluxc.store.AccountStore.OnSocialChanged;
-import org.wordpress.android.fluxc.store.AccountStore.PushSocialLoginPayload;
+import org.wordpress.android.fluxc.store.AccountStore.PushSocialPayload;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 
@@ -234,7 +234,7 @@ public class LoginGoogleFragment extends Fragment implements ConnectionCallbacks
                             mGoogleEmail = account.getEmail();
                             mGoogleLoginListener.onGoogleEmailSelected(mGoogleEmail);
                             mIdToken = account.getIdToken();
-                            PushSocialLoginPayload payload = new PushSocialLoginPayload(mIdToken, SERVICE_TYPE_GOOGLE);
+                            PushSocialPayload payload = new PushSocialPayload(mIdToken, SERVICE_TYPE_GOOGLE);
                             mDispatcher.dispatch(AccountActionBuilder.newPushSocialLoginAction(payload));
                         } catch (NullPointerException exception) {
                             disconnectGoogleClient();

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginWpcomService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginWpcomService.java
@@ -306,7 +306,7 @@ public class LoginWpcomService extends AutoForeground<OnLoginStateUpdated> {
 
         if (isSocialLogin) {
             setState(LoginPhase.SOCIAL_LOGIN);
-            AccountStore.PushSocialLoginPayload payload = new AccountStore.PushSocialLoginPayload(mIdToken, mService);
+            AccountStore.PushSocialPayload payload = new AccountStore.PushSocialPayload(mIdToken, mService);
             mDispatcher.dispatch(AccountActionBuilder.newPushSocialConnectAction(payload));
         } else {
             signalCredentialsOK();

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -346,7 +346,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
             return;
         }
 
-        ThemeModel theme = mThemeStore.getInstalledThemeByThemeId(themeId);
+        ThemeModel theme = mThemeStore.getInstalledThemeByThemeId(mSite, themeId);
         if (theme == null) {
             theme = mThemeStore.getWpComThemeByThemeId(themeId);
             if (theme == null) {


### PR DESCRIPTION
Fixes #6988 & #6976. This PR fixes the theme activation issues through the changes in FluxC https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/649.

In order to update the FluxC hash, I had to cherry pick #6972. /cc @mzorz @maxme 

To test:
* Both of the issues have steps to reproduce the issue. Please make sure you can reliably reproduce the issues first in `release/9.0` before switching to this branch to check out fixes
* I'd suggest doing subsequent testes on one install as well as uninstalling the app before each run to make sure we covered every case (first ensures continuity, second ensures previous changes to the Theme table changes don't affect it)
* Don't search for the themes as it looks like they are pretty broken right now #6995. This is most likely due to the changes in FluxC, but we still have to make those changes.

/cc @kwonye for review. The FluxC PR needs to be merged first, I am opening this PR right now to provide a way to test the FluxC changes.