### PR TITLE
Plugins: Better handle network conditions

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -38,6 +38,7 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
+import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.viewmodel.PluginBrowserViewModel;
 import org.wordpress.android.viewmodel.PluginBrowserViewModel.PluginListType;
@@ -196,7 +197,10 @@ public class PluginBrowserActivity extends AppCompatActivity
                 showProgress(listStatus == PluginBrowserViewModel.PluginListStatus.FETCHING
                         && mViewModel.isSitePluginsEmpty());
 
-                if (listStatus == PluginBrowserViewModel.PluginListStatus.ERROR) {
+                // We should ignore the errors due to network condition, unless this is the first fetch, the user can
+                // use the cached version of them and showing the error while the data is loaded might cause confusion
+                if (listStatus == PluginBrowserViewModel.PluginListStatus.ERROR
+                        && NetworkUtils.isNetworkAvailable(PluginBrowserActivity.this)) {
                     ToastUtils.showToast(PluginBrowserActivity.this, R.string.plugin_fetch_error);
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -237,7 +237,9 @@ public class PluginDetailActivity extends AppCompatActivity {
             onBackPressed();
             return true;
         } else if (item.getItemId() == R.id.menu_trash) {
-            confirmRemovePlugin();
+            if (NetworkUtils.checkConnection(this)) {
+                confirmRemovePlugin();
+            }
             return true;
         }
         return super.onOptionsItemSelected(item);
@@ -356,6 +358,20 @@ public class PluginDetailActivity extends AppCompatActivity {
                         compoundButton.setChecked(mIsAutoUpdateEnabled);
                     }
                 }
+            }
+        });
+
+        mUpdateButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                dispatchUpdatePluginAction();
+            }
+        });
+
+        mInstallButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                dispatchInstallPluginAction();
             }
         });
 
@@ -484,24 +500,10 @@ public class PluginDetailActivity extends AppCompatActivity {
             boolean canUpdate = isUpdateAvailable && !mIsUpdatingPlugin;
             mUpdateButton.setVisibility(canUpdate ? View.VISIBLE : View.GONE);
             mInstalledText.setVisibility(isUpdateAvailable || mIsUpdatingPlugin ? View.GONE : View.VISIBLE);
-            if (canUpdate) {
-                mUpdateButton.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View view) {
-                        dispatchUpdatePluginAction();
-                    }
-                });
-            }
         } else {
             mUpdateButton.setVisibility(View.GONE);
             mInstalledText.setVisibility(View.GONE);
             mInstallButton.setVisibility(mIsInstallingPlugin ? View.GONE : View.VISIBLE);
-            mInstallButton.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    dispatchInstallPluginAction();
-                }
-            });
         }
 
         findViewById(R.id.plugin_update_progress_bar).setVisibility(mIsUpdatingPlugin || mIsInstallingPlugin
@@ -767,7 +769,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     }
 
     protected void dispatchInstallPluginAction() {
-        if (!NetworkUtils.checkConnection(this) || mIsInstallingPlugin) {
+        if (!NetworkUtils.checkConnection(this) || mPlugin.isInstalled() || mIsInstallingPlugin) {
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -335,10 +335,10 @@ public class PluginDetailActivity extends AppCompatActivity {
 
         mSwitchActive.setOnCheckedChangeListener(new OnCheckedChangeListener() {
             @Override
-            public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
+            public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
                 if (compoundButton.isPressed()) {
                     if (NetworkUtils.checkConnection(PluginDetailActivity.this)) {
-                        mIsActive = b;
+                        mIsActive = isChecked;
                         dispatchConfigurePluginAction(false);
                     } else {
                         compoundButton.setChecked(mIsActive);
@@ -349,10 +349,10 @@ public class PluginDetailActivity extends AppCompatActivity {
 
         mSwitchAutoupdates.setOnCheckedChangeListener(new OnCheckedChangeListener() {
             @Override
-            public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
+            public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
                 if (compoundButton.isPressed()) {
                     if (NetworkUtils.checkConnection(PluginDetailActivity.this)) {
-                        mIsAutoUpdateEnabled = b;
+                        mIsAutoUpdateEnabled = isChecked;
                         dispatchConfigurePluginAction(false);
                     } else {
                         compoundButton.setChecked(mIsAutoUpdateEnabled);

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -335,8 +335,12 @@ public class PluginDetailActivity extends AppCompatActivity {
             @Override
             public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
                 if (compoundButton.isPressed()) {
-                    mIsActive = b;
-                    dispatchConfigurePluginAction(false);
+                    if (NetworkUtils.checkConnection(PluginDetailActivity.this)) {
+                        mIsActive = b;
+                        dispatchConfigurePluginAction(false);
+                    } else {
+                        compoundButton.setChecked(mIsActive);
+                    }
                 }
             }
         });
@@ -345,8 +349,12 @@ public class PluginDetailActivity extends AppCompatActivity {
             @Override
             public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
                 if (compoundButton.isPressed()) {
-                    mIsAutoUpdateEnabled = b;
-                    dispatchConfigurePluginAction(false);
+                    if (NetworkUtils.checkConnection(PluginDetailActivity.this)) {
+                        mIsAutoUpdateEnabled = b;
+                        dispatchConfigurePluginAction(false);
+                    } else {
+                        compoundButton.setChecked(mIsAutoUpdateEnabled);
+                    }
                 }
             }
         });
@@ -729,7 +737,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     // Network Helpers
 
     protected void dispatchConfigurePluginAction(boolean forceUpdate) {
-        if (!NetworkUtils.checkConnection(this)) {
+        if (!NetworkUtils.isNetworkAvailable(this)) {
             return;
         }
         if (!forceUpdate && mIsConfiguringPlugin) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
@@ -28,6 +28,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.plugin.ImmutablePluginModel;
 import org.wordpress.android.ui.ActivityLauncher;
+import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
@@ -193,7 +194,11 @@ public class PluginListFragment extends Fragment {
                 new SwipeToRefreshHelper.RefreshListener() {
                     @Override
                     public void onRefreshStarted() {
-                        mViewModel.pullToRefresh(mListType);
+                        if (NetworkUtils.checkConnection(getActivity())) {
+                            mViewModel.pullToRefresh(mListType);
+                        } else {
+                            mSwipeToRefreshHelper.setRefreshing(false);
+                        }
                     }
                 }
         );


### PR DESCRIPTION
This is a small PR that improves the network connection handling and should be reviewed after #7364. I think this is good enough for now, but I really would like to be able to handle the network conditions in the view model itself without having to access to the context object. I'll think about this a bit and probably make it a part of future improvements to the view model.

Note that I have moved the `setOnClickListener`s to the setup view method. I've no idea why they were in the refresh method in the first place.

/cc @theck13 