### PR TITLE
Show stats for WordPress.com sites

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/MySiteFragment.java
@@ -212,7 +212,7 @@ public class MySiteFragment extends Fragment
                     if (!mAccountStore.hasAccessToken() && selectedSite.isJetpackConnected()) {
                         // If the user is not connected to WordPress.com, ask him to connect first.
                         startWPComLoginForJetpackStats();
-                    } else if (selectedSite.isJetpackInstalled() && selectedSite.isJetpackConnected()) {
+                    } else if (selectedSite.isWPCom() || (selectedSite.isJetpackInstalled() && selectedSite.isJetpackConnected())) {
                         ActivityLauncher.viewBlogStats(getActivity(), selectedSite);
                     } else {
                         ActivityLauncher.startJetpackConnectionFlow(getActivity(), selectedSite);


### PR DESCRIPTION
Fixes #
WordPress.com site has `false` values for isJetpackInstalled and isJetpackConnected so we have to add additional check to not show Jetpack prompt.

To test:
* Login with WordPress.com site
* Click Stats
* The app shows stats
