### PR TITLE
Bump the Helpshift library dependency to v6.4.1

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -104,7 +104,7 @@ dependencies {
     compile 'com.google.android.gms:play-services-auth:10.0.1'
     compile 'com.google.android.gms:play-services-places:10.0.1'
     compile 'com.github.chrisbanes.photoview:library:1.2.4'
-    compile 'com.helpshift:android-helpshift-aar:4.9.1'
+    compile 'com.helpshift:android-helpshift-aar:6.4.1'
     compile 'de.greenrobot:eventbus:2.4.0'
     compile 'com.automattic:rest:1.0.7'
     compile 'org.wordpress:graphview:3.4.0'


### PR DESCRIPTION
Lot of fixes between 4.9.1 and 6.4.1 and they didn't change the prototypes of the methods we use - Read more: https://developers.helpshift.com/android/release-notes