### PR TITLE
Move FluxC hash to gradle property

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     compile 'com.google.dagger:dagger-android-support:2.11'
     apt 'com.google.dagger:dagger-android-processor:2.11'
 
-    compile ('com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:918a9975bd5ac329006d39042b1312cc112781f6') {
+    compile ("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:$fluxCVersion") {
         exclude group: "com.android.volley"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,3 +9,7 @@ subprojects {
         }
     }
 }
+
+ext {
+    fluxCVersion = '918a9975bd5ac329006d39042b1312cc112781f6'
+}

--- a/libs/login/README.md
+++ b/libs/login/README.md
@@ -44,6 +44,16 @@ dependencies {
 in your project, and prevents a duplicated dependency, forcing WordPress-Login-Flow-Android to use
 your project's FluxC config.)
 
+You can also force the login library to use the same FluxC version as your project by declaring the version
+in a `fluxCVersion` variable in your project's root `build.gradle` (and using that same variable anywhere
+else your project uses FluxC):
+
+```groovy
+ext {
+    fluxCVersion = '83baae61804b65cc73a7201a7252750c76066a30'
+}
+```
+
 ## Contributing ##
 
 You can fetch the latest changes made to this library into your project using:

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -41,7 +41,12 @@ dependencies {
 
     compile 'com.google.android.gms:play-services-auth:10.0.1'
 
-    compile 'com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:fd47635fb823d74405c56edc37c6c7a6a59e5fb5'
+    // Share FluxC version from host project if defined, otherwise fallback to default
+    if (project.hasProperty("fluxCVersion")) {
+        compile "com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:$fluxCVersion"
+    } else {
+        compile 'com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:918a9975bd5ac329006d39042b1312cc112781f6'
+    }
 
     compile 'com.github.bumptech.glide:glide:4.1.1'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.1.1'


### PR DESCRIPTION
Moves the FluxC hash to a gradle property in the root `build.gradle`. We don't use this pattern in WPAndroid yet (though some of our other projects do), but we can start to use it for other repeated variables too (like support library version).

The specific reason to make this change now is so that the new login library is always using the same FluxC hash as the WPAndroid project, to avoid surprise conflicts (and so we don't have to do it manually).

~This relies on the changes in #6935 (extracting login flow into a separate library), and this PR should be merged after that one.~