### PR TITLE
Issue/7394 publish confirmation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -965,7 +965,18 @@ public class EditPostActivity extends AppCompatActivity implements
 
         if (itemId == R.id.menu_save_post) {
             if (!AppPrefs.isAsyncPromoRequired()) {
-                publishPost();
+                AlertDialog.Builder builder = new AlertDialog.Builder(this);
+                builder.setTitle(getResources().getText(R.string.dialog_confirm_publish_title))
+                        .setMessage(R.string.dialog_confirm_publish_message)
+                        .setPositiveButton(R.string.dialog_confirm_publish_yes, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialogInterface, int i) {
+                                publishPost();
+                            }
+                        })
+                        .setNegativeButton(R.string.dialog_confirm_publish_no, null)
+                        .setCancelable(true);
+                builder.create().show();
             } else {
                 showAsyncPromoDialog();
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -994,8 +994,8 @@ public class EditPostActivity extends AppCompatActivity implements
     private void showPublishConfirmationDialog() {
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
         builder.setTitle(getResources().getText(R.string.dialog_confirm_publish_title))
-                .setMessage(mPost.isPage() ? getString(R.string.dialog_confirm_publish_message_page) :
-                        getString(R.string.dialog_confirm_publish_message_post))
+                .setMessage(mPost.isPage() ? getString(R.string.dialog_confirm_publish_message_page)
+                                    : getString(R.string.dialog_confirm_publish_message_post))
                 .setPositiveButton(R.string.dialog_confirm_publish_yes, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -237,8 +237,6 @@ public class EditPostActivity extends AppCompatActivity implements
     private PhotoPickerFragment mPhotoPickerFragment;
     private int mPhotoPickerOrientation = Configuration.ORIENTATION_UNDEFINED;
 
-    private PromoDialogAdvanced mAsyncPromoDialog;
-
     // For opening the context menu after permissions have been granted
     private View mMenuView = null;
 
@@ -1003,7 +1001,7 @@ public class EditPostActivity extends AppCompatActivity implements
                         publishPost();
                     }
                 })
-                .setNegativeButton(R.string.dialog_confirm_publish_no, null)
+                .setNegativeButton(R.string.keep_editing, null)
                 .setCancelable(true);
         builder.create().show();
     }
@@ -3035,17 +3033,16 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private void showAsyncPromoDialog() {
-        if (mAsyncPromoDialog == null) {
-            mAsyncPromoDialog = new PromoDialogAdvanced.Builder(
-                    R.drawable.img_promo_async,
-                    R.string.async_promo_title,
-                    R.string.async_promo_description,
-                    android.R.string.ok)
-                    .setLinkText(R.string.async_promo_link)
-                    .build();
-        }
+        final PromoDialogAdvanced asyncPromoDialog = new PromoDialogAdvanced.Builder(
+                R.drawable.img_promo_async,
+                R.string.async_promo_title,
+                R.string.async_promo_description,
+                android.R.string.ok)
+                .setNegativeButtonText(R.string.keep_editing)
+                .setLinkText(R.string.async_promo_link)
+                .build();
 
-        mAsyncPromoDialog.setLinkOnClickListener(new View.OnClickListener() {
+        asyncPromoDialog.setLinkOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 Intent intent = new Intent(EditPostActivity.this, ReleaseNotesActivity.class);
@@ -3055,15 +3052,21 @@ public class EditPostActivity extends AppCompatActivity implements
             }
         });
 
-        mAsyncPromoDialog.setPositiveButtonOnClickListener(new View.OnClickListener() {
+        asyncPromoDialog.setPositiveButtonOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                mAsyncPromoDialog.dismiss();
-                showPublishConfirmationOrUpdateIfNotLocalDraft();
+                publishPost();
             }
         });
 
-        mAsyncPromoDialog.show(getSupportFragmentManager(), ASYNC_PROMO_DIALOG_TAG);
+        asyncPromoDialog.setNegativeButtonOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                asyncPromoDialog.dismiss();
+            }
+        });
+
+        asyncPromoDialog.show(getSupportFragmentManager(), ASYNC_PROMO_DIALOG_TAG);
         AppPrefs.setAsyncPromoRequired(false);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -965,18 +965,25 @@ public class EditPostActivity extends AppCompatActivity implements
 
         if (itemId == R.id.menu_save_post) {
             if (!AppPrefs.isAsyncPromoRequired()) {
-                AlertDialog.Builder builder = new AlertDialog.Builder(this);
-                builder.setTitle(getResources().getText(R.string.dialog_confirm_publish_title))
-                        .setMessage(R.string.dialog_confirm_publish_message)
-                        .setPositiveButton(R.string.dialog_confirm_publish_yes, new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialogInterface, int i) {
-                                publishPost();
-                            }
-                        })
-                        .setNegativeButton(R.string.dialog_confirm_publish_no, null)
-                        .setCancelable(true);
-                builder.create().show();
+                // if post is a draft, first make sure to confirm the PUBLISH action, in case
+                // the user tapped on it accidentally
+                if (mPost.isLocalDraft()) {
+                    AlertDialog.Builder builder = new AlertDialog.Builder(this);
+                    builder.setTitle(getResources().getText(R.string.dialog_confirm_publish_title))
+                            .setMessage(R.string.dialog_confirm_publish_message)
+                            .setPositiveButton(R.string.dialog_confirm_publish_yes, new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialogInterface, int i) {
+                                    publishPost();
+                                }
+                            })
+                            .setNegativeButton(R.string.dialog_confirm_publish_no, null)
+                            .setCancelable(true);
+                    builder.create().show();
+                } else {
+                    // otherwise, if they're updating a Post, just go ahead and save it to the server
+                    publishPost();
+                }
             } else {
                 showAsyncPromoDialog();
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -994,7 +994,8 @@ public class EditPostActivity extends AppCompatActivity implements
     private void showPublishConfirmationDialog() {
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
         builder.setTitle(getResources().getText(R.string.dialog_confirm_publish_title))
-                .setMessage(mPost.isPage() ? getString(R.string.dialog_confirm_publish_message_page) : getString(R.string.dialog_confirm_publish_message_post))
+                .setMessage(mPost.isPage() ? getString(R.string.dialog_confirm_publish_message_page) :
+                        getString(R.string.dialog_confirm_publish_message_post))
                 .setPositiveButton(R.string.dialog_confirm_publish_yes, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -994,8 +994,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private void showPublishConfirmationDialog() {
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
         builder.setTitle(getResources().getText(R.string.dialog_confirm_publish_title))
-                .setMessage(String.format(getString(R.string.dialog_confirm_publish_message),
-                                          mPost.isPage() ? getString(R.string.page) : getString(R.string.post)))
+                .setMessage(mPost.isPage() ? getString(R.string.dialog_confirm_publish_message_page) : getString(R.string.dialog_confirm_publish_message_post))
                 .setPositiveButton(R.string.dialog_confirm_publish_yes, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -994,7 +994,8 @@ public class EditPostActivity extends AppCompatActivity implements
     private void showPublishConfirmationDialog() {
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
         builder.setTitle(getResources().getText(R.string.dialog_confirm_publish_title))
-                .setMessage(R.string.dialog_confirm_publish_message)
+                .setMessage(String.format(getString(R.string.dialog_confirm_publish_message),
+                                          mPost.isPage() ? getString(R.string.page) : getString(R.string.post)))
                 .setPositiveButton(R.string.dialog_confirm_publish_yes, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3037,7 +3037,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 R.drawable.img_promo_async,
                 R.string.async_promo_title,
                 R.string.async_promo_description,
-                android.R.string.ok)
+                R.string.async_promo_publish_now)
                 .setNegativeButtonText(R.string.keep_editing)
                 .setLinkText(R.string.async_promo_link)
                 .build();

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -529,7 +529,7 @@ public class PostsListFragment extends Fragment
             case PostListButton.BUTTON_SUBMIT:
             case PostListButton.BUTTON_SYNC:
             case PostListButton.BUTTON_PUBLISH:
-                UploadUtils.publishPost(getActivity(), post, mSite, mDispatcher);
+                showPublishConfirmationDialog(post);
                 break;
             case PostListButton.BUTTON_VIEW:
                 ActivityLauncher.browsePostOrPage(getActivity(), mSite, post);
@@ -560,6 +560,22 @@ public class PostsListFragment extends Fragment
                 }
                 break;
         }
+    }
+
+    private void showPublishConfirmationDialog(final PostModel post) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle(getResources().getText(R.string.dialog_confirm_publish_title))
+               .setMessage(post.isPage() ? getString(R.string.dialog_confirm_publish_message_page) :
+                       getString(R.string.dialog_confirm_publish_message_post))
+               .setPositiveButton(R.string.dialog_confirm_publish_yes, new DialogInterface.OnClickListener() {
+                   @Override
+                   public void onClick(DialogInterface dialogInterface, int i) {
+                       UploadUtils.publishPost(getActivity(), post, mSite, mDispatcher);
+                   }
+               })
+               .setNegativeButton(R.string.cancel, null)
+               .setCancelable(true);
+        builder.create().show();
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostsListFragment.java
@@ -565,8 +565,8 @@ public class PostsListFragment extends Fragment
     private void showPublishConfirmationDialog(final PostModel post) {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setTitle(getResources().getText(R.string.dialog_confirm_publish_title))
-               .setMessage(post.isPage() ? getString(R.string.dialog_confirm_publish_message_page) :
-                       getString(R.string.dialog_confirm_publish_message_post))
+               .setMessage(post.isPage() ? getString(R.string.dialog_confirm_publish_message_page)
+                                   : getString(R.string.dialog_confirm_publish_message_post))
                .setPositiveButton(R.string.dialog_confirm_publish_yes, new DialogInterface.OnClickListener() {
                    @Override
                    public void onClick(DialogInterface dialogInterface, int i) {

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -328,6 +328,10 @@
     <string name="pages_fetching">Fetching pages…</string>
     <string name="toast_err_post_uploading">Unable to open post while it\'s uploading</string>
     <string name="dialog_confirm_cancel_post_media_uploading">Are you sure? Deleting this post will also cancel the media upload.</string>
+    <string name="dialog_confirm_publish_title">Confirmation</string>
+    <string name="dialog_confirm_publish_message">Are you sure you want to publish now?</string>
+    <string name="dialog_confirm_publish_yes">Publish now</string>
+    <string name="dialog_confirm_publish_no">Keep editing</string>
 
     <!-- reload drop down -->
     <string name="loading">Loading…</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -328,8 +328,8 @@
     <string name="pages_fetching">Fetching pages…</string>
     <string name="toast_err_post_uploading">Unable to open post while it\'s uploading</string>
     <string name="dialog_confirm_cancel_post_media_uploading">Are you sure? Deleting this post will also cancel the media upload.</string>
-    <string name="dialog_confirm_publish_title">Confirmation</string>
-    <string name="dialog_confirm_publish_message">Are you sure you want to publish now?</string>
+    <string name="dialog_confirm_publish_title">Ready to Publish?</string>
+    <string name="dialog_confirm_publish_message">This post will be published immediately.</string>
     <string name="dialog_confirm_publish_yes">Publish now</string>
 
     <!-- reload drop down -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -329,7 +329,8 @@
     <string name="toast_err_post_uploading">Unable to open post while it\'s uploading</string>
     <string name="dialog_confirm_cancel_post_media_uploading">Are you sure? Deleting this post will also cancel the media upload.</string>
     <string name="dialog_confirm_publish_title">Ready to Publish?</string>
-    <string name="dialog_confirm_publish_message">This %s will be published immediately.</string>
+    <string name="dialog_confirm_publish_message_post">This post will be published immediately.</string>
+    <string name="dialog_confirm_publish_message_page">This page will be published immediately.</string>
     <string name="dialog_confirm_publish_yes">Publish now</string>
 
     <!-- reload drop down -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -329,7 +329,7 @@
     <string name="toast_err_post_uploading">Unable to open post while it\'s uploading</string>
     <string name="dialog_confirm_cancel_post_media_uploading">Are you sure? Deleting this post will also cancel the media upload.</string>
     <string name="dialog_confirm_publish_title">Ready to Publish?</string>
-    <string name="dialog_confirm_publish_message">This post will be published immediately.</string>
+    <string name="dialog_confirm_publish_message">This %s will be published immediately.</string>
     <string name="dialog_confirm_publish_yes">Publish now</string>
 
     <!-- reload drop down -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1070,6 +1070,7 @@
     <string name="async_promo_title">Publish with Confidence</string>
     <string name="async_promo_description">You can now leave the editor and your post will save and publish behind the scenes! Give it a try!</string>
     <string name="async_promo_link">How does it work?</string>
+    <string name="async_promo_publish_now">Publish now</string>
 
     <!-- Post Settings -->
     <string name="post_settings">Post settings</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -331,7 +331,6 @@
     <string name="dialog_confirm_publish_title">Confirmation</string>
     <string name="dialog_confirm_publish_message">Are you sure you want to publish now?</string>
     <string name="dialog_confirm_publish_yes">Publish now</string>
-    <string name="dialog_confirm_publish_no">Keep editing</string>
 
     <!-- reload drop down -->
     <string name="loading">Loading…</string>


### PR DESCRIPTION
Fixes #7394

![publish_alert_without_promo](https://user-images.githubusercontent.com/6597771/37040857-8f5d254a-2139-11e8-8922-d71b49391656.gif)
Publishing without Async promo dialog

![publish_alert_with_promo](https://user-images.githubusercontent.com/6597771/37040858-8f87efb4-2139-11e8-9225-5be1565e74c9.gif)
Publishing with Async promo dialog (i.e. first time after installing app)

To test:
CASE A new draft, empty app:
1. delete all app data
2. login to the app
3. start a draft, do write something
4. tap on PUBLISH
5. observe the Async promo dialog appears. Tap OK.
6. observe the Async promo dialog is dismissed, and the  Confirmation dialog appears.
7. tap on KEEP EDITING.
8. repeat steps 4-5 and now tap on PUBLISH NOW.
9. confirm the post has been published.

CASE B existing published post (edit): 
1. go to the post list
2. edit a currently published post (maybe the one you published as part of the previous test)
4. tap UPDATE
5. observe no dialog is shown, and the post gets updated.

CASE C new draft, no async promo dialog: 
1. start a draft, do write something
2. tap on PUBLISH
3. observe the Confirmation dialog appears.
4. tap on KEEP EDITING.
5. repeat steps 2-3 and now tap on PUBLISH NOW.
6. confirm the post has been published.


