### PR TITLE
Use jetpack settings for comment likes

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/JetpackSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/JetpackSettingsModel.java
@@ -18,6 +18,7 @@ public class JetpackSettingsModel {
     public boolean ssoRequireTwoFactor;
     public boolean serveImagesFromOurServers;
     public boolean lazyLoadImages;
+    public boolean commentLikes;
 
     public JetpackSettingsModel() {
         super();
@@ -37,6 +38,7 @@ public class JetpackSettingsModel {
         ssoActive = other.ssoActive;
         ssoMatchEmail = other.ssoMatchEmail;
         ssoRequireTwoFactor = other.ssoRequireTwoFactor;
+        commentLikes = other.commentLikes;
         jetpackProtectWhitelist.addAll(other.jetpackProtectWhitelist);
         serveImagesFromOurServers = other.serveImagesFromOurServers;
         lazyLoadImages = other.lazyLoadImages;
@@ -55,6 +57,7 @@ public class JetpackSettingsModel {
                 ssoRequireTwoFactor == otherModel.ssoRequireTwoFactor &&
                 serveImagesFromOurServers == otherModel.serveImagesFromOurServers &&
                 lazyLoadImages == otherModel.lazyLoadImages &&
+                commentLikes == otherModel.commentLikes &&
                 whitelistMatches(otherModel.jetpackProtectWhitelist);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -241,6 +241,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
                 mRemoteJpSettings.ssoActive = data.optBoolean("sso", false);
                 mRemoteJpSettings.ssoMatchEmail = data.optBoolean("jetpack_sso_match_by_email", false);
                 mRemoteJpSettings.ssoRequireTwoFactor = data.optBoolean("jetpack_sso_require_two_step", false);
+                mRemoteJpSettings.commentLikes = data.optBoolean("comment-likes", false);
 
                 JSONObject jetpackProtectWhitelist = data.optJSONObject("jetpack_protect_global_whitelist");
                 if (jetpackProtectWhitelist != null) {
@@ -265,6 +266,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
                 mJpSettings.ssoActive = mRemoteJpSettings.ssoActive;
                 mJpSettings.ssoMatchEmail = mRemoteJpSettings.ssoMatchEmail;
                 mJpSettings.ssoRequireTwoFactor = mRemoteJpSettings.ssoRequireTwoFactor;
+                mJpSettings.commentLikes = mRemoteJpSettings.commentLikes;
                 onFetchResponseReceived(null);
             }
         }, new RestRequest.ErrorListener() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -73,6 +73,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
     private static final String POSTS_PER_PAGE_KEY = "posts_per_page";
     private static final String AMP_SUPPORTED_KEY = "amp_is_supported";
     private static final String AMP_ENABLED_KEY = "amp_is_enabled";
+    private static final String COMMENT_LIKES = "comment-likes";
 
     // WP.com REST keys used to GET certain site settings
     private static final String GET_TITLE_KEY = "name";
@@ -241,7 +242,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
                 mRemoteJpSettings.ssoActive = data.optBoolean("sso", false);
                 mRemoteJpSettings.ssoMatchEmail = data.optBoolean("jetpack_sso_match_by_email", false);
                 mRemoteJpSettings.ssoRequireTwoFactor = data.optBoolean("jetpack_sso_require_two_step", false);
-                mRemoteJpSettings.commentLikes = data.optBoolean("comment-likes", false);
+                mRemoteJpSettings.commentLikes = data.optBoolean(COMMENT_LIKES, false);
 
                 JSONObject jetpackProtectWhitelist = data.optJSONObject("jetpack_protect_global_whitelist");
                 if (jetpackProtectWhitelist != null) {
@@ -415,6 +416,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
                         mRemoteJpSettings.ssoActive = sentJpData.ssoActive;
                         mRemoteJpSettings.ssoMatchEmail = sentJpData.ssoMatchEmail;
                         mRemoteJpSettings.ssoRequireTwoFactor = sentJpData.ssoRequireTwoFactor;
+                        mRemoteJpSettings.commentLikes = sentJpData.commentLikes;
                         onSaveResponseReceived(null);
                     }
                 }, new RestRequest.ErrorListener() {
@@ -799,6 +801,9 @@ class DotComSiteSettings extends SiteSettingsInterface {
         }
         if (mJpSettings.ssoRequireTwoFactor != mRemoteJpSettings.ssoRequireTwoFactor) {
             params.put("jetpack_sso_require_two_step", mJpSettings.ssoRequireTwoFactor);
+        }
+        if (mJpSettings.commentLikes != mRemoteJpSettings.commentLikes) {
+            params.put(COMMENT_LIKES, mJpSettings.commentLikes);
         }
         return params;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -539,7 +539,7 @@ public abstract class SiteSettingsInterface {
     }
 
     public boolean getAllowCommentLikes() {
-        return mSettings.allowCommentLikes;
+        return mJpSettings.commentLikes;
     }
 
     public @NonNull String getTwitterUsername() {
@@ -823,6 +823,7 @@ public abstract class SiteSettingsInterface {
 
     public void setAllowCommentLikes(boolean allowCommentLikes) {
         mSettings.allowCommentLikes = allowCommentLikes;
+        mJpSettings.commentLikes = allowCommentLikes;
     }
 
     public void setTwitterUsername(String twitterUsername) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -539,7 +539,8 @@ public abstract class SiteSettingsInterface {
     }
 
     public boolean getAllowCommentLikes() {
-        return mJpSettings.commentLikes;
+        //We have different settings for comment likes for dotcom and Jetpack sites
+        return mSite.isJetpackConnected() ? mJpSettings.commentLikes : mSettings.allowCommentLikes;
     }
 
     public @NonNull String getTwitterUsername() {
@@ -822,8 +823,12 @@ public abstract class SiteSettingsInterface {
     }
 
     public void setAllowCommentLikes(boolean allowCommentLikes) {
-        mSettings.allowCommentLikes = allowCommentLikes;
-        mJpSettings.commentLikes = allowCommentLikes;
+        //We have different settings for comment likes for dotcom and Jetpack sites
+        if (mSite.isJetpackConnected()) {
+            mJpSettings.commentLikes = allowCommentLikes;
+        } else {
+            mSettings.allowCommentLikes = allowCommentLikes;
+        }
     }
 
     public void setTwitterUsername(String twitterUsername) {


### PR DESCRIPTION
Fixes #7161
We have 2 different settings for enabling Comment likes. One is for WordPress.com sites and one for Jetpack sites. The current setting in the app was only working for WordPress.com sites. After the fix we are syncing both the setting for both site types and only showing/letting user set the right one based on the site type. There is no UI change.

To test - WordPress.com site - watch network requests:
* Connect with WordPress.com site
* Go to Sharing > Manage > Likes
  * Check that Comment Likes state is the same as in Calypso > Sharing > Options > Comment Likes
  * Set the value
  * There is a POST request to `../v1.1/sites/<siteId>/settings` with value `jetpack_comment_likes_enabled` being sent
* Go back to the Site page
* Go to Sharing > Manage > Likes and check that the value of `Comment Likes` is correct

To test - Jetpack site - watch network requests:
* Connect with WordPress.com site
* Go to Sharing > Manage > Likes
  * Check that Comment Likes state is the same as in Calypso > Settings > Discussion > Enable Comment Likes
  * Set the value
  * There is a POST request to `../jetpack-blogs/<siteId>/rest-api` with value `comment-likes` being sent
* Go back to the Site page
* Go to Sharing > Manage > Likes and check that the value of `Comment Likes` is correct
