### PR TITLE
Aztec - Fix problems with media thumbnails that were loaded at different sizes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1041,17 +1041,15 @@ public class EditPostActivity extends AppCompatActivity implements
             aztecEditorFragment.setEditorBetaClickListener(EditPostActivity.this);
             aztecEditorFragment.setEditorImageSettingsListener(EditPostActivity.this);
 
-            Drawable loadingImagePlaceholder = getResources().getDrawable(org.wordpress.android.editor.R.drawable.ic_gridicons_image);
-            loadingImagePlaceholder.setBounds(0, 0,
-                    AztecEditorFragment.DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP,
-                    AztecEditorFragment.DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP);
+            Drawable loadingImagePlaceholder = aztecEditorFragment.getAztecPlaceholderDrawableFromResID(
+                    org.wordpress.android.editor.R.drawable.ic_gridicons_image
+            );
             aztecEditorFragment.setAztecImageLoader(new AztecImageLoader(getBaseContext(), loadingImagePlaceholder));
             aztecEditorFragment.setLoadingImagePlaceholder(loadingImagePlaceholder);
 
-            Drawable loadingVideoPlaceholder = getResources().getDrawable(org.wordpress.android.editor.R.drawable.ic_gridicons_video_camera);
-            loadingVideoPlaceholder.setBounds(0, 0,
-                    AztecEditorFragment.DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP,
-                    AztecEditorFragment.DEFAULT_MEDIA_PLACEHOLDER_DIMENSION_DP);
+            Drawable loadingVideoPlaceholder = aztecEditorFragment.getAztecPlaceholderDrawableFromResID(
+                    org.wordpress.android.editor.R.drawable.ic_gridicons_video_camera
+            );
             aztecEditorFragment.setAztecVideoLoader(new AztecVideoLoader(getBaseContext(), loadingVideoPlaceholder));
             aztecEditorFragment.setLoadingVideoPlaceholder(loadingVideoPlaceholder);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1041,14 +1041,22 @@ public class EditPostActivity extends AppCompatActivity implements
             aztecEditorFragment.setEditorBetaClickListener(EditPostActivity.this);
             aztecEditorFragment.setEditorImageSettingsListener(EditPostActivity.this);
 
-            Drawable loadingImagePlaceholder = aztecEditorFragment.getAztecPlaceholderDrawableFromResID(
-                    org.wordpress.android.editor.R.drawable.ic_gridicons_image
+            // Here we should set the max width for picture, but the default size is already OK. No need
+            // to customize it further
+            // int maxImageWidthForVisualEditor = ImageUtils.getMaximumThumbnailWidthForEditor(getActivity());
+
+            Drawable loadingImagePlaceholder = org.wordpress.android.editor.MediaUtils.getAztecPlaceholderDrawableFromResID(
+                    this,
+                    org.wordpress.android.editor.R.drawable.ic_gridicons_image,
+                    aztecEditorFragment.getMaxImageWidth()
             );
             aztecEditorFragment.setAztecImageLoader(new AztecImageLoader(getBaseContext(), loadingImagePlaceholder));
             aztecEditorFragment.setLoadingImagePlaceholder(loadingImagePlaceholder);
 
-            Drawable loadingVideoPlaceholder = aztecEditorFragment.getAztecPlaceholderDrawableFromResID(
-                    org.wordpress.android.editor.R.drawable.ic_gridicons_video_camera
+            Drawable loadingVideoPlaceholder = org.wordpress.android.editor.MediaUtils.getAztecPlaceholderDrawableFromResID(
+                    this,
+                    org.wordpress.android.editor.R.drawable.ic_gridicons_video_camera,
+                    aztecEditorFragment.getMaxImageWidth()
             );
             aztecEditorFragment.setAztecVideoLoader(new AztecVideoLoader(getBaseContext(), loadingVideoPlaceholder));
             aztecEditorFragment.setLoadingVideoPlaceholder(loadingVideoPlaceholder);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -60,6 +60,7 @@ import org.wordpress.android.editor.EditorFragmentAbstract.TrackableEvent;
 import org.wordpress.android.editor.EditorFragmentActivity;
 import org.wordpress.android.editor.EditorImageMetaData;
 import org.wordpress.android.editor.EditorMediaUploadListener;
+import org.wordpress.android.editor.EditorMediaUtils;
 import org.wordpress.android.editor.EditorWebViewAbstract.ErrorListener;
 import org.wordpress.android.editor.EditorWebViewCompatibility;
 import org.wordpress.android.editor.EditorWebViewCompatibility.ReflectionException;
@@ -1044,7 +1045,7 @@ public class EditPostActivity extends AppCompatActivity implements
             // Here we should set the max width for media, but the default size is already OK. No need
             // to customize it further
 
-            Drawable loadingImagePlaceholder = org.wordpress.android.editor.MediaUtils.getAztecPlaceholderDrawableFromResID(
+            Drawable loadingImagePlaceholder = EditorMediaUtils.getAztecPlaceholderDrawableFromResID(
                     this,
                     org.wordpress.android.editor.R.drawable.ic_gridicons_image,
                     aztecEditorFragment.getMaxMediaSize()
@@ -1052,7 +1053,7 @@ public class EditPostActivity extends AppCompatActivity implements
             aztecEditorFragment.setAztecImageLoader(new AztecImageLoader(getBaseContext(), loadingImagePlaceholder));
             aztecEditorFragment.setLoadingImagePlaceholder(loadingImagePlaceholder);
 
-            Drawable loadingVideoPlaceholder = org.wordpress.android.editor.MediaUtils.getAztecPlaceholderDrawableFromResID(
+            Drawable loadingVideoPlaceholder = EditorMediaUtils.getAztecPlaceholderDrawableFromResID(
                     this,
                     org.wordpress.android.editor.R.drawable.ic_gridicons_video_camera,
                     aztecEditorFragment.getMaxMediaSize()
@@ -1481,7 +1482,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
     private int getMaximumThumbnailWidthForEditor() {
         if (mMaxThumbWidth == 0) {
-            mMaxThumbWidth = org.wordpress.android.editor.MediaUtils.getMaximumThumbnailSizeForEditor(this);
+            mMaxThumbWidth = EditorMediaUtils.getMaximumThumbnailSizeForEditor(this);
         }
         return mMaxThumbWidth;
     }
@@ -2373,7 +2374,7 @@ public class EditPostActivity extends AppCompatActivity implements
             FileOutputStream outputStream = new FileOutputStream(outputFile);
             Bitmap thumb = ImageUtils.getVideoFrameFromVideo(
                     videoPath,
-                    org.wordpress.android.editor.MediaUtils.getMaximumThumbnailSizeForEditor(this)
+                    EditorMediaUtils.getMaximumThumbnailSizeForEditor(this)
             );
             if (thumb != null) {
                 thumb.compress(Bitmap.CompressFormat.PNG, 75, outputStream);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1047,7 +1047,7 @@ public class EditPostActivity extends AppCompatActivity implements
             Drawable loadingImagePlaceholder = org.wordpress.android.editor.MediaUtils.getAztecPlaceholderDrawableFromResID(
                     this,
                     org.wordpress.android.editor.R.drawable.ic_gridicons_image,
-                    aztecEditorFragment.getMaxImageWidth()
+                    aztecEditorFragment.getMaxMediaSize()
             );
             aztecEditorFragment.setAztecImageLoader(new AztecImageLoader(getBaseContext(), loadingImagePlaceholder));
             aztecEditorFragment.setLoadingImagePlaceholder(loadingImagePlaceholder);
@@ -1055,7 +1055,7 @@ public class EditPostActivity extends AppCompatActivity implements
             Drawable loadingVideoPlaceholder = org.wordpress.android.editor.MediaUtils.getAztecPlaceholderDrawableFromResID(
                     this,
                     org.wordpress.android.editor.R.drawable.ic_gridicons_video_camera,
-                    aztecEditorFragment.getMaxImageWidth()
+                    aztecEditorFragment.getMaxMediaSize()
             );
             aztecEditorFragment.setAztecVideoLoader(new AztecVideoLoader(getBaseContext(), loadingVideoPlaceholder));
             aztecEditorFragment.setLoadingVideoPlaceholder(loadingVideoPlaceholder);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1041,9 +1041,8 @@ public class EditPostActivity extends AppCompatActivity implements
             aztecEditorFragment.setEditorBetaClickListener(EditPostActivity.this);
             aztecEditorFragment.setEditorImageSettingsListener(EditPostActivity.this);
 
-            // Here we should set the max width for picture, but the default size is already OK. No need
+            // Here we should set the max width for media, but the default size is already OK. No need
             // to customize it further
-            // int maxImageWidthForVisualEditor = ImageUtils.getMaximumThumbnailWidthForEditor(getActivity());
 
             Drawable loadingImagePlaceholder = org.wordpress.android.editor.MediaUtils.getAztecPlaceholderDrawableFromResID(
                     this,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1481,7 +1481,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
     private int getMaximumThumbnailWidthForEditor() {
         if (mMaxThumbWidth == 0) {
-            mMaxThumbWidth = ImageUtils.getMaximumThumbnailWidthForEditor(this);
+            mMaxThumbWidth = org.wordpress.android.editor.MediaUtils.getMaximumThumbnailSizeForEditor(this);
         }
         return mMaxThumbWidth;
     }
@@ -2373,7 +2373,7 @@ public class EditPostActivity extends AppCompatActivity implements
             FileOutputStream outputStream = new FileOutputStream(outputFile);
             Bitmap thumb = ImageUtils.getVideoFrameFromVideo(
                     videoPath,
-                    ImageUtils.getMaximumThumbnailWidthForEditor(this)
+                    org.wordpress.android.editor.MediaUtils.getMaximumThumbnailSizeForEditor(this)
             );
             if (thumb != null) {
                 thumb.compress(Bitmap.CompressFormat.PNG, 75, outputStream);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
@@ -12,7 +12,6 @@ import com.android.volley.VolleyError;
 import com.android.volley.toolbox.ImageLoader;
 
 import org.wordpress.android.WordPress;
-import org.wordpress.android.editor.MediaUtils;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.aztec.Html;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
@@ -12,6 +12,7 @@ import com.android.volley.VolleyError;
 import com.android.volley.toolbox.ImageLoader;
 
 import org.wordpress.android.WordPress;
+import org.wordpress.android.editor.MediaUtils;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.aztec.Html;
 
@@ -46,12 +47,17 @@ public class AztecImageLoader implements Html.ImageGetter {
 
         if (new File(url).exists()) {
             int orientation = ImageUtils.getImageOrientation(this.context, url);
+            // `createThumbnailFromUri` takes in consideration both width and height of the picture.
+            // We need to make sure to set the correct max dimension for the current picture
+            // keeping the correct aspect ratio and the max width setting for the editor
+            int maxRequestedSize =  MediaUtils.getMaxMediaSizeForEditor(this.context, url, maxWidth);
             byte[] bytes = ImageUtils.createThumbnailFromUri(
-                   context, Uri.parse(url), maxWidth, null, orientation);
+                   context, Uri.parse(url), maxRequestedSize, null, orientation);
             if (bytes != null) {
                 Bitmap bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
                 if (bitmap != null) {
                     WordPress.getBitmapCache().putBitmap(cacheKey, bitmap);
+                    bitmap.setDensity(DisplayMetrics.DENSITY_DEFAULT);
                 }
                 BitmapDrawable bitmapDrawable = new BitmapDrawable(context.getResources(), bitmap);
                 callbacks.onImageLoaded(bitmapDrawable);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
@@ -47,12 +47,8 @@ public class AztecImageLoader implements Html.ImageGetter {
 
         if (new File(url).exists()) {
             int orientation = ImageUtils.getImageOrientation(this.context, url);
-            // `createThumbnailFromUri` takes in consideration both width and height of the picture.
-            // We need to make sure to set the correct max dimension for the current picture
-            // keeping the correct aspect ratio and the max width setting for the editor
-            int maxRequestedSize =  MediaUtils.getMaxMediaSizeForEditor(this.context, url, maxWidth);
             byte[] bytes = ImageUtils.createThumbnailFromUri(
-                   context, Uri.parse(url), maxRequestedSize, null, orientation);
+                   context, Uri.parse(url), maxWidth, null, orientation);
             if (bytes != null) {
                 Bitmap bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
                 if (bitmap != null) {
@@ -79,6 +75,8 @@ public class AztecImageLoader implements Html.ImageGetter {
                     callbacks.onImageFailed();
                 } else if (bitmap != null) {
                     final String cacheKey = url + maxWidth;
+                    // Make sure both width ad height respect the max size for the editor
+                    bitmap = ImageUtils.getScaledBitmapAtLongestSide(bitmap, maxWidth);
                     WordPress.getBitmapCache().putBitmap(cacheKey, bitmap);
                     // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so, we need
                     // to correctly set the input density to 160 ourselves.

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
@@ -33,12 +33,8 @@ public class AztecImageLoader implements Html.ImageGetter {
     }
 
     @Override
-    public void loadImage(final String url, final Callbacks callbacks, int maxWidth, int minWidth) {
-        // FIXME: Aztec has now the option to set the desired image width. We should respect it
-        // Ignore the maxWidth passed from Aztec, since it's the MAX of screen width/height
-        final int maxWidthForEditor = ImageUtils.getMaximumThumbnailWidthForEditor(context);
-
-        final String cacheKey = url + maxWidthForEditor;
+    public void loadImage(final String url, final Callbacks callbacks, final int maxWidth, final int minWidth) {
+        final String cacheKey = url + maxWidth;
         Bitmap cachedBitmap = WordPress.getBitmapCache().get(cacheKey);
         if (cachedBitmap != null) {
             // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so, we need
@@ -51,7 +47,7 @@ public class AztecImageLoader implements Html.ImageGetter {
         if (new File(url).exists()) {
             int orientation = ImageUtils.getImageOrientation(this.context, url);
             byte[] bytes = ImageUtils.createThumbnailFromUri(
-                   context, Uri.parse(url), maxWidthForEditor, null, orientation);
+                   context, Uri.parse(url), maxWidth, null, orientation);
             if (bytes != null) {
                 Bitmap bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
                 if (bitmap != null) {
@@ -76,7 +72,7 @@ public class AztecImageLoader implements Html.ImageGetter {
                     // isImmediate is true as soon as the request starts.
                     callbacks.onImageFailed();
                 } else if (bitmap != null) {
-                    final String cacheKey = url + maxWidthForEditor;
+                    final String cacheKey = url + maxWidth;
                     WordPress.getBitmapCache().putBitmap(cacheKey, bitmap);
                     // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so, we need
                     // to correctly set the input density to 160 ourselves.
@@ -90,6 +86,6 @@ public class AztecImageLoader implements Html.ImageGetter {
             public void onErrorResponse(VolleyError error) {
                 callbacks.onImageFailed();
             }
-        }, maxWidthForEditor, 0);
+        }, maxWidth, 0);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecImageLoader.java
@@ -6,6 +6,7 @@ import android.graphics.BitmapFactory;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.util.DisplayMetrics;
 
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.ImageLoader;
@@ -40,6 +41,9 @@ public class AztecImageLoader implements Html.ImageGetter {
         final String cacheKey = url + maxWidthForEditor;
         Bitmap cachedBitmap = WordPress.getBitmapCache().get(cacheKey);
         if (cachedBitmap != null) {
+            // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so, we need
+            // to correctly set the input density to 160 ourselves.
+            cachedBitmap.setDensity(DisplayMetrics.DENSITY_DEFAULT);
             callbacks.onImageLoaded(new BitmapDrawable(context.getResources(), cachedBitmap));
             return;
         }
@@ -74,6 +78,9 @@ public class AztecImageLoader implements Html.ImageGetter {
                 } else if (bitmap != null) {
                     final String cacheKey = url + maxWidthForEditor;
                     WordPress.getBitmapCache().putBitmap(cacheKey, bitmap);
+                    // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so, we need
+                    // to correctly set the input density to 160 ourselves.
+                    bitmap.setDensity(DisplayMetrics.DENSITY_DEFAULT);
                     BitmapDrawable bitmapDrawable = new BitmapDrawable(context.getResources(), bitmap);
                     callbacks.onImageLoaded(bitmapDrawable);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
@@ -8,6 +8,7 @@ import android.media.ThumbnailUtils;
 import android.os.AsyncTask;
 import android.provider.MediaStore;
 import android.text.TextUtils;
+import android.util.DisplayMetrics;
 
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.aztec.Html;
@@ -43,7 +44,8 @@ public class AztecVideoLoader implements Html.VideoThumbnailGetter {
                 // If local file
                 if (new File(url).exists()) {
                     Bitmap thumb = ThumbnailUtils.createVideoThumbnail(url, MediaStore.Images.Thumbnails.FULL_SCREEN_KIND);
-                    return ImageUtils.getScaledBitmapAtLongestSide(thumb, maxWidth);
+                    thumb = ImageUtils.getScaledBitmapAtLongestSide(thumb, maxWidth);
+                    thumb.setDensity(DisplayMetrics.DENSITY_DEFAULT);
                 }
 
                 return ImageUtils.getVideoFrameFromVideo(url, maxWidth);
@@ -53,6 +55,7 @@ public class AztecVideoLoader implements Html.VideoThumbnailGetter {
                 if (thumb == null) {
                     callbacks.onThumbnailFailed();
                 }
+                thumb.setDensity(DisplayMetrics.DENSITY_DEFAULT);
                 BitmapDrawable bitmapDrawable = new BitmapDrawable(context.getResources(), thumb);
                 callbacks.onThumbnailLoaded(bitmapDrawable);
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
@@ -31,9 +31,7 @@ public class AztecVideoLoader implements Html.VideoThumbnailGetter {
 
     public void loadVideoThumbnail(final String url, final Html.VideoThumbnailGetter.Callbacks callbacks,
                                    final int maxWidth, final int minWidth) {
-        // Ignore the maxWidth passed from Aztec, since it's the MAX of screen width/height
-        final int maxWidthForEditor = ImageUtils.getMaximumThumbnailWidthForEditor(context);
-        if (TextUtils.isEmpty(url) || maxWidthForEditor <= 0) {
+        if (TextUtils.isEmpty(url) || maxWidth <= 0) {
             callbacks.onThumbnailFailed();
             return;
         }
@@ -45,10 +43,10 @@ public class AztecVideoLoader implements Html.VideoThumbnailGetter {
                 // If local file
                 if (new File(url).exists()) {
                     Bitmap thumb = ThumbnailUtils.createVideoThumbnail(url, MediaStore.Images.Thumbnails.FULL_SCREEN_KIND);
-                    return ImageUtils.getScaledBitmapAtLongestSide(thumb, maxWidthForEditor);
+                    return ImageUtils.getScaledBitmapAtLongestSide(thumb, maxWidth);
                 }
 
-                return ImageUtils.getVideoFrameFromVideo(url, maxWidthForEditor);
+                return ImageUtils.getVideoFrameFromVideo(url, maxWidth);
             }
 
             protected void onPostExecute(Bitmap thumb) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
@@ -47,19 +47,14 @@ public class AztecVideoLoader implements Html.VideoThumbnailGetter {
                    return ThumbnailUtils.createVideoThumbnail(url, MediaStore.Images.Thumbnails.FULL_SCREEN_KIND);
                 }
 
-                // `getVideoFrameFromVideo` takes in consideration both width and height of the picture.
-                // We need to make sure to set the correct max width for the current thumb
-                // keeping the correct aspect ratio and the max width setting from the editor.
-                // Request double the width for now
-                return ImageUtils.getVideoFrameFromVideo(url, 2 * maxWidth);
+                return ImageUtils.getVideoFrameFromVideo(url, maxWidth);
             }
 
             protected void onPostExecute(Bitmap thumb) {
                 if (thumb == null) {
                     callbacks.onThumbnailFailed();
                 }
-                int maxRequestedSize =  MediaUtils.getMaxMediaSizeForEditor(thumb.getWidth(), thumb.getHeight(), maxWidth);
-                thumb = ImageUtils.getScaledBitmapAtLongestSide(thumb, maxRequestedSize);
+                thumb = ImageUtils.getScaledBitmapAtLongestSide(thumb, maxWidth);
                 thumb.setDensity(DisplayMetrics.DENSITY_DEFAULT);
                 BitmapDrawable bitmapDrawable = new BitmapDrawable(context.getResources(), thumb);
                 callbacks.onThumbnailLoaded(bitmapDrawable);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/services/AztecVideoLoader.java
@@ -10,7 +10,6 @@ import android.provider.MediaStore;
 import android.text.TextUtils;
 import android.util.DisplayMetrics;
 
-import org.wordpress.android.editor.MediaUtils;
 import org.wordpress.android.util.ImageUtils;
 import org.wordpress.aztec.Html;
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -889,13 +889,13 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         if (drawable instanceof BitmapDrawable) {
             bitmap = ((BitmapDrawable) drawable).getBitmap();
             bitmap = ImageUtils.getScaledBitmapAtLongestSide(bitmap, maxImageWidthForVisualEditor);
-            bitmap.setDensity(DisplayMetrics.DENSITY_DEFAULT);
         } else if (drawable instanceof VectorDrawable) {
              bitmap = getScaledBitmapFromVectorDrawable((VectorDrawable) drawable, maxImageWidthForVisualEditor,
                     maxImageWidthForVisualEditor);
         } else {
             throw new IllegalArgumentException("unsupported drawable type");
         }
+        bitmap.setDensity(DisplayMetrics.DENSITY_DEFAULT);
         return new BitmapDrawable(getResources(), bitmap);
     }
 
@@ -909,7 +909,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         }
 
         Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
-        bitmap.setDensity(DisplayMetrics.DENSITY_DEFAULT);
         Canvas canvas = new Canvas(bitmap);
         vectorDrawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
         vectorDrawable.draw(canvas);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -832,12 +832,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
             addDefaultSizeClassIfMissing(attrs);
 
-            // `getWPImageSpanThumbnailFromFilePath` takes in consideration both width and height of the picture.
-            // We need to make sure to set the correct max dimension for the current picture
-            // keeping the correct aspect ratio and the max width setting for the editor
-            int maxRequestedSize = MediaUtils.getMaxMediaSizeForEditor(getActivity(), safeMediaPreviewUrl, maxImageWidthForVisualEditor);
             Bitmap bitmapToShow = ImageUtils.getWPImageSpanThumbnailFromFilePath(
-                    getActivity(), safeMediaPreviewUrl, maxRequestedSize
+                    getActivity(), safeMediaPreviewUrl, maxImageWidthForVisualEditor
             );
             MediaPredicate localMediaIdPredicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
             if (bitmapToShow != null) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -20,7 +20,9 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
+import android.support.graphics.drawable.VectorDrawableCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
@@ -883,36 +885,22 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         return getAztecPlaceholderDrawableFromResID(R.drawable.ic_image_failed_grey_a_40_48dp);
     }
 
-    public BitmapDrawable getAztecPlaceholderDrawableFromResID(int drawableId) {
+    public BitmapDrawable getAztecPlaceholderDrawableFromResID(@DrawableRes int drawableId) {
         Drawable drawable = getResources().getDrawable(drawableId);
         Bitmap bitmap;
         if (drawable instanceof BitmapDrawable) {
             bitmap = ((BitmapDrawable) drawable).getBitmap();
             bitmap = ImageUtils.getScaledBitmapAtLongestSide(bitmap, maxImageWidthForVisualEditor);
-        } else if (drawable instanceof VectorDrawable) {
-             bitmap = getScaledBitmapFromVectorDrawable((VectorDrawable) drawable, maxImageWidthForVisualEditor,
-                    maxImageWidthForVisualEditor);
+        } else if (drawable instanceof VectorDrawableCompat || drawable instanceof VectorDrawable) {
+            bitmap = Bitmap.createBitmap(maxImageWidthForVisualEditor, maxImageWidthForVisualEditor, Bitmap.Config.ARGB_8888);
+            Canvas canvas = new Canvas(bitmap);
+            drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+            drawable.draw(canvas);
         } else {
             throw new IllegalArgumentException("unsupported drawable type");
         }
         bitmap.setDensity(DisplayMetrics.DENSITY_DEFAULT);
         return new BitmapDrawable(getResources(), bitmap);
-    }
-
-    // we can move this to utils
-    private static Bitmap getScaledBitmapFromVectorDrawable(VectorDrawable vectorDrawable, int width, int height) {
-        if (width < 1) {
-            width = vectorDrawable.getIntrinsicWidth();
-        }
-        if (height < 1) {
-            height = vectorDrawable.getIntrinsicHeight();
-        }
-
-        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
-        Canvas canvas = new Canvas(bitmap);
-        vectorDrawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
-        vectorDrawable.draw(canvas);
-        return bitmap;
     }
 
     @Override

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -26,6 +26,7 @@ import android.text.Editable;
 import android.text.Spanned;
 import android.text.TextUtils;
 import android.text.TextWatcher;
+import android.util.DisplayMetrics;
 import android.view.DragEvent;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -842,7 +843,9 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                     getActivity(),
                     safeMediaPreviewUrl,
                     maxWidth > realBitmapWidth && realBitmapWidth > 0 ? realBitmapWidth : maxWidth);
-
+            // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so, we need
+            // to correctly set the input density to 160 ourselves.
+            bitmapToShow.setDensity(DisplayMetrics.DENSITY_DEFAULT);
             MediaPredicate localMediaIdPredicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
 
             if (bitmapToShow != null) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -817,9 +817,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                         return;
                     }
 
-                    Bitmap resizedBitmap = ImageUtils.getScaledBitmapAtLongestSide(downloadedBitmap, maxImageWidthForVisualEditor);
-                    resizedBitmap.setDensity(DisplayMetrics.DENSITY_DEFAULT);
-                    replaceDrawable(new BitmapDrawable(getResources(), resizedBitmap));
+                    downloadedBitmap.setDensity(DisplayMetrics.DENSITY_DEFAULT);
+                    replaceDrawable(new BitmapDrawable(getResources(), downloadedBitmap));
                 }
             }, maxImageWidthForVisualEditor, 0);
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -190,7 +190,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         source = (SourceViewEditText) view.findViewById(R.id.source);
 
         // Set the default value for max and min picture sizes.
-        maxMediaSize = ImageUtils.getMaximumThumbnailWidthForEditor(getActivity());
+        maxMediaSize = MediaUtils.getMaximumThumbnailSizeForEditor(getActivity());
         minMediaSize = DisplayUtils.dpToPx(getActivity(), MIN_BITMAP_DIMENSION_DP);
         content.setMinImagesWidth(minMediaSize);
         content.setMaxImagesWidth(maxMediaSize);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -156,8 +156,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
     private Drawable loadingImagePlaceholder;
     private Drawable loadingVideoPlaceholder;
 
-    private int maxImageWidthForVisualEditor;
-    private int minImageWidthForVisualEditor;
+    private int maxMediaSize;
+    private int minMediaSize;
 
     public static AztecEditorFragment newInstance(String title, String content, boolean isExpanded) {
         mIsToolbarExpanded = isExpanded;
@@ -190,10 +190,10 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         source = (SourceViewEditText) view.findViewById(R.id.source);
 
         // Set the default value for max and min picture sizes.
-        maxImageWidthForVisualEditor = ImageUtils.getMaximumThumbnailWidthForEditor(getActivity());
-        minImageWidthForVisualEditor = DisplayUtils.dpToPx(getActivity(), MIN_BITMAP_DIMENSION_DP);
-        content.setMinImagesWidth(minImageWidthForVisualEditor);
-        content.setMaxImagesWidth(maxImageWidthForVisualEditor);
+        maxMediaSize = ImageUtils.getMaximumThumbnailWidthForEditor(getActivity());
+        minMediaSize = DisplayUtils.dpToPx(getActivity(), MIN_BITMAP_DIMENSION_DP);
+        content.setMinImagesWidth(minMediaSize);
+        content.setMaxImagesWidth(maxMediaSize);
 
         // request dependency injection. Do this after setting min/max dimensions
         if (getActivity() instanceof EditorFragmentActivity) {
@@ -807,7 +807,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                         return;
                     }
 
-                    if (downloadedBitmap.getHeight() < minImageWidthForVisualEditor || downloadedBitmap.getWidth() < minImageWidthForVisualEditor) {
+                    if (downloadedBitmap.getHeight() < minMediaSize || downloadedBitmap.getWidth() < minMediaSize) {
                         // Bitmap is too small.  Show image placeholder.
                         replaceDrawable(getLoadingMediaErrorPlaceholder(getString(R.string.error_media_small)));
                         return;
@@ -816,7 +816,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                     downloadedBitmap.setDensity(DisplayMetrics.DENSITY_DEFAULT);
                     replaceDrawable(new BitmapDrawable(getResources(), downloadedBitmap));
                 }
-            }, maxImageWidthForVisualEditor, 0);
+            }, maxMediaSize, 0);
 
             mActionStartedAt = System.currentTimeMillis();
         } else {
@@ -833,7 +833,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             addDefaultSizeClassIfMissing(attrs);
 
             Bitmap bitmapToShow = ImageUtils.getWPImageSpanThumbnailFromFilePath(
-                    getActivity(), safeMediaPreviewUrl, maxImageWidthForVisualEditor
+                    getActivity(), safeMediaPreviewUrl, maxMediaSize
             );
             MediaPredicate localMediaIdPredicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
             if (bitmapToShow != null) {
@@ -873,7 +873,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         } else {
             ToastUtils.showToast(getActivity(), msg);
         }
-        return MediaUtils.getAztecPlaceholderDrawableFromResID(this.getActivity(), R.drawable.ic_image_failed_grey_a_40_48dp, maxImageWidthForVisualEditor);
+        return MediaUtils.getAztecPlaceholderDrawableFromResID(this.getActivity(), R.drawable.ic_image_failed_grey_a_40_48dp, maxMediaSize);
     }
 
     @Override
@@ -2018,17 +2018,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         this.loadingVideoPlaceholder = loadingVideoPlaceholder;
     }
 
-    public void setMaxImageWidth(int maxWidth) {
-        this.maxImageWidthForVisualEditor = maxWidth;
-        content.setMaxImagesWidth(maxWidth);
-    }
-
-    public int getMaxImageWidth() {
-        return maxImageWidthForVisualEditor;
-    }
-
-    public void setMinImageWidth(int minWidth) {
-        this.minImageWidthForVisualEditor = minWidth;
-        content.setMinImagesWidth(minWidth);
+    public int getMaxMediaSize() {
+        return maxMediaSize;
     }
 }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -190,7 +190,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         source = (SourceViewEditText) view.findViewById(R.id.source);
 
         // Set the default value for max and min picture sizes.
-        maxMediaSize = MediaUtils.getMaximumThumbnailSizeForEditor(getActivity());
+        maxMediaSize = EditorMediaUtils.getMaximumThumbnailSizeForEditor(getActivity());
         minMediaSize = DisplayUtils.dpToPx(getActivity(), MIN_BITMAP_DIMENSION_DP);
         content.setMinImagesWidth(minMediaSize);
         content.setMaxImagesWidth(maxMediaSize);
@@ -873,7 +873,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         } else {
             ToastUtils.showToast(getActivity(), msg);
         }
-        return MediaUtils.getAztecPlaceholderDrawableFromResID(this.getActivity(), R.drawable.ic_image_failed_grey_a_40_48dp, maxMediaSize);
+        return EditorMediaUtils.getAztecPlaceholderDrawableFromResID(this.getActivity(), R.drawable.ic_image_failed_grey_a_40_48dp, maxMediaSize);
     }
 
     @Override

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -842,7 +842,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
                     safeMediaPreviewUrl,
                     maxImageWidthForVisualEditor > realBitmapWidth && realBitmapWidth > 0 ? realBitmapWidth
                             : maxImageWidthForVisualEditor);
-            MediaPredicate localMediaIdPredicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId); if (bitmapToShow != null) {
+            MediaPredicate localMediaIdPredicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
+            if (bitmapToShow != null) {
                 // By default, BitmapFactory.decodeFile sets the bitmap's density to the device default so, we need
                 // to correctly set the input density to 160 ourselves.
                 bitmapToShow.setDensity(DisplayMetrics.DENSITY_DEFAULT);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -252,6 +252,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             }
         };
 
+        content.setMaxImagesWidth(ImageUtils.getMaximumThumbnailWidthForEditor(getActivity()));
         content.refreshText();
 
         mAztecReady = true;
@@ -2018,5 +2019,13 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     public void setLoadingVideoPlaceholder(Drawable loadingVideoPlaceholder) {
         this.loadingVideoPlaceholder = loadingVideoPlaceholder;
+    }
+
+    public void setMaxImageWidth(int maxWidth) {
+        content.setMaxImagesWidth(maxWidth);
+    }
+
+    public void setMinImageWidth(int minWidth) {
+        content.setMinImagesWidth(minWidth);
     }
 }

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUtils.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorMediaUtils.java
@@ -15,7 +15,7 @@ import android.util.DisplayMetrics;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.ImageUtils;
 
-public class MediaUtils {
+public class EditorMediaUtils {
     public static BitmapDrawable getAztecPlaceholderDrawableFromResID(Context context, @DrawableRes int drawableId, int maxImageSizeForVisualEditor) {
         Drawable drawable = ContextCompat.getDrawable(context, drawableId);
         Bitmap bitmap;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/MediaUtils.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/MediaUtils.java
@@ -1,0 +1,63 @@
+package org.wordpress.android.editor;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.VectorDrawable;
+import android.net.Uri;
+import android.support.annotation.DrawableRes;
+import android.support.graphics.drawable.VectorDrawableCompat;
+import android.support.v4.content.ContextCompat;
+import android.text.TextUtils;
+import android.util.DisplayMetrics;
+
+import org.wordpress.android.util.ImageUtils;
+
+public class MediaUtils {
+    public static int getMaxMediaSizeForEditor(Context context, String url, int maxImageWidthForVisualEditor) {
+        if (TextUtils.isEmpty(url) || context == null) {
+            return maxImageWidthForVisualEditor;
+        }
+
+        // Most of the functions in ImageUtils uses during resize both the width and height to calculate the max size allowed.
+        // Here in the editor we're only using the width of the picture.
+        // We need to make sure to set the correct max dimension for the current picture
+        // keeping the correct aspect ratio and the max width setting from the editor
+        int[] bitmapDimensions = ImageUtils.getImageSize(Uri.parse(url), context);
+        int realBitmapWidth = bitmapDimensions[0];
+        int realBitmapHeight = bitmapDimensions[1];
+        return getMaxMediaSizeForEditor(realBitmapWidth, realBitmapHeight, maxImageWidthForVisualEditor);
+    }
+
+    public static int getMaxMediaSizeForEditor(int realBitmapWidth, int realBitmapHeight, int maxImageWidthForVisualEditor) {
+        int requiredWidth = maxImageWidthForVisualEditor > realBitmapWidth && realBitmapWidth > 0 ? realBitmapWidth
+                : maxImageWidthForVisualEditor;
+        int maxRequestedSize = requiredWidth;
+        if (realBitmapHeight > realBitmapWidth) {
+            // Calculate the max height keeping the correct aspect ratio
+            float proportionateHeight = (requiredWidth * realBitmapHeight) / ((float) realBitmapWidth);
+            maxRequestedSize = (int) Math.rint(proportionateHeight);
+        }
+        return maxRequestedSize;
+    }
+
+    public static BitmapDrawable getAztecPlaceholderDrawableFromResID(Context context, @DrawableRes int drawableId, int maxImageWidthForVisualEditor) {
+        Drawable drawable = ContextCompat.getDrawable(context, drawableId);
+        Bitmap bitmap;
+        if (drawable instanceof BitmapDrawable) {
+            bitmap = ((BitmapDrawable) drawable).getBitmap();
+            bitmap = ImageUtils.getScaledBitmapAtLongestSide(bitmap, maxImageWidthForVisualEditor);
+        } else if (drawable instanceof VectorDrawableCompat || drawable instanceof VectorDrawable) {
+            bitmap = Bitmap.createBitmap(maxImageWidthForVisualEditor, maxImageWidthForVisualEditor, Bitmap.Config.ARGB_8888);
+            Canvas canvas = new Canvas(bitmap);
+            drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+            drawable.draw(canvas);
+        } else {
+            throw new IllegalArgumentException("Unsupported drawable type");
+        }
+        bitmap.setDensity(DisplayMetrics.DENSITY_DEFAULT);
+        return new BitmapDrawable(context.getResources(), bitmap);
+    }
+}

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/MediaUtils.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/MediaUtils.java
@@ -6,43 +6,14 @@ import android.graphics.Canvas;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.VectorDrawable;
-import android.net.Uri;
 import android.support.annotation.DrawableRes;
 import android.support.graphics.drawable.VectorDrawableCompat;
 import android.support.v4.content.ContextCompat;
-import android.text.TextUtils;
 import android.util.DisplayMetrics;
 
 import org.wordpress.android.util.ImageUtils;
 
 public class MediaUtils {
-    public static int getMaxMediaSizeForEditor(Context context, String url, int maxImageWidthForVisualEditor) {
-        if (TextUtils.isEmpty(url) || context == null) {
-            return maxImageWidthForVisualEditor;
-        }
-
-        // Most of the functions in ImageUtils uses during resize both the width and height to calculate the max size allowed.
-        // Here in the editor we're only using the width of the picture.
-        // We need to make sure to set the correct max dimension for the current picture
-        // keeping the correct aspect ratio and the max width setting from the editor
-        int[] bitmapDimensions = ImageUtils.getImageSize(Uri.parse(url), context);
-        int realBitmapWidth = bitmapDimensions[0];
-        int realBitmapHeight = bitmapDimensions[1];
-        return getMaxMediaSizeForEditor(realBitmapWidth, realBitmapHeight, maxImageWidthForVisualEditor);
-    }
-
-    public static int getMaxMediaSizeForEditor(int realBitmapWidth, int realBitmapHeight, int maxImageWidthForVisualEditor) {
-        int requiredWidth = maxImageWidthForVisualEditor > realBitmapWidth && realBitmapWidth > 0 ? realBitmapWidth
-                : maxImageWidthForVisualEditor;
-        int maxRequestedSize = requiredWidth;
-        if (realBitmapHeight > realBitmapWidth) {
-            // Calculate the max height keeping the correct aspect ratio
-            float proportionateHeight = (requiredWidth * realBitmapHeight) / ((float) realBitmapWidth);
-            maxRequestedSize = (int) Math.rint(proportionateHeight);
-        }
-        return maxRequestedSize;
-    }
-
     public static BitmapDrawable getAztecPlaceholderDrawableFromResID(Context context, @DrawableRes int drawableId, int maxImageWidthForVisualEditor) {
         Drawable drawable = ContextCompat.getDrawable(context, drawableId);
         Bitmap bitmap;

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/MediaUtils.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/MediaUtils.java
@@ -16,19 +16,19 @@ import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.ImageUtils;
 
 public class MediaUtils {
-    public static BitmapDrawable getAztecPlaceholderDrawableFromResID(Context context, @DrawableRes int drawableId, int maxImageWidthForVisualEditor) {
+    public static BitmapDrawable getAztecPlaceholderDrawableFromResID(Context context, @DrawableRes int drawableId, int maxImageSizeForVisualEditor) {
         Drawable drawable = ContextCompat.getDrawable(context, drawableId);
         Bitmap bitmap;
         if (drawable instanceof BitmapDrawable) {
             bitmap = ((BitmapDrawable) drawable).getBitmap();
-            bitmap = ImageUtils.getScaledBitmapAtLongestSide(bitmap, maxImageWidthForVisualEditor);
+            bitmap = ImageUtils.getScaledBitmapAtLongestSide(bitmap, maxImageSizeForVisualEditor);
         } else if (drawable instanceof VectorDrawableCompat || drawable instanceof VectorDrawable) {
-            bitmap = Bitmap.createBitmap(maxImageWidthForVisualEditor, maxImageWidthForVisualEditor, Bitmap.Config.ARGB_8888);
+            bitmap = Bitmap.createBitmap(maxImageSizeForVisualEditor, maxImageSizeForVisualEditor, Bitmap.Config.ARGB_8888);
             Canvas canvas = new Canvas(bitmap);
             drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
             drawable.draw(canvas);
         } else {
-            throw new IllegalArgumentException("Unsupported drawable type");
+            throw new IllegalArgumentException("Unsupported Drawable Type: " + drawable.getClass().getName());
         }
         bitmap.setDensity(DisplayMetrics.DENSITY_DEFAULT);
         return new BitmapDrawable(context.getResources(), bitmap);

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/MediaUtils.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/MediaUtils.java
@@ -3,6 +3,7 @@ package org.wordpress.android.editor;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.Point;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.VectorDrawable;
@@ -11,6 +12,7 @@ import android.support.graphics.drawable.VectorDrawableCompat;
 import android.support.v4.content.ContextCompat;
 import android.util.DisplayMetrics;
 
+import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.ImageUtils;
 
 public class MediaUtils {
@@ -30,5 +32,15 @@ public class MediaUtils {
         }
         bitmap.setDensity(DisplayMetrics.DENSITY_DEFAULT);
         return new BitmapDrawable(context.getResources(), bitmap);
+    }
+
+    public static int getMaximumThumbnailSizeForEditor(Context context) {
+        Point size = DisplayUtils.getDisplayPixelSize(context);
+        int screenWidth = size.x;
+        int screenHeight = size.y;
+        int maximumThumbnailWidthForEditor = screenWidth > screenHeight?screenHeight:screenWidth;
+        int padding = DisplayUtils.dpToPx(context, 48) * 2;
+        maximumThumbnailWidthForEditor -= padding;
+        return maximumThumbnailWidthForEditor;
     }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/ImageUtils.java
@@ -719,6 +719,7 @@ public class ImageUtils {
 
     /**
      * Get the maximum size a thumbnail can be to fit in either portrait or landscape orientations.
+     * @deprecated Use `getMaximumThumbnailSizeForEditor` available in MediaUtils class in Editors project
      */
     public static int getMaximumThumbnailWidthForEditor(Context context) {
         int maximumThumbnailWidthForEditor;


### PR DESCRIPTION
Fixes #6945 (and partially #6942 that requires an Aztec patch for full resolution), by making sure pictures added to the editor are properly resized by the MediaLoader(s) to the correct width requested by the editor. The max width for pictures is set by us at run-time by using the value returned in `ImageUtils.getMaximumThumbnailWidthForEditor(getActivity())`.

One of the problem fixed was different thumb sizes for the same picture in the editor. The culprit  is the way the preview thumb is created by the functions that load it from the disk, or from the network. Volley code does only take in consideration the width of the picture, instead our ImageUtils does take in consideration both height and width of the picture. So the different sizes of the preview thumb for portrait pictures if loaded from the network.

Also fixed the problem with placeholders that could appear too small in some cases. 
_Note that for a full resolution of this, error placeholder that appear when a network error occurs,  we need a patch in Aztec._

Test 1:
- Add pictures to the editor. 
- Wait until both of those are uploaded
- Exit the editor
- Re-open the editor and pictures should have the same size

Test 2:
- Add pictures to the editor from local device. 
- Add picture to the editor from Media Library
- All the pictures should have the same size (* make sure to use pictures bigger than the max size, since pictures are not upscaled. If you use small pictures than their real size is used).

cc  @mzorz 

