### PR TITLE
Fix/display site quota i18n

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -1046,7 +1046,12 @@ public abstract class SiteSettingsInterface {
         // Quota information always comes from the main site table
         if (mSite.hasDiskSpaceQuotaInformation()) {
             String percentage = FormatUtils.formatPercentage(mSite.getSpacePercentUsed() / 100);
-            String spaceAllowed = FormatUtils.formatFileSize(mSite.getSpaceAvailable());
+            final String[] units = new String[] {mContext.getString(R.string.file_size_in_bytes),
+                    mContext.getString(R.string.file_size_in_kilobytes),
+                    mContext.getString(R.string.file_size_in_megabytes),
+                    mContext.getString(R.string.file_size_in_gigabytes),
+                    mContext.getString(R.string.file_size_in_terabytes) };
+            String spaceAllowed = FormatUtils.formatFileSize(mSite.getSpaceAvailable(), units);
             String quotaAvailableSentence = String.format(mContext.getString(R.string.site_settings_quota_space_value),
                     percentage, spaceAllowed);
             setQuotaDiskSpace(quotaAvailableSentence);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -474,6 +474,13 @@
     <string name="site_settings_quota_space_hint">If you need more space consider upgrading your WordPress plan.</string>
     <string name="site_settings_quota_space_value">%s of %s</string>
 
+    <!-- these represent an amount along with a measuring unit, i.e. 10 bytes, or 132 kb, or 10.2 MB, etc. -->
+    <string name="file_size_in_bytes">%d B</string>
+    <string name="file_size_in_kilobytes">%d kB</string>
+    <string name="file_size_in_megabytes">%d MB</string>
+    <string name="file_size_in_gigabytes">%d GB</string>
+    <string name="file_size_in_terabytes">%d TB</string>
+
     <!-- Speed up your site -->
     <string name="site_settings_speed_up_your_site">Speed up your site</string>
     <string name="site_settings_serve_images_from_our_servers">Serve images from our servers</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -474,12 +474,12 @@
     <string name="site_settings_quota_space_hint">If you need more space consider upgrading your WordPress plan.</string>
     <string name="site_settings_quota_space_value">%s of %s</string>
 
-    <!-- these represent an amount along with a measuring unit, i.e. 10 bytes, or 132 kb, or 10.2 MB, etc. -->
-    <string name="file_size_in_bytes">%d B</string>
-    <string name="file_size_in_kilobytes">%d kB</string>
-    <string name="file_size_in_megabytes">%d MB</string>
-    <string name="file_size_in_gigabytes">%d GB</string>
-    <string name="file_size_in_terabytes">%d TB</string>
+    <!-- these represent a formatted amount along with a measuring unit, i.e. 10 B, or 132 kB, or 10.2 MB, 1,037.76 kB etc. -->
+    <string name="file_size_in_bytes">%s B</string>
+    <string name="file_size_in_kilobytes">%s kB</string>
+    <string name="file_size_in_megabytes">%s MB</string>
+    <string name="file_size_in_gigabytes">%s GB</string>
+    <string name="file_size_in_terabytes">%s TB</string>
 
     <!-- Speed up your site -->
     <string name="site_settings_speed_up_your_site">Speed up your site</string>

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/FormatUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/FormatUtils.java
@@ -38,10 +38,11 @@ public class FormatUtils {
      * unitStrings is expected to be an array of all possible sizes from byte to TeraByte, in the current locale
      */
     public static final String formatFileSize(long size, final String[] unitStrings) {
+        final double log1024 = Math.log10(1024);
         if (size <= 0) {
             return "0";
         }
-        int digitGroups = (int) (Math.log10(size) / Math.log10(1024));
+        int digitGroups = (int) (Math.log10(size) / log1024);
 
         return String.format(unitStrings[digitGroups], DECIMAL_INSTANCE.get().format(size / Math.pow(1024, digitGroups)));
     }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/FormatUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/FormatUtils.java
@@ -35,15 +35,15 @@ public class FormatUtils {
 
     /*
      * returns the passed long formatted has an human readable filesize. Ex: 10 GB
+     * unitStrings is expected to be an array of all possible sizes from byte to TeraByte, in the current locale
      */
-    public static final String formatFileSize(long size) {
+    public static final String formatFileSize(long size, final String[] unitStrings) {
         if (size <= 0) {
             return "0";
         }
-        final String[] units = new String[] {"B", "kB", "MB", "GB", "TB" };
         int digitGroups = (int) (Math.log10(size) / Math.log10(1024));
 
-        return DECIMAL_INSTANCE.get().format(size / Math.pow(1024, digitGroups)) + " " + units[digitGroups];
+        return String.format(unitStrings[digitGroups], DECIMAL_INSTANCE.get().format(size / Math.pow(1024, digitGroups)));
     }
 
     /*

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/FormatUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/FormatUtils.java
@@ -47,7 +47,7 @@ public class FormatUtils {
     }
 
     /*
-     * returns the passed double percentage (0 to 1) formatted has an human readable percentage. Ex: 0.25 returns 25%
+     * returns the passed double percentage (0 to 1) formatted as an human readable percentage. Ex: 0.25 returns 25%
      */
     public static final String formatPercentage(double value) {
         NumberFormat percentFormat = NumberFormat.getPercentInstance();

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/FormatUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/FormatUtils.java
@@ -34,7 +34,7 @@ public class FormatUtils {
     }
 
     /*
-     * returns the passed long formatted has an human readable filesize. Ex: 10 GB
+     * returns the passed long formatted as an human readable filesize. Ex: 10 GB
      * unitStrings is expected to be an array of all possible sizes from byte to TeraByte, in the current locale
      */
     public static final String formatFileSize(long size, final String[] unitStrings) {

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/FormatUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/FormatUtils.java
@@ -43,7 +43,7 @@ public class FormatUtils {
         final String[] units = new String[] {"B", "kB", "MB", "GB", "TB" };
         int digitGroups = (int) (Math.log10(size) / Math.log10(1024));
 
-        return new DecimalFormat("#,##0.#").format(size / Math.pow(1024, digitGroups)) + " " + units[digitGroups];
+        return DECIMAL_INSTANCE.get().format(size / Math.pow(1024, digitGroups)) + " " + units[digitGroups];
     }
 
     /*

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/FormatUtils.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/FormatUtils.java
@@ -44,7 +44,8 @@ public class FormatUtils {
         }
         int digitGroups = (int) (Math.log10(size) / log1024);
 
-        return String.format(unitStrings[digitGroups], DECIMAL_INSTANCE.get().format(size / Math.pow(1024, digitGroups)));
+        return String.format(unitStrings[digitGroups],
+                new DecimalFormat("#,##0.#").format(size / Math.pow(1024, digitGroups)));
     }
 
     /*


### PR DESCRIPTION
Makes i18n easier for the Display site quota functionality written in #7465 

To test:
1. go to settings
2. check the quota is displayed using the separators according to your locale
3. change the locale in App Settings
4. repeat steps 1-2 and verify the separators used now correspond to your new locale.

For example:
English:
![english](https://user-images.githubusercontent.com/6597771/37289304-257ed28c-25e8-11e8-8e4e-91556bc6e467.png)

Spanish:
![spanish](https://user-images.githubusercontent.com/6597771/37289305-25a3ccf4-25e8-11e8-8266-273e0521f79b.png)

cc @SergioEstevao  we can check this one in and merge into your PR, then merge your PR 👍 
cc @akirk once more 🙇 🙇 