### PR TITLE
Make sure no space-only title, content or excerpt are allowed in Posts

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostUtils.java
@@ -158,7 +158,7 @@ public class PostUtils {
 
     public static boolean isPublishable(PostModel post) {
         return post != null
-                && !(post.getContent().isEmpty() && post.getExcerpt().isEmpty() && post.getTitle().isEmpty());
+                && !(post.getContent().trim().isEmpty() && post.getExcerpt().trim().isEmpty() && post.getTitle().trim().isEmpty());
     }
 
     public static boolean hasEmptyContentFields(PostModel post) {


### PR DESCRIPTION

Fixes #7384 

To test:
1. go to posts list
2. tap on the "Edit" floating button
3. insert a space in the title
4. tap back: observe nothing happens (no draft is attempted to be saved or uploaded).
5. repeat step 1-3 but this time try inserting a space in the content area, then tapping Back.

**Notes**
I've investigated where the loop comes from, to try and see what the real culprit for this behavior was.

This is the part in the logs that gets repeated:

```
03-05 16:52:15.301 15705-16007/org.wordpress.android D/WordPress-API: Dispatching action: PostAction-UPDATE_POST
03-05 16:52:26.655 15705-15705/org.wordpress.android E/WordPress-API: Volley error on https://public-api.wordpress.com/rest/v1.1/sites/109511380/posts/new/?context=edit&locale=en_US
                                                                      com.android.volley.ServerError
                                                                          at com.android.volley.toolbox.BasicNetwork.performRequest(BasicNetwork.java:179)
                                                                          at com.android.volley.NetworkDispatcher.run(NetworkDispatcher.java:114)
03-05 16:52:26.664 15705-15705/org.wordpress.android D/WordPress-API: Dispatching action: UploadAction-PUSHED_POST
03-05 16:52:26.675 15705-15705/org.wordpress.android I/WordPress-NOTIFS: notifications update service > created
03-05 16:52:26.688 15705-15705/org.wordpress.android I/Choreographer: Skipped 796 frames!  The application may be doing too much work on its main thread.
03-05 16:52:26.704 15705-16021/org.wordpress.android D/WordPress-API: Dispatching action: PostAction-PUSHED_POST
03-05 16:52:26.831 15705-16027/org.wordpress.android D/FA: Connected to remote service
03-05 16:52:26.831 15705-16027/org.wordpress.android V/FA: Processing queued up service tasks: 3
03-05 16:52:26.836 15705-15705/org.wordpress.android W/WordPress-POSTS: PostUploadHandler > Post upload failed. GENERIC_ERROR: Content, title, and excerpt are empty.
03-05 16:52:26.846 15705-15705/org.wordpress.android D/WordPress-POSTS: updateNotificationErrorForPost: There was an error uploading this post: Content, title, and excerpt are empty..

```

The problem is that in the UploadService we're listening for the FluxC `onPostUploaded` signal to make sure we've got nothing else to do, and for that we end up running [`stopServiceIfUploadsComplete()`](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java#L961). Within `stopServiceIfUploadsComplete()` we make a call to [`doFinalProcessingOfPosts`](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java#L603) which gets all registered posts and [tries to re-upload](https://github.com/wordpress-mobile/WordPress-Android/blob/develop/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java#L894) those that need be sent to the server.
This is where the loop goes, as each time the same Post is retried, it will fail (`GENERIC_ERROR: Content, title, and excerpt are empty.`).

This would in turn get an error from the server each time, and we would re-collect the Post for upload in the `UploadService` again and again, as it’s part of the `doFinalProcessingOfPosts` duty.

What we should not do as per what the server error says, is to let content, title or excerpt be empty (or for what matters, have spaces only), which is exactly what this PR cares for.
