### PR TITLE
Check if fragment is still part of the Activity

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverFragment.java
@@ -155,6 +155,10 @@ public class ShareIntentReceiverFragment extends Fragment {
                         mRecyclerView.post(new Runnable() {
                             @Override
                             public void run() {
+                                if (!isAdded()) {
+                                    return;
+                                }
+
                                 if (mRecyclerView.computeVerticalScrollRange() > mRecyclerView.getHeight()) {
                                     mBottomButtonsShadow.setVisibility(View.VISIBLE);
                                     mBottomButtonsContainer.setBackgroundResource(R.color.white);


### PR DESCRIPTION
Fixes #7072 

Check if the fragment is still added. By the time the SitePicker's data are loaded, the user might have already stepped back.

To test:
No steps available.
