### PR TITLE
Issue/6957 image delete shows error

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -456,7 +456,7 @@ public class EditPostActivity extends AppCompatActivity implements
         allMedia.addAll(completedMedia);
         allMedia.addAll(uploadingMedia);
 
-        if (allMedia != null && !allMedia.isEmpty()) {
+        if (!allMedia.isEmpty()) {
             HashSet<MediaModel> mediaToDeleteAssociationFor = new HashSet<>();
             for (MediaModel media : allMedia) {
                 if (!AztecEditorFragment.isMediaInPostBody(this, mPost.getContent(), String.valueOf(media.getId()))) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -449,12 +449,9 @@ public class EditPostActivity extends AppCompatActivity implements
 
     private void purgeMediaToPostAssociationsIfNotInPostAnymore() {
         ArrayList<MediaModel> allMedia = new ArrayList<>();
-        Set<MediaModel> failedMedia = mUploadStore.getFailedMediaForPost(mPost);
-        Set<MediaModel> completedMedia = mUploadStore.getCompletedMediaForPost(mPost);
-        Set<MediaModel> uploadingMedia = mUploadStore.getUploadingMediaForPost(mPost);
-        allMedia.addAll(failedMedia);
-        allMedia.addAll(completedMedia);
-        allMedia.addAll(uploadingMedia);
+        allMedia.addAll(mUploadStore.getFailedMediaForPost(mPost));
+        allMedia.addAll(mUploadStore.getCompletedMediaForPost(mPost));
+        allMedia.addAll(mUploadStore.getUploadingMediaForPost(mPost));
 
         if (!allMedia.isEmpty()) {
             HashSet<MediaModel> mediaToDeleteAssociationFor = new HashSet<>();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2547,6 +2547,7 @@ public class EditPostActivity extends AppCompatActivity implements
     public void onMediaDeleted(String localMediaId) {
         if (!TextUtils.isEmpty(localMediaId)) {
             mAztecBackspaceDeletedMediaItemIds.add(localMediaId);
+            UploadService.setDeletedMediaItemIds(mAztecBackspaceDeletedMediaItemIds);
             // passing false here as we need to keep the media item in case the user wants to undo
             cancelMediaUpload(StringUtils.stringToInt(localMediaId), false);
         }
@@ -2611,6 +2612,8 @@ public class EditPostActivity extends AppCompatActivity implements
             if (!found) {
                 if (mEditorFragment instanceof AztecEditorFragment) {
                     mAztecBackspaceDeletedMediaItemIds.remove(mediaId);
+                    // update the mediaIds list in UploadService
+                    UploadService.setDeletedMediaItemIds(mAztecBackspaceDeletedMediaItemIds);
                     ((AztecEditorFragment)mEditorFragment).setMediaToFailed(mediaId);
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -335,7 +335,7 @@ public class PostUtils {
                 || (PostStatus.fromPost(post) == PostStatus.PUBLISHED && post.isLocalDraft());
     }
 
-    public static Set<PostModel> getPostsThatIncludeThisMedia(PostStore postStore, List<MediaModel> mediaModelList) {
+    public static Set<PostModel> getPostsThatIncludeAnyOfTheseMedia(PostStore postStore, List<MediaModel> mediaModelList) {
         // if there' a Post to which the retried media belongs, clear their status
         HashSet<PostModel> postsThatContainListedMedia = new HashSet<>();
         for (MediaModel media : mediaModelList) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -782,7 +782,7 @@ public class PostsListFragment extends Fragment
 
         if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
             // if there' a Post to which the retried media belongs, clear their status
-            Set<PostModel> postsToRefresh = PostUtils.getPostsThatIncludeThisMedia(mPostStore, event.mediaModelList);
+            Set<PostModel> postsToRefresh = PostUtils.getPostsThatIncludeAnyOfTheseMedia(mPostStore, event.mediaModelList);
             // now that we know which Posts  to refresh, let's do it
             for (PostModel post : postsToRefresh) {
                 int position = getPostListAdapter().getPositionForPost(post);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -43,6 +43,7 @@ import org.wordpress.android.util.WPMediaUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -66,6 +67,11 @@ public class UploadService extends Service {
 
     // we hold this reference here for the success notification for Media uploads
     private List<MediaModel> mMediaBatchUploaded = new ArrayList<>();
+
+    // we keep this list so we don't tell the user an error happened when we find a FAILED media item
+    // for media that the user actively cancelled uploads for
+    private static HashSet<String> mUserDeletedMediaItemIds = new HashSet<>();
+
 
     @Inject Dispatcher mDispatcher;
     @Inject MediaStore mMediaStore;
@@ -188,27 +194,33 @@ public class UploadService extends Service {
                 mMediaBatchUploaded.addAll(mediaList);
             }
 
-            if (intent.getBooleanExtra(KEY_SHOULD_RETRY, false)) {
-                // Bump analytics
-                AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATION_UPLOAD_MEDIA_ERROR_RETRY);
-
-                // send event so Editors can handle clearing Failed statuses properly if Post is being edited right now
-                if (mediaList != null && !mediaList.isEmpty()) {
-                    Set<PostModel> postsToRefresh = PostUtils.getPostsThatIncludeThisMedia(mPostStore, mediaList);
-                    for (PostModel post : postsToRefresh) {
-                        mUploadStore.registerPostModel(post, mediaList);
-                        if (isThisPostTotallyNewOrFailed(post)) {
-                            mPostUploadNotifier.addPostInfoToForegroundNotification(post, null);
-                        }
-                    }
-                    EventBus.getDefault().post(new UploadService.UploadMediaRetryEvent(mediaList));
-                }
-            }
+            // if this media belongs to some post, register such Post
+            registerPostModelsForMedia(mediaList, intent.getBooleanExtra(KEY_SHOULD_RETRY, false));
 
             for (MediaModel media : mediaList) {
                 mMediaUploadHandler.upload(media);
             }
             mPostUploadNotifier.addMediaInfoToForegroundNotification(mediaList);
+        }
+    }
+
+    private void registerPostModelsForMedia(List<MediaModel> mediaList, boolean isRetry) {
+        if (mediaList != null && !mediaList.isEmpty()) {
+            Set<PostModel> postsToRefresh = PostUtils.getPostsThatIncludeThisMedia(mPostStore, mediaList);
+            for (PostModel post : postsToRefresh) {
+                mUploadStore.registerPostModel(post, mediaList);
+                if (isThisPostTotallyNewOrFailed(post)) {
+                    mPostUploadNotifier.addPostInfoToForegroundNotification(post, null);
+                }
+            }
+
+            if (isRetry) {
+                // Bump analytics
+                AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATION_UPLOAD_MEDIA_ERROR_RETRY);
+
+                // send event so Editors can handle clearing Failed statuses properly if Post is being edited right now
+                EventBus.getDefault().post(new UploadService.UploadMediaRetryEvent(mediaList));
+            }
         }
     }
 
@@ -853,10 +865,12 @@ public class UploadService extends Service {
                         // but tell the user about the error
                         cancelQueuedPostUpload(postModel);
 
-                        // update error notification for Post
-                        SiteModel site = mSiteStore.getSiteByLocalId(postModel.getLocalSiteId());
-                        String message = UploadUtils.getErrorMessage(this, postModel, getString(R.string.error_generic_error), true);
-                        mPostUploadNotifier.updateNotificationErrorForPost(postModel, site, message, 0);
+                        // update error notification for Post, unless the media is in the user-deleted media set
+                        if (!isAllFailedMediaUserDeleted(failedMedia)) {
+                            SiteModel site = mSiteStore.getSiteByLocalId(postModel.getLocalSiteId());
+                            String message = UploadUtils.getErrorMessage(this, postModel, getString(R.string.error_generic_error), true);
+                            mPostUploadNotifier.updateNotificationErrorForPost(postModel, site, message, 0);
+                        }
 
                         mPostUploadHandler.unregisterPostForAnalyticsTracking(postModel);
                         EventBus.getDefault().post(
@@ -874,6 +888,26 @@ public class UploadService extends Service {
         return false;
     }
 
+    private boolean isAllFailedMediaUserDeleted(Set<MediaModel> failedMediaSet) {
+        if (failedMediaSet != null && failedMediaSet.size() == mUserDeletedMediaItemIds.size()) {
+            int numberOfMatches = 0;
+            for (MediaModel media : failedMediaSet) {
+                String mediaIdToCompare = String.valueOf(media.getId());
+                if (mUserDeletedMediaItemIds.contains(mediaIdToCompare)) {
+                    numberOfMatches++;
+                }
+            }
+
+            if (numberOfMatches == mUserDeletedMediaItemIds.size()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static void setDeletedMediaItemIds(List<String> mediaIds) {
+        mUserDeletedMediaItemIds.addAll(mediaIds);
+    }
 
     private List<MediaModel> getRetriableStandaloneMedia(SiteModel selectedSite) {
         // get all retriable media ? To retry or not to retry, that is the question

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -749,6 +749,10 @@ public class UploadService extends Service {
             // If the post is already registered, the new media will be added to its list
             mUploadStore.registerPostModel(post, mediaToRetry);
             mPostUploadNotifier.addPostInfoToForegroundNotification(post, mediaToRetry);
+
+            // send event so Editors can handle clearing Failed statuses properly if Post is being edited right now
+            EventBus.getDefault().post(new UploadService.UploadMediaRetryEvent(mediaToRetry));
+
         } else {
             // retry uploading the Post
             mPostUploadHandler.upload(post);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -206,7 +206,7 @@ public class UploadService extends Service {
 
     private void registerPostModelsForMedia(List<MediaModel> mediaList, boolean isRetry) {
         if (mediaList != null && !mediaList.isEmpty()) {
-            Set<PostModel> postsToRefresh = PostUtils.getPostsThatIncludeThisMedia(mPostStore, mediaList);
+            Set<PostModel> postsToRefresh = PostUtils.getPostsThatIncludeAnyOfTheseMedia(mPostStore, mediaList);
             for (PostModel post : postsToRefresh) {
                 mUploadStore.registerPostModel(post, mediaList);
                 if (isThisPostTotallyNewOrFailed(post)) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -909,6 +909,7 @@ public class UploadService extends Service {
     }
 
     public static void setDeletedMediaItemIds(List<String> mediaIds) {
+        mUserDeletedMediaItemIds.clear();
         mUserDeletedMediaItemIds.addAll(mediaIds);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -208,9 +208,8 @@ public class UploadService extends Service {
         if (mediaList != null && !mediaList.isEmpty()) {
             Set<PostModel> postsToRefresh = PostUtils.getPostsThatIncludeAnyOfTheseMedia(mPostStore, mediaList);
             for (PostModel post : postsToRefresh) {
-                mUploadStore.registerPostModel(post, mediaList);
-                if (isThisPostTotallyNewOrFailed(post)) {
-                    mPostUploadNotifier.addPostInfoToForegroundNotification(post, null);
+                if (!mUploadStore.isRegisteredPostModel(post)) {
+                    mUploadStore.registerPostModel(post, mediaList);
                 }
             }
 
@@ -259,7 +258,7 @@ public class UploadService extends Service {
             // is this a new post? only add count to the notification when the post is totally new
             // i.e. it still doesn't have any tracked state in the UploadStore
             // or it's a failed one the user is actively retrying.
-            if (isThisPostTotallyNewOrFailed(post)) {
+            if (isThisPostTotallyNewOrFailed(post) && !PostUploadHandler.isPostUploadingOrQueued(post)) {
                 mPostUploadNotifier.addPostInfoToForegroundNotification(post, null);
             }
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -1881,6 +1881,19 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         return postContent;
     }
 
+    public static boolean isMediaInPostBody(Context context, @NonNull String postContent,
+                                         String localMediaId) {
+        // fill in Aztec with the post's content
+        AztecParser parser = getAztecParserWithPlugins();
+        SpannableStringBuilder builder = getCalypsoCompatibleStringBuilder(context, postContent, parser);
+
+        MediaPredicate predicate = MediaPredicate.getLocalMediaIdPredicate(localMediaId);
+
+        Attributes firstElementAttributes = getFirstElementAttributes(builder, predicate);
+        // is this media item not there anymore within the Post's content?
+        return (firstElementAttributes != null);
+    }
+
     public static boolean hasMediaItemsMarkedUploading(Context context, @NonNull String postContent) {
         return hasMediaItemsMarkedWithTag(context, postContent, ATTR_STATUS_UPLOADING);
     }


### PR DESCRIPTION
Fixes #6957 

While fixing this specific case, I realized some things were not being worked out correctly in the background (i.e. some associations between Media and Posts were being left even when no visible glitch was shown to the user).

These are the test cases:

TEST CASE A: force close the app while in the Editor
1. start a draft
2. include an image/video
3. while it’s uploading, and without exiting the editor, force close the app
4. restart the app and check the image is there and can be retried.
 


TEST CASE B (purge):
1. start a draft
2. include image
3. delete it, wait for autosave to save the post
4. restart the app
5. check that the image is not there anymore as per autosave
6. also check the purge is run upon opening the Editor, deleting the association for the previous media associated to the Post.



TEST CASE C: notification should not appear anymore (this is the specific fix for #6957)
1. start a draft
2. include image
3. while it’s uploading, delete it.
4. observe the progress notification is gone, and the error notification doesn’t appear.


TEST CASE D: error notification appears when an external cause makes the upload fail
1. start a draft
2. include image
3. while it’s uploading, turn airplane mode ON
4. observe the progress notification is gone, and the error notification appears.



TEST CASE E: reattachment wasn't working if the RETRY quick action is tapped, after having an errored image upload within the Editor.
1. start a draft
2. include image
3. while its uploading, turn airplane mode ON/OFF to make it fail and make the error notification appear.
4. without exiting the editor, tap on the RETRY quick action in the error notification
5. note that the image overlay and progress gets reattached in the Editor.

cc @daniloercoli 

