### PR TITLE
Site creation rework: Offer a "Close" button on failure after creation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SiteCreationActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SiteCreationActivity.java
@@ -112,7 +112,8 @@ public class SiteCreationActivity extends AppCompatActivity implements SiteCreat
     private enum SiteCreationBackStackMode {
         NORMAL,
         MODAL,
-        FINISH_OK
+        FINISH_OK,
+        FINISH_DISMISS
     }
 
     private SiteCreationBackStackMode getSiteCreationBackStackMode() {
@@ -120,14 +121,14 @@ public class SiteCreationActivity extends AppCompatActivity implements SiteCreat
                 (SiteCreationCreatingFragment) getSupportFragmentManager()
                         .findFragmentByTag(SiteCreationCreatingFragment.TAG);
 
-        if (siteCreationCreatingFragment == null) {
+        if (siteCreationCreatingFragment == null || siteCreationCreatingFragment.canGoBack()) {
             return SiteCreationBackStackMode.NORMAL;
         } else if (siteCreationCreatingFragment.isInModalMode()) {
             return SiteCreationBackStackMode.MODAL;
         } else if (siteCreationCreatingFragment.isCreationSucceeded()) {
             return SiteCreationBackStackMode.FINISH_OK;
         } else {
-            return SiteCreationBackStackMode.NORMAL;
+            return SiteCreationBackStackMode.FINISH_DISMISS;
         }
     }
 
@@ -142,6 +143,9 @@ public class SiteCreationActivity extends AppCompatActivity implements SiteCreat
                 break;
             case FINISH_OK:
                 setResult(RESULT_OK);
+                finish();
+                break;
+            case FINISH_DISMISS:
                 finish();
                 break;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationBaseFormFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationBaseFormFragment.java
@@ -78,10 +78,13 @@ public abstract class SiteCreationBaseFormFragment<SiteCreationListenerType> ext
         }
     }
 
-    protected void showHomeButton(boolean visible) {
+    protected void showHomeButton(boolean visible, boolean isCloseButton) {
         ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
         if (actionBar != null) {
             actionBar.setDisplayHomeAsUpEnabled(visible);
+            if (isCloseButton) {
+                actionBar.setHomeAsUpIndicator(R.drawable.ic_close_white_24dp);
+            }
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
@@ -69,7 +69,7 @@ public class SiteCreationService extends AutoForeground<SiteCreationState> {
     }
 
     public static class SiteCreationState implements AutoForeground.ServiceState {
-        private final SiteCreationStep mStep;
+        private @NonNull final SiteCreationStep mStep;
         private final Object payload;
 
         SiteCreationState(@NonNull SiteCreationStep step, @Nullable Object payload) {
@@ -77,6 +77,7 @@ public class SiteCreationService extends AutoForeground<SiteCreationState> {
             this.payload = payload;
         }
 
+        @NonNull
         SiteCreationStep getStep() {
             return mStep;
         }
@@ -108,6 +109,10 @@ public class SiteCreationService extends AutoForeground<SiteCreationState> {
         @Override
         public String getStepName() {
             return mStep.name();
+        }
+
+        boolean isAfterCreation() {
+            return mStep.ordinal() > SiteCreationStep.NEW_SITE.ordinal();
         }
     }
 
@@ -181,6 +186,10 @@ public class SiteCreationService extends AutoForeground<SiteCreationState> {
 
     public static void clearSiteCreationServiceState() {
         clearServiceState(SiteCreationState.class);
+    }
+
+    public static SiteCreationState getState() {
+        return getState(SiteCreationState.class);
     }
 
     public SiteCreationService() {

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-    compile ('org.wordpress:utils:1.20.0-beta5') {
+    compile ('org.wordpress:utils:1.20.0-beta6') {
         exclude group: "com.mcxiaoke.volley"
     }
 

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -34,7 +34,7 @@ android {
     buildToolsVersion "25.0.3"
 
     defaultConfig {
-        versionName "1.20.0-beta5"
+        versionName "1.20.0-beta6"
         minSdkVersion 15
         targetSdkVersion 25
     }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AutoForeground.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AutoForeground.java
@@ -89,8 +89,14 @@ public abstract class AutoForeground<StateClass extends ServiceState>
         return mIsForeground;
     }
 
-    protected StateClass getState() {
-        return EventBus.getDefault().getStickyEvent(mStateClass);
+    @Nullable
+    private StateClass getState() {
+        return getState(mStateClass);
+    }
+
+    @Nullable
+    protected static <StateClass> StateClass getState(Class<StateClass> stateClass) {
+        return EventBus.getDefault().getStickyEvent(stateClass);
     }
 
     @Nullable


### PR DESCRIPTION
Fixes #7221 

Shows a "Close" button when the site-creation process finishes but the new site has been created remotely. If it hasn't, a "Back" button is displayed.

To test #1:
* With the app logged in to wpcom, go to the site picker and start creating a new site. Bring the wizard up to step 4 (subdomain selection) but wait.
* Turn connectivity off
* Push the "CREATE SITE" button
* The "Creating" screen comes up, it informs that something went wrong and it displays a "Back" button on the toolbar
* Tap the "Back" button and notice the wizard returning to step 4

To test #2:
* With the app logged in to wpcom, go to the site picker and start creating a new site. Bring the wizard up to step 4 (subdomain selection).
* Be ready to turn connectivity off after the "Creating" screen comes up
* Push the "CREATE SITE" button and wait for the process to reach the "Retrieving site information" step
* Turn connectivity off
* The app informs that something went wrong and it displays a "X" button on the toolbar
* Tap the "X" button and notice the app returning directly to the site picker
