### PR TITLE
Populate the "Email" field instead of the "Your Name" in Helpshift

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.java
@@ -87,6 +87,8 @@ public class HelpActivity extends AppCompatActivity {
                             HelpshiftHelper.ENTERED_URL_KEY));
                     HelpshiftHelper.getInstance().addMetaData(MetadataKey.USER_ENTERED_USERNAME, extras.getString(
                             HelpshiftHelper.ENTERED_USERNAME_KEY));
+                    HelpshiftHelper.getInstance().addMetaData(MetadataKey.USER_ENTERED_EMAIL, extras.getString(
+                            HelpshiftHelper.ENTERED_EMAIL_KEY));
                     origin = (Tag) extras.get(HelpshiftHelper.ORIGIN_KEY);
                     extraTags = (Tag[]) extras.get(HelpshiftHelper.EXTRA_TAGS_KEY);
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -492,11 +492,11 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
         });
     }
 
-    private void launchHelpshift(String url, String username, boolean isWpcom, Tag origin) {
+    private void launchHelpshift(String url, String email, boolean isWpcom, Tag origin) {
         Intent intent = new Intent(this, HelpActivity.class);
         // Used to pass data to an eventual support service
         intent.putExtra(HelpshiftHelper.ENTERED_URL_KEY, url);
-        intent.putExtra(HelpshiftHelper.ENTERED_USERNAME_KEY, username);
+        intent.putExtra(HelpshiftHelper.ENTERED_EMAIL_KEY, email);
         intent.putExtra(HelpshiftHelper.ORIGIN_KEY, origin);
         if (getLoginMode() == LoginMode.JETPACK_STATS) {
             Tag[] tags = new Tag[]{Tag.CONNECTING_JETPACK};

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/SignInDialogFragment.java
@@ -182,6 +182,8 @@ public class SignInDialogFragment extends DialogFragment {
                         HelpshiftHelper.ENTERED_URL_KEY));
                 HelpshiftHelper.getInstance().addMetaData(MetadataKey.USER_ENTERED_USERNAME, arguments.getString(
                         HelpshiftHelper.ENTERED_USERNAME_KEY));
+                HelpshiftHelper.getInstance().addMetaData(MetadataKey.USER_ENTERED_EMAIL, arguments.getString(
+                        HelpshiftHelper.ENTERED_EMAIL_KEY));
                 Tag origin = (Tag) arguments.getSerializable(HelpshiftHelper.ORIGIN_KEY);
                 HelpshiftHelper.getInstance().showConversation(getActivity(), mSiteStore,
                                                                origin, mAccountStore.getAccount().getUserName());

--- a/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
@@ -44,8 +44,7 @@ public class HelpshiftHelper {
     public enum MetadataKey {
         USER_ENTERED_URL("user-entered-url"),
         USER_ENTERED_USERNAME("user-entered-username"),
-        USER_ENTERED_EMAIL("user-entered-email")
-        ;
+        USER_ENTERED_EMAIL("user-entered-email");
 
         private final String mStringValue;
 

--- a/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/HelpshiftHelper.java
@@ -37,12 +37,15 @@ public class HelpshiftHelper {
 
     public static final String ENTERED_URL_KEY = "ENTERED_URL_KEY";
     public static final String ENTERED_USERNAME_KEY = "ENTERED_USERNAME_KEY";
+    public static final String ENTERED_EMAIL_KEY = "ENTERED_EMAIL_KEY";
 
     private static HelpshiftHelper mInstance = null;
 
     public enum MetadataKey {
         USER_ENTERED_URL("user-entered-url"),
-        USER_ENTERED_USERNAME("user-entered-username");
+        USER_ENTERED_USERNAME("user-entered-username"),
+        USER_ENTERED_EMAIL("user-entered-email")
+        ;
 
         private final String mStringValue;
 
@@ -351,7 +354,10 @@ public class HelpshiftHelper {
     }
 
     private HashMap getHelpshiftConfig(Context context, SiteStore siteStore, String wpComUsername) {
-        String emailAddress = UserEmailUtils.getPrimaryEmail(context);
+        String emailAddress = (String) getMetaData(MetadataKey.USER_ENTERED_EMAIL);
+        if (TextUtils.isEmpty(emailAddress)) {
+            emailAddress = UserEmailUtils.getPrimaryEmail(context);
+        }
         // Use the user entered username to pre-fill name
         String name = (String) getMetaData(MetadataKey.USER_ENTERED_USERNAME);
         // If it's null or empty, use split email address to pre-fill name
@@ -361,6 +367,7 @@ public class HelpshiftHelper {
                 name = splitEmail[0];
             }
         }
+
         Core.setNameAndEmail(name, emailAddress);
         addDefaultMetaData(context, siteStore, wpComUsername);
         addPlanTags(siteStore);


### PR DESCRIPTION
Fixes #6892 

**To test:**
1. With the app data cleaned, launch the app and hit "LOG IN"
2. Put in some email address and hit the "HELP" button on the toolbar
3. On the Helpshift dialog that comes up, notice that the email populates the email field and for the name field is split the email address to pre-fill name

<div class="row">
<img src="https://user-images.githubusercontent.com/2581647/37169014-71a574dc-22e5-11e8-9a35-9148a823fc24.png" width="250"/>

<img src="https://user-images.githubusercontent.com/2581647/37169016-71ce39e4-22e5-11e8-98e0-4255381b446b.png" width="250"/>
</div>
