### PR TITLE
Fix errors not shown in some locales on the people invite screen

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
@@ -365,6 +365,7 @@ public class PeopleUtils {
                                             callback.onUsernameValidation(username, ValidationResult.INVALID_EMAIL);
                                             continue;
                                         case "User not found":
+                                            // fall through to the default case
                                         default:
                                             callback.onUsernameValidation(username, ValidationResult.USER_NOT_FOUND);
                                             continue;

--- a/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/people/utils/PeopleUtils.java
@@ -361,14 +361,14 @@ public class PeopleUtils {
                             switch (userError.optString("code")) {
                                 case "invalid_input":
                                     switch (userError.optString("message")) {
-                                        case "User not found":
-                                            callback.onUsernameValidation(username, ValidationResult.USER_NOT_FOUND);
-                                            continue;
                                         case "Invalid email":
                                             callback.onUsernameValidation(username, ValidationResult.INVALID_EMAIL);
                                             continue;
+                                        case "User not found":
+                                        default:
+                                            callback.onUsernameValidation(username, ValidationResult.USER_NOT_FOUND);
+                                            continue;
                                     }
-                                    break;
                                 case "invalid_input_has_role":
                                     callback.onUsernameValidation(username, ValidationResult.ALREADY_MEMBER);
                                     continue;


### PR DESCRIPTION
Fixes #7230

To test:
1. Set default locale to Spanish or Hebrew.
2. Go to Invite people screen and enter some random string such as "jhfdakfhakh35hkh3" into the username field.
3. Error "user not found" is shown.

Note: Json attribute "message" received from the API is already translated. The switch statement doesn't work as expected, since it expects that the json attribute "message" is in English. 

This quickfix will always fallback to "User not found" message. We may consider separating "invalid_input - user not found" and "invalid_input - invalid email" into two different "codes" (eg. invalid_input_unknown_user" and "invalid_input_invalid_email").