### PR TITLE
Issue/7054 theme fragment activity reference

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -52,9 +52,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
     private static final long WP_COM_THEMES_SYNC_TIMEOUT = 1000 * 60 * 60 * 24 * 3;
 
     private static final String IS_IN_SEARCH_MODE = "is_in_search_mode";
-    private static final String ALERT_TAB = "alert";
 
-    private boolean mIsRunning;
     private ThemeBrowserFragment mThemeBrowserFragment;
     private ThemeSearchFragment mThemeSearchFragment;
     private ThemeModel mCurrentTheme;
@@ -106,15 +104,8 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
     protected void onResume() {
         super.onResume();
         showCorrectToolbar();
-        mIsRunning = true;
         ActivityId.trackLastActivity(ActivityId.THEMES);
         fetchCurrentTheme();
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-        mIsRunning = false;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -111,6 +111,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
         showCorrectToolbar();
         mIsRunning = true;
         ActivityId.trackLastActivity(ActivityId.THEMES);
+        fetchCurrentTheme();
     }
 
     @Override
@@ -329,11 +330,11 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
         }
     }
 
-    public void setIsInSearchMode(boolean isInSearchMode) {
+    private void setIsInSearchMode(boolean isInSearchMode) {
         mIsInSearchMode = isInSearchMode;
     }
 
-    public void searchThemes(String searchTerm) {
+    private void searchThemes(String searchTerm) {
         if (TextUtils.isEmpty(searchTerm)) {
             return;
         }
@@ -341,25 +342,25 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
         mDispatcher.dispatch(ThemeActionBuilder.newSearchThemesAction(payload));
     }
 
-    public void fetchCurrentTheme() {
+    private void fetchCurrentTheme() {
         mDispatcher.dispatch(ThemeActionBuilder.newFetchCurrentThemeAction(mSite));
     }
 
-    public void fetchWpComThemesIfSyncTimedOut(boolean force) {
+    private void fetchWpComThemesIfSyncTimedOut(boolean force) {
         long currentTime = System.currentTimeMillis();
         if (force || currentTime - AppPrefs.getLastWpComThemeSync() > WP_COM_THEMES_SYNC_TIMEOUT) {
             mDispatcher.dispatch(ThemeActionBuilder.newFetchWpComThemesAction());
         }
     }
 
-    public void fetchInstalledThemesIfJetpackSite() {
+    private void fetchInstalledThemesIfJetpackSite() {
         if (mSite.isJetpackConnected() && mSite.isUsingWpComRestApi() && !mIsFetchingInstalledThemes) {
             mDispatcher.dispatch(ThemeActionBuilder.newFetchInstalledThemesAction(mSite));
             mIsFetchingInstalledThemes = true;
         }
     }
 
-    public void activateTheme(String themeId) {
+    private void activateTheme(String themeId) {
         if (!mSite.isUsingWpComRestApi()) {
             AppLog.i(T.THEMES, "Theme activation requires a site using WP.com REST API. Aborting request.");
             return;
@@ -383,16 +384,8 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
         mDispatcher.dispatch(ThemeActionBuilder.newActivateThemeAction(new ActivateThemePayload(mSite, theme)));
     }
 
-    protected void setThemeBrowserFragment(ThemeBrowserFragment themeBrowserFragment) {
-        mThemeBrowserFragment = themeBrowserFragment;
-    }
-
-    protected void setThemeSearchFragment(ThemeSearchFragment themeSearchFragment) {
-        mThemeSearchFragment = themeSearchFragment;
-    }
-
-    protected void showToolbar() {
-        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+    private void showToolbar() {
+        Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
         ActionBar actionBar = getSupportActionBar();
@@ -414,7 +407,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
     }
 
     private void showSearchToolbar() {
-        Toolbar toolbarSearch = (Toolbar) findViewById(R.id.toolbar_search);
+        Toolbar toolbarSearch = findViewById(R.id.toolbar_search);
         setSupportActionBar(toolbarSearch);
         toolbarSearch.setTitle("");
         findViewById(R.id.toolbar).setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -118,9 +118,9 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener {
         View view = inflater.inflate(R.layout.theme_browser_fragment, container, false);
 
         setRetainInstance(true);
-        mNoResultText = (TextView) view.findViewById(R.id.theme_no_search_result_text);
-        mEmptyTextView = (TextView) view.findViewById(R.id.text_empty);
-        mEmptyView = (RelativeLayout) view.findViewById(R.id.empty_view);
+        mNoResultText = view.findViewById(R.id.theme_no_search_result_text);
+        mEmptyTextView = view.findViewById(R.id.text_empty);
+        mEmptyView = view.findViewById(R.id.empty_view);
 
         configureGridView(inflater, view);
         configureSwipeToRefresh(view);
@@ -143,15 +143,9 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener {
     }
 
     @Override
-    public void onResume() {
-        super.onResume();
-        // TODO mThemeBrowserActivity.fetchCurrentTheme();
-    }
-
-    @Override
     public void onMovedToScrapHeap(View view) {
         // cancel image fetch requests if the view has been moved to recycler.
-        WPNetworkImageView niv = (WPNetworkImageView) view.findViewById(R.id.theme_grid_item_image);
+        WPNetworkImageView niv = view.findViewById(R.id.theme_grid_item_image);
         if (niv != null) {
             // this tag is set in the ThemeBrowserAdapter class
             String requestUrl = (String) niv.getTag();
@@ -208,7 +202,7 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener {
     }
 
     private void configureGridView(LayoutInflater inflater, View view) {
-        mGridView = (HeaderGridView) view.findViewById(R.id.theme_listview);
+        mGridView = view.findViewById(R.id.theme_listview);
         addHeaderViews(inflater);
         mGridView.setRecyclerListener(this);
     }
@@ -216,10 +210,10 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener {
     private void addMainHeader(LayoutInflater inflater) {
         @SuppressLint("InflateParams")
         View header = inflater.inflate(R.layout.theme_grid_cardview_header, null);
-        mCurrentThemeTextView = (TextView) header.findViewById(R.id.header_theme_text);
+        mCurrentThemeTextView = header.findViewById(R.id.header_theme_text);
 
         setThemeNameIfAlreadyAvailable();
-        LinearLayout customize = (LinearLayout) header.findViewById(R.id.customize);
+        LinearLayout customize = header.findViewById(R.id.customize);
         customize.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -227,7 +221,7 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener {
             }
         });
 
-        LinearLayout details = (LinearLayout) header.findViewById(R.id.details);
+        LinearLayout details = header.findViewById(R.id.details);
         details.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -235,7 +229,7 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener {
             }
         });
 
-        LinearLayout support = (LinearLayout) header.findViewById(R.id.support);
+        LinearLayout support = header.findViewById(R.id.support);
         support.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -273,7 +267,7 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener {
             }
         });
         mGridView.addHeaderView(headerSearch);
-        ImageButton searchButton = (ImageButton) headerSearch.findViewById(R.id.theme_search);
+        ImageButton searchButton = headerSearch.findViewById(R.id.theme_search);
         searchButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
@@ -27,7 +27,7 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
         MenuItemCompat.OnActionExpandListener {
     public static final String TAG = ThemeSearchFragment.class.getName();
     private static final String BUNDLE_LAST_SEARCH = "BUNDLE_LAST_SEARCH";
-    public static final int SEARCH_VIEW_MAX_WIDTH = 10000;
+    private static final int SEARCH_VIEW_MAX_WIDTH = 10000;
 
     private List<ThemeModel> mSearchResults;
     private String mLastSearch = "";

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
@@ -48,18 +48,15 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
-        if (savedInstanceState != null) {
-            mLastSearch = savedInstanceState.getString(BUNDLE_LAST_SEARCH);
-        }
-        if (savedInstanceState == null) {
-            mSite = (SiteModel) getArguments().getSerializable(WordPress.SITE);
-        } else {
-            mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
-        }
 
+        mSite = (SiteModel) getArguments().getSerializable(WordPress.SITE);
         if (mSite == null) {
             ToastUtils.showToast(getActivity(), R.string.blog_not_found, ToastUtils.Duration.SHORT);
             getActivity().finish();
+        }
+
+        if (savedInstanceState != null) {
+            mLastSearch = savedInstanceState.getString(BUNDLE_LAST_SEARCH);
         }
     }
 
@@ -67,7 +64,6 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putString(BUNDLE_LAST_SEARCH, mLastSearch);
-        outState.putSerializable(WordPress.SITE, mSite);
     }
 
     @Override
@@ -89,9 +85,7 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
 
     @Override
     public boolean onMenuItemActionCollapse(MenuItem item) {
-        mThemeBrowserActivity.setIsInSearchMode(false);
-        mThemeBrowserActivity.showToolbar();
-        mThemeBrowserActivity.getFragmentManager().popBackStack();
+        mCallback.onSearchClosed();
         return true;
     }
 
@@ -165,8 +159,8 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
 
     private void search(String searchTerm) {
         mLastSearch = searchTerm;
-        if (NetworkUtils.isNetworkAvailable(mThemeBrowserActivity)) {
-            mThemeBrowserActivity.searchThemes(searchTerm);
+        if (NetworkUtils.isNetworkAvailable(getActivity())) {
+            mCallback.onSearchRequested(searchTerm);
         } else {
             refreshView();
         }


### PR DESCRIPTION
Fixes #7054 - this PR removes the reference to `ThemeBrowserActivity` from both theme fragments and addresses a number of cleanup issues (unused variables, unnecessary fragment creation, unnecessary public variables/methods, etc.).

cc @oguzkocer 

  