### PR TITLE
Set a constant height for theme browser items

### DIFF
--- a/WordPress/src/main/res/layout/theme_grid_item.xml
+++ b/WordPress/src/main/res/layout/theme_grid_item.xml
@@ -31,7 +31,7 @@
                 <org.wordpress.android.widgets.WPNetworkImageView
                     android:id="@+id/theme_grid_item_image"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="@dimen/theme_browser_preview_image_height"
                     android:adjustViewBounds="true"
                     android:scaleType="fitCenter" />
 

--- a/WordPress/src/main/res/values/dimens.xml
+++ b/WordPress/src/main/res/values/dimens.xml
@@ -246,6 +246,7 @@
     <dimen name="theme_browser_header_button_height">50dp</dimen>
     <dimen name="theme_browser_header_button_width">100dp</dimen>
     <dimen name="theme_browser_more_button_padding">8dp</dimen>
+    <dimen name="theme_browser_preview_image_height">280dp</dimen>
     <dimen name="drake_themes_width">400dp</dimen>
     <dimen name="start_over_url_margin">22dp</dimen>
     <dimen name="start_over_preference_margin_large">15dp</dimen>


### PR DESCRIPTION
Fixes #7164.

The theme browser layout relied on identical preview image dimensions for every item, which wasn't the case. This PR sets a constant height so that every grid item is the same.

Before:
![image](https://user-images.githubusercontent.com/1522856/37151401-a8041cbe-22d5-11e8-8503-7445b296a6fd.png)
![image](https://user-images.githubusercontent.com/1522856/37151413-b0f58ac4-22d5-11e8-8ecf-9bb276a9a648.png)

After:
![image](https://user-images.githubusercontent.com/1522856/37151421-bdaf1ec4-22d5-11e8-95aa-5025b39f69d3.png)
![image](https://user-images.githubusercontent.com/1522856/37151448-d0860fee-22d5-11e8-8170-cfbc1caef336.png)
