### PR TITLE
Feature/reader rtl audit

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/FilteredRecyclerView.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui;
 import android.content.Context;
 import android.support.annotation.MenuRes;
 import android.support.design.widget.AppBarLayout;
+import android.support.v4.view.ViewCompat;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
@@ -300,26 +301,15 @@ public class FilteredRecyclerView extends RelativeLayout {
     }
 
     public void setToolbarLeftPadding(int paddingLeft){
-        mToolbar.setPadding(paddingLeft,
-                mToolbar.getPaddingTop(),
-                mToolbar.getPaddingRight(),
-                mToolbar.getPaddingBottom());
+        ViewCompat.setPaddingRelative(mToolbar, paddingLeft, mToolbar.getPaddingTop(), mToolbar.getPaddingRight(), mToolbar.getPaddingBottom());
     }
 
     public void setToolbarRightPadding(int paddingRight){
-        mToolbar.setPadding(
-                mToolbar.getPaddingLeft(),
-                mToolbar.getPaddingTop(),
-                paddingRight,
-                mToolbar.getPaddingBottom());
+        ViewCompat.setPaddingRelative(mToolbar, mToolbar.getPaddingLeft(), mToolbar.getPaddingTop(), paddingRight, mToolbar.getPaddingBottom());
     }
 
     public void setToolbarLeftAndRightPadding(int paddingLeft, int paddingRight){
-        mToolbar.setPadding(
-                paddingLeft,
-                mToolbar.getPaddingTop(),
-                paddingRight,
-                mToolbar.getPaddingBottom());
+        ViewCompat.setPaddingRelative(mToolbar, paddingLeft, mToolbar.getPaddingTop(), paddingRight, mToolbar.getPaddingBottom());
     }
 
     public void scrollRecycleViewToPosition(int position) {
@@ -422,9 +412,8 @@ public class FilteredRecyclerView extends RelativeLayout {
                 }
 
                 if (mSpinnerDrawableRight != 0){
-                    text.setCompoundDrawablesWithIntrinsicBounds(0, 0, mSpinnerDrawableRight, 0);
                     text.setCompoundDrawablePadding(getResources().getDimensionPixelSize(R.dimen.margin_medium));
-                    text.setGravity(Gravity.CENTER_VERTICAL | Gravity.LEFT);
+                    text.setGravity(Gravity.CENTER_VERTICAL | Gravity.START);
                 }
 
             } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -3,6 +3,7 @@ package org.wordpress.android.ui.reader;
 import android.app.Fragment;
 import android.content.Context;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
@@ -563,6 +564,9 @@ public class ReaderPostListFragment extends Fragment
         mSearchView.setSubmitButtonEnabled(false);
         mSearchView.setIconifiedByDefault(true);
         mSearchView.setIconified(true);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            mSearchView.setTextDirection(View.TEXT_DIRECTION_LOCALE);
+        }
 
         // force the search view to take up as much horizontal space as possible (without this
         // it looks truncated on landscape)

--- a/WordPress/src/main/res/layout/filter_spinner_item.xml
+++ b/WordPress/src/main/res/layout/filter_spinner_item.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<org.wordpress.android.widgets.WPTextView xmlns:android="http://schemas.android.com/apk/res/android"
+<org.wordpress.android.widgets.WPTextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/text"
     style="@style/FilteredRecyclerViewFilterTextView.WordPress"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:textColor="@color/white"
-    android:paddingRight="0dp"
-    android:paddingLeft="0dp"
+    android:drawableEnd="@drawable/ic_dropdown_24dp"
     android:drawableRight="@drawable/ic_dropdown_24dp"
-    tools:text="spinner item"
-    android:paddingStart="0dp"
-    android:paddingEnd="0dp"
-    android:drawableEnd="@drawable/ic_dropdown_24dp"/>
+    android:paddingLeft="0dp"
+    android:paddingRight="0dp"
+    android:textColor="@color/white"
+    tools:text="spinner item" />

--- a/WordPress/src/main/res/layout/reader_activity_subs.xml
+++ b/WordPress/src/main/res/layout/reader_activity_subs.xml
@@ -54,6 +54,8 @@
         android:paddingEnd="@dimen/margin_extra_large">
 
         <EditText
+            android:textAlignment="viewStart"
+            android:gravity="start"
             android:id="@+id/edit_add"
             style="@style/ReaderEditText.Topic"
             android:layout_width="0dp"

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -63,6 +63,8 @@
                 android:layout_marginEnd="@dimen/margin_large">
 
                 <org.wordpress.android.widgets.WPTextView
+                    android:textAlignment="viewStart"
+                    android:gravity="start"
                     android:id="@+id/text_author_and_blog_name"
                     style="@style/ReaderTextView"
                     android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/reader_include_comment_box.xml
+++ b/WordPress/src/main/res/layout/reader_include_comment_box.xml
@@ -34,8 +34,10 @@
             android:layout_marginStart="@dimen/content_margin"/>
 
         <org.wordpress.android.widgets.SuggestionAutoCompleteText
+            android:textAlignment="viewStart"
+            android:gravity="start|center_vertical"
             android:id="@+id/edit_comment"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
             android:layout_weight="1"

--- a/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
@@ -79,8 +79,6 @@
         tools:visibility="visible"/>
 
     <org.wordpress.android.widgets.WPTextView
-        android:textAlignment="viewStart"
-        android:gravity="start"
         android:id="@+id/text_liking_users_label"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
+++ b/WordPress/src/main/res/layout/reader_include_post_detail_content.xml
@@ -14,18 +14,12 @@
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/text_title"
         style="@style/ReaderTextView.Post.Title.Detail"
-        android:layout_alignLeft="@+id/reader_webview"
-        android:layout_alignRight="@+id/reader_webview"
-        tools:text="text_title"
-        android:layout_alignStart="@+id/reader_webview"
-        android:layout_alignEnd="@+id/reader_webview"/>
+        tools:text="text_title" />
 
     <LinearLayout
         android:id="@+id/layout_dateline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
         android:orientation="horizontal">
 
         <org.wordpress.android.widgets.WPTextView
@@ -85,8 +79,10 @@
         tools:visibility="visible"/>
 
     <org.wordpress.android.widgets.WPTextView
+        android:textAlignment="viewStart"
+        android:gravity="start"
         android:id="@+id/text_liking_users_label"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center_vertical"
         android:layout_marginTop="@dimen/margin_medium"
@@ -103,7 +99,6 @@
         android:id="@+id/layout_liking_users_view"
         android:layout_width="match_parent"
         android:layout_height="@dimen/avatar_sz_small"
-        android:layout_below="@id/text_liking_users_label"
         android:layout_marginBottom="@dimen/margin_medium"
         android:layout_marginTop="@dimen/margin_medium"
         android:background="?android:selectableItemBackground"

--- a/WordPress/src/main/res/layout/reader_listitem_blog.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_blog.xml
@@ -33,6 +33,8 @@
         android:orientation="vertical">
 
         <org.wordpress.android.widgets.WPTextView
+            android:textAlignment="viewStart"
+            android:gravity="start"
             android:id="@+id/text_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -45,6 +47,8 @@
             android:layout_marginEnd="@dimen/margin_medium"/>
 
         <org.wordpress.android.widgets.WPTextView
+            android:textAlignment="viewStart"
+            android:gravity="start"
             android:id="@+id/text_url"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -55,6 +59,8 @@
             tools:text="text_url" />
 
         <org.wordpress.android.widgets.WPTextView
+            android:textAlignment="viewStart"
+            android:gravity="start"
             android:id="@+id/text_description"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/reader_listitem_comment.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_comment.xml
@@ -79,8 +79,7 @@
 
         <RelativeLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:layout_height="wrap_content">
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/text_comment_date"
@@ -132,6 +131,8 @@
                 android:layout_centerVertical="true"
                 android:paddingBottom="@dimen/margin_small"
                 android:paddingLeft="@dimen/margin_large"
+                android:paddingRight="0dp"
+                android:paddingEnd="0dp"
                 android:paddingTop="@dimen/margin_small"
                 android:layout_alignParentEnd="true"
                 android:paddingStart="@dimen/margin_large"/>

--- a/WordPress/src/main/res/layout/reader_listitem_tag.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_tag.xml
@@ -19,6 +19,8 @@
     android:paddingStart="@dimen/margin_extra_large">
 
     <org.wordpress.android.widgets.WPTextView
+        android:textAlignment="viewStart"
+        android:gravity="start"
         android:id="@+id/text_topic"
         android:layout_width="0dp"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/reader_simple_post_view.xml
+++ b/WordPress/src/main/res/layout/reader_simple_post_view.xml
@@ -87,8 +87,6 @@
     </RelativeLayout>
 
     <org.wordpress.android.widgets.WPTextView
-        android:textAlignment="viewStart"
-        android:gravity="start"
         android:id="@+id/text_simple_post_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -104,8 +102,6 @@
         android:layout_toEndOf="@+id/image_featured"/>
 
     <org.wordpress.android.widgets.WPTextView
-        android:textAlignment="viewStart"
-        android:gravity="start"
         android:id="@+id/text_simple_post_excerpt"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/reader_simple_post_view.xml
+++ b/WordPress/src/main/res/layout/reader_simple_post_view.xml
@@ -60,6 +60,8 @@
             android:layout_toStartOf="@+id/simple_post_follow_button">
 
             <org.wordpress.android.widgets.WPTextView
+                android:textAlignment="viewStart"
+                android:gravity="start"
                 android:id="@+id/text_author_name"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -70,6 +72,8 @@
                 tools:text="text_author_name" />
 
             <org.wordpress.android.widgets.WPTextView
+                android:textAlignment="viewStart"
+                android:gravity="start"
                 android:id="@+id/text_site_name"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -83,6 +87,8 @@
     </RelativeLayout>
 
     <org.wordpress.android.widgets.WPTextView
+        android:textAlignment="viewStart"
+        android:gravity="start"
         android:id="@+id/text_simple_post_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -98,6 +104,8 @@
         android:layout_toEndOf="@+id/image_featured"/>
 
     <org.wordpress.android.widgets.WPTextView
+        android:textAlignment="viewStart"
+        android:gravity="start"
         android:id="@+id/text_simple_post_excerpt"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/reader_simple_posts_container_view.xml
+++ b/WordPress/src/main/res/layout/reader_simple_posts_container_view.xml
@@ -12,8 +12,6 @@
         android:background="@color/reader_divider_grey" />
 
     <org.wordpress.android.widgets.WPTextView
-        android:textAlignment="viewStart"
-        android:gravity="start"
         android:id="@+id/text_related_posts_label"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/reader_simple_posts_container_view.xml
+++ b/WordPress/src/main/res/layout/reader_simple_posts_container_view.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -13,6 +12,8 @@
         android:background="@color/reader_divider_grey" />
 
     <org.wordpress.android.widgets.WPTextView
+        android:textAlignment="viewStart"
+        android:gravity="start"
         android:id="@+id/text_related_posts_label"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/WordPress/src/main/res/layout/reader_site_header_view.xml
+++ b/WordPress/src/main/res/layout/reader_site_header_view.xml
@@ -32,6 +32,8 @@
             android:layout_marginEnd="@dimen/margin_large"/>
 
         <org.wordpress.android.widgets.WPTextView
+            android:textAlignment="viewStart"
+            android:gravity="start"
             android:id="@+id/text_blog_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -44,6 +46,8 @@
             android:layout_toEndOf="@+id/image_blavatar"/>
 
         <org.wordpress.android.widgets.WPTextView
+            android:textAlignment="viewStart"
+            android:gravity="start"
             android:id="@+id/text_domain"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -110,7 +114,6 @@
                 android:id="@+id/text_blog_follow_count"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_below="@+id/text_domain"
                 android:textColor="@color/grey_darken_10"
                 android:textSize="@dimen/text_sz_small"
                 tools:text="12 followers" />

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -25,7 +25,7 @@
         <item name="android:textSize">@dimen/text_sz_large</item>
     </style>
     <style name="ReaderTextView.Post.Title" parent="ReaderTextView">
-        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:textSize">@dimen/text_sz_large</item>
         <item name="android:textColor">@color/grey_dark</item>


### PR DESCRIPTION
Part of #2278

Fixes RTL issues in Reader.

Post content/title respects its own locale over the device one.

What to check:

- Reader post list.
- Reader post details (footer too).
- Post photo viewer.
- Post comments.
- Post liked users list.
- Reader Search.
- Reader settings (Followed Tags, Followed Sites, Sites You May Like).

Known issue:
ViewPager swipe direction.
Mixed RTL/LRT tags that come from the server.


