### PR TITLE
Issue/7492 username changer crash

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/UsernameChangerFullScreenDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/UsernameChangerFullScreenDialogFragment.java
@@ -187,9 +187,13 @@ public class UsernameChangerFullScreenDialogFragment extends Fragment implements
     public boolean onConfirmClicked(FullScreenDialogController controller) {
         ActivityUtils.hideKeyboard(getActivity());
 
-        Bundle result = new Bundle();
-        result.putString(RESULT_USERNAME, mUsernamesAdapter.mItems.get(mUsernamesAdapter.getSelectedItem()));
-        controller.confirm(result);
+        if (mUsernamesAdapter != null && mUsernamesAdapter.mItems != null) {
+            Bundle result = new Bundle();
+            result.putString(RESULT_USERNAME, mUsernamesAdapter.mItems.get(mUsernamesAdapter.getSelectedItem()));
+            controller.confirm(result);
+        } else {
+            controller.dismiss();
+        }
 
         return true;
     }


### PR DESCRIPTION
### Fix
Resolve the `NullPointerException` as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7492 by adding a null check on the Username Changer screen when the Save action is tapped while the username suggestions list is not yet loaded.

### Test
0. Clear app data.
1. Tap ***Sign Up for WordPress.com*** button.
2. Tap ***Sign Up with Google*** button.
3. Choose Google account not associated with WordPress.com account.
4. Notice ***Epilogue for Social*** screen.
5. Change network speed to very slow.
6. Tap ***Username*** input field.
7. Tap ***Save*** button.
8. Notice ***Username Changer*** dismisses without crash.

#### Note
Creating a new account can be avoided by using an existing Google/WordPress.com account and replacing [these two lines](https://github.com/wordpress-mobile/WordPress-Android/blob/release/9.6/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupGoogleFragment.java#L157-L158) with `mGoogleListener.onGoogleSignupFinished(mDisplayName, mGoogleEmail, mPhotoUrl, event.userName);`.