### PR TITLE
Fix #7475 set vector drawable programatically to avoid crash in Android 4.x

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationDomainAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationDomainAdapter.java
@@ -1,8 +1,10 @@
 package org.wordpress.android.ui.accounts.signup;
 
 import android.content.Context;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.support.v7.content.res.AppCompatResources;
 import android.support.v7.widget.RecyclerView;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -60,6 +62,16 @@ public class SiteCreationDomainAdapter extends RecyclerView.Adapter<RecyclerView
         private InputViewHolder(View itemView) {
             super(itemView);
             this.mInput = itemView.findViewById(R.id.input);
+            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                this.mInput.setCompoundDrawablesRelativeWithIntrinsicBounds(
+                        AppCompatResources.getDrawable(itemView.getContext(), R.drawable.ic_search_grey_24dp),
+                        null, null, null);
+            } else {
+                this.mInput.setCompoundDrawablesWithIntrinsicBounds(
+                        AppCompatResources.getDrawable(itemView.getContext(), R.drawable.ic_search_grey_24dp),
+                        null, null, null);
+
+            }
             this.mProgressBar = itemView.findViewById(R.id.progress_bar);
 
             this.mTextWatcher = new TextWatcher() {

--- a/WordPress/src/main/res/layout/site_creation_domain_input.xml
+++ b/WordPress/src/main/res/layout/site_creation_domain_input.xml
@@ -13,8 +13,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/white"
-        android:drawableLeft="@drawable/ic_search_grey_24dp"
-        android:drawableStart="@drawable/ic_search_grey_24dp"
         android:drawablePadding="@dimen/margin_extra_large"
         android:hint="@string/site_creation_domain_keywords_hint"
         android:singleLine="true"


### PR DESCRIPTION
Fix #7475 set vector drawable programatically to avoid crash in Android 4.x

Before the patch on Android 4.x:
* My sites -> Add Site
* Tap "New wpcom" site
* Follow the process until the last step (domain search) -> 💥 

After the patch on Android 4.x:
* My sites -> Add Site
* Tap "New wpcom" site
* Follow the process until the last step (domain search) -> 🍸 🏖 