### PR TITLE
issue/6955-media-picker-videos-in-galleries

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2222,13 +2222,24 @@ public class EditPostActivity extends AppCompatActivity implements
             return;
         }
 
-        // if only one item was chosen insert it as a media object, otherwise show the insert
-        // media dialog so the user can choose how to insert the items
-        if (ids.size() == 1) {
-            long mediaId = ids.get(0);
-            addExistingMediaToEditorAndSave(mediaId);
-        } else {
+        boolean allAreImages = true;
+        for (Long id: ids) {
+            MediaModel media = mMediaStore.getSiteMediaWithId(mSite, id);
+            if (media != null && !MediaUtils.isValidImage(media.getUrl())) {
+                allAreImages = false;
+                break;
+            }
+        }
+
+        // if the user selected multiple items and they're all images, show the insert media
+        // dialog so the user can choose whether to insert them individually or as a gallery
+        if (ids.size() > 1 && allAreImages) {
             showInsertMediaDialog(ids);
+        } else {
+            for (Long id: ids) {
+                addExistingMediaToEditor(id);
+            }
+            savePostAsync(null);
         }
     }
 


### PR DESCRIPTION
Fixes #6955 - previously when the user choose to insert multiple items from the WP media library into a post, the app would always ask whether to insert them as a gallery even when one or more of the items wasn't an image. This PR corrects this by only asking to insert as a gallery if all selected items are images.