### PR TITLE
Issue/7327 update signup magic

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupMagicLinkFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupMagicLinkFragment.java
@@ -40,7 +40,7 @@ public class SignupMagicLinkFragment extends Fragment {
 
     public static final String TAG = "signup_magic_link_fragment_tag";
 
-    private Button mTryAgainButton;
+    private Button mOpenMailButton;
     private ProgressDialog mProgressDialog;
 
     protected @Inject Dispatcher mDispatcher;
@@ -72,8 +72,8 @@ public class SignupMagicLinkFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View layout = inflater.inflate(R.layout.signup_magic_link, container, false);
 
-        mTryAgainButton = layout.findViewById(R.id.signup_magic_link_button);
-        mTryAgainButton.setOnClickListener(new View.OnClickListener() {
+        mOpenMailButton = layout.findViewById(R.id.signup_magic_link_button);
+        mOpenMailButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 if (mLoginListener != null) {
@@ -148,7 +148,7 @@ public class SignupMagicLinkFragment extends Fragment {
     }
 
     protected void startProgress(String message) {
-        mTryAgainButton.setEnabled(false);
+        mOpenMailButton.setEnabled(false);
 
         mProgressDialog = ProgressDialog.show(getActivity(), "", message, true, true,
                 new DialogInterface.OnCancelListener() {
@@ -171,7 +171,7 @@ public class SignupMagicLinkFragment extends Fragment {
         }
 
         mProgressDialog = null;
-        mTryAgainButton.setEnabled(true);
+        mOpenMailButton.setEnabled(true);
     }
 
     protected void sendMagicLinkEmail() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupMagicLinkFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupMagicLinkFragment.java
@@ -76,7 +76,9 @@ public class SignupMagicLinkFragment extends Fragment {
         mTryAgainButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                sendMagicLinkEmail();
+                if (mLoginListener != null) {
+                    mLoginListener.openEmailClient();
+                }
             }
         });
 

--- a/WordPress/src/main/res/layout-land/signup_magic_link.xml
+++ b/WordPress/src/main/res/layout-land/signup_magic_link.xml
@@ -64,7 +64,7 @@
             android:layout_alignParentRight="true"
             android:layout_height="wrap_content"
             android:layout_width="wrap_content"
-            android:text="@string/try_again"
+            android:text="@string/open_mail"
             style="@style/WordPress.Button.Primary" >
         </android.support.v7.widget.AppCompatButton>
 

--- a/WordPress/src/main/res/layout/signup_magic_link.xml
+++ b/WordPress/src/main/res/layout/signup_magic_link.xml
@@ -49,7 +49,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_extra_large"
             android:layout_width="wrap_content"
-            android:text="@string/try_again"
+            android:text="@string/open_mail"
             android:theme="@style/LoginTheme.Button"
             style="@style/Widget.AppCompat.Button.Colored" >
         </Button>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2090,7 +2090,6 @@
     <string name="signup_with_email_button">Sign Up with Email</string>
     <string name="signup_with_google_button">Sign Up with Google</string>
     <string name="content_description_add_avatar">Add avatar</string>
-    <string name="try_again">Try again</string>
 
     <string name="username_changer_action">Save</string>
     <string name="username_changer_dismiss_button_positive">Discard</string>


### PR DESCRIPTION
### Fix
Update button text and functionality on the signup magic link screen as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7327.

### Test
0. Clear app data.
1. Tap ***Sign Up*** button.
2. Tap ***Sign Up with Email*** button.
3. Enter email not associated with existing WordPress.com account.
4. Tap ***Next*** button.
5. Notice ***Open Mail*** button.
6. Tap ***Open Mail*** button.
7. Notice device's mail app is opened.