### PR TITLE
Issue/7453 update permissions dialog

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/WPPermissionUtils.java
@@ -175,13 +175,11 @@ public class WPPermissionUtils {
      */
     private static void showPermissionAlwaysDeniedDialog(@NonNull final Activity activity,
                                                          @NonNull String permission) {
-        String message = "<strong>" + activity.getString(R.string.permissions_denied_title) + "</strong>"
-                         + "<br /><br />"
-                         + String.format(
-                activity.getString(R.string.permissions_denied_message),
-                "<strong>" + getPermissionName(activity, permission) + "</strong>");
+        String message = String.format(activity.getString(R.string.permissions_denied_message),
+                getPermissionName(activity, permission));
 
         AlertDialog.Builder builder = new AlertDialog.Builder(activity)
+                .setTitle(activity.getString(R.string.permissions_denied_title))
                 .setMessage(Html.fromHtml(message))
                 .setPositiveButton(R.string.button_edit_permissions, new DialogInterface.OnClickListener() {
                     @Override

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1768,8 +1768,8 @@
 
     <!-- permissions -->
     <string name="button_edit_permissions">Edit permissions</string>
-    <string name="permissions_denied_title">It looks like you turned off permissions required for this feature</string>
-    <string name="permissions_denied_message">To change this, edit your permissions and make sure %s is enabled</string>
+    <string name="permissions_denied_title">Permissions</string>
+    <string name="permissions_denied_message">It looks like you turned off permissions required for this feature.&lt;br/&gt;&lt;br/&gt;To change this, edit your permissions and make sure &lt;strong&gt;%s&lt;/strong&gt; is enabled.</string>
     <string name="permission_storage">Storage</string>
     <string name="permission_camera">Camera</string>
     <string name="permission_location">Location</string>


### PR DESCRIPTION
### Fix
Update the dialog shown when permissions are required to use a feature of the app as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7453.  See the screenshots below for illustration.

![dialog_denied_permissions](https://user-images.githubusercontent.com/3827611/37220473-0464796e-2384-11e8-8d49-3360f06320d9.png)

### Test
0. Clear permissions for WordPress app through Settings.
1. Go to ***Sites*** tab.
2. Tap ***Media*** item under ***Publish*** section.
3. Tap ***New Media*** action (i.e. plus icon).
4. Tap ***Take photo*** item.
5. Tap ***Deny*** button in system dialog.
6. Tap ***New Media*** action (i.e. plus icon).
7. Tap ***Take photo*** item.
8. Tap ***Don't ask again*** checkbox in system dialog.
9. Tap ***Deny*** button in system dialog.
10. Notice denied permissions WordPress dialog.