### PR TITLE
Drop include/exclude rules from checkstyle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,6 @@ allprojects {
 
     task checkstyle(type: Checkstyle) {
         source 'src'
-        include '**/*.java'
-        include '**/*.kt'
-        include '**/*.xml'
-        exclude '**/gen/**'
 
         classpath = files()
     }

--- a/libs/login/build.gradle
+++ b/libs/login/build.gradle
@@ -23,9 +23,6 @@ allprojects {
     if (tasks.findByPath('checkstyle') == null) {
         tasks.create(name: 'checkstyle', type: Checkstyle) {
             source 'src'
-            include '**/*.java'
-            include '**/*.kt'
-            exclude '**/gen/**'
 
             classpath = files()
         }


### PR DESCRIPTION
Small bit of cleanup missed from #7435 - the include/exclude rules aren't needed anymore since the `checkstyle.xml` file now specifies the supported filetypes and excludes files in `gen` directories.