### PR TITLE
Don't modify adapter's data in a subthread

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsTagsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsTagsActivity.java
@@ -247,16 +247,17 @@ public class PostSettingsTagsActivity extends AppCompatActivity implements TextW
         }
 
         public void filter(final String text) {
+            final List<TermModel> allTags = mAllTags;
             new Thread(new Runnable() {
                 @Override
                 public void run() {
-                    mFilteredTags.clear();
+                    final List<TermModel> filteredTags = new ArrayList<>();
                     if (TextUtils.isEmpty(text)) {
-                        mFilteredTags.addAll(mAllTags);
+                        filteredTags.addAll(allTags);
                     } else {
-                        for (TermModel tag : mAllTags) {
+                        for (TermModel tag : allTags) {
                             if (tag.getName().toLowerCase().contains(text.toLowerCase())) {
-                                mFilteredTags.add(tag);
+                                filteredTags.add(tag);
                             }
                         }
                     }
@@ -264,6 +265,7 @@ public class PostSettingsTagsActivity extends AppCompatActivity implements TextW
                     ((Activity) mContext).runOnUiThread(new Runnable() {
                         @Override
                         public void run() {
+                            mFilteredTags = filteredTags;
                             notifyDataSetChanged();
                         }
                     });


### PR DESCRIPTION
Fixes #7078 , fixes #7079 

Instead of modifying the adapter's data in the subthread, do the filtering in a local list and assign that one to mFilteredTags in the main thread, right before calling notifyDataSetChanged().

To test:
No steps available. Post Tags screen should work as normal.