### PR TITLE
Wrapping Aztec external logger log into an exception

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1162,7 +1162,13 @@ public class EditPostActivity extends AppCompatActivity implements
             aztecEditorFragment.setExternalLogger(new AztecLog.ExternalLogger() {
                 @Override
                 public void log(String s) {
-                    CrashlyticsUtils.log(s);
+                    // For now, we're wrapping up the actual log into a Crashlytics exception to reduce possibility
+                    // of information not travelling to Crashlytics (Crashlytics rolls logs up to 8
+                    // entries and 64kb max, and they only travel with the next crash happening, so logging an
+                    // Exception assures us to have this information sent in the next batch).
+                    // For more info: https://docs.fabric.io/android/crashlytics/enhanced-reports.html?#custom-logging
+                    // and https://docs.fabric.io/android/crashlytics/caught-exceptions.html?caught%20exceptions#caught-exceptions
+                    CrashlyticsUtils.logException(new AztecEditorFragment.AztecLoggingException(s));
                 }
 
                 @Override

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -113,6 +113,12 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         IAztecToolbarClickListener,
         IHistoryListener {
 
+    static public class AztecLoggingException extends Exception {
+        public AztecLoggingException(String message) {
+            super(message);
+        }
+    }
+
     private static final String ATTR_TAPPED_MEDIA_PREDICATE = "tapped_media_predicate";
 
     private static final String ATTR_ALIGN = "align";


### PR DESCRIPTION
Re-writing this PR in WPAndroid as per this suggestion https://github.com/wordpress-mobile/AztecEditor-Android/pull/609#issuecomment-358586361


Copying the underlaying reasoning here for easy reading:

According to Crashlytics docs, it seems that just adding a normal logging only enqueues the log to be sent in batch to Crashlytics the next time the app crashes at some point.

https://docs.fabric.io/android/crashlytics/enhanced-reports.html?#custom-logging

`In addition to writing to the next crash report…`

I believe we should be doing something like the following thing instead:
https://docs.fabric.io/android/crashlytics/caught-exceptions.html?caught%20exceptions#caught-exceptions

Also note these two notes:

`For any individual app session, only the most recent 8 logged exceptions are stored.` (in https://docs.fabric.io/android/crashlytics/caught-exceptions.html?caught%20exceptions#caught-exceptions)

and

`To make sure that sending crash reports has the smallest impact on your user’s devices, Crashlytics logs have a maximum size of 64 KB. When a log exceeds 64 KB, the earliest logged values will be dropped in order to maintain this threshold.` (https://docs.fabric.io/android/crashlytics/enhanced-reports.html?#custom-logging)


This makes me think we should probably change the approach and, given that a single Post could potentially be larger than 64 kb, and given we can’t store many logs but need to make the app crash (or catch an exception and log it manually with Crashlytics.logException for the info to be sent), something like this change in this PR would probably be more useful for the case at hand in AztecText.

cc @daniloercoli 