### PR TITLE
Guard saving to smartlock on Login

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -515,6 +515,15 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     @Override
     public void saveCredentialsInSmartLock(@Nullable final String username, @Nullable final String password,
                                            @NonNull final String displayName, @Nullable final Uri profilePicture) {
+        if (getLoginMode() == LoginMode.SELFHOSTED_ONLY) {
+            // bail if we are on the selfhosted flow since we haven't initialized SmartLock-for-Passwords for it.
+            //  Otherwise, logging in to WPCOM via the site-picker flow (for example) results in a crash.
+            //  See https://github.com/wordpress-mobile/WordPress-Android/issues/7182#issuecomment-362791364
+            //  There might be more circumstances that lead to this crash though. Not all Crashlytics reports seem to
+            //  originate from the site-picker.
+            return;
+        }
+
         mSmartLockHelper.saveCredentialsInSmartLock(StringUtils.notNullStr(username), StringUtils.notNullStr(password),
                 displayName, profilePicture);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -41,6 +41,7 @@ import org.wordpress.android.ui.accounts.login.LoginPrologueListener;
 import org.wordpress.android.ui.notifications.services.NotificationsUpdateService;
 import org.wordpress.android.ui.reader.services.ReaderUpdateService;
 import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.CrashlyticsUtils;
 import org.wordpress.android.util.HelpshiftHelper;
 import org.wordpress.android.util.HelpshiftHelper.Tag;
 import org.wordpress.android.util.SelfSignedSSLUtils;
@@ -521,6 +522,19 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
             //  See https://github.com/wordpress-mobile/WordPress-Android/issues/7182#issuecomment-362791364
             //  There might be more circumstances that lead to this crash though. Not all Crashlytics reports seem to
             //  originate from the site-picker.
+            return;
+        }
+
+        if (mSmartLockHelper == null) {
+            // log some data to help us debug https://github.com/wordpress-mobile/WordPress-Android/issues/7182
+            final String loginModeStr = "LoginMode: " + (getLoginMode() != null ? getLoginMode().name() : "null");
+            AppLog.w(AppLog.T.NUX, "Internal inconsistency error! mSmartLockHelper found null!" + loginModeStr);
+            CrashlyticsUtils.logException(
+                    new RuntimeException("Internal inconsistency error! mSmartLockHelper found null!"),
+                    AppLog.T.NUX,
+                    loginModeStr);
+
+            // bail
             return;
         }
 


### PR DESCRIPTION
Fixes #7182 

This PR does 2 things:
1. drops the attempt to save to SmartLock for Passwords if the Login activity is in the SELFHOSTED_ONLY mode. That mode doesn't setup SmartLock so, drop saving. Ticket #7300 is created as an enhancement to add such functionality.
2. drops the attempt to save to SmartLock for Passwords if `mSmartLockHelper` is `null`. The circumstances for that case are not know and for now, we'll just drop the save attempt and log some data in hope to debug the issue.

To test #1:
1. Have the app logged in to selfhosted sites only
2. Go to "MySite"
3. Tap on "Switch site"
4. Tap on the "+" button at the top right
5. Enter the WPCOM site's address and hit "Next"
6. Enter the WPCOM username and password and hit "Next"
7. After a little while, the app will have logged in to WPCOM without a crash
