### PR TITLE
Handle plugin change events in PluginBrowserViewModel

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -182,13 +182,13 @@ public class ActivityLauncher {
         }
     }
 
-    public static void viewPluginDetailForResult(Activity context, SiteModel site, String slug) {
+    public static void viewPluginDetail(Activity context, SiteModel site, String slug) {
         if (PluginUtils.isPluginFeatureAvailable(site)) {
             AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.OPENED_PLUGIN_DETAIL, site);
             Intent intent = new Intent(context, PluginDetailActivity.class);
             intent.putExtra(WordPress.SITE, site);
             intent.putExtra(PluginDetailActivity.KEY_PLUGIN_SLUG, slug);
-            context.startActivityForResult(intent, RequestCodes.PLUGIN_DETAIL);
+            context.startActivity(intent);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/RequestCodes.java
@@ -33,6 +33,4 @@ public class RequestCodes {
     // Jetpack
     public static final int REQUEST_JETPACK = 3000;
     public static final int JETPACK_LOGIN = 3100;
-    public static final int PLUGIN_DETAIL = 3200;
-
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -4,7 +4,6 @@ import android.arch.lifecycle.Observer;
 import android.arch.lifecycle.ViewModelProvider;
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Context;
-import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DrawableRes;
@@ -35,7 +34,6 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.plugin.ImmutablePluginModel;
 import org.wordpress.android.ui.ActivityLauncher;
-import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.ToastUtils;
@@ -181,15 +179,6 @@ public class PluginBrowserActivity extends AppCompatActivity
                 }
             }
         });
-
-        mViewModel.getLastUpdatedWpOrgPluginSlug().observe(this, new Observer<String>() {
-            @Override
-            public void onChanged(@Nullable String slug) {
-                if (!TextUtils.isEmpty(slug)) {
-                    reloadPluginWithSlug(slug);
-                }
-            }
-        });
     }
 
     private void configureRecycler(@NonNull RecyclerView recycler) {
@@ -236,14 +225,6 @@ public class PluginBrowserActivity extends AppCompatActivity
         return super.onOptionsItemSelected(item);
     }
 
-    @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        if (requestCode == RequestCodes.PLUGIN_DETAIL) {
-            mViewModel.reloadAllPluginsFromStore();
-        }
-    }
-
     protected void reloadPluginAdapterAndVisibility(@NonNull PluginListType pluginType,
                                                     @Nullable List<ImmutablePluginModel> plugins) {
         PluginBrowserAdapter adapter;
@@ -273,12 +254,6 @@ public class PluginBrowserActivity extends AppCompatActivity
         } else if (newVisibility != View.VISIBLE && oldVisibility == View.VISIBLE) {
             AniUtils.fadeOut(cardView, AniUtils.Duration.MEDIUM);
         }
-    }
-
-    protected void reloadPluginWithSlug(@NonNull String slug) {
-        ((PluginBrowserAdapter) mSitePluginsRecycler.getAdapter()).reloadPluginWithSlug(slug);
-        ((PluginBrowserAdapter) mPopularPluginsRecycler.getAdapter()).reloadPluginWithSlug(slug);
-        ((PluginBrowserAdapter) mNewPluginsRecycler.getAdapter()).reloadPluginWithSlug(slug);
     }
 
     @Override
@@ -405,13 +380,6 @@ public class PluginBrowserActivity extends AppCompatActivity
             }
         }
 
-        void reloadPluginWithSlug(@NonNull String slug) {
-            int index = mItems.indexOfPluginWithSlug(slug);
-            if (index != -1) {
-                notifyItemChanged(index);
-            }
-        }
-
         private class PluginBrowserViewHolder extends ViewHolder {
             final TextView nameText;
             final TextView authorText;
@@ -439,7 +407,7 @@ public class PluginBrowserActivity extends AppCompatActivity
                         ImmutablePluginModel plugin = (ImmutablePluginModel) getItem(position);
                         if (plugin == null) return;
 
-                        ActivityLauncher.viewPluginDetailForResult(PluginBrowserActivity.this, mViewModel.getSite(),
+                        ActivityLauncher.viewPluginDetail(PluginBrowserActivity.this, mViewModel.getSite(),
                                 plugin.getSlug());
                     }
                 });

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -740,7 +740,8 @@ public class PluginDetailActivity extends AppCompatActivity {
         }
         mIsConfiguringPlugin = true;
         mDispatcher.dispatch(PluginActionBuilder.newConfigureSitePluginAction(
-                new ConfigureSitePluginPayload(mSite, mPlugin.getName(), mIsActive, mIsAutoUpdateEnabled)));
+                new ConfigureSitePluginPayload(mSite, mPlugin.getName(), mPlugin.getSlug(),
+                        mIsActive, mIsAutoUpdateEnabled)));
     }
 
     protected void dispatchUpdatePluginAction() {
@@ -753,7 +754,7 @@ public class PluginDetailActivity extends AppCompatActivity {
 
         mIsUpdatingPlugin = true;
         refreshUpdateVersionViews();
-        UpdateSitePluginPayload payload = new UpdateSitePluginPayload(mSite, mPlugin.getName());
+        UpdateSitePluginPayload payload = new UpdateSitePluginPayload(mSite, mPlugin.getName(), mPlugin.getSlug());
         mDispatcher.dispatch(PluginActionBuilder.newUpdateSitePluginAction(payload));
     }
 
@@ -773,7 +774,7 @@ public class PluginDetailActivity extends AppCompatActivity {
             return;
         }
         mRemovePluginProgressDialog.setMessage(getRemovingPluginMessage());
-        DeleteSitePluginPayload payload = new DeleteSitePluginPayload(mSite, mSlug, mPlugin.getName());
+        DeleteSitePluginPayload payload = new DeleteSitePluginPayload(mSite, mPlugin.getName(), mSlug);
         mDispatcher.dispatch(PluginActionBuilder.newDeleteSitePluginAction(payload));
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginList.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginList.java
@@ -8,18 +8,6 @@ import org.wordpress.android.fluxc.model.plugin.ImmutablePluginModel;
 import java.util.ArrayList;
 
 class PluginList extends ArrayList<ImmutablePluginModel> {
-    int indexOfPluginWithSlug(@Nullable String slug) {
-        if (slug != null) {
-            for (int i = 0; i < this.size(); i++) {
-                ImmutablePluginModel item = this.get(i);
-                if (slug.equalsIgnoreCase(item.getSlug())) {
-                    return i;
-                }
-            }
-        }
-        return -1;
-    }
-
     long getItemId(int position) {
         ImmutablePluginModel plugin = (ImmutablePluginModel) getItem(position);
         if (plugin == null || TextUtils.isEmpty(plugin.getSlug())) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
@@ -14,7 +14,6 @@ import android.support.annotation.StringRes;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -161,15 +160,6 @@ public class PluginListFragment extends Fragment {
                 }
             }
         });
-
-        mViewModel.getLastUpdatedWpOrgPluginSlug().observe(this, new Observer<String>() {
-            @Override
-            public void onChanged(@Nullable String slug) {
-                if (!TextUtils.isEmpty(slug) && mRecycler.getAdapter() != null) {
-                    ((PluginListAdapter) mRecycler.getAdapter()).reloadPluginWithSlug(slug);
-                }
-            }
-        });
     }
 
     @Override
@@ -244,13 +234,6 @@ public class PluginListFragment extends Fragment {
             mItems.clear();
             mItems.addAll(items);
             notifyDataSetChanged();
-        }
-
-        void reloadPluginWithSlug(@NonNull String slug) {
-            int index = mItems.indexOfPluginWithSlug(slug);
-            if (index != -1) {
-                notifyItemChanged(index);
-            }
         }
 
         protected @Nullable Object getItem(int position) {
@@ -342,7 +325,7 @@ public class PluginListFragment extends Fragment {
                         ImmutablePluginModel plugin = (ImmutablePluginModel) getItem(position);
                         if (plugin == null) return;
 
-                        ActivityLauncher.viewPluginDetailForResult(getActivity(), mViewModel.getSite(),
+                        ActivityLauncher.viewPluginDetail(getActivity(), mViewModel.getSite(),
                                 plugin.getSlug());
                     }
                 });

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
@@ -58,7 +58,8 @@ public class PluginBrowserViewModel extends ViewModel {
     private SiteModel mSite;
 
     private final Handler mHandler;
-    @SuppressWarnings("WeakerAccess") // To avoid synthetic accessor
+    // We don't want synthetic accessor methods to be introduced, so `protected` is used over `private` and the warning suppressed
+    @SuppressWarnings("WeakerAccess")
     protected final Set<String> mUpdatedPluginSlugSet;
 
     private final MutableLiveData<PluginListStatus> mNewPluginsListStatus;
@@ -374,8 +375,9 @@ public class PluginBrowserViewModel extends ViewModel {
         }, 250);
     }
 
+    // We don't want synthetic accessor methods to be introduced, so `protected` is used over `private` and the warning suppressed
     @WorkerThread
-    @SuppressWarnings("WeakerAccess") // To avoid synthetic accessor
+    @SuppressWarnings("WeakerAccess")
     protected void updateAllPluginListsWithNewPlugins(@NonNull Set<String> updatedPluginSlugSet) {
         if (updatedPluginSlugSet.size() == 0) {
             return;
@@ -441,7 +443,7 @@ public class PluginBrowserViewModel extends ViewModel {
         return getSearchQuery() != null && getSearchQuery().length() > 1;
     }
 
-    // Make the method protected to avoid synthetic accessor methods
+    // We don't want synthetic accessor methods to be introduced, so `protected` is used over `private` and the warning suppressed
     @SuppressWarnings("WeakerAccess")
     @WorkerThread
     protected void submitSearch(@Nullable final String query, boolean delayed) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
@@ -66,7 +66,6 @@ public class PluginBrowserViewModel extends ViewModel {
     private final MutableLiveData<List<ImmutablePluginModel>> mSitePlugins;
     private final MutableLiveData<List<ImmutablePluginModel>> mSearchResults;
 
-    private final MutableLiveData<String> mLastUpdatedWpOrgPluginSlug;
     private final MutableLiveData<String> mTitle;
 
     @SuppressWarnings("WeakerAccess")
@@ -89,7 +88,6 @@ public class PluginBrowserViewModel extends ViewModel {
         mPopularPluginsListStatus = new MutableLiveData<>();
         mSitePluginsListStatus = new MutableLiveData<>();
         mSearchPluginsListStatus = new MutableLiveData<>();
-        mLastUpdatedWpOrgPluginSlug = new MutableLiveData<>();
         mTitle = new MutableLiveData<>();
     }
 
@@ -135,7 +133,7 @@ public class PluginBrowserViewModel extends ViewModel {
 
     // Site & WPOrg plugin management
 
-    public void reloadAllPluginsFromStore() {
+    private void reloadAllPluginsFromStore() {
         reloadPluginDirectory(PluginDirectoryType.NEW);
         reloadPluginDirectory(PluginDirectoryType.POPULAR);
         reloadPluginDirectory(PluginDirectoryType.SITE);
@@ -256,7 +254,7 @@ public class PluginBrowserViewModel extends ViewModel {
         }
 
         if (!TextUtils.isEmpty(event.pluginSlug)) {
-            mLastUpdatedWpOrgPluginSlug.postValue(event.pluginSlug);
+            // TODO: update live data lists
         }
     }
 
@@ -410,10 +408,6 @@ public class PluginBrowserViewModel extends ViewModel {
 
     public LiveData<PluginListStatus> getSearchPluginsListStatus() {
         return mSearchPluginsListStatus;
-    }
-
-    public LiveData<String> getLastUpdatedWpOrgPluginSlug() {
-        return mLastUpdatedWpOrgPluginSlug;
     }
 
     public void setTitle(String title) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
@@ -27,7 +27,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-@WorkerThread
 public class PluginBrowserViewModel extends ViewModel {
     public enum PluginListType {
         SITE,
@@ -114,11 +113,14 @@ public class PluginBrowserViewModel extends ViewModel {
         setTitle(savedInstanceState.getString(KEY_TITLE));
     }
 
+    @WorkerThread
     public void start() {
         if (mIsStarted) {
             return;
         }
-        reloadAllPluginsFromStore();
+        reloadPluginDirectory(PluginDirectoryType.NEW);
+        reloadPluginDirectory(PluginDirectoryType.POPULAR);
+        reloadPluginDirectory(PluginDirectoryType.SITE);
 
         fetchPlugins(PluginListType.SITE, false);
         fetchPlugins(PluginListType.POPULAR, false);
@@ -133,12 +135,7 @@ public class PluginBrowserViewModel extends ViewModel {
 
     // Site & WPOrg plugin management
 
-    private void reloadAllPluginsFromStore() {
-        reloadPluginDirectory(PluginDirectoryType.NEW);
-        reloadPluginDirectory(PluginDirectoryType.POPULAR);
-        reloadPluginDirectory(PluginDirectoryType.SITE);
-    }
-
+    @WorkerThread
     private void reloadPluginDirectory(PluginDirectoryType directoryType) {
         switch (directoryType) {
             case NEW:
@@ -161,6 +158,7 @@ public class PluginBrowserViewModel extends ViewModel {
 
     // Network Requests
 
+    @WorkerThread
     private void fetchPlugins(@NonNull PluginListType listType, boolean loadMore) {
         if (!shouldFetchPlugins(listType, loadMore)) {
             return;
@@ -193,6 +191,7 @@ public class PluginBrowserViewModel extends ViewModel {
         }
     }
 
+    @WorkerThread
     private boolean shouldFetchPlugins(PluginListType listType, boolean loadMore) {
         if (loadMore && !isLoadMoreEnabled(listType)) {
             // If we are trying to load more and it's not allowed
@@ -315,6 +314,7 @@ public class PluginBrowserViewModel extends ViewModel {
 
     // Make the method protected to avoid synthetic accessor methods
     @SuppressWarnings("WeakerAccess")
+    @WorkerThread
     protected void submitSearch(@Nullable final String query, boolean delayed) {
         if (delayed) {
             mHandler.postDelayed(new Runnable() {
@@ -344,6 +344,7 @@ public class PluginBrowserViewModel extends ViewModel {
         }
     }
 
+    @WorkerThread
     private void clearSearchResults() {
         mSearchResults.postValue(new ArrayList<ImmutablePluginModel>());
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
@@ -261,23 +261,14 @@ public class PluginBrowserViewModel extends ViewModel {
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPluginDirectoryFetched(PluginStore.OnPluginDirectoryFetched event) {
+        PluginListStatus listStatus;
         if (event.isError()) {
             AppLog.e(AppLog.T.PLUGINS, "An error occurred while fetching the plugin directory " + event.type + ": "
                     + event.error.type);
-            switch (event.type) {
-                case NEW:
-                    mNewPluginsListStatus.setValue(PluginListStatus.ERROR);
-                    break;
-                case POPULAR:
-                    mPopularPluginsListStatus.setValue(PluginListStatus.ERROR);
-                    break;
-                case SITE:
-                    mSitePluginsListStatus.setValue(PluginListStatus.ERROR);
-                    break;
-            }
-            return;
+            listStatus = PluginListStatus.ERROR;
+        } else {
+            listStatus = event.canLoadMore ? PluginListStatus.CAN_LOAD_MORE : PluginListStatus.DONE;
         }
-        PluginListStatus listStatus = event.canLoadMore ? PluginListStatus.CAN_LOAD_MORE : PluginListStatus.DONE;
         switch (event.type) {
             case NEW:
                 mNewPluginsListStatus.setValue(listStatus);
@@ -288,7 +279,9 @@ public class PluginBrowserViewModel extends ViewModel {
             case SITE:
                 mSitePluginsListStatus.setValue(listStatus);
         }
-        reloadPluginDirectory(event.type);
+        if (!event.isError()) {
+            reloadPluginDirectory(event.type);
+        }
     }
 
     @SuppressWarnings("unused")

--- a/build.gradle
+++ b/build.gradle
@@ -22,5 +22,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'a76abcda5fb3dcfc4eb2e76731ff23bc35a11782'
+    fluxCVersion = '66659087fb2f3d59b182965cdf2b18d3b845c9d5'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,5 +22,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '66659087fb2f3d59b182965cdf2b18d3b845c9d5'
+    fluxCVersion = '515b5424d803d8b75f42324d2aface96f2c7081e'
 }


### PR DESCRIPTION
Please note that before reviewing this PR, both #7280 & https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/722 needs to be reviewed.

**Using background threads**

We want `PluginBrowserViewModel` to work in a bg thread as much as possible. I've introduced `@WorkerThread` annotation for this to a lot of methods. I feel like we should mark the whole class with it, but I am not sure if any future change can be risky that way. As a result of this change, and probably a good practice in general, now the LiveData models are updated with `postValue` instead of `setValue` which ensures the update happens in the main thread. Finally, the FluxC events are marked with `BACKGROUND` thread instead of the `MAIN` one since we don't directly update the UI from any of it. These changes will hopefully make things much more responsive for the user.

**Properly handling FluxC events in `PluginBrowserViewModel`**

Due to the changes in #7280 and some oversight by me in the initial implementation of the `PluginBrowserViewModel` not all plugin change events were being handled. When any of these events happen, we can simply re-query all the plugins from store, but that can become very expensive especially if a lot of wporg plugins are fetched quickly.

To avoid constant UI updates, I decided to go with the following optimizations:

1. All single plugin update events share a set, whenever a successful change happens, we'll add the slug of the plugin to this set and trigger an update to all lists if necessary.
2. There is a 250ms delay to combine these events. It could be that multiple plugins are updated, or a single plugin had multiple updates (activated and enabled autoupdates etc). Updating the UI is an expensive operation and we currently do it with `notifyDataSetChanged` which is not recommended. The less time we have to do this, the better it will be.
3. Once we decide that we have items to update, we prepare a map that has the slug as the key and plugin as the value. For each list (except for site plugins), we check whether the list item's slug is in the key set, if so we replace the item, if not keep the old item. We do this with a map instead of 1 by 1, so that we can post a single event to the UI that it's list is updated.
4. Site plugins is a special case, because plugins might be installed or removed, it can be really tricky to keep that list up to date. Although possible, I don't think it's worth the effort and might even be more costly than asking the store for the up to date information. Also, we care more about site plugins than anything else.

I added a lot of comments to point out some issues, so hopefully that'll be enough. If anything is not very clear let me know and I'll add comment for that as well!

To test:
* Installing a fresh copy of the app to test how fast the plugin page is loading and if there is any input lag would be a good test for this PR
* Aside from that, all plugin actions should be tested and it's affects should be checked in the plugin lists.

I've recorded a couple videos to showcase this PR a bit. I unfortunately forgot about the search list in my first video, so the second one is only about that. https://cloudup.com/czbFw8tBsIG & https://cloudup.com/c8FmkJjOfXt. Please note that it was actually impossible to update the search results before this change since it's not kept in the store. However, as it can be seen from the second video, it works pretty well here.

/cc @theck13 (for the review) @nbradbury (to keep you in the loop for plugin changes)