### PR TITLE
Use FluxC with authenticated /domains/suggestions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,5 +22,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '9d90f262c86c284eae06776e68ab604ef5a3907c'
+    fluxCVersion = 'cac602a6c31a9c63eb42d25305e8d0e40780d2e2'
 }


### PR DESCRIPTION
Fixes #7336 

Depended on https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/731 which is now merged.

To test:
1. Clear app data and launch app
2. Login to wpcom using a *site-less* account
3. Tap on "Add new site" on the MySite screen
4. Proceed to step 4of4, type in the account's username in the search field
5. Notice the exact username based suggestion be offered first on the list
