### PR TITLE
issue/7437-email-availability-error

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -33,6 +33,7 @@ import com.google.android.gms.common.api.GoogleApiClient.OnConnectionFailedListe
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import org.wordpress.android.fluxc.generated.AccountActionBuilder;
+import org.wordpress.android.fluxc.store.AccountStore;
 import org.wordpress.android.fluxc.store.AccountStore.OnAvailabilityChecked;
 import org.wordpress.android.login.util.SiteUtils;
 import org.wordpress.android.login.widgets.WPLoginInputRow;
@@ -349,7 +350,12 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             AppLog.e(T.API, "OnAvailabilityChecked has error: " + event.error.type + " - " + event.error.message);
             // hide the keyboard to ensure the link to login using the site address is visible
             ActivityUtils.hideKeyboardForced(mEmailInput);
-            showEmailError(R.string.error_generic_network);
+            // we validate the email prior to making the request, but just to be safe...
+            if (event.error.type == AccountStore.IsAvailableErrorType.INVALID) {
+                showEmailError(R.string.email_invalid);
+            } else {
+                showErrorDialog(getString(R.string.error_generic_network));
+            }
             return;
         }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -349,7 +349,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
             AppLog.e(T.API, "OnAvailabilityChecked has error: " + event.error.type + " - " + event.error.message);
             // hide the keyboard to ensure the link to login using the site address is visible
             ActivityUtils.hideKeyboardForced(mEmailInput);
-            showEmailError(R.string.email_not_registered_wpcom);
+            showEmailError(R.string.error_generic_network);
             return;
         }
 


### PR DESCRIPTION
Fixes #7437 - prior to this PR we were telling users their email isn't registered with WordPress.com when the availability check returns an error. This PR corrects this by show a generic network error message instead.
