### PR TITLE
Bug Fix: Approved Text Different Colour

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/CommentDetailFragment.java
@@ -1002,7 +1002,7 @@ public class CommentDetailFragment extends Fragment implements NotificationFragm
         if (status == CommentStatus.APPROVED) {
             mBtnModerateIcon.setImageResource(R.drawable.ic_checkmark_orange_jazzy_24dp);
             mBtnModerateTextView.setText(R.string.comment_status_approved);
-            mBtnModerateTextView.setTextColor(ContextCompat.getColor(getActivity(), R.color.notification_status_unapproved_dark));
+            mBtnModerateTextView.setTextColor(ContextCompat.getColor(getActivity(), R.color.orange_jazzy));
         } else {
             mBtnModerateIcon.setImageResource(R.drawable.ic_checkmark_grey_24dp);
             mBtnModerateTextView.setText(R.string.mnu_comment_approve);


### PR DESCRIPTION
Fixes #7159 

To test:
According to #7159:
1. Go to Notifications tab.
2. Tap approved comment notification.
3. Notice Approved text color.
