### PR TITLE
Issue/7339 crash download avatar

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -744,7 +744,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                             AppLog.i(T.NUX, "Google avatar download and Gravatar upload failed.");
                         }
                     });
-            } catch (URISyntaxException exception) {
+            } catch (NullPointerException | URISyntaxException exception) {
                 AppLog.e(T.NUX, "Google avatar download and Gravatar upload failed - " +
                         exception.toString() + " - " + exception.getMessage());
             }


### PR DESCRIPTION
### Fix
Add `NullPointerException` to catch branch to avoid crash as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7339.

### Test
0. Change [`mPhotoUrl` assignment](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java#L249) to be `null`.
1. Tap ***Sign Up*** button.
2. Tap ***Sign Up with Google*** button.
3. Tap Google account not associated with WordPress.com account.
4. Notice epilogue screen is shown.
5. Notice app does not crash.
6. Notice the following log cat message.
```
02-28 20:27:40.577 4650-4773/org.wordpress.android.beta E/WordPress-NUX: Google avatar download and Gravatar upload failed - java.lang.NullPointerException: uriString - uriString
```