### PR TITLE
Issue/7369 update toolbar style

### DIFF
--- a/WordPress/src/main/res/values/styles.xml
+++ b/WordPress/src/main/res/values/styles.xml
@@ -10,7 +10,6 @@
         <item name="colorControlHighlight">@color/color_control_highlight</item>
 
         <item name="android:windowBackground">@color/grey_lighten_30</item>
-        <item name="android:actionBarItemBackground">@drawable/selectable_background_wordpress</item>
         <item name="android:popupMenuStyle">@style/PopupMenu.WordPress</item>
         <item name="android:dropDownListViewStyle">@style/DropDownListView.Light.WordPress</item>
         <item name="android:actionDropDownStyle">@style/DropDownNav.WordPress</item>


### PR DESCRIPTION
### Fix
Update toolbar touch feedback to use new style as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7369.  See the screenshots below for illustration.

![background_notifications_search](https://user-images.githubusercontent.com/3827611/37183207-2234a4d8-22f2-11e8-83ed-2510779b8b44.png)

![background_reader_search](https://user-images.githubusercontent.com/3827611/37183209-24c69a9e-22f2-11e8-8cb1-07d945f491c1.png)

![background_reader_settings](https://user-images.githubusercontent.com/3827611/37183214-2979a662-22f2-11e8-8a6d-3a165b6add31.png)

### Test
Go throughout the app and tap or long-press actions in the toolbar.  Use the screenshots above of Notification Settings and the Reader as examples.  Notice the background is no longer a solid, flat, square color and it's now a fading, ripple, circular shape.