### PR TITLE
changed Photon strip parameter value from 'all' to 'info'

### DIFF
--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
@@ -57,7 +57,7 @@ public class PhotonUtils {
             return imageUrl + "?w=" + width + "&h=" + height;
         }
 
-        // strip=all removes EXIF and other non-visual data from JPEGs
+        // strip=info removes Exif, IPTC and comment data from the output image.
         String query = "?strip=info";
 
         switch (quality) {

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/PhotonUtils.java
@@ -58,7 +58,7 @@ public class PhotonUtils {
         }
 
         // strip=all removes EXIF and other non-visual data from JPEGs
-        String query = "?strip=all";
+        String query = "?strip=info";
 
         switch (quality) {
             case HIGH:


### PR DESCRIPTION
Changes the `?strip=` querystring parameter value used for accesing Photon from `all` to `info` by suggestion of @blowery

To test: check the reader's featured image is shown correctly

cc @nbradbury 
