### PR TITLE
Media - Take new picture - fix for "Denial: not allowed to send broadcast android.intent.action.MEDIA_MOUNTED"

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -2172,8 +2172,15 @@ public class EditPostActivity extends AppCompatActivity implements
             File f = new File(mMediaCapturePath);
             Uri capturedImageUri = Uri.fromFile(f);
             if (addMedia(capturedImageUri, true)) {
-                this.sendBroadcast(new Intent(Intent.ACTION_MEDIA_MOUNTED, Uri.parse("file://"
-                        + Environment.getExternalStorageDirectory())));
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                    final Intent scanIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
+                    scanIntent.setData(capturedImageUri);
+                    sendBroadcast(scanIntent);
+                } else {
+                    this.sendBroadcast(new Intent(Intent.ACTION_MEDIA_MOUNTED,
+                            Uri.parse("file://" + Environment.getExternalStorageDirectory()))
+                    );
+                }
             } else {
                 ToastUtils.showToast(this, R.string.gallery_error, Duration.SHORT);
             }


### PR DESCRIPTION
I've noticed a `java.lang.SecurityException: Permission Denial: not allowed to send broadcast android.intent.action.MEDIA_MOUNTED `when taking a new picture in the editor (I bet this issue is there since long time).

This PR fixes it by making sure to not broadcast `MEDIA_MOUNTED` on KitKat and above, but broadcasting `ACTION_MEDIA_SCANNER_SCAN_FILE` instead. 

Note: I also think that it's not necessary to send a broadcast, since we're using `MediaScannerConnection` [here](https://github.com/wordpress-mobile/WordPress-Android/compare/issue/fix-media-Permission-Denial-not-allowed-send-broadcast?expand=1#diff-38b6aea9cfff5f3e0e4b7389b44de602L2171). Maybe @nbradbury remembers why we're calling the media scanner in 2 different ways.



