### PR TITLE
Issue/7456 update site error

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1933,7 +1933,7 @@
     <string name="site_creation_creating_configuring_theme">Configuring site style…</string>
     <string name="site_creation_creating_preparing_frontend">Preparing frontend…</string>
     <string name="site_creation_creating_failed">Something went wrong&#8230;</string>
-    <string name="site_creation_creating_failed_extended">A parliament of owls distracted our servers with their superior oratory skills</string>
+    <string name="site_creation_creating_failed_extended">We ran into an unexpected problem. How about giving it another shot?</string>
     <string name="site_creation_creating_retry">Try again</string>
     <string name="site_creation_creating_modal">Please wait until site creation is completed.</string>
     <string name="site_creation_epilogue_congrats">Congratulations!\nYour site is ready.</string>


### PR DESCRIPTION
### Fix
Update the error message shown during site creation as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7456.

### Test
1. Go to ***Sites*** tab.
2. Tap ***Switch Site*** item.
3. Tap ***Add Site*** action.
4. Tap ***Create WordPress.com Site*** item.
5. Tap ***Start with a Blog*** item.
6. Tap ***Intergalactic 2*** item.
7. Enter ***Site Title*** value.
8. Tap ***Next*** button.
9. Tap domain from suggestions list.
9. Turn off data and wifi connections.
10. Tap ***Create Site*** button.
11. Notice ***We ran into an unexpected problem. How about giving it another shot?*** error message.