### PR TITLE
Activate the plugin after installation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -898,7 +898,7 @@ public class PluginDetailActivity extends AppCompatActivity {
 
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void OnSitePluginInstalled(OnSitePluginInstalled event) {
+    public void onSitePluginInstalled(OnSitePluginInstalled event) {
         if (isFinishing()) return;
 
         if (mSite.getId() != event.site.getId() || !mSlug.equals(event.slug)) {
@@ -917,10 +917,10 @@ public class PluginDetailActivity extends AppCompatActivity {
 
         refreshPluginFromStore();
 
-        // We want to activate and enable auto updates for the plugin after install
+        // FluxC will try to activate and enable autoupdates for the plugin after it's installed, let's assume that
+        // it'll be successful.
         mIsActive = true;
         mIsAutoUpdateEnabled = true;
-        dispatchConfigurePluginAction(true);
 
         refreshViews();
         showSuccessfulInstallSnackbar();

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -916,6 +916,12 @@ public class PluginDetailActivity extends AppCompatActivity {
         }
 
         refreshPluginFromStore();
+
+        // We want to activate and enable auto updates for the plugin after install
+        mIsActive = true;
+        mIsAutoUpdateEnabled = true;
+        dispatchConfigurePluginAction(true);
+
         refreshViews();
         showSuccessfulInstallSnackbar();
         invalidateOptionsMenu();

--- a/build.gradle
+++ b/build.gradle
@@ -22,5 +22,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '515b5424d803d8b75f42324d2aface96f2c7081e'
+    fluxCVersion = '9a80c77f10de2def3e06c267bdab8c5d4e161667'
 }


### PR DESCRIPTION
#7292 needs to be reviewed and merged before this is reviewed!

This is a single commit PR that activates and enables the autoupdates for a plugin after it's installed.

To test:
* Install a plugin and check that it's active after a few seconds (we need to dispatch a network event to actually change the plugin's state even though we show it as enabled from the start)

/cc @theck13 (for the review) @nbradbury (to keep you in the loop for plugin changes)