### PR TITLE
issue/7082-plugins-invalid-version-crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
@@ -15,7 +15,6 @@ public class PluginUtils {
         String jetpackVersion = site.getJetpackVersion();
         if (site.isUsingWpComRestApi() && site.isJetpackConnected() && !TextUtils.isEmpty(jetpackVersion)) {
             try {
-                jetpackVersion = "5.6-alpha";
                 // strip any trailing "-beta" or "-alpha" from the version
                 int index = jetpackVersion.lastIndexOf("-");
                 if (index > 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
@@ -7,15 +7,20 @@ import org.wordpress.android.fluxc.model.PluginInfoModel;
 import org.wordpress.android.fluxc.model.PluginModel;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.PluginStore;
+import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.helpers.Version;
 
 public class PluginUtils {
     public static boolean isPluginFeatureAvailable(SiteModel site) {
         String jetpackVersion = site.getJetpackVersion();
         if (site.isUsingWpComRestApi() && site.isJetpackConnected() && !TextUtils.isEmpty(jetpackVersion)) {
-            Version siteJetpackVersion = new Version(jetpackVersion);
-            Version minVersion = new Version("5.6");
-            return siteJetpackVersion.compareTo(minVersion) >= 0; // if the site has Jetpack 5.6 or newer installed
+            try {
+                Version siteJetpackVersion = new Version(jetpackVersion);
+                Version minVersion = new Version("5.6");
+                return siteJetpackVersion.compareTo(minVersion) >= 0; // if the site has Jetpack 5.6 or newer installed
+            } catch (IllegalArgumentException e) {
+                AppLog.e(AppLog.T.UTILS, "Invalid site jetpack version " + jetpackVersion, e);
+            }
         }
         return false;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
@@ -15,11 +15,18 @@ public class PluginUtils {
         String jetpackVersion = site.getJetpackVersion();
         if (site.isUsingWpComRestApi() && site.isJetpackConnected() && !TextUtils.isEmpty(jetpackVersion)) {
             try {
+                jetpackVersion = "5.6-alpha";
+                // strip any trailing "-beta" or "-alpha" from the version
+                int index = jetpackVersion.lastIndexOf("-");
+                if (index > 0) {
+                    jetpackVersion = jetpackVersion.substring(0, index);
+                }
                 Version siteJetpackVersion = new Version(jetpackVersion);
                 Version minVersion = new Version("5.6");
                 return siteJetpackVersion.compareTo(minVersion) >= 0; // if the site has Jetpack 5.6 or newer installed
             } catch (IllegalArgumentException e) {
                 AppLog.e(AppLog.T.UTILS, "Invalid site jetpack version " + jetpackVersion, e);
+                return true;
             }
         }
         return false;


### PR DESCRIPTION
Fixes #7082 by catching the `IllegalArgumentException` when there's an invalid Jetpack version in the site model.

cc @oguzkocer 