### PR TITLE
issue/7142-reader-featured-image

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/ReaderCardType.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/ReaderCardType.java
@@ -34,9 +34,10 @@ public enum ReaderCardType {
             return VIDEO;
         }
 
-        // if this post has enough usable images to fill the stream's thumbnail strip, treat it
-        // as a gallery
-        if (post.hasImages()
+        // if this post doesn't have a featured image but has enough usable images to fill the
+        // stream's thumbnail strip, treat it as a gallery
+        if (!post.hasFeaturedImage()
+                && post.hasImages()
                 && new ReaderImageScanner(post.getText(), post.isPrivate)
                     .hasUsableImageCount(ReaderThumbnailStrip.IMAGE_COUNT, ReaderConstants.MIN_GALLERY_IMAGE_WIDTH)) {
             return GALLERY;


### PR DESCRIPTION
Fixes #7142 - Prior to this PR, when a reader post has several images we would show a gallery of those images even when the post has a featured image. This PR fixes this by only showing a gallery when no featured image has been assigned.