### PR TITLE
Fix for crash uploading media

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -661,7 +661,8 @@ class PostUploadNotifier {
         float currentMediaProgress = 0.0f;
         int size = sNotificationData.mediaItemToProgressMap.size();
         for (int i = 0; i < size; i++) {
-            float itemProgress = sNotificationData.mediaItemToProgressMap.get(i);
+            int key = sNotificationData.mediaItemToProgressMap.keyAt(i);
+            float itemProgress = sNotificationData.mediaItemToProgressMap.get(key);
             currentMediaProgress += (itemProgress / size);
         }
         return currentMediaProgress;


### PR DESCRIPTION
Fixes #7468 by making sure to use the `key` when accessing the SparseArray that holds uploading info.

Bug introduced here https://github.com/wordpress-mobile/WordPress-Android/commit/4a19f15db347c3fb41e9625f225964aaa1a04138#diff-91785f1b533d89800b5f791a4f102cb4 when we switched from `HashMap` to `SparseArray`.

cc @mzorz 
