### PR TITLE
Issue/plugins-toolbar-shadow

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -82,7 +82,6 @@ public class PluginBrowserActivity extends AppCompatActivity
         if (actionBar != null) {
             actionBar.setHomeButtonEnabled(true);
             actionBar.setDisplayHomeAsUpEnabled(true);
-            actionBar.setElevation(0);
         }
 
         if (savedInstanceState == null) {


### PR DESCRIPTION
Add a shadow to the toolbar as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7206 by removing the `setElevation(0)` call from the plugin directory view.