### PR TITLE
issue/7127 - do not call getActivity when fragment is not added.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -51,7 +51,7 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.analytics.AnalyticsTracker.Stat;
 import org.wordpress.android.editor.AztecEditorFragment;
 import org.wordpress.android.editor.EditorFragment;
-import org.wordpress.android.editor.EditorFragment.IllegalEditorStateException;
+import org.wordpress.android.editor.EditorFragment.EditorFragmentNotAddedException;
 import org.wordpress.android.editor.EditorFragmentAbstract;
 import org.wordpress.android.editor.EditorFragmentAbstract.EditorDragAndDropListener;
 import org.wordpress.android.editor.EditorFragmentAbstract.EditorFragmentListener;
@@ -522,7 +522,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 public void run() {
                     try {
                         updatePostObject(true);
-                    } catch (IllegalEditorStateException e) {
+                    } catch (EditorFragmentNotAddedException e) {
                         AppLog.e(T.EDITOR, "Impossible to save the post, we weren't able to update it.");
                         return;
                     }
@@ -1076,7 +1076,7 @@ public class EditPostActivity extends AppCompatActivity implements
         );
     }
 
-    private synchronized void updatePostObject(boolean isAutosave) throws IllegalEditorStateException {
+    private synchronized void updatePostObject(boolean isAutosave) throws EditorFragmentNotAddedException {
         if (mPost == null) {
             AppLog.e(AppLog.T.POSTS, "Attempted to save an invalid Post.");
             return;
@@ -1108,7 +1108,7 @@ public class EditPostActivity extends AppCompatActivity implements
             public void run() {
                 try {
                     updatePostObject(false);
-                } catch (IllegalEditorStateException e) {
+                } catch (EditorFragmentNotAddedException e) {
                     AppLog.e(T.EDITOR, "Impossible to save the post, we weren't able to update it.");
                     return;
                 }
@@ -1489,7 +1489,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private boolean updatePostObject() {
         try {
             updatePostObject(false);
-        } catch (IllegalEditorStateException e) {
+        } catch (EditorFragmentNotAddedException e) {
             AppLog.e(T.EDITOR, "Impossible to save and publish the post, we weren't able to update it.");
             return false;
         }
@@ -1805,7 +1805,7 @@ public class EditPostActivity extends AppCompatActivity implements
     /**
      * Updates post object with content of this fragment
      */
-    public boolean updatePostContent(boolean isAutoSave) throws IllegalEditorStateException {
+    public boolean updatePostContent(boolean isAutoSave) throws EditorFragmentNotAddedException {
         if (mPost == null) {
             return false;
         }

--- a/libs/editor/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/EditorFragmentTest.java
+++ b/libs/editor/WordPressEditor/src/androidTest/java/org.wordpress.android.editor/EditorFragmentTest.java
@@ -5,7 +5,7 @@ import android.test.ActivityInstrumentationTestCase2;
 import android.view.View;
 import android.widget.ToggleButton;
 
-import org.wordpress.android.editor.EditorFragment.IllegalEditorStateException;
+import org.wordpress.android.editor.EditorFragment.EditorFragmentNotAddedException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -101,7 +101,7 @@ public class EditorFragmentTest extends ActivityInstrumentationTestCase2<MockEdi
         assertTrue(htmlButton.isEnabled());
     }
 
-    public void testHtmlModeToggleTextTransfer() throws InterruptedException, IllegalEditorStateException {
+    public void testHtmlModeToggleTextTransfer() throws InterruptedException, EditorFragmentNotAddedException {
         waitForOnDomLoaded();
 
         final View view = mFragment.getView();
@@ -153,7 +153,7 @@ public class EditorFragmentTest extends ActivityInstrumentationTestCase2<MockEdi
                 try {
                     assertEquals("new title", mFragment.getTitle());
                     assertEquals("new <b>content</b>", mFragment.getContent());
-                } catch (IllegalEditorStateException e) {
+                } catch (EditorFragmentNotAddedException e) {
                     throw new RuntimeException();
                 }
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -72,7 +72,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         OnJsEditorStateChangedListener, OnImeBackListener, EditorWebViewAbstract.AuthHeaderRequestListener,
         EditorMediaUploadListener {
 
-    public class IllegalEditorStateException extends Exception {
+    public class EditorFragmentNotAddedException extends Exception {
 
     }
 
@@ -418,7 +418,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         try {
             outState.putCharSequence(ATTR_TITLE, getTitle());
             outState.putCharSequence(ATTR_CONTENT, getContent());
-        } catch (IllegalEditorStateException e) {
+        } catch (EditorFragmentNotAddedException e) {
             AppLog.e(T.EDITOR, "onSaveInstanceState: unable to get title or content");
         }
     }
@@ -633,7 +633,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                     try {
                         getTitle();
                         getContent();
-                    } catch (IllegalEditorStateException e) {
+                    } catch (EditorFragmentNotAddedException e) {
                         AppLog.e(T.EDITOR, "toggleHtmlMode: unable to get title or content");
                         return;
                     }
@@ -925,9 +925,9 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
      * where possible.
      */
     @Override
-    public CharSequence getTitle() throws IllegalEditorStateException {
+    public CharSequence getTitle() throws EditorFragmentNotAddedException {
         if (!isAdded()) {
-            throw new IllegalEditorStateException();
+            throw new EditorFragmentNotAddedException();
         }
 
         if (mSourceView != null && mSourceView.getVisibility() == View.VISIBLE) {
@@ -964,9 +964,9 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
      * where possible.
      */
     @Override
-    public CharSequence getContent() throws IllegalEditorStateException {
+    public CharSequence getContent() throws EditorFragmentNotAddedException {
         if (!isAdded()) {
-            throw new IllegalEditorStateException();
+            throw new EditorFragmentNotAddedException();
         }
 
         if (mSourceView != null && mSourceView.getVisibility() == View.VISIBLE) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -635,14 +635,14 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
                         getContent();
                     } catch (IllegalEditorStateException e) {
                         AppLog.e(T.EDITOR, "toggleHtmlMode: unable to get title or content");
-                        getActivity().runOnUiThread(new Runnable() {
-                            @Override
-                            public void run() {
-                                toggleButton.setChecked(false);
-                            }
-                        });
                         return;
                     }
+
+                    //sanity check
+                    if (!isAdded()) {
+                        return;
+                    }
+
                     getActivity().runOnUiThread(new Runnable() {
                         @Override
                         public void run() {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragmentAbstract.java
@@ -9,7 +9,7 @@ import android.view.DragEvent;
 
 import com.android.volley.toolbox.ImageLoader;
 
-import org.wordpress.android.editor.EditorFragment.IllegalEditorStateException;
+import org.wordpress.android.editor.EditorFragment.EditorFragmentNotAddedException;
 import org.wordpress.android.util.helpers.MediaFile;
 import org.wordpress.android.util.helpers.MediaGallery;
 
@@ -19,8 +19,8 @@ import java.util.HashMap;
 public abstract class EditorFragmentAbstract extends Fragment {
     public abstract void setTitle(CharSequence text);
     public abstract void setContent(CharSequence text);
-    public abstract CharSequence getTitle() throws IllegalEditorStateException;
-    public abstract CharSequence getContent() throws IllegalEditorStateException;
+    public abstract CharSequence getTitle() throws EditorFragmentNotAddedException;
+    public abstract CharSequence getContent() throws EditorFragmentNotAddedException;
     public abstract void appendMediaFile(MediaFile mediaFile, String imageUrl, ImageLoader imageLoader);
     public abstract void appendGallery(MediaGallery mediaGallery);
     public abstract void setUrlForVideoPressId(String videoPressId, String url, String posterUrl);


### PR DESCRIPTION
Fixes #7127 

`IllegalEditorStateException` will be thrown when fragment `isAdded()` check fails in `getTitle()` or `getContent()`. Trying to call ` getActivity()` when fragment is not added leads to NPE.