### PR TITLE
Fix onAppComesFromBackground not being called on initial app launch

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -108,7 +108,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
     public static final String SITE = "SITE";
     public static String versionName;
     public static WordPressDB wpDB;
-    public static boolean sAppIsInTheBackground;
+    public static boolean sAppIsInTheBackground = true;
 
     private static RestClientUtils sRestClientUtils;
     private static RestClientUtils sRestClientUtilsVersion1_1;


### PR DESCRIPTION
Initialisation of "app in the background" flag was removed in #6756, and this is causing app launches to not be correctly tracked (and maybe something else too).

`sAppIsInTheBackground` is false by default, so `onAppComesFromBackground` in `onActivityResumed` is not called when app starts for the first time.