### PR TITLE
Notification for the rest of the failure cases

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginWpcomService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginWpcomService.java
@@ -167,6 +167,8 @@ public class LoginWpcomService extends AutoForeground<OnLoginStateUpdated> {
                 return LoginNotification.failure(this, R.string.notification_2fa_needed);
             case FAILURE_SOCIAL_2FA:
                 return LoginNotification.failure(this, R.string.notification_2fa_needed);
+            case FAILURE_FETCHING_ACCOUNT:
+            case FAILURE_CANNOT_ADD_DUPLICATE_SITE:
             case FAILURE:
                 return LoginNotification.failure(this, R.string.notification_login_failed);
         }


### PR DESCRIPTION
Fixes #7008 

Adds the two failure cases that where missing from the switch in `LoginWpcomService.getNotification()`.

To test:
No steps available.