### PR TITLE
WIP: Fix viewPagers in RtL mode

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -113,6 +113,7 @@ dependencies {
     compile 'com.squareup.okio:okio:1.13.0'
     compile 'org.apache.commons:commons-text:1.1'
     compile 'com.airbnb.android:lottie:2.0.0-rc2'
+    compile 'com.duolingo.open:rtl-viewpager:1.0.2'
 
     compile ('com.yalantis:ucrop:2.2.0') {
         exclude group: 'com.squareup.okhttp3'

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPViewPager.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPViewPager.java
@@ -1,9 +1,10 @@
 package org.wordpress.android.widgets;
 
 import android.content.Context;
-import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
+
+import com.duolingo.open.rtlviewpager.RtlViewPager;
 
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -13,8 +14,10 @@ import org.wordpress.android.util.AppLog.T;
  * https://code.google.com/p/android/issues/detail?id=16836
  * https://code.google.com/p/android/issues/detail?id=18990
  * https://github.com/chrisbanes/PhotoView/issues/31
+ *
+ * The class extends from RtlViewPager - fixes the scroll/swipe direction in the RtL mode.
  */
-public class WPViewPager extends ViewPager {
+public class WPViewPager extends RtlViewPager {
     private boolean mPagingEnabled = true;
 
     public WPViewPager(Context context) {


### PR DESCRIPTION
Partially fixes #2278 
Fixes ViewPager swipe direction in RtL mode.

To test:
1. Change your locale to a RTL language (eg. Hebrew) or force RtL layouts in the developer options.
2. Try to change pages using the swipe gesture on
- login screen (intro) -> swipe
- main screen (My site, Notifications, Account, Reader)
- reader -> post detail -> swipe
- notifications -> notification detail -> swipe
- my site -> plans -> swipe
- my site -> media -> image preview -> swipe

Reasoning behind using the Duolingo - RtlViewPager
- all viewPager usages are fixed at once - with single line of code
- we can simple change the WPViewPager parent and remove the dependency, when the support library is fixed
- developers don't have to think about RtL languages when they use viewPager
