### PR TITLE
Add contentDescription to image views

### DIFF
--- a/WordPress/src/main/res/layout-sw720dp/stats_insights_all_time_item.xml
+++ b/WordPress/src/main/res/layout-sw720dp/stats_insights_all_time_item.xml
@@ -28,6 +28,7 @@
                 android:layout_height="12dp"
                 android:layout_marginRight="3dp"
                 android:layout_marginEnd="3dp"
+                android:contentDescription="@null"
                 app:srcCompat="@drawable/ic_posts_grey_dark_24dp" />
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
@@ -73,6 +74,7 @@
                 android:layout_height="12dp"
                 android:layout_marginRight="3dp"
                 android:layout_marginEnd="3dp"
+                android:contentDescription="@null"
                 app:srcCompat="@drawable/ic_visible_on_grey_dark_12dp" />
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
@@ -118,6 +120,7 @@
                 android:layout_height="12dp"
                 android:layout_marginRight="3dp"
                 android:layout_marginEnd="3dp"
+                android:contentDescription="@null"
                 app:srcCompat="@drawable/ic_user_grey_dark_12dp" />
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
@@ -163,6 +166,7 @@
                 android:layout_height="12dp"
                 android:layout_marginRight="3dp"
                 android:layout_marginEnd="3dp"
+                android:contentDescription="@null"
                 app:srcCompat="@drawable/ic_trophy_alert_yellow_32dp" />
 
             <org.wordpress.android.util.widgets.AutoResizeTextView

--- a/WordPress/src/main/res/layout/add_category.xml
+++ b/WordPress/src/main/res/layout/add_category.xml
@@ -19,6 +19,7 @@
             android:text="@string/category_name"
             android:textColor="@color/grey_dark"
             android:textStyle="bold"
+            android:labelFor="@+id/category_name"
             android:textSize="@dimen/text_sz_large" />
 
         <!-- Category name -->
@@ -46,6 +47,7 @@
             android:text="@string/category_parent"
             android:textColor="@color/grey_dark"
             android:textStyle="bold"
+            android:labelFor="@+id/parent_category"
             android:textSize="@dimen/text_sz_large" />
 
         <Spinner

--- a/WordPress/src/main/res/layout/comment_listitem.xml
+++ b/WordPress/src/main/res/layout/comment_listitem.xml
@@ -30,7 +30,8 @@
             <org.wordpress.android.widgets.WPNetworkImageView
                 android:id="@+id/avatar"
                 android:layout_width="@dimen/notifications_avatar_sz"
-                android:layout_height="@dimen/notifications_avatar_sz" />
+                android:layout_height="@dimen/notifications_avatar_sz"
+                android:contentDescription="@string/comment_avatar_desc"/>
 
             <ImageView
                 android:id="@+id/image_checkmark"
@@ -39,6 +40,7 @@
                 android:background="@drawable/shape_oval_blue"
                 android:padding="@dimen/margin_medium"
                 app:srcCompat="@drawable/ic_checkmark_white_24dp"
+                android:contentDescription="@string/comment_checkmark_desc"
                 android:visibility="gone" />
 
         </FrameLayout>

--- a/WordPress/src/main/res/layout/comment_listitem.xml
+++ b/WordPress/src/main/res/layout/comment_listitem.xml
@@ -30,8 +30,7 @@
             <org.wordpress.android.widgets.WPNetworkImageView
                 android:id="@+id/avatar"
                 android:layout_width="@dimen/notifications_avatar_sz"
-                android:layout_height="@dimen/notifications_avatar_sz"
-                android:contentDescription="@string/comment_avatar_desc"/>
+                android:layout_height="@dimen/notifications_avatar_sz"/>
 
             <ImageView
                 android:id="@+id/image_checkmark"

--- a/WordPress/src/main/res/layout/create_blog_fragment.xml
+++ b/WordPress/src/main/res/layout/create_blog_fragment.xml
@@ -57,7 +57,8 @@
                     app:srcCompat="@drawable/ic_pencil_white_24dp"
                     android:layout_centerVertical="true"
                     android:layout_marginLeft="10dp"
-                    android:tint="@color/grey_darken_10"/>
+                    android:tint="@color/grey_darken_10"
+                    android:contentDescription="@null"/>
             </RelativeLayout>
 
 
@@ -111,6 +112,7 @@
                     android:layout_alignParentStart="false"
                     android:layout_alignParentLeft="false"
                     app:srcCompat="@drawable/ic_globe_black_24dp"
+                    android:contentDescription="@null"
                     android:layout_centerVertical="true"
                     android:layout_marginLeft="10dp"
                     android:tint="@color/grey_darken_10"/>

--- a/WordPress/src/main/res/layout/endlist_indicator.xml
+++ b/WordPress/src/main/res/layout/endlist_indicator.xml
@@ -25,7 +25,9 @@
         android:layout_gravity="center"
         android:layout_marginLeft="@dimen/margin_medium"
         android:layout_marginRight="@dimen/margin_medium"
-        app:srcCompat="@drawable/ic_wordpress_grey_20dp" />
+        app:srcCompat="@drawable/ic_wordpress_grey_20dp"
+        android:contentDescription="@null"
+        />
 
     <View
         android:layout_width="match_parent"

--- a/WordPress/src/main/res/layout/insert_media_dialog.xml
+++ b/WordPress/src/main/res/layout/insert_media_dialog.xml
@@ -87,6 +87,7 @@
                     android:layout_gravity="center_vertical|right"
                     android:layout_marginRight="@dimen/margin_extra_large"
                     android:tint="@color/grey_darken_10"
+                    android:contentDescription="@null"
                     tools:src="@drawable/gallery_icon_thumbnailgrid" />
             </FrameLayout>
 

--- a/WordPress/src/main/res/layout/invite_username_button.xml
+++ b/WordPress/src/main/res/layout/invite_username_button.xml
@@ -23,5 +23,6 @@
         android:layout_height="wrap_content"
         android:layout_gravity="top"
         android:src="@drawable/ic_cross_grey_600_24dp"
+        android:contentDescription="@string/invite_user_delete_desc"
         android:background="?attr/selectableItemBackgroundBorderless"/>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/media_grid_item.xml
+++ b/WordPress/src/main/res/layout/media_grid_item.xml
@@ -11,6 +11,7 @@
         android:id="@+id/media_grid_item_image"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:contentDescription="@string/media_grid_item_image_desc"
         android:scaleType="centerCrop" />
 
     <RelativeLayout
@@ -34,7 +35,9 @@
                 android:layout_height="24dp"
                 android:layout_gravity="center_horizontal"
                 android:tint="@color/grey_dark"
-                tools:src="@drawable/ic_gridicons_page" />
+                tools:src="@drawable/ic_gridicons_page"
+                android:contentDescription="@null"
+                />
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/media_grid_item_filetype"
@@ -95,6 +98,7 @@
                     android:layout_marginRight="@dimen/margin_medium"
                     android:background="@drawable/media_icon_circle"
                     android:padding="10dp"
+                    android:contentDescription="@string/media_grid_item_retry_desc"
                     app:srcCompat="@drawable/media_retry_image" />
 
                 <ImageView
@@ -105,6 +109,7 @@
                     android:layout_marginRight="@dimen/margin_medium"
                     android:background="@drawable/media_icon_circle"
                     android:padding="10dp"
+                    android:contentDescription="@string/media_grid_item_trash_desc"
                     app:srcCompat="@drawable/ic_trash_white_24dp" />
             </LinearLayout>
 
@@ -164,6 +169,7 @@
             android:layout_width="@dimen/photo_picker_preview_icon"
             android:layout_height="@dimen/photo_picker_preview_icon"
             android:padding="@dimen/margin_extra_small"
+            android:contentDescription="@string/media_grid_item_play_video_desc"
             app:srcCompat="@drawable/ic_play_video" />
 
     </FrameLayout>

--- a/WordPress/src/main/res/layout/media_preview_fragment.xml
+++ b/WordPress/src/main/res/layout/media_preview_fragment.xml
@@ -50,14 +50,16 @@
             android:layout_width="128dp"
             android:layout_height="128dp"
             android:layout_centerInParent="true"
-            app:srcCompat="@drawable/ic_gridicons_audio"/>
+            app:srcCompat="@drawable/ic_gridicons_audio"
+            android:contentDescription="@string/media_preview_audio_desc"/>
 
     </RelativeLayout>
 
     <ImageView
         android:id="@+id/image_preview"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent"
+        android:contentDescription="@string/media_preview_desc"/>
 
     <TextView
         android:id="@+id/text_error"

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -37,6 +37,7 @@
                     android:scaleType="centerCrop"
                     tools:layout_height="224dp"
                     tools:src="@drawable/ic_gridicons_audio"
+                    android:contentDescription="@string/media_settings_image_preview_desc"
                     tools:targetApi="lollipop" />
 
                 <ImageView
@@ -45,6 +46,7 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="top"
                     android:background="@drawable/media_settings_gradient_scrim"
+                    android:contentDescription="@null"
                     tools:layout_height="74dp" />
 
                 <ImageView
@@ -54,6 +56,7 @@
                     android:layout_gravity="center"
                     android:visibility="gone"
                     app:srcCompat="@drawable/play_video_selector_large"
+                    android:contentDescription="@string/media_settings_play"
                     tools:visibility="visible" />
             </FrameLayout>
 

--- a/WordPress/src/main/res/layout/my_profile_dialog.xml
+++ b/WordPress/src/main/res/layout/my_profile_dialog.xml
@@ -14,6 +14,7 @@
         android:layout_marginStart="@dimen/margin_small"
         android:fontFamily="sans-serif-light"
         android:textColor="@color/grey_dark"
+        android:labelFor="@+id/my_profile_dialog_hint"
         android:textSize="@dimen/text_sz_extra_large"
         android:textStyle="bold"/>
 

--- a/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
+++ b/WordPress/src/main/res/layout/new_account_user_fragment_screen.xml
@@ -77,6 +77,7 @@
                     android:layout_centerVertical="true"
                     android:layout_marginLeft="10dp"
                     android:layout_marginStart="10dp"
+                    android:contentDescription="@null"
                     android:tint="@color/grey_darken_10"/>
 
             </RelativeLayout>
@@ -111,6 +112,7 @@
                     android:layout_centerVertical="true"
                     android:layout_marginLeft="10dp"
                     android:layout_marginStart="10dp"
+                    android:contentDescription="@null"
                     android:tint="@color/grey_darken_10"/>
             </RelativeLayout>
 
@@ -144,6 +146,7 @@
                     android:layout_centerVertical="true"
                     android:layout_marginLeft="10dp"
                     android:layout_marginStart="10dp"
+                    android:contentDescription="@null"
                     android:tint="@color/grey_darken_10"/>
 
                 <ImageView
@@ -159,6 +162,7 @@
                     android:layout_centerVertical="true"
                     android:layout_marginRight="16dp"
                     android:layout_marginEnd="16dp"
+                    android:contentDescription="@string/new_account_user_password_visibility_desc"
                     android:tint="@color/nux_eye_icon_color_closed"/>
             </RelativeLayout>
 
@@ -219,6 +223,7 @@
                     android:layout_centerVertical="true"
                     android:layout_marginLeft="10dp"
                     android:layout_marginStart="10dp"
+                    android:contentDescription="@null"
                     android:tint="@color/grey_darken_10"/>
             </RelativeLayout>
 

--- a/WordPress/src/main/res/layout/page_item.xml
+++ b/WordPress/src/main/res/layout/page_item.xml
@@ -83,6 +83,7 @@
                         android:layout_height="16dp"
                         android:layout_gravity="center"
                         android:layout_marginRight="@dimen/margin_small"
+                        android:contentDescription="@null"
                         tools:src="@drawable/ic_gridicons_page"
                         />
 
@@ -110,7 +111,7 @@
                 android:layout_marginLeft="@dimen/margin_medium"
                 android:background="?android:selectableItemBackground"
                 android:padding="@dimen/margin_medium"
-                android:contentDescription="@string/more"
+                android:contentDescription="@string/show_more_desc"
                 app:srcCompat="@drawable/ic_ellipsis_blue_wordpress_32dp" />
         </RelativeLayout>
 

--- a/WordPress/src/main/res/layout/people_invite_fragment.xml
+++ b/WordPress/src/main/res/layout/people_invite_fragment.xml
@@ -97,7 +97,6 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:labelFor="@+id/imgRoleInfo"
                 android:orientation="horizontal">
 
                 <org.wordpress.android.widgets.WPTextView
@@ -108,6 +107,7 @@
                     android:gravity="center_vertical"
                     android:text="@string/role"
                     android:textColor="@color/grey_dark"
+                    android:labelFor="@+id/role"
                     android:textSize="@dimen/text_sz_large"
                     tools:text="@string/role" />
 

--- a/WordPress/src/main/res/layout/people_invite_fragment.xml
+++ b/WordPress/src/main/res/layout/people_invite_fragment.xml
@@ -24,6 +24,7 @@
             android:layout_marginTop="@dimen/margin_large"
             android:text="@string/invite_names_title"
             android:textColor="@color/grey_dark"
+            android:labelFor="@+id/usernames_container"
             android:textSize="@dimen/text_sz_large" />
 
         <LinearLayout
@@ -96,6 +97,7 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:labelFor="@+id/imgRoleInfo"
                 android:orientation="horizontal">
 
                 <org.wordpress.android.widgets.WPTextView
@@ -115,6 +117,7 @@
                     android:layout_height="wrap_content"
                     android:paddingLeft="@dimen/margin_small"
                     android:paddingRight="@dimen/margin_small"
+                    android:contentDescription="@string/people_invite_role_info_desc"
                     app:srcCompat="@drawable/ic_info_black_24dp" />
             </LinearLayout>
 
@@ -141,9 +144,11 @@
             android:layout_marginTop="@dimen/margin_medium"
             android:text="@string/invite_message_title"
             android:textColor="@color/grey_dark"
+            android:labelFor="@+id/message_container"
             android:textSize="@dimen/text_sz_large" />
 
         <RelativeLayout
+            android:id="@+id/message_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"

--- a/WordPress/src/main/res/layout/photo_picker_fragment.xml
+++ b/WordPress/src/main/res/layout/photo_picker_fragment.xml
@@ -42,6 +42,7 @@
             android:layout_width="175dp"
             android:layout_height="140dp"
             android:layout_gravity="center_horizontal"
+            android:contentDescription="@null"
             app:srcCompat="@drawable/ic_soft_ask_media" />
 
         <org.wordpress.android.widgets.WPTextView
@@ -87,6 +88,7 @@
             android:background="?android:selectableItemBackground"
             android:padding="@dimen/margin_medium"
             android:tint="@color/white"
+            android:contentDescription="@string/photo_picker_device_desc"
             app:srcCompat="@drawable/ic_image_white_48dp" />
 
         <ImageView
@@ -97,6 +99,7 @@
             android:background="?android:selectableItemBackground"
             android:padding="@dimen/margin_medium"
             android:tint="@color/white"
+            android:contentDescription="@string/photo_picker_camera_desc"
             app:srcCompat="@drawable/ic_camera_white_48dp" />
 
         <ImageView
@@ -107,6 +110,7 @@
             android:background="?android:selectableItemBackground"
             android:padding="@dimen/margin_medium"
             android:tint="@color/white"
+            android:contentDescription="@string/photo_picker_wpmedia_desc"
             app:srcCompat="@drawable/ic_my_sites_white_50dp" />
     </LinearLayout>
 

--- a/WordPress/src/main/res/layout/photo_picker_thumbnail.xml
+++ b/WordPress/src/main/res/layout/photo_picker_thumbnail.xml
@@ -12,6 +12,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="@drawable/photo_picker_item_background"
+        android:contentDescription="@null"
         android:scaleType="centerCrop" />
 
     <TextView
@@ -37,6 +38,7 @@
         android:padding="@dimen/margin_extra_small"
         android:src="@drawable/play_video_selector"
         android:visibility="gone"
+        android:contentDescription="@string/photo_picker_thumbnail_desc"
         tools:visibility="visible" />
 
 </FrameLayout>

--- a/WordPress/src/main/res/layout/plugin_browser_row.xml
+++ b/WordPress/src/main/res/layout/plugin_browser_row.xml
@@ -58,6 +58,7 @@
                 android:layout_width="12dp"
                 android:layout_height="12dp"
                 android:layout_gravity="center_vertical"
+                android:contentDescription="@null"
                 tools:src="@drawable/plugin_update_available_icon" />
 
             <TextView

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -35,6 +35,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/plugin_banner_size"
                     android:background="@color/grey_lighten_20"
+                    android:contentDescription="@string/plugin_detail_banner_desc"
                     android:scaleType="centerCrop" />
 
                 <ImageView
@@ -42,6 +43,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_gravity="top"
+                    android:contentDescription="@null"
                     android:background="@drawable/media_settings_gradient_scrim"
                     tools:layout_height="74dp" />
             </FrameLayout>
@@ -87,6 +89,7 @@
                             android:layout_width="@dimen/plugin_icon_size"
                             android:layout_height="@dimen/plugin_icon_size"
                             android:layout_centerVertical="true"
+                            android:contentDescription="@string/plugin_detail_logo_desc"
                             tools:src="@drawable/plugin_placeholder" />
 
                         <LinearLayout

--- a/WordPress/src/main/res/layout/plugin_list_row.xml
+++ b/WordPress/src/main/res/layout/plugin_list_row.xml
@@ -72,6 +72,7 @@
             android:layout_width="12dp"
             android:layout_height="12dp"
             android:layout_gravity="center_vertical"
+            android:contentDescription="@null"
             tools:src="@drawable/plugin_update_available_icon" />
 
         <TextView

--- a/WordPress/src/main/res/layout/plugin_ratings_cardview.xml
+++ b/WordPress/src/main/res/layout/plugin_ratings_cardview.xml
@@ -45,6 +45,7 @@
                 style="@style/PluginCardViewSecondaryElement.ExternalLinkImage"
                 android:layout_gravity="center_vertical"
                 android:tint="@color/blue_medium"
+                android:contentDescription="@string/open_external_link_desc"
                 app:srcCompat="@drawable/ic_external_black_24dp" />
         </LinearLayout>
 

--- a/WordPress/src/main/res/layout/popup_menu_item.xml
+++ b/WordPress/src/main/res/layout/popup_menu_item.xml
@@ -13,6 +13,7 @@
         android:layout_height="wrap_content"
         android:layout_marginRight="@dimen/margin_large"
         android:tint="@color/grey_dark"
+        android:contentDescription="@null"
         tools:src="@drawable/ic_trash_blue_wordpress_18dp" />
 
     <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/post_cardview.xml
+++ b/WordPress/src/main/res/layout/post_cardview.xml
@@ -24,6 +24,7 @@
             android:layout_below="@+id/layout_post_header"
             android:scaleType="centerCrop"
             android:visibility="gone"
+            android:contentDescription="@string/post_cardview_featured_desc"
             tools:visibility="visible" />
 
         <org.wordpress.android.widgets.WPTextView
@@ -69,6 +70,7 @@
                 android:layout_height="16dp"
                 android:layout_gravity="center"
                 android:layout_marginRight="@dimen/margin_small"
+                android:contentDescription="@null"
                 tools:src="@drawable/ic_gridicons_cloud_upload"
                 />
 

--- a/WordPress/src/main/res/layout/post_list_button.xml
+++ b/WordPress/src/main/res/layout/post_list_button.xml
@@ -13,6 +13,7 @@
         android:id="@+id/image"
         android:layout_width="16dp"
         android:layout_height="16dp"
+        android:contentDescription="@null"
         android:layout_marginRight="@dimen/margin_extra_small"
         tools:src="@drawable/ic_ellipsis_blue_wordpress_18dp" />
 

--- a/WordPress/src/main/res/layout/post_list_fragment.xml
+++ b/WordPress/src/main/res/layout/post_list_fragment.xml
@@ -23,6 +23,7 @@
             android:layout_width="112dp"
             android:layout_height="86dp"
             android:layout_marginBottom="@dimen/margin_medium"
+            android:contentDescription="@null"
             app:srcCompat="@drawable/penandink_223dp" />
 
         <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/promo_dialog.xml
+++ b/WordPress/src/main/res/layout/promo_dialog.xml
@@ -23,7 +23,8 @@
             android:layout_width="wrap_content"
             android:layout_gravity="center"
             android:background="@color/grey_light"
-            app:srcCompat="@drawable/stats_widget_promo_header" >
+            app:srcCompat="@drawable/stats_widget_promo_header"
+            android:contentDescription="@null">
         </ImageView>
 
     </LinearLayout>

--- a/WordPress/src/main/res/layout/promo_dialog_advanced.xml
+++ b/WordPress/src/main/res/layout/promo_dialog_advanced.xml
@@ -23,6 +23,7 @@
             android:layout_width="wrap_content"
             android:layout_gravity="center"
             android:background="@color/grey_light"
+            android:contentDescription="@null"
             app:srcCompat="@drawable/img_promo_editor" >
         </ImageView>
 

--- a/WordPress/src/main/res/layout/publicize_list_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_list_fragment.xml
@@ -111,6 +111,7 @@
                         android:layout_width="24dp"
                         android:layout_height="24dp"
                         android:layout_gravity="center_vertical"
+                        android:contentDescription="@null"
                         app:srcCompat="@drawable/ic_cog_blue_wordpress_24dp" />
 
                     <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -36,6 +36,7 @@
                 android:id="@+id/image_avatar_or_blavatar"
                 style="@style/ReaderImageView.Avatar"
                 android:layout_marginRight="@dimen/margin_large"
+                android:contentDescription="@string/reader_cardview_post_avatar_desc"
                 app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp" />
 
             <org.wordpress.android.ui.reader.views.ReaderFollowButton
@@ -88,7 +89,8 @@
 
             <org.wordpress.android.widgets.WPNetworkImageView
                 android:id="@+id/image_featured"
-                style="@style/ReaderImageView.Featured.CardView" />
+                style="@style/ReaderImageView.Featured.CardView"
+                android:contentDescription="@string/reader_cardview_post_featured_desc"/>
 
             <org.wordpress.android.widgets.WPTextView
                 android:id="@+id/text_photo_title"
@@ -113,6 +115,7 @@
                 android:layout_height="@dimen/reader_video_overlay_size"
                 android:layout_gravity="center"
                 android:src="@drawable/play_video_selector"
+                android:contentDescription="@string/reader_cardview_post_play_video_desc"
                 android:visibility="gone"
                 tools:visibility="visible" />
         </FrameLayout>
@@ -153,6 +156,7 @@
                 style="@style/ReaderImageView.Avatar.Small"
                 android:layout_marginRight="@dimen/margin_large"
                 android:background="?android:selectableItemBackground"
+                android:contentDescription="@string/reader_cardview_post_discover_avatar_desc"
                 app:srcCompat="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp" />
 
             <org.wordpress.android.widgets.WPTextView
@@ -189,6 +193,7 @@
                     android:layout_marginLeft="-2dp"
                     android:layout_marginRight="@dimen/margin_extra_small"
                     android:background="?android:selectableItemBackground"
+                    android:contentDescription="@null"
                     app:srcCompat="@drawable/reader_visit" />
 
                 <org.wordpress.android.widgets.WPTextView
@@ -230,7 +235,7 @@
                 android:layout_alignParentRight="true"
                 android:layout_centerVertical="true"
                 android:background="?android:selectableItemBackground"
-                android:contentDescription="@string/more"
+                android:contentDescription="@string/show_more_desc"
                 android:paddingBottom="@dimen/margin_medium"
                 android:paddingTop="@dimen/margin_medium"
                 app:srcCompat="@drawable/ic_ellipsis_grey_lighten_10_24dp" />

--- a/WordPress/src/main/res/layout/reader_cardview_post.xml
+++ b/WordPress/src/main/res/layout/reader_cardview_post.xml
@@ -36,7 +36,6 @@
                 android:id="@+id/image_avatar_or_blavatar"
                 style="@style/ReaderImageView.Avatar"
                 android:layout_marginRight="@dimen/margin_large"
-                android:contentDescription="@string/reader_cardview_post_avatar_desc"
                 app:srcCompat="@drawable/ic_placeholder_blavatar_grey_lighten_20_40dp" />
 
             <org.wordpress.android.ui.reader.views.ReaderFollowButton
@@ -156,7 +155,6 @@
                 style="@style/ReaderImageView.Avatar.Small"
                 android:layout_marginRight="@dimen/margin_large"
                 android:background="?android:selectableItemBackground"
-                android:contentDescription="@string/reader_cardview_post_discover_avatar_desc"
                 app:srcCompat="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp" />
 
             <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/reader_empty_view.xml
+++ b/WordPress/src/main/res/layout/reader_empty_view.xml
@@ -23,6 +23,7 @@
             android:layout_width="86dp"
             android:layout_height="54dp"
             android:layout_alignParentBottom="true"
+            android:contentDescription="@null"
             app:srcCompat="@drawable/box_with_pages_bottom" />
 
         <ImageView
@@ -32,6 +33,7 @@
             android:layout_alignParentBottom="true"
             android:layout_alignParentLeft="true"
             android:layout_marginLeft="2dp"
+            android:contentDescription="@null"
             app:srcCompat="@drawable/box_with_pages_page3" />
 
         <ImageView
@@ -42,6 +44,7 @@
             android:layout_alignParentLeft="true"
             android:layout_marginBottom="15dp"
             android:layout_marginLeft="17dp"
+            android:contentDescription="@null"
             app:srcCompat="@drawable/box_with_pages_page2" />
 
         <ImageView
@@ -51,6 +54,7 @@
             android:layout_alignParentBottom="true"
             android:layout_alignParentLeft="true"
             android:layout_marginLeft="28dp"
+            android:contentDescription="@null"
             app:srcCompat="@drawable/box_with_pages_page1" />
 
         <ImageView
@@ -58,6 +62,7 @@
             android:layout_width="86dp"
             android:layout_height="54dp"
             android:layout_alignParentBottom="true"
+            android:contentDescription="@null"
             app:srcCompat="@drawable/box_with_pages_top" />
     </RelativeLayout>
 

--- a/WordPress/src/main/res/layout/reader_follow_button.xml
+++ b/WordPress/src/main/res/layout/reader_follow_button.xml
@@ -12,6 +12,7 @@
         android:layout_width="@dimen/reader_follow_icon"
         android:layout_height="@dimen/reader_follow_icon"
         android:layout_gravity="center_vertical"
+        android:contentDescription="@null"
         app:srcCompat="@drawable/ic_reader_follow_blue_medium_24dp" />
 
     <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/reader_gap_marker_view.xml
+++ b/WordPress/src/main/res/layout/reader_gap_marker_view.xml
@@ -10,6 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_centerVertical="true"
+        android:contentDescription="@null"
         android:background="@drawable/reader_tear_repeat" />
 
     <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/reader_icon_count_view.xml
+++ b/WordPress/src/main/res/layout/reader_icon_count_view.xml
@@ -11,6 +11,7 @@
         android:layout_width="@dimen/reader_count_icon"
         android:layout_height="@dimen/reader_count_icon"
         android:layout_gravity="center_vertical"
+        android:contentDescription="@null"
         tools:src="@drawable/reader_button_comment" />
 
     <TextView

--- a/WordPress/src/main/res/layout/reader_include_comment_box.xml
+++ b/WordPress/src/main/res/layout/reader_include_comment_box.xml
@@ -30,6 +30,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
             android:layout_marginLeft="@dimen/content_margin"
+            android:contentDescription="@null"
             app:srcCompat="@drawable/ic_reply_grey_24dp" />
 
         <org.wordpress.android.widgets.SuggestionAutoCompleteText

--- a/WordPress/src/main/res/layout/reader_listitem_comment.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_comment.xml
@@ -39,6 +39,7 @@
                 android:layout_width="@dimen/avatar_sz_extra_small"
                 android:layout_height="@dimen/avatar_sz_extra_small"
                 android:layout_marginRight="@dimen/margin_small"
+                android:contentDescription="@string/reader_listitem_comment_avatar_desc"
                 tools:src="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp" />
 
             <org.wordpress.android.widgets.WPTextView
@@ -101,6 +102,7 @@
                     android:layout_height="@dimen/reader_button_icon"
                     android:layout_gravity="center_vertical"
                     android:padding="@dimen/margin_extra_small"
+                    android:contentDescription="@null"
                     app:srcCompat="@drawable/ic_reply_grey_24dp" />
 
                 <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/reader_listitem_comment.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_comment.xml
@@ -39,7 +39,6 @@
                 android:layout_width="@dimen/avatar_sz_extra_small"
                 android:layout_height="@dimen/avatar_sz_extra_small"
                 android:layout_marginRight="@dimen/margin_small"
-                android:contentDescription="@string/reader_listitem_comment_avatar_desc"
                 tools:src="@drawable/ic_placeholder_gravatar_grey_lighten_20_100dp" />
 
             <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/reader_listitem_suggestion.xml
+++ b/WordPress/src/main/res/layout/reader_listitem_suggestion.xml
@@ -31,6 +31,7 @@
         android:layout_centerVertical="true"
         android:layout_marginLeft="@dimen/margin_small"
         android:background="?android:selectableItemBackground"
+        android:contentDescription="@string/reader_list_item_suggestion_remove_desc"
         android:padding="@dimen/margin_small"
         android:src="@drawable/ic_cross_grey_600_24dp" />
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/reader_photo_view.xml
+++ b/WordPress/src/main/res/layout/reader_photo_view.xml
@@ -8,7 +8,8 @@
     <ImageView
         android:id="@+id/image_photo"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:contentDescription="@string/reader_photo_view_desc"/>
 
     <org.wordpress.android.widgets.WPTextView
         android:id="@+id/text_error"

--- a/WordPress/src/main/res/layout/reader_popup_menu_item.xml
+++ b/WordPress/src/main/res/layout/reader_popup_menu_item.xml
@@ -12,6 +12,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginRight="@dimen/margin_large"
+        android:contentDescription="@null"
         tools:src="@drawable/ic_reader_following_alert_green_24dp" />
 
     <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/signin_dialog_fragment.xml
+++ b/WordPress/src/main/res/layout/signin_dialog_fragment.xml
@@ -22,6 +22,7 @@
             android:layout_height="52dp"
             app:srcCompat="@drawable/ic_my_sites_white_50dp"
             android:tint="@color/white"
+            android:contentDescription="@string/sign_in_dialog_logo_desc"
             android:layout_marginBottom="16dp"/>
 
         <org.wordpress.android.widgets.WPTextView

--- a/WordPress/src/main/res/layout/signin_fragment.xml
+++ b/WordPress/src/main/res/layout/signin_fragment.xml
@@ -65,6 +65,7 @@
                         android:layout_height="72dp"
                         android:layout_width="wrap_content"
                         android:scaleType="fitCenter"
+                        android:contentDescription="@string/sign_in_logo_desc"
                         app:srcCompat="@drawable/img_wordpress_com_white_144dp" >
                     </ImageView>
 
@@ -73,6 +74,7 @@
                         android:layout_height="50dp"
                         android:layout_width="50dp"
                         android:scaleType="fitCenter"
+                        android:contentDescription="@null"
                         app:srcCompat="@drawable/img_wordpress_org_blue_wordpress_50dp" >
                     </ImageView>
 
@@ -134,6 +136,7 @@
                     android:layout_gravity="center_horizontal"
                     android:layout_marginLeft="10dp"
                     android:layout_marginStart="10dp"
+                    android:contentDescription="@null"
                     app:srcCompat="@drawable/ic_user_black_24dp"
                     android:tint="@color/grey_darken_10" />
             </RelativeLayout>
@@ -167,6 +170,7 @@
                     android:layout_gravity="center_horizontal"
                     android:layout_marginLeft="10dp"
                     android:layout_marginStart="10dp"
+                    android:contentDescription="@null"
                     app:srcCompat="@drawable/ic_lock_black_24dp"
                     android:tint="@color/grey_darken_10" />
 
@@ -182,6 +186,7 @@
                     android:layout_gravity="center_horizontal"
                     android:layout_marginRight="16dp"
                     android:layout_marginEnd="16dp"
+                    android:contentDescription="@string/sign_in_password_visibility_desc"
                     app:srcCompat="@drawable/ic_visible_off_black_24dp"
                     android:tint="@color/nux_eye_icon_color_closed" />
             </RelativeLayout>
@@ -235,6 +240,7 @@
                     android:layout_gravity="center_horizontal"
                     android:layout_marginLeft="10dp"
                     android:layout_marginStart="10dp"
+                    android:contentDescription="@null"
                     app:srcCompat="@drawable/ic_globe_black_24dp"
                     android:tint="@color/grey_darken_10" />
             </RelativeLayout>

--- a/WordPress/src/main/res/layout/start_over_preference.xml
+++ b/WordPress/src/main/res/layout/start_over_preference.xml
@@ -23,6 +23,7 @@
             android:layout_height="@dimen/start_over_icon_size"
             android:layout_marginRight="@dimen/start_over_icon_margin_right"
             android:padding="@dimen/start_over_icon_padding"
+            android:contentDescription="@null"
             android:layout_gravity="center_vertical"
             android:tint="@color/grey_darken_30"/>
 

--- a/WordPress/src/main/res/layout/stats_insights_all_time_item.xml
+++ b/WordPress/src/main/res/layout/stats_insights_all_time_item.xml
@@ -34,6 +34,7 @@
                     android:layout_height="12dp"
                     android:layout_marginRight="3dp"
                     android:layout_marginEnd="3dp"
+                    android:contentDescription="@null"
                     app:srcCompat="@drawable/ic_posts_grey_dark_24dp" />
 
                 <org.wordpress.android.util.widgets.AutoResizeTextView
@@ -79,6 +80,7 @@
                     android:layout_height="12dp"
                     android:layout_marginRight="3dp"
                     android:layout_marginEnd="3dp"
+                    android:contentDescription="@null"
                     app:srcCompat="@drawable/ic_visible_on_grey_dark_12dp" />
 
                 <org.wordpress.android.util.widgets.AutoResizeTextView
@@ -131,6 +133,7 @@
                     android:layout_height="12dp"
                     android:layout_marginRight="3dp"
                     android:layout_marginEnd="3dp"
+                    android:contentDescription="@null"
                     app:srcCompat="@drawable/ic_user_grey_dark_12dp" />
 
                 <org.wordpress.android.util.widgets.AutoResizeTextView
@@ -176,6 +179,7 @@
                     android:layout_height="12dp"
                     android:layout_marginRight="3dp"
                     android:layout_marginEnd="3dp"
+                    android:contentDescription="@null"
                     app:srcCompat="@drawable/ic_trophy_alert_yellow_32dp" />
 
                 <org.wordpress.android.util.widgets.AutoResizeTextView

--- a/WordPress/src/main/res/layout/stats_jetpack_connection_activity.xml
+++ b/WordPress/src/main/res/layout/stats_jetpack_connection_activity.xml
@@ -29,6 +29,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/margin_extra_large"
+                    android:contentDescription="@null"
                     app:srcCompat="@drawable/jetpack_connection" />
 
                 <TextView

--- a/WordPress/src/main/res/layout/stats_list_cell.xml
+++ b/WordPress/src/main/res/layout/stats_list_cell.xml
@@ -25,6 +25,7 @@
             android:layout_marginRight="10dp"
             android:layout_marginEnd="10dp"
             android:visibility="gone"
+            android:contentDescription="@string/open_external_link_desc"
             app:srcCompat="@drawable/ic_external_blue_wordpress_18dp" />
 
         <ImageView
@@ -34,6 +35,7 @@
             android:layout_marginRight="@dimen/margin_large"
             android:layout_marginEnd="@dimen/margin_large"
             android:visibility="gone"
+            android:contentDescription="@string/stats_list_cell_chevron_desc"
             app:srcCompat="@drawable/ic_chevron_right_blue_wordpress_24dp" />
 
         <org.wordpress.android.widgets.WPNetworkImageView
@@ -42,6 +44,7 @@
             android:layout_height="@dimen/avatar_sz_small"
             android:layout_marginRight="@dimen/margin_large"
             android:layout_marginEnd="@dimen/margin_large"
+            android:contentDescription="@null"
             android:visibility="gone" />
 
         <!-- Alternative to the Network image view above, can be used to display emojis (flags for instance) -->
@@ -84,7 +87,7 @@
             android:background="?android:selectableItemBackground"
             android:paddingLeft="@dimen/margin_small"
             android:paddingRight="@dimen/margin_small"
-            android:contentDescription="@string/more"
+            android:contentDescription="@string/show_more_desc"
             app:srcCompat="@drawable/ic_ellipsis_blue_wordpress_32dp" />
 
         <LinearLayout

--- a/WordPress/src/main/res/layout/stats_visitors_and_views_fragment.xml
+++ b/WordPress/src/main/res/layout/stats_visitors_and_views_fragment.xml
@@ -87,6 +87,7 @@
                     android:layout_width="24dp"
                     android:layout_height="24dp"
                     app:srcCompat="@drawable/ic_info_grey_800_32dp"
+                    android:contentDescription="@null"
                     android:paddingEnd="@dimen/margin_medium"
                     android:paddingRight="@dimen/margin_medium"/>
                 <TextView

--- a/WordPress/src/main/res/layout/stats_visitors_and_views_tab.xml
+++ b/WordPress/src/main/res/layout/stats_visitors_and_views_tab.xml
@@ -29,6 +29,7 @@
                 android:layout_height="12dp"
                 android:layout_marginRight="3dp"
                 android:layout_marginEnd="3dp"
+                android:contentDescription="@null"
                 app:srcCompat="@drawable/ic_star_white_48dp" />
 
             <org.wordpress.android.util.widgets.AutoResizeTextView

--- a/WordPress/src/main/res/layout/stats_widget_layout.xml
+++ b/WordPress/src/main/res/layout/stats_widget_layout.xml
@@ -20,7 +20,8 @@
         <ImageView
             android:layout_width="@dimen/stats_widget_icon_size"
             android:layout_height="@dimen/stats_widget_icon_size"
-            app:srcCompat="@drawable/ic_my_sites_white_32dp" />
+            app:srcCompat="@drawable/ic_my_sites_white_32dp"
+            android:contentDescription="@null"/>
 
         <TextView
             android:id="@+id/blog_title"
@@ -72,6 +73,7 @@
                     android:layout_height="@dimen/stats_widget_image_layout_size"
                     android:layout_marginRight="@dimen/stats_widget_image_layout_margin"
                     android:layout_marginEnd="@dimen/stats_widget_image_layout_margin"
+                    android:contentDescription="@null"
                     app:srcCompat="@drawable/ic_visible_on_grey_dark_12dp" />
 
                 <TextView
@@ -118,6 +120,7 @@
                     android:layout_height="@dimen/stats_widget_image_layout_size"
                     android:layout_marginRight="@dimen/stats_widget_image_layout_margin"
                     android:layout_marginEnd="@dimen/stats_widget_image_layout_margin"
+                    android:contentDescription="@null"
                     app:srcCompat="@drawable/ic_user_grey_dark_12dp" />
 
                 <TextView
@@ -164,6 +167,7 @@
                     android:layout_height="@dimen/stats_widget_image_layout_size"
                     android:layout_marginRight="@dimen/stats_widget_image_layout_margin"
                     android:layout_marginEnd="@dimen/stats_widget_image_layout_margin"
+                    android:contentDescription="@null"
                     app:srcCompat="@drawable/ic_star_grey_dark_12dp" />
 
                 <TextView
@@ -210,6 +214,7 @@
                     android:layout_height="@dimen/stats_widget_image_layout_size"
                     android:layout_marginRight="@dimen/stats_widget_image_layout_margin"
                     android:layout_marginEnd="@dimen/stats_widget_image_layout_margin"
+                    android:contentDescription="@null"
                     app:srcCompat="@drawable/ic_comment_grey_dark_12dp" />
 
                 <TextView

--- a/WordPress/src/main/res/layout/tab_icon.xml
+++ b/WordPress/src/main/res/layout/tab_icon.xml
@@ -16,6 +16,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
+        tools:ignore="ContentDescription"
         tools:src="@drawable/main_tab_notifications" />
 
     <View

--- a/WordPress/src/main/res/layout/toolbar_login.xml
+++ b/WordPress/src/main/res/layout/toolbar_login.xml
@@ -17,5 +17,6 @@
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:layout_gravity="center"
+        android:contentDescription="@string/toolbar_login_logo_desc"
         app:srcCompat="@drawable/ic_my_sites_white_32dp"/>
 </android.support.v7.widget.Toolbar>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2107,7 +2107,6 @@
     <string name="notification_login_failed">An error has occurred.</string>
     <string name="change_photo">Change photo</string>
 
-    <string name="comment_avatar_desc">avatar</string>
     <string name="comment_checkmark_desc">check mark</string>
     <string name="invite_user_delete_desc">remove user</string>
     <string name="media_grid_item_image_desc">media preview</string>
@@ -2126,12 +2125,9 @@
     <string name="plugin_detail_banner_desc">plugin banner</string>
     <string name="plugin_detail_logo_desc">plugin logo</string>
     <string name="post_cardview_featured_desc">featured</string>
-    <string name="reader_cardview_post_avatar_desc">user avatar</string>
     <string name="reader_cardview_post_featured_desc">featured</string>
     <string name="reader_cardview_post_play_video_desc">play featured video</string>
-    <string name="reader_cardview_post_discover_avatar_desc">avatar</string>
     <string name="photo_picker_thumbnail_desc">Play video</string>
-    <string name="reader_listitem_comment_avatar_desc">avatar</string>
     <string name="reader_list_item_suggestion_remove_desc">delete</string>
     <string name="reader_photo_view_desc">photo</string>
     <string name="sign_in_dialog_logo_desc">WordPress logo</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2107,6 +2107,7 @@
     <string name="notification_login_failed">An error has occurred.</string>
     <string name="change_photo">Change photo</string>
 
+    <!-- ImageView content description  -->
     <string name="comment_checkmark_desc">check mark</string>
     <string name="invite_user_delete_desc">remove user</string>
     <string name="media_grid_item_image_desc">media preview</string>
@@ -2135,6 +2136,6 @@
     <string name="sign_in_password_visibility_desc">change password visibility</string>
     <string name="stats_list_cell_chevron_desc">expand</string>
     <string name="show_more_desc">show more</string>
-    <string name="open_external_link_desc">sopen external link</string>
+    <string name="open_external_link_desc">open external link</string>
 
 </resources>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2107,4 +2107,38 @@
     <string name="notification_login_failed">An error has occurred.</string>
     <string name="change_photo">Change photo</string>
 
+    <string name="comment_avatar_desc">avatar</string>
+    <string name="comment_checkmark_desc">check mark</string>
+    <string name="invite_user_delete_desc">remove user</string>
+    <string name="media_grid_item_image_desc">media preview</string>
+    <string name="media_grid_item_retry_desc">retry</string>
+    <string name="media_grid_item_trash_desc">trash</string>
+    <string name="media_grid_item_play_video_desc">play video</string>
+    <string name="media_preview_audio_desc">audio</string>
+    <string name="media_preview_desc">preview</string>
+    <string name="media_settings_image_preview_desc">image preview</string>
+    <string name="media_settings_play">play</string>
+    <string name="new_account_user_password_visibility_desc">change password visibility</string>
+    <string name="people_invite_role_info_desc">role info</string>
+    <string name="photo_picker_device_desc">pick from device</string>
+    <string name="photo_picker_camera_desc">open camera</string>
+    <string name="photo_picker_wpmedia_desc">pick from WordPress media</string>
+    <string name="plugin_detail_banner_desc">plugin banner</string>
+    <string name="plugin_detail_logo_desc">plugin logo</string>
+    <string name="post_cardview_featured_desc">featured</string>
+    <string name="reader_cardview_post_avatar_desc">user avatar</string>
+    <string name="reader_cardview_post_featured_desc">featured</string>
+    <string name="reader_cardview_post_play_video_desc">play featured video</string>
+    <string name="reader_cardview_post_discover_avatar_desc">avatar</string>
+    <string name="photo_picker_thumbnail_desc">Play video</string>
+    <string name="reader_listitem_comment_avatar_desc">avatar</string>
+    <string name="reader_list_item_suggestion_remove_desc">delete</string>
+    <string name="reader_photo_view_desc">photo</string>
+    <string name="sign_in_dialog_logo_desc">WordPress logo</string>
+    <string name="sign_in_logo_desc">WordPress logo</string>
+    <string name="sign_in_password_visibility_desc">change password visibility</string>
+    <string name="stats_list_cell_chevron_desc">expand</string>
+    <string name="show_more_desc">show more</string>
+    <string name="open_external_link_desc">sopen external link</string>
+
 </resources>

--- a/libs/login/WordPressLoginFlow/src/main/res/layout/toolbar_login.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/layout/toolbar_login.xml
@@ -17,5 +17,6 @@
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:layout_gravity="center"
+        android:contentDescription="@string/toolbar_login_logo_desc"
         app:srcCompat="@drawable/ic_my_sites_white_32dp"/>
 </android.support.v7.widget.Toolbar>

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -109,4 +109,5 @@
 
     <!-- Image Descriptions for Accessibility -->
     <string name="login_site_address_help_image">The site address can be found in the navigation bar of your web browser</string>
+    <string name="toolbar_login_logo_desc">WordPress logo</string>
 </resources>


### PR DESCRIPTION
Fixes the missing contentDescription lint issues.

This PR is not production ready. It's a first phase of improving accessibility in the app. 

Note: We might consider adding `missing contentDescription` lint check for `WPNetworkImageView`. However most of the `WPNetworkImage` views display an avatar and I'm not sure whether the TalkBack should say "avatar" or skip the element.

