### PR TITLE
Remove onUnexpectedError forwarding to Crashlytics

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -474,15 +474,8 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onParseError(OnUnexpectedError event) {
+    public void onUnexpectedError(OnUnexpectedError event) {
         AppLog.d(T.API, "Receiving OnUnexpectedError event, message: " + event.exception.getMessage());
-        String description = "FluxC: " + event.description;
-        if (event.extras != null) {
-            for (String key : event.extras.keySet()) {
-                CrashlyticsUtils.setString(key, event.extras.get(key));
-            }
-        }
-        CrashlyticsUtils.logException(event.exception, event.type, description);
     }
 
     public void removeWpComUserRelatedData(Context context) {


### PR DESCRIPTION
Remove onUnexpectedError forwarding to Crashlytics.

There are a lot of these reports in Crashlytics coming from different errors, a common issue comes from user entering an erroneous URLs when signing in. This makes a lot a noise in Crashlytics and make non-fatals unvaluable.

