### PR TITLE
Feature/rtl audit login

### DIFF
--- a/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
+++ b/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
@@ -65,6 +65,8 @@
                     style="@style/WordPress.NUXEditText"
                     android:hint="@string/email_hint"
                     android:inputType="textEmailAddress"
+                    android:textAlignment="viewStart"
+                    android:gravity="start"
                     app:persistenceEnabled="true"/>
 
                 <ImageView
@@ -99,6 +101,8 @@
                     android:digits="0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
                     android:hint="@string/username"
                     android:maxLength="@integer/max_length_username"
+                    android:textAlignment="viewStart"
+                    android:gravity="start"
                     app:persistenceEnabled="true"/>
 
                 <ImageView
@@ -133,7 +137,9 @@
                     android:maxLength="@integer/max_length_password"
                     android:layout_marginRight="38dp"
                     android:layout_marginStart="38dp"
-                    android:layout_marginEnd="38dp" />
+                    android:layout_marginEnd="38dp"
+                    android:textAlignment="viewStart"
+                    android:gravity="start"/>
 
                 <ImageView
                     android:layout_width="wrap_content"
@@ -209,7 +215,9 @@
                         android:layout_toLeftOf="@+id/textView"
                         app:persistenceEnabled="true"
                         android:layout_marginLeft="0dp"
-                        android:layout_marginStart="0dp" />
+                        android:layout_marginStart="0dp"
+                        android:textAlignment="viewStart"
+                        android:gravity="start"/>
 
                     <org.wordpress.android.widgets.WPTextView
                         android:layout_width="wrap_content"

--- a/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
+++ b/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
@@ -166,57 +166,17 @@
                     android:tint="@color/nux_eye_icon_color_closed"/>
             </RelativeLayout>
 
-            <RelativeLayout
+            <LinearLayout
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:background="@color/white"
                 android:layout_marginBottom="16dp">
 
-                <org.wordpress.android.widgets.AutoCompleteEmptyTextView
-                    android:id="@+id/site_url"
-                    style="@style/WordPress.NUXEditText"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:hint="@string/add_account_blog_url"
-                    android:inputType="textUri"
-                    android:digits="0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                    android:clickable="true"
-                    android:paddingLeft="0dp"
-                    android:paddingTop="12dp"
-                    android:paddingRight="0dp"
-                    android:paddingBottom="12dp"
-                    android:layout_toLeftOf="@+id/textView"
-                    android:layout_toStartOf="@+id/textView"
-                    app:persistenceEnabled="true"
-                    android:paddingEnd="0dp"
-                    android:paddingStart="0dp" />
-
-                <org.wordpress.android.widgets.WPTextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/dot_wordpress_dot_com_url"
-                    android:id="@+id/textView"
-                    android:layout_alignParentEnd="false"
-                    android:layout_marginTop="4dp"
-                    android:layout_alignParentStart="false"
-                    android:layout_alignParentLeft="false"
-                    android:layout_alignParentTop="false"
-                    android:paddingRight="8dp"
-                    android:paddingEnd="8dp"
-                    android:enabled="false"
-                    android:focusable="false"
-                    android:layout_alignParentRight="true"
-                    android:layout_centerVertical="true"
-                    android:layout_marginRight="4dp"
-                    android:layout_marginEnd="4dp"
-                    android:textColor="@color/grey_darken_10"
-                    android:textSize="@dimen/nux_edit_field_font_size"/>
-
                 <ImageView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:id="@+id/imageView4"
-                    android:layout_gravity="center_horizontal"
+                    android:layout_gravity="center"
                     android:layout_alignParentLeft="false"
                     android:layout_alignParentStart="false"
                     android:layout_alignParentRight="false"
@@ -225,8 +185,53 @@
                     android:layout_centerVertical="true"
                     android:layout_marginLeft="10dp"
                     android:layout_marginStart="10dp"
+                    android:layout_toLeftOf="@+id/site_url_layout"
+                    android:layout_toStartOf="@+id/site_url_layout"
                     android:tint="@color/grey_darken_10"/>
-            </RelativeLayout>
+
+                <RelativeLayout
+                    android:id="@+id/site_url_layout"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="4dp">
+
+                    <org.wordpress.android.widgets.AutoCompleteEmptyTextView
+                        android:id="@+id/site_url"
+                        style="@style/WordPress.NUXEditText"
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/add_account_blog_url"
+                        android:inputType="textUri"
+                        android:digits="0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                        android:clickable="true"
+                        android:paddingTop="12dp"
+                        android:paddingBottom="12dp"
+                        android:layout_toLeftOf="@+id/textView"
+                        app:persistenceEnabled="true"
+                        android:layout_marginLeft="0dp"
+                        android:layout_marginStart="0dp" />
+
+                    <org.wordpress.android.widgets.WPTextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/dot_wordpress_dot_com_url"
+                        android:id="@+id/textView"
+                        android:layout_alignParentEnd="false"
+                        android:layout_marginTop="4dp"
+                        android:layout_alignParentStart="false"
+                        android:layout_alignParentLeft="false"
+                        android:layout_alignParentTop="false"
+                        android:layout_marginRight="16dp"
+                        android:enabled="false"
+                        android:focusable="false"
+                        android:layout_alignParentRight="true"
+                        android:layout_centerVertical="true"
+                        android:textColor="@color/grey_darken_10"
+                        android:textSize="@dimen/nux_edit_field_font_size"/>
+                </RelativeLayout>
+
+
+            </LinearLayout>
 
             <RelativeLayout
                 android:layout_width="wrap_content"

--- a/WordPress/src/main/res/values-sw600dp/styles.xml
+++ b/WordPress/src/main/res/values-sw600dp/styles.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:android="http://schemas.android.com/apk/res/android">
+<resources xmlns:tools="http://schemas.android.com/tools" xmlns:android="http://schemas.android.com/apk/res/android">
     <style name="WordPress.BorderedBackground">
         <item name="android:layout_marginLeft">@dimen/notifications_list_margin</item>
         <item name="android:layout_marginRight">@dimen/notifications_list_margin</item>
-        <item name="android:layout_marginStart">@dimen/notifications_list_margin</item>
-        <item name="android:layout_marginEnd">@dimen/notifications_list_margin</item>
+        <item name="android:layout_marginStart" tools:targetApi="jelly_bean_mr1">@dimen/notifications_list_margin</item>
+        <item name="android:layout_marginEnd" tools:targetApi="jelly_bean_mr1">@dimen/notifications_list_margin</item>
         <item name="android:background">@drawable/calypso_bordered_bg</item>
         <item name="android:paddingLeft">1dp</item>
         <item name="android:paddingRight">1dp</item>
-        <item name="android:paddingStart">1dp</item>
-        <item name="android:paddingEnd">1dp</item>
+        <item name="android:paddingStart" tools:targetApi="jelly_bean_mr1">1dp</item>
+        <item name="android:paddingEnd" tools:targetApi="jelly_bean_mr1">1dp</item>
     </style>
 </resources>

--- a/WordPress/src/main/res/values-sw720dp/styles.xml
+++ b/WordPress/src/main/res/values-sw720dp/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <style name="WordPressTitleAppearance" parent="@android:style/TextAppearance">
         <item name="android:singleLine">true</item>
         <item name="android:shadowColor">#BB000000</item>
@@ -19,9 +19,9 @@
         <item name="android:layout_marginTop">1px</item>
         <item name="android:layout_marginRight">1px</item>
         <item name="android:layout_marginLeft">1px</item>
-        <item name="android:layout_marginStart">1px</item>
+        <item name="android:layout_marginStart" tools:targetApi="jelly_bean_mr1">1px</item>
         <item name="android:paddingLeft">6dp</item>
-        <item name="android:paddingStart">6dp</item>
+        <item name="android:paddingStart" tools:targetApi="jelly_bean_mr1">6dp</item>
         <item name="android:paddingRight">4dp</item>
         <item name="android:paddingBottom">6dp</item>
         <item name="android:paddingTop">2dp</item>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -97,9 +97,9 @@
     <style name="FilteredRecyclerViewFilterTextView.WordPress" parent="android:TextAppearance.Widget.TextView">
         <item name="android:padding">@dimen/margin_medium</item>
         <item name="android:layout_marginLeft">@dimen/margin_extra_large</item>
-        <item name="android:layout_marginStart">@dimen/margin_extra_large</item>
+        <item name="android:layout_marginStart" tools:targetApi="jelly_bean_mr1">@dimen/margin_extra_large</item>
         <item name="android:paddingRight">@dimen/margin_large</item>
-        <item name="android:paddingEnd">@dimen/margin_large</item>
+        <item name="android:paddingEnd" tools:targetApi="jelly_bean_mr1">@dimen/margin_large</item>
         <item name="android:textSize">@dimen/text_sz_large</item>
     </style>
 
@@ -118,7 +118,7 @@
 
     <style name="FilteredRecyclerViewToolbar" parent="Widget.AppCompat.Toolbar">
         <item name="android:paddingLeft">@dimen/margin_filter_spinner</item>
-        <item name="android:paddingStart">@dimen/margin_filter_spinner</item>
+        <item name="android:paddingStart" tools:targetApi="jelly_bean_mr1">@dimen/margin_filter_spinner</item>
         <item name="android:elevation">@dimen/filter_subbar_elevation</item>
         <item name="android:theme">@style/FilteredRecyclerViewToolbar.Theme</item>
     </style>
@@ -228,17 +228,17 @@
     </style>
     <style name="MediaSettings.Label">
         <item name="android:layout_marginLeft">@dimen/media_settings_margin</item>
-        <item name="android:layout_marginStart">@dimen/media_settings_margin</item>
+        <item name="android:layout_marginStart" tools:targetApi="jelly_bean_mr1">@dimen/media_settings_margin</item>
         <item name="android:layout_marginRight">@dimen/media_settings_margin</item>
-        <item name="android:layout_marginEnd">@dimen/media_settings_margin</item>
+        <item name="android:layout_marginEnd" tools:targetApi="jelly_bean_mr1">@dimen/media_settings_margin</item>
         <item name="android:textColor">@color/grey_dark</item>
         <item name="android:textSize">@dimen/text_sz_large</item>
     </style>
     <style name="MediaSettings.Value">
         <item name="android:layout_marginLeft">@dimen/media_settings_margin</item>
-        <item name="android:layout_marginStart">@dimen/media_settings_margin</item>
+        <item name="android:layout_marginStart" tools:targetApi="jelly_bean_mr1">@dimen/media_settings_margin</item>
         <item name="android:layout_marginRight">@dimen/media_settings_margin</item>
-        <item name="android:layout_marginEnd">@dimen/media_settings_margin</item>
+        <item name="android:layout_marginEnd" tools:targetApi="jelly_bean_mr1">@dimen/media_settings_margin</item>
         <item name="android:textColor">@color/grey</item>
         <item name="android:textSize">@dimen/text_sz_medium</item>
     </style>
@@ -279,9 +279,9 @@
         <item name="android:textColor">@color/nux_primary_button</item>
         <item name="android:layout_height">@dimen/nux_main_button_height</item>
         <item name="android:layout_marginLeft">4dp</item>
-        <item name="android:layout_marginStart">4dp</item>
+        <item name="android:layout_marginStart" tools:targetApi="jelly_bean_mr1">4dp</item>
         <item name="android:layout_marginRight">4dp</item>
-        <item name="android:layout_marginEnd">4dp</item>
+        <item name="android:layout_marginEnd" tools:targetApi="jelly_bean_mr1">4dp</item>
         <item name="android:layout_marginBottom">8dp</item>
         <item name="android:clickable">true</item>
         <item name="android:background">@drawable/nux_primary_button_selector</item>
@@ -315,7 +315,7 @@
         <item name="android:textColorHint">#AAAAAA</item>
         <item name="android:padding">12dp</item>
         <item name="android:layout_marginLeft">40dp</item>
-        <item name="android:layout_marginStart">40dp</item>
+        <item name="android:layout_marginStart" tools:targetApi="jelly_bean_mr1">40dp</item>
     </style>
 
     <style name="WordPress.NUXTitle">
@@ -332,9 +332,9 @@
         <item name="android:textColor">@color/grey_darken_30</item>
         <item name="android:gravity">center</item>
         <item name="android:layout_marginLeft">16dp</item>
-        <item name="android:layout_marginStart">16dp</item>
+        <item name="android:layout_marginStart" tools:targetApi="jelly_bean_mr1">16dp</item>
         <item name="android:layout_marginRight">16dp</item>
-        <item name="android:layout_marginEnd">16dp</item>
+        <item name="android:layout_marginEnd" tools:targetApi="jelly_bean_mr1">16dp</item>
     </style>
 
     <style name="WordPress.EmptyList.Title" parent="WordPress.EmptyList">
@@ -357,9 +357,9 @@
         <item name="android:background">@drawable/moderate_button_selector</item>
         <item name="android:paddingTop">@dimen/margin_small</item>
         <item name="android:paddingRight">@dimen/margin_small</item>
-        <item name="android:paddingEnd">@dimen/margin_small</item>
+        <item name="android:paddingEnd" tools:targetApi="jelly_bean_mr1">@dimen/margin_small</item>
         <item name="android:paddingLeft">@dimen/margin_small</item>
-        <item name="android:paddingStart">@dimen/margin_small</item>
+        <item name="android:paddingStart" tools:targetApi="jelly_bean_mr1">@dimen/margin_small</item>
         <item name="android:paddingBottom">@dimen/margin_medium</item>
         <item name="android:drawablePadding">-4dp</item>
         <item name="android:focusable">true</item>
@@ -376,7 +376,7 @@
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:paddingLeft">@dimen/my_site_list_row_padding_left</item>
-        <item name="android:paddingStart">@dimen/my_site_list_row_padding_left</item>
+        <item name="android:paddingStart" tools:targetApi="jelly_bean_mr1">@dimen/my_site_list_row_padding_left</item>
         <item name="android:background">?android:attr/selectableItemBackground</item>
     </style>
 
@@ -384,12 +384,12 @@
         <item name="android:layout_width">@dimen/my_site_list_row_icon_size</item>
         <item name="android:layout_height">@dimen/my_site_list_row_icon_size</item>
         <item name="android:layout_alignParentLeft">true</item>
-        <item name="android:layout_alignParentStart">true</item>
+        <item name="android:layout_alignParentStart" tools:targetApi="jelly_bean_mr1">true</item>
         <item name="android:layout_centerVertical">true</item>
         <item name="android:layout_marginTop">@dimen/margin_large</item>
         <item name="android:layout_marginBottom">@dimen/margin_large</item>
         <item name="android:layout_marginRight">@dimen/margin_extra_large</item>
-        <item name="android:layout_marginEnd">@dimen/margin_extra_large</item>
+        <item name="android:layout_marginEnd" tools:targetApi="jelly_bean_mr1">@dimen/margin_extra_large</item>
         <item name="android:gravity">center_vertical</item>
     </style>
 
@@ -398,7 +398,7 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_centerVertical">true</item>
         <item name="android:layout_marginRight">@dimen/margin_medium</item>
-        <item name="android:layout_marginEnd">@dimen/margin_medium</item>
+        <item name="android:layout_marginEnd" tools:targetApi="jelly_bean_mr1">@dimen/margin_medium</item>
         <item name="android:ellipsize">end</item>
         <item name="android:gravity">center_vertical</item>
         <item name="android:maxLines">1</item>
@@ -407,20 +407,20 @@
         <item name="android:paddingTop">@dimen/margin_large</item>
         <item name="android:paddingBottom">@dimen/margin_large</item>
         <item name="android:paddingLeft">@dimen/margin_extra_large</item>
-        <item name="android:paddingStart">@dimen/margin_extra_large</item>
+        <item name="android:paddingStart" tools:targetApi="jelly_bean_mr1">@dimen/margin_extra_large</item>
     </style>
 
     <style name="MySiteListRowSecondaryElement">
         <item name="android:layout_centerVertical">true</item>
         <item name="android:layout_marginRight">@dimen/margin_extra_large</item>
-        <item name="android:layout_marginEnd">@dimen/margin_extra_large</item>
+        <item name="android:layout_marginEnd" tools:targetApi="jelly_bean_mr1">@dimen/margin_extra_large</item>
         <item name="android:gravity">end|center_vertical</item>
     </style>
 
     <style name="MySiteListRowSecondaryTextView" parent="MySiteListRowSecondaryElement">
         <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_alignParentEnd">true</item>
+        <item name="android:layout_alignParentEnd" tools:targetApi="jelly_bean_mr1">true</item>
         <item name="android:layout_alignParentRight">true</item>
         <item name="android:ellipsize">end</item>
         <item name="android:maxLines">1</item>
@@ -429,7 +429,7 @@
         <item name="android:paddingTop">@dimen/margin_large</item>
         <item name="android:paddingBottom">@dimen/margin_large</item>
         <item name="android:paddingLeft">@dimen/margin_extra_large</item>
-        <item name="android:paddingStart">@dimen/margin_extra_large</item>
+        <item name="android:paddingStart" tools:targetApi="jelly_bean_mr1">@dimen/margin_extra_large</item>
     </style>
 
     <style name="MySiteListRowSecondaryIcon" parent="MySiteListRowSecondaryElement">
@@ -442,7 +442,7 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:paddingBottom">@dimen/my_site_margin_general</item>
         <item name="android:paddingLeft">@dimen/my_site_list_row_padding_left</item>
-        <item name="android:paddingStart">@dimen/my_site_list_row_padding_left</item>
+        <item name="android:paddingStart" tools:targetApi="jelly_bean_mr1">@dimen/my_site_list_row_padding_left</item>
         <item name="android:paddingTop">@dimen/my_site_margin_general</item>
     </style>
 
@@ -460,10 +460,10 @@
         <item name="android:layout_height">1dp</item>
         <item name="android:layout_gravity">center_vertical</item>
         <item name="android:layout_marginLeft">@dimen/margin_large</item>
-        <item name="android:layout_marginStart">@dimen/margin_large</item>
+        <item name="android:layout_marginStart" tools:targetApi="jelly_bean_mr1">@dimen/margin_large</item>
         <item name="android:background">@color/grey_lighten_20</item>
         <item name="android:layout_marginRight">@dimen/margin_extra_large</item>
-        <item name="android:layout_marginEnd">@dimen/margin_extra_large</item>
+        <item name="android:layout_marginEnd" tools:targetApi="jelly_bean_mr1">@dimen/margin_extra_large</item>
     </style>
 
     <style name="MeListRowLayout">
@@ -480,9 +480,9 @@
         <item name="android:layout_marginTop">@dimen/margin_large</item>
         <item name="android:layout_marginBottom">@dimen/margin_large</item>
         <item name="android:layout_marginLeft">@dimen/margin_medium</item>
-        <item name="android:layout_marginStart">@dimen/margin_medium</item>
+        <item name="android:layout_marginStart" tools:targetApi="jelly_bean_mr1">@dimen/margin_medium</item>
         <item name="android:layout_marginRight">@dimen/margin_extra_large</item>
-        <item name="android:layout_marginEnd">@dimen/margin_extra_large</item>
+        <item name="android:layout_marginEnd" tools:targetApi="jelly_bean_mr1">@dimen/margin_extra_large</item>
     </style>
 
     <style name="MeListRowTextView">
@@ -578,10 +578,10 @@
         <item name="android:textStyle">bold</item>
         <item name="android:layout_marginBottom">@dimen/margin_small</item>
         <item name="android:layout_marginTop">@dimen/margin_extra_large</item>
-        <item name="android:layout_marginEnd">@dimen/margin_extra_large</item>
+        <item name="android:layout_marginEnd" tools:targetApi="jelly_bean_mr1">@dimen/margin_extra_large</item>
         <item name="android:layout_marginLeft">@dimen/margin_extra_large</item>
         <item name="android:layout_marginRight">@dimen/margin_extra_large</item>
-        <item name="android:layout_marginStart">@dimen/margin_extra_large</item>
+        <item name="android:layout_marginStart" tools:targetApi="jelly_bean_mr1">@dimen/margin_extra_large</item>
     </style>
 
     <style name="PostSettingsContainer">
@@ -691,7 +691,7 @@
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:layout_centerVertical">true</item>
-        <item name="android:layout_alignParentEnd">true</item>
+        <item name="android:layout_alignParentEnd" tools:targetApi="jelly_bean_mr1">true</item>
         <item name="android:layout_alignParentRight">true</item>
     </style>
 
@@ -700,7 +700,7 @@
         <item name="android:layout_height">@dimen/plugin_external_link_image_size</item>
         <item name="android:tint">@color/grey_darken_10</item>
         <item name="android:layout_marginRight">@dimen/margin_medium</item>
-        <item name="android:layout_marginEnd">@dimen/margin_medium</item>
+        <item name="android:layout_marginEnd" tools:targetApi="jelly_bean_mr1">@dimen/margin_medium</item>
     </style>
 
     <style name="PluginCardViewSecondaryElement.ChevronImage" parent="PluginCardViewSecondaryElement.ExternalLinkImage">

--- a/WordPress/src/main/res/values/styles_calypso.xml
+++ b/WordPress/src/main/res/values/styles_calypso.xml
@@ -71,9 +71,9 @@
         <item name="android:textStyle">bold</item>
         <item name="android:textColor">@color/grey_dark</item>
         <item name="android:paddingLeft">@dimen/dlp_title_padding_start</item>
-        <item name="android:paddingStart">@dimen/dlp_title_padding_start</item>
+        <item name="android:paddingStart" tools:targetApi="jelly_bean_mr1">@dimen/dlp_title_padding_start</item>
         <item name="android:paddingRight">@dimen/dlp_title_padding_end</item>
-        <item name="android:paddingEnd">@dimen/dlp_title_padding_end</item>
+        <item name="android:paddingEnd" tools:targetApi="jelly_bean_mr1">@dimen/dlp_title_padding_end</item>
     </style>
 
     <style name="CalypsoTheme.NoActionBarShadow" parent="CalypsoTheme">

--- a/libs/editor/WordPressEditor/src/main/res/values/styles.xml
+++ b/libs/editor/WordPressEditor/src/main/res/values/styles.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <resources
-    xmlns:android="http://schemas.android.com/apk/res/android" >
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <style name="LegacyToggleButton">
         <item name="android:minWidth">@dimen/legacy_format_bar_height</item>
@@ -20,13 +21,13 @@
     <style name="FormatBarButtonTablet" parent="FormatBarButton">
         <item name="android:layout_marginRight">@dimen/format_bar_button_margin_tablet</item>
         <item name="android:layout_marginLeft">@dimen/format_bar_button_margin_tablet</item>
-        <item name="android:layout_marginStart">@dimen/format_bar_button_margin_tablet</item>
-        <item name="android:layout_marginEnd">@dimen/format_bar_button_margin_tablet</item>
+        <item name="android:layout_marginStart" tools:targetApi="jelly_bean_mr1">@dimen/format_bar_button_margin_tablet</item>
+        <item name="android:layout_marginEnd" tools:targetApi="jelly_bean_mr1">@dimen/format_bar_button_margin_tablet</item>
     </style>
 
     <style name="FormatBarHtmlButton" parent="FormatBarButton">
         <item name="android:layout_marginLeft">@dimen/format_bar_html_button_left_margin</item>
-        <item name="android:layout_marginStart">@dimen/format_bar_html_button_left_margin</item>
+        <item name="android:layout_marginStart" tools:targetApi="jelly_bean_mr1">@dimen/format_bar_html_button_left_margin</item>
     </style>
 
     <style name="Divider">
@@ -40,15 +41,15 @@
     <style name="FormatBarTabletGroup">
         <item name="android:layout_marginLeft">@dimen/format_bar_button_group_tablet</item>
         <item name="android:layout_marginRight">@dimen/format_bar_button_group_tablet</item>
-        <item name="android:layout_marginStart">@dimen/format_bar_button_group_tablet</item>
-        <item name="android:layout_marginEnd">@dimen/format_bar_button_group_tablet</item>
+        <item name="android:layout_marginStart" tools:targetApi="jelly_bean_mr1">@dimen/format_bar_button_group_tablet</item>
+        <item name="android:layout_marginEnd" tools:targetApi="jelly_bean_mr1">@dimen/format_bar_button_group_tablet</item>
     </style>
 
     <style name="ImageOptionsDialogLabel">
         <item name="android:textColor">@color/image_options_label</item>
         <item name="android:textStyle">bold</item>
         <item name="android:paddingLeft">@dimen/image_settings_dialog_label_indent</item>
-        <item name="android:paddingStart">@dimen/image_settings_dialog_label_indent</item>
+        <item name="android:paddingStart" tools:targetApi="jelly_bean_mr1">@dimen/image_settings_dialog_label_indent</item>
         <item name="android:layout_marginBottom">@dimen/image_settings_dialog_label_margin_bottom</item>
     </style>
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/widgets/WPLoginInputRow.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/widgets/WPLoginInputRow.java
@@ -6,7 +6,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.TextInputLayout;
 import android.text.TextWatcher;

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/widgets/WPLoginInputRow.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/widgets/WPLoginInputRow.java
@@ -2,6 +2,7 @@ package org.wordpress.android.login.widgets;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -62,9 +63,9 @@ public class WPLoginInputRow extends RelativeLayout {
     private void init(Context context, AttributeSet attrs) {
         inflate(context, R.layout.login_input_row, this);
 
-        mIcon =  findViewById(R.id.icon);
-        mTextInputLayout =  findViewById(R.id.input_layout);
-        mEditText =  findViewById(R.id.input);
+        mIcon = findViewById(R.id.icon);
+        mTextInputLayout = findViewById(R.id.input_layout);
+        mEditText = findViewById(R.id.input);
 
         if (attrs != null) {
             TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable.wpLoginInputRow, 0, 0);
@@ -97,6 +98,12 @@ public class WPLoginInputRow extends RelativeLayout {
                 if (a.hasValue(R.styleable.wpLoginInputRow_passwordToggleTint)) {
                     mTextInputLayout.setPasswordVisibilityToggleTintList(
                             a.getColorStateList(R.styleable.wpLoginInputRow_passwordToggleTint));
+                }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                    if (a.hasValue(R.styleable.wpLoginInputRow_android_textAlignment)) {
+                        mEditText.setTextAlignment(
+                                a.getInt(R.styleable.wpLoginInputRow_android_textAlignment, TEXT_ALIGNMENT_GRAVITY));
+                    }
                 }
             } finally {
                 a.recycle();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/widgets/WPLoginInputRow.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/widgets/WPLoginInputRow.java
@@ -119,7 +119,8 @@ public class WPLoginInputRow extends RelativeLayout {
     @Override
     public Parcelable onSaveInstanceState() {
         Bundle bundle = new Bundle();
-        bundle.putParcelable(KEY_SUPER_STATE, saveViewsState());
+        Parcelable editTextState = mEditText.onSaveInstanceState();
+        bundle.putParcelable(KEY_SUPER_STATE, new SavedState(super.onSaveInstanceState(), editTextState));
         return bundle;
     }
 
@@ -131,12 +132,6 @@ public class WPLoginInputRow extends RelativeLayout {
         }
 
         super.onRestoreInstanceState(state);
-    }
-
-    @NonNull
-    private SavedState saveViewsState() {
-        Parcelable editTextState = mEditText.onSaveInstanceState();
-        return new SavedState(super.onSaveInstanceState(), editTextState);
     }
 
     private Parcelable restoreViewsState(SavedState state) {

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_password_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_password_screen.xml
@@ -46,6 +46,8 @@
                 style="@style/LoginTheme.InputLabelStatic"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:textAlignment="viewStart"
+                android:gravity="start"
                 android:text="@string/email_address"/>
 
             <TextView

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_password_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_password_screen.xml
@@ -53,6 +53,8 @@
                 android:id="@+id/login_email"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:textAlignment="viewStart"
+                android:gravity="start"
                 tools:text="s@b.com"/>
         </LinearLayout>
     </LinearLayout>

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_password_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_password_screen.xml
@@ -66,6 +66,8 @@
         android:hint="@string/password"
         android:importantForAutofill="noExcludeDescendants"
         android:inputType="textPassword"
+        android:textAlignment="viewStart"
+        android:gravity="start"
         app:passwordToggleEnabled="true"
         app:passwordToggleTint="@color/grey"
         app:wpIconDrawable="@drawable/ic_lock_grey_24dp"

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_email_screen.xml
@@ -32,6 +32,8 @@
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
         app:wpIconDrawable="@drawable/ic_user_grey_24dp"
+        android:textAlignment="viewStart"
+        android:gravity="start"
         tools:ignore="UnusedAttribute" >
     </org.wordpress.android.login.widgets.WPLoginInputRow>
 

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_input_row.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_input_row.xml
@@ -31,6 +31,8 @@
             android:layout_height="wrap_content"
             android:layout_marginRight="@dimen/textinputlayout_correction_margin_right"
             android:layout_marginEnd="@dimen/textinputlayout_correction_margin_right"
+            android:paddingRight="@dimen/textinputlayout_correction_padding_right"
+            android:paddingEnd="@dimen/textinputlayout_correction_padding_right"
             android:hint="@string/email_address"/>
     </org.wordpress.android.util.widgets.WPTextInputLayout>
 </RelativeLayout>

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_site_address_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_site_address_screen.xml
@@ -27,5 +27,7 @@
         android:hint="@string/login_site_address"
         android:inputType="textUri"
         android:imeOptions="actionNext"
+        android:textAlignment="viewStart"
+        android:gravity="start"
         app:wpIconDrawable="@drawable/ic_globe_grey_24dp"/>
 </LinearLayout>

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/login_username_password_screen.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/login_username_password_screen.xml
@@ -59,7 +59,9 @@
                 android:layout_weight="1"
                 android:text="@string/login_site_address"
                 android:visibility="gone"
-                tools:visibility="visible"/>
+                tools:visibility="visible"
+                android:textAlignment="viewStart"
+                android:gravity="start"/>
 
             <TextView
                 style="@style/Base.TextAppearance.AppCompat.Body2"
@@ -67,6 +69,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:textAlignment="viewStart"
+                android:gravity="start"
                 tools:text="Arround the World with Pam"/>
 
             <TextView
@@ -75,6 +79,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:textAlignment="viewStart"
+                android:gravity="start"
                 tools:text="pamelanguyyen.wordpress.com"/>
         </LinearLayout>
     </LinearLayout>
@@ -86,6 +92,8 @@
         android:hint="@string/username"
         android:inputType="textPersonName"
         android:imeOptions="actionNext"
+        android:textAlignment="viewStart"
+        android:gravity="start"
         app:wpIconDrawable="@drawable/ic_user_grey_24dp"/>
 
     <org.wordpress.android.login.widgets.WPLoginInputRow
@@ -98,5 +106,7 @@
         android:inputType="textPassword"
         app:passwordToggleEnabled="true"
         app:passwordToggleTint="@color/grey"
+        android:textAlignment="viewStart"
+        android:gravity="start"
         app:wpIconDrawable="@drawable/ic_lock_grey_24dp"/>
 </LinearLayout>

--- a/libs/login/WordPressLoginFlow/src/main/res/values/attrs.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/attrs.xml
@@ -11,6 +11,7 @@
         <attr name="android:imeOptions" />
         <attr name="passwordToggleEnabled" />
         <attr name="passwordToggleTint" />
+        <attr name="android:textAlignment" />
     </declare-styleable>
 
 </resources>

--- a/libs/login/WordPressLoginFlow/src/main/res/values/dimens.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/dimens.xml
@@ -35,4 +35,5 @@
     <dimen name="promo_indicator_bullet_size">4dp</dimen>
     <dimen name="magic_link_sent_illustration_sz">120dp</dimen>
     <dimen name="google_button_icon_sz">24dp</dimen>
+    <dimen name="textinputlayout_correction_padding_right">9dp</dimen>
 </resources>


### PR DESCRIPTION
Partially fixes #2278 - Fixes RTL layouts on sign in/up screens.

Some Views are not properly positioned in the RTL language mode. 

To test: 
1. Check layouts of the 
WordPress.com login (email) + email password screens
Selft-hosted site login (site URL) + username and password screens
Create Wordpress.com account screen
2. Change your locale to a RTL language (eg. Hebrew) or force RTL layouts in the developer options.
3. Check the layouts, see step 1

Doesn't fix the ViewPager swipe direction in the RTL mode on the first app screen. 
