### PR TITLE
Preserving mSite when activity is destroyed.

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java
@@ -193,6 +193,7 @@ public class MediaPreviewActivity extends AppCompatActivity implements MediaPrev
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
+        outState.putSerializable(WordPress.SITE, mSite);
         outState.putInt(MediaPreviewFragment.ARG_MEDIA_ID, mMediaId);
         outState.putString(MediaPreviewFragment.ARG_MEDIA_CONTENT_URI, mContentUri);
         if (mMediaIdList != null) {


### PR DESCRIPTION
Fixes #7133 

We forgot to preserve site model when activity is destroyed, so it becomes `null` [here](https://github.com/wordpress-mobile/WordPress-Android/blob/6a79d43a87ad8bc786bfc0e9101437fb50cae024/WordPress/src/main/java/org/wordpress/android/ui/media/MediaPreviewActivity.java#L130).

To test:

1. Turn on "Do not keep Activities"
2. Navigate to Media Browser that has at least 3-5 images.
3. Tap on the image and navigate to media settings.
4. Tap on the image at the top, and navigate to full-screen preview.
5. Press Home button, and minimize the app.
6. Navigate back to the app.
7. Swipe right.
8. Notice that nothing is crashing or on fire.