### PR TITLE
Issue/6652 site settings amp

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPressDB.java
@@ -21,7 +21,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 public class WordPressDB {
-    private static final int DATABASE_VERSION = 62;
+    private static final int DATABASE_VERSION = 63;
 
     // Warning if you rename DATABASE_NAME, that could break previous App backups (see: xml/backup_scheme.xml)
     private static final String DATABASE_NAME = "wordpress";
@@ -209,6 +209,11 @@ public class WordPressDB {
                 // add timezone and posts per page site setting as part of #betterjetpackxp
                 db.execSQL(SiteSettingsModel.ADD_TIMEZONE);
                 db.execSQL(SiteSettingsModel.ADD_POSTS_PER_PAGE);
+                currentVersion++;
+            case 62:
+                // add AMP site setting as part of #betterjetpackxp
+                db.execSQL(SiteSettingsModel.ADD_AMP_SUPPORTED);
+                db.execSQL(SiteSettingsModel.ADD_AMP_ENABLED);
                 currentVersion++;
         }
         db.setVersion(DATABASE_VERSION);

--- a/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
@@ -89,10 +89,10 @@ public class SiteSettingsModel {
             " add " + TIMEZONE_COLUMN_NAME + " TEXT;";
     public static final String ADD_POSTS_PER_PAGE = "alter table " + SETTINGS_TABLE_NAME +
             " add " + POSTS_PER_PAGE_COLUMN_NAME + " INTEGER;";
-    public static final String ADD_AMP_SUPPORTED = "alter table " + SETTINGS_TABLE_NAME +
-            " add " + AMP_ENABLED_COLUMN_NAME + " BOOLEAN;";
     public static final String ADD_AMP_ENABLED = "alter table " + SETTINGS_TABLE_NAME +
             " add " + AMP_ENABLED_COLUMN_NAME + " BOOLEAN;";
+    public static final String ADD_AMP_SUPPORTED = "alter table " + SETTINGS_TABLE_NAME +
+            " add " + AMP_SUPPORTED_COLUMN_NAME + " BOOLEAN;";
 
     public static final String CREATE_SETTINGS_TABLE_SQL =
             "CREATE TABLE IF NOT EXISTS " +

--- a/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/SiteSettingsModel.java
@@ -62,6 +62,8 @@ public class SiteSettingsModel {
     private static final String TIME_FORMAT_COLUMN_NAME = "timeFormat";
     private static final String TIMEZONE_COLUMN_NAME = "siteTimezone";
     private static final String POSTS_PER_PAGE_COLUMN_NAME = "postsPerPage";
+    private static final String AMP_SUPPORTED_COLUMN_NAME = "ampSupported";
+    private static final String AMP_ENABLED_COLUMN_NAME = "ampEnabled";
 
     public static final String SETTINGS_TABLE_NAME = "site_settings";
 
@@ -87,6 +89,10 @@ public class SiteSettingsModel {
             " add " + TIMEZONE_COLUMN_NAME + " TEXT;";
     public static final String ADD_POSTS_PER_PAGE = "alter table " + SETTINGS_TABLE_NAME +
             " add " + POSTS_PER_PAGE_COLUMN_NAME + " INTEGER;";
+    public static final String ADD_AMP_SUPPORTED = "alter table " + SETTINGS_TABLE_NAME +
+            " add " + AMP_ENABLED_COLUMN_NAME + " BOOLEAN;";
+    public static final String ADD_AMP_ENABLED = "alter table " + SETTINGS_TABLE_NAME +
+            " add " + AMP_ENABLED_COLUMN_NAME + " BOOLEAN;";
 
     public static final String CREATE_SETTINGS_TABLE_SQL =
             "CREATE TABLE IF NOT EXISTS " +
@@ -172,6 +178,8 @@ public class SiteSettingsModel {
     public String timeFormat;
     public String timezone;
     public int postsPerPage;
+    public boolean ampSupported;
+    public boolean ampEnabled;
 
     @Override
     public boolean equals(Object other) {
@@ -208,6 +216,8 @@ public class SiteSettingsModel {
                 commentsRequireUserAccount == otherModel.commentsRequireUserAccount &&
                 commentAutoApprovalKnownUsers == otherModel.commentAutoApprovalKnownUsers &&
                 postsPerPage == otherModel.postsPerPage &&
+                ampEnabled == otherModel.ampEnabled &&
+                ampSupported == otherModel.ampSupported &&
                 maxLinks == otherModel.maxLinks &&
                 equals(defaultPostFormat, otherModel.defaultPostFormat) &&
                 holdForModeration != null
@@ -266,6 +276,8 @@ public class SiteSettingsModel {
         timeFormat = other.timeFormat;
         timezone = other.timezone;
         postsPerPage = other.postsPerPage;
+        ampSupported = other.ampSupported;
+        ampEnabled = other.ampEnabled;
         if (other.holdForModeration != null) {
             holdForModeration = new ArrayList<>(other.holdForModeration);
         }
@@ -323,6 +335,8 @@ public class SiteSettingsModel {
         timeFormat = getStringFromCursor(cursor, TIME_FORMAT_COLUMN_NAME);
         timezone = getStringFromCursor(cursor, TIMEZONE_COLUMN_NAME);
         postsPerPage = getIntFromCursor(cursor, POSTS_PER_PAGE_COLUMN_NAME);
+        ampSupported = getBooleanFromCursor(cursor, AMP_SUPPORTED_COLUMN_NAME);
+        ampEnabled = getBooleanFromCursor(cursor, AMP_ENABLED_COLUMN_NAME);
 
         String moderationKeys = getStringFromCursor(cursor, MODERATION_KEYS_COLUMN_NAME);
         String blacklistKeys = getStringFromCursor(cursor, BLACKLIST_KEYS_COLUMN_NAME);
@@ -410,6 +424,8 @@ public class SiteSettingsModel {
         values.put(TIME_FORMAT_COLUMN_NAME, timeFormat);
         values.put(TIMEZONE_COLUMN_NAME, timezone);
         values.put(POSTS_PER_PAGE_COLUMN_NAME, postsPerPage);
+        values.put(AMP_SUPPORTED_COLUMN_NAME, ampSupported);
+        values.put(AMP_ENABLED_COLUMN_NAME, ampEnabled);
         
         String moderationKeys = "";
         if (holdForModeration != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -68,6 +68,8 @@ class DotComSiteSettings extends SiteSettingsInterface {
     private static final String TIME_FORMAT_KEY = "time_format";
     private static final String TIMEZONE_KEY = "timezone_string";
     private static final String POSTS_PER_PAGE_KEY = "posts_per_page";
+    private static final String AMP_SUPPORTED_KEY = "amp_supported";
+    private static final String AMP_ENABLED_KEY = "amp_enabled";
 
     // WP.com REST keys used to GET certain site settings
     private static final String GET_TITLE_KEY = "name";
@@ -454,6 +456,8 @@ class DotComSiteSettings extends SiteSettingsInterface {
         mRemoteSettings.timeFormat = settingsObject.optString(TIME_FORMAT_KEY, "");
         mRemoteSettings.timezone = settingsObject.optString(TIMEZONE_KEY, "");
         mRemoteSettings.postsPerPage = settingsObject.optInt(POSTS_PER_PAGE_KEY, 0);
+        mRemoteSettings.ampSupported = settingsObject.optBoolean(AMP_SUPPORTED_KEY, false);
+        mRemoteSettings.ampEnabled = settingsObject.optBoolean(AMP_ENABLED_KEY, false);
 
         boolean reblogsDisabled = settingsObject.optBoolean(SHARING_REBLOGS_DISABLED_KEY, false);
         boolean likesDisabled = settingsObject.optBoolean(SHARING_LIKES_DISABLED_KEY, false);
@@ -631,6 +635,12 @@ class DotComSiteSettings extends SiteSettingsInterface {
         }
         if (mSettings.postsPerPage != mRemoteSettings.postsPerPage) {
             params.put(POSTS_PER_PAGE_KEY, String.valueOf(mSettings.postsPerPage));
+        }
+        if (mSettings.ampSupported != mRemoteSettings.ampSupported) {
+            params.put(AMP_SUPPORTED_KEY, String.valueOf(mSettings.ampSupported));
+        }
+        if (mSettings.ampEnabled != mRemoteSettings.ampEnabled) {
+            params.put(AMP_ENABLED_KEY, String.valueOf(mSettings.ampEnabled));
         }
 
         return params;

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -68,8 +68,8 @@ class DotComSiteSettings extends SiteSettingsInterface {
     private static final String TIME_FORMAT_KEY = "time_format";
     private static final String TIMEZONE_KEY = "timezone_string";
     private static final String POSTS_PER_PAGE_KEY = "posts_per_page";
-    private static final String AMP_SUPPORTED_KEY = "amp_supported";
-    private static final String AMP_ENABLED_KEY = "amp_enabled";
+    private static final String AMP_SUPPORTED_KEY = "amp_is_supported";
+    private static final String AMP_ENABLED_KEY = "amp_is_enabled";
 
     // WP.com REST keys used to GET certain site settings
     private static final String GET_TITLE_KEY = "name";

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -1170,7 +1170,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (mSiteSettings.getAmpSupported()) {
             mAmpPref.setChecked(mSiteSettings.getAmpEnabled());
         } else {
-            WPPrefUtils.removePreference(this, R.string.pref_key_site_traffic, R.string.pref_key_site_amp);
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_traffic);
         }
 
         setDateTimeFormatPref(FormatType.DATE_FORMAT, mDateFormatPref, mSiteSettings.getDateFormat());

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -178,6 +178,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     private Preference mRelatedPostsPref;
     private Preference mTimezonePref;
     private Preference mPostsPerPagePref;
+    private WPSwitchPreference mAmpPref;
 
     // Discussion settings preview
     private WPSwitchPreference mAllowCommentsPref;
@@ -682,6 +683,8 @@ public class SiteSettingsFragment extends PreferenceFragment
         } else if (preference == mPostsPerPagePref) {
             mPostsPerPagePref.setSummary(newValue.toString());
             mSiteSettings.setPostsPerPage(Integer.parseInt(newValue.toString()));
+        } else if (preference == mAmpPref) {
+            mSiteSettings.setAmpEnabled((Boolean) newValue);
         } else if (preference == mTimezonePref) {
             setTimezonePref(newValue.toString());
             mSiteSettings.setTimezone(newValue.toString());
@@ -839,6 +842,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         mTimeFormatPref = (WPPreference) getChangePref(R.string.pref_key_site_time_format);
         mPostsPerPagePref = getClickPref(R.string.pref_key_site_posts_per_page);
         mTimezonePref = getClickPref(R.string.pref_key_site_timezone);
+        mAmpPref = (WPSwitchPreference) getChangePref(R.string.pref_key_site_amp);
 
         sortLanguages();
 
@@ -872,7 +876,7 @@ public class SiteSettingsFragment extends PreferenceFragment
                 mReceivePingbacksNested, mIdentityRequiredPreference, mUserAccountRequiredPref,
                 mSortByPref, mWhitelistPref, mRelatedPostsPref, mCloseAfterPref, mPagingPref,
                 mThreadingPref, mMultipleLinksPref, mModerationHoldPref, mBlacklistPref, mWeekStartPref,
-                mDateFormatPref, mTimeFormatPref, mTimezonePref, mPostsPerPagePref,
+                mDateFormatPref, mTimeFormatPref, mTimezonePref, mPostsPerPagePref, mAmpPref,
                 mDeleteSitePref, mJpMonitorActivePref, mJpMonitorEmailNotesPref, mJpSsoPref,
                 mJpMonitorWpNotesPref, mJpBruteForcePref, mJpWhitelistPref, mJpMatchEmailPref, mJpUseTwoFactorPref
         };
@@ -1162,6 +1166,12 @@ public class SiteSettingsFragment extends PreferenceFragment
         mJpWhitelistPref.setSummary(mSiteSettings.getJetpackProtectWhitelistSummary());
         mWeekStartPref.setValue(mSiteSettings.getStartOfWeek());
         mWeekStartPref.setSummary(mWeekStartPref.getEntry());
+
+        if (mSiteSettings.getAmpSupported()) {
+            mAmpPref.setChecked(mSiteSettings.getAmpEnabled());
+        } else {
+            WPPrefUtils.removePreference(this, R.string.pref_key_site_traffic, R.string.pref_key_site_amp);
+        }
 
         setDateTimeFormatPref(FormatType.DATE_FORMAT, mDateFormatPref, mSiteSettings.getDateFormat());
         setDateTimeFormatPref(FormatType.TIME_FORMAT, mTimeFormatPref, mSiteSettings.getTimeFormat());

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -597,6 +597,21 @@ public abstract class SiteSettingsInterface {
         mSettings.postsPerPage = postsPerPage;
     }
 
+    public boolean getAmpSupported() {
+        return mSettings.ampSupported;
+    }
+
+    public void setAmpSupported(boolean supported) {
+        mSettings.ampSupported = supported;
+    }
+
+    public boolean getAmpEnabled() {
+        return mSettings.ampEnabled;
+    }
+
+    public void setAmpEnabled(boolean enabled) {
+        mSettings.ampEnabled = enabled;
+    }
     public boolean isJetpackMonitorEnabled() {
         return mJpSettings.monitorActive;
     }

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -52,6 +52,8 @@
     <string name="pref_key_site_time_format" translatable="false">wp_pref_site_time_format</string>
     <string name="pref_key_site_timezone" translatable="false">wp_pref_site_timezone</string>
     <string name="pref_key_site_posts_per_page" translatable="false">wp_pref_site_post_per_page</string>
+    <string name="pref_key_site_amp" translatable="false">wp_pref_site_amp</string>
+    <string name="pref_key_site_traffic" translatable="false">wp_pref_site_traffic</string>
     <string name="pref_key_optimize_media" translatable="false">wp_pref_optimize_media</string>
     <string name="pref_key_optimize_image" translatable="false">wp_pref_key_optimize_image</string>
     <string name="pref_key_site_image_width" translatable="false">wp_pref_site_default_image_width</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -519,6 +519,7 @@
     <string name="site_settings_discussion_new_posts_header">Defaults for new posts</string>
     <string name="site_settings_comments_header" translatable="false">@string/comments</string>
     <string name="site_settings_advanced_header">Advanced</string>
+    <string name="site_settings_traffic_header">Traffic</string>
 
     <!-- Preference Titles -->
     <string name="site_settings_title_title">Site Title</string>
@@ -564,6 +565,8 @@
     <string name="site_settings_blacklist_title">Blacklist</string>
     <string name="site_settings_delete_site_title">Delete Site</string>
     <string name="site_settings_timezones_error">Unable to load timezones</string>
+    <string name="site_settings_amp_title">AMP</string>
+    <string name="site_settings_amp_summary">Improve the loading speed of your site on phones and tablets</string>
 
     <!-- Jetpack settings -->
     <string name="jetpack_site_settings_category_title">Jetpack Settings</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -565,8 +565,8 @@
     <string name="site_settings_blacklist_title">Blacklist</string>
     <string name="site_settings_delete_site_title">Delete Site</string>
     <string name="site_settings_timezones_error">Unable to load timezones</string>
-    <string name="site_settings_amp_title">AMP</string>
-    <string name="site_settings_amp_summary">Improve the loading speed of your site on phones and tablets</string>
+    <string name="site_settings_amp_title">Accelerated Mobile Pages (AMP)</string>
+    <string name="site_settings_amp_summary">Your WordPress.com site supports the use of Accelerated Mobile Pages, a Google-led initiative that dramatically speeds up loading times on mobile devices</string>
 
     <!-- Jetpack settings -->
     <string name="jetpack_site_settings_category_title">Jetpack Settings</string>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -140,6 +140,20 @@
 
     </PreferenceCategory>
 
+    <!-- Traffic settings -->
+    <PreferenceCategory
+        android:id="@+id/pref_traffic"
+        android:key="@string/pref_key_site_traffic"
+        android:title="@string/site_settings_traffic_header">
+
+        <org.wordpress.android.ui.prefs.WPSwitchPreference
+            android:id="@+id/pref_toggle_amp"
+            android:key="@string/pref_key_site_amp"
+            android:summary="@string/site_settings_amp_summary"
+            android:title="@string/site_settings_amp_title" />
+
+    </PreferenceCategory>
+
     <!-- Discussion settings -->
     <PreferenceCategory
         android:id="@+id/pref_discussion_settings2"


### PR DESCRIPTION
Adds AMP switch to site settings as per #6652.

![screenshot_1513960828](https://user-images.githubusercontent.com/3903757/34305602-fa3b9372-e70c-11e7-9739-4991e4b75a10.png)

Note that AMP is only supported on public wp.com sites so this setting doesn't exist for .org, Jetpack, or hidden/private sites.
