### PR TITLE
issue/7114-tags-keyboard

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagDetailFragment.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.prefs;
 
 import android.app.Fragment;
+import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -11,12 +12,14 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.TermModel;
 import org.wordpress.android.fluxc.store.TaxonomyStore;
+import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.EditTextUtils;
 import org.wordpress.android.util.StringUtils;
 
@@ -82,6 +85,10 @@ public class SiteSettingsTagDetailFragment extends Fragment {
 
         mTerm = (TermModel) getArguments().getSerializable(ARGS_TERM);
         mIsNewTerm = getArguments().getBoolean(ARGS_IS_NEW_TERM);
+
+        if (savedInstanceState == null && !DisplayUtils.isLandscape(getActivity())) {
+            EditTextUtils.showSoftInput(mNameView);
+        }
 
         loadTagDetail();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsTagDetailFragment.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.prefs;
 
 import android.app.Fragment;
-import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -12,7 +11,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
 import org.wordpress.android.R;


### PR DESCRIPTION
Fixes #7114 - the soft keyboard now automatically appears when editing a tag

To test:
* Go to site settings
* Choose Tags
* Tap a tag, soft keyboard should appear