### PR TITLE
Kotlin support + ktlint setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ install:
   - cp libs/login/gradle.properties-example libs/login/gradle.properties
 
 script:
-  - ./gradlew -PdisablePreDex checkstyle assembleVanillaRelease lintVanillaRelease testVanillaRelease || (grep -A20 -B2 'severity="Error"' -r --include="*.xml" WordPress libs; exit 1)
+  - ./gradlew -PdisablePreDex checkstyle ktlint assembleVanillaRelease lintVanillaRelease testVanillaRelease || (grep -A20 -B2 'severity="Error"' -r --include="*.xml" WordPress libs; exit 1)

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -21,6 +21,7 @@ repositories {
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-kapt'
 apply plugin: 'io.fabric'
 
 android {
@@ -137,7 +138,7 @@ dependencies {
     }
 
     implementation 'com.github.bumptech.glide:glide:4.1.1'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.1.1'
+    kapt 'com.github.bumptech.glide:compiler:4.1.1'
     implementation 'com.github.bumptech.glide:volley-integration:4.1.1@aar'
 
     testImplementation 'junit:junit:4.12'
@@ -155,10 +156,10 @@ dependencies {
 
     // Dagger
     implementation 'com.google.dagger:dagger:2.11'
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.11'
+    kapt 'com.google.dagger:dagger-compiler:2.11'
     compileOnly 'org.glassfish:javax.annotation:10.0-b28'
     implementation 'com.google.dagger:dagger-android-support:2.11'
-    annotationProcessor 'com.google.dagger:dagger-android-processor:2.11'
+    kapt 'com.google.dagger:dagger-android-processor:2.11'
 
     implementation ("com.github.wordpress-mobile.WordPress-FluxC-Android:fluxc:$fluxCVersion") {
         exclude group: "com.android.volley"

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -4,6 +4,7 @@ buildscript {
         maven { url 'https://maven.fabric.io/public' }
     }
     dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'io.fabric.tools:gradle:1.+'
         classpath 'com.google.gms:google-services:3.1.0'
     }
@@ -18,6 +19,8 @@ repositories {
 }
 
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 apply plugin: 'io.fabric'
 
 android {
@@ -93,6 +96,8 @@ dependencies {
     implementation('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {
         transitive = true;
     }
+
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // Provided by maven central
     implementation 'com.google.code.gson:gson:2.6.+'

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,26 @@ subprojects {
             project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
         }
     }
+
+    configurations {
+        ktlint
+    }
+
+    dependencies {
+        ktlint 'com.github.shyiko:ktlint:0.14.0'
+    }
+
+    task ktlint(type: JavaExec) {
+        main = "com.github.shyiko.ktlint.Main"
+        classpath = configurations.ktlint
+        args "src/**/*.kt"
+    }
+
+    task ktlintFormat(type: JavaExec) {
+        main = "com.github.shyiko.ktlint.Main"
+        classpath = configurations.ktlint
+        args "-F", "src/**/*.kt"
+    }
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 buildscript {
+    ext.kotlin_version = '1.2.30'
+
     repositories {
         jcenter()
         google()


### PR DESCRIPTION
With checkstyle and shared IDEA configurations now added to the project (#7388), we can now turn on ktlint and have style rules in place for Kotlin development! 🎉

_(Actual Kotlin code sold separately.)_

This PR adds the basics for Kotlin support:

* Add the Kotlin gradle plugin
* Switch to using [Kapt](https://kotlinlang.org/docs/reference/kapt.html)
* Support for [Kotlin Android Extensions](https://kotlinlang.org/docs/tutorials/android-plugin.html) (eliminates `findViewById`, for Kotlin classes)
* Add ktlint (standard configs, plus the 120 line limit already configured through the `.editorconfig` file in the project root)
* Configure Travis to run `ktlint`

To run ktlint:

```
$ ./gradlew ktlint
```

Ktlint also comes with an auto-formatter, which can be used to fix any style violations:

```
$ ./gradlew ktlintFormat
```

## Notes on style:

### Property prefixes

Per previous discussion for FluxC's Kotlin support, **Kotlin classes should not use `m/s` prefixes** (sometimes referred to as Hungarian notation) for fields. The exception is for fields inherited from a Java superclass, which is something that can't be helped (until that superclass is converted to Kotlin as well).

### Ktlint

Kotlin is still pretty young and style conventions are still being debated and expanded. As ktlint adds more rules, and as we come up with patterns of our own we might want to enforce, we might make changes to the style rules which will require refactoring existing code. I don't expect this to happen a lot, and ktlint comes with a formatting tool, so hopefully any new additions should not be hard to apply.

There is also no IDEA plugin for ktlint yet, so it won't highlight style errors in files in realtime like checkstyle does (though some rules, like unneeded whitespace, also exist in checkstyle and will be flagged even in `.kt` files). This means running `./gradlew ktlint` manually from time to time is handy to avoid surprises after pushing, but it's also possible to set up a pre-commit hook or to modify your build configuration in AS to run `ktlint` as an external tool.