### PR TITLE
Add gradle fetchstyle plugin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.{kt,kts}]
+max_line_length=120

--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -3,12 +3,14 @@
   <component name="CheckStyle-IDEA">
     <option name="configuration">
       <map>
-        <entry key="checkstyle-version" value="8.5" />
+        <entry key="active-configuration" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
+        <entry key="checkstyle-version" value="8.2" />
         <entry key="copy-libs" value="false" />
         <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
+        <entry key="location-2" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
         <entry key="scan-before-checkin" value="false" />
-        <entry key="scanscope" value="JavaOnly" />
+        <entry key="scanscope" value="AllSourcesWithTests" />
         <entry key="suppress-errors" value="false" />
       </map>
     </option>

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -3,6 +3,8 @@
   <component name="ProjectCodeStyleSettingsManager">
     <option name="PER_PROJECT_SETTINGS">
       <value>
+        <option name="FIELD_NAME_PREFIX" value="m" />
+        <option name="STATIC_FIELD_NAME_PREFIX" value="s" />
         <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
         <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
         <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
@@ -30,7 +32,7 @@
             <emptyLine />
           </value>
         </option>
-        <option name="ENABLE_JAVADOC_FORMATTING" value="false" />
+        <option name="RIGHT_MARGIN" value="120" />
         <AndroidXmlCodeStyleSettings>
           <option name="USE_CUSTOM_SETTINGS" value="true" />
         </AndroidXmlCodeStyleSettings>
@@ -76,7 +78,6 @@
         </XML>
         <codeStyleSettings language="JAVA">
           <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
-          <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
           <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
           <option name="ALIGN_MULTILINE_METHOD_BRACKETS" value="true" />
           <option name="CALL_PARAMETERS_WRAP" value="1" />

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
+    <option name="DEFAULT_COMPILER" value="Javac" />
+    <resourceExtensions />
     <wildcardResourcePatterns>
       <entry name="!?*.java" />
       <entry name="!?*.form" />
@@ -11,5 +13,10 @@
       <entry name="!?*.kt" />
       <entry name="!?*.clj" />
     </wildcardResourcePatterns>
+    <annotationProcessing>
+      <profile default="true" name="Default" enabled="false">
+        <processorPath useClasspath="true" />
+      </profile>
+    </annotationProcessing>
   </component>
 </project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,14 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <option name="myLocal" value="true" />
+    <inspection_tool class="EnumSwitchStatementWhichMissesCases" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="ignoreSwitchStatementsWithDefault" value="false" />
+    </inspection_tool>
+    <inspection_tool class="IllegalIdentifier" enabled="true" level="ERROR" enabled_by_default="true">
+      <scope name="Tests" level="ERROR" enabled="false" />
+    </inspection_tool>
+    <inspection_tool class="KotlinUnusedImport" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="RedundantSemicolon" enabled="true" level="ERROR" enabled_by_default="true" />
+  </profile>
+</component>

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,11 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.automattic.android:fetchstyle:1.0'
     }
 }
+
+apply plugin: 'com.automattic.android.fetchstyle'
 
 project.ext.preDexLibs = !project.hasProperty('disablePreDex')
 

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -4,6 +4,16 @@
     "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 
 <module name="Checker">
+    <!-- Restricts scan to specific extensions.           -->
+    <!-- See http://checkstyle.sf.net/config.html#Checker -->
+    <property name="fileExtensions" value="java, kt, xml"/>
+
+    <!-- Excludes given file patterns from scan.              -->
+    <!-- See http://checkstyle.sf.net/config_filefilters.html -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="[/\\]gen[/\\]"/>
+    </module>
+
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
     <module name="NewlineAtEndOfFile"/>
@@ -35,13 +45,13 @@
 
     <module name="RegexpMultiline">
       <property name="format"
-                value="\n[\t ]*\n[\t ]*\}"/>
+                value="(\n|\r\n)[\t ]*(\n|\r\n)[\t ]*\}"/>
       <property name="message" value="Empty line not allowed before brace"/>
     </module>
 
     <module name="RegexpMultiline">
       <property name="format"
-                value="\{[\t ]*\n[\t ]*\n"/>
+                value="\{[\t ]*(\n|\r\n)[\t ]*(\n|\r\n)"/>
       <property name="message" value="Empty line not allowed after brace"/>
     </module>
 
@@ -57,10 +67,33 @@
         <property name="severity" value="error"/>
     </module>
 
+    <module name="RegexpMultiline">
+        <property name="format" value="@Inject(\n|\r\n).*[^{,(]$"/>
+        <property name="message" value="Inject annotation should be in-line with the annotated field or property"/>
+    </module>
+
+    <module name="RegexpSingleline">
+        <property name="format" value="^(?!.*\bclass\b).*\S.*@Inject"/>
+        <property name="message" value="In-line inject annotation should precede the rest of the declaration"/>
+    </module>
+
+    <!-- Specific to FluxC -->
     <module name="RegexpSingleline">
         <property name="format" value="extends Payload[^&lt;]"/>
         <property name="message" value="Payload should not be used as a raw type"/>
         <property name="severity" value="error"/>
+    </module>
+
+    <!-- Specific to FluxC -->
+    <module name="RegexpMultiline">
+        <property name="format" value="(?&lt;!^@Singleton)\n.*extends Store[\s{]"/>
+        <property name="message" value="Stores must be annotated with @Singleton"/>
+    </module>
+
+    <!-- Specific to FluxC -->
+    <module name="RegexpMultiline">
+        <property name="format" value="(?&lt;!^@Singleton)\n.*extends Base[\w]*Client[\s{]"/>
+        <property name="message" value="Network clients must be annotated with @Singleton"/>
     </module>
 
     <!-- Specific to WordPress -->

--- a/libs/login/.editorconfig
+++ b/libs/login/.editorconfig
@@ -1,0 +1,2 @@
+[*.{kt,kts}]
+max_line_length=120

--- a/libs/login/.idea/checkstyle-idea.xml
+++ b/libs/login/.idea/checkstyle-idea.xml
@@ -5,6 +5,7 @@
       <map>
         <entry key="active-configuration" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />
         <entry key="checkstyle-version" value="8.2" />
+        <entry key="copy-libs" value="false" />
         <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
         <entry key="location-2" value="LOCAL_FILE:$PRJ_DIR$/config/checkstyle.xml:a8c Style" />

--- a/libs/login/.idea/codeStyleSettings.xml
+++ b/libs/login/.idea/codeStyleSettings.xml
@@ -3,6 +3,8 @@
   <component name="ProjectCodeStyleSettingsManager">
     <option name="PER_PROJECT_SETTINGS">
       <value>
+        <option name="FIELD_NAME_PREFIX" value="m" />
+        <option name="STATIC_FIELD_NAME_PREFIX" value="s" />
         <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
         <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
         <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
@@ -34,6 +36,9 @@
         <AndroidXmlCodeStyleSettings>
           <option name="USE_CUSTOM_SETTINGS" value="true" />
         </AndroidXmlCodeStyleSettings>
+        <JavaCodeStyleSettings>
+          <option name="DO_NOT_WRAP_AFTER_SINGLE_ANNOTATION" value="true" />
+        </JavaCodeStyleSettings>
         <JetCodeStyleSettings>
           <option name="PACKAGES_TO_USE_STAR_IMPORTS">
             <value>
@@ -44,9 +49,6 @@
           <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
         </JetCodeStyleSettings>
         <Objective-C-extensions>
-          <option name="GENERATE_INSTANCE_VARIABLES_FOR_PROPERTIES" value="ASK" />
-          <option name="RELEASE_STYLE" value="IVAR" />
-          <option name="TYPE_QUALIFIERS_PLACEMENT" value="BEFORE" />
           <file>
             <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
             <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />
@@ -72,10 +74,36 @@
           </extensions>
         </Objective-C-extensions>
         <XML>
-          <option name="XML_KEEP_LINE_BREAKS" value="false" />
-          <option name="XML_ALIGN_ATTRIBUTES" value="false" />
-          <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
+          <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
         </XML>
+        <codeStyleSettings language="JAVA">
+          <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
+          <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
+          <option name="ALIGN_MULTILINE_METHOD_BRACKETS" value="true" />
+          <option name="CALL_PARAMETERS_WRAP" value="1" />
+          <option name="METHOD_PARAMETERS_WRAP" value="1" />
+          <option name="RESOURCE_LIST_WRAP" value="1" />
+          <option name="EXTENDS_LIST_WRAP" value="1" />
+          <option name="THROWS_LIST_WRAP" value="1" />
+          <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+          <option name="THROWS_KEYWORD_WRAP" value="1" />
+          <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+          <option name="BINARY_OPERATION_WRAP" value="1" />
+          <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+          <option name="TERNARY_OPERATION_WRAP" value="1" />
+          <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+          <option name="FOR_STATEMENT_WRAP" value="1" />
+          <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+          <option name="ASSIGNMENT_WRAP" value="1" />
+          <option name="ASSERT_STATEMENT_WRAP" value="1" />
+          <option name="IF_BRACE_FORCE" value="3" />
+          <option name="DOWHILE_BRACE_FORCE" value="1" />
+          <option name="WHILE_BRACE_FORCE" value="1" />
+          <option name="FOR_BRACE_FORCE" value="3" />
+          <option name="WRAP_LONG_LINES" value="true" />
+          <option name="METHOD_ANNOTATION_WRAP" value="1" />
+          <option name="FIELD_ANNOTATION_WRAP" value="1" />
+        </codeStyleSettings>
         <codeStyleSettings language="XML">
           <option name="FORCE_REARRANGE_MODE" value="1" />
           <indentOptions>

--- a/libs/login/.idea/inspectionProfiles/Project_Default.xml
+++ b/libs/login/.idea/inspectionProfiles/Project_Default.xml
@@ -5,6 +5,9 @@
     <inspection_tool class="EnumSwitchStatementWhichMissesCases" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="ignoreSwitchStatementsWithDefault" value="false" />
     </inspection_tool>
+    <inspection_tool class="IllegalIdentifier" enabled="true" level="ERROR" enabled_by_default="true">
+      <scope name="Tests" level="ERROR" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="KotlinUnusedImport" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="RedundantSemicolon" enabled="true" level="ERROR" enabled_by_default="true" />
   </profile>

--- a/libs/login/build.gradle
+++ b/libs/login/build.gradle
@@ -1,3 +1,15 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'com.automattic.android:fetchstyle:1.0'
+    }
+}
+
+apply plugin: 'com.automattic.android.fetchstyle'
+
 allprojects {
     apply plugin: 'checkstyle'
 

--- a/libs/login/config/checkstyle.xml
+++ b/libs/login/config/checkstyle.xml
@@ -4,6 +4,16 @@
     "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 
 <module name="Checker">
+    <!-- Restricts scan to specific extensions.           -->
+    <!-- See http://checkstyle.sf.net/config.html#Checker -->
+    <property name="fileExtensions" value="java, kt, xml"/>
+
+    <!-- Excludes given file patterns from scan.              -->
+    <!-- See http://checkstyle.sf.net/config_filefilters.html -->
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="[/\\]gen[/\\]"/>
+    </module>
+
     <!-- Checks whether files end with a new line.                        -->
     <!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
     <module name="NewlineAtEndOfFile"/>
@@ -35,32 +45,55 @@
 
     <module name="RegexpMultiline">
       <property name="format"
-                value="\n[\t ]*\n[\t ]*\}"/>
+                value="(\n|\r\n)[\t ]*(\n|\r\n)[\t ]*\}"/>
       <property name="message" value="Empty line not allowed before brace"/>
     </module>
 
     <module name="RegexpMultiline">
       <property name="format"
-                value="\{[\t ]*\n[\t ]*\n"/>
+                value="\{[\t ]*(\n|\r\n)[\t ]*(\n|\r\n)"/>
       <property name="message" value="Empty line not allowed after brace"/>
     </module>
 
     <module name="RegexpSingleline">
-      <property name="format" value=" \/\/[^ \t]"/>
+      <property name="format" value=" \/\/(?!noinspection)[^ \t]"/>
       <property name="message" value="Line comments '//' must be followed by one whitespace"/>
       <property name="severity" value="error"/>
     </module>
 
     <module name="RegexpSingleline">
-        <property name="format" value="@[\S]*(\([{]?\&quot;.*\&quot;[}]?\)++|\([^\&quot;]*\)++)[^ \t]"/>
+        <property name="format" value="[^\S\r\n]@[\S]*(\([{]?\&quot;.*\&quot;[}]?\)++|\([^\&quot;]*\)++)[^ \t]"/>
         <property name="message" value="In-line annotations must be followed by one whitespace"/>
         <property name="severity" value="error"/>
     </module>
 
+    <module name="RegexpMultiline">
+        <property name="format" value="@Inject(\n|\r\n).*[^{,(]$"/>
+        <property name="message" value="Inject annotation should be in-line with the annotated field or property"/>
+    </module>
+
+    <module name="RegexpSingleline">
+        <property name="format" value="^(?!.*\bclass\b).*\S.*@Inject"/>
+        <property name="message" value="In-line inject annotation should precede the rest of the declaration"/>
+    </module>
+
+    <!-- Specific to FluxC -->
     <module name="RegexpSingleline">
         <property name="format" value="extends Payload[^&lt;]"/>
         <property name="message" value="Payload should not be used as a raw type"/>
         <property name="severity" value="error"/>
+    </module>
+
+    <!-- Specific to FluxC -->
+    <module name="RegexpMultiline">
+        <property name="format" value="(?&lt;!^@Singleton)\n.*extends Store[\s{]"/>
+        <property name="message" value="Stores must be annotated with @Singleton"/>
+    </module>
+
+    <!-- Specific to FluxC -->
+    <module name="RegexpMultiline">
+        <property name="format" value="(?&lt;!^@Singleton)\n.*extends Base[\w]*Client[\s{]"/>
+        <property name="message" value="Network clients must be annotated with @Singleton"/>
     </module>
 
     <!-- Specific to WordPress -->


### PR DESCRIPTION
Adds our [gradle fetchstyle plugin](https://github.com/Automattic/style-config-android/tree/develop/fetchstyle-gradle) to the project, and updates the style rule files to the latest (and also for the login library).

To fetch style files using the fetchstyle plugin:

```
$ ./gradlew downloadConfigs
```

There are also more narrow tasks to only update certain files if necessary, they're defined [here](https://github.com/Automattic/style-config-android/blob/03b0557ea931299fd440de68252e4900e6e9a502/fetchstyle-gradle/src/main/groovy/com/automattic/android/fetchstyle/FetchStylePlugin.groovy).