### PR TITLE
Abandon GoogleApiClient connection if PlayServices unavailable

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -227,15 +227,19 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
         slideInFragment(loginUsernamePasswordFragment, true, LoginUsernamePasswordFragment.TAG);
     }
 
-    private void initSmartLockHelperConnection() {
+    private boolean initSmartLockHelperConnection() {
         mSmartLockHelper = new SmartLockHelper(this);
-        mSmartLockHelper.initSmartLockForPasswords();
+        return mSmartLockHelper.initSmartLockForPasswords();
     }
 
     private void checkSmartLockPasswordAndStartLogin() {
         if (mSmartLockHelperState == SmartLockHelperState.NOT_TRIGGERED) {
-            initSmartLockHelperConnection();
-            mSmartLockHelperState = SmartLockHelperState.TRIGGER_FILL_IN_ON_CONNECT;
+            if (initSmartLockHelperConnection()) {
+                mSmartLockHelperState = SmartLockHelperState.TRIGGER_FILL_IN_ON_CONNECT;
+            } else {
+                // just shortcircuit the attempt to use SmartLockHelper
+                mSmartLockHelperState = SmartLockHelperState.FINISHED;
+            }
         }
 
         if (mSmartLockHelperState == SmartLockHelperState.FINISHED) {


### PR DESCRIPTION
Fixes #7191 

Just abandon the attempt to _connect_ the SmartLockHelper if PlayServices are not available.

To test:
1. Downgrade Gooogle PlayServices on your device
2. Clear app's data and launch the app
3. Dismiss the "Play Services need updating" popup
4. Tap on the "Login" button and notice that app goes directly to the email input screen