### PR TITLE
get posts list from the server only if there are no posts being uploaded

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -202,7 +202,16 @@ public class PostsListFragment extends Fragment
         });
 
         if (savedInstanceState == null) {
-            requestPosts(false);
+            if (UploadService.hasPendingOrInProgressPostUploads()) {
+                // if there are some in-progress uploads, we'd better just load the DB Posts and reflect upload
+                // changes there. Otherwise, a duplicate-post situation can happen when:
+                // a FETCH_POSTS completing *after* the post has been uploaded to the server but *before*
+                // the PUSH_POST action completes and a PUSHED_POST is emitted.
+                loadPosts(LoadMode.IF_CHANGED);
+            } else {
+                // refresh normally
+                requestPosts(false);
+            }
         }
 
         initSwipeToRefreshHelper(view);

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -155,6 +155,10 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
         return post != null && sCurrentUploadingPost != null && sCurrentUploadingPost.getId() == post.getId();
     }
 
+    static boolean hasPendingOrInProgressPostUploads() {
+        return sCurrentUploadingPost != null || !sQueuedPostsList.isEmpty() ;
+    }
+
     private void uploadNextPost() {
         synchronized (sQueuedPostsList) {
             if (mCurrentTask == null) { //make sure nothing is running

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -469,6 +469,10 @@ public class UploadService extends Service {
         return MediaUploadHandler.getPendingOrInProgressMediaUploadsForPost(post);
     }
 
+    public static boolean hasPendingOrInProgressPostUploads() {
+        return PostUploadHandler.hasPendingOrInProgressPostUploads();
+    }
+
     public static float getMediaUploadProgressForPost(PostModel postModel) {
         if (postModel == null || sInstance == null) {
             // If the UploadService isn't running, there's no progress for this post


### PR DESCRIPTION
Fixes #5318 

This PR takes care of handling the situation when a `FETCH_POSTS` is completing *after* the post has been uploaded to the server but *before* the `PUSH_POST` action completes and a `PUSHED_POST` is emitted.
Basically, this would turn out into a duplicate Post (one made locally, another one as the `FETCH_POSTS` finishes and brings the new Post (with different, server-side created PostId) from the other side).

To test:

Using Charles throttling capabilities, setting download at 28.8kbps and upload a 4.8kbps to purposely make the situation happen (i.e. the upload starts first, then a fetch starts and ends before the upload ends, then the upload ends).

1. start a draft
2. write some title, some text
3. hit PUBLISH
4. hit back to get to the main WP app screen
5. tap on “Blog Posts” to go to the posts list again and trigger the new code path: given a Post upload is happening, the app should only load the posts currently in its local DB and just will refresh the data for the uploading Post as the upload progresses, as expected.


