### PR TITLE
Jetpack speed up settings

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/JetpackSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/JetpackSettingsModel.java
@@ -16,6 +16,8 @@ public class JetpackSettingsModel {
     public boolean ssoActive;
     public boolean ssoMatchEmail;
     public boolean ssoRequireTwoFactor;
+    public boolean serveImagesFromOurServers;
+    public boolean lazyLoadImages;
 
     public JetpackSettingsModel() {
         super();
@@ -36,6 +38,8 @@ public class JetpackSettingsModel {
         ssoMatchEmail = other.ssoMatchEmail;
         ssoRequireTwoFactor = other.ssoRequireTwoFactor;
         jetpackProtectWhitelist.addAll(other.jetpackProtectWhitelist);
+        serveImagesFromOurServers = other.serveImagesFromOurServers;
+        lazyLoadImages = other.lazyLoadImages;
     }
 
     @Override
@@ -49,6 +53,8 @@ public class JetpackSettingsModel {
                 ssoActive == otherModel.ssoActive &&
                 ssoMatchEmail == otherModel.ssoMatchEmail &&
                 ssoRequireTwoFactor == otherModel.ssoRequireTwoFactor &&
+                serveImagesFromOurServers == otherModel.serveImagesFromOurServers &&
+                lazyLoadImages == otherModel.lazyLoadImages &&
                 whitelistMatches(otherModel.jetpackProtectWhitelist);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
@@ -9,30 +9,13 @@ import org.wordpress.android.fluxc.model.plugin.WPOrgPluginModel;
 import org.wordpress.android.fluxc.store.PluginStore;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.CrashlyticsUtils;
+import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.helpers.Version;
 
 public class PluginUtils {
     public static boolean isPluginFeatureAvailable(SiteModel site) {
-        String jetpackVersion = site.getJetpackVersion();
-        if (site.isUsingWpComRestApi() && site.isJetpackConnected() && !TextUtils.isEmpty(jetpackVersion)) {
-            try {
-                // strip any trailing "-beta" or "-alpha" from the version
-                int index = jetpackVersion.lastIndexOf("-");
-                if (index > 0) {
-                    jetpackVersion = jetpackVersion.substring(0, index);
-                }
-                Version siteJetpackVersion = new Version(jetpackVersion);
-                Version minVersion = new Version("5.6");
-                return siteJetpackVersion.compareTo(minVersion) >= 0; // if the site has Jetpack 5.6 or newer installed
-            } catch (IllegalArgumentException e) {
-                String errorStr = "Invalid site jetpack version " + jetpackVersion;
-                AppLog.e(AppLog.T.UTILS, errorStr, e);
-                CrashlyticsUtils.logException(e, AppLog.T.UTILS, errorStr);
-                return true;
-            }
-        }
-        return false;
+        return SiteUtils.checkMinimalJetpackVersion(site, "5.6");
     }
 
     public static WPOrgPluginModel getWPOrgPlugin(@NonNull PluginStore pluginStore, @NonNull SitePluginModel plugin) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -288,7 +288,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
                 mSite.getSiteId(), new RestRequest.Listener() {
                     @Override
                     public void onResponse(JSONObject response) {
-                        AppLog.v(AppLog.T.API, "Received Jetpack speed-up options");
+                        AppLog.v(AppLog.T.API, "Received Jetpack module settings");
                         if (response == null) return;
                         JSONArray array = response.optJSONArray("modules");
                         if (array == null) return;
@@ -314,7 +314,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
                 }, new RestRequest.ErrorListener() {
                     @Override
                     public void onErrorResponse(VolleyError error) {
-                        AppLog.w(AppLog.T.API, "Error fetching Jetpack speed-up options: " + error);
+                        AppLog.w(AppLog.T.API, "Error fetching Jetpack module settings: " + error);
                         onFetchResponseReceived(error);
                     }
                 });
@@ -444,7 +444,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
                         public void onErrorResponse(VolleyError error) {
                             mRemoteJpSettings.serveImagesFromOurServers = fallbackValue;
                             error.printStackTrace();
-                            AppLog.w(AppLog.T.API, "Error updating Jetpack module - Serve images from our servers: " + error.getMessage());
+                            AppLog.w(AppLog.T.API, "Error updating Jetpack module - Serve images from our servers: " + error);
                             onSaveResponseReceived(error);
                         }
                     });

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -81,6 +81,8 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import static org.wordpress.android.ui.prefs.DotComSiteSettings.supportsJetpackSpeedUpSettings;
+
 /**
  * Allows interfacing with WordPress site settings. Works with WP.com and WP.org v4.5+ (pending).
  *
@@ -885,6 +887,11 @@ public class SiteSettingsFragment extends PreferenceFragment
             || (isAccessedViaWPComRest && !mSite.getHasCapabilityManageOptions())) {
             hideAdminRequiredPreferences();
         }
+
+        // hide speed-up jetpack settings if plugin version < 5.8
+        if (!supportsJetpackSpeedUpSettings(mSite)) {
+            removeSpeedUpJetpackPreferences();
+        }
     }
 
     public void setEditingEnabled(boolean enabled) {
@@ -1609,6 +1616,10 @@ public class SiteSettingsFragment extends PreferenceFragment
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_advanced);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_screen, R.string.pref_key_site_account);
         WPPrefUtils.removePreference(this, R.string.pref_key_site_general, R.string.pref_key_site_language);
+    }
+
+    private void removeSpeedUpJetpackPreferences() {
+        WPPrefUtils.removePreference(this, R.string.pref_key_site_writing, R.string.pref_key_speed_up_your_site_screen);
     }
 
     private void removePrivateOptionFromPrivacySetting() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsFragment.java
@@ -83,17 +83,17 @@ import javax.inject.Inject;
 
 /**
  * Allows interfacing with WordPress site settings. Works with WP.com and WP.org v4.5+ (pending).
- * <p>
+ *
  * Settings are synced automatically when local changes are made.
  */
 
 public class SiteSettingsFragment extends PreferenceFragment
         implements Preference.OnPreferenceChangeListener,
-        Preference.OnPreferenceClickListener,
-        AdapterView.OnItemLongClickListener,
-        ViewGroup.OnHierarchyChangeListener,
-        Dialog.OnDismissListener,
-        SiteSettingsInterface.SiteSettingsListener {
+                   Preference.OnPreferenceClickListener,
+                   AdapterView.OnItemLongClickListener,
+                   ViewGroup.OnHierarchyChangeListener,
+                   Dialog.OnDismissListener,
+                   SiteSettingsInterface.SiteSettingsListener {
     /**
      * When the user removes a site (by selecting Delete Site) the parent {@link Activity} result
      * is set to this value and {@link Activity#finish()} is invoked.
@@ -102,7 +102,7 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     /**
      * Provides the regex to identify domain HTTP(S) protocol and/or 'www' sub-domain.
-     * <p>
+     *
      * Used to format user-facing {@link String}'s in certain preferences.
      */
     public static final String ADDRESS_FORMAT_REGEX = "^(https?://(w{3})?|www\\.)";
@@ -143,12 +143,9 @@ public class SiteSettingsFragment extends PreferenceFragment
 
     private static final long FETCH_DELAY = 1000;
 
-    @Inject
-    AccountStore mAccountStore;
-    @Inject
-    SiteStore mSiteStore;
-    @Inject
-    Dispatcher mDispatcher;
+    @Inject AccountStore mAccountStore;
+    @Inject SiteStore mSiteStore;
+    @Inject Dispatcher mDispatcher;
 
     public SiteModel mSite;
 
@@ -560,26 +557,26 @@ public class SiteSettingsFragment extends PreferenceFragment
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setMessage(R.string.jetpack_disconnect_confirmation_message);
         builder.setPositiveButton(R.string.jetpack_disconnect_confirm, new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                String url = String.format(Locale.US, "jetpack-blogs/%d/mine/delete", mSite.getSiteId());
-                WordPress.getRestClientUtilsV1_1().post(url, new RestRequest.Listener() {
                     @Override
-                    public void onResponse(JSONObject response) {
-                        AppLog.v(AppLog.T.API, "Successfully disconnected Jetpack site");
-                        ToastUtils.showToast(getActivity(), R.string.jetpack_disconnect_success_toast);
-                        mDispatcher.dispatch(SiteActionBuilder.newRemoveSiteAction(mSite));
-                        mSite = null;
-                    }
-                }, new RestRequest.ErrorListener() {
-                    @Override
-                    public void onErrorResponse(VolleyError error) {
-                        AppLog.e(AppLog.T.API, "Error disconnecting Jetpack site");
-                        ToastUtils.showToast(getActivity(), R.string.jetpack_disconnect_error_toast);
+                    public void onClick(DialogInterface dialog, int which) {
+                        String url = String.format(Locale.US, "jetpack-blogs/%d/mine/delete", mSite.getSiteId());
+                        WordPress.getRestClientUtilsV1_1().post(url, new RestRequest.Listener() {
+                            @Override
+                            public void onResponse(JSONObject response) {
+                                AppLog.v(AppLog.T.API, "Successfully disconnected Jetpack site");
+                                ToastUtils.showToast(getActivity(), R.string.jetpack_disconnect_success_toast);
+                                mDispatcher.dispatch(SiteActionBuilder.newRemoveSiteAction(mSite));
+                                mSite = null;
+                            }
+                        }, new RestRequest.ErrorListener() {
+                            @Override
+                            public void onErrorResponse(VolleyError error) {
+                                AppLog.e(AppLog.T.API, "Error disconnecting Jetpack site");
+                                ToastUtils.showToast(getActivity(), R.string.jetpack_disconnect_error_toast);
+                            }
+                        });
                     }
                 });
-            }
-        });
         builder.setNegativeButton(android.R.string.cancel, null);
         builder.show();
     }
@@ -885,7 +882,7 @@ public class SiteSettingsFragment extends PreferenceFragment
 
         // hide Admin options depending of capabilities on this site
         if ((!isAccessedViaWPComRest && !mSite.isSelfHostedAdmin())
-                || (isAccessedViaWPComRest && !mSite.getHasCapabilityManageOptions())) {
+            || (isAccessedViaWPComRest && !mSite.getHasCapabilityManageOptions())) {
             hideAdminRequiredPreferences();
         }
     }
@@ -1110,8 +1107,7 @@ public class SiteSettingsFragment extends PreferenceFragment
     }
 
     private void showDeleteSiteDialog() {
-        if (mIsFragmentPaused)
-            return; // Do not show the DeleteSiteDialogFragment if the fragment was paused.
+        if (mIsFragmentPaused) return; // Do not show the DeleteSiteDialogFragment if the fragment was paused.
         // DialogFragment internally uses commit(), and not commitAllowingStateLoss, crashing the app in case like that.
         Bundle args = new Bundle();
         args.putString(DeleteSiteDialogFragment.SITE_DOMAIN_KEY, UrlUtils.getHost(mSite.getUrl()));
@@ -1326,7 +1322,8 @@ public class SiteSettingsFragment extends PreferenceFragment
     /**
      * Detail strings for the dialog are generated in the selected language.
      *
-     * @param newValue languageCode
+     * @param newValue
+     * languageCode
      */
     private void changeLanguageValue(String newValue) {
         if (mLanguagePref == null || newValue == null) return;
@@ -1412,45 +1409,45 @@ public class SiteSettingsFragment extends PreferenceFragment
         mAdapter = null;
         final EmptyViewRecyclerView list = (EmptyViewRecyclerView) view.findViewById(android.R.id.list);
         list.setLayoutManager(
-                new SmoothScrollLinearLayoutManager(
-                        getActivity(),
-                        LinearLayoutManager.VERTICAL,
-                        false,
-                        getResources().getInteger(android.R.integer.config_mediumAnimTime)
-                )
+            new SmoothScrollLinearLayoutManager(
+                getActivity(),
+                LinearLayoutManager.VERTICAL,
+                false,
+                getResources().getInteger(android.R.integer.config_mediumAnimTime)
+            )
         );
         list.setAdapter(getAdapter());
         list.setEmptyView(view.findViewById(R.id.empty_view));
         list.addOnItemTouchListener(
-                new RecyclerViewItemClickListener(
-                        getActivity(),
-                        list,
-                        new RecyclerViewItemClickListener.OnItemClickListener() {
-                            @Override
-                            public void onItemClick(View view, int position) {
-                                if (mActionMode != null) {
-                                    getAdapter().toggleItemSelected(position);
-                                    mActionMode.invalidate();
-                                    if (getAdapter().getItemsSelected().size() <= 0) {
-                                        mActionMode.finish();
-                                    }
-                                }
-                            }
-
-                            @Override
-                            public void onLongItemClick(View view, int position) {
-                                if (mActionMode == null) {
-                                    if (view.isHapticFeedbackEnabled()) {
-                                        view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
-                                    }
-
-                                    mDialog.getWindow().getDecorView().startActionMode(new ActionModeCallback());
-                                    getAdapter().setItemSelected(position);
-                                    mActionMode.invalidate();
-                                }
+            new RecyclerViewItemClickListener(
+                getActivity(),
+                list,
+                new RecyclerViewItemClickListener.OnItemClickListener() {
+                    @Override
+                    public void onItemClick(View view, int position) {
+                        if (mActionMode != null) {
+                            getAdapter().toggleItemSelected(position);
+                            mActionMode.invalidate();
+                            if (getAdapter().getItemsSelected().size() <= 0) {
+                                mActionMode.finish();
                             }
                         }
-                )
+                    }
+
+                    @Override
+                    public void onLongItemClick(View view, int position) {
+                        if (mActionMode == null) {
+                            if (view.isHapticFeedbackEnabled()) {
+                                view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
+                            }
+
+                            mDialog.getWindow().getDecorView().startActionMode(new ActionModeCallback());
+                            getAdapter().setItemSelected(position);
+                            mActionMode.invalidate();
+                        }
+                    }
+                }
+            )
         );
         view.findViewById(R.id.fab_button).setOnClickListener(new View.OnClickListener() {
             @Override
@@ -1475,12 +1472,12 @@ public class SiteSettingsFragment extends PreferenceFragment
                             mEditingList.add(entry);
                             getAdapter().notifyItemInserted(getAdapter().getItemCount() - 1);
                             list.post(
-                                    new Runnable() {
-                                        @Override
-                                        public void run() {
-                                            list.smoothScrollToPosition(getAdapter().getItemCount() - 1);
-                                        }
+                                new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        list.smoothScrollToPosition(getAdapter().getItemCount() - 1);
                                     }
+                                }
                             );
                             mSiteSettings.saveSettings();
                             AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.SITE_SETTINGS_ADDED_LIST_ITEM,
@@ -1640,28 +1637,28 @@ public class SiteSettingsFragment extends PreferenceFragment
         if (mSite.isWPCom()) {
             final ProgressDialog progressDialog = ProgressDialog.show(getActivity(), "", getActivity().getString(R.string.exporting_content_progress), true, true);
             WordPress.getRestClientUtils().exportContentAll(mSite.getSiteId(), new RestRequest.Listener() {
-                @Override
-                public void onResponse(JSONObject response) {
-                    if (isAdded()) {
-                        AnalyticsUtils.trackWithSiteDetails(
-                                AnalyticsTracker.Stat.SITE_SETTINGS_EXPORT_SITE_RESPONSE_OK, mSite);
-                        dismissProgressDialog(progressDialog);
-                        Snackbar.make(getView(), R.string.export_email_sent, Snackbar.LENGTH_LONG).show();
-                    }
-                }
-            }, new RestRequest.ErrorListener() {
-                @Override
-                public void onErrorResponse(VolleyError error) {
-                    if (isAdded()) {
-                        HashMap<String, Object> errorProperty = new HashMap<>();
-                        errorProperty.put(ANALYTICS_ERROR_PROPERTY_KEY, error.getMessage());
-                        AnalyticsUtils.trackWithSiteDetails(
-                                AnalyticsTracker.Stat.SITE_SETTINGS_EXPORT_SITE_RESPONSE_ERROR,
-                                mSite, errorProperty);
-                        dismissProgressDialog(progressDialog);
-                    }
-                }
-            });
+                        @Override
+                        public void onResponse(JSONObject response) {
+                            if (isAdded()) {
+                                AnalyticsUtils.trackWithSiteDetails(
+                                        AnalyticsTracker.Stat.SITE_SETTINGS_EXPORT_SITE_RESPONSE_OK, mSite);
+                                dismissProgressDialog(progressDialog);
+                                Snackbar.make(getView(), R.string.export_email_sent, Snackbar.LENGTH_LONG).show();
+                            }
+                        }
+                    }, new RestRequest.ErrorListener() {
+                        @Override
+                        public void onErrorResponse(VolleyError error) {
+                            if (isAdded()) {
+                                HashMap<String, Object> errorProperty = new HashMap<>();
+                                errorProperty.put(ANALYTICS_ERROR_PROPERTY_KEY, error.getMessage());
+                                AnalyticsUtils.trackWithSiteDetails(
+                                        AnalyticsTracker.Stat.SITE_SETTINGS_EXPORT_SITE_RESPONSE_ERROR,
+                                        mSite, errorProperty);
+                                dismissProgressDialog(progressDialog);
+                            }
+                        }
+                    });
         }
     }
 
@@ -1784,9 +1781,7 @@ public class SiteSettingsFragment extends PreferenceFragment
         }
     }
 
-    /**
-     * Show Disconnect button for development purposes. Only available in debug builds on Jetpack sites.
-     */
+    /** Show Disconnect button for development purposes. Only available in debug builds on Jetpack sites. */
     private boolean shouldShowDisconnect() {
         return BuildConfig.DEBUG && mSite.isJetpackConnected() && mSite.isUsingWpComRestApi();
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -677,6 +677,22 @@ public abstract class SiteSettingsInterface {
         return mJpSettings.ssoRequireTwoFactor;
     }
 
+    public void enableServeImagesFromOurServers(boolean enabled) {
+        mJpSettings.serveImagesFromOurServers = enabled;
+    }
+
+    public boolean isServeImagesFromOurServersEnabled() {
+        return mJpSettings.serveImagesFromOurServers;
+    }
+
+    public void enableLazyLoadImages(boolean enabled) {
+        mJpSettings.lazyLoadImages = enabled;
+    }
+
+    public boolean isLazyLoadImagesEnabled() {
+        return mJpSettings.lazyLoadImages;
+    }
+
     public void setTitle(String title) {
         mSettings.title = title;
     }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -4,6 +4,7 @@ import android.text.TextUtils;
 
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.util.helpers.Version;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -56,5 +57,33 @@ public class SiteUtils {
         }
 
         return siteIDs;
+    }
+
+    /**
+     * Checks if site Jetpack version is higher than limit version
+     * @param site
+     * @param limitVersion minimal acceptable Jetpack version
+     * @return
+     */
+    public static boolean checkMinimalJetpackVersion(SiteModel site, String limitVersion) {
+        String jetpackVersion = site.getJetpackVersion();
+        if (site.isUsingWpComRestApi() && site.isJetpackConnected() && !TextUtils.isEmpty(jetpackVersion)) {
+            try {
+                // strip any trailing "-beta" or "-alpha" from the version
+                int index = jetpackVersion.lastIndexOf("-");
+                if (index > 0) {
+                    jetpackVersion = jetpackVersion.substring(0, index);
+                }
+                Version siteJetpackVersion = new Version(jetpackVersion);
+                Version minVersion = new Version(limitVersion);
+                return siteJetpackVersion.compareTo(minVersion) >= 0; // if the site has Jetpack 5.8 or newer installed
+            } catch (IllegalArgumentException e) {
+                String errorStr = "Invalid site jetpack version " + jetpackVersion + ", expected " + limitVersion;
+                AppLog.e(AppLog.T.UTILS, errorStr, e);
+                CrashlyticsUtils.logException(e, AppLog.T.UTILS, errorStr);
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -76,7 +76,7 @@ public class SiteUtils {
                 }
                 Version siteJetpackVersion = new Version(jetpackVersion);
                 Version minVersion = new Version(limitVersion);
-                return siteJetpackVersion.compareTo(minVersion) >= 0; // if the site has Jetpack 5.8 or newer installed
+                return siteJetpackVersion.compareTo(minVersion) >= 0;
             } catch (IllegalArgumentException e) {
                 String errorStr = "Invalid site jetpack version " + jetpackVersion + ", expected " + limitVersion;
                 AppLog.e(AppLog.T.UTILS, errorStr, e);

--- a/WordPress/src/main/res/values/key_strings.xml
+++ b/WordPress/src/main/res/values/key_strings.xml
@@ -100,6 +100,10 @@
     <string name="pref_key_comment_likes" translatable="false">wp_pref_comment_likes</string>
     <string name="pref_key_more_buttons" translatable="false">wp_pref_more_buttons</string>
     <string name="pref_key_twitter_category" translatable="false">wp_pref_twitter_category</string>
+    <!-- Speed up your site -->
+    <string name="pref_key_speed_up_your_site_screen" translatable="false">wp_pref_speed_up_your_site_screen</string>
+    <string name="pref_key_serve_images_from_our_servers" translatable="false">wp_pref_serve_images_from_our_servers</string>
+    <string name="pref_key_lazy_load_images" translatable="false">wp_pref_lazy_load_images</string>
 
     <!-- Jetpack Security -->
     <string name="pref_key_jetpack_settings" translatable="false">wp_pref_jetpack_settings</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -558,6 +558,12 @@
     <string name="site_settings_timezones_error">Unable to load timezones</string>
     <string name="site_settings_amp_title">Accelerated Mobile Pages (AMP)</string>
     <string name="site_settings_amp_summary">Your WordPress.com site supports the use of Accelerated Mobile Pages, a Google-led initiative that dramatically speeds up loading times on mobile devices</string>
+    <!-- Speed up your site -->
+    <string name="site_settings_speed_up_your_site">Speed up your site</string>
+    <string name="site_settings_serve_images_from_our_servers">Serve images from our servers</string>
+    <string name="site_settings_serve_images_from_our_servers_summary">Jetpack will optimize your images and serve them from the server location nearest to your visitors. Using our global content delivery network will boost the loading speed of your site.</string>
+    <string name="site_settings_lazy_load_images">"Lazy-load" images</string>
+    <string name="site_settings_lazy_load_images_summary">Improve your site\'s speed by only loading images visible on the screen. New images will load just before they scroll into view. This prevents viewers from having to download all the images on a page all at once, even ones they can\'t see.</string>
 
     <!-- tag list and detail -->
     <string name="tag_name_hint">Tag</string>

--- a/WordPress/src/main/res/xml/site_settings.xml
+++ b/WordPress/src/main/res/xml/site_settings.xml
@@ -144,6 +144,27 @@
             android:key="@string/pref_key_site_posts_per_page"
             android:title="@string/site_settings_posts_per_page_title" />
 
+        <PreferenceScreen
+            android:id="@+id/speed_up_your_site_screen"
+            android:key="@string/pref_key_speed_up_your_site_screen"
+            android:title="@string/site_settings_speed_up_your_site">
+
+            <org.wordpress.android.ui.prefs.WPSwitchPreference
+                android:id="@+id/pref_serve_images_from_our_servers"
+                android:key="@string/pref_key_serve_images_from_our_servers"
+                android:layout="@layout/preference_layout"
+                android:summary="@string/site_settings_serve_images_from_our_servers_summary"
+                android:title="@string/site_settings_serve_images_from_our_servers" />
+
+            <org.wordpress.android.ui.prefs.WPSwitchPreference
+                android:id="@+id/pref_lazy_load_images"
+                android:key="@string/pref_key_lazy_load_images"
+                android:layout="@layout/preference_layout"
+                android:summary="@string/site_settings_lazy_load_images_summary"
+                android:title="@string/site_settings_lazy_load_images" />
+        </PreferenceScreen>
+
+
     </PreferenceCategory>
 
     <!-- Traffic settings -->

--- a/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
+++ b/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
@@ -165,6 +165,12 @@ public class RestClientUtils {
         get(path, listener, errorListener);
     }
 
+
+    public void getJetpackModuleSettings(long siteId, Listener listener, ErrorListener errorListener) {
+        String path = String.format(Locale.US, "sites/%d/jetpack/modules", siteId);
+        get(path, listener, errorListener);
+    }
+
     public void setGeneralSiteSettings(long siteId, JSONObject params, Listener listener, ErrorListener errorListener) {
         String path = String.format(Locale.US, "sites/%d/settings", siteId);
         post(path, params, null, listener, errorListener);
@@ -195,6 +201,14 @@ public class RestClientUtils {
     public void setJetpackMonitorSettings(long siteId, Map<String, String> params,
                                           Listener listener, ErrorListener errorListener) {
         String path = String.format(Locale.US, "jetpack-blogs/%d", siteId);
+        post(path, params, null, listener, errorListener);
+    }
+
+    public void setJetpackModuleSettings(long siteId, String module, boolean active,
+                                         Listener listener, ErrorListener errorListener) {
+        String path = String.format(Locale.US, "sites/%d/jetpack/modules/%s", siteId, module);
+        HashMap<String, String> params = new HashMap<>();
+        params.put("active", String.valueOf(active));
         post(path, params, null, listener, errorListener);
     }
 
@@ -233,7 +247,7 @@ public class RestClientUtils {
      * Make GET request with params
      */
     public Request<JSONObject> get(String path, Map<String, String> params, RetryPolicy retryPolicy, Listener listener,
-                    ErrorListener errorListener) {
+                                   ErrorListener errorListener) {
         // turn params into query string
         HashMap<String, String> paramsWithLocale = getRestLocaleParams(mContext);
         if (params != null) {
@@ -247,7 +261,7 @@ public class RestClientUtils {
         paramsWithLocale.putAll(getSanitizedParameters(path));
 
         RestRequest request = mRestClient.makeRequest(Method.GET, mRestClient
-                        .getAbsoluteURL(realPath, paramsWithLocale), null, listener, errorListener);
+                .getAbsoluteURL(realPath, paramsWithLocale), null, listener, errorListener);
 
         if (retryPolicy == null) {
             retryPolicy = new DefaultRetryPolicy(REST_TIMEOUT_MS, REST_MAX_RETRIES_GET, REST_BACKOFF_MULT);
@@ -271,7 +285,7 @@ public class RestClientUtils {
     public void post(final String path, Map<String, String> params, RetryPolicy retryPolicy, Listener listener,
                      ErrorListener errorListener) {
         final RestRequest request = mRestClient.makeRequest(Method.POST, mRestClient
-                        .getAbsoluteURL(path, getRestLocaleParams(mContext)), params, listener, errorListener);
+                .getAbsoluteURL(path, getRestLocaleParams(mContext)), params, listener, errorListener);
         if (retryPolicy == null) {
             retryPolicy = new DefaultRetryPolicy(REST_TIMEOUT_MS, REST_MAX_RETRIES_POST,
                     REST_BACKOFF_MULT); //Do not retry on failure
@@ -288,7 +302,7 @@ public class RestClientUtils {
     public void post(final String path, JSONObject params, RetryPolicy retryPolicy, Listener listener,
                      ErrorListener errorListener) {
         final JsonRestRequest request = mRestClient.makeRequest(mRestClient
-                        .getAbsoluteURL(path, getRestLocaleParams(mContext)), params, listener, errorListener);
+                .getAbsoluteURL(path, getRestLocaleParams(mContext)), params, listener, errorListener);
         if (retryPolicy == null) {
             retryPolicy = new DefaultRetryPolicy(REST_TIMEOUT_MS, REST_MAX_RETRIES_POST,
                     REST_BACKOFF_MULT); //Do not retry on failure
@@ -301,11 +315,11 @@ public class RestClientUtils {
     /**
      * Takes a URL and returns the path within, or an empty string (not null)
      */
-    private static String getSanitizedPath(String unsanitizedPath){
+    private static String getSanitizedPath(String unsanitizedPath) {
         if (unsanitizedPath != null) {
             int qmarkPos = unsanitizedPath.indexOf('?');
             if (qmarkPos > -1) { //strip any query string params off this to obtain the path
-                return unsanitizedPath.substring(0, qmarkPos+1);
+                return unsanitizedPath.substring(0, qmarkPos + 1);
             } else {
                 // return the string as is, consider the whole string as the path
                 return unsanitizedPath;
@@ -317,17 +331,17 @@ public class RestClientUtils {
     /**
      * Takes a URL with query strings and returns a Map of query string values.
      */
-    private static HashMap<String, String> getSanitizedParameters(String unsanitizedPath){
+    private static HashMap<String, String> getSanitizedParameters(String unsanitizedPath) {
         HashMap<String, String> queryParams = new HashMap<>();
 
         Uri uri = Uri.parse(unsanitizedPath);
 
         if (uri.getHost() == null) {
             uri = Uri.parse("://" + unsanitizedPath); // path may contain a ":" leading to Uri.parse to misinterpret
-                    // it as opaque so, try it with a empty scheme in front
+            // it as opaque so, try it with a empty scheme in front
         }
 
-        if (uri.getQueryParameterNames() != null ) {
+        if (uri.getQueryParameterNames() != null) {
             for (String paramName : uri.getQueryParameterNames()) {
                 String value = uri.getQueryParameter(paramName);
                 queryParams.put(paramName, value);

--- a/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
+++ b/libs/networking/WordPressNetworking/src/main/java/org/wordpress/android/networking/RestClientUtils.java
@@ -247,7 +247,7 @@ public class RestClientUtils {
      * Make GET request with params
      */
     public Request<JSONObject> get(String path, Map<String, String> params, RetryPolicy retryPolicy, Listener listener,
-                                   ErrorListener errorListener) {
+                    ErrorListener errorListener) {
         // turn params into query string
         HashMap<String, String> paramsWithLocale = getRestLocaleParams(mContext);
         if (params != null) {
@@ -261,7 +261,7 @@ public class RestClientUtils {
         paramsWithLocale.putAll(getSanitizedParameters(path));
 
         RestRequest request = mRestClient.makeRequest(Method.GET, mRestClient
-                .getAbsoluteURL(realPath, paramsWithLocale), null, listener, errorListener);
+                        .getAbsoluteURL(realPath, paramsWithLocale), null, listener, errorListener);
 
         if (retryPolicy == null) {
             retryPolicy = new DefaultRetryPolicy(REST_TIMEOUT_MS, REST_MAX_RETRIES_GET, REST_BACKOFF_MULT);
@@ -285,7 +285,7 @@ public class RestClientUtils {
     public void post(final String path, Map<String, String> params, RetryPolicy retryPolicy, Listener listener,
                      ErrorListener errorListener) {
         final RestRequest request = mRestClient.makeRequest(Method.POST, mRestClient
-                .getAbsoluteURL(path, getRestLocaleParams(mContext)), params, listener, errorListener);
+                        .getAbsoluteURL(path, getRestLocaleParams(mContext)), params, listener, errorListener);
         if (retryPolicy == null) {
             retryPolicy = new DefaultRetryPolicy(REST_TIMEOUT_MS, REST_MAX_RETRIES_POST,
                     REST_BACKOFF_MULT); //Do not retry on failure
@@ -302,7 +302,7 @@ public class RestClientUtils {
     public void post(final String path, JSONObject params, RetryPolicy retryPolicy, Listener listener,
                      ErrorListener errorListener) {
         final JsonRestRequest request = mRestClient.makeRequest(mRestClient
-                .getAbsoluteURL(path, getRestLocaleParams(mContext)), params, listener, errorListener);
+                        .getAbsoluteURL(path, getRestLocaleParams(mContext)), params, listener, errorListener);
         if (retryPolicy == null) {
             retryPolicy = new DefaultRetryPolicy(REST_TIMEOUT_MS, REST_MAX_RETRIES_POST,
                     REST_BACKOFF_MULT); //Do not retry on failure
@@ -315,11 +315,11 @@ public class RestClientUtils {
     /**
      * Takes a URL and returns the path within, or an empty string (not null)
      */
-    private static String getSanitizedPath(String unsanitizedPath) {
+    private static String getSanitizedPath(String unsanitizedPath){
         if (unsanitizedPath != null) {
             int qmarkPos = unsanitizedPath.indexOf('?');
             if (qmarkPos > -1) { //strip any query string params off this to obtain the path
-                return unsanitizedPath.substring(0, qmarkPos + 1);
+                return unsanitizedPath.substring(0, qmarkPos+1);
             } else {
                 // return the string as is, consider the whole string as the path
                 return unsanitizedPath;
@@ -331,17 +331,17 @@ public class RestClientUtils {
     /**
      * Takes a URL with query strings and returns a Map of query string values.
      */
-    private static HashMap<String, String> getSanitizedParameters(String unsanitizedPath) {
+    private static HashMap<String, String> getSanitizedParameters(String unsanitizedPath){
         HashMap<String, String> queryParams = new HashMap<>();
 
         Uri uri = Uri.parse(unsanitizedPath);
 
         if (uri.getHost() == null) {
             uri = Uri.parse("://" + unsanitizedPath); // path may contain a ":" leading to Uri.parse to misinterpret
-            // it as opaque so, try it with a empty scheme in front
+                    // it as opaque so, try it with a empty scheme in front
         }
 
-        if (uri.getQueryParameterNames() != null) {
+        if (uri.getQueryParameterNames() != null ) {
             for (String paramName : uri.getQueryParameterNames()) {
                 String value = uri.getQueryParameter(paramName);
                 queryParams.put(paramName, value);


### PR DESCRIPTION
Fixes #7196 
Add "Speed up" settings to Site settings. There are two options with descriptions. One is to load images lazily and the second to server images from our servers. Both have been added to the "General" tab. Settings are only visible on Jetpack version >= 5.8

To test:

* Log in with site connected to Jetpack with version >= 5.8
* Go to site settings
* Click on "Speed up your site" 
* See 2 new settings with description
  * Both are clickable and are saved when clicked

![screenshot_1519051194](https://user-images.githubusercontent.com/1079756/36385908-53f1b210-1594-11e8-8256-848d5afccdff.png)
