### PR TITLE
Issue/7035 no account avatar

### DIFF
--- a/WordPress/src/main/res/drawable/gravatar_background_circle.xml
+++ b/WordPress/src/main/res/drawable/gravatar_background_circle.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-       android:shape="oval">
-    <stroke
-        android:width="2dp"
-        android:color="@color/grey_darken_10"/>
-</shape>

--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -29,11 +29,6 @@
                     android:layout_height="wrap_content"
                     android:layout_centerHorizontal="true">
 
-                    <ImageView
-                        android:layout_width="@dimen/avatar_sz_circle"
-                        android:layout_height="@dimen/avatar_sz_circle"
-                        android:src="@drawable/gravatar_background_circle"/>
-
                     <FrameLayout
                         android:id="@+id/avatar_container"
                         android:layout_width="wrap_content"

--- a/WordPress/src/main/res/layout/me_fragment.xml
+++ b/WordPress/src/main/res/layout/me_fragment.xml
@@ -40,7 +40,9 @@
                         <org.wordpress.android.widgets.WPNetworkImageView
                             android:id="@+id/me_avatar"
                             android:layout_width="@dimen/avatar_sz_inner_circle"
-                            android:layout_height="@dimen/avatar_sz_inner_circle" />
+                            android:layout_height="@dimen/avatar_sz_inner_circle"
+                            app:wpDefaultImageDrawable="@drawable/ic_gridicons_user_circle_100dp"
+                            app:wpErrorImageDrawable="@drawable/ic_gridicons_user_circle_100dp" />
                     </FrameLayout>
 
                     <ProgressBar


### PR DESCRIPTION
### Fix
Add a image for the default and error cases when loading the user's avatar on the ***Me*** screen as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7035.  Consequently, this also removes the circle around the avatar for consistency with similar designs in the app.  See the screenshots below for illustration.

![avatar designs](https://user-images.githubusercontent.com/3827611/34385844-c7787bb0-eae2-11e7-9fe5-71abb691b81d.png)

### Test
1. Remove [Gravatar](https://en.gravatar.com/emails).
2. Clear app data.
3. Log in to app.
4. Go to ***Me*** tab.
5. Notice avatar is [gridicons-user-circle](https://github.com/Automattic/gridicons/blob/master/svg-min/gridicons-user-circle.svg).