### PR TITLE
Add pull to refresh to plugin list

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
@@ -167,7 +167,7 @@ public class PluginListActivity extends AppCompatActivity {
         }
         mSwipeToRefreshHelper.setRefreshing(false);
         if (event.isError()) {
-            AppLog.e(T.API, "An error occurred while fetching the plugins: " + event.error.message);
+            ToastUtils.showToast(this, getString(R.string.plugin_fetch_error, event.error.message));
             return;
         }
         refreshPluginList();

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
@@ -167,7 +167,7 @@ public class PluginListActivity extends AppCompatActivity {
         }
         mSwipeToRefreshHelper.setRefreshing(false);
         if (event.isError()) {
-            ToastUtils.showToast(this, getString(R.string.plugin_fetch_error, event.error.message));
+            ToastUtils.showToast(this, R.string.plugin_fetch_error);
             return;
         }
         refreshPluginList();

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListActivity.java
@@ -16,7 +16,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
-import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -56,7 +55,6 @@ public class PluginListActivity extends AppCompatActivity {
     private SiteModel mSite;
     private RecyclerView mRecyclerView;
     private PluginListAdapter mAdapter;
-    private ProgressBar mProgressBar;
     private SwipeToRefreshHelper mSwipeToRefreshHelper;
 
     @Inject PluginStore mPluginStore;
@@ -91,9 +89,6 @@ public class PluginListActivity extends AppCompatActivity {
         }
 
         setupViews();
-        if (mPluginStore.getSitePlugins(mSite).size() == 0) {
-            mProgressBar.setVisibility(View.VISIBLE);
-        }
 
         if (savedInstanceState != null) {
             mSwipeToRefreshHelper.setRefreshing(savedInstanceState.getBoolean(KEY_REFRESHING, false));
@@ -135,8 +130,6 @@ public class PluginListActivity extends AppCompatActivity {
         mRecyclerView.addItemDecoration(dividerItemDecoration);
         mAdapter = new PluginListAdapter(this);
         mRecyclerView.setAdapter(mAdapter);
-
-        mProgressBar = findViewById(R.id.plugin_progress_bar);
 
         mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
                 (CustomSwipeRefreshLayout) findViewById(R.id.ptr_layout),

--- a/WordPress/src/main/res/layout/plugin_list_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_list_activity.xml
@@ -19,11 +19,4 @@
             android:layout_height="match_parent"
             android:scrollbars="vertical" />
     </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
-
-    <ProgressBar
-        android:id="@+id/plugin_progress_bar"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:visibility="gone" />
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/plugin_list_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_list_activity.xml
@@ -1,24 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <include
         android:id="@+id/toolbar"
-        layout="@layout/toolbar"/>
+        layout="@layout/toolbar" />
 
-    <android.support.v7.widget.RecyclerView
-        android:id="@+id/plugins_recycler_view"
+    <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
+        android:id="@+id/ptr_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_below="@id/toolbar"
-        android:scrollbars="vertical"/>
+        android:layout_below="@id/toolbar">
+
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/plugins_recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scrollbars="vertical" />
+    </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
     <ProgressBar
         android:id="@+id/plugin_progress_bar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
-        android:visibility="gone"/>
+        android:visibility="gone" />
 </RelativeLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1830,6 +1830,7 @@
     <string name="plugin_remove_progress_dialog_message">Removing %s&#8230;</string>
     <string name="plugin_remove_dialog_title">Remove Plugin</string>
     <string name="plugin_remove_dialog_message">Are you sure you want to remove %1$s from %2$s?\n\nThis will deactivate the plugin and delete all associated files and data.</string>
+    <string name="plugin_fetch_error">An error occurred while fetching the plugins: %s</string>
 
     <string name="wordpress_dot_org_plugin_page">WordPress.org Plugin page</string>
     <string name="plugin_home_page">Plugin homepage</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1830,7 +1830,7 @@
     <string name="plugin_remove_progress_dialog_message">Removing %s&#8230;</string>
     <string name="plugin_remove_dialog_title">Remove Plugin</string>
     <string name="plugin_remove_dialog_message">Are you sure you want to remove %1$s from %2$s?\n\nThis will deactivate the plugin and delete all associated files and data.</string>
-    <string name="plugin_fetch_error">An error occurred while fetching the plugins: %s</string>
+    <string name="plugin_fetch_error">Unable to load plugins</string>
 
     <string name="wordpress_dot_org_plugin_page">WordPress.org Plugin page</string>
     <string name="plugin_home_page">Plugin homepage</string>


### PR DESCRIPTION
Fixes #7015 & #7013. This PR adds the ability to pull to refresh the plugin list. Since we only start an automated fetch when the page is first opened, it actually fixes the issue where you see a deleted plugin (since we don't fetch it just after it was deleted). Also, now that we are sure that fetch only happens when user triggers it, I don't see any reason not to show an error when it fails.

To test:
* Open plugins page
* Install a new plugin from browser
* Pull to refresh and verify the new plugin shows up

* Open plugins page
* Delete a plugin
* Verify that it's now gone from the list when delete completes (this used to not be the case and required a manual fetch as already explained)