### PR TITLE
Local theme search

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -144,6 +144,7 @@ public class ActivityLauncher {
             Intent intent = new Intent(context, ThemeBrowserActivity.class);
             intent.putExtra(WordPress.SITE, site);
             context.startActivity(intent);
+            AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.THEMES_ACCESSED_THEMES_BROWSER, site);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -184,11 +184,6 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
     }
 
     @Override
-    public void onSearchRequested(String searchTerm) {
-        searchThemes(searchTerm);
-    }
-
-    @Override
     public void onSearchClosed() {
         setIsInSearchMode(false);
         showToolbar();
@@ -313,13 +308,6 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
 
     private void setIsInSearchMode(boolean isInSearchMode) {
         mIsInSearchMode = isInSearchMode;
-    }
-
-    private void searchThemes(String searchTerm) {
-        if (TextUtils.isEmpty(searchTerm)) {
-            return;
-        }
-        // TODO: implement local theme search
     }
 
     private void fetchCurrentTheme() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -83,7 +83,6 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
         setContentView(R.layout.theme_browser_activity);
 
         if (savedInstanceState == null) {
-            AnalyticsUtils.trackWithSiteDetails(Stat.THEMES_ACCESSED_THEMES_BROWSER, mSite);
             addBrowserFragment();
         } else {
             mThemeBrowserFragment = (ThemeBrowserFragment) getFragmentManager().findFragmentByTag(ThemeBrowserFragment.TAG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -63,7 +63,6 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener {
         void onDetailsSelected(String themeId);
         void onSupportSelected(String themeId);
         void onSearchClicked();
-        void onSearchRequested(String searchTerm);
         void onSearchClosed();
         void onSwipeToRefresh();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -75,7 +75,7 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener {
     private TextView mCurrentThemeTextView;
     private ThemeBrowserAdapter mAdapter;
     private boolean mShouldRefreshOnStart;
-    private TextView mEmptyTextView;
+    protected TextView mEmptyTextView;
     private SiteModel mSite;
 
     ThemeBrowserFragmentCallback mCallback;
@@ -268,7 +268,7 @@ public class ThemeBrowserFragment extends Fragment implements RecyclerListener {
         });
     }
 
-    private void setEmptyViewVisible(boolean visible) {
+    protected void setEmptyViewVisible(boolean visible) {
         if (!isAdded() || getView() == null) {
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
@@ -92,7 +92,7 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
 
     @Override
     public boolean onQueryTextChange(String newText) {
-        if (!mLastSearch.equals(newText) && !newText.equals("")) {
+        if (!mLastSearch.equals(newText)) {
             search(newText);
         }
         return true;

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
@@ -1,8 +1,10 @@
 package org.wordpress.android.ui.themes;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.widget.SearchView;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -12,6 +14,10 @@ import android.view.View;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.SiteModel;
+import org.wordpress.android.fluxc.model.ThemeModel;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A fragment for display the results of a theme search
@@ -114,8 +120,15 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
         // No header on Search
     }
 
+    @Override
+    protected List<ThemeModel> fetchThemes() {
+        List<ThemeModel> themes = super.fetchThemes();
+        return filter(themes);
+    }
+
     private void search(String searchTerm) {
         mLastSearch = searchTerm;
+        refreshView();
     }
 
     private void configureSearchView() {
@@ -123,5 +136,18 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
         mSearchView.setOnQueryTextListener(this);
         mSearchView.setQuery(mLastSearch, true);
         mSearchView.setMaxWidth(SEARCH_VIEW_MAX_WIDTH);
+    }
+
+    private List<ThemeModel> filter(@NonNull List<ThemeModel> themes) {
+        if (TextUtils.isEmpty(mLastSearch)) {
+            return themes;
+        }
+        List<ThemeModel> filteredThemes = new ArrayList<>();
+        for (ThemeModel theme : themes) {
+            if (theme.getName().toLowerCase().contains(mLastSearch.toLowerCase())) {
+                filteredThemes.add(theme);
+            }
+        }
+        return filteredThemes;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
@@ -14,7 +14,6 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.ThemeModel;
 import org.wordpress.android.util.NetworkUtils;
-import org.wordpress.android.util.ToastUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,8 +32,6 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
     private SearchView mSearchView;
     private MenuItem mSearchMenuItem;
 
-    private SiteModel mSite;
-
     public static ThemeSearchFragment newInstance(SiteModel site) {
         ThemeSearchFragment fragment = new ThemeSearchFragment();
         Bundle bundle = new Bundle();
@@ -47,12 +44,6 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
-
-        mSite = (SiteModel) getArguments().getSerializable(WordPress.SITE);
-        if (mSite == null) {
-            ToastUtils.showToast(getActivity(), R.string.blog_not_found, ToastUtils.Duration.SHORT);
-            getActivity().finish();
-        }
 
         if (savedInstanceState != null) {
             mLastSearch = savedInstanceState.getString(BUNDLE_LAST_SEARCH);

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
@@ -126,6 +126,14 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
         return filter(themes);
     }
 
+    @Override
+    protected void setEmptyViewVisible(boolean visible) {
+        super.setEmptyViewVisible(visible);
+        if (!TextUtils.isEmpty(mLastSearch)) {
+            mEmptyTextView.setText(R.string.theme_no_search_result_found);
+        }
+    }
+
     private void search(String searchTerm) {
         mLastSearch = searchTerm;
         refreshView();

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
@@ -12,11 +12,6 @@ import android.view.View;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.SiteModel;
-import org.wordpress.android.fluxc.model.ThemeModel;
-import org.wordpress.android.util.NetworkUtils;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * A fragment for display the results of a theme search
@@ -27,7 +22,6 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
     private static final String BUNDLE_LAST_SEARCH = "BUNDLE_LAST_SEARCH";
     private static final int SEARCH_VIEW_MAX_WIDTH = 10000;
 
-    private List<ThemeModel> mSearchResults;
     private String mLastSearch = "";
     private SearchView mSearchView;
     private MenuItem mSearchMenuItem;
@@ -82,7 +76,6 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
     @Override
     public boolean onQueryTextSubmit(String query) {
         if (!mLastSearch.equals(query)) {
-            mLastSearch = query;
             search(query);
         }
         if (mSearchView != null) {
@@ -94,7 +87,6 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
     @Override
     public boolean onQueryTextChange(String newText) {
         if (!mLastSearch.equals(newText) && !newText.equals("")) {
-            mLastSearch = newText;
             search(newText);
         }
         return true;
@@ -111,26 +103,6 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
     }
 
     @Override
-    protected List<ThemeModel> fetchThemes() {
-        if (mSearchResults == null) {
-            return mThemeStore.getWpComThemes();
-        }
-
-        // create a copy of the search results list to filter without changing results
-        List<ThemeModel> themes = new ArrayList<>(mSearchResults);
-
-        // move active theme to the top of the list if it's in the search results
-        moveActiveThemeToFront(themes);
-
-        // remove premium themes if plan doesn't support it
-        if (!shouldShowPremiumThemes()) {
-            removeNonActivePremiumThemes(themes);
-        }
-
-        return themes;
-    }
-
-    @Override
     protected void configureSwipeToRefresh(View view) {
         super.configureSwipeToRefresh(view);
         mSwipeToRefreshHelper.setRefreshing(false);
@@ -142,18 +114,8 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
         // No header on Search
     }
 
-    public void setSearchResults(List<ThemeModel> results) {
-        mSearchResults = results;
-        refreshView();
-    }
-
     private void search(String searchTerm) {
         mLastSearch = searchTerm;
-        if (NetworkUtils.isNetworkAvailable(getActivity())) {
-            mCallback.onSearchRequested(searchTerm);
-        } else {
-            refreshView();
-        }
     }
 
     private void configureSearchView() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeSearchFragment.java
@@ -151,8 +151,10 @@ public class ThemeSearchFragment extends ThemeBrowserFragment implements SearchV
             return themes;
         }
         List<ThemeModel> filteredThemes = new ArrayList<>();
+        String lcSearch = mLastSearch.toLowerCase();
         for (ThemeModel theme : themes) {
-            if (theme.getName().toLowerCase().contains(mLastSearch.toLowerCase())) {
+            if (theme.getName().toLowerCase().contains(lcSearch)
+                    || (theme.getDescription() != null && theme.getDescription().toLowerCase().contains(lcSearch))) {
                 filteredThemes.add(theme);
             }
         }


### PR DESCRIPTION
This PR adds support for searching themes using the local DB. For now, it only looks for the name field, but we can expand on that. I am also not super happy about the way I needed to do some things here, but since we are considering removing the fragments, I don't think it's worth spending time on them as they will just go away with that change. I am also keeping the headers for the search sections compared to the previous implementation simply because this implementation searches both wp.com and Jetpack themes instead of just wp.com ones.
