### PR TITLE
Fix for failed uploads that loop and drains battery

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -591,27 +591,7 @@ public class UploadService extends Service {
     }
 
     private synchronized void stopServiceIfUploadsComplete() {
-        if (mPostUploadHandler != null && mPostUploadHandler.hasInProgressUploads()) {
-            return;
-        }
-
-        if (mMediaUploadHandler != null && mMediaUploadHandler.hasInProgressUploads()) {
-            return;
-        } else {
-            verifyMediaOnlyUploadsAndNotify();
-        }
-
-        if (doFinalProcessingOfPosts(null)) {
-            // when more Posts have been re-enqueued, don't stop the service just yet.
-            return;
-        }
-
-        if (!mUploadStore.getPendingPosts().isEmpty()) {
-            return;
-        }
-
-        AppLog.i(T.MAIN, "UploadService > Completed");
-        stopSelf();
+        stopServiceIfUploadsComplete(null);
     }
 
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/UploadService.java
@@ -920,16 +920,7 @@ public class UploadService extends Service {
                                 new PostEvents.PostUploadCanceled(postModel.getLocalSiteId()));
                     } else {
                         // Do not re-enqueue a post that has already failed
-                        boolean isPostAlreadyFailed = false;
-                        if (event != null && event.isError()) {
-                            for (PostModel postModel2 : mUploadStore.getAllRegisteredPosts()) {
-                                if (event.post.getLocalSiteId() == postModel2.getLocalSiteId()
-                                    && event.post.getId() == postModel2.getId()) {
-                                    isPostAlreadyFailed = true;
-                                }
-                            }
-                        }
-                        if (isPostAlreadyFailed) {
+                        if (event != null && event.isError() && mUploadStore.isFailedPost(event.post)) {
                             continue;
                         }
                         // TODO Should do some extra validation here


### PR DESCRIPTION
Fixes #7017 by making sure to not automatically re-enqueue posts that failed.

Details and steps to repro in the original ticket.

cc @mzorz 

Side note:
I see a lot of parts in `PostUploadHandler` where we're checking for equality between 2 posts by only using postID.  EX: `queuedPost.getId() == post.getId()` and `sCurrentUploadingPost.getId() == post.getId();`. Full code snippet below:
```
    static boolean isPostQueued(PostModel post) {
        if (post == null) {
            return false;
        }

        // Check the list of posts waiting to be uploaded
        if (sQueuedPostsList.size() > 0) {
            synchronized (sQueuedPostsList) {
                for (PostModel queuedPost : sQueuedPostsList) {
                    if (queuedPost.getId() == post.getId()) {
                        return true;
                    }
                }
            }
        }
        return false;
    }

    static boolean isPostUploading(PostModel post) {
        return post != null && sCurrentUploadingPost != null && sCurrentUploadingPost.getId() == post.getId();
    }
```

Is it correct? Should not we also check the `siteId`?