### PR TITLE
Hide plugin install button while already installing

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -859,7 +859,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         mIsUpdatingPlugin = false;
         if (event.isError()) {
             AppLog.e(AppLog.T.PLUGINS, "An error occurred while updating the plugin with type: "
-                    + event.error.type);
+                    + event.error.type + " and message: " + event.error.message);
             refreshPluginVersionViews();
             showUpdateFailedSnackbar();
             return;
@@ -880,7 +880,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         mIsUpdatingPlugin = false;
         if (event.isError()) {
             AppLog.e(AppLog.T.PLUGINS, "An error occurred while installing the plugin with type: "
-                    + event.error.type);
+                    + event.error.type + " and message: " + event.error.message);
             refreshPluginVersionViews();
             showInstallFailedSnackbar();
             return;
@@ -903,7 +903,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         cancelRemovePluginProgressDialog();
         if (event.isError()) {
             AppLog.e(AppLog.T.PLUGINS, "An error occurred while removing the plugin with type: "
-                    + event.error.type);
+                    + event.error.type + " and message: " + event.error.message);
             String toastMessage = getString(R.string.plugin_updated_failed_detailed,
                     mSitePlugin.getDisplayName(), event.error.message);
             ToastUtils.showToast(this, toastMessage, Duration.LONG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -484,7 +484,7 @@ public class PluginDetailActivity extends AppCompatActivity {
             }
         } else if (mWPOrgPlugin != null) {
             mUpdateButton.setVisibility(View.GONE);
-            mInstallButton.setVisibility(View.VISIBLE);
+            mInstallButton.setVisibility(mIsUpdatingPlugin ? View.GONE : View.VISIBLE);
             mInstallButton.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
@@ -276,7 +276,8 @@ public class PluginBrowserViewModel extends ViewModel {
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onSitePluginsFetched(PluginStore.OnSitePluginsFetched event) {
         if (event.isError()) {
-            AppLog.e(AppLog.T.PLUGINS, "An error occurred while fetching site plugins with type: " + event.error.type);
+            AppLog.e(AppLog.T.PLUGINS, "An error occurred while fetching site plugins with type: " + event.error.type
+                    + " and message: " + event.error.message);
             mSitePluginsListStatus.setValue(PluginListStatus.ERROR);
             return;
         }
@@ -301,7 +302,8 @@ public class PluginBrowserViewModel extends ViewModel {
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onPluginDirectoryFetched(PluginStore.OnPluginDirectoryFetched event) {
         if (event.isError()) {
-            AppLog.e(AppLog.T.PLUGINS, "An error occurred while fetching the plugin directory: " + event.type);
+            AppLog.e(AppLog.T.PLUGINS, "An error occurred while fetching the plugin directory: " + event.type
+                    + " and message: " + event.error.message);
             if (event.type == PluginDirectoryType.NEW) {
                 mNewPluginsListStatus.setValue(PluginListStatus.ERROR);
             } else if (event.type == PluginDirectoryType.POPULAR) {
@@ -329,7 +331,8 @@ public class PluginBrowserViewModel extends ViewModel {
             return;
         }
         if (event.isError()) {
-            AppLog.e(AppLog.T.PLUGINS, "An error occurred while searching the plugin directory");
+            AppLog.e(AppLog.T.PLUGINS, "An error occurred while searching the plugin directory: " + event.error.type
+                    + " and message: " + event.error.message);
             mSearchPluginsListStatus.setValue(PluginListStatus.ERROR);
             return;
         }


### PR DESCRIPTION
While a plugin is being installed, we still show the install button under the progress bar. I have fixed this issue in `issue/plugin-fluxc-improvements-master` but that branch failed to merge in time for the release.

I've also added the error messages to the FluxC logs for us to better debug some issues.

/cc @nbradbury 