### PR TITLE
Add the ability to log message (and exceptions) in Crashlytics from Aztec

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -137,6 +137,7 @@ import org.wordpress.android.util.helpers.MediaGalleryImageSpan;
 import org.wordpress.android.util.helpers.WPImageSpan;
 import org.wordpress.android.widgets.WPViewPager;
 import org.wordpress.aztec.AztecExceptionHandler;
+import org.wordpress.aztec.util.AztecLog;
 import org.wordpress.passcodelock.AppLockManager;
 
 import java.io.File;
@@ -1158,6 +1159,22 @@ public class EditPostActivity extends AppCompatActivity implements
                         }
                 );
             }
+            aztecEditorFragment.setExternalLogger(new AztecLog.ExternalLogger() {
+                @Override
+                public void log(String s) {
+                    CrashlyticsUtils.log(s);
+                }
+
+                @Override
+                public void logException(Throwable throwable) {
+                    CrashlyticsUtils.logException(throwable);
+                }
+
+                @Override
+                public void logException(Throwable throwable, String s) {
+                    CrashlyticsUtils.logException(throwable, T.EDITOR, s);
+                }
+            });
         }
     }
 

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -53,9 +53,9 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.5'
     compile 'org.wordpress:utils:1.18.1'
 
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:861f7a9d3e38eaf6281e49bc510cf11e92f37288')
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:861f7a9d3e38eaf6281e49bc510cf11e92f37288')
-    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:861f7a9d3e38eaf6281e49bc510cf11e92f37288')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:aztec:4e2fa321220890a5b5f79fb4ff36eee77b20e490')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-shortcodes:4e2fa321220890a5b5f79fb4ff36eee77b20e490')
+    compile ('com.github.wordpress-mobile.WordPress-Aztec-Android:wordpress-comments:4e2fa321220890a5b5f79fb4ff36eee77b20e490')
 
     // Required Aztec dependencies (they should be included but Jitpack seems to be stripping these out)
     compile "org.jetbrains.kotlin:kotlin-stdlib:1.1.4"

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -88,6 +88,7 @@ import org.wordpress.aztec.spans.AztecMediaSpan;
 import org.wordpress.aztec.spans.IAztecAttributedSpan;
 import org.wordpress.aztec.toolbar.AztecToolbar;
 import org.wordpress.aztec.toolbar.IAztecToolbarClickListener;
+import org.wordpress.aztec.util.AztecLog;
 import org.wordpress.aztec.watchers.EndOfBufferMarkerAdder;
 import org.xml.sax.Attributes;
 
@@ -2108,5 +2109,9 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     public void disableContentLogOnCrashes() {
         content.disableCrashLogging();
+    }
+
+    public void setExternalLogger(AztecLog.ExternalLogger logger) {
+        content.setExternalLogger(logger);
     }
 }


### PR DESCRIPTION
This PR add the ability to log messages, and exceptions, in Crashlytics from Aztec.
It basically sets Aztec external logger with our Crashlytics instance.

cc @mzorz 