### PR TITLE
VideoPress: wp-data-id attribute and temporal id for media handling

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1006,8 +1006,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 if (mediaType.equals(MediaType.VIDEO)) {
                     overlayVideoIcon(0, predicate);
                 }
-                content.updateElementAttributes(predicate, attrs);
                 content.resetAttributedMediaSpan(predicate);
+                // finally remove the local id as it won't be necessary anynmore
+                attrs.removeAttribute(ATTR_ID_WP);
+                attrs.removeAttribute(TEMP_IMAGE_ID);
+                content.updateElementAttributes(predicate, attrs);
 
                 mUploadingMediaProgressMax.remove(localMediaId);
             }
@@ -1406,8 +1409,12 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         onMediaTapped(attrs, 0, 0, MediaType.VIDEO);
     }
 
+    private void setIdAttributeOnMedia(AztecAttributes attrs, String idName, String localMediaId) {
+        attrs.setValue(idName, localMediaId);
+        mTappedMediaPredicate = new MediaPredicate(localMediaId, idName);
+    }
 
-    private void onMediaTapped(@NonNull AztecAttributes attrs, int naturalWidth, int naturalHeight, final MediaType mediaType) {
+    private void onMediaTapped(@NonNull final AztecAttributes attrs, int naturalWidth, int naturalHeight, final MediaType mediaType) {
         if (mediaType == null || !isAdded()) {
             return;
         }
@@ -1435,11 +1442,11 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             localMediaId = attrs.getValue(idName);
         }
 
-        attrs.setValue(idName, localMediaId);
-        mTappedMediaPredicate = new MediaPredicate(localMediaId, idName);
 
         switch (uploadStatus) {
             case ATTR_STATUS_UPLOADING:
+                setIdAttributeOnMedia(attrs, idName, localMediaId);
+
                 // Display 'cancel upload' dialog
                 AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
                 builder.setTitle(getString(R.string.stop_upload_dialog_title));
@@ -1475,6 +1482,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 dialog.show();
                 break;
             case ATTR_STATUS_FAILED:
+                setIdAttributeOnMedia(attrs, idName, localMediaId);
+
                 // Retry media upload
                 boolean successfullyRetried = true;
                 if (mFailedMediaIds.contains(localMediaId)) {


### PR DESCRIPTION

Fixes the comment made here https://github.com/wordpress-mobile/WordPress-Android/pull/7010#issue-283561657, and https://github.com/wordpress-mobile/WordPress-Android/pull/7010#pullrequestreview-85170304 specifically takes care that `wp-data-id` and `data-temp-aztec-id` are only set for tapped failed or uploading media items, so we don't leave the media reference "dirty" in the Post content.

To test:
CASE A: successful:
1. start a new draft and upload some video.
2. wait until media is finished uploading
3. tap on it to play it 
4. come back to the editor
5. switch to HTML mode
6. observe there is no `wp-data-id` or `data-temp-aztec-id` class in the code

CASE B: unsuccessful:
1. start a new draft and upload some video.
2. while media is uploading, turn airplane mode on to make it fail. Then turn airplane mode OFF again.
3. tap on it, it will retry
4. wait until media is finished uploading
5. tap on it to play it 
6. come back to the editor
7. switch to HTML mode
8. observe there is no `wp-data-id` or `data-temp-aztec-id` class in the code

