### PR TITLE
Don't fetch me/sites if the user is not .com authenticated

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/SitePickerActivity.java
@@ -266,7 +266,7 @@ public class SitePickerActivity extends AppCompatActivity
                         if (isFinishing()) {
                             return;
                         }
-                        if (!NetworkUtils.checkConnection(SitePickerActivity.this)) {
+                        if (!NetworkUtils.checkConnection(SitePickerActivity.this) || !mAccountStore.hasAccessToken()) {
                             mSwipeToRefreshHelper.setRefreshing(false);
                             return;
                         }


### PR DESCRIPTION
Fixes #7406

Don't fetch from `me/sites` if the user is not authenticated to wpcom.

To test:
- Start a clean app
- Add a self hosted site
- Open sites list
- PullToRefresh

The REST API should not be called.

