### PR TITLE
Implement the site-creation epilogue button jumps

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SiteCreationActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SiteCreationActivity.java
@@ -17,12 +17,15 @@ import org.wordpress.android.ui.accounts.signup.SiteCreationListener;
 import org.wordpress.android.ui.accounts.signup.SiteCreationSiteDetailsFragment;
 import org.wordpress.android.ui.accounts.signup.SiteCreationThemeFragment;
 import org.wordpress.android.ui.accounts.signup.SiteCreationThemeLoaderFragment;
+import org.wordpress.android.ui.main.SitePickerActivity;
 import org.wordpress.android.util.HelpshiftHelper;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.UrlUtils;
 
 public class SiteCreationActivity extends AppCompatActivity implements SiteCreationListener {
     public static final String ARG_USERNAME = "ARG_USERNAME";
+
+    public static final String KEY_DO_NEW_POST = "KEY_DO_NEW_POST";
 
     private static final String KEY_CATERGORY = "KEY_CATERGORY";
     private static final String KEY_THEME_ID = "KEY_THEME_ID";
@@ -201,13 +204,20 @@ public class SiteCreationActivity extends AppCompatActivity implements SiteCreat
     }
 
     @Override
-    public void doConfigureSite() {
-        // TODO: jump to MySite
+    public void doConfigureSite(int siteLocalId) {
+        Intent intent = new Intent();
+        intent.putExtra(SitePickerActivity.KEY_LOCAL_ID, siteLocalId);
+        setResult(RESULT_OK, intent);
+        finish();
     }
 
     @Override
-    public void doWriteFirstPost() {
-        // TODO: Jump directly to the editor
+    public void doWriteFirstPost(int siteLocalId) {
+        Intent intent = new Intent();
+        intent.putExtra(SitePickerActivity.KEY_LOCAL_ID, siteLocalId);
+        intent.putExtra(KEY_DO_NEW_POST, true);
+        setResult(RESULT_OK, intent);
+        finish();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
@@ -47,6 +47,7 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
     private boolean mInModalMode;
     private boolean mCreationSucceeded;
     private boolean mWebViewLoadedInTime;
+    private int mNewSiteLocalId;
 
     private PreviewWebViewClient mPreviewWebViewClient;
 
@@ -99,14 +100,14 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
         secondaryButton.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 if (isAdded()) {
-                    mSiteCreationListener.doConfigureSite();
+                    mSiteCreationListener.doConfigureSite(mNewSiteLocalId);
                 }
             }
         });
         primaryButton.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
                 if (isAdded()) {
-                    mSiteCreationListener.doWriteFirstPost();
+                    mSiteCreationListener.doWriteFirstPost(mNewSiteLocalId);
                 }
             }
         });
@@ -308,6 +309,7 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
                 break;
             case SUCCESS:
                 mCreationSucceeded = true;
+                mNewSiteLocalId = (Integer) event.getPayload();
                 setModalMode(false);
 
                 if (mPreviewWebViewClient == null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationListener.java
@@ -19,8 +19,8 @@ public interface SiteCreationListener {
 
     // Site Creation Creating and epilogue screen callbacks
     void helpSiteCreatingScreen();
-    void doConfigureSite();
-    void doWriteFirstPost();
+    void doConfigureSite(int siteLocalId);
+    void doWriteFirstPost(int siteLocalId);
 
     void setHelpContext(String faqId, String faqSection);
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
@@ -320,7 +320,7 @@ public class SiteCreationService extends AutoForeground<SiteCreationState> {
                 doPreloadDelay();
                 break;
             case SUCCESS:
-                setState(SiteCreationStep.SUCCESS, null);
+                setState(SiteCreationStep.SUCCESS, mSiteStore.getLocalIdForRemoteSiteId(mNewSiteRemoteId));
                 break;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -46,6 +46,7 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.accounts.LoginActivity;
 import org.wordpress.android.ui.accounts.SignupEpilogueActivity;
+import org.wordpress.android.ui.accounts.SiteCreationActivity;
 import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter;
@@ -574,16 +575,37 @@ public class WPMainActivity extends AppCompatActivity {
         }
     }
 
+    private void setSite(Intent data) {
+        if (data != null) {
+            int selectedSite = data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1);
+            setSelectedSite(selectedSite);
+        }
+    }
+
+    private void jumpNewPost(Intent data) {
+        if (data != null && data.getBooleanExtra(SiteCreationActivity.KEY_DO_NEW_POST, false)) {
+            ActivityLauncher.addNewPostOrPageForResult(this, mSelectedSite, false, false);
+        }
+    }
+
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         switch (requestCode) {
             case RequestCodes.EDIT_POST:
-            case RequestCodes.CREATE_SITE:
                 MySiteFragment mySiteFragment = getMySiteFragment();
                 if (mySiteFragment != null) {
                     mySiteFragment.onActivityResult(requestCode, resultCode, data);
                 }
+                break;
+            case RequestCodes.CREATE_SITE:
+                mySiteFragment = getMySiteFragment();
+                if (mySiteFragment != null) {
+                    mySiteFragment.onActivityResult(requestCode, resultCode, data);
+                }
+
+                setSite(data);
+                jumpNewPost(data);
                 break;
             case RequestCodes.ADD_ACCOUNT:
                 if (resultCode == RESULT_OK) {
@@ -603,10 +625,9 @@ public class WPMainActivity extends AppCompatActivity {
             case RequestCodes.SITE_PICKER:
                 if (getMySiteFragment() != null) {
                     getMySiteFragment().onActivityResult(requestCode, resultCode, data);
-                    if (data != null) {
-                        int selectedSite = data.getIntExtra(SitePickerActivity.KEY_LOCAL_ID, -1);
-                        setSelectedSite(selectedSite);
-                    }
+
+                    setSite(data);
+                    jumpNewPost(data);
                 }
                 break;
             case RequestCodes.SITE_SETTINGS:


### PR DESCRIPTION
Fixes #7250 

To test A:
1. With the app logged in to a WPCOM account, launch the app and create a new WPCOM site via the site-picker
2. At the end of the creation process tap on the "CONFIGURE" button
3. Notice the app returning to the MySite screen with the newly created site selected

To test B:
1. With the app logged in to a WPCOM account, launch the app and create a new WPCOM site via the site-picker
2. At the end of the creation process tap on the "WRITE FIRST POST" button
3. Notice the app opening the post editor directly
4. Go back and notice the MySite screen is visible with the newly created site selected



