### PR TITLE
Issue/7321 signup epilogue blank

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -262,7 +262,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                 // Start progress and wait for account to be fetched before populating views when
                 // email does not exist in account store.
                 if (TextUtils.isEmpty(mAccountStore.getAccount().getEmail())) {
-                    startProgress();
+                    startProgress(false);
                 // Skip progress and populate views when email does exist in account store.
                 } else {
                     populateViews();
@@ -431,7 +431,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
             endProgress();
             populateViews();
         } else if (changedUsername()) {
-            startProgress();
+            startProgress(false);
             PushUsernamePayload payload = new PushUsernamePayload(mUsername,
                     AccountUsernameActionType.KEEP_OLD_SITE_AND_ADDRESS);
             mDispatcher.dispatch(AccountActionBuilder.newPushUsernameAction(payload));
@@ -661,7 +661,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
             final File file = new File(filePath);
 
             if (file.exists()) {
-                startProgress();
+                startProgress(false);
 
                 GravatarApi.uploadGravatar(file, mAccountStore.getAccount().getEmail(), mAccountStore.getAccessToken(),
                         new GravatarApi.GravatarUploadListener() {
@@ -701,7 +701,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
 
     protected void updateAccountOrContinue() {
         if (changedDisplayName()) {
-            startProgress();
+            startProgress(false);
             PushAccountSettingsPayload payload = new PushAccountSettingsPayload();
             payload.params = new HashMap<>();
             payload.params.put("display_name", mDisplayName);
@@ -712,13 +712,13 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
 
             mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
         } else if (changedPassword()) {
-            startProgress();
+            startProgress(false);
             PushAccountSettingsPayload payload = new PushAccountSettingsPayload();
             payload.params = new HashMap<>();
             payload.params.put("password", mInputPassword.getEditText().getText().toString());
             mDispatcher.dispatch(AccountActionBuilder.newPushSettingsAction(payload));
         } else if (changedUsername()) {
-            startProgress();
+            startProgress(false);
             PushUsernamePayload payload = new PushUsernamePayload(mUsername,
                     AccountUsernameActionType.KEEP_OLD_SITE_AND_ADDRESS);
             mDispatcher.dispatch(AccountActionBuilder.newPushUsernameAction(payload));


### PR DESCRIPTION
### Fix
Add a conditional statement when loading the signup epilogue screen to populate the views once the account store has an email address either during `onActivityCreated` or once `onAccountChanged` occurs.  Also, all `startProgress()` instances were updated to `startProgress(false)` making the progress dialog unable to be cancelled since dismissing the dialog manually may cause confusion for the user when views are populated on callbacks.  These two additions avoid showing a screen without values as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7321.

### Test
***Self-Hosted Login***

0. Clear app data.
1. Tap ***Log In*** button.
2. Tap ***Log in by entering your site address.*** button.
3. Enter self-hosted site address in ***Site Address*** field.
4. Tap ***Next*** button.
5. Enter self-hosted site username in ***Username*** field.
6. Enter self-hosted site password in ***Password*** field.
7. Tap ***Next*** button.
8. Tap ***Continue*** button.

***New Account Signup***

1. Go to ***Me*** tab.
2. Tap ***Log in to WordPress.com*** button.
3. Tap ***Sign Up*** button.
4. Tap ***Sign Up with Email*** button.
5. Enter email address not associated with WordPress.com account in ***Email Address*** field.
6. Tap ***Next*** button.
7. Notice magic link screen.
8. Go to email app on device.
9. Tap ***Sign up to WordPress.com*** magic link button.
10. Notice signup epilogue screen is shown with views populated.