### PR TITLE
Fix crash while social login. Cover the missing case.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginWpcomService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginWpcomService.java
@@ -154,6 +154,7 @@ public class LoginWpcomService extends AutoForeground<OnLoginStateUpdated> {
     public Notification getNotification() {
         switch (mLoginPhase) {
             case AUTHENTICATING:
+            case SOCIAL_LOGIN:
             case FETCHING_ACCOUNT:
             case FETCHING_SETTINGS:
             case FETCHING_SITES:


### PR DESCRIPTION
Fixes #7005 

To test:
* Try to log in with Google with an account that is not already connected to WPCOM
* The app will ask for your WPCOM password. Type it in and right after hitting "NEXT" hit Home to background the app.
* App should continue to log in, putting out the notification while logging in as normal. No crash should happen.