### PR TITLE
issue/7306-plugin-detail-npe-9.5

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -403,7 +403,9 @@ public class PluginDetailActivity extends AppCompatActivity {
             setCollapsibleHtmlText(mFaqTextView, mWPOrgPlugin.getFaqAsHtml());
 
             mByLineTextView.setMovementMethod(WPLinkMovementMethod.getInstance());
-            mByLineTextView.setText(Html.fromHtml(mWPOrgPlugin.getAuthorAsHtml()));
+            if (mWPOrgPlugin.getAuthorAsHtml() != null) {
+                mByLineTextView.setText(Html.fromHtml(mWPOrgPlugin.getAuthorAsHtml()));
+            }
         } else if (mSitePlugin != null) {
             mTitleTextView.setText(mSitePlugin.getDisplayName());
 


### PR DESCRIPTION
Fixes #7306 by ensuring the author name isn't null before calling `Html.fromHtml()` on it.