### PR TITLE
Issue/7342 tos link locale

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -50,6 +50,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.CrashlyticsUtils;
 import org.wordpress.android.util.HelpshiftHelper;
 import org.wordpress.android.util.HelpshiftHelper.Tag;
+import org.wordpress.android.util.LanguageUtils;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.SelfSignedSSLUtils;
 import org.wordpress.android.util.StringUtils;
@@ -336,7 +337,10 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     @Override
     public void onSignupSheetTermsOfServiceClicked() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_TERMS_OF_SERVICE_TAPPED);
-        ActivityLauncher.openUrlExternal(this, getResources().getString(R.string.wordpresscom_tos_url));
+        // Get device locale and remove region to pass only language.
+        String locale = LanguageUtils.getPatchedCurrentDeviceLanguage(this);
+        locale = locale.substring(0, locale.indexOf("_"));
+        ActivityLauncher.openUrlExternal(this, getResources().getString(R.string.wordpresscom_tos_url, locale));
     }
 
     @Override


### PR DESCRIPTION
### Fix
Add language based on device locale to the terms of service link as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7342.

### Test
0. Clear app data.
1. Tap ***Sign Up*** button.
2. Tap ***By signing up, you agree to our Terms of Service*** link.
3. Choose web browser if prompted.
4. Notice terms of service web page.