### PR TITLE
Fix title TalkBack announcements in me section

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -95,7 +95,8 @@
         <!-- Main tab activity -->
         <activity
             android:name=".ui.main.WPMainActivity"
-            android:theme="@style/Calypso.NoActionBar" />
+            android:theme="@style/Calypso.NoActionBar"
+            android:label=""/>
 
         <!-- Account activities -->
         <activity
@@ -138,13 +139,14 @@
 
         <activity
             android:name=".ui.accounts.HelpActivity"
-            android:label=""
+            android:label="@string/help_screen_title"
             android:theme="@style/CalypsoTheme.NoActionBarShadow" />
         <!-- empty title -->
 
         <!-- Preferences activities -->
         <activity
             android:name=".ui.prefs.AboutActivity"
+            android:label="@string/about_the_app"
             android:theme="@style/Theme.AppCompat.NoActionBar" />
         <activity
             android:name=".ui.prefs.BlogPreferencesActivity"
@@ -153,9 +155,11 @@
             android:theme="@style/CalypsoTheme" />
         <activity
             android:name=".ui.prefs.ReleaseNotesActivity"
-            android:theme="@style/Calypso.NoActionBar" />
+            android:theme="@style/Calypso.NoActionBar"
+            android:label="@string/release_notes_screen_title"/>
         <activity
             android:name=".ui.prefs.LicensesActivity"
+            android:label="@string/license_screen_title"
             android:theme="@style/Calypso.NoActionBar" />
         <activity android:name=".ui.prefs.SiteSettingsTagListActivity"
             android:theme="@style/CalypsoTheme"
@@ -173,7 +177,8 @@
         <activity
             android:name=".ui.prefs.notifications.NotificationsSettingsActivity"
             android:configChanges="orientation|screenSize"
-            android:theme="@style/Calypso.NoActionBar" >
+            android:theme="@style/Calypso.NoActionBar"
+            android:label="@string/notif_settings_screen_title">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.NOTIFICATION_PREFERENCES" />
@@ -469,10 +474,12 @@
             android:name="org.wordpress.passcodelock.PasscodeUnlockActivity"
             android:theme="@style/CalypsoTheme"
             android:launchMode="singleInstance"
+            android:label="@string/passcode_screen_title"
             android:windowSoftInputMode="stateHidden" />
         <activity
             android:name="org.wordpress.passcodelock.PasscodeManagePasswordActivity"
             android:theme="@style/CalypsoTheme"
+            android:label="@string/passcode_screen_title"
             android:windowSoftInputMode="stateHidden" />
 
         <!--People Management-->

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/HelpActivity.java
@@ -38,13 +38,14 @@ public class HelpActivity extends AppCompatActivity {
             actionBar.setHomeButtonEnabled(true);
             actionBar.setDisplayHomeAsUpEnabled(true);
             actionBar.setElevation(0); //remove shadow
+            actionBar.setDisplayShowTitleEnabled(false);
         }
 
         // Init common elements
-        WPTextView version = (WPTextView) findViewById(R.id.nux_help_version);
+        WPTextView version = findViewById(R.id.nux_help_version);
         version.setText(getString(R.string.version) + " " + WordPress.versionName);
 
-        WPTextView applogButton = (WPTextView) findViewById(R.id.applog_button);
+        WPTextView applogButton = findViewById(R.id.applog_button);
         applogButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -71,9 +72,9 @@ public class HelpActivity extends AppCompatActivity {
     private void initHelpshiftLayout() {
         setContentView(R.layout.help_activity_with_helpshift);
 
-        WPTextView version = (WPTextView) findViewById(R.id.nux_help_version);
+        WPTextView version = findViewById(R.id.nux_help_version);
         version.setText(getString(R.string.version) + " " + WordPress.versionName);
-        WPTextView contactUsButton = (WPTextView) findViewById(R.id.contact_us_button);
+        WPTextView contactUsButton = findViewById(R.id.contact_us_button);
         contactUsButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -96,7 +97,7 @@ public class HelpActivity extends AppCompatActivity {
             }
         });
 
-        WPTextView faqbutton = (WPTextView) findViewById(R.id.faq_button);
+        WPTextView faqbutton = findViewById(R.id.faq_button);
         faqbutton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -10,6 +10,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.Nullable;
+import android.support.annotation.StringRes;
 import android.support.design.widget.TabLayout;
 import android.support.v4.app.RemoteInput;
 import android.support.v4.view.ViewPager;
@@ -125,13 +126,13 @@ public class WPMainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main_activity);
 
-        mViewPager = (WPViewPager) findViewById(R.id.viewpager_main);
+        mViewPager = findViewById(R.id.viewpager_main);
         mViewPager.setOffscreenPageLimit(WPMainTabAdapter.NUM_TABS - 1);
 
         mTabAdapter = new WPMainTabAdapter(getFragmentManager());
         mViewPager.setAdapter(mTabAdapter);
 
-        mConnectionBar = (TextView) findViewById(R.id.connection_bar);
+        mConnectionBar = findViewById(R.id.connection_bar);
         mConnectionBar.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -147,7 +148,7 @@ public class WPMainActivity extends AppCompatActivity {
                 }, 2000);
             }
         });
-        mTabLayout = (WPMainTabLayout) findViewById(R.id.tab_layout);
+        mTabLayout = findViewById(R.id.tab_layout);
         mTabLayout.createTabs();
 
         mTabLayout.setOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
@@ -467,6 +468,8 @@ public class WPMainActivity extends AppCompatActivity {
             GCMMessageService.removeAllNotifications(this);
         }
 
+        announceTitleForAccessibility(currentItem);
+
         checkConnection();
 
         // Update account to update the notification unseen status
@@ -477,6 +480,29 @@ public class WPMainActivity extends AppCompatActivity {
         ProfilingUtils.split("WPMainActivity.onResume");
         ProfilingUtils.dump();
         ProfilingUtils.stop();
+    }
+
+    private void announceTitleForAccessibility(int currentTabIndex) {
+        @StringRes int stringRes = -1;
+        switch (currentTabIndex) {
+            case WPMainTabAdapter.TAB_MY_SITE:
+                stringRes = R.string.my_site_section_screen_title;
+                break;
+            case WPMainTabAdapter.TAB_READER:
+                stringRes = R.string.reader_screen_title;
+                break;
+            case WPMainTabAdapter.TAB_ME:
+                stringRes = R.string.me_section_screen_title;
+                break;
+            case WPMainTabAdapter.TAB_NOTIFS:
+                stringRes = R.string.notifications_screen_title;
+                break;
+            default:
+                AppLog.w(T.MAIN, "announceTitleForAccessibility unknown tab index.");
+        }
+        if (stringRes != -1) {
+            getWindow().getDecorView().announceForAccessibility(getString(stringRes));
+        }
     }
 
     @Override

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -33,6 +33,18 @@
     <!-- comment form labels -->
     <string name="anonymous">Anonymous</string>
 
+    <!-- Screen titles -->
+    <string name="release_notes_screen_title">Release notes</string>
+    <string name="license_screen_title">License</string>
+    <string name="help_screen_title">Help and Support</string>
+    <string name="passcode_screen_title">WordPress Passcode</string>
+    <string name="me_screen_title">Me</string>
+    <string name="notif_settings_screen_title">Notification settings</string>
+    <string name="my_site_section_screen_title">My site</string>
+    <string name="me_section_screen_title">Me</string>
+    <string name="reader_screen_title">Reader</string>
+    <string name="notifications_screen_title">Notifications</string>
+
     <!-- general strings -->
     <string name="device">Device</string>
     <string name="post">Post</string>


### PR DESCRIPTION
Partially fixes #7370

Fixes screen titles in the Me section (and tab titles in the WPMainActivity).

To test:
1. turn on TalkBack
2. Enter each screen and make sure, that it's title is announced (the title should be announced also when you get back to the screen - either from a nested activity or from another app/system ui)
