### PR TITLE
Reader - Hide error UI item when article loaded without issue

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostDetailFragment.java
@@ -1001,6 +1001,8 @@ public class ReaderPostDetailFragment extends Fragment
                     showError(mErrorMessage);
                 }
                 return;
+            } else {
+                showError(null);
             }
 
             if (mDirectOperation != null) {


### PR DESCRIPTION
Fixes #7268 by making sure the Error UI is not displayed on the screen when the article correctly loaded and displayed on the screen.