### PR TITLE
Fix color of collapsible text in plugin detail

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -421,6 +421,7 @@ public class PluginDetailActivity extends AppCompatActivity {
 
     private void setCollapsibleHtmlText(@NonNull TextView textView, @Nullable String htmlText) {
         if (!TextUtils.isEmpty(htmlText)) {
+            textView.setTextColor(getResources().getColor(R.color.grey_dark));
             textView.setMovementMethod(WPLinkMovementMethod.getInstance());
             textView.setText(Html.fromHtml(htmlText));
         } else {


### PR DESCRIPTION
Fixes #7186 - problem was caused by the text color being set to `grey_lighten_10` the first time the screen appears (before the plugin data is loaded) and not be reset to `grey_dark`.

See [the issue](https://github.com/wordpress-mobile/WordPress-Android/issues/7186) before a "before" screenshot, "after" screenshot is below:

![screenshot_1517515183](https://user-images.githubusercontent.com/3903757/35700336-bc87007e-0760-11e8-9dae-3721e1b3d3e3.png)
