### PR TITLE
Feature/plugin detail collapsing toolbar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -51,6 +51,7 @@ import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DateTimeUtils;
+import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SiteUtils;
@@ -380,6 +381,11 @@ public class PluginDetailActivity extends AppCompatActivity {
                 ActivityLauncher.openUrlExternal(PluginDetailActivity.this, getWpOrgReviewsUrl());
             }
         });
+
+        // set the height of the gradient scrim that appears atop the banner image
+        int toolbarHeight = DisplayUtils.getActionBarHeight(this);
+        ImageView imgScrim = findViewById(R.id.image_gradient_scrim);
+        imgScrim.getLayoutParams().height = toolbarHeight * 2;
 
         refreshViews();
     }

--- a/WordPress/src/main/res/drawable/media_settings_gradient_scrim.xml
+++ b/WordPress/src/main/res/drawable/media_settings_gradient_scrim.xml
@@ -3,7 +3,7 @@
     <gradient
         android:angle="90"
         android:centerY="75%"
-        android:endColor="#602e4453"
+        android:endColor="@color/grey_dark_translucent_50"
         android:startColor="@color/transparent"
         android:type="linear"/>
 </shape>

--- a/WordPress/src/main/res/drawable/media_settings_gradient_scrim.xml
+++ b/WordPress/src/main/res/drawable/media_settings_gradient_scrim.xml
@@ -3,7 +3,7 @@
     <gradient
         android:angle="90"
         android:centerY="75%"
-        android:endColor="@color/black_translucent_50"
+        android:endColor="#602e4453"
         android:startColor="@color/transparent"
         android:type="linear"/>
 </shape>

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -1,20 +1,68 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/plugin_detail_container"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="false">
 
-    <include
-        android:id="@+id/toolbar"
-        layout="@layout/toolbar" />
-
-    <ScrollView
+    <android.support.design.widget.AppBarLayout
+        android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="false"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+
+        <android.support.design.widget.CollapsingToolbarLayout
+            android:id="@+id/collapsing_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:fitsSystemWindows="false"
+            app:contentScrim="?attr/colorPrimary"
+            app:expandedTitleMarginEnd="64dp"
+            app:expandedTitleMarginStart="48dp"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_collapseMode="parallax">
+
+                <org.wordpress.android.widgets.WPNetworkImageView
+                    android:id="@+id/image_banner"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/plugin_banner_size"
+                    android:background="@color/grey_lighten_20"
+                    android:scaleType="centerCrop" />
+
+                <ImageView
+                    android:id="@+id/image_gradient_scrim"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="top"
+                    android:background="@drawable/media_settings_gradient_scrim"
+                    tools:layout_height="74dp" />
+            </FrameLayout>
+
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                app:layout_collapseMode="pin"
+                app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
+
+        </android.support.design.widget.CollapsingToolbarLayout>
+
+    </android.support.design.widget.AppBarLayout>
+
+    <android.support.v4.widget.NestedScrollView
+        android:id="@+id/scroll_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -27,13 +75,6 @@
                 card_view:cardCornerRadius="@dimen/cardview_default_radius">
 
                 <LinearLayout style="@style/PluginCardViewVerticalContainer">
-
-                    <org.wordpress.android.widgets.WPNetworkImageView
-                        android:id="@+id/image_banner"
-                        android:layout_width="match_parent"
-                        android:layout_height="@dimen/plugin_banner_size"
-                        android:background="@color/grey_lighten_20"
-                        android:scaleType="centerCrop" />
 
                     <RelativeLayout
                         android:layout_width="match_parent"
@@ -144,6 +185,7 @@
             </android.support.v7.widget.CardView>
 
             <android.support.v7.widget.CardView
+                android:id="@+id/plugin_card_site"
                 style="@style/PluginCardView"
                 card_view:cardBackgroundColor="@color/white"
                 card_view:cardCornerRadius="@dimen/cardview_default_radius">
@@ -361,5 +403,6 @@
 
             <include layout="@layout/plugin_ratings_cardview" />
         </LinearLayout>
-    </ScrollView>
-</LinearLayout>
+    </android.support.v4.widget.NestedScrollView>
+
+</android.support.design.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -336,5 +336,5 @@
     <!--plugin-->
     <dimen name="plugin_icon_size">40dp</dimen>
     <dimen name="plugin_external_link_image_size">16dp</dimen>
-    <dimen name="plugin_banner_size">128dp</dimen>
+    <dimen name="plugin_banner_size">192dp</dimen>
 </resources>


### PR DESCRIPTION
Updates the plugin detail screen to use a collapsing toolbar rather than a fixed toolbar. 

![plugin detail](https://user-images.githubusercontent.com/3903757/35234695-fe7c92ee-ff6f-11e7-958c-cdd409fec93f.gif)
