### PR TITLE
Dismiss progress dialog before Login Activity finish

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginBaseFormFragment.java
@@ -258,14 +258,11 @@ public abstract class LoginBaseFormFragment<LoginListenerType> extends Fragment 
     protected void onLoginFinished(boolean success) {
         mLoginFinished = true;
 
-        if (!success) {
-            endProgress();
-            return;
-        }
-
-        if (mLoginListener != null) {
+        if (success && mLoginListener != null) {
             onLoginFinished();
         }
+
+        endProgress();
     }
 
     protected void saveCredentialsInSmartLock(LoginListener loginListener, String username, String password) {

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -462,6 +462,8 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
 
             mLoginListener.loggedInViaUsernamePassword(mOldSitesIDs);
         }
+
+        endProgress();
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
Addresses #7147 

Login Activity was finished on success without tearing down the progress dialog. That caused a `WindowLeaked` warning by the system.

To test:
1. With the app data cleared, launch the app
2. Have the logcat window open in AndroidStudio and login to wpcom
3. Notice that there is no `WindowLeaked` log entry
