### PR TITLE
Issue/7111 fix media upload status

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -512,6 +512,7 @@ public class MySiteFragment extends Fragment
 
     @SuppressWarnings("unused")
     public void onEventMainThread(UploadService.UploadErrorEvent event) {
+        EventBus.getDefault().removeStickyEvent(event);
         SiteModel site = getSelectedSite();
         if (site != null && event.post != null) {
             if (event.post.getLocalSiteId() == site.getId()) {
@@ -529,6 +530,7 @@ public class MySiteFragment extends Fragment
 
     @SuppressWarnings("unused")
     public void onEventMainThread(UploadService.UploadMediaSuccessEvent event) {
+        EventBus.getDefault().removeStickyEvent(event);
         SiteModel site = getSelectedSite();
         if (site != null && event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
             UploadUtils.onMediaUploadedSnackbarHandler(getActivity(),

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -298,6 +298,10 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         registerReceiver(mReceiver, new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
         mDispatcher.register(this);
         EventBus.getDefault().register(this);
+        // FluxC and App events are not reflecting on the grid while the app is sent to the
+        // background as listeners are unregistered in onStop(), so let's refresh the content
+        // when we're back on the foreground (don't worry - it will only refresh if differences are found)
+        reloadMediaGrid();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -673,8 +673,15 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         }
 
         for (MediaModel otherMedia : otherList) {
-            if (!mediaExists(otherMedia)) {
+            int idxCurrentList = indexOfMedia(otherMedia);
+            if (idxCurrentList == -1) {
                 return false;
+            } else {
+                MediaModel modelInCurrentList = mMediaList.get(idxCurrentList);
+                if (modelInCurrentList.getUploadState() != null &&
+                        !modelInCurrentList.getUploadState().equals(otherMedia.getUploadState())) {
+                    return false;
+                }
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -673,15 +673,8 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         }
 
         for (MediaModel otherMedia : otherList) {
-            int idxCurrentList = indexOfMedia(otherMedia);
-            if (idxCurrentList == -1) {
+            if (!mediaExists(otherMedia)) {
                 return false;
-            } else {
-                MediaModel modelInCurrentList = mMediaList.get(idxCurrentList);
-                if (modelInCurrentList.getUploadState() != null &&
-                        !modelInCurrentList.getUploadState().equals(otherMedia.getUploadState())) {
-                    return false;
-                }
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -754,6 +754,7 @@ public class PostsListFragment extends Fragment
 
     @SuppressWarnings("unused")
     public void onEventMainThread(UploadService.UploadErrorEvent event) {
+        EventBus.getDefault().removeStickyEvent(event);
         if (event.post != null) {
             UploadUtils.onPostUploadedSnackbarHandler(getActivity(),
                     getActivity().findViewById(R.id.coordinator), true, event.post, event.errorMessage, mSite, mDispatcher);
@@ -767,6 +768,7 @@ public class PostsListFragment extends Fragment
 
     @SuppressWarnings("unused")
     public void onEventMainThread(UploadService.UploadMediaSuccessEvent event) {
+        EventBus.getDefault().removeStickyEvent(event);
         if (event.mediaModelList != null && !event.mediaModelList.isEmpty()) {
             UploadUtils.onMediaUploadedSnackbarHandler(getActivity(),
                     getActivity().findViewById(R.id.coordinator), false,

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -346,7 +346,7 @@ class PostUploadNotifier {
         // show the snackbar
         if (mediaList != null && !mediaList.isEmpty()) {
             String snackbarMessage = buildSnackbarSuccessMessageForMedia(mediaList.size());
-            EventBus.getDefault().post(new UploadService.UploadMediaSuccessEvent(mediaList, snackbarMessage));
+            EventBus.getDefault().postSticky(new UploadService.UploadMediaSuccessEvent(mediaList, snackbarMessage));
         }
 
         if (!WordPress.sAppIsInTheBackground) {
@@ -472,7 +472,7 @@ class PostUploadNotifier {
                     actionPendingIntent).setColor(mContext.getResources().getColor(R.color.orange_jazzy));
         }
 
-        EventBus.getDefault().post(new UploadService.UploadErrorEvent(post, snackbarMessage));
+        EventBus.getDefault().postSticky(new UploadService.UploadErrorEvent(post, snackbarMessage));
 
         doNotify(notificationId, notificationBuilder.build());
     }
@@ -521,7 +521,7 @@ class PostUploadNotifier {
 
         }
 
-        EventBus.getDefault().post(new UploadService.UploadErrorEvent(mediaList, snackbarMessage));
+        EventBus.getDefault().postSticky(new UploadService.UploadErrorEvent(mediaList, snackbarMessage));
         doNotify(notificationId, notificationBuilder.build());
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -581,8 +581,9 @@ class PostUploadNotifier {
 
     private String buildSuccessMessageForMedia(int mediaItemsUploaded) {
         // all media items were uploaded successfully
-        String successMessage =  String.format(mContext.getString(R.string.media_all_files_uploaded_successfully),
-                    mediaItemsUploaded);
+        String successMessage =  mediaItemsUploaded == 1 ? mContext.getString(R.string.media_file_uploaded)
+                                    : String.format(mContext.getString(R.string.media_all_files_uploaded_successfully),
+                                            mediaItemsUploaded);
         return successMessage;
     }
 


### PR DESCRIPTION
Fixes #7111 

This was happening because when we send the app to the background we de-register the EventBus and FluxC listeners in `onStop`, thus failing to catch the finalizing `success` and `error` events to ultimately update the screen. In order to avoid this from happening, we're making these events sticky events and then removing them right as they are consumed, to make sure they are consumed once and only once. This way, no matter where the user left when they were uploading media/posts (main screen, media browser or posts list), they can rest assured they will be notified (through the snackbar and updating the UI, i.e. media grid in the case of the media browser) about the latest important stuff that happened they need to know about right when they return to the app.

Note this fix doesn't affect native notifications, which remain as they were  - just the actual app's UI when users come back (either by tapping an error or success notification, or returning by switching apps natively).

To test:
1. go to media browser
2. start a media upload
3. send the app to the background and wait for the upload to finish.
4. once the upload is finished, you should see a success notification with the right singular wording ( i.e. "1 file uploaded").
5. tap on the notification to bring the WordPress app back to the foreground
6. see the Media Browser screen gets updated and the item that was uploading doesn't show the  "UPLOADING" overlay anymore.


