### PR TITLE
Issue/7322 signup gravatar upload

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -574,7 +574,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
             } catch (IOException exception) {
                 AppLog.e(T.NUX, "Gravatar image could not be injected into request cache - " +
                         exception.toString() + " - " + exception.getMessage());
-                showErrorDialogAvatar();
+                showErrorDialogAvatar(getString(R.string.signup_epilogue_error_avatar));
             }
 
             mHeaderAvatar.resetImage();
@@ -584,7 +584,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
         mHeaderAvatar.setImageUrl(avatarUrl, ImageType.AVATAR, new WPNetworkImageView.ImageLoadListener() {
             @Override
             public void onError() {
-                showErrorDialogAvatar();
+                showErrorDialogAvatar(getString(R.string.signup_epilogue_error_avatar_view));
             }
 
             @Override
@@ -618,9 +618,9 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
         dialog.show();
     }
 
-    protected void showErrorDialogAvatar() {
+    protected void showErrorDialogAvatar(String message) {
         AlertDialog dialog = new AlertDialog.Builder(new ContextThemeWrapper(getActivity(), R.style.LoginTheme))
-                .setMessage(R.string.signup_epilogue_error_avatar)
+                .setMessage(message)
                 .setPositiveButton(R.string.login_error_button, null)
                 .create();
         dialog.show();
@@ -666,7 +666,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
                             @Override
                             public void onError() {
                                 endProgress();
-                                showErrorDialogAvatar();
+                                showErrorDialogAvatar(getString(R.string.signup_epilogue_error_avatar));
                                 AppLog.e(T.NUX, "Uploading image to Gravatar failed");
                             }
                         });

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEpilogueFragment.java
@@ -584,6 +584,7 @@ public class SignupEpilogueFragment extends LoginBaseFormFragment<SignupEpilogue
         mHeaderAvatar.setImageUrl(avatarUrl, ImageType.AVATAR, new WPNetworkImageView.ImageLoadListener() {
             @Override
             public void onError() {
+                AppLog.e(T.NUX, "Uploading image to Gravatar succeeded, but setting image view failed");
                 showErrorDialogAvatar(getString(R.string.signup_epilogue_error_avatar_view));
             }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2071,6 +2071,7 @@
     <string name="signup_email_error_generic">There was some trouble checking the email address.</string>
     <string name="signup_email_header">To create your new WordPress.com account, please enter your email address.</string>
     <string name="signup_epilogue_error_avatar">There was some trouble uploading your avatar.</string>
+    <string name="signup_epilogue_error_avatar_view">Your avatar has been uploaded and will be available shortly.</string>
     <string name="signup_epilogue_error_generic">There was some trouble updating your account. You can retry or revert your changes to continue.</string>
     <string name="signup_epilogue_error_button_negative">Revert</string>
     <string name="signup_epilogue_error_button_positive">Retry</string>


### PR DESCRIPTION
### Fix
Update the error message and add application logged when uploading an avatar image to Gravatar succeeds and setting the image view fails to address https://github.com/wordpress-mobile/WordPress-Android/issues/7322

### Test
0. Clear app data.
1. Tap ***Sign Up*** button.
2. Tap ***Sign Up with Email*** button.
3. Enter email address _not_ associated with WordPress.com account.
4. Notice ***Signup Magic Link*** screen.
5. Check email inbox of address used in Step 3.
6. Notice signup email from WordPress.com.
7. Tap ***Sign up to WordPress.com*** button in email.
8. Notice  ***Epilogue for Email*** screen.
9. Tap avatar icon in header.
10. Notice add avatar interface.
11. Notice ***Your avatar has been uploaded and will be available shortly.*** message.