### PR TITLE
Suggestion: simpler notification calls

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
@@ -4,6 +4,7 @@ import android.app.Notification;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
@@ -76,6 +77,32 @@ public class SiteCreationService extends AutoForeground<SiteCreationPhase, OnSit
         }
     }
 
+    private static class SiteCreationNotification {
+        static Notification progress(Context context, int progress) {
+            return AutoForegroundNotification.progress(context, progress,
+                    org.wordpress.android.login.R.string.notification_site_creation_title_in_progress,
+                    org.wordpress.android.login.R.string.notification_site_creation_please_wait,
+                    org.wordpress.android.login.R.drawable.ic_my_sites_24dp,
+                    org.wordpress.android.login.R.color.blue_wordpress);
+        }
+
+        static Notification success(Context context) {
+            return AutoForegroundNotification.success(context,
+                    org.wordpress.android.login.R.string.notification_site_creation_title_success,
+                    org.wordpress.android.login.R.string.notification_site_creation_created,
+                    org.wordpress.android.login.R.drawable.ic_my_sites_24dp,
+                    org.wordpress.android.login.R.color.blue_wordpress);
+        }
+
+        static Notification failure(Context context, @StringRes int content) {
+            return AutoForegroundNotification.failure(context,
+                    org.wordpress.android.login.R.string.notification_site_creation_title_stopped,
+                    content,
+                    org.wordpress.android.login.R.drawable.ic_my_sites_24dp,
+                    org.wordpress.android.login.R.color.blue_wordpress);
+        }
+    }
+
     public static class OnSiteCreationStateUpdated implements AutoForeground.ServiceEvent<SiteCreationPhase> {
         private final SiteCreationPhase state;
 
@@ -141,23 +168,11 @@ public class SiteCreationService extends AutoForeground<SiteCreationPhase, OnSit
             case FETCHING_NEW_SITE:
             case SET_TAGLINE:
             case SET_THEME:
-                return AutoForegroundNotification.progress(this, 25,
-                        R.string.notification_site_creation_title_in_progress,
-                        R.string.notification_site_creation_please_wait,
-                        R.drawable.ic_my_sites_24dp,
-                        R.color.blue_wordpress);
+                return SiteCreationNotification.progress(this, 25);
             case SUCCESS:
-                return AutoForegroundNotification.success(this,
-                        R.string.notification_site_creation_title_success,
-                        R.string.notification_site_creation_created,
-                        R.drawable.ic_my_sites_24dp,
-                        R.color.blue_wordpress);
+                return SiteCreationNotification.success(this);
             case FAILURE:
-                return AutoForegroundNotification.success(this,
-                        R.string.notification_site_creation_title_stopped,
-                        R.string.notification_site_creation_failed,
-                        R.drawable.ic_my_sites_24dp,
-                        R.color.blue_wordpress);
+                return SiteCreationNotification.failure(this, R.string.notification_site_creation_failed);
         }
 
         return null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
@@ -80,26 +80,26 @@ public class SiteCreationService extends AutoForeground<SiteCreationPhase, OnSit
     private static class SiteCreationNotification {
         static Notification progress(Context context, int progress) {
             return AutoForegroundNotification.progress(context, progress,
-                    org.wordpress.android.login.R.string.notification_site_creation_title_in_progress,
-                    org.wordpress.android.login.R.string.notification_site_creation_please_wait,
-                    org.wordpress.android.login.R.drawable.ic_my_sites_24dp,
-                    org.wordpress.android.login.R.color.blue_wordpress);
+                    R.string.notification_site_creation_title_in_progress,
+                    R.string.notification_site_creation_please_wait,
+                    R.drawable.ic_my_sites_24dp,
+                    R.color.blue_wordpress);
         }
 
         static Notification success(Context context) {
             return AutoForegroundNotification.success(context,
-                    org.wordpress.android.login.R.string.notification_site_creation_title_success,
-                    org.wordpress.android.login.R.string.notification_site_creation_created,
-                    org.wordpress.android.login.R.drawable.ic_my_sites_24dp,
-                    org.wordpress.android.login.R.color.blue_wordpress);
+                    R.string.notification_site_creation_title_success,
+                    R.string.notification_site_creation_created,
+                    R.drawable.ic_my_sites_24dp,
+                    R.color.blue_wordpress);
         }
 
         static Notification failure(Context context, @StringRes int content) {
             return AutoForegroundNotification.failure(context,
-                    org.wordpress.android.login.R.string.notification_site_creation_title_stopped,
+                    R.string.notification_site_creation_title_stopped,
                     content,
-                    org.wordpress.android.login.R.drawable.ic_my_sites_24dp,
-                    org.wordpress.android.login.R.color.blue_wordpress);
+                    R.drawable.ic_my_sites_24dp,
+                    R.color.blue_wordpress);
         }
     }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginWpcomService.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginWpcomService.java
@@ -4,6 +4,7 @@ import android.app.Notification;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
@@ -93,6 +94,32 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
         }
     }
 
+    private static class LoginNotification {
+        static Notification progress(Context context, int progress) {
+            return AutoForegroundNotification.progress(context, progress,
+                    R.string.notification_login_title_in_progress,
+                    R.string.notification_logging_in,
+                    R.drawable.ic_my_sites_24dp,
+                    R.color.blue_wordpress);
+        }
+
+        static Notification success(Context context) {
+            return AutoForegroundNotification.success(context,
+                    R.string.notification_login_title_success,
+                    R.string.notification_logged_in,
+                    R.drawable.ic_my_sites_24dp,
+                    R.color.blue_wordpress);
+        }
+
+        static Notification failure(Context context, @StringRes int content) {
+            return AutoForegroundNotification.failure(context,
+                    R.string.notification_login_title_stopped,
+                    content,
+                    R.drawable.ic_my_sites_24dp,
+                    R.color.blue_wordpress);
+        }
+    }
+
     public static class OnLoginStateUpdated implements AutoForeground.ServiceEvent<LoginPhase> {
         private final LoginPhase mState;
 
@@ -164,43 +191,19 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
             case FETCHING_ACCOUNT:
             case FETCHING_SETTINGS:
             case FETCHING_SITES:
-                return AutoForegroundNotification.progress(this, phase.progressPercent,
-                        R.string.notification_login_title_in_progress,
-                        R.string.notification_logging_in,
-                        R.drawable.ic_my_sites_24dp,
-                        R.color.blue_wordpress);
+                return LoginNotification.progress(this, phase.progressPercent);
             case SUCCESS:
-                return AutoForegroundNotification.success(this,
-                        R.string.notification_login_title_success,
-                        R.string.notification_logged_in,
-                        R.drawable.ic_my_sites_24dp,
-                        R.color.blue_wordpress);
+                return LoginNotification.success(this);
             case FAILURE_EMAIL_WRONG_PASSWORD:
-                return AutoForegroundNotification.failure(this,
-                        R.string.notification_login_title_stopped,
-                        R.string.notification_error_wrong_password,
-                        R.drawable.ic_my_sites_24dp,
-                        R.color.blue_wordpress);
+                return LoginNotification.failure(this, R.string.notification_error_wrong_password);
             case FAILURE_2FA:
-                return AutoForegroundNotification.failure(this,
-                        R.string.notification_login_title_stopped,
-                        R.string.notification_2fa_needed,
-                        R.drawable.ic_my_sites_24dp,
-                        R.color.blue_wordpress);
+                return LoginNotification.failure(this, R.string.notification_2fa_needed);
             case FAILURE_SOCIAL_2FA:
-                return AutoForegroundNotification.failure(this,
-                        R.string.notification_login_title_stopped,
-                        R.string.notification_2fa_needed,
-                        R.drawable.ic_my_sites_24dp,
-                        R.color.blue_wordpress);
+                return LoginNotification.failure(this, R.string.notification_2fa_needed);
             case FAILURE_FETCHING_ACCOUNT:
             case FAILURE_CANNOT_ADD_DUPLICATE_SITE:
             case FAILURE:
-                return AutoForegroundNotification.failure(this,
-                        R.string.notification_login_title_stopped,
-                        R.string.notification_login_failed,
-                        R.drawable.ic_my_sites_24dp,
-                        R.color.blue_wordpress);
+                return LoginNotification.failure(this, R.string.notification_login_failed);
         }
 
         return null;

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AutoForegroundNotification.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AutoForegroundNotification.java
@@ -9,6 +9,10 @@ import android.support.annotation.DrawableRes;
 import android.support.annotation.StringRes;
 import android.support.v4.app.NotificationCompat;
 
+import static org.wordpress.android.util.AutoForeground.NOTIFICATION_ID_PROGRESS;
+import static org.wordpress.android.util.AutoForeground.NOTIFICATION_ID_SUCCESS;
+import static org.wordpress.android.util.AutoForeground.NOTIFICATION_ID_FAILURE;
+
 public class AutoForegroundNotification {
     private static Intent getResumeIntent(Context context) {
         // Let's get an Intent with the sole purpose of _resuming_ the app from the background
@@ -22,9 +26,9 @@ public class AutoForegroundNotification {
         return resumeIntent;
     }
 
-    private static NotificationCompat.Builder getNotificationBuilder(Context context, @StringRes int title,
-                                                                     @StringRes int content, @DrawableRes int icon,
-                                                                     @ColorRes int accentColor) {
+    private static NotificationCompat.Builder getNotificationBuilder(Context context, int requestCode,
+                                                                     @StringRes int title, @StringRes int content,
+                                                                     @DrawableRes int icon, @ColorRes int accentColor) {
         NotificationCompat.BigTextStyle bigTextStyle = new NotificationCompat.BigTextStyle();
         bigTextStyle.setBigContentTitle(context.getString(title));
         bigTextStyle.bigText(context.getString(content));
@@ -35,40 +39,28 @@ public class AutoForegroundNotification {
                 .setContentText(context.getString(content))
                 .setSmallIcon(icon)
                 .setColor(context.getResources().getColor(accentColor))
-                .setAutoCancel(true);
+                .setAutoCancel(true)
+                .setContentIntent(PendingIntent.getActivity(
+                        context,
+                        requestCode,
+                        getResumeIntent(context),
+                        PendingIntent.FLAG_ONE_SHOT));
     }
 
     public static Notification progress(Context context, int progress, @StringRes int title, @StringRes int content,
                                         @DrawableRes int icon, @ColorRes int accentColor) {
-        return getNotificationBuilder(context, title, content, icon, accentColor)
-                .setContentIntent(PendingIntent.getActivity(
-                        context,
-                        AutoForeground.NOTIFICATION_ID_PROGRESS,
-                        getResumeIntent(context),
-                        PendingIntent.FLAG_ONE_SHOT))
+        return getNotificationBuilder(context, NOTIFICATION_ID_PROGRESS, title, content, icon, accentColor)
                 .setProgress(100, progress, false)
                 .build();
     }
 
     public static Notification success(Context context, @StringRes int title, @StringRes int content,
                                        @DrawableRes int icon, @ColorRes int accentColor) {
-        return getNotificationBuilder(context, title, content, icon, accentColor)
-                .setContentIntent(PendingIntent.getActivity(
-                        context,
-                        AutoForeground.NOTIFICATION_ID_SUCCESS,
-                        getResumeIntent(context),
-                        PendingIntent.FLAG_ONE_SHOT))
-                .build();
+        return getNotificationBuilder(context, NOTIFICATION_ID_SUCCESS, title, content, icon, accentColor).build();
     }
 
     public static Notification failure(Context context, @StringRes int title, @StringRes int content,
                                        @DrawableRes int icon, @ColorRes int accentColor) {
-        return getNotificationBuilder(context, title, content, icon, accentColor)
-                .setContentIntent(PendingIntent.getActivity(
-                        context,
-                        AutoForeground.NOTIFICATION_ID_FAILURE,
-                        getResumeIntent(context),
-                        PendingIntent.FLAG_ONE_SHOT))
-                .build();
+        return getNotificationBuilder(context, NOTIFICATION_ID_FAILURE, title, content, icon, accentColor).build();
     }
 }


### PR DESCRIPTION
This is a PR against #7105 with a couple of minor change suggestions.

* Simplify calls to login/site-creation notification builders by tacking away their common configuration details
* Use string, color resources directly via wpandroid instead of accessing them via loginlib