### PR TITLE
Null check before logging the theme name

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -236,7 +236,7 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
         } else {
             AppLog.d(T.THEMES, "Current Theme fetch successful!");
             mCurrentTheme = mThemeStore.getActiveThemeForSite(event.site);
-            AppLog.d(T.THEMES, "Current theme is " + mCurrentTheme.getName());
+            AppLog.d(T.THEMES, "Current theme is " + (mCurrentTheme == null ? "(null)" : mCurrentTheme.getName()));
             updateCurrentThemeView();
 
             if (mThemeSearchFragment != null && mThemeSearchFragment.isVisible()) {


### PR DESCRIPTION
Fixes #7027 

Null-checks the variable before logging the theme's name.

To test:
No steps available.
