### PR TITLE
Suppress plurals candidate lint check

### DIFF
--- a/WordPress/lint.xml
+++ b/WordPress/lint.xml
@@ -65,6 +65,7 @@
     <!-- IGNORE -->
     <issue id="MissingTranslation" severity="ignore" />
     <issue id="ExtraTranslation" severity="ignore" />
+    <issue id="PluralsCandidate" severity="ignore" /> <!-- GlotPress doesn't support plurals -->
 
     <issue id="InvalidPackage">
         <ignore regexp="okio-1.9.0.jar" />


### PR DESCRIPTION
Suppress plurals candidate lint check as the GlotPress doesn't support plurals.
