### PR TITLE
Fix the missing gravatar icon in anonymous comments

### DIFF
--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/GravatarUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/GravatarUtils.java
@@ -8,7 +8,7 @@ import android.text.TextUtils;
 public class GravatarUtils {
     // by default tell gravatar to respond to non-existent images with a 404 - this means
     // it's up to the caller to catch the 404 and provide a suitable default image
-    private static final DefaultImage DEFAULT_GRAVATAR = DefaultImage.STATUS_404;
+    private static final DefaultImage DEFAULT_GRAVATAR = DefaultImage.MYSTERY_MAN;
 
     private enum DefaultImage {
         MYSTERY_MAN,


### PR DESCRIPTION
Fixes #6918.

The 404 error was not handled, so I switched to the default mystery man icon.

Before:
![image](https://user-images.githubusercontent.com/1522856/37092486-638e7904-220c-11e8-9379-7188ad886868.png)
![image](https://user-images.githubusercontent.com/1522856/37092492-6eff8ea4-220c-11e8-85a7-5dc95715b296.png)

After:
![image](https://user-images.githubusercontent.com/1522856/37092551-9925423c-220c-11e8-80dc-153d84cd2306.png)
![image](https://user-images.githubusercontent.com/1522856/37092591-b4ba7800-220c-11e8-9339-bba8d8285b59.png)
