### PR TITLE
Issue/7113 jetpack installed theme

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserActivity.java
@@ -356,37 +356,36 @@ public class ThemeBrowserActivity extends AppCompatActivity implements ThemeBrow
     }
 
     private void startWebActivity(String themeId, ThemeWebActivity.ThemeWebActivityType type) {
-        String toastText = getString(R.string.no_network_message);
+        if (!NetworkUtils.checkConnection(this)) return;
 
-        if (NetworkUtils.isNetworkAvailable(this)) {
-            ThemeModel theme = TextUtils.isEmpty(themeId) ? null : mThemeStore.getWpComThemeByThemeId(themeId.replace("-wpcom", ""));
-            if (theme != null) {
-                Map<String, Object> themeProperties = new HashMap<>();
-                themeProperties.put(THEME_ID, themeId);
-                theme.setActive(isActiveThemeForSite(theme.getThemeId()));
-
-                switch (type) {
-                    case PREVIEW:
-                        AnalyticsUtils.trackWithSiteDetails(Stat.THEMES_PREVIEWED_SITE, mSite, themeProperties);
-                        break;
-                    case DEMO:
-                        AnalyticsUtils.trackWithSiteDetails(Stat.THEMES_DEMO_ACCESSED, mSite, themeProperties);
-                        break;
-                    case DETAILS:
-                        AnalyticsUtils.trackWithSiteDetails(Stat.THEMES_DETAILS_ACCESSED, mSite, themeProperties);
-                        break;
-                    case SUPPORT:
-                        AnalyticsUtils.trackWithSiteDetails(Stat.THEMES_SUPPORT_ACCESSED, mSite, themeProperties);
-                        break;
-                }
-                ThemeWebActivity.openTheme(this, mSite, theme, type);
+        ThemeModel theme = TextUtils.isEmpty(themeId) ? null : mThemeStore.getWpComThemeByThemeId(themeId.replace("-wpcom", ""));
+        if (theme == null) {
+            theme = mThemeStore.getInstalledThemeByThemeId(mSite, themeId);
+            if (theme == null) {
+                ToastUtils.showToast(this, R.string.could_not_load_theme);
                 return;
-            } else {
-                toastText = getString(R.string.could_not_load_theme);
             }
         }
 
-        ToastUtils.showToast(this, toastText, ToastUtils.Duration.SHORT);
+        Map<String, Object> themeProperties = new HashMap<>();
+        themeProperties.put(THEME_ID, themeId);
+        theme.setActive(isActiveThemeForSite(theme.getThemeId()));
+
+        switch (type) {
+            case PREVIEW:
+                AnalyticsUtils.trackWithSiteDetails(Stat.THEMES_PREVIEWED_SITE, mSite, themeProperties);
+                break;
+            case DEMO:
+                AnalyticsUtils.trackWithSiteDetails(Stat.THEMES_DEMO_ACCESSED, mSite, themeProperties);
+                break;
+            case DETAILS:
+                AnalyticsUtils.trackWithSiteDetails(Stat.THEMES_DETAILS_ACCESSED, mSite, themeProperties);
+                break;
+            case SUPPORT:
+                AnalyticsUtils.trackWithSiteDetails(Stat.THEMES_SUPPORT_ACCESSED, mSite, themeProperties);
+                break;
+        }
+        ThemeWebActivity.openTheme(this, mSite, theme, type);
     }
 
     private boolean isActiveThemeForSite(@NonNull String themeId) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
@@ -45,7 +45,7 @@ public class ThemeWebActivity extends WPWebViewActivity {
 
     public static void openTheme(Activity activity, SiteModel site, ThemeModel theme, ThemeWebActivityType type) {
         String url = getUrl(site, theme, type, false);
-        if (type == ThemeWebActivityType.PREVIEW) {
+        if (type == ThemeWebActivityType.PREVIEW || !url.contains("wordpress.com")) {
             // Do not open the Customizer with the in-app browser.
             // Customizer may need to access local files (mostly pictures) on the device storage,
             // and our internal webview doesn't handle this feature yet.
@@ -85,6 +85,10 @@ public class ThemeWebActivity extends WPWebViewActivity {
                 String domain = isPremium ? THEME_DOMAIN_PREMIUM : THEME_DOMAIN_PUBLIC;
                 return String.format(THEME_URL_PREVIEW, UrlUtils.getHost(site.getUrl()), domain, theme.getThemeId());
             case DEMO:
+                // demo URL may be empty for installed themes on .org sites
+                if (TextUtils.isEmpty(theme.getDemoUrl())) {
+                    return site.getAdminUrl() + "themes.php?theme=" + theme.getThemeId();
+                }
                 String url = theme.getDemoUrl();
                 if (url.contains("?")) {
                     return url + "&" + THEME_URL_DEMO_PARAMETER;

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeWebActivity.java
@@ -108,9 +108,8 @@ public class ThemeWebActivity extends WPWebViewActivity {
                 case DEMO:
                     return site.getAdminUrl() + "themes.php?theme=" + theme.getThemeId();
                 case DETAILS:
-                    return theme.getThemeUrl();
                 case SUPPORT:
-                    return theme.getAuthorUrl();
+                    return theme.getThemeUrl();
             }
         }
         return "";


### PR DESCRIPTION
Fixes #7113 - currently we assume all themes are wp.com themes, so previewing non-wp.com themes is broken. This PR resolves this by using variations of the admin URL for actions related to non-wp.com themes.

To test:
* Upload a theme to a Jetpack site
* Tap that theme in the app's theme browser
