### PR TITLE
Tracks: stop sending analytics immediately when `send analytics` is turned off

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -66,6 +66,19 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
         setRetainInstance(true);
         addPreferencesFromResource(R.xml.app_settings);
 
+        findPreference(getString(R.string.pref_key_send_usage)).setOnPreferenceChangeListener(
+                new Preference.OnPreferenceChangeListener() {
+                    @Override
+                    public boolean onPreferenceChange(Preference preference, Object newValue) {
+                        if (newValue == null) return false;
+                        // flush gathered events (if any)
+                        AnalyticsTracker.flush();
+                        AnalyticsTracker.setHasUserOptedOut(!(boolean)newValue);
+                        return true;
+                    }
+                }
+        );
+
         mLanguagePreference = (DetailListPreference) findPreference(getString(R.string.pref_key_language));
         mLanguagePreference.setOnPreferenceChangeListener(this);
 
@@ -122,6 +135,8 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
         super.onActivityCreated(savedInstanceState);
 
         updateLanguagePreference(getResources().getConfiguration().locale.toString());
+        // flush gathered events (if any)
+        AnalyticsTracker.flush();
     }
 
     @Override

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -302,12 +302,14 @@ public final class AnalyticsTracker {
     }
 
     public static void init(Context context) {
-        loadPrefHasUserOptedOut(context);
-    }
-
-    public static void loadPrefHasUserOptedOut(Context context) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         boolean hasUserOptedOut = !prefs.getBoolean("wp_pref_send_usage_stats", true);
+        if (hasUserOptedOut != mHasUserOptedOut) {
+            mHasUserOptedOut = hasUserOptedOut;
+        }
+    }
+
+    public static void setHasUserOptedOut(boolean hasUserOptedOut){
         if (hasUserOptedOut != mHasUserOptedOut) {
             mHasUserOptedOut = hasUserOptedOut;
         }


### PR DESCRIPTION
This PR fixes #7178 by making sure to disable analytics immediately when the user turn off the option. 

There was a bug on how the tracker was implemented that doesn't really turn off sending events up the wire immediately. We were still sending events after opt-out until the app is relaunched.

To test: 
- Enable the proxy and setup your device to use the proxy
- Start the app
- Disable the `Send usage Analytics` option in `Me -> App Settings`
- You should see the last batch of events sent to the server. The ones collected up till the feature was set to off
- Try the app for a while
- Check that no Track event is sent