### PR TITLE
Async upload: compare postId and siteId for extra security

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/MediaUploadHandler.java
@@ -78,7 +78,8 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
 
         synchronized (sInProgressUploads) {
             for (MediaModel queuedMedia : sInProgressUploads) {
-                if (queuedMedia.getLocalPostId() == postModel.getId()) {
+                if (queuedMedia.getLocalPostId() == postModel.getId()
+                        && queuedMedia.getLocalSiteId() == postModel.getLocalSiteId()) {
                     return true;
                 }
             }
@@ -94,7 +95,8 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
 
         synchronized (sPendingUploads) {
             for (MediaModel queuedMedia : sPendingUploads) {
-                if (queuedMedia.getLocalPostId() == postModel.getId()) {
+                if (queuedMedia.getLocalPostId() == postModel.getId()
+                        && queuedMedia.getLocalSiteId() == postModel.getLocalSiteId()) {
                     return true;
                 }
             }
@@ -119,7 +121,8 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
         List<MediaModel> mediaList = new ArrayList<>();
         synchronized (sInProgressUploads) {
             for (MediaModel queuedMedia : sInProgressUploads) {
-                if (queuedMedia.getLocalPostId() == postModel.getId()) {
+                if (queuedMedia.getLocalPostId() == postModel.getId()
+                    && queuedMedia.getLocalSiteId() == postModel.getLocalSiteId()) {
                     mediaList.add(queuedMedia);
                 }
             }
@@ -127,7 +130,8 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
 
         synchronized (sPendingUploads) {
             for (MediaModel queuedMedia : sPendingUploads) {
-                if (queuedMedia.getLocalPostId() == postModel.getId()) {
+                if (queuedMedia.getLocalPostId() == postModel.getId()
+                    && queuedMedia.getLocalSiteId() == postModel.getLocalSiteId()) {
                     mediaList.add(queuedMedia);
                 }
             }
@@ -322,14 +326,16 @@ public class MediaUploadHandler implements UploadHandler<MediaModel>, VideoOptim
         }
         synchronized (sInProgressUploads) {
             for (MediaModel inProgressUpload : sInProgressUploads) {
-                if (inProgressUpload.getLocalPostId() == event.post.getId()) {
+                if (inProgressUpload.getLocalPostId() == event.post.getId()
+                    && inProgressUpload.getLocalSiteId() == event.post.getLocalSiteId()) {
                     cancelUpload(inProgressUpload, true);
                 }
             }
         }
         synchronized (sPendingUploads) {
             for (MediaModel pendingUpload : sPendingUploads) {
-                if (pendingUpload.getLocalPostId() == event.post.getId()) {
+                if (pendingUpload.getLocalPostId() == event.post.getId()
+                    && pendingUpload.getLocalSiteId() == event.post.getLocalSiteId()) {
                     cancelUpload(pendingUpload, true);
                 }
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadHandler.java
@@ -102,7 +102,8 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
             // first check whether there was an old version of this Post still enqueued waiting
             // for being uploaded
             for (PostModel queuedPost : sQueuedPostsList) {
-                if (queuedPost.getId() == post.getId()) {
+                if (queuedPost.getId() == post.getId()
+                    && queuedPost.getLocalSiteId() == post.getLocalSiteId()) {
                     // we found an older version, so let's remove it and replace it with the newest copy
                     sQueuedPostsList.remove(queuedPost);
                     break;
@@ -142,7 +143,8 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
         if (sQueuedPostsList.size() > 0) {
             synchronized (sQueuedPostsList) {
                 for (PostModel queuedPost : sQueuedPostsList) {
-                    if (queuedPost.getId() == post.getId()) {
+                    if (queuedPost.getId() == post.getId()
+                        && queuedPost.getLocalSiteId() == post.getLocalSiteId()) {
                         return true;
                     }
                 }
@@ -152,7 +154,8 @@ public class PostUploadHandler implements UploadHandler<PostModel> {
     }
 
     static boolean isPostUploading(PostModel post) {
-        return post != null && sCurrentUploadingPost != null && sCurrentUploadingPost.getId() == post.getId();
+        return post != null && sCurrentUploadingPost != null && sCurrentUploadingPost.getId() == post.getId()
+                && sCurrentUploadingPost.getLocalSiteId() == post.getLocalSiteId();
     }
 
     static boolean hasPendingOrInProgressPostUploads() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -230,7 +230,8 @@ class PostUploadNotifier {
 
     private boolean isPostAlreadyInPostCount(@NonNull PostModel post) {
         for (PostModel onePost : sNotificationData.mUploadedPostsCounted) {
-            if (onePost.getId() == post.getId()) {
+            if (onePost.getId() == post.getId()
+                && onePost.getLocalSiteId() == post.getLocalSiteId()) {
                 return true;
             }
         }


### PR DESCRIPTION
As brought up by @daniloercoli in https://github.com/wordpress-mobile/WordPress-Android/pull/7439#issue-173806568, added check for LocalSiteId when comparing PostModels for extra security

To test:
1. make sure you have at least 2 sites configured in your app
2. create a post and put lots of media in it, to make sure the post is enqueued
3. while uploading, exit the editor, then go to the main screen
4. switch sites
5. create another post similar to point 2, and make sure everything is working correctly: 2 posts are uploaded with their corresponding media to their corresponding sites.

cc @daniloercoli 

**Another side note**: the `sFirstPublishPosts` static var that is used to track first posts on Tracks is only saving post IDs. We should probably create a small private class that contains these 2 things as members (postId and siteId) here as well.

```
    void registerPostForAnalyticsTracking(@NonNull PostModel post) {
        synchronized (sFirstPublishPosts) {
            sFirstPublishPosts.add(post.getId());
        }
    }

    void unregisterPostForAnalyticsTracking(@NonNull PostModel post) {
        synchronized (sFirstPublishPosts) {
            sFirstPublishPosts.remove(post.getId());
        }
    }

```