### PR TITLE
issue/7038 fixing MediaSettings crash on ASUS devices

### DIFF
--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -213,6 +213,10 @@
         <!-- Label color in TRUE state and bar color FALSE and TRUE State -->
         <item name="colorControlNormal">@color/grey_500</item>
         <item name="colorControlActivated">@color/blue_wordpress</item>
+
+        <!-- Fix for crash on ASUS devices - https://github.com/wordpress-mobile/WordPress-Android/issues/7038 -->
+        <item name="android:textColorHighlight">@color/transparent</item>
+        <item name="android:textColorLink">@color/transparent</item>
     </style>
     <style name="MediaSettings.Divider">
         <item name="android:background">@color/divider_grey</item>


### PR DESCRIPTION
Fixes #7038 
Fixes #6858

The crash happens only ASUS devices.

Proposed solution in comment thread [here](https://stackoverflow.com/a/30914037/569430) suggest setting parent theme of `TextInputLayout` to `ThemeOverlay.AppCompat.Light`, but after some research, I think I figured out what is missing in ASUS version of Android, and we can probably get around the crash by explicitly setting color values of `android:textColorHighlight` and `android:textColorLink`.

I don't have ASUS device to test it, but in case it does not work I have another workaround prepared.
