### PR TITLE
Issue/7379 signup password toggle

### DIFF
--- a/WordPress/src/main/res/layout/signup_epilogue.xml
+++ b/WordPress/src/main/res/layout/signup_epilogue.xml
@@ -156,6 +156,8 @@
                 android:paddingRight="@dimen/margin_extra_large"
                 android:paddingEnd="@dimen/margin_extra_large"
                 android:visibility="gone"
+                app:passwordToggleEnabled="true"
+                app:passwordToggleTint="@color/grey"
                 app:wpIconDrawable="@drawable/ic_lock_grey_24dp"
                 tools:visibility="visible" >
             </org.wordpress.android.login.widgets.WPLoginInputRow>


### PR DESCRIPTION
### Fix
Add visibility toggle button to the password field on the signup epilogue screen when signing up via email as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7379.

### Test
0. Clear app data.
1. Tap ***Sign Up*** button.
2. Tap ***Sign Up with Email*** button.
3. Enter email address _not_ associated with WordPress.com account.
4. Notice ***Signup Magic Link*** screen.
5. Check email inbox of address used in Step 3.
6. Notice signup email from WordPress.com.
7. Tap ***Sign up to WordPress.com*** button in email.
8. Notice  ***Epilogue for Email*** screen.
9. Notice ***Password*** field contains visibility toggle button.
10. Enter text into ***Password*** field.
11. Notice text is hidden.
12. Tap password visibility toggle button.
13. Notice text is shown.