### PR TITLE
Add editor content logging in case of crashes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1153,7 +1153,7 @@ public class EditPostActivity extends AppCompatActivity implements
                             public boolean shouldLog(Throwable throwable) {
                                 // Do not log private or password protected post
                                 return getPost() != null && TextUtils.isEmpty(getPost().getPassword()) &&
-                                        !"private".equals(getPost().getStatus());
+                                        !PostStatus.PRIVATE.toString().equals(getPost().getStatus());
                             }
                         }
                 );

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -136,6 +136,7 @@ import org.wordpress.android.util.helpers.MediaGallery;
 import org.wordpress.android.util.helpers.MediaGalleryImageSpan;
 import org.wordpress.android.util.helpers.WPImageSpan;
 import org.wordpress.android.widgets.WPViewPager;
+import org.wordpress.aztec.AztecExceptionHandler;
 import org.wordpress.passcodelock.AppLockManager;
 
 import java.io.File;
@@ -596,6 +597,9 @@ public class EditPostActivity extends AppCompatActivity implements
         mDispatcher.unregister(this);
         cancelAddMediaListThread();
         removePostOpenInEditorStickyEvent();
+        if (mEditorFragment instanceof AztecEditorFragment) {
+            ((AztecEditorFragment)mEditorFragment).disableContentLogOnCrashes();
+        }
         super.onDestroy();
     }
 
@@ -1140,6 +1144,20 @@ public class EditPostActivity extends AppCompatActivity implements
             );
             aztecEditorFragment.setAztecVideoLoader(new AztecVideoLoader(getBaseContext(), loadingVideoPlaceholder));
             aztecEditorFragment.setLoadingVideoPlaceholder(loadingVideoPlaceholder);
+
+            if (getSite() != null && getSite().isWPCom() && !getSite().isPrivate()) {
+                // Add the content reporting for wpcom blogs that are not private
+                aztecEditorFragment.enableContentLogOnCrashes(
+                        new AztecExceptionHandler.ExceptionHandlerHelper() {
+                            @Override
+                            public boolean shouldLog(Throwable throwable) {
+                                // Do not log private or password protected post
+                                return getPost() != null && TextUtils.isEmpty(getPost().getPassword()) &&
+                                        !"private".equals(getPost().getStatus());
+                            }
+                        }
+                );
+            }
         }
     }
 

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -53,9 +53,9 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.18.1'
 
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:v1.0')
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:v1.0')
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:v1.0')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:861f7a9d3e38eaf6281e49bc510cf11e92f37288')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:861f7a9d3e38eaf6281e49bc510cf11e92f37288')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:861f7a9d3e38eaf6281e49bc510cf11e92f37288')
 
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)
     compile "org.jetbrains.kotlin:kotlin-stdlib:1.1.4"

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -64,6 +64,7 @@ import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 import org.wordpress.aztec.Aztec;
 import org.wordpress.aztec.AztecAttributes;
+import org.wordpress.aztec.AztecExceptionHandler;
 import org.wordpress.aztec.AztecParser;
 import org.wordpress.aztec.AztecText;
 import org.wordpress.aztec.AztecTextFormat;
@@ -2099,5 +2100,13 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     public int getMaxMediaSize() {
         return maxMediaSize;
+    }
+
+    public void enableContentLogOnCrashes(AztecExceptionHandler.ExceptionHandlerHelper helper) {
+        content.enableCrashLogging(helper);
+    }
+
+    public void disableContentLogOnCrashes() {
+        content.disableCrashLogging();
     }
 }


### PR DESCRIPTION
This PR enables Aztec content logging in case of crashes.
_Content logging will be enabled for wpcom sites, and public posts only._


cc @mzorz 