### PR TITLE
Improve how post upload callback is handled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -647,8 +647,12 @@ public class PostsListFragment extends Fragment
         switch (event.causeOfChange) {
             // if a Post is updated, let's refresh the whole list, because we can't really know
             // from FluxC which post has changed, or when. So to make sure, we go to the source,
-            // which is the FkuxC PostStore.
+            // which is the FluxC PostStore.
             case UPDATE_POST:
+                if (!event.isError()) {
+                    loadPosts(LoadMode.IF_CHANGED);
+                }
+                break;
             case FETCH_POSTS:
             case FETCH_PAGES:
                 mIsFetchingPosts = false;


### PR DESCRIPTION
We were handling both fetch and update callbacks for posts the same way which was breaking the pagination as well as some other minor UI components.

To test:
* Do a fresh install
* Login and open a site's post list (make sure you have more than 20 posts so multiple pages needs to be fetched)
* Do not scroll at all (to prevent next pages to load just yet)
* Upload a new post and wait for it to finish (verify that the post list is updated once it's successful and the post is not saying "uploading" anymore)
* Scroll to the end of post list and make sure a new page is loaded (if you try the same thing on `develop` this part will break and no new posts will be loaded until you do a pull to refresh or leave the post list and come back in)

/cc @aforcier (since we discussed this on Slack before)