### PR TITLE
Shortened email login error message

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2030,7 +2030,7 @@
     <string name="login_text_otp">Text me a code instead.</string>
     <string name="login_text_otp_another">Text me another code instead.</string>
     <string name="requesting_otp">Requesting a verification code via SMS.</string>
-    <string name="email_not_registered_wpcom">Hmm, this email address isn\'t registered with WordPress.com.\nAre you trying to access a self-hosted site? Log in using the link at the bottom of this screen.</string>
+    <string name="email_not_registered_wpcom">Hmm, this email isn’t registered with WordPress.com. Maybe try the link below to sign in using your site address?</string>
     <string name="password_incorrect">It looks like this password is incorrect. Please double check your information and try again.</string>
     <string name="login_magic_links_label">We\'ll email you a magic link that\'ll log you in instantly, no password needed. Hunt and peck no more!</string>
     <string name="login_magic_links_sent_label">Your magic link is on its way! Check your email on this device and tap the link in the email you received from WordPress.com.</string>


### PR DESCRIPTION
Fixes #7408 - shortened the email login error message. Before & after shots below.

![before-and-after](https://user-images.githubusercontent.com/3903757/37060368-1014db8c-215e-11e8-92a5-4d73b96a2137.png)

