### PR TITLE
NPE fix: makes sure to set the media ID in all cases so media is tappable

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1434,11 +1434,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             localMediaId = attrs.getValue(idName);
         }
 
+        setIdAttributeOnMedia(attrs, idName, localMediaId);
 
         switch (uploadStatus) {
             case ATTR_STATUS_UPLOADING:
-                setIdAttributeOnMedia(attrs, idName, localMediaId);
-
                 // Display 'cancel upload' dialog
                 AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
                 builder.setTitle(getString(R.string.stop_upload_dialog_title));
@@ -1474,8 +1473,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                 dialog.show();
                 break;
             case ATTR_STATUS_FAILED:
-                setIdAttributeOnMedia(attrs, idName, localMediaId);
-
                 // Retry media upload
                 boolean successfullyRetried = true;
                 if (mFailedMediaIds.contains(localMediaId)) {


### PR DESCRIPTION
Fixes NPE reported by @khaykov due to `mTappedMediaPredicate` not being set in the default case; bug introduced in https://github.com/wordpress-mobile/WordPress-Android/pull/7024

To test:
1. start a new draft
2. insert a media item
3. exit the editor and leave it uploading in the background
4. once the upload is  finished, open the Post in the editor again
5. tap on the media item - observe it doesn't crash anymore

cc @khaykov @daniloercoli 
