### PR TITLE
Save PluginBrowserViewModel to Bundle

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -88,6 +88,7 @@ public class PluginBrowserActivity extends AppCompatActivity
         if (savedInstanceState == null) {
             mViewModel.setSite((SiteModel) getIntent().getSerializableExtra(WordPress.SITE));
         }
+        mViewModel.start(savedInstanceState);
 
         if (mViewModel.getSite() == null) {
             ToastUtils.showToast(this, R.string.blog_not_found);
@@ -132,8 +133,13 @@ public class PluginBrowserActivity extends AppCompatActivity
         configureRecycler(mPopularPluginsRecycler);
         configureRecycler(mNewPluginsRecycler);
 
-        mViewModel.start();
         setupObservers();
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        mViewModel.writeToBundle(outState);
     }
 
     private void setupObservers() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -87,8 +87,10 @@ public class PluginBrowserActivity extends AppCompatActivity
 
         if (savedInstanceState == null) {
             mViewModel.setSite((SiteModel) getIntent().getSerializableExtra(WordPress.SITE));
+        } else {
+            mViewModel.readFromBundle(savedInstanceState);
         }
-        mViewModel.start(savedInstanceState);
+        mViewModel.start();
 
         if (mViewModel.getSite() == null) {
             ToastUtils.showToast(this, R.string.blog_not_found);

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
@@ -3,6 +3,7 @@ package org.wordpress.android.viewmodel;
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.MutableLiveData;
 import android.arch.lifecycle.ViewModel;
+import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -10,6 +11,7 @@ import android.text.TextUtils;
 
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
+import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.PluginActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -42,9 +44,13 @@ public class PluginBrowserViewModel extends ViewModel {
         LOADING_MORE
     }
 
+    private static final String KEY_SEARCH_QUERY = "KEY_SEARCH_QUERY";
+    private static final String KEY_TITLE = "KEY_TITLE";
+
     private final Dispatcher mDispatcher;
     private final PluginStore mPluginStore;
 
+    private boolean mIsStarted = false;
     private String mSearchQuery;
     private SiteModel mSite;
 
@@ -93,12 +99,37 @@ public class PluginBrowserViewModel extends ViewModel {
         mDispatcher.unregister(this);
     }
 
-    public void start() {
+    public void writeToBundle(@NonNull Bundle outState) {
+        outState.putSerializable(WordPress.SITE, mSite);
+        outState.putString(KEY_SEARCH_QUERY, mSearchQuery);
+        outState.putString(KEY_TITLE, mTitle.getValue());
+    }
+
+    private void readFromBundle(@Nullable Bundle savedInstanceState) {
+        if (savedInstanceState == null) {
+            return;
+        }
+        mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
+        mSearchQuery = savedInstanceState.getString(KEY_SEARCH_QUERY);
+        setTitle(savedInstanceState.getString(KEY_TITLE));
+    }
+
+    public void start(@Nullable Bundle savedInstanceState) {
+        if (mIsStarted) {
+            return;
+        }
+        readFromBundle(savedInstanceState);
         reloadAllPluginsFromStore();
 
         fetchPlugins(PluginListType.SITE, false);
         fetchPlugins(PluginListType.POPULAR, false);
         fetchPlugins(PluginListType.NEW, false);
+        // If activity is recreated we need to re-search
+        if (shouldSearch()) {
+            fetchPlugins(PluginListType.SEARCH, false);
+        }
+
+        mIsStarted = true;
     }
 
     // Site & WPOrg plugin management

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
@@ -105,8 +105,10 @@ public class PluginBrowserViewModel extends ViewModel {
         outState.putString(KEY_TITLE, mTitle.getValue());
     }
 
-    private void readFromBundle(@Nullable Bundle savedInstanceState) {
-        if (savedInstanceState == null) {
+    public void readFromBundle(@NonNull Bundle savedInstanceState) {
+        if (mIsStarted) {
+            // This was called due to a config change where the data survived, we don't need to
+            // read from the bundle
             return;
         }
         mSite = (SiteModel) savedInstanceState.getSerializable(WordPress.SITE);
@@ -114,11 +116,10 @@ public class PluginBrowserViewModel extends ViewModel {
         setTitle(savedInstanceState.getString(KEY_TITLE));
     }
 
-    public void start(@Nullable Bundle savedInstanceState) {
+    public void start() {
         if (mIsStarted) {
             return;
         }
-        readFromBundle(savedInstanceState);
         reloadAllPluginsFromStore();
 
         fetchPlugins(PluginListType.SITE, false);


### PR DESCRIPTION
Fixes #7237. Please see the issue for more details. A few notes about the implementation:

* We only need to read from Bundle if the Activity (hence the ViewModel) is destroyed, which is pretty rare as the device needs to be running low on resources. After a config change our ViewModel will survive, which means we do not want to reload the plugins or do another set of fetches. Which was something we were doing before on config changes and this PR fixes it.
* We use a property `mIsStarted` to see if the ViewModel was already created and used before. This property will be `false` only for when the ViewModel is first created and before `start()` method is handled.
* We only want to save small data to the Bundle. The rest should be retrieved from the PluginStore again.
* We save all the data in the DB except for Search, which means we'll have to redo the search.

I've a few ideas on how to streamline this solution and follow the same pattern in our other ViewModels in the future. However, I feel like that's a different discussion and should be done in its own PR. We also shouldn't block the feature just for that discussion.

To test:
* Enable "Do not keep activities" in your device/emulator, go into plugins page tap on any of the plugins to go into detail and tap on the back button and make sure it's not crashing and the view is properly recreated
* Search a plugin, go into details page for one of them and tap back. Make sure the view is properly recreated. Note that you might lose your position since we have to do a re-search right now. I am thinking about keeping the search results in DB in FluxC, but I am not sure if it's worth it since this will only occur in the very rare cases.

/cc @malinajirka @nbradbury @theck13 - We don't need everyone to review, just pinging you all if you're interested in it.