### PR TITLE
Issue/7112 jetpack theme grid no headers

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -340,7 +340,7 @@ public class ThemeBrowserFragment extends Fragment
 
     private ThemeBrowserAdapter getAdapter() {
         if (mAdapter == null) {
-            mAdapter = new ThemeBrowserAdapter(getActivity(), mSite.isWPCom(), mCallback);
+            mAdapter = new ThemeBrowserAdapter(getActivity(), mCallback);
         }
         return mAdapter;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/themes/ThemeBrowserFragment.java
@@ -334,7 +334,6 @@ public class ThemeBrowserFragment extends Fragment
             return getSortedWpComThemes();
         }
 
-        // this is a Jetpack site, show two sections with headers
         return getSortedJetpackThemes();
     }
 

--- a/WordPress/src/main/res/layout/theme_grid_item.xml
+++ b/WordPress/src/main/res/layout/theme_grid_item.xml
@@ -1,57 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/theme_grid_card_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-
-    <RelativeLayout
-        android:id="@+id/section_header"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:clipToPadding="false"
-        android:paddingBottom="@dimen/margin_medium"
-        android:paddingEnd="@dimen/margin_extra_large"
-        android:paddingLeft="@dimen/margin_extra_large"
-        android:paddingRight="@dimen/margin_extra_large"
-        android:paddingStart="@dimen/margin_extra_large"
-        android:paddingTop="@dimen/margin_extra_large"
-        android:visibility="gone"
-        tools:visibility="visible">
-
-        <TextView
-            android:id="@+id/section_header_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentTop="true"
-            android:layout_marginEnd="@dimen/margin_large"
-            android:layout_marginRight="@dimen/margin_large"
-            android:textColor="@color/grey_darken_20"
-            android:textSize="@dimen/text_sz_large"
-            tools:text="WordPress.com themes" />
-
-        <TextView
-            android:id="@+id/section_header_count"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignBaseline="@id/section_header_text"
-            android:layout_toEndOf="@id/section_header_text"
-            android:layout_toRightOf="@id/section_header_text"
-            android:background="@drawable/theme_count_border"
-            android:textColor="@color/grey_darken_20"
-            android:textSize="@dimen/text_sz_large"
-            tools:text="4" />
-
-    </RelativeLayout>
 
     <android.support.v7.widget.CardView
         android:id="@+id/theme_grid_card"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/section_header"
         android:layout_marginLeft="@dimen/theme_browser_cardview_margin_large"
         android:layout_marginRight="@dimen/theme_browser_cardview_margin_large"
         android:layout_marginTop="@dimen/theme_browser_cardview_margin_large"


### PR DESCRIPTION
Fixes #7112 - the issue involved the headers we show on the theme grid for Jetpack sites, which are used to separate the "Uploaded themes" and "WordPress.com themes." 

After discussing with @kwonye and @elibud we decided the best solution was to simply remove the headers from the theme grid, which is what this PR does.