### PR TITLE
Hide Sharing settings when Jetpack Sharing module is disabled

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/JetpackSettingsModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/models/JetpackSettingsModel.java
@@ -16,8 +16,10 @@ public class JetpackSettingsModel {
     public boolean ssoActive;
     public boolean ssoMatchEmail;
     public boolean ssoRequireTwoFactor;
+    //Modules
     public boolean serveImagesFromOurServers;
     public boolean lazyLoadImages;
+    public boolean sharingEnabled = true;
 
     public JetpackSettingsModel() {
         super();
@@ -40,6 +42,7 @@ public class JetpackSettingsModel {
         jetpackProtectWhitelist.addAll(other.jetpackProtectWhitelist);
         serveImagesFromOurServers = other.serveImagesFromOurServers;
         lazyLoadImages = other.lazyLoadImages;
+        sharingEnabled = other.sharingEnabled;
     }
 
     @Override
@@ -55,6 +58,7 @@ public class JetpackSettingsModel {
                 ssoRequireTwoFactor == otherModel.ssoRequireTwoFactor &&
                 serveImagesFromOurServers == otherModel.serveImagesFromOurServers &&
                 lazyLoadImages == otherModel.lazyLoadImages &&
+                sharingEnabled == otherModel.sharingEnabled &&
                 whitelistMatches(otherModel.jetpackProtectWhitelist);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/DotComSiteSettings.java
@@ -64,8 +64,11 @@ class DotComSiteSettings extends SiteSettingsInterface {
     private static final String JP_MONITOR_EMAIL_NOTES_KEY = "email_notifications";
     private static final String JP_MONITOR_WP_NOTES_KEY = "wp_note_notifications";
     private static final String JP_PROTECT_WHITELIST_KEY = "jetpack_protect_whitelist";
+    //Jetpack modules
     private static final String SERVE_IMAGES_FROM_OUR_SERVERS = "photon";
     private static final String LAZY_LOAD_IMAGES = "lazy-images";
+    private static final String SHARING_MODULE = "sharedaddy";
+
     private static final String START_OF_WEEK_KEY = "start_of_week";
     private static final String DATE_FORMAT_KEY = "date_format";
     private static final String TIME_FORMAT_KEY = "time_format";
@@ -94,6 +97,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
     private static final String DEFAULT_SHARING_BUTTON_STYLE = "icon-only";
 
     private static final String SPEED_UP_SETTINGS_JETPACK_VERSION = "5.8";
+    private static final String ACTIVE = "active";
 
     // used to track network fetches to prevent multiple errors from generating multiple toasts
     private int mFetchRequestCount = 0;
@@ -216,9 +220,7 @@ class DotComSiteSettings extends SiteSettingsInterface {
     private void fetchJetpackSettings() {
         fetchJetpackMonitorSettings();
         fetchJetpackProtectAndSsoSettings();
-        if (supportsJetpackSpeedUpSettings(mSite)) {
-            fetchJetpackModuleSettings();
-        }
+        fetchJetpackModuleSettings();
     }
 
     private void fetchJetpackProtectAndSsoSettings() {
@@ -322,14 +324,22 @@ class DotComSiteSettings extends SiteSettingsInterface {
                                 if (id == null) {
                                     continue;
                                 }
-                                if (id.equals(SERVE_IMAGES_FROM_OUR_SERVERS)) {
-                                    mRemoteJpSettings.serveImagesFromOurServers = module.optBoolean("active", false);
-                                } else if (id.equals(LAZY_LOAD_IMAGES)) {
-                                    mRemoteJpSettings.lazyLoadImages = module.optBoolean("active", false);
+                                boolean isActive = module.optBoolean(ACTIVE, false);
+                                switch (id) {
+                                    case SERVE_IMAGES_FROM_OUR_SERVERS:
+                                        mRemoteJpSettings.serveImagesFromOurServers = isActive;
+                                        break;
+                                    case LAZY_LOAD_IMAGES:
+                                        mRemoteJpSettings.lazyLoadImages = isActive;
+                                        break;
+                                    case SHARING_MODULE:
+                                        mRemoteJpSettings.sharingEnabled = isActive;
+                                        break;
                                 }
                             }
                             mJpSettings.serveImagesFromOurServers = mRemoteJpSettings.serveImagesFromOurServers;
                             mJpSettings.lazyLoadImages = mRemoteJpSettings.lazyLoadImages;
+                            mJpSettings.sharingEnabled = mRemoteJpSettings.sharingEnabled;
                         }
                         onFetchResponseReceived(null);
                     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -677,20 +677,24 @@ public abstract class SiteSettingsInterface {
         return mJpSettings.ssoRequireTwoFactor;
     }
 
-    public void enableServeImagesFromOurServers(boolean enabled) {
+    void enableServeImagesFromOurServers(boolean enabled) {
         mJpSettings.serveImagesFromOurServers = enabled;
     }
 
-    public boolean isServeImagesFromOurServersEnabled() {
+    boolean isServeImagesFromOurServersEnabled() {
         return mJpSettings.serveImagesFromOurServers;
     }
 
-    public void enableLazyLoadImages(boolean enabled) {
+    void enableLazyLoadImages(boolean enabled) {
         mJpSettings.lazyLoadImages = enabled;
     }
 
-    public boolean isLazyLoadImagesEnabled() {
+    boolean isLazyLoadImagesEnabled() {
         return mJpSettings.lazyLoadImages;
+    }
+
+    public boolean isSharingModuleEnabled() {
+        return mJpSettings.sharingEnabled;
     }
 
     public void setTitle(String title) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
@@ -55,6 +55,9 @@ public class PublicizeButtonPrefsFragment extends Fragment implements
     private WPPrefView mPrefAllowCommentLikes;
     private WPPrefView mPrefTwitterName;
 
+    private View mSharingDisabledNotification;
+    private View mSharingSettingsWrapper;
+
     private SiteModel mSite;
     private SiteSettingsInterface mSiteSettings;
 
@@ -120,6 +123,9 @@ public class PublicizeButtonPrefsFragment extends Fragment implements
             mPrefShowLike.setHeading(getString(R.string.site_settings_like_header));
             mPrefShowReblog.setVisibility(View.GONE);
         }
+
+        mSharingDisabledNotification = view.findViewById(R.id.sharing_disabled_notification);
+        mSharingSettingsWrapper = view.findViewById(R.id.sharing_settings_wrapper);
 
         return view;
     }
@@ -322,6 +328,11 @@ public class PublicizeButtonPrefsFragment extends Fragment implements
     private void setPreferencesFromSiteSettings() {
         assignPrefListeners(false);
         try {
+            if (!mSiteSettings.isSharingModuleEnabled()) {
+                mSharingDisabledNotification.setVisibility(View.VISIBLE);
+                mSharingSettingsWrapper.setVisibility(View.GONE);
+            }
+
             mPrefLabel.setTextEntry(mSiteSettings.getSharingLabel());
             mPrefButtonStyle.setSummary(mSiteSettings.getSharingButtonStyleDisplayText(getActivity()));
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/PublicizeButtonPrefsFragment.java
@@ -328,10 +328,9 @@ public class PublicizeButtonPrefsFragment extends Fragment implements
     private void setPreferencesFromSiteSettings() {
         assignPrefListeners(false);
         try {
-            if (!mSiteSettings.isSharingModuleEnabled()) {
-                mSharingDisabledNotification.setVisibility(View.VISIBLE);
-                mSharingSettingsWrapper.setVisibility(View.GONE);
-            }
+            boolean sharingModuleEnabled = mSiteSettings.isSharingModuleEnabled();
+            mSharingDisabledNotification.setVisibility(sharingModuleEnabled ? View.GONE : View.VISIBLE);
+            mSharingSettingsWrapper.setVisibility(sharingModuleEnabled ? View.VISIBLE : View.GONE);
 
             mPrefLabel.setTextEntry(mSiteSettings.getSharingLabel());
             mPrefButtonStyle.setSummary(mSiteSettings.getSharingButtonStyleDisplayText(getActivity()));

--- a/WordPress/src/main/res/layout/publicize_button_prefs_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_button_prefs_fragment.xml
@@ -1,152 +1,193 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:card_view="http://schemas.android.com/apk/res-auto"
     xmlns:wp="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <LinearLayout
+    <android.support.v7.widget.CardView
+        android:id="@+id/sharing_disabled_notification"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:visibility="gone">
 
-        <android.support.v7.widget.CardView
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            card_view:cardBackgroundColor="@color/white"
-            card_view:cardCornerRadius="@dimen/cardview_default_radius">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_extra_large"
-                android:orientation="vertical">
-
-                <org.wordpress.android.widgets.WPPrefView
-                    android:id="@+id/pref_sharing_buttons"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    wp:wpHeading="@string/buttons"
-                    wp:wpPrefType="checklist"
-                    wp:wpShowDivider="true"
-                    wp:wpSummary="@string/sharing_sharing_buttons_description"
-                    wp:wpTitle="@string/sharing_buttons" />
-
-                <org.wordpress.android.widgets.WPPrefView
-                    android:id="@+id/pref_more_button"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    wp:wpPrefType="checklist"
-                    wp:wpShowDivider="true"
-                    wp:wpSummary="@string/sharing_more_description"
-                    wp:wpTitle="@string/sharing_edit_more_buttons" />
-
-                <org.wordpress.android.widgets.WPPrefView
-                    android:id="@+id/pref_label"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    wp:wpPrefType="text"
-                    wp:wpShowDivider="true"
-                    wp:wpTextDialogSubtitle="@string/sharing_label_message"
-                    wp:wpTitle="@string/label" />
-
-                <org.wordpress.android.widgets.WPPrefView
-                    android:id="@+id/pref_button_style"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    wp:wpPrefType="radiolist"
-                    wp:wpShowDivider="false"
-                    wp:wpTitle="@string/button_style" />
-
-            </LinearLayout>
-        </android.support.v7.widget.CardView>
-
-        <android.support.v7.widget.CardView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_large"
+            android:layout_marginLeft="@dimen/content_margin"
+            android:layout_marginRight="@dimen/content_margin"
             android:layout_marginTop="@dimen/margin_large"
-            card_view:cardBackgroundColor="@color/white"
-            card_view:cardCornerRadius="@dimen/cardview_default_radius">
+            android:orientation="vertical"
+            android:paddingLeft="@dimen/margin_medium"
+            android:paddingRight="@dimen/margin_medium">
 
-            <LinearLayout
+            <org.wordpress.android.widgets.WPTextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/margin_medium"
+                android:text="@string/sharing_disabled"
+                android:textColor="@color/blue_wordpress"
+                android:textSize="@dimen/text_sz_medium"
+                android:textStyle="bold" />
+
+            <org.wordpress.android.widgets.WPTextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_extra_large"
-                android:orientation="vertical">
+                android:text="@string/sharing_disabled_description"
+                android:textColor="@color/grey"
+                android:textSize="@dimen/text_sz_medium" />
 
-                <org.wordpress.android.widgets.WPPrefView
-                    android:id="@+id/pref_show_reblog"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    wp:wpHeading="@string/site_settings_reblog_and_like_header"
-                    wp:wpPrefType="toggle"
-                    wp:wpShowDivider="true"
-                    wp:wpTitle="@string/site_settings_reblog" />
+        </LinearLayout>
+    </android.support.v7.widget.CardView>
 
-                <org.wordpress.android.widgets.WPPrefView
-                    android:id="@+id/pref_show_like"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    wp:wpPrefType="toggle"
-                    wp:wpShowDivider="false"
-                    wp:wpTitle="@string/site_settings_like" />
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/sharing_settings_wrapper">
 
-            </LinearLayout>
-        </android.support.v7.widget.CardView>
-
-        <android.support.v7.widget.CardView
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_large"
-            card_view:cardBackgroundColor="@color/white"
-            card_view:cardCornerRadius="@dimen/cardview_default_radius">
+            android:orientation="vertical">
 
-            <LinearLayout
+            <android.support.v7.widget.CardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_extra_large"
-                android:orientation="vertical">
+                card_view:cardBackgroundColor="@color/white"
+                card_view:cardCornerRadius="@dimen/cardview_default_radius">
 
-                <org.wordpress.android.widgets.WPPrefView
-                    android:id="@+id/pref_allow_comment_likes"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    wp:wpHeading="@string/likes"
-                    wp:wpPrefType="toggle"
-                    wp:wpShowDivider="false"
-                    wp:wpSummary="@string/sharing_comment_likes_description"
-                    wp:wpTitle="@string/sharing_comment_likes" />
+                    android:layout_marginBottom="@dimen/margin_extra_large"
+                    android:orientation="vertical">
 
-            </LinearLayout>
-        </android.support.v7.widget.CardView>
+                    <org.wordpress.android.widgets.WPPrefView
+                        android:id="@+id/pref_sharing_buttons"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        wp:wpHeading="@string/buttons"
+                        wp:wpPrefType="checklist"
+                        wp:wpShowDivider="true"
+                        wp:wpSummary="@string/sharing_sharing_buttons_description"
+                        wp:wpTitle="@string/sharing_buttons" />
 
-        <android.support.v7.widget.CardView
-            android:id="@+id/card_view_twitter"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_large"
-            card_view:cardBackgroundColor="@color/white"
-            card_view:cardCornerRadius="@dimen/cardview_default_radius">
+                    <org.wordpress.android.widgets.WPPrefView
+                        android:id="@+id/pref_more_button"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        wp:wpPrefType="checklist"
+                        wp:wpShowDivider="true"
+                        wp:wpSummary="@string/sharing_more_description"
+                        wp:wpTitle="@string/sharing_edit_more_buttons" />
 
-            <LinearLayout
+                    <org.wordpress.android.widgets.WPPrefView
+                        android:id="@+id/pref_label"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        wp:wpPrefType="text"
+                        wp:wpShowDivider="true"
+                        wp:wpTextDialogSubtitle="@string/sharing_label_message"
+                        wp:wpTitle="@string/label" />
+
+                    <org.wordpress.android.widgets.WPPrefView
+                        android:id="@+id/pref_button_style"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        wp:wpPrefType="radiolist"
+                        wp:wpShowDivider="false"
+                        wp:wpTitle="@string/button_style" />
+
+                </LinearLayout>
+            </android.support.v7.widget.CardView>
+
+            <android.support.v7.widget.CardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_extra_large"
-                android:orientation="vertical">
+                android:layout_marginTop="@dimen/margin_large"
+                card_view:cardBackgroundColor="@color/white"
+                card_view:cardCornerRadius="@dimen/cardview_default_radius">
 
-                <org.wordpress.android.widgets.WPPrefView
-                    android:id="@+id/pref_twitter_name"
+                <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    wp:wpHeading="@string/twitter"
-                    wp:wpPrefType="text"
-                    wp:wpShowDivider="false"
-                    wp:wpTextDialogSubtitle="@string/sharing_twitter_message"
-                    wp:wpTitle="@string/twitter_username" />
+                    android:layout_marginBottom="@dimen/margin_extra_large"
+                    android:orientation="vertical">
 
-            </LinearLayout>
-        </android.support.v7.widget.CardView>
+                    <org.wordpress.android.widgets.WPPrefView
+                        android:id="@+id/pref_show_reblog"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        wp:wpHeading="@string/site_settings_reblog_and_like_header"
+                        wp:wpPrefType="toggle"
+                        wp:wpShowDivider="true"
+                        wp:wpTitle="@string/site_settings_reblog" />
 
-    </LinearLayout>
-</ScrollView>
+                    <org.wordpress.android.widgets.WPPrefView
+                        android:id="@+id/pref_show_like"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        wp:wpPrefType="toggle"
+                        wp:wpShowDivider="false"
+                        wp:wpTitle="@string/site_settings_like" />
+
+                </LinearLayout>
+            </android.support.v7.widget.CardView>
+
+            <android.support.v7.widget.CardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_large"
+                card_view:cardBackgroundColor="@color/white"
+                card_view:cardCornerRadius="@dimen/cardview_default_radius">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/margin_extra_large"
+                    android:orientation="vertical">
+
+                    <org.wordpress.android.widgets.WPPrefView
+                        android:id="@+id/pref_allow_comment_likes"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        wp:wpHeading="@string/likes"
+                        wp:wpPrefType="toggle"
+                        wp:wpShowDivider="false"
+                        wp:wpSummary="@string/sharing_comment_likes_description"
+                        wp:wpTitle="@string/sharing_comment_likes" />
+
+                </LinearLayout>
+            </android.support.v7.widget.CardView>
+
+            <android.support.v7.widget.CardView
+                android:id="@+id/card_view_twitter"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_large"
+                card_view:cardBackgroundColor="@color/white"
+                card_view:cardCornerRadius="@dimen/cardview_default_radius">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/margin_extra_large"
+                    android:orientation="vertical">
+
+                    <org.wordpress.android.widgets.WPPrefView
+                        android:id="@+id/pref_twitter_name"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        wp:wpHeading="@string/twitter"
+                        wp:wpPrefType="text"
+                        wp:wpShowDivider="false"
+                        wp:wpTextDialogSubtitle="@string/sharing_twitter_message"
+                        wp:wpTitle="@string/twitter_username" />
+
+                </LinearLayout>
+            </android.support.v7.widget.CardView>
+
+        </LinearLayout>
+    </ScrollView>
+</FrameLayout>

--- a/WordPress/src/main/res/layout/publicize_list_fragment.xml
+++ b/WordPress/src/main/res/layout/publicize_list_fragment.xml
@@ -81,6 +81,7 @@
             <RelativeLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:id="@+id/sharing_module"
                 android:layout_marginBottom="@dimen/margin_extra_large"
                 android:layout_marginLeft="@dimen/content_margin"
                 android:layout_marginRight="@dimen/content_margin"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1635,6 +1635,8 @@
 
     <!-- Publicize and sharing -->
     <string name="sharing">Sharing</string>
+    <string name="sharing_disabled">Sharing module disabled</string>
+    <string name="sharing_disabled_description">You cannot access your sharing settings because your Sharing Jetpack module is disabled.</string>
     <string name="connections_label">Connections</string>
     <string name="connections_description">Connect your favorite social media services to automatically share new posts with friends.</string>
     <string name="connected_accounts_label">Connected accounts</string>


### PR DESCRIPTION
Fixes #7160 
- Show notification that Sharing Jetpack module is disabled and disable sharing options.
- some additional grooming of Jetpack modules
 
To test:
1. Go to the old Jetpack > Modules page in your dashboard.
https://yourjetpacksite.com/wp-admin/admin.php?page=jetpack_modules
2. Deactivate the Sharing module.
3. Open the WordPress app.
4. Go to Sharing > Manage
5. Wait for the Jetpack settings to sync
6. Notification is visible and Sharing settings is hidden.

![screenshot_1519738127](https://user-images.githubusercontent.com/1079756/36733576-533288ca-1bd1-11e8-8d97-e1dc2e40875e.png)
 

