### PR TITLE
Removing caption hotfixes from client side

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -73,7 +73,6 @@ import org.wordpress.aztec.plugins.shortcodes.CaptionShortcodePlugin;
 import org.wordpress.aztec.plugins.shortcodes.VideoShortcodePlugin;
 import org.wordpress.aztec.plugins.shortcodes.extensions.CaptionExtensionsKt;
 import org.wordpress.aztec.plugins.shortcodes.extensions.VideoPressExtensionsKt;
-import org.wordpress.aztec.plugins.shortcodes.spans.CaptionShortcodeSpan;
 import org.wordpress.aztec.plugins.wpcomments.CommentsTextFormat;
 import org.wordpress.aztec.plugins.wpcomments.WordPressCommentsPlugin;
 import org.wordpress.aztec.plugins.wpcomments.toolbar.MoreToolbarButton;
@@ -1015,35 +1014,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         mUploadingMediaProgressMax.remove(localMediaId);
         if (!TextUtils.isEmpty(localMediaId)) {
             mEditorFragmentListener.onMediaDeleted(localMediaId);
-            removeCaptionFromDeletedMedia(localMediaId);
-        }
-    }
-
-    private void removeCaptionFromDeletedMedia(String localMediaId) {
-        AztecText.AttributePredicate localMediaIdPredicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
-        List<IAztecAttributedSpan> imageSpanThatWasDeleted =
-                getSpansForPredicate(content.getEditableText(), localMediaIdPredicate, true);
-        if (imageSpanThatWasDeleted.size() > 0) {
-            int imageSpanEnd = content.getEditableText().getSpanEnd(imageSpanThatWasDeleted.get(0));
-
-            //look for the caption span somewhere inside tapped image
-            CaptionShortcodeSpan[] captions = content.getEditableText().getSpans(imageSpanEnd, imageSpanEnd, CaptionShortcodeSpan.class);
-
-            //TODO remove span size adjustment when https://github.com/wordpress-mobile/AztecEditor-Android/issues/573 is fixed
-            if (captions.length > 0) { //found caption span
-                int captionStart = content.getEditableText().getSpanStart(captions[0]);
-                int captionEnd = content.getEditableText().getSpanEnd(captions[0]);
-                int captionFlags = content.getEditableText().getSpanFlags(captions[0]);
-
-                if (captionStart < captionEnd && content.getEditableText().charAt(7) != '\n') {
-                    int newCaptionEnd = content.getEditableText().toString().indexOf('\n', captionStart);
-                    if (newCaptionEnd != -1 && captionStart > newCaptionEnd) {
-                        content.getEditableText().setSpan(captions[0], captionStart, newCaptionEnd, captionFlags);
-                    }
-                }
-
-                CaptionExtensionsKt.removeImageCaption(content, localMediaIdPredicate);
-            }
         }
     }
 
@@ -1675,43 +1645,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                         captionAttributes.setValue(ATTR_DIMEN_WIDTH, metaData.getWidth());
 
                         CaptionExtensionsKt.setImageCaption(content, mTappedMediaPredicate, metaData.getCaption(), captionAttributes);
-
-                        //TODO remove when https://github.com/wordpress-mobile/AztecEditor-Android/issues/572 is fixed
-                        //Workaround removes \n before caption text and shifts span one character to the left
-                        List<IAztecAttributedSpan> tappedImageSpan =
-                                getSpansForPredicate(content.getEditableText(), mTappedMediaPredicate, true);
-
-                        if (tappedImageSpan.size() > 0) {
-                            int imageSpanEnd = content.getEditableText().getSpanEnd(tappedImageSpan.get(0));
-
-                            //look for the caption span somewhere inside tapped image
-                            CaptionShortcodeSpan[] captions = content.getEditableText().getSpans(imageSpanEnd, imageSpanEnd, CaptionShortcodeSpan.class);
-
-                            if (captions.length > 0) { //found caption span
-                                int captionStart = content.getEditableText().getSpanStart(captions[0]);
-                                int captionEnd = content.getEditableText().getSpanEnd(captions[0]);
-                                int captionFlags = content.getEditableText().getSpanFlags(captions[0]);
-
-                                //if span has text after it it will have a newline at the end, we shouldn't count it
-                                if (content.getEditableText().charAt(captionEnd - 1) == '\n') {
-                                    captionEnd--;
-                                }
-
-                                //we are looking for caption text with newline in front of it
-                                String expectedString = "\n" + metaData.getCaption();
-                                CharSequence actualContent = content.getEditableText().subSequence(imageSpanEnd, captionEnd);
-
-                                //make sure that caption ends where we expect it too, and that actual caption is right
-                                if (captionEnd == imageSpanEnd + expectedString.length() && actualContent.toString().equals(expectedString)) {
-                                    content.disableTextChangedListener();
-                                    content.getEditableText().delete(imageSpanEnd, imageSpanEnd + 1); //delete newline
-                                    content.getEditableText().setSpan(captions[0], captionStart, captionEnd - 1, captionFlags); //we have an empty space, resize span
-                                    content.enableTextChangedListener();
-                                    //reset content of the post after passing it through parser/formatter
-                                    content.fromHtml(content.toHtml(false));
-                                }
-                            }
-                        }
+                        content.fromHtml(content.toHtml(false));
                     } else {
                         //if no caption present apply align attribute directly to image
                         if (!TextUtils.isEmpty(metaData.getAlign())) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1645,6 +1645,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                         captionAttributes.setValue(ATTR_DIMEN_WIDTH, metaData.getWidth());
 
                         CaptionExtensionsKt.setImageCaption(content, mTappedMediaPredicate, metaData.getCaption(), captionAttributes);
+
+                        //setting caption causes rendering issue in some cases, reset content to avoid them
                         content.fromHtml(content.toHtml(false));
                     } else {
                         //if no caption present apply align attribute directly to image


### PR DESCRIPTION
This PR removes client side fixes for the following caption issues, that were fixed on Azec side:

https://github.com/wordpress-mobile/AztecEditor-Android/issues/572
https://github.com/wordpress-mobile/AztecEditor-Android/issues/573
https://github.com/wordpress-mobile/AztecEditor-Android/issues/574

cc @nbradbury 