### PR TITLE
Fix broken image selection in the Media Library

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -285,6 +285,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
 
             videoOverlayContainer = (ViewGroup) view.findViewById(R.id.frame_video_overlay);
             selectionCountContainer = (ViewGroup) view.findViewById(R.id.frame_selection_count);
+            selectionCountContainer.setVisibility(mBrowserType.isPicker() ? View.VISIBLE : View.GONE);
 
             imageView.setErrorImageResId(R.drawable.media_item_background);
             imageView.setDefaultImageResId(R.drawable.media_item_background);

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridAdapter.java
@@ -185,6 +185,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
         }
 
         if (mBrowserType.canMultiselect() && canSelect) {
+            holder.selectionCountContainer.setVisibility(View.VISIBLE);
             holder.selectionCountTextView.setVisibility(View.VISIBLE);
             holder.selectionCountTextView.setSelected(isSelected);
             if (isSelected) {
@@ -194,6 +195,7 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
                 holder.selectionCountTextView.setText(null);
             }
         } else {
+            holder.selectionCountContainer.setVisibility(View.GONE);
             holder.selectionCountTextView.setVisibility(View.GONE);
         }
 
@@ -285,7 +287,6 @@ public class MediaGridAdapter extends RecyclerView.Adapter<MediaGridAdapter.Grid
 
             videoOverlayContainer = (ViewGroup) view.findViewById(R.id.frame_video_overlay);
             selectionCountContainer = (ViewGroup) view.findViewById(R.id.frame_selection_count);
-            selectionCountContainer.setVisibility(mBrowserType.isPicker() ? View.VISIBLE : View.GONE);
 
             imageView.setErrorImageResId(R.drawable.media_item_background);
             imageView.setDefaultImageResId(R.drawable.media_item_background);


### PR DESCRIPTION
Fixes #7278 

To test:
 1. Open media browser
 2. Tapping wherever on an image in the Media Library opens the image detail. (Make sure to also tap on the bottom-left corner of an image) 

This PR could also solve #7277 
