### PR TITLE
issue/7157-app-log-plugins

### DIFF
--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AppLog.java
@@ -23,9 +23,32 @@ import static java.lang.String.format;
  * simple wrapper for Android log calls, enables recording and displaying log
  */
 public class AppLog {
+
     // T for Tag
-    public enum T {READER, EDITOR, MEDIA, NUX, API, STATS, UTILS, NOTIFS, DB, POSTS, COMMENTS, THEMES, TESTS, PROFILING,
-        SIMPERIUM, SUGGESTION, MAIN, SETTINGS, PLANS, PEOPLE, SHARING}
+    public enum T {
+        READER,
+        EDITOR,
+        MEDIA,
+        NUX,
+        API,
+        STATS,
+        UTILS,
+        NOTIFS,
+        DB,
+        POSTS,
+        COMMENTS,
+        THEMES,
+        TESTS,
+        PROFILING,
+        SIMPERIUM,
+        SUGGESTION,
+        MAIN,
+        SETTINGS,
+        PLANS,
+        PEOPLE,
+        SHARING,
+        PLUGINS
+    }
 
     public static final String TAG = "WordPress";
     public static final int HEADER_LINE_COUNT = 2;


### PR DESCRIPTION
Fixes #7157 - adds `PLUGINS` to the AppLog types. For now this type is unused, but it will be used in #7156 once merged.