### PR TITLE
issue/7100 check if fragment is added before getting resources

### DIFF
--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -407,12 +407,20 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void onRedoEnabled() {
+        if(!isAdded()){
+            return;
+        }
+
         invalidateOptionsHandler.removeCallbacks(invalidateOptionsRunnable);
         invalidateOptionsHandler.postDelayed(invalidateOptionsRunnable, getResources().getInteger(android.R.integer.config_mediumAnimTime));
     }
 
     @Override
     public void onUndoEnabled() {
+        if(!isAdded()){
+            return;
+        }
+
         invalidateOptionsHandler.removeCallbacks(invalidateOptionsRunnable);
         invalidateOptionsHandler.postDelayed(invalidateOptionsRunnable, getResources().getInteger(android.R.integer.config_mediumAnimTime));
     }


### PR DESCRIPTION
Fixes #7100

Both `onRedoEnabled()` and `onUndoEnabled()` are called from delayed runnable, so we cant guarantee the fragment will still be attached when they execute.
