### PR TITLE
Fix plugin search and update fluxc hash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -997,6 +997,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         } else {
             // Refresh the views to show wporg plugin details
             refreshViews();
+            invalidateOptionsMenu();
         }
         showSuccessfulPluginRemovedSnackbar();
     }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
@@ -235,8 +235,9 @@ public class PluginBrowserViewModel extends ViewModel {
                 currentStatus = getNewPluginsListStatus().getValue();
                 break;
             case SEARCH:
-                currentStatus = getSearchPluginsListStatus().getValue();
-                break;
+                // We should always do the search because the string might have changed and it is
+                // already optimized in submitSearch with a delay
+                return true;
         }
         if (currentStatus == PluginListStatus.FETCHING || currentStatus == PluginListStatus.LOADING_MORE) {
             // if we are already fetching something we shouldn't start a new one. Even if we are loading more plugins

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
@@ -235,9 +235,10 @@ public class PluginBrowserViewModel extends ViewModel {
                 currentStatus = getNewPluginsListStatus().getValue();
                 break;
             case SEARCH:
-                // We should always do the search because the string might have changed and it is
-                // already optimized in submitSearch with a delay
-                return true;
+                // We should always do the initial search because the string might have changed and it is
+                // already optimized in submitSearch with a delay. Even though FluxC allows it, we don't do multiple
+                // pages of search, so if we are trying to load more, we can ignore it
+                return !loadMore;
         }
         if (currentStatus == PluginListStatus.FETCHING || currentStatus == PluginListStatus.LOADING_MORE) {
             // if we are already fetching something we shouldn't start a new one. Even if we are loading more plugins

--- a/build.gradle
+++ b/build.gradle
@@ -51,5 +51,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = 'b9f1b291526808d36ac26fa1dc9818a01028377e'
+    fluxCVersion = '83072117124811e2bd02f728d2498205ea245090'
 }


### PR DESCRIPTION
This PR fixes a minor issue with the plugin search and updates the FluxC hash now that the changes are merged to `develop` in FluxC library: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/741

Quick note about the `issue/plugin-fluxc-improvements` branch: I merged `develop` into it  which resulted in a big merge conflict. I did my best with it and had to follow up with 2 minor fixes in the main branch afterwards: d8e813abe6dd3a10699e363508bede172c84bcad & aee694e156bd03d15fa2717452164b58c6117cbc. I don't think we are at a big risk with that merge, but I wanted to note here just in case.

@theck13 Let's do our final tests in this branch and get ready to merge the `issue/plugin-fluxc-improvements` into `develop` as soon as we merge this PR. I'll start doing my tests, but I was hoping you can do them as well and we can merge this today. Thanks again for all the reviews, this is our final step!