### PR TITLE
Reflect FluxC theme changes

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -136,7 +136,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.11'
     provided 'org.glassfish:javax.annotation:10.0-b28'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:bb6ac01f9d2964edc0ba132462182d5d6a33f4b0') {
+    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:837f89b0caf62739b01969e340c4653e9af84709') {
         exclude group: "com.android.volley"
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -20,6 +20,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.fluxc.Dispatcher;
+import org.wordpress.android.fluxc.action.ThemeAction;
 import org.wordpress.android.fluxc.generated.ThemeActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.ThemeModel;
@@ -213,19 +214,24 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSiteThemesChanged(ThemeStore.OnSiteThemesChanged event) {
-        // always unset refreshing status to remove progress indicator
-        if (mThemeBrowserFragment != null) {
-            mThemeBrowserFragment.setRefreshing(false);
-            mThemeBrowserFragment.refreshView();
-        }
+        if (event.origin == ThemeAction.FETCH_INSTALLED_THEMES) {
+            // always unset refreshing status to remove progress indicator
+            if (mThemeBrowserFragment != null) {
+                mThemeBrowserFragment.setRefreshing(false);
+                mThemeBrowserFragment.refreshView();
+            }
 
-        mIsFetchingInstalledThemes = false;
+            mIsFetchingInstalledThemes = false;
 
-        if (event.isError()) {
-            AppLog.e(T.THEMES, "Error fetching themes: " + event.error.message);
-            ToastUtils.showToast(this, R.string.theme_fetch_failed, ToastUtils.Duration.SHORT);
-        } else {
-            AppLog.d(T.THEMES, "Installed themes fetch successful!");
+            if (event.isError()) {
+                AppLog.e(T.THEMES, "Error fetching themes: " + event.error.message);
+                ToastUtils.showToast(this, R.string.theme_fetch_failed, ToastUtils.Duration.SHORT);
+            } else {
+                AppLog.d(T.THEMES, "Installed themes fetch successful!");
+            }
+        } else if (event.origin == ThemeAction.REMOVE_SITE_THEMES){
+            // Since this is a logout event, we don't need to do anything
+            AppLog.d(T.THEMES, "Site themes removed for site: " + event.site.getDisplayName());
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -25,7 +25,6 @@ import org.wordpress.android.fluxc.generated.ThemeActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.ThemeModel;
 import org.wordpress.android.fluxc.store.ThemeStore;
-import org.wordpress.android.fluxc.store.ThemeStore.SearchThemesPayload;
 import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -247,30 +246,6 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onThemesSearched(ThemeStore.OnThemesSearched event) {
-        if (event.isError()) {
-            AppLog.e(T.THEMES, "Error searching themes: " + event.error.message);
-            if (event.error.type == ThemeStore.ThemeErrorType.UNAUTHORIZED) {
-                AppLog.d(T.THEMES, getString(R.string.theme_auth_error_authenticate));
-                String errorTitle = getString(R.string.theme_auth_error_title);
-                String errorMsg = getString(R.string.theme_auth_error_message);
-
-                if (mIsRunning) {
-                    FragmentTransaction ft = getFragmentManager().beginTransaction();
-                    WPAlertDialogFragment fragment = WPAlertDialogFragment.newAlertDialog(errorMsg,
-                            errorTitle);
-                    ft.add(fragment, ALERT_TAB);
-                    ft.commitAllowingStateLoss();
-                }
-            }
-        } else {
-            AppLog.d(T.THEMES, "Themes search successful!");
-            mThemeSearchFragment.setSearchResults(event.searchResults);
-        }
-    }
-
-    @SuppressWarnings("unused")
-    @Subscribe(threadMode = ThreadMode.MAIN)
     public void onThemeInstalled(ThemeStore.OnThemeInstalled event) {
         if (event.isError()) {
             AppLog.e(T.THEMES, "Error installing theme: " + event.error.message);
@@ -318,8 +293,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
         if (TextUtils.isEmpty(searchTerm)) {
             return;
         }
-        SearchThemesPayload payload = new SearchThemesPayload(searchTerm);
-        mDispatcher.dispatch(ThemeActionBuilder.newSearchThemesAction(payload));
+        // TODO: implement local theme search
     }
 
     public void fetchCurrentTheme() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -25,7 +25,7 @@ import org.wordpress.android.fluxc.generated.ThemeActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.ThemeModel;
 import org.wordpress.android.fluxc.store.ThemeStore;
-import org.wordpress.android.fluxc.store.ThemeStore.ActivateThemePayload;
+import org.wordpress.android.fluxc.store.ThemeStore.SiteThemePayload;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.themes.ThemeBrowserFragment.ThemeBrowserFragmentCallback;
@@ -34,7 +34,6 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
-import org.wordpress.android.widgets.WPAlertDialogFragment;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -195,7 +194,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onThemesChanged(ThemeStore.OnThemesChanged event) {
+    public void onSiteThemesChanged(ThemeStore.OnSiteThemesChanged event) {
         // always unset refreshing status to remove progress indicator
         if (mThemeBrowserFragment != null) {
             mThemeBrowserFragment.setRefreshing(false);
@@ -330,12 +329,12 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
 
             if (mSite.isJetpackConnected()) {
                 // first install the theme, then activate it
-                mDispatcher.dispatch(ThemeActionBuilder.newInstallThemeAction(new ActivateThemePayload(mSite, theme)));
+                mDispatcher.dispatch(ThemeActionBuilder.newInstallThemeAction(new SiteThemePayload(mSite, theme)));
                 return;
             }
         }
 
-        mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(new ActivateThemePayload(mSite, theme)));
+        mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(new SiteThemePayload(mSite, theme)));
     }
 
     protected void setThemeBrowserFragment(ThemeBrowserFragment themeBrowserFragment) {


### PR DESCRIPTION
We have been fixing a few issues for themes in FluxC and this PR reflects those changes in WPAndroid. @nbradbury and I are still working on a few more issues and we decided to go with a WIP branch for our PRs. As a result of https://github.com/wordpress-mobile/WordPress-FluxC-Android/issues/654, we'll be re-implementing the theme search as local, so for now, we could ignore anything related to that.

Finally, we feel that having fragments for themes doesn't really contribute much and it'd be better to have the activity handle everything. We'll at least explore how we can do this and if it actually makes sense.
