### PR TITLE
Fix comment reply and comment unapproved background drawables in RtL …

### DIFF
--- a/WordPress/src/main/res/drawable-ldrtl-v18/comment_reply_background.xml
+++ b/WordPress/src/main/res/drawable-ldrtl-v18/comment_reply_background.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/white" />
+        </shape>
+    </item>
+    <item
+        android:left="@dimen/margin_extra_large"
+        android:right="@dimen/margin_extra_large"
+        android:top="9dp">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/grey_lighten_30" />
+            <padding
+                android:bottom="1dp"
+                android:right="20dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/white" />
+        </shape>
+    </item>
+</layer-list>

--- a/WordPress/src/main/res/drawable-ldrtl-v18/comment_reply_unapproved_background.xml
+++ b/WordPress/src/main/res/drawable-ldrtl-v18/comment_reply_unapproved_background.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/white" />
+        </shape>
+    </item>
+    <item
+        android:right="@dimen/margin_extra_large">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/notification_status_unapproved" />
+            <padding
+                android:bottom="1dp"
+                android:right="20dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/notification_status_unapproved_background" />
+        </shape>
+    </item>
+</layer-list>

--- a/WordPress/src/main/res/drawable-ldrtl-v18/comment_unapproved_background.xml
+++ b/WordPress/src/main/res/drawable-ldrtl-v18/comment_unapproved_background.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/notification_status_unapproved" />
+            <padding
+                android:bottom="1dp"
+                android:right="4dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/notification_status_unapproved_background" />
+        </shape>
+    </item>
+</layer-list>


### PR DESCRIPTION
Fixes #7323
Fixes background drawable for `comment reply`, `comment reply unapproved` and `comment unapproved`.

To test:
1. Go to Notifications
2. Open detail for 
- unapproved reply to your comment
- unapproved comment
- approved reply to your comment
