### PR TITLE
Wrapping unregisterReceiver in a try/catch block

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -754,7 +754,12 @@ public class WordPress extends MultiDexApplication {
             // the receiver twice.
             if (mConnectionReceiverRegistered) {
                 mConnectionReceiverRegistered = false;
-                unregisterReceiver(ConnectionChangeReceiver.getInstance());
+                try {
+                    unregisterReceiver(ConnectionChangeReceiver.getInstance());
+                    AppLog.d(T.MAIN, "ConnectionChangeReceiver successfully unregistered");
+                } catch (IllegalArgumentException e) {
+                    AppLog.e(T.MAIN, "ConnectionChangeReceiver was already unregistered");
+                }
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -759,6 +759,7 @@ public class WordPress extends MultiDexApplication {
                     AppLog.d(T.MAIN, "ConnectionChangeReceiver successfully unregistered");
                 } catch (IllegalArgumentException e) {
                     AppLog.e(T.MAIN, "ConnectionChangeReceiver was already unregistered");
+                    Crashlytics.logException(e);
                 }
             }
         }


### PR DESCRIPTION

Fixes #6667

This issue appeared more times with our latest build, so adding this patch to avoid more crashes from happening until we find a better solution.

Found some more info here https://stackoverflow.com/questions/6165070/receiver-not-registered-exception-error/24986171#24986171
and  [here ](https://github.com/androidannotations/androidannotations/issues/1843#issuecomment-264645873)

To test: N/A

