### PR TITLE
Fix rtl layouts in notification and me sections

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AccountSettingsFragment.java
@@ -1,6 +1,7 @@
 package org.wordpress.android.ui.prefs;
 
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
@@ -8,10 +9,12 @@ import android.support.design.widget.CoordinatorLayout;
 import android.support.design.widget.Snackbar;
 import android.support.v4.content.ContextCompat;
 import android.text.InputType;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.EditText;
 import android.widget.TextView;
 
 import org.greenrobot.eventbus.Subscribe;
@@ -70,6 +73,9 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
         mEmailPreference.setOnPreferenceChangeListener(this);
         mPrimarySitePreference.setOnPreferenceChangeListener(this);
         mWebAddressPreference.setOnPreferenceChangeListener(this);
+
+        setTextAlignement(mEmailPreference.getEditText());
+        setTextAlignement(mWebAddressPreference.getEditText());
 
         // load site list asynchronously
         new LoadSitesTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
@@ -139,6 +145,14 @@ public class AccountSettingsFragment extends PreferenceFragment implements Prefe
                 getActivity().finish();
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    private void setTextAlignement(EditText editText) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            editText.setTextAlignment(View.TEXT_ALIGNMENT_VIEW_START);
+        } else {
+            editText.setGravity(Gravity.START);
+        }
     }
 
     private void refreshAccountDetails() {

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -62,7 +62,7 @@ public class WPActivityUtils {
         titleView.setText(title);
 
         toolbar.setTitle("");
-        toolbar.setNavigationIcon(org.wordpress.android.R.drawable.ic_arrow_left_white_24dp);
+        toolbar.setNavigationIcon(org.wordpress.android.R.drawable.ic_arrow_left_rtl_white_24dp);
         toolbar.setNavigationOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/WordPress/src/main/res/drawable-ldrtl/calypso_segmented_control_button_end.xml
+++ b/WordPress/src/main/res/drawable-ldrtl/calypso_segmented_control_button_end.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/calypso_segmented_control_selected_start" android:state_checked="true" android:state_pressed="false" />
+    <item android:drawable="@drawable/calypso_segmented_control_normal_start" android:state_checked="false" android:state_pressed="false" />
+    <item android:drawable="@drawable/calypso_segmented_control_selected_start" android:state_checked="true" android:state_pressed="true" />
+    <item android:drawable="@drawable/calypso_segmented_control_normal_start" android:state_checked="false" android:state_pressed="true" />
+</selector>

--- a/WordPress/src/main/res/drawable-ldrtl/calypso_segmented_control_button_start.xml
+++ b/WordPress/src/main/res/drawable-ldrtl/calypso_segmented_control_button_start.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/calypso_segmented_control_selected_end" android:state_checked="true" android:state_pressed="false" />
+    <item android:drawable="@android:color/transparent" android:state_checked="false" android:state_pressed="false" />
+    <item android:drawable="@drawable/calypso_segmented_control_selected_end" android:state_checked="true" android:state_pressed="true" />
+    <item android:drawable="@android:color/transparent" android:state_checked="false" android:state_pressed="true" />
+</selector>

--- a/WordPress/src/main/res/drawable/ic_arrow_left_rtl_white_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_arrow_left_rtl_white_24dp.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rotate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:fromDegrees="@integer/mirror_flip"
+    android:toDegrees="0"
+    android:drawable="@drawable/ic_arrow_left_white_24dp">
+</rotate>

--- a/WordPress/src/main/res/layout/detail_list_preference.xml
+++ b/WordPress/src/main/res/layout/detail_list_preference.xml
@@ -41,6 +41,7 @@
             android:textSize="@dimen/text_sz_large"
             android:textColor="@color/grey_dark"
             android:gravity="start"
+            android:textAlignment="viewStart"
             tools:text="Main Text" />
 
         <TextView
@@ -50,6 +51,7 @@
             android:textSize="@dimen/text_sz_small"
             android:textColor="@color/grey_darken_10"
             android:gravity="start"
+            android:textAlignment="viewStart"
             tools:text="Detail Text" />
 
     </LinearLayout>

--- a/WordPress/src/main/res/layout/detail_list_preference_title.xml
+++ b/WordPress/src/main/res/layout/detail_list_preference_title.xml
@@ -16,6 +16,8 @@
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
         android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true" />
+        android:layout_alignParentStart="true"
+        android:textAlignment="viewStart"
+        android:gravity="start"/>
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/my_profile_dialog.xml
+++ b/WordPress/src/main/res/layout/my_profile_dialog.xml
@@ -30,6 +30,8 @@
     <EditText
         android:id="@+id/my_profile_dialog_input"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content"
+        android:textAlignment="viewStart"
+        android:gravity="start"/>
 
 </LinearLayout>

--- a/WordPress/src/main/res/layout/note_block_comment_user.xml
+++ b/WordPress/src/main/res/layout/note_block_comment_user.xml
@@ -39,6 +39,8 @@
                 android:singleLine="true"
                 android:textColor="@color/grey_dark"
                 android:textSize="@dimen/text_sz_large"
+                android:textAlignment="viewStart"
+                android:gravity="start"
                 tools:text="Bob Ross" />
 
             <LinearLayout
@@ -56,6 +58,8 @@
                     android:textSize="@dimen/text_sz_large"
                     android:visibility="gone"
                     tools:text="5h"
+                    android:textAlignment="viewStart"
+                    android:gravity="start"
                     tools:visibility="visible" />
 
                 <org.wordpress.android.widgets.WPTextView
@@ -70,7 +74,9 @@
                     android:textSize="@dimen/text_sz_large"
                     android:textStyle="bold"
                     android:layout_marginStart="@dimen/margin_small"
-                    android:layout_marginEnd="@dimen/margin_small"/>
+                    android:layout_marginEnd="@dimen/margin_small"
+                    android:textAlignment="viewStart"
+                    android:gravity="start"/>
 
                 <org.wordpress.android.widgets.WPTextView
                     android:id="@+id/user_comment_site"
@@ -83,6 +89,8 @@
                     android:singleLine="true"
                     android:textColor="@color/grey"
                     android:textSize="@dimen/text_sz_large"
+                    android:textAlignment="viewStart"
+                    android:gravity="start"
                     tools:text="example.com" />
             </LinearLayout>
 

--- a/WordPress/src/main/res/layout/notifications_list_item.xml
+++ b/WordPress/src/main/res/layout/notifications_list_item.xml
@@ -121,6 +121,8 @@
                         android:layout_height="wrap_content"
                         android:layout_marginTop="@dimen/margin_extra_small"
                         android:textColor="@color/grey_lighten_10"
+                        android:textAlignment="viewStart"
+                        android:gravity="start"
                         android:textSize="18sp" />
 
                     <org.wordpress.android.widgets.WPTextView
@@ -131,6 +133,8 @@
                         android:maxLines="2"
                         android:textColor="@color/grey_dark"
                         android:textSize="@dimen/text_sz_large"
+                        android:textAlignment="viewStart"
+                        android:gravity="start"
                         tools:text="Bob Ross commented on your post Happy Trees" />
 
                 </FrameLayout>

--- a/WordPress/src/main/res/layout/reader_include_comment_box.xml
+++ b/WordPress/src/main/res/layout/reader_include_comment_box.xml
@@ -31,6 +31,7 @@
             android:layout_gravity="center_vertical"
             android:layout_marginLeft="@dimen/content_margin"
             app:srcCompat="@drawable/ic_reply_grey_24dp"
+            android:rotationY="@integer/mirror_flip"
             android:layout_marginStart="@dimen/content_margin"/>
 
         <org.wordpress.android.widgets.SuggestionAutoCompleteText

--- a/WordPress/src/main/res/layout/reader_include_comment_box.xml
+++ b/WordPress/src/main/res/layout/reader_include_comment_box.xml
@@ -31,7 +31,6 @@
             android:layout_gravity="center_vertical"
             android:layout_marginLeft="@dimen/content_margin"
             app:srcCompat="@drawable/ic_reply_grey_24dp"
-            android:rotationY="@integer/mirror_flip"
             android:layout_marginStart="@dimen/content_margin"/>
 
         <org.wordpress.android.widgets.SuggestionAutoCompleteText

--- a/WordPress/src/main/res/values-ldrtl/locale_mirror_flip.xml
+++ b/WordPress/src/main/res/values-ldrtl/locale_mirror_flip.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="mirror_flip">180</integer>
+</resources>

--- a/WordPress/src/main/res/values/locale_mirror_flip.xml
+++ b/WordPress/src/main/res/values/locale_mirror_flip.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="mirror_flip">0</integer>
+</resources>

--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -493,6 +493,8 @@
         <item name="android:padding">@dimen/margin_extra_large</item>
         <item name="android:textColor">@color/grey_dark</item>
         <item name="android:textSize">@dimen/text_sz_large</item>
+        <item name="android:textAlignment" tools:targetApi="jelly_bean_mr1">viewStart</item>
+        <item name="android:gravity">start</item>
     </style>
 
     <style name="MeListSectionDividerView">


### PR DESCRIPTION
Partially fixes #2278 - Fixes RTL layouts on me and notification screens.

Some Views are not properly positioned in the RTL language mode.

To test:
1. Check layouts of the 
       Notifications screen + sub-screens
       Me + sub-screens
2. Change your locale to a RTL language (eg. Hebrew) or force RTL layouts in the developer options.
3. Check the layouts, see step 1

Doesn't fix the ViewPager swipe direction in the RTL mode.