### PR TITLE
Remove list toolbar menu button highlighting on click

### DIFF
--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ol_selector.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ol_selector.xml
@@ -4,7 +4,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <item android:drawable="@drawable/format_bar_button_ol_disabled" android:state_enabled="false" />
-    <item android:drawable="@drawable/format_bar_button_ol_highlighted" android:state_checked="true" />
     <item android:drawable="@drawable/format_bar_button_ol_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_ol" />
 

--- a/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ul_selector.xml
+++ b/libs/editor/WordPressEditor/src/main/res/drawable/format_bar_button_ul_selector.xml
@@ -4,7 +4,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <item android:drawable="@drawable/format_bar_button_ul_disabled" android:state_enabled="false" />
-    <item android:drawable="@drawable/format_bar_button_ul_highlighted" android:state_checked="true" />
     <item android:drawable="@drawable/format_bar_button_ul_highlighted" android:state_focused="true" />
     <item android:drawable="@drawable/format_bar_button_ul" />
 


### PR DESCRIPTION
Fixes #6956. This PR removes the highlighted state of the list toolbar button when it's clicked. The list style is indicated by the icon (ordered list has a different one). It now behaves the same way as the heading toolbar button.