### PR TITLE
Don't promote to foreground if null state

### DIFF
--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -31,7 +31,7 @@ android {
 }
 
 dependencies {
-    implementation ('org.wordpress:utils:1.20.0-beta6') {
+    implementation ('org.wordpress:utils:1.20.0-beta7') {
         exclude group: "com.mcxiaoke.volley"
     }
 

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -33,7 +33,7 @@ android {
     buildToolsVersion '26.0.2'
 
     defaultConfig {
-        versionName "1.20.0-beta6"
+        versionName "1.20.0-beta7"
         minSdkVersion 15
         targetSdkVersion 25
     }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AutoForeground.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AutoForeground.java
@@ -120,7 +120,10 @@ public abstract class AutoForeground<StateClass extends ServiceState>
     @Override
     public boolean onUnbind(Intent intent) {
         if (!hasConnectedClients()) {
-            promoteForeground();
+            final StateClass state = getState();
+            if (state != null && state.isInProgress()) {
+                promoteForeground(state);
+            }
         }
 
         return true; // call onRebind() if new clients connect
@@ -140,12 +143,9 @@ public abstract class AutoForeground<StateClass extends ServiceState>
         return getEventBus().hasSubscriberForEvent(mStateClass);
     }
 
-    private void promoteForeground() {
-        final StateClass state = getState();
-        if (state.isInProgress()) {
-            startForeground(NOTIFICATION_ID_PROGRESS, getNotification(state));
-            mIsForeground = true;
-        }
+    private void promoteForeground(StateClass currentState) {
+        startForeground(NOTIFICATION_ID_PROGRESS, getNotification(currentState));
+        mIsForeground = true;
     }
 
     private void background() {


### PR DESCRIPTION
Fixes #7266 

To test:
1. With the app data cleared, launch the app
2. Try to login to WPCOM using an account that has 2FA enabled
3. Use your email and choose to enter a password instead of magiclink
4. After entering your password and hitting Next, some time goes by and the 2FA screen comes up normally
