### PR TITLE
Design tweak of Plugin Detail layout

### DIFF
--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -128,7 +128,11 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_centerVertical="true"
-                            android:orientation="vertical">
+                            android:orientation="vertical"
+                            android:layout_alignParentLeft="true"
+                            android:layout_alignParentStart="true"
+                            android:layout_toLeftOf="@+id/plugin_btn_container"
+                            android:layout_toStartOf="@+id/plugin_btn_container">
 
                             <TextView
                                 android:id="@+id/plugin_version_top"
@@ -147,11 +151,14 @@
                         </LinearLayout>
 
                         <FrameLayout
+                            android:id="@+id/plugin_btn_container"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_alignParentEnd="true"
                             android:layout_alignParentRight="true"
-                            android:layout_centerVertical="true">
+                            android:layout_centerVertical="true"
+                            android:layout_marginLeft="@dimen/margin_extra_large"
+                            android:layout_marginStart="@dimen/margin_extra_large">
 
                             <TextView
                                 android:id="@+id/plugin_btn_update"


### PR DESCRIPTION
Fixes #7171 - Plugin Detail: update button wider than expected in French

To test:

**Default (English)t**

1. Go to **Sites** Tab
2. Plugins
3. Tap on any Plugin 
4. Notice that Plugin version show as always

<img src="https://user-images.githubusercontent.com/2581647/37034255-728dc9fe-2127-11e8-8cfb-c7840cbcdd0c.png" width="300"/>

Test after Change language to **French**
1. Go to Sites Tab
2. Plugins (Extensions)
3. Tap on any Plugin 
4. Since the description in French is longer there's 2 lines and now notice that the plugin description is not longer behind the button

<img src="https://user-images.githubusercontent.com/2581647/37034260-7759f7d2-2127-11e8-96d9-aafcd1a0360f.png" width="300"/>
