### PR TITLE
Issue/7088 duplicate post fix

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -433,6 +433,9 @@ public class EditPostActivity extends AppCompatActivity implements
                     AztecEditorFragment.getMediaMarkedUploadingInPostContent(this, mPost.getContent());
             Collections.sort(mMediaMarkedUploadingOnStartIds);
             mIsPage = mPost.isPage();
+
+            EventBus.getDefault().post(
+                    new PostEvents.PostOpenedInEditor(mPost.getLocalSiteId(), mPost.getId()));
         }
     }
 
@@ -1144,6 +1147,8 @@ public class EditPostActivity extends AppCompatActivity implements
         @Override
         protected void onPostExecute(Void saved) {
             saveResult(true, false);
+            EventBus.getDefault().post(
+                    new PostEvents.PostClosedInEditor(mPost.getLocalSiteId(), mPost.getId()));
             finish();
         }
     }
@@ -1178,6 +1183,8 @@ public class EditPostActivity extends AppCompatActivity implements
         @Override
         protected void onPostExecute(Boolean saved) {
             saveResult(saved, true);
+            EventBus.getDefault().post(
+                    new PostEvents.PostClosedInEditor(mPost.getLocalSiteId(), mPost.getId()));
             finish();
         }
     }
@@ -1347,6 +1354,8 @@ public class EditPostActivity extends AppCompatActivity implements
                     if (!isPublishable && isNewPost()) {
                         mDispatcher.dispatch(PostActionBuilder.newRemovePostAction(mPost));
                     }
+                    EventBus.getDefault().post(
+                            new PostEvents.PostClosedInEditor(mPost.getLocalSiteId(), mPost.getId()));
                     finish();
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostEvents.java
@@ -28,4 +28,24 @@ public class PostEvents {
             this.post = post;
         }
     }
+
+    public static class PostOpenedInEditor {
+        public final int localSiteId;
+        public final int postId;
+
+        public PostOpenedInEditor(int localSiteId, int postId) {
+            this.localSiteId = localSiteId;
+            this.postId = postId;
+        }
+    }
+
+    public static class PostClosedInEditor {
+        public final int localSiteId;
+        public final int postId;
+
+        public PostClosedInEditor(int localSiteId, int postId) {
+            this.localSiteId = localSiteId;
+            this.postId = postId;
+        }
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostEvents.java
@@ -21,22 +21,6 @@ public class PostEvents {
         }
     }
 
-    public static class PostMediaInfoUpdated {
-        private long mMediaId;
-        private String mMediaUrl;
-
-        PostMediaInfoUpdated(long mediaId, String mediaUrl) {
-            mMediaId = mediaId;
-            mMediaUrl = mediaUrl;
-        }
-        public long getMediaId() {
-            return mMediaId;
-        }
-        public String getMediaUrl() {
-            return StringUtils.notNullStr(mMediaUrl);
-        }
-    }
-
     public static class PostMediaCanceled {
         public PostModel post;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostEvents.java
@@ -38,14 +38,4 @@ public class PostEvents {
             this.postId = postId;
         }
     }
-
-    public static class PostClosedInEditor {
-        public final int localSiteId;
-        public final int postId;
-
-        public PostClosedInEditor(int localSiteId, int postId) {
-            this.localSiteId = localSiteId;
-            this.postId = postId;
-        }
-    }
 }


### PR DESCRIPTION
Fixes #7088 

This PR introduces a patch so a Post is not sent to the server twice when the Post is opened in the Editor. The patch consist briefly just by signaling the opening and closing of EditPostActivity and having the UploadService listen to such an event, so the service can be aware that the Editor is in charge of uploading (as anything that the user is actively editing right now has obviously more importance than anything that may happen in the background).

TEST CASE A: start media item uploads and stay there.
1. start a draft
2. insert some media
3. wait for it to finish
4. check on the web, there should not be any new posts
5. exit the editor and let the app upload the post
6. check on the web, the post should be there (although no duplicates)


TEST CASE B: start media item uploads, enqueue the Post, and enter the Editor again.
1. start a draft
2. insert some media
3. before it finishes, exit the editor. Observe the progress foreground notification now reads “1 post, xxxx files remaining”
4. check on the web, there should not be any new posts (as long as the app is still uploading media)
5. come back to the editor and wait for all media to finish.
6. check on the web, there should not be any new posts
7. exit the editor and let the app upload the post
8. check on the web, the post should be there (although no duplicates)

cc @daniloercoli 
