### PR TITLE
Pull to Refresh Plugins

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
@@ -222,7 +222,7 @@ public class PluginListFragment extends Fragment {
         }
         // We want to show the swipe refresher for the initial fetch but not while loading more
         mSwipeToRefreshHelper.setRefreshing(pluginListStatus == PluginBrowserViewModel.PluginListStatus.FETCHING);
-        // We want to show the progress bar in the middle while loading more but not for initial fetch
+        // We want to show the progress bar at the bottom while loading more but not for initial fetch
         boolean showLoadMore = pluginListStatus == PluginBrowserViewModel.PluginListStatus.LOADING_MORE;
         getView().findViewById(R.id.progress).setVisibility(showLoadMore ? View.VISIBLE : View.GONE);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
@@ -32,6 +32,8 @@ import org.wordpress.android.fluxc.model.plugin.WPOrgPluginModel;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.util.HtmlUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
+import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
 import org.wordpress.android.viewmodel.PluginBrowserViewModel;
 import org.wordpress.android.viewmodel.PluginBrowserViewModel.PluginListType;
 import org.wordpress.android.widgets.DividerItemDecoration;
@@ -40,6 +42,8 @@ import org.wordpress.android.widgets.WPNetworkImageView;
 import java.util.List;
 
 import javax.inject.Inject;
+
+import static org.wordpress.android.util.WPSwipeToRefreshHelper.buildSwipeToRefreshHelper;
 
 public class PluginListFragment extends Fragment {
     public static final String TAG = PluginListFragment.class.getName();
@@ -52,6 +56,7 @@ public class PluginListFragment extends Fragment {
 
     protected RecyclerView mRecycler;
     protected PluginListType mListType;
+    private SwipeToRefreshHelper mSwipeToRefreshHelper;
 
     public static PluginListFragment newInstance(@NonNull SiteModel site, @NonNull PluginListType listType) {
         PluginListFragment fragment = new PluginListFragment();
@@ -170,6 +175,16 @@ public class PluginListFragment extends Fragment {
         mRecycler = view.findViewById(R.id.recycler);
         mRecycler.setLayoutManager(new LinearLayoutManager(getActivity(), LinearLayoutManager.VERTICAL, false));
         mRecycler.addItemDecoration(new DividerItemDecoration(getActivity(), DividerItemDecoration.VERTICAL_LIST));
+
+        mSwipeToRefreshHelper = buildSwipeToRefreshHelper(
+                (CustomSwipeRefreshLayout) view.findViewById(R.id.ptr_layout),
+                new SwipeToRefreshHelper.RefreshListener() {
+                    @Override
+                    public void onRefreshStarted() {
+                        mViewModel.pullToRefresh(mListType);
+                    }
+                }
+        );
 
         return view;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
@@ -123,6 +123,15 @@ public class PluginListFragment extends Fragment {
             }
         });
 
+        mViewModel.getSitePluginsListStatus().observe(this, new Observer<PluginBrowserViewModel.PluginListStatus>() {
+            @Override
+            public void onChanged(@Nullable PluginBrowserViewModel.PluginListStatus listStatus) {
+                if (mListType == PluginListType.SITE) {
+                    refreshProgressBars(listStatus);
+                }
+            }
+        });
+
         mViewModel.getNewPluginsListStatus().observe(this, new Observer<PluginBrowserViewModel.PluginListStatus>() {
             @Override
             public void onChanged(@Nullable PluginBrowserViewModel.PluginListStatus listStatus) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
@@ -56,7 +56,7 @@ public class PluginListFragment extends Fragment {
 
     protected RecyclerView mRecycler;
     protected PluginListType mListType;
-    private SwipeToRefreshHelper mSwipeToRefreshHelper;
+    protected SwipeToRefreshHelper mSwipeToRefreshHelper;
 
     public static PluginListFragment newInstance(@NonNull SiteModel site, @NonNull PluginListType listType) {
         PluginListFragment fragment = new PluginListFragment();
@@ -127,8 +127,7 @@ public class PluginListFragment extends Fragment {
             @Override
             public void onChanged(@Nullable PluginBrowserViewModel.PluginListStatus listStatus) {
                 if (mListType == PluginListType.NEW) {
-                    showProgress(listStatus == PluginBrowserViewModel.PluginListStatus.FETCHING
-                            || listStatus == PluginBrowserViewModel.PluginListStatus.LOADING_MORE);
+                    refreshProgressBars(listStatus);
                 }
             }
         });
@@ -137,8 +136,7 @@ public class PluginListFragment extends Fragment {
             @Override
             public void onChanged(@Nullable PluginBrowserViewModel.PluginListStatus listStatus) {
                 if (mListType == PluginListType.POPULAR) {
-                    showProgress(listStatus == PluginBrowserViewModel.PluginListStatus.FETCHING
-                            || listStatus == PluginBrowserViewModel.PluginListStatus.LOADING_MORE);
+                    refreshProgressBars(listStatus);
                 }
             }
         });
@@ -147,8 +145,7 @@ public class PluginListFragment extends Fragment {
             @Override
             public void onChanged(@Nullable PluginBrowserViewModel.PluginListStatus listStatus) {
                 if (mListType == PluginListType.SEARCH) {
-                    showProgress(listStatus == PluginBrowserViewModel.PluginListStatus.FETCHING
-                            || listStatus == PluginBrowserViewModel.PluginListStatus.LOADING_MORE);
+                    refreshProgressBars(listStatus);
                     if (listStatus == PluginBrowserViewModel.PluginListStatus.ERROR) {
                         ToastUtils.showToast(getActivity(), R.string.plugin_search_error);
                     }
@@ -210,14 +207,19 @@ public class PluginListFragment extends Fragment {
         adapter.setPlugins(plugins);
     }
 
-    protected void showProgress(boolean show) {
-        if (isAdded() && getView() != null) {
-            getView().findViewById(R.id.progress).setVisibility(show ? View.VISIBLE : View.GONE);
+    protected void refreshProgressBars(PluginBrowserViewModel.PluginListStatus pluginListStatus) {
+        if (!isAdded() || getView() == null) {
+            return;
         }
+        // We want to show the swipe refresher for the initial fetch but not while loading more
+        mSwipeToRefreshHelper.setRefreshing(pluginListStatus == PluginBrowserViewModel.PluginListStatus.FETCHING);
+        // We want to show the progress bar in the middle while loading more but not for initial fetch
+        boolean showLoadMore = pluginListStatus == PluginBrowserViewModel.PluginListStatus.LOADING_MORE;
+        getView().findViewById(R.id.progress).setVisibility(showLoadMore ? View.VISIBLE : View.GONE);
     }
 
     void showEmptyView(boolean show) {
-        if (isAdded()) {
+        if (isAdded() && getView() != null) {
             getView().findViewById(R.id.text_empty).setVisibility(show ? View.VISIBLE : View.GONE);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
@@ -217,6 +217,10 @@ public class PluginBrowserViewModel extends ViewModel {
     }
 
     private boolean shouldFetchPlugins(PluginListType listType, boolean loadMore) {
+        if (loadMore && !isLoadMoreEnabled(listType)) {
+            // If we are trying to load more and it's not allowed
+            return false;
+        }
         switch (listType) {
             case SITE:
                 if (getSitePluginsListStatus().getValue() == PluginListStatus.FETCHING) {
@@ -256,7 +260,14 @@ public class PluginBrowserViewModel extends ViewModel {
     }
 
     public void loadMore(PluginListType listType) {
-        fetchPlugins(listType, true);
+        if (isLoadMoreEnabled(listType)) {
+            fetchPlugins(listType, true);
+        }
+    }
+
+    private boolean isLoadMoreEnabled(PluginListType listType) {
+        // We don't use pagination for Site plugins or Search results
+        return listType != PluginListType.SITE && listType != PluginListType.SEARCH;
     }
 
     // Network Callbacks

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
@@ -178,6 +178,12 @@ public class PluginBrowserViewModel extends ViewModel {
         mPopularPlugins.setValue(mPluginStore.getPluginDirectory(PluginDirectoryType.POPULAR));
     }
 
+    // Pull to refresh
+
+    public void pullToRefresh(@NonNull PluginListType pluginListType) {
+        fetchPlugins(pluginListType, false);
+    }
+
     // Network Requests
 
     private void fetchPlugins(@NonNull PluginListType listType, boolean loadMore) {

--- a/WordPress/src/main/res/layout/plugin_list_fragment.xml
+++ b/WordPress/src/main/res/layout/plugin_list_fragment.xml
@@ -1,33 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/white">
 
-    <android.support.v7.widget.RecyclerView
-        android:id="@+id/recycler"
+    <org.wordpress.android.util.widgets.CustomSwipeRefreshLayout
+        android:id="@+id/ptr_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:layout_below="@id/toolbar">
 
-    <org.wordpress.android.widgets.WPTextView
-        android:id="@+id/text_empty"
-        style="@style/WordPress.EmptyList.Title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:text="@string/plugins_empty_search_list"
-        android:visibility="gone"
-        tools:visibility="visible" />
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/recycler"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
 
-    <ProgressBar
-        android:id="@+id/progress"
-        style="?android:attr/progressBarStyle"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:visibility="gone"
-        tools:visibility="visible" />
+        <org.wordpress.android.widgets.WPTextView
+            android:id="@+id/text_empty"
+            style="@style/WordPress.EmptyList.Title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:text="@string/plugins_empty_search_list"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+        <ProgressBar
+            android:id="@+id/progress"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:visibility="gone"
+            tools:visibility="visible" />
+    </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/plugin_list_fragment.xml
+++ b/WordPress/src/main/res/layout/plugin_list_fragment.xml
@@ -15,25 +15,27 @@
             android:id="@+id/recycler"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
-
-        <org.wordpress.android.widgets.WPTextView
-            android:id="@+id/text_empty"
-            style="@style/WordPress.EmptyList.Title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:text="@string/plugins_empty_search_list"
-            android:visibility="gone"
-            tools:visibility="visible" />
-
-        <ProgressBar
-            android:id="@+id/progress"
-            style="?android:attr/progressBarStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerInParent="true"
-            android:visibility="gone"
-            tools:visibility="visible" />
     </org.wordpress.android.util.widgets.CustomSwipeRefreshLayout>
+
+    <org.wordpress.android.widgets.WPTextView
+        android:id="@+id/text_empty"
+        style="@style/WordPress.EmptyList.Title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:text="@string/plugins_empty_search_list"
+        android:visibility="gone"
+        tools:visibility="visible" />
+
+    <ProgressBar
+        android:id="@+id/progress"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:layout_marginBottom="@dimen/margin_extra_large"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
 </RelativeLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -22,5 +22,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '6245848e56af9d253e01171cc7bd03cc90023a60'
+    fluxCVersion = '9d90f262c86c284eae06776e68ab604ef5a3907c'
 }


### PR DESCRIPTION
This PR adds the ability to pull to refresh all the plugin lists. I was initially going to implement this for site plugins only, however as a user who doesn't have an idea about the implementation details, it feels weird to be able to pull to refresh a page sometimes but not others. There is no harm in refreshing new or popular plugins. And when they refresh the search results, they will simply get the same list.

I've also fixed a minor bug. We do not have pagination for site plugins or search results. So, I've disabled it for those lists.

Since we now have multiple progress bars, I've separated their usages. If the user pulls to refresh, or we are refreshing/fetching the first page, we'll show the progress bar of the pull to refresh component. If we are loading more plugins (fetching second/third etc page) we show the progress bar in our xml. I've moved that progress bar to the bottom since it's only indicating more plugins are being loaded.

Finally, FluxC hash has been updated to include the fix in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/715.

To test:
* Pull to refresh plugin lists (site, new, popular, search)
* Load more plugins by going to the end of the list and verify that the progress bar is shown for a bit and more plugins are loaded afterwards (only for new & popular plugins)

/cc @nbradbury @theck13 