### PR TITLE
Aztec - Switch the `Title` field EditText

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -22,10 +22,10 @@ import android.support.annotation.NonNull;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
-import android.text.InputFilter;
-import android.text.SpannableStringBuilder;
+import android.text.Editable;
 import android.text.Spanned;
 import android.text.TextUtils;
+import android.text.TextWatcher;
 import android.view.DragEvent;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -203,9 +203,26 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         content.setOnImeBackListener(this);
         source.setOnImeBackListener(this);
 
-        // We need to intercept the "Enter" key on the title field, and replace it with a space instead
-        title.setFilters(new InputFilter[]{replaceEnterKeyWithSpaceInputFilter});
+        title.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
 
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                for (int i = s.length(); i > 0; i--) {
+                    if (s.subSequence(i - 1, i).toString().equals("\n")) {
+                        s.replace(i - 1, i, " ");
+                    }
+                }
+            }
+        });
+
+        // We need to intercept the "Enter" key on the title field, and replace it with a space instead
         source.setHint("<p>" + getString(R.string.editor_content_hint) + "</p>");
 
         formattingToolbar = (AztecToolbar) view.findViewById(R.id.formatting_toolbar);
@@ -282,35 +299,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     public void setAztecVideoLoader(Html.VideoThumbnailGetter videoLoader) {
         this.aztecVideoLoader = videoLoader;
     }
-
-    private InputFilter replaceEnterKeyWithSpaceInputFilter = new InputFilter() {
-        @Override
-        public CharSequence filter(CharSequence source, int start, int end,
-                                   Spanned dest, int dstart, int dend) {
-            //  You sometimes get a SpannableStringBuilder, sometimes a plain String in the source parameter
-            if (source instanceof SpannableStringBuilder) {
-                SpannableStringBuilder sourceAsSpannableBuilder = (SpannableStringBuilder) source;
-                for (int i = end - 1; i >= start; i--) {
-                    char currentChar = source.charAt(i);
-                    if (currentChar == '\n') {
-                        sourceAsSpannableBuilder.replace(i, i + 1, " ");
-                    }
-                }
-                return source;
-            } else {
-                StringBuilder filteredStringBuilder = new StringBuilder();
-                for (int i = start; i < end; i++) {
-                    char currentChar = source.charAt(i);
-                    if (currentChar == '\n') {
-                        filteredStringBuilder.append(" ");
-                    } else {
-                        filteredStringBuilder.append(currentChar);
-                    }
-                }
-                return filteredStringBuilder.toString();
-            }
-        }
-    };
 
     @Override
     public void onPause() {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -129,7 +129,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     private boolean mEditorWasPaused = false;
     private boolean mHideActionBarOnSoftKeyboardUp = false;
 
-    private AztecText title;
+    private org.wordpress.android.editor.SourceViewEditText title;
     private AztecText content;
     private boolean mAztecReady;
     private SourceViewEditText source;
@@ -184,7 +184,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             ((EditorFragmentActivity) getActivity()).initializeEditorFragment();
         }
 
-        title = (AztecText) view.findViewById(R.id.title);
+        title = (org.wordpress.android.editor.SourceViewEditText) view.findViewById(R.id.title);
         content = (AztecText) view.findViewById(R.id.aztec);
         source = (SourceViewEditText) view.findViewById(R.id.source);
 
@@ -192,7 +192,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         content.setOnTouchListener(this);
         source.setOnTouchListener(this);
 
-        title.setOnImeBackListener(this);
+        title.setOnImeBackListener(new org.wordpress.android.editor.OnImeBackListener() {
+            public void onImeBack() {
+                showActionBarIfNeeded();
+            }
+        });
         content.setOnImeBackListener(this);
         source.setOnImeBackListener(this);
 

--- a/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
+++ b/libs/editor/WordPressEditor/src/main/res/layout/fragment_aztec_editor.xml
@@ -30,10 +30,11 @@
                 android:layout_height="wrap_content"
                 android:layout_width="match_parent" >
 
-                <org.wordpress.aztec.AztecText
+                <org.wordpress.android.editor.SourceViewEditText
                     android:id="@+id/title"
                     android:hint="@string/post_title"
-                    android:inputType="textCapSentences|textMultiLine"
+                    android:inputType="textCapSentences|textAutoCorrect|textMultiLine"
+                    android:background="@null"
                     android:layout_height="wrap_content"
                     android:layout_toLeftOf="@+id/title_beta"
                     android:layout_toStartOf="@+id/title_beta"
@@ -43,10 +44,10 @@
                     android:textStyle="bold"
                     android:textSize="@dimen/aztec_title_size"
                     android:imeOptions="flagNoExtractUi"
-                    aztec:lineSpacingExtra="@dimen/spacing_extra_title"
-                    aztec:textColor="@color/grey_dark"
-                    aztec:textColorHint="@color/hint_text">
-                </org.wordpress.aztec.AztecText>
+                    android:lineSpacingExtra="@dimen/spacing_extra_title"
+                    android:textColor="@color/grey_dark"
+                    android:textColorHint="@color/hint_text">
+                </org.wordpress.android.editor.SourceViewEditText>
 
                 <ImageButton
                     android:id="@+id/title_beta"


### PR DESCRIPTION
The `title` field in AztecEditorFragment is a `AztecText` object. Since there is no formatting, no advanced features on the title we can switch back to EditText.


Don't think this will fix https://github.com/wordpress-mobile/AztecEditor-Android/issues/580, but didn't try.