### PR TITLE
Site creation rework: new wpcom dotorg site popup

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -8,11 +8,14 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.content.res.AppCompatResources;
 import android.support.v7.view.ActionMode;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
@@ -20,9 +23,11 @@ import android.support.v7.widget.RecyclerView;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.ArrayAdapter;
 import android.widget.SearchView;
+import android.widget.TextView;
 
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
@@ -636,7 +641,19 @@ public class SitePickerActivity extends AppCompatActivity
             AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
             builder.setTitle(R.string.site_picker_add_site);
             builder.setAdapter(
-                    new ArrayAdapter<>(getActivity(), R.layout.add_new_site_dialog_item, R.id.text, items),
+                    new ArrayAdapter<CharSequence>(getActivity(), R.layout.add_new_site_dialog_item, R.id.text, items) {
+                        @NonNull
+                        @Override
+                        public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+                            TextView tv = (TextView) super.getView(position, convertView, parent);
+                            Drawable leftDrawable = AppCompatResources.getDrawable(tv.getContext(),
+                                    R.drawable.ic_add_outline_grey_dark_24dp);
+                            tv.setCompoundDrawablesWithIntrinsicBounds(leftDrawable, null, null, null);
+                            tv.setCompoundDrawablePadding(
+                                    getResources().getDimensionPixelSize(R.dimen.margin_extra_large));
+                            return tv;
+                        }
+                    },
                     new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialog, int which) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -21,6 +21,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
+import android.widget.ArrayAdapter;
 import android.widget.SearchView;
 
 import com.android.volley.VolleyError;
@@ -634,15 +635,18 @@ public class SitePickerActivity extends AppCompatActivity
                             getString(R.string.site_picker_add_self_hosted)};
             AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
             builder.setTitle(R.string.site_picker_add_site);
-            builder.setItems(items, new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    if (which == 0) {
-                        ActivityLauncher.newBlogForResult(getActivity(), getArguments().getString(ARG_USERNAME));
-                    } else {
-                        ActivityLauncher.addSelfHostedSiteForResult(getActivity());
-                    }
-                }
+            builder.setAdapter(
+                    new ArrayAdapter<>(getActivity(), R.layout.add_new_site_dialog_item, R.id.text, items),
+                    new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            if (which == 0) {
+                                ActivityLauncher.newBlogForResult(getActivity(),
+                                        getArguments().getString(ARG_USERNAME));
+                            } else {
+                                ActivityLauncher.addSelfHostedSiteForResult(getActivity());
+                            }
+                        }
             });
             return builder.create();
         }

--- a/WordPress/src/main/res/drawable/ic_add_outline_grey_dark_24dp.xml
+++ b/WordPress/src/main/res/drawable/ic_add_outline_grey_dark_24dp.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/grey_dark"
+        android:pathData="
+        M12,4
+        c4.41,0 8,3.59 8,8
+        s-3.59,8 -8,8 -8,-3.59 -8,-8 3.59,-8 8,-8
+        m0,-2
+        C6.477,2 2,6.477 2,12
+        s4.477,10 10,10 10,-4.477 10,-10
+        S17.523,2 12,2
+        M17,13 h-4
+        v4 h-2 v-4
+        h-4 v-2 h4
+        v-4 h2 v4
+        h4 z"/>
+</vector>

--- a/WordPress/src/main/res/layout/add_new_site_dialog_item.xml
+++ b/WordPress/src/main/res/layout/add_new_site_dialog_item.xml
@@ -7,9 +7,9 @@
     android:minHeight="?android:attr/listPreferredItemHeightSmall"
     android:textAppearance="?android:attr/textAppearanceListItem"
     android:textColor="?android:attr/textColorAlertDialogListItem"
-    android:drawableStart="@drawable/ic_add_outline_grey_dark_24dp"
-    android:drawablePadding="@dimen/margin_extra_large"
     android:gravity="center_vertical"
     android:paddingStart="@dimen/margin_extra_medium_large"
+    android:paddingLeft="@dimen/margin_extra_medium_large"
     android:paddingEnd="@dimen/margin_extra_large"
+    android:paddingRight="@dimen/margin_extra_large"
     tools:text="Dialog item"/>

--- a/WordPress/src/main/res/layout/add_new_site_dialog_item.xml
+++ b/WordPress/src/main/res/layout/add_new_site_dialog_item.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/text"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?android:attr/listPreferredItemHeightSmall"
+    android:textAppearance="?android:attr/textAppearanceListItem"
+    android:textColor="?android:attr/textColorAlertDialogListItem"
+    android:drawableStart="@drawable/ic_add_outline_grey_dark_24dp"
+    android:drawablePadding="@dimen/margin_extra_large"
+    android:gravity="center_vertical"
+    android:paddingStart="@dimen/margin_extra_medium_large"
+    android:paddingEnd="@dimen/margin_extra_large"
+    tools:text="Dialog item"/>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1580,7 +1580,7 @@
     <!-- site picker -->
     <string name="site_picker_title">Choose site</string>
     <string name="site_picker_edit_visibility">Show/hide sites</string>
-    <string name="site_picker_add_site">Add site</string>
+    <string name="site_picker_add_site">Add new site</string>
     <string name="site_picker_add_self_hosted">Add self-hosted site</string>
     <string name="site_picker_create_dotcom">Create WordPress.com site</string>
     <string name="site_picker_cant_hide_current_site">\"%s\" wasn\'t hidden because it\'s the current site</string>


### PR DESCRIPTION
Fixes #7208 

To test:
1. With the app logged in to wpcom, head over to the site picker
2. Tap on the "+" toolbar action to add a new site
3. The wpcom/.org dialog will popup and notice the icon addition and the new title, as per #7208