### PR TITLE
Guard for file:// and Toast to user to select another

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -702,7 +702,8 @@ public class GCMMessageService extends GcmListenerService {
                     String notificationSound = prefs.getString(context.getString(R.string.wp_pref_custom_notification_sound),
                             context.getString(R.string.notification_settings_item_sights_and_sounds_choose_sound_default));
 
-                    if (!TextUtils.isEmpty(notificationSound) && !notificationSound.trim().startsWith("file://")) {
+                    if (!TextUtils.isEmpty(notificationSound)
+                            && !notificationSound.trim().toLowerCase().startsWith("file://")) {
                         builder.setSound(Uri.parse(notificationSound));
                     }
 

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -699,9 +699,10 @@ public class GCMMessageService extends GcmListenerService {
                 if (notifyUser) {
                     boolean shouldVibrate = prefs.getBoolean(context.getString(R.string.wp_pref_notification_vibrate), false);
                     boolean shouldBlinkLight = prefs.getBoolean(context.getString(R.string.wp_pref_notification_light), true);
-                    String notificationSound = prefs.getString(context.getString(R.string.wp_pref_custom_notification_sound), "content://settings/system/notification_sound"); //"" if None is selected
+                    String notificationSound = prefs.getString(context.getString(R.string.wp_pref_custom_notification_sound),
+                            context.getString(R.string.notification_settings_item_sights_and_sounds_choose_sound_default));
 
-                    if (!TextUtils.isEmpty(notificationSound)) {
+                    if (!TextUtils.isEmpty(notificationSound) && !notificationSound.trim().startsWith("file://")) {
                         builder.setSound(Uri.parse(notificationSound));
                     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.ui.prefs.notifications;
 
+import android.app.Application;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.Intent;
@@ -548,8 +549,8 @@ public class NotificationsSettingsFragment extends PreferenceFragment implements
                 //  default and let the user know.
                 AppLog.w(T.NOTIFS, "Notification sound starts with unacceptable scheme: " + value);
 
-                Context context = getActivity();
-                if (context != null && isAdded()) {
+                Context context = WordPress.getContext();
+                if (context != null) {
                     // let the user know we won't be using the selected sound
                     ToastUtils.showToast(context, R.string.notification_sound_has_invalid_path);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -42,6 +42,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.SiteUtils;
 import org.wordpress.android.util.ToastUtils;
+import org.wordpress.android.util.ToastUtils.Duration;
 import org.wordpress.android.util.WPActivityUtils;
 
 import java.util.ArrayList;
@@ -552,7 +553,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment implements
                 Context context = WordPress.getContext();
                 if (context != null) {
                     // let the user know we won't be using the selected sound
-                    ToastUtils.showToast(context, R.string.notification_sound_has_invalid_path);
+                    ToastUtils.showToast(context, R.string.notification_sound_has_invalid_path, Duration.LONG);
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -40,6 +40,7 @@ import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
 import org.wordpress.android.util.SiteUtils;
+import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.WPActivityUtils;
 
 import java.util.ArrayList;
@@ -105,19 +106,24 @@ public class NotificationsSettingsFragment extends PreferenceFragment implements
         }
     }
 
+    @Override
+    public void onStart() {
+        super.onStart();
+
+        getPreferenceManager().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
+    }
 
     @Override
     public void onResume() {
         super.onResume();
-        getPreferenceManager().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
 
         mNotificationsEnabled = NotificationsUtils.isNotificationsEnabled(getActivity());
         refreshSettings();
     }
 
     @Override
-    public void onPause() {
-        super.onPause();
+    public void onStop() {
+        super.onStop();
 
         getPreferenceManager().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(this);
     }
@@ -530,6 +536,22 @@ public class NotificationsSettingsFragment extends PreferenceFragment implements
                     AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATION_PENDING_DRAFTS_SETTINGS_ENABLED);
                 } else {
                     AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATION_PENDING_DRAFTS_SETTINGS_DISABLED);
+                }
+            }
+        } else if (key.equals(getString(R.string.wp_pref_custom_notification_sound))) {
+            final String defaultPath =
+                    getString(R.string.notification_settings_item_sights_and_sounds_choose_sound_default);
+            final String value = sharedPreferences.getString(key, defaultPath);
+
+            if (value.trim().startsWith("file://")) {
+                // sound path begins with 'file://` which will lead to FileUriExposedException when used. Revert to
+                //  default and let the user know.
+                AppLog.w(T.NOTIFS, "Notification sound starts with unacceptable scheme: " + value);
+
+                Context context = getActivity();
+                if (context != null && isAdded()) {
+                    // let the user know we won't be using the selected sound
+                    ToastUtils.showToast(context, R.string.notification_sound_has_invalid_path);
                 }
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -543,7 +543,7 @@ public class NotificationsSettingsFragment extends PreferenceFragment implements
                     getString(R.string.notification_settings_item_sights_and_sounds_choose_sound_default);
             final String value = sharedPreferences.getString(key, defaultPath);
 
-            if (value.trim().startsWith("file://")) {
+            if (value.trim().toLowerCase().startsWith("file://")) {
                 // sound path begins with 'file://` which will lead to FileUriExposedException when used. Revert to
                 //  default and let the user know.
                 AppLog.w(T.NOTIFS, "Notification sound starts with unacceptable scheme: " + value);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -984,6 +984,7 @@
     <string name="notification_settings_item_other_account_emails_summary">We\'ll always send important emails regarding your account, but you can get some helpful extras, too.</string>
     <string name="notification_settings_category_sights_and_sounds">Sights and Sounds</string>
     <string name="notification_settings_item_sights_and_sounds_choose_sound">Choose sound</string>
+    <string name="notification_settings_item_sights_and_sounds_choose_sound_default" translatable="false">content://settings/system/notification_sound</string>
     <string name="notification_settings_item_sights_and_sounds_vibrate_device">Vibrate device</string>
     <string name="notification_settings_item_sights_and_sounds_blink_light">Blink light</string>
     <string name="notifications_wpcom_updates">WordPress.com Updates</string>
@@ -1001,6 +1002,7 @@
     <string name="notifications_push_summary">Settings for notifications that appear on your device.</string>
     <string name="search_sites">Search sites</string>
     <string name="notifications_no_search_results">No sites matched \'%s\'</string>
+    <string name="notification_sound_has_invalid_path">Invalid sound path. Please choose another.</string>
 
     <string name="comments_on_my_site">Comments on my site</string>
     <string name="likes_on_my_comments">Likes on my comments</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1002,7 +1002,7 @@
     <string name="notifications_push_summary">Settings for notifications that appear on your device.</string>
     <string name="search_sites">Search sites</string>
     <string name="notifications_no_search_results">No sites matched \'%s\'</string>
-    <string name="notification_sound_has_invalid_path">Invalid sound path. Please choose another.</string>
+    <string name="notification_sound_has_invalid_path">The chosen sound has invalid path. Please choose another.</string>
 
     <string name="comments_on_my_site">Comments on my site</string>
     <string name="likes_on_my_comments">Likes on my comments</string>

--- a/WordPress/src/main/res/xml/notifications_settings.xml
+++ b/WordPress/src/main/res/xml/notifications_settings.xml
@@ -29,7 +29,7 @@
 
         <RingtonePreference
             android:key="@string/wp_pref_custom_notification_sound"
-            android:defaultValue="content://settings/system/notification_sound"
+            android:defaultValue="@string/notification_settings_item_sights_and_sounds_choose_sound_default"
             android:ringtoneType="notification"
             android:showDefault="true"
             android:title="@string/notification_settings_item_sights_and_sounds_choose_sound" />


### PR DESCRIPTION
Fixes #7372 

Seems that the app may receive ringtone sound paths that start with the `file://` scheme and that's not usable. Let's guard against it and notify the user that the selected sound is invalid.

Implementation detail: Need to do the Pref change listener reg/unreg in onStart/onStop
instead of onResume/onPause because the RingtonePreference opens an
activity and causes parent to pause. So, in order to detect the
'file://' value being saved, we need to reg/ in onStart/onStop.

To test:
No steps known.