### PR TITLE
Fix layout direction when UI language is changed

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -205,8 +205,6 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         mContext = this;
         long startDate = SystemClock.elapsedRealtime();
 
-        disableRtlLayoutDirectionOnSdk17();
-
         // Init WellSql
         WellSql.init(new WellSqlConfig(getApplicationContext()));
 
@@ -276,6 +274,8 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
 
         // If users uses a custom locale set it on start of application
         WPActivityUtils.applyLocale(getContext());
+
+        disableRtlLayoutDirectionOnSdk17();
 
         // Allows vector drawable from resources (in selectors for instance) on Android < 21 (can cause issues
         // with memory usage and the use of Configuration). More informations:

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/AppSettingsFragment.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.ListPreference;
 import android.preference.Preference;
@@ -283,6 +284,9 @@ public class AppSettingsFragment extends PreferenceFragment implements OnPrefere
 
         // update configuration
         conf.locale = newLocale;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            conf.setLayoutDirection(newLocale);
+        }
         res.updateConfiguration(conf, res.getDisplayMetrics());
 
         // Track language change on Analytics because we have both the device language and app selected language

--- a/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPActivityUtils.java
@@ -13,6 +13,7 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
 import android.preference.PreferenceManager;
+import android.support.v4.text.TextUtilsCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
@@ -114,7 +115,11 @@ public class WPActivityUtils {
             if (!locale.equals(contextLanguage)) {
                 Resources resources = context.getResources();
                 Configuration conf = resources.getConfiguration();
-                conf.locale = WPPrefUtils.languageLocale(locale);
+                Locale newLocale = WPPrefUtils.languageLocale(locale);
+                conf.locale = newLocale;
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                    conf.setLayoutDirection(newLocale);
+                }
                 resources.updateConfiguration(conf, resources.getDisplayMetrics());
             }
         }


### PR DESCRIPTION
When a user changes interface language in the app settings, layout direction is set accordingly.

To test:
1. Change the language to Hebrew in the in-app settings.
2. Check that the current layout direction is RtL

Note: I've noticed that when the app is killed current in-app language settings is cleared - is this expected behaviour or should I create a GitHub issue?