### PR TITLE
EditPost: use dialog fragment for failed uploads

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -190,6 +190,7 @@ public class EditPostActivity extends AppCompatActivity implements
     private static final String STATE_KEY_IS_PHOTO_PICKER_VISIBLE = "stateKeyPhotoPickerVisible";
     private static final String STATE_KEY_HTML_MODE_ON = "stateKeyHtmlModeOn";
     private static final String TAG_PUBLISH_CONFIRMATION_DIALOG = "tag_publish_confirmation_dialog";
+    private static final String TAG_REMOVE_FAILED_UPLOADS_DIALOG = "tag_remove_failed_uploads_dialog";
 
     private static final int PAGE_CONTENT = 0;
     private static final int PAGE_SETTINGS = 1;
@@ -1316,9 +1317,14 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     @Override public void onPositiveClicked(String instanceTag) {
-        if (instanceTag != null && instanceTag == TAG_PUBLISH_CONFIRMATION_DIALOG) {
-            mPost.setStatus(PostStatus.PUBLISHED.toString());
-            publishPost();
+        if (instanceTag != null) {
+            if (instanceTag == TAG_PUBLISH_CONFIRMATION_DIALOG) {
+                mPost.setStatus(PostStatus.PUBLISHED.toString());
+                publishPost();
+            } else if (instanceTag == TAG_REMOVE_FAILED_UPLOADS_DIALOG) {
+                // Clear failed uploads
+                mEditorFragment.removeAllFailedMediaUploads();
+            }
         }
     }
 
@@ -1554,15 +1560,14 @@ public class EditPostActivity extends AppCompatActivity implements
     }
 
     private void showRemoveFailedUploadsDialog() {
-        AlertDialog.Builder builder = new AlertDialog.Builder(this);
-        builder.setMessage(R.string.editor_toast_failed_uploads)
-               .setPositiveButton(R.string.editor_remove_failed_uploads, new DialogInterface.OnClickListener() {
-                   public void onClick(DialogInterface dialog, int id) {
-                       // Clear failed uploads
-                       mEditorFragment.removeAllFailedMediaUploads();
-                   }
-               }).setNegativeButton(android.R.string.cancel, null);
-        builder.create().show();
+        BaseYesNoFragmentDialog removeFailedUploadsDialog = new BaseYesNoFragmentDialog();
+        removeFailedUploadsDialog.setArgs(
+                TAG_REMOVE_FAILED_UPLOADS_DIALOG,
+                null,
+                getString(R.string.editor_toast_failed_uploads),
+                getString(R.string.editor_remove_failed_uploads),
+                getString(android.R.string.cancel));
+        removeFailedUploadsDialog.show(getSupportFragmentManager(), TAG_REMOVE_FAILED_UPLOADS_DIALOG);
     }
 
     private void savePostAndOptionallyFinish(final boolean doFinish) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1325,6 +1325,10 @@ public class EditPostActivity extends AppCompatActivity implements
                 // Clear failed uploads
                 mEditorFragment.removeAllFailedMediaUploads();
             }
+        } else {
+            ToastUtils.showToast(EditPostActivity.this,
+                    getString(R.string.editor_toast_no_action_taken));
+            AppLog.e(T.EDITOR, "Dialog instanceTag is null - positive button clicked, but no action taken");
         }
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1807,6 +1807,7 @@
     <string name="editor_toast_uploading_please_wait">You are currently uploading media. Please wait until this completes.</string>
     <string name="editor_toast_failed_uploads">Some media uploads have failed. You can\'t save or publish
         your post in this state. Would you like to remove all failed media?</string>
+    <string name="editor_toast_no_action_taken">An error occurred. No action taken.</string>
     <string name="editor_remove_failed_uploads">Remove failed uploads</string>
     <string name="error_all_media_upload_canceled">All media uploads have been cancelled due to an unknown error. Please retry uploading</string>
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -370,6 +370,8 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
             mHideActionBarOnSoftKeyboardUp = true;
             hideActionBarIfNeeded();
         }
+
+        updateFailedAndUploadingMedia();
     }
 
     @Override
@@ -521,11 +523,7 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
         mContent.fromHtml(removeVisualEditorProgressTag(text.toString()));
 
-        updateFailedMediaList();
-        overlayFailedMedia();
-
-        updateUploadingMediaList();
-        overlayProgressingMedia();
+        updateFailedAndUploadingMedia();
 
         mAztecReady = true;
     }
@@ -670,6 +668,14 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
         if (mSource.getVisibility() == View.VISIBLE) {
             updateFailedMediaList();
         }
+    }
+
+    private void updateFailedAndUploadingMedia() {
+        updateFailedMediaList();
+        overlayFailedMedia();
+
+        updateUploadingMediaList();
+        overlayProgressingMedia();
     }
 
     public void enableMediaMode(boolean enable) {

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/AztecEditorFragment.java
@@ -387,8 +387,6 @@ public class AztecEditorFragment extends EditorFragmentAbstract implements
 
     @Override
     public void onSaveInstanceState(Bundle outState) {
-        outState.putCharSequence(ATTR_TITLE, getTitle());
-        outState.putCharSequence(ATTR_CONTENT, getContent());
         outState.putParcelable(ATTR_TAPPED_MEDIA_PREDICATE, mTappedMediaPredicate);
     }
 


### PR DESCRIPTION
Comes from https://github.com/wordpress-mobile/WordPress-Android/pull/7466#issuecomment-372798315

This PR tackles the problem of orientation changes with failed media uploads in two instances:

1) Replaces the usage of `AlertDialog.Builder` for `FragmentDialog`, specifically targetted towards the failed media dialog. With this, the Dialog is not dismissed in the case of an orientation change.

2) Refreshes the Post content to make sure failed media overlays are re-drawn in `onResume`, which was needed in order to keep the visual cue ready after an orientation change as well.

To test:
1. start a new draft
2. type some title and some content
3. add some media, but right before trying to add it, turn airplane mode ON.
4. observe the media is added and immediately painted with the FAILED overlay.
5. Now, change the device orientation
6. observe the failed overlay is kept on the failed image (that’s good!)
7. turn airplane mode OFF
8. tap on PUBLISH
9. observe the publish confirmation dialog appears
10. tap on PUBLISH NOW on the dialog option
11. observe the new dialog appears reading “Some media uploads have failed…” [cancel] [Remove failed uploads]
13. rotate the phone as many times as you wish
14. observe the “remove failed uploads” dialog is kept at all times.

cc @malinajirka 
