### PR TITLE
Fix noticon position and direction on notification screen in rtl mode

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/adapters/NotesAdapter.java
@@ -2,11 +2,14 @@ package org.wordpress.android.ui.notifications.adapters;
 
 import android.content.Context;
 import android.os.AsyncTask;
+import android.support.v4.text.BidiFormatter;
+import android.support.v4.view.ViewCompat;
 import android.support.v7.widget.RecyclerView;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewParent;
 import android.widget.TextView;
 
 import org.wordpress.android.R;
@@ -16,6 +19,7 @@ import org.wordpress.android.models.Note;
 import org.wordpress.android.ui.comments.CommentUtils;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
 import org.wordpress.android.util.GravatarUtils;
+import org.wordpress.android.util.RtlUtils;
 import org.wordpress.android.widgets.NoticonTextView;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
@@ -224,6 +228,17 @@ public class NotesAdapter extends RecyclerView.Adapter<NotesAdapter.NoteViewHold
 
         String noteSubjectNoticon = note.getCommentSubjectNoticon();
         if (!TextUtils.isEmpty(noteSubjectNoticon)) {
+            ViewParent parent = noteViewHolder.txtSubject.getParent();
+            // Fix position of the subject noticon in the RtL mode
+            if (parent instanceof ViewGroup) {
+                int textDirection = BidiFormatter.getInstance().isRtl(noteViewHolder.txtSubject.getText())
+                        ? ViewCompat.LAYOUT_DIRECTION_RTL : ViewCompat.LAYOUT_DIRECTION_LTR;
+                ViewCompat.setLayoutDirection((ViewGroup) parent, textDirection);
+            }
+            // mirror noticon in the rtl mode
+            if (RtlUtils.isRtl(noteViewHolder.itemView.getContext())) {
+                noteViewHolder.txtSubjectNoticon.setScaleX(-1);
+            }
             CommentUtils.indentTextViewFirstLine(noteViewHolder.txtSubject, mTextIndentSize);
             noteViewHolder.txtSubjectNoticon.setText(noteSubjectNoticon);
             noteViewHolder.txtSubjectNoticon.setVisibility(View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/FooterNoteBlock.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/blocks/FooterNoteBlock.java
@@ -10,6 +10,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.util.JSONUtils;
+import org.wordpress.android.util.RtlUtils;
 
 public class FooterNoteBlock extends NoteBlock {
     private NoteBlockClickableSpan mClickableSpan;
@@ -57,6 +58,10 @@ public class FooterNoteBlock extends NoteBlock {
         if (!TextUtils.isEmpty(noticonGlyph)) {
             noteBlockHolder.getNoticonView().setVisibility(View.VISIBLE);
             noteBlockHolder.getNoticonView().setText(noticonGlyph);
+            // mirror noticon in the rtl mode
+            if (RtlUtils.isRtl(noteBlockHolder.getNoticonView().getContext())) {
+                noteBlockHolder.getNoticonView().setScaleX(-1);
+            }
         } else {
             noteBlockHolder.getNoticonView().setVisibility(View.GONE);
         }


### PR DESCRIPTION
Fixes #7328 

To test:
1. Change system language to Hebrew.
2. Go to notifications
3. Notice that the indicator that you replied to a comment is on the left side of the text and **points to the right**.
4. Click on the item
5. Check that the indicator **points to the right**.

6. Change system language to English.
7. Go to notifications
8. Notice that the indicator that you replied to a comment is on the left side of the text and **points to the left**.
9. Click on the item
10. Check that the indicator **points to the left**.
