### PR TITLE
Fix copy/paste error

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -252,7 +252,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
         outState.putBoolean(KEY_LOGIN_FINISHED, mLoginFinished);
         outState.putString(KEY_REQUESTED_USERNAME, mRequestedUsername);
         outState.putString(KEY_REQUESTED_PASSWORD, mRequestedPassword);
-        outState.putIntegerArrayList(KEY_REQUESTED_PASSWORD, mOldSitesIDs);
+        outState.putIntegerArrayList(KEY_OLD_SITES_IDS, mOldSitesIDs);
     }
 
     protected void next() {


### PR DESCRIPTION
Fixes #7302 

A copy/paste error was causing the `mOldSitesIDs` variable to not be restored properly on rotation.

To test:
Follow the steps in #7302 and notice the app not crashing.