### PR TITLE
Enable Aztec for all users when they upgrade to the latest version

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -21,7 +21,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 public class WordPressDB {
-    private static final int DATABASE_VERSION = 60;
+    private static final int DATABASE_VERSION = 61;
 
     // Warning if you rename DATABASE_NAME, that could break previous App backups (see: xml/backup_scheme.xml)
     private static final String DATABASE_NAME = "wordpress";
@@ -199,6 +199,10 @@ public class WordPressDB {
             case 59:
                 // add Start of Week site setting as part of #betterjetpackxp
                 db.execSQL(SiteSettingsModel.ADD_START_OF_WEEK);
+                currentVersion++;
+            case 60:
+                AppPrefs.setVisualEditorEnabled(false);
+                AppPrefs.setAztecEditorEnabled(true);
                 currentVersion++;
         }
         db.setVersion(DATABASE_VERSION);


### PR DESCRIPTION
Fixes #6958: Enable Aztec for all users when they upgrade to the latest version.

Better to wait for https://github.com/wordpress-mobile/WordPress-Android/pull/7019 before merging this one.