### PR TITLE
Wrap long lines when auto-formatting

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -99,6 +99,7 @@
           <option name="DOWHILE_BRACE_FORCE" value="1" />
           <option name="WHILE_BRACE_FORCE" value="1" />
           <option name="FOR_BRACE_FORCE" value="3" />
+          <option name="WRAP_LONG_LINES" value="true" />
           <option name="METHOD_ANNOTATION_WRAP" value="1" />
           <option name="FIELD_ANNOTATION_WRAP" value="1" />
         </codeStyleSettings>


### PR DESCRIPTION
As checkstyle now fails builds with long lines (over 120 characters) it makes sense to wrap them when using autoformatting in AS.