### PR TITLE
Only show error toast if post is null and it wasn't empty

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1480,10 +1480,7 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private boolean isDiscardable() {
-        if (!PostUtils.isPublishable(mPost) && isNewPost()) {
-            return true;
-        }
-        return false;
+        return !PostUtils.isPublishable(mPost) && isNewPost();
     }
 
     private boolean isFirstTimePublish() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -227,7 +227,8 @@ public class PostsListFragment extends Fragment
         final PostModel post = mPostStore.
                 getPostByLocalPostId(data.getIntExtra(EditPostActivity.EXTRA_POST_LOCAL_ID, 0));
 
-        if (post == null) {
+        if ((post == null)
+                && !data.getBooleanExtra(EditPostActivity.EXTRA_IS_DISCARDABLE, false)) {
             ToastUtils.showToast(getActivity(), R.string.post_not_found, ToastUtils.Duration.LONG);
             return;
         }


### PR DESCRIPTION

Fixes #7382 

To test:
1. go to Posts list
2. tap on the floating "Edit new post" button
3. without adding any content, just tap BACK
4. observe the error Toast is not shown anymore.
