### PR TITLE
Plugin stats and minor improvements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ActivityLauncher.java
@@ -175,7 +175,7 @@ public class ActivityLauncher {
 
     public static void viewPluginBrowser(Context context, SiteModel site) {
         if (PluginUtils.isPluginFeatureAvailable(site)) {
-            AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.OPENED_PLUGINS, site);
+            AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.OPENED_PLUGIN_DIRECTORY, site);
             Intent intent = new Intent(context, PluginBrowserActivity.class);
             intent.putExtra(WordPress.SITE, site);
             context.startActivity(intent);

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -31,10 +31,12 @@ import android.widget.TextView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
+import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.plugin.ImmutablePluginModel;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.util.ActivityUtils;
+import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.viewmodel.PluginBrowserViewModel;
@@ -42,7 +44,9 @@ import org.wordpress.android.viewmodel.PluginBrowserViewModel.PluginListType;
 import org.wordpress.android.widgets.WPNetworkImageView;
 import org.wordpress.android.widgets.WPNetworkImageView.ImageType;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -301,6 +305,7 @@ public class PluginBrowserActivity extends AppCompatActivity
                 .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
                 .commit();
         mViewModel.setTitle(getTitleForListType(listType));
+        trackPluginListOpened(listType);
     }
 
     private void hideListFragment() {
@@ -451,5 +456,31 @@ public class PluginBrowserActivity extends AppCompatActivity
                 return getString(R.string.plugin_caption_installed);
         }
         return getString(R.string.plugins);
+    }
+
+    void trackPluginListOpened(PluginListType listType) {
+        if (listType == PluginListType.SEARCH) {
+            // Although it's named as "search performed" we are actually only tracking the first search
+            AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.PLUGIN_SEARCH_PERFORMED, mViewModel.getSite());
+            return;
+        }
+        Map<String, Object> properties = new HashMap<>();
+        String type = null;
+        switch (listType) {
+            case SITE:
+                type = "installed";
+                break;
+            case FEATURED:
+                type = "installed";
+                break;
+            case POPULAR:
+                type = "installed";
+                break;
+            case NEW:
+                type = "installed";
+                break;
+        }
+        properties.put("type", type);
+        AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.OPENED_PLUGIN_LIST, mViewModel.getSite(), properties);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -54,6 +54,7 @@ public class PluginBrowserActivity extends AppCompatActivity
     protected PluginBrowserViewModel mViewModel;
 
     private RecyclerView mSitePluginsRecycler;
+    private RecyclerView mFeaturedPluginsRecycler;
     private RecyclerView mPopularPluginsRecycler;
     private RecyclerView mNewPluginsRecycler;
 
@@ -69,6 +70,7 @@ public class PluginBrowserActivity extends AppCompatActivity
         mViewModel = ViewModelProviders.of(this, mViewModelFactory).get(PluginBrowserViewModel.class);
 
         mSitePluginsRecycler = findViewById(R.id.installed_plugins_recycler);
+        mFeaturedPluginsRecycler = findViewById(R.id.featured_plugins_recycler);
         mPopularPluginsRecycler = findViewById(R.id.popular_plugins_recycler);
         mNewPluginsRecycler = findViewById(R.id.new_plugins_recycler);
 
@@ -101,6 +103,14 @@ public class PluginBrowserActivity extends AppCompatActivity
             }
         });
 
+        // featured plugin list
+        findViewById(R.id.text_all_featured).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                showListFragment(PluginListType.FEATURED);
+            }
+        });
+
         // popular plugin list
         findViewById(R.id.text_all_popular).setOnClickListener(new View.OnClickListener() {
             @Override
@@ -127,6 +137,7 @@ public class PluginBrowserActivity extends AppCompatActivity
         });
 
         configureRecycler(mSitePluginsRecycler);
+        configureRecycler(mFeaturedPluginsRecycler);
         configureRecycler(mPopularPluginsRecycler);
         configureRecycler(mNewPluginsRecycler);
 
@@ -151,6 +162,13 @@ public class PluginBrowserActivity extends AppCompatActivity
             @Override
             public void onChanged(@Nullable final List<ImmutablePluginModel> sitePlugins) {
                 reloadPluginAdapterAndVisibility(PluginListType.SITE, sitePlugins);
+            }
+        });
+
+        mViewModel.getFeaturedPlugins().observe(this, new Observer<List<ImmutablePluginModel>>() {
+            @Override
+            public void onChanged(@Nullable final List<ImmutablePluginModel> featuredPlugins) {
+                reloadPluginAdapterAndVisibility(PluginListType.FEATURED, featuredPlugins);
             }
         });
 
@@ -230,6 +248,10 @@ public class PluginBrowserActivity extends AppCompatActivity
         PluginBrowserAdapter adapter;
         View cardView;
         switch (pluginType) {
+            case FEATURED:
+                adapter = (PluginBrowserAdapter) mFeaturedPluginsRecycler.getAdapter();
+                cardView = findViewById(R.id.featured_plugins_cardview);
+                break;
             case POPULAR:
                 adapter = (PluginBrowserAdapter) mPopularPluginsRecycler.getAdapter();
                 cardView = findViewById(R.id.popular_plugins_cardview);
@@ -417,6 +439,8 @@ public class PluginBrowserActivity extends AppCompatActivity
 
     private String getTitleForListType(@NonNull PluginListType pluginListType) {
         switch (pluginListType) {
+            case FEATURED:
+                return getString(R.string.plugin_caption_featured);
             case POPULAR:
                 return getString(R.string.plugin_caption_popular);
             case NEW:

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -798,11 +798,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     public void onSitePluginConfigured(OnSitePluginConfigured event) {
         if (isFinishing()) return;
 
-        if (mSite.getId() != event.site.getId() // Wrong site
-                || !mPlugin.isInstalled() // Plugin is not installed, this event can't be about this plugin
-                || mPlugin.getName() == null // Sanity check for NPE, but if the plugin is installed name will be there
-                || !mPlugin.getName().equals(event.pluginName)) { // Checking if the configured plugin is the one we are showing
-            // Not the event we are interested in
+        if (!shouldHandleFluxCSitePluginEvent(event.site, event.pluginName)) {
             return;
         }
 
@@ -872,11 +868,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     public void onSitePluginUpdated(OnSitePluginUpdated event) {
         if (isFinishing()) return;
 
-        if (mSite.getId() != event.site.getId() // Wrong site
-                || !mPlugin.isInstalled() // Plugin is not installed, this event can't be about this plugin
-                || mPlugin.getName() == null // Sanity check for NPE, but if the plugin is installed name will be there
-                || !mPlugin.getName().equals(event.pluginName)) { // Checking if the configured plugin is the one we are showing
-            // Not the event we are interested in
+        if (!shouldHandleFluxCSitePluginEvent(event.site, event.pluginName)) {
             return;
         }
 
@@ -934,11 +926,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     public void onSitePluginDeleted(OnSitePluginDeleted event) {
         if (isFinishing()) return;
 
-        if (mSite.getId() != event.site.getId() // Wrong site
-                || !mPlugin.isInstalled() // Plugin is not installed, this event can't be about this plugin
-                || mPlugin.getName() == null // Sanity check for NPE, but if the plugin is installed name will be there
-                || !mPlugin.getName().equals(event.pluginName)) { // Checking if the configured plugin is the one we are showing
-            // Not the event we are interested in
+        if (!shouldHandleFluxCSitePluginEvent(event.site, event.pluginName)) {
             return;
         }
 
@@ -963,6 +951,14 @@ public class PluginDetailActivity extends AppCompatActivity {
             refreshViews();
         }
         showSuccessfulPluginRemovedSnackbar();
+    }
+
+    // This check should only handle events for already installed plugins - onSitePluginConfigured, onSitePluginUpdated, onSitePluginDeleted
+    private boolean shouldHandleFluxCSitePluginEvent(SiteModel eventSite, String eventPluginName) {
+        return mSite.getId() == eventSite.getId() // correct site
+                && mPlugin.isInstalled() // needs plugin to be already installed
+                && mPlugin.getName() != null // sanity check for NPE since if plugin is installed it'll have the name
+                && mPlugin.getName().equals(eventPluginName); // event is for the plugin we are showing
     }
 
     // Utils

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -854,9 +854,14 @@ public class PluginDetailActivity extends AppCompatActivity {
     public void onWPOrgPluginFetched(PluginStore.OnWPOrgPluginFetched event) {
         if (isFinishing()) return;
 
+        if (!mSlug.equals(event.pluginSlug)) {
+            // another plugin fetched, no need to handle it
+            return;
+        }
+
         if (event.isError()) {
-            AppLog.e(AppLog.T.PLUGINS, "An error occurred while fetching wporg plugin with type: "
-                    + event.error.type);
+            AppLog.e(AppLog.T.PLUGINS, "An error occurred while fetching wporg plugin" + event.pluginSlug
+                    + " with type: " + event.error.type);
         } else {
             refreshPluginFromStore();
             refreshViews();

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
@@ -93,6 +93,15 @@ public class PluginListFragment extends Fragment {
             }
         });
 
+        mViewModel.getFeaturedPlugins().observe(this, new Observer<List<ImmutablePluginModel>>() {
+            @Override
+            public void onChanged(@Nullable final List<ImmutablePluginModel> featuredPlugins) {
+                if (mListType == PluginListType.FEATURED) {
+                    reloadPlugins();
+                }
+            }
+        });
+
         mViewModel.getNewPlugins().observe(this, new Observer<List<ImmutablePluginModel>>() {
             @Override
             public void onChanged(@Nullable final List<ImmutablePluginModel> newPlugins) {
@@ -124,6 +133,15 @@ public class PluginListFragment extends Fragment {
             @Override
             public void onChanged(@Nullable PluginBrowserViewModel.PluginListStatus listStatus) {
                 if (mListType == PluginListType.SITE) {
+                    refreshProgressBars(listStatus);
+                }
+            }
+        });
+
+        mViewModel.getFeaturedPluginsListStatus().observe(this, new Observer<PluginBrowserViewModel.PluginListStatus>() {
+            @Override
+            public void onChanged(@Nullable PluginBrowserViewModel.PluginListStatus listStatus) {
+                if (mListType == PluginListType.FEATURED) {
                     refreshProgressBars(listStatus);
                 }
             }

--- a/WordPress/src/main/res/layout/plugin_browser_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_browser_activity.xml
@@ -75,6 +75,61 @@
             </android.support.v7.widget.CardView>
 
             <android.support.v7.widget.CardView
+                android:id="@+id/featured_plugins_cardview"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_extra_large"
+                android:visibility="gone"
+                card_view:cardBackgroundColor="@color/white"
+                card_view:cardCornerRadius="@dimen/cardview_default_radius"
+                tools:visibility="visible">
+
+                <RelativeLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <TextView
+                        android:id="@+id/text_featured"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="@dimen/margin_extra_large"
+                        android:layout_marginStart="@dimen/margin_extra_large"
+                        android:layout_marginTop="@dimen/margin_extra_large"
+                        android:text="@string/plugin_caption_featured"
+                        android:textColor="@color/grey_dark"
+                        android:textSize="@dimen/text_sz_large" />
+
+                    <TextView
+                        android:id="@+id/text_all_featured"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:minHeight="@dimen/min_touch_target_sz"
+                        android:layout_alignParentRight="true"
+                        android:layout_alignParentEnd="true"
+                        android:paddingEnd="@dimen/margin_extra_large"
+                        android:paddingLeft="@dimen/margin_extra_large"
+                        android:paddingRight="@dimen/margin_extra_large"
+                        android:paddingStart="@dimen/margin_extra_large"
+                        android:paddingTop="@dimen/margin_extra_large"
+                        android:background="?android:attr/selectableItemBackground"
+                        android:text="@string/plugin_see_all"
+                        android:textAllCaps="true"
+                        android:textColor="@color/blue_medium"
+                        android:textSize="@dimen/text_sz_medium"
+                        android:textStyle="bold" />
+
+                    <android.support.v7.widget.RecyclerView
+                        android:id="@+id/featured_plugins_recycler"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_below="@+id/text_all_featured"
+                        android:layout_marginBottom="@dimen/margin_small"
+                        android:layout_marginTop="@dimen/margin_small"
+                        android:scrollbars="none" />
+                </RelativeLayout>
+            </android.support.v7.widget.CardView>
+
+            <android.support.v7.widget.CardView
                 android:id="@+id/popular_plugins_cardview"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1804,6 +1804,7 @@
     <string name="plugins_empty_search_list">No matches</string>
 
     <string name="plugin_caption_installed" translatable="false">@string/plugin_installed</string>
+    <string name="plugin_caption_featured">Featured</string>
     <string name="plugin_caption_popular">Popular</string>
     <string name="plugin_caption_new">New</string>
     <string name="plugin_caption_search">Search Plugins</string>

--- a/build.gradle
+++ b/build.gradle
@@ -22,5 +22,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '9a80c77f10de2def3e06c267bdab8c5d4e161667'
+    fluxCVersion = 'b9f1b291526808d36ac26fa1dc9818a01028377e'
 }

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTracker.java
@@ -173,7 +173,8 @@ public final class AnalyticsTracker {
         OPENED_MY_PROFILE,
         OPENED_PEOPLE_MANAGEMENT,
         OPENED_PERSON,
-        OPENED_PLUGINS,
+        OPENED_PLUGIN_DIRECTORY,
+        OPENED_PLUGIN_LIST,
         OPENED_PLUGIN_DETAIL,
         CREATE_ACCOUNT_INITIATED,
         CREATE_ACCOUNT_EMAIL_EXISTS,
@@ -327,9 +328,14 @@ public final class AnalyticsTracker {
         APP_PERMISSION_GRANTED,
         APP_PERMISSION_DENIED,
         SHARE_TO_WP_SUCCEEDED,
+        PLUGIN_ACTIVATED,
+        PLUGIN_AUTOUPDATE_ENABLED,
+        PLUGIN_AUTOUPDATE_DISABLED,
+        PLUGIN_DEACTIVATED,
+        PLUGIN_INSTALLED,
         PLUGIN_REMOVED,
-        PLUGIN_UPDATED,
-        PLUGIN_INSTALLED
+        PLUGIN_SEARCH_PERFORMED,
+        PLUGIN_UPDATED
     }
 
     private static final List<Tracker> TRACKERS = new ArrayList<>();

--- a/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
+++ b/libs/analytics/WordPressAnalytics/src/main/java/org/wordpress/android/analytics/AnalyticsTrackerNosara.java
@@ -575,10 +575,12 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "people_management_list_opened";
             case OPENED_PERSON:
                 return "people_management_details_opened";
-            case OPENED_PLUGINS:
-                return "plugins_opened";
             case OPENED_PLUGIN_DETAIL:
                 return "plugin_detail_opened";
+            case OPENED_PLUGIN_DIRECTORY:
+                return "plugin_directory_opened";
+            case OPENED_PLUGIN_LIST:
+                return "plugin_list_opened";
             case CREATE_ACCOUNT_INITIATED:
                 return "account_create_initiated";
             case CREATE_ACCOUNT_EMAIL_EXISTS:
@@ -935,12 +937,22 @@ public class AnalyticsTrackerNosara extends Tracker {
                 return "app_permission_denied";
             case SHARE_TO_WP_SUCCEEDED:
                 return "share_to_wp_succeeded";
-            case PLUGIN_REMOVED:
-                return "plugin_removed";
-            case PLUGIN_UPDATED:
-                return "plugin_updated";
+            case PLUGIN_ACTIVATED:
+                return "plugin_activated";
+            case PLUGIN_AUTOUPDATE_ENABLED:
+                return "plugin_autoupdate_enabled";
+            case PLUGIN_AUTOUPDATE_DISABLED:
+                return "plugin_autoupdate_disabled";
+            case PLUGIN_DEACTIVATED:
+                return "plugin_deactivated";
             case PLUGIN_INSTALLED:
                 return "plugin_installed";
+            case PLUGIN_REMOVED:
+                return "plugin_removed";
+            case PLUGIN_SEARCH_PERFORMED:
+                return "plugin_search_performed";
+            case PLUGIN_UPDATED:
+                return "plugin_updated";
             default:
                 return null;
         }


### PR DESCRIPTION
This PR addresses 3 small things and should be reviewed after #7347:

1. Adds the missing stats for plugins matching the iOS counterpart here: https://github.com/wordpress-mobile/WordPress-iOS/pull/8720
2. Updates FluxC hash to include this fix: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/733
3. Addresses [this comment](https://github.com/wordpress-mobile/WordPress-Android/pull/7280/files#r170735404)

Test:
1. Breakpoints is probably the best way to test stat changes
2. Search for "random" and tap on the first plugin. If it's opening the detail page without error, it means the fix is working. Before this change the plugins that were not in the `new` or `popular` directory were giving an error (only in the WIP branch, develop and release branches work fine)
3. By quickly going into the detail pages of multiple plugins could help with this test, but just making sure activation etc is working fine is enough.

/cc @theck13 - There should be one more PR coming for plugins which will improve network loss better and we should be ready to merge all this into `develop` after.