### PR TITLE
Rename to Site Pages and move above posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListActivity.java
@@ -85,7 +85,7 @@ public class PostsListActivity extends AppCompatActivity {
 
         ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
-            actionBar.setTitle(getString(mIsPage ? R.string.pages : R.string.posts));
+            actionBar.setTitle(getString(mIsPage ? R.string.my_site_btn_site_pages : R.string.my_site_btn_blog_posts));
             actionBar.setDisplayShowTitleEnabled(true);
             actionBar.setDisplayHomeAsUpEnabled(true);
         }

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -148,6 +148,24 @@
 
             </LinearLayout>
 
+            <!--Pages-->
+            <LinearLayout
+                android:id="@+id/row_pages"
+                style="@style/MySiteListRowLayout">
+
+                <ImageView
+                    android:id="@+id/my_site_pages_icon"
+                    style="@style/MySiteListRowIcon"
+                    app:srcCompat="@drawable/ic_pages_grey_24dp"
+                    android:importantForAccessibility="no"/>
+
+                <org.wordpress.android.widgets.WPTextView
+                    android:id="@+id/my_site_pages_text_view"
+                    style="@style/MySiteListRowTextView"
+                    android:text="@string/my_site_btn_site_pages" />
+
+            </LinearLayout>
+
             <!--Blog Posts-->
             <FrameLayout
                 android:layout_width="match_parent"
@@ -195,24 +213,6 @@
                     android:id="@+id/my_site_media_text_view"
                     style="@style/MySiteListRowTextView"
                     android:text="@string/media" />
-
-            </LinearLayout>
-
-            <!--Pages-->
-            <LinearLayout
-                android:id="@+id/row_pages"
-                style="@style/MySiteListRowLayout">
-
-                <ImageView
-                    android:id="@+id/my_site_pages_icon"
-                    style="@style/MySiteListRowIcon"
-                    app:srcCompat="@drawable/ic_pages_grey_24dp"
-                    android:importantForAccessibility="no"/>
-
-                <org.wordpress.android.widgets.WPTextView
-                    android:id="@+id/my_site_pages_text_view"
-                    style="@style/MySiteListRowTextView"
-                    android:text="@string/pages" />
 
             </LinearLayout>
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1613,6 +1613,7 @@
     <string name="my_site_header_configuration">Configuration</string>
     <string name="my_site_header_look_and_feel">Look and Feel</string>
     <string name="my_site_header_publish">Publish</string>
+    <string name="my_site_btn_site_pages">Site Pages</string>
     <string name="my_site_btn_blog_posts">Blog Posts</string>
     <string name="my_site_btn_sharing">Sharing</string>
     <string name="my_site_btn_site_settings">Settings</string>


### PR DESCRIPTION
Fixes #7076 

To test:
* With the app logged in to some account, observe the MySite screen
* The "Site Pages" item should be there and right above the "Blog Posts" item.
