### PR TITLE
Don't continue with setting up if finishing

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
@@ -75,11 +75,6 @@ public class PublicizeButtonPrefsFragment extends Fragment implements
 
         setRetainInstance(true);
 
-        if (!NetworkUtils.checkConnection(getActivity())) {
-            getActivity().finish();
-            return;
-        }
-
         if (savedInstanceState == null) {
             mSite = (SiteModel) getArguments().getSerializable(WordPress.SITE);
         } else {
@@ -88,6 +83,11 @@ public class PublicizeButtonPrefsFragment extends Fragment implements
 
         if (mSite == null) {
             ToastUtils.showToast(getActivity(), R.string.blog_not_found, ToastUtils.Duration.SHORT);
+            getActivity().finish();
+            return;
+        }
+
+        if (!NetworkUtils.checkConnection(getActivity())) {
             getActivity().finish();
             return;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
@@ -136,12 +136,10 @@ public class PublicizeButtonPrefsFragment extends Fragment implements
     public void onViewStateRestored(Bundle savedInstanceState) {
         super.onViewStateRestored(savedInstanceState);
 
-        if (getActivity() != null && !getActivity().isFinishing()) {
-            boolean shouldFetchSettings = (savedInstanceState == null);
-            getSiteSettings(shouldFetchSettings);
+        boolean shouldFetchSettings = (savedInstanceState == null);
+        getSiteSettings(shouldFetchSettings);
 
-            configureSharingButtons();
-        }
+        configureSharingButtons();
     }
 
     /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
@@ -136,10 +136,12 @@ public class PublicizeButtonPrefsFragment extends Fragment implements
     public void onViewStateRestored(Bundle savedInstanceState) {
         super.onViewStateRestored(savedInstanceState);
 
-        boolean shouldFetchSettings = (savedInstanceState == null);
-        getSiteSettings(shouldFetchSettings);
+        if (getActivity() != null && !getActivity().isFinishing()) {
+            boolean shouldFetchSettings = (savedInstanceState == null);
+            getSiteSettings(shouldFetchSettings);
 
-        configureSharingButtons();
+            configureSharingButtons();
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #7070 

This can happen when the device is offline. Check line 79.

To test:
1. Log into the app
2. Disable wifi/data
3. Tap on "Sharing" in MySite
4. Tap on "Manage" in the "Sharing buttons section"
5. Screen should return to MySite with a Toast announcing that there is no network available
