### PR TITLE
Site creation rework: Retry the site-creation depending on the error

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
@@ -228,12 +228,12 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN, sticky = true)
     public void onSiteCreationPhaseUpdated(OnSiteCreationStateUpdated event) {
-        AppLog.i(T.NUX, "Received state: " + event.getState().name());
+        AppLog.i(T.NUX, "Received state: " + event.getPhase().name());
 
         mProgressContainer.setVisibility(View.VISIBLE);
         mErrorContainer.setVisibility(View.GONE);
 
-        switch (event.getState()) {
+        switch (event.getPhase()) {
             case IDLE:
                 disableUntil(0);
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
@@ -237,6 +237,11 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
         showHomeButton(!mInModalMode);
     }
 
+    private void configureImage(boolean hasFailure) {
+        mImageView.setImageResource(hasFailure ? R.drawable.img_site_error_camera_pencils_226dp
+                : R.drawable.img_site_wordpress_camera_pencils_226dp);
+    }
+
     private void handleFailure(final OnSiteCreationStateUpdated failedState) {
         // update UI depending on which phase the process failed so to properly offer retry options
         mRetryButton.setOnClickListener(new View.OnClickListener() {
@@ -272,28 +277,34 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
         switch (event.getPhase()) {
             case IDLE:
                 disableUntil(0);
+                configureImage(false);
                 break;
             case NEW_SITE:
                 disableUntil(R.id.site_creation_creating_laying_foundation);
+                configureImage(false);
                 break;
             case FETCHING_NEW_SITE:
                 disableUntil(R.id.site_creation_creating_fetching_info);
+                configureImage(false);
                 break;
             case SET_TAGLINE:
                 disableUntil(R.id.site_creation_creating_configuring_content);
+                configureImage(false);
                 break;
             case SET_THEME:
                 disableUntil(R.id.site_creation_creating_configuring_theme);
+                configureImage(false);
                 break;
             case FAILURE:
                 setModalMode(false);
-                mImageView.setImageResource(R.drawable.img_site_error_camera_pencils_226dp);
+                configureImage(true);
                 mProgressContainer.setVisibility(View.GONE);
                 mErrorContainer.setVisibility(View.VISIBLE);
                 handleFailure((OnSiteCreationStateUpdated) event.getPayload());
                 break;
             case PRELOAD:
                 disableUntil(R.id.site_creation_creating_preparing_frontend);
+                configureImage(false);
                 mPreviewWebViewClient = loadWebview();
                 break;
             case SUCCESS:

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationDomainFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationDomainFragment.java
@@ -190,7 +190,7 @@ public class SiteCreationDomainFragment extends SiteCreationBaseFormFragment<Sit
                     });
         }
 
-        switch (event.phase) {
+        switch (event.step) {
             case UPDATING:
                 mSelectedDomain = mCarryOverDomain;
                 mSiteCreationDomainAdapter.setData(true, mCarryOverDomain, mSelectedDomain, null);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationDomainLoaderFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationDomainLoaderFragment.java
@@ -20,19 +20,19 @@ public class SiteCreationDomainLoaderFragment extends Fragment {
 
     private static final String ARG_USERNAME = "ARG_USERNAME";
 
-    public enum DomainUpdatePhase {
+    public enum DomainUpdateStep {
         UPDATING,
         FINISHED,
         ERROR
     }
 
     static class DomainSuggestionEvent {
-        final DomainUpdatePhase phase;
+        final DomainUpdateStep step;
         final String query;
         final OnSuggestedDomains event;
 
-        DomainSuggestionEvent(DomainUpdatePhase phase, String query, OnSuggestedDomains event) {
-            this.phase = phase;
+        DomainSuggestionEvent(DomainUpdateStep step, String query, OnSuggestedDomains event) {
+            this.step = step;
             this.query = query;
             this.event = event;
         }
@@ -71,7 +71,7 @@ public class SiteCreationDomainLoaderFragment extends Fragment {
     }
 
     public void load(String keywords) {
-        postUpdate(new DomainSuggestionEvent(DomainUpdatePhase.UPDATING, keywords, null));
+        postUpdate(new DomainSuggestionEvent(DomainUpdateStep.UPDATING, keywords, null));
 
         SiteStore.SuggestDomainsPayload payload = new SiteStore.SuggestDomainsPayload(keywords, true, false, 20);
         mDispatcher.dispatch(SiteActionBuilder.newSuggestDomainsAction(payload));
@@ -82,10 +82,10 @@ public class SiteCreationDomainLoaderFragment extends Fragment {
     public void onSuggestedDomains(OnSuggestedDomains event) {
         if (event.isError()) {
             AppLog.e(AppLog.T.API, "Error fetching domain suggestions: " + event.error.message);
-            postUpdate(new DomainSuggestionEvent(DomainUpdatePhase.ERROR, event.query, event));
+            postUpdate(new DomainSuggestionEvent(DomainUpdateStep.ERROR, event.query, event));
         } else {
             AppLog.d(AppLog.T.API, "WordPress.com domain suggestions fetch successful!");
-            postUpdate(new DomainSuggestionEvent(DomainUpdatePhase.FINISHED, event.query, event));
+            postUpdate(new DomainSuggestionEvent(DomainUpdateStep.FINISHED, event.query, event));
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
@@ -152,7 +152,7 @@ public class SiteCreationService extends AutoForeground<SiteCreationPhase, OnSit
     }
 
     public SiteCreationService() {
-        super(SiteCreationPhase.IDLE, OnSiteCreationStateUpdated.class);
+        super(new OnSiteCreationStateUpdated(SiteCreationPhase.IDLE));
     }
 
     @Override
@@ -166,13 +166,8 @@ public class SiteCreationService extends AutoForeground<SiteCreationPhase, OnSit
     }
 
     @Override
-    protected OnSiteCreationStateUpdated getStateEvent(SiteCreationPhase phase) {
-        return new OnSiteCreationStateUpdated(phase);
-    }
-
-    @Override
-    public Notification getNotification(SiteCreationPhase phase) {
-        switch (phase) {
+    public Notification getNotification(OnSiteCreationStateUpdated state) {
+        switch (state.getPhase()) {
             case NEW_SITE:
                 return SiteCreationNotification.progress(this, 25, R.string.site_creation_creating_laying_foundation,
                         R.string.notification_site_creation_step_creating);
@@ -199,6 +194,14 @@ public class SiteCreationService extends AutoForeground<SiteCreationPhase, OnSit
     @Override
     protected void trackPhaseUpdate(Map<String, ?> props) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SITE_CREATION_BACKGROUND_SERVICE_UPDATE, props);
+    }
+
+    /**
+     * Helper method to create a new State object and set it as the new state.
+     * @param phase The phase of the new state
+     */
+    private void setState(SiteCreationPhase phase) {
+        setState(new OnSiteCreationStateUpdated(phase));
     }
 
     @Override
@@ -283,7 +286,7 @@ public class SiteCreationService extends AutoForeground<SiteCreationPhase, OnSit
         }
 
         final SiteModel site = mSiteStore.getSiteBySiteId(mNewSiteRemoteId);
-        final SiteCreationPhase phase = getPhase();
+        final SiteCreationPhase phase = getState().getPhase();
 
         if (phase == SiteCreationPhase.FETCHING_NEW_SITE) {
             Intent intent = new Intent();

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
@@ -112,15 +112,14 @@ public class SiteCreationService extends AutoForeground<SiteCreationPhase, OnSit
     }
 
     public static class OnSiteCreationStateUpdated implements AutoForeground.ServiceEvent<SiteCreationPhase> {
-        private final SiteCreationPhase state;
+        private final SiteCreationPhase phase;
 
-        public OnSiteCreationStateUpdated(SiteCreationPhase state) {
-            this.state = state;
+        public OnSiteCreationStateUpdated(SiteCreationPhase phase) {
+            this.phase = phase;
         }
 
-        @Override
-        public SiteCreationPhase getState() {
-            return state;
+        public SiteCreationPhase getPhase() {
+            return phase;
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationThemeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationThemeFragment.java
@@ -103,7 +103,7 @@ public class SiteCreationThemeFragment extends SiteCreationBaseFormFragment<Site
             mSiteCreationThemeAdapter = new SiteCreationThemeAdapter(getContext(), mSiteCreationListener);
         }
 
-        switch (event.getState()) {
+        switch (event.getPhase()) {
             case UPDATING:
                 mSiteCreationThemeAdapter.setData(true, null);
                 break;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationThemeLoaderFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationThemeLoaderFragment.java
@@ -11,7 +11,6 @@ import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.ThemeActionBuilder;
 import org.wordpress.android.fluxc.store.ThemeStore;
 import org.wordpress.android.util.AppLog;
-import org.wordpress.android.util.AutoForeground;
 
 import javax.inject.Inject;
 
@@ -24,14 +23,14 @@ public class SiteCreationThemeLoaderFragment extends Fragment {
         ERROR
     }
 
-    public static class OnThemeLoadingUpdated implements AutoForeground.ServiceEvent<ThemesUpdateState> {
+    static class OnThemeLoadingUpdated {
         private final ThemesUpdateState state;
 
         OnThemeLoadingUpdated(ThemesUpdateState state) {
             this.state = state;
         }
 
-        public ThemesUpdateState getPhase() {
+        ThemesUpdateState getPhase() {
             return state;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationThemeLoaderFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationThemeLoaderFragment.java
@@ -31,8 +31,7 @@ public class SiteCreationThemeLoaderFragment extends Fragment {
             this.state = state;
         }
 
-        @Override
-        public ThemesUpdateState getState() {
+        public ThemesUpdateState getPhase() {
             return state;
         }
     }

--- a/WordPress/src/main/res/layout/site_creation_creating_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_creating_screen.xml
@@ -87,7 +87,8 @@
                 android:paddingBottom="@dimen/margin_extra_large"
                 android:visibility="gone"
                 tools:visibility="visible"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:clipToPadding="false">
 
                 <TextView
                     style="@style/Base.TextAppearance.AppCompat.Body2"

--- a/WordPress/src/main/res/layout/site_creation_creating_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_creating_screen.xml
@@ -102,6 +102,15 @@
                     android:layout_marginTop="@dimen/margin_medium"
                     android:gravity="center"
                     android:text="@string/site_creation_creating_failed_extended"/>
+
+                <android.support.v7.widget.AppCompatButton
+                    style="@style/WordPress.Button.Primary"
+                    android:id="@+id/button_retry"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_extra_extra_large"
+                    android:layout_gravity="center_horizontal"
+                    android:text="@string/site_creation_creating_retry"/>
             </LinearLayout>
         </LinearLayout>
     </ScrollView>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2153,6 +2153,7 @@
     <string name="site_creation_creating_preparing_frontend">Preparing frontend…</string>
     <string name="site_creation_creating_failed">Something went wrong&#8230;</string>
     <string name="site_creation_creating_failed_extended">A parliament of owls distracted our servers with their superior oratory skills</string>
+    <string name="site_creation_creating_retry">Try again</string>
     <string name="site_creation_creating_modal">Please wait until site creation is completed.</string>
     <string name="site_creation_epilogue_congrats">Congratulations!\nYour site is ready.</string>
     <string name="site_creation_epilogue_configure">Configure</string>

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-    compile ('org.wordpress:utils:1.20.0-beta4') {
+    compile ('org.wordpress:utils:1.20.0-beta5') {
         exclude group: "com.mcxiaoke.volley"
     }
 

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-    compile ('org.wordpress:utils:1.20.0-beta3') {
+    compile ('org.wordpress:utils:1.20.0-beta4') {
         exclude group: "com.mcxiaoke.volley"
     }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
@@ -18,7 +18,7 @@ import android.widget.TextView;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.login.LoginWpcomService.OnCredentialsOK;
-import org.wordpress.android.login.LoginWpcomService.OnLoginStateUpdated;
+import org.wordpress.android.login.LoginWpcomService.LoginState;
 import org.wordpress.android.login.util.SiteUtils;
 import org.wordpress.android.login.widgets.WPLoginInputRow;
 import org.wordpress.android.login.widgets.WPLoginInputRow.OnEditorCommitListener;
@@ -267,10 +267,10 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN, sticky = true)
-    public void onLoginStateUpdated(OnLoginStateUpdated event) {
-        AppLog.i(T.NUX, "Received state: " + event.getPhase().name());
+    public void onLoginStateUpdated(LoginState loginState) {
+        AppLog.i(T.NUX, "Received state: " + loginState.getStepName());
 
-        switch (event.getPhase()) {
+        switch (loginState.getStep()) {
             case IDLE:
                 // nothing special to do, we'll start the service on next()
                 break;

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
@@ -268,9 +268,9 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN, sticky = true)
     public void onLoginStateUpdated(OnLoginStateUpdated event) {
-        AppLog.i(T.NUX, "Received state: " + event.getState().name());
+        AppLog.i(T.NUX, "Received state: " + event.getPhase().name());
 
-        switch (event.getState()) {
+        switch (event.getPhase()) {
             case IDLE:
                 // nothing special to do, we'll start the service on next()
                 break;

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginWpcomService.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginWpcomService.java
@@ -121,15 +121,15 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
     }
 
     public static class OnLoginStateUpdated implements AutoForeground.ServiceEvent<LoginPhase> {
-        private final LoginPhase mState;
+        private final LoginPhase mPhase;
 
-        OnLoginStateUpdated(LoginPhase state) {
-            this.mState = state;
+        OnLoginStateUpdated(LoginPhase phase) {
+            this.mPhase = phase;
         }
 
         @Override
-        public LoginPhase getState() {
-            return mState;
+        public LoginPhase getPhase() {
+            return mPhase;
         }
     }
 
@@ -165,7 +165,7 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
     }
 
     public LoginWpcomService() {
-        super(LoginPhase.IDLE, OnLoginStateUpdated.class);
+        super(new OnLoginStateUpdated(LoginPhase.IDLE));
     }
 
     @Override
@@ -179,19 +179,14 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
     }
 
     @Override
-    protected OnLoginStateUpdated getStateEvent(LoginPhase phase) {
-        return new OnLoginStateUpdated(phase);
-    }
-
-    @Override
-    public Notification getNotification(LoginPhase phase) {
-        switch (phase) {
+    public Notification getNotification(OnLoginStateUpdated state) {
+        switch (state.getPhase()) {
             case AUTHENTICATING:
             case SOCIAL_LOGIN:
             case FETCHING_ACCOUNT:
             case FETCHING_SETTINGS:
             case FETCHING_SITES:
-                return LoginNotification.progress(this, phase.progressPercent);
+                return LoginNotification.progress(this, state.getPhase().progressPercent);
             case SUCCESS:
                 return LoginNotification.success(this);
             case FAILURE_EMAIL_WRONG_PASSWORD:
@@ -212,6 +207,10 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
     @Override
     protected void trackPhaseUpdate(Map<String, ?> props) {
         mAnalyticsListener.trackWpComBackgroundServiceUpdate(props);
+    }
+
+    private void setState(LoginPhase phase) {
+        setState(new OnLoginStateUpdated(phase));
     }
 
     @Override

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginWpcomService.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginWpcomService.java
@@ -3,6 +3,7 @@ package org.wordpress.android.login;
 import android.app.Notification;
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 
@@ -22,8 +23,7 @@ import org.wordpress.android.fluxc.store.AccountStore.OnSocialChanged;
 import org.wordpress.android.fluxc.store.AccountStore.PushSocialPayload;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.SiteErrorType;
-import org.wordpress.android.login.LoginWpcomService.LoginPhase;
-import org.wordpress.android.login.LoginWpcomService.OnLoginStateUpdated;
+import org.wordpress.android.login.LoginWpcomService.LoginState;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.AutoForeground;
@@ -36,14 +36,14 @@ import javax.inject.Inject;
 
 import dagger.android.AndroidInjection;
 
-public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUpdated> {
+public class LoginWpcomService extends AutoForeground<LoginState> {
     private static final String ARG_EMAIL = "ARG_EMAIL";
     private static final String ARG_PASSWORD = "ARG_PASSWORD";
     private static final String ARG_SOCIAL_ID_TOKEN = "ARG_SOCIAL_ID_TOKEN";
     private static final String ARG_SOCIAL_LOGIN = "ARG_SOCIAL_LOGIN";
     private static final String ARG_SOCIAL_SERVICE = "ARG_SOCIAL_SERVICE";
 
-    public enum LoginPhase implements AutoForeground.ServicePhase {
+    public enum LoginStep {
         IDLE,
         AUTHENTICATING(25),
         SOCIAL_LOGIN(25),
@@ -60,37 +60,54 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
 
         public final int progressPercent;
 
-        LoginPhase() {
+        LoginStep() {
             this.progressPercent = 0;
         }
 
-        LoginPhase(int progressPercent) {
+        LoginStep(int progressPercent) {
             this.progressPercent = progressPercent;
+        }
+    }
+
+    public static class LoginState implements AutoForeground.ServiceState {
+        private final LoginStep mStep;
+
+        LoginState(@NonNull LoginStep step) {
+            this.mStep = step;
+        }
+
+        LoginStep getStep() {
+            return mStep;
         }
 
         @Override
         public boolean isIdle() {
-            return this == IDLE;
+            return mStep == LoginStep.IDLE;
         }
 
         @Override
         public boolean isInProgress() {
-            return this != IDLE && !isTerminal();
+            return mStep != LoginStep.IDLE && !isTerminal();
         }
 
         @Override
         public boolean isError() {
-            return this == FAILURE
-                    || this == FAILURE_EMAIL_WRONG_PASSWORD
-                    || this == FAILURE_2FA
-                    || this == FAILURE_SOCIAL_2FA
-                    || this == FAILURE_FETCHING_ACCOUNT
-                    || this == FAILURE_CANNOT_ADD_DUPLICATE_SITE;
+            return mStep == LoginStep.FAILURE
+                    || mStep == LoginStep.FAILURE_EMAIL_WRONG_PASSWORD
+                    || mStep == LoginStep.FAILURE_2FA
+                    || mStep == LoginStep.FAILURE_SOCIAL_2FA
+                    || mStep == LoginStep.FAILURE_FETCHING_ACCOUNT
+                    || mStep == LoginStep.FAILURE_CANNOT_ADD_DUPLICATE_SITE;
         }
 
         @Override
         public boolean isTerminal() {
-            return this == LoginPhase.SUCCESS || isError();
+            return mStep == LoginStep.SUCCESS || isError();
+        }
+
+        @Override
+        public String getStepName() {
+            return mStep.name();
         }
     }
 
@@ -117,19 +134,6 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
                     content,
                     R.drawable.ic_my_sites_24dp,
                     R.color.blue_wordpress);
-        }
-    }
-
-    public static class OnLoginStateUpdated implements AutoForeground.ServiceEvent<LoginPhase> {
-        private final LoginPhase mPhase;
-
-        OnLoginStateUpdated(LoginPhase phase) {
-            this.mPhase = phase;
-        }
-
-        @Override
-        public LoginPhase getPhase() {
-            return mPhase;
         }
     }
 
@@ -161,11 +165,11 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
     }
 
     public static void clearLoginServiceState() {
-        clearServiceState(OnLoginStateUpdated.class);
+        clearServiceState(LoginState.class);
     }
 
     public LoginWpcomService() {
-        super(new OnLoginStateUpdated(LoginPhase.IDLE));
+        super(new LoginState(LoginStep.IDLE));
     }
 
     @Override
@@ -179,14 +183,14 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
     }
 
     @Override
-    public Notification getNotification(OnLoginStateUpdated state) {
-        switch (state.getPhase()) {
+    public Notification getNotification(LoginState state) {
+        switch (state.getStep()) {
             case AUTHENTICATING:
             case SOCIAL_LOGIN:
             case FETCHING_ACCOUNT:
             case FETCHING_SETTINGS:
             case FETCHING_SITES:
-                return LoginNotification.progress(this, state.getPhase().progressPercent);
+                return LoginNotification.progress(this, state.getStep().progressPercent);
             case SUCCESS:
                 return LoginNotification.success(this);
             case FAILURE_EMAIL_WRONG_PASSWORD:
@@ -205,12 +209,12 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
     }
 
     @Override
-    protected void trackPhaseUpdate(Map<String, ?> props) {
+    protected void trackStateUpdate(Map<String, ?> props) {
         mAnalyticsListener.trackWpComBackgroundServiceUpdate(props);
     }
 
-    private void setState(LoginPhase phase) {
-        setState(new OnLoginStateUpdated(phase));
+    private void setState(LoginStep phase) {
+        setState(new LoginState(phase));
     }
 
     @Override
@@ -235,7 +239,7 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
             return START_NOT_STICKY;
         }
 
-        setState(LoginPhase.AUTHENTICATING);
+        setState(LoginStep.AUTHENTICATING);
 
         String email = intent.getStringExtra(ARG_EMAIL);
         String password = intent.getStringExtra(ARG_PASSWORD);
@@ -265,23 +269,23 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
         switch (error) {
             case INCORRECT_USERNAME_OR_PASSWORD:
             case NOT_AUTHENTICATED: // NOT_AUTHENTICATED is the generic error from XMLRPC response on first call.
-                setState(LoginPhase.FAILURE_EMAIL_WRONG_PASSWORD);
+                setState(LoginStep.FAILURE_EMAIL_WRONG_PASSWORD);
                 break;
             case NEEDS_2FA:
                 // login credentials were correct anyway so, offer to save to SmartLock
                 signalCredentialsOK();
 
                 if (mIsSocialLogin) {
-                    setState(LoginPhase.FAILURE_SOCIAL_2FA);
+                    setState(LoginStep.FAILURE_SOCIAL_2FA);
                 } else {
-                    setState(LoginPhase.FAILURE_2FA);
+                    setState(LoginStep.FAILURE_2FA);
                 }
 
                 break;
             case INVALID_REQUEST:
                 // TODO: FluxC: could be specific?
             default:
-                setState(LoginPhase.FAILURE);
+                setState(LoginStep.FAILURE);
                 AppLog.e(T.NUX, "Server response: " + errorMessage);
 
                 ToastUtils.showToast(this, errorMessage == null ? getString(R.string.error_generic) : errorMessage);
@@ -290,7 +294,7 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
     }
 
     private void fetchAccount() {
-        setState(LoginPhase.FETCHING_ACCOUNT);
+        setState(LoginStep.FETCHING_ACCOUNT);
         mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
     }
 
@@ -312,7 +316,7 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
         AppLog.i(T.NUX, "onAuthenticationChanged: " + event.toString());
 
         if (mIsSocialLogin) {
-            setState(LoginPhase.SOCIAL_LOGIN);
+            setState(LoginStep.SOCIAL_LOGIN);
             PushSocialPayload payload = new PushSocialPayload(mIdToken, mService);
             mDispatcher.dispatch(AccountActionBuilder.newPushSocialConnectAction(payload));
         } else {
@@ -348,16 +352,16 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
     public void onAccountChanged(OnAccountChanged event) {
         if (event.isError()) {
             AppLog.e(T.API, "onAccountChanged has error: " + event.error.type + " - " + event.error.message);
-            setState(LoginPhase.FAILURE_FETCHING_ACCOUNT);
+            setState(LoginStep.FAILURE_FETCHING_ACCOUNT);
             return;
         }
 
         if (event.causeOfChange == AccountAction.FETCH_ACCOUNT) {
-            setState(LoginPhase.FETCHING_SETTINGS);
+            setState(LoginStep.FETCHING_SETTINGS);
             // The user's account info has been fetched and stored - next, fetch the user's settings
             mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
         } else if (event.causeOfChange == AccountAction.FETCH_SETTINGS) {
-            setState(LoginPhase.FETCHING_SITES);
+            setState(LoginStep.FETCHING_SITES);
             // The user's account settings have also been fetched and stored - now we can fetch the user's sites
             mDispatcher.dispatch(SiteActionBuilder.newFetchSitesAction());
         }
@@ -369,14 +373,14 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
         if (event.isError()) {
             AppLog.e(T.API, "onSiteChanged has error: " + event.error.type + " - " + event.error.toString());
             if (event.error.type != SiteErrorType.DUPLICATE_SITE) {
-                setState(LoginPhase.FAILURE);
+                setState(LoginStep.FAILURE);
                 return;
             }
 
             if (event.rowsAffected == 0) {
                 // If there is a duplicate site and not any site has been added, show an error and
                 // stop the sign in process
-                setState(LoginPhase.FAILURE_CANNOT_ADD_DUPLICATE_SITE);
+                setState(LoginStep.FAILURE_CANNOT_ADD_DUPLICATE_SITE);
                 return;
             } else {
                 // If there is a duplicate site, notify the user something could be wrong,
@@ -385,6 +389,6 @@ public class LoginWpcomService extends AutoForeground<LoginPhase, OnLoginStateUp
             }
         }
 
-        setState(LoginPhase.SUCCESS);
+        setState(LoginStep.SUCCESS);
     }
 }

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -34,7 +34,7 @@ android {
     buildToolsVersion "25.0.3"
 
     defaultConfig {
-        versionName "1.20.0-beta4"
+        versionName "1.20.0-beta5"
         minSdkVersion 15
         targetSdkVersion 25
     }

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -34,7 +34,7 @@ android {
     buildToolsVersion "25.0.3"
 
     defaultConfig {
-        versionName "1.19.0"
+        versionName "1.20.0-beta4"
         minSdkVersion 15
         targetSdkVersion 25
     }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AutoForeground.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AutoForeground.java
@@ -20,7 +20,7 @@ import org.wordpress.android.util.AutoForeground.ServicePhase;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class AutoForeground<PhaseClass extends ServicePhase, EventClass extends ServiceEvent<PhaseClass>>
+public abstract class AutoForeground<PhaseClass extends ServicePhase, StateClass extends ServiceEvent<PhaseClass>>
         extends Service {
 
     public static final int NOTIFICATION_ID_PROGRESS = 1;
@@ -70,39 +70,32 @@ public abstract class AutoForeground<PhaseClass extends ServicePhase, EventClass
 
     private final IBinder mBinder = new LocalBinder();
 
-    private final Class<EventClass> mEventClass;
-    private final PhaseClass mInitialPhase;
+    private final Class<StateClass> mStateClass;
 
     private boolean mIsForeground;
 
     protected abstract void onProgressStart();
     protected abstract void onProgressEnd();
 
-    protected abstract EventClass getStateEvent(PhaseClass phase);
-    protected abstract Notification getNotification(PhaseClass phase);
+    protected abstract Notification getNotification(StateClass state);
     protected abstract void trackPhaseUpdate(Map<String, ?> props);
 
-    protected AutoForeground(PhaseClass initialPhase, Class<EventClass> eventClass) {
-        mEventClass = eventClass;
-        mInitialPhase = initialPhase;
+    @SuppressWarnings("unchecked")
+    protected AutoForeground(StateClass initialState) {
+        mStateClass = (Class<StateClass>) initialState.getClass();
+
+        // initialize the sticky phase if it hasn't already
+        if (EventBus.getDefault().getStickyEvent(mStateClass) == null) {
+            notifyState(initialState);
+        }
     }
 
     public boolean isForeground() {
         return mIsForeground;
     }
 
-    protected PhaseClass getPhase() {
-        return EventBus.getDefault().getStickyEvent(mEventClass).getPhase();
-    }
-
-    @Override
-    public void onCreate() {
-        super.onCreate();
-
-        // initialize the sticky phase if it hasn't already
-        if (EventBus.getDefault().getStickyEvent(mEventClass) == null) {
-            notifyState(mInitialPhase);
-        }
+    protected StateClass getState() {
+        return EventBus.getDefault().getStickyEvent(mStateClass);
     }
 
     @Nullable
@@ -143,13 +136,13 @@ public abstract class AutoForeground<PhaseClass extends ServicePhase, EventClass
     }
 
     private boolean hasConnectedClients() {
-        return getEventBus().hasSubscriberForEvent(mEventClass);
+        return getEventBus().hasSubscriberForEvent(mStateClass);
     }
 
     private void promoteForeground() {
-        final PhaseClass phase = getPhase();
-        if (phase.isInProgress()) {
-            startForeground(NOTIFICATION_ID_PROGRESS, getNotification(phase));
+        final StateClass state = getState();
+        if (state.getPhase().isInProgress()) {
+            startForeground(NOTIFICATION_ID_PROGRESS, getNotification(state));
             mIsForeground = true;
         }
     }
@@ -160,15 +153,16 @@ public abstract class AutoForeground<PhaseClass extends ServicePhase, EventClass
     }
 
     @CallSuper
-    protected void setState(PhaseClass newPhase) {
-        if (!getPhase().isInProgress() && newPhase.isInProgress()) {
+    protected void setState(StateClass newState) {
+        StateClass currentState = getState();
+        if ((currentState == null || !currentState.getPhase().isInProgress()) && newState.getPhase().isInProgress()) {
             onProgressStart();
         }
 
-        track(newPhase);
-        notifyState(newPhase);
+        track(newState.getPhase());
+        notifyState(newState);
 
-        if (newPhase.isTerminal()) {
+        if (newState.getPhase().isTerminal()) {
             onProgressEnd();
             stopSelf();
         }
@@ -186,9 +180,9 @@ public abstract class AutoForeground<PhaseClass extends ServicePhase, EventClass
     }
 
     @CallSuper
-    protected void notifyState(PhaseClass phase) {
+    protected void notifyState(StateClass state) {
         // sticky emit the state. The stickiness serves as a state keeping mechanism for clients to re-read upon connect
-        getEventBus().postSticky(getStateEvent(phase));
+        getEventBus().postSticky(state);
 
         if (hasConnectedClients()) {
             // there are connected clients so, nothing more to do here
@@ -197,14 +191,14 @@ public abstract class AutoForeground<PhaseClass extends ServicePhase, EventClass
 
         // ok, no connected clients so, update might need to be delivered to a notification as well
 
-        if (phase.isIdle()) {
+        if (state.getPhase().isIdle()) {
             // no need to have a notification when idle
             return;
         }
 
-        if (phase.isInProgress()) {
+        if (state.getPhase().isInProgress()) {
             // operation still is progress so, update the notification
-            NotificationManagerCompat.from(this).notify(NOTIFICATION_ID_PROGRESS, getNotification(phase));
+            NotificationManagerCompat.from(this).notify(NOTIFICATION_ID_PROGRESS, getNotification(state));
             return;
         }
 
@@ -215,7 +209,8 @@ public abstract class AutoForeground<PhaseClass extends ServicePhase, EventClass
         NotificationManagerCompat.from(this).cancel(NOTIFICATION_ID_PROGRESS);
 
         // put out a simple success/failure notification
-        NotificationManagerCompat.from(this).notify(phase.isError() ? NOTIFICATION_ID_FAILURE : NOTIFICATION_ID_SUCCESS,
-                getNotification(phase));
+        NotificationManagerCompat.from(this).notify(
+                state.getPhase().isError() ? NOTIFICATION_ID_FAILURE : NOTIFICATION_ID_SUCCESS,
+                getNotification(state));
     }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AutoForeground.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AutoForeground.java
@@ -36,7 +36,7 @@ public abstract class AutoForeground<PhaseClass extends ServicePhase, EventClass
     }
 
     public interface ServiceEvent<T> {
-        T getState();
+        T getPhase();
     }
 
     public static class ServiceEventConnection {
@@ -92,7 +92,7 @@ public abstract class AutoForeground<PhaseClass extends ServicePhase, EventClass
     }
 
     protected PhaseClass getPhase() {
-        return EventBus.getDefault().getStickyEvent(mEventClass).getState();
+        return EventBus.getDefault().getStickyEvent(mEventClass).getPhase();
     }
 
     @Override


### PR DESCRIPTION
Additional PR for #6929 

This PR adds the "Try again" button.

Implementation details:
* The SiteCreationService now has to be able to start the process from an intermediate phase of the whole flow. The code is refactored to in a way that hopefully makes it more clear that there is only one sequence essentially but we enter it at different points.
* The message sent out by the Service now holds a _payload_ field that depending on the phase itself can be a different type of object
* The "FAILURE" phase has the _previous_ state object as a payload. Useful for retrying the operation.
* All _in-progress_ states hold the new site's remote ID as the payload

To test:
No specific steps. Need to manually make each step fail and see that the UI offers the "Try again" button and the via a debugger (or logcat) verify that the process is indeed resumed from that step.
