### PR TITLE
ViewModelInterface

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -97,7 +97,7 @@ public class PluginBrowserActivity extends AppCompatActivity
         } else {
             mViewModel.readFromBundle(savedInstanceState);
         }
-        mViewModel.start();
+        mViewModel.onStart();
 
         if (mViewModel.getSite() == null) {
             ToastUtils.showToast(this, R.string.blog_not_found);

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
@@ -31,7 +31,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-public class PluginBrowserViewModel extends ViewModel {
+public class PluginBrowserViewModel extends ViewModel implements ViewModelInterface {
     public enum PluginListType {
         SITE,
         FEATURED,
@@ -110,12 +110,14 @@ public class PluginBrowserViewModel extends ViewModel {
         mDispatcher.unregister(this);
     }
 
+    @Override
     public void writeToBundle(@NonNull Bundle outState) {
         outState.putSerializable(WordPress.SITE, mSite);
         outState.putString(KEY_SEARCH_QUERY, mSearchQuery);
         outState.putString(KEY_TITLE, mTitle.getValue());
     }
 
+    @Override
     public void readFromBundle(@NonNull Bundle savedInstanceState) {
         if (mIsStarted) {
             // This was called due to a config change where the data survived, we don't need to
@@ -128,8 +130,9 @@ public class PluginBrowserViewModel extends ViewModel {
     }
 
     @WorkerThread
-    public void start() {
-        if (mIsStarted) {
+    @Override
+    public void onStart() {
+        if (isStarted()) {
             return;
         }
         reloadPluginDirectory(PluginDirectoryType.FEATURED);
@@ -147,6 +150,11 @@ public class PluginBrowserViewModel extends ViewModel {
         }
 
         mIsStarted = true;
+    }
+
+    @Override
+    public boolean isStarted() {
+        return mIsStarted;
     }
 
     // Site & WPOrg plugin management

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.java
@@ -106,8 +106,8 @@ public class PluginBrowserViewModel extends ViewModel implements ViewModelInterf
 
     @Override
     protected void onCleared() {
-        super.onCleared();
         mDispatcher.unregister(this);
+        super.onCleared();
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/ViewModelInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/ViewModelInterface.java
@@ -4,8 +4,54 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 
 interface ViewModelInterface {
+    /**
+     * ViewModels only survive configuration changes, so if the activity is completely destroyed and re-created, we will
+     * need to re-create the ViewModel as well. Unfortunately, activity will not be aware of this and should call the
+     * `onStart` method regardless of where it was a re-creation or a configuration change. We need a way to identify
+     * such cases which is done through this method. A typical implementation would be to define a property called
+     * `mIsStarted` and set that to true in `onStart` and return this variable from this method.
+     * @return false if the ViewModel's `onStart` has been called before, return true otherwise.
+     */
     boolean isStarted();
+
+    /**
+     * At the time of the construction of the ViewModel we may not have access to crucial information, such as the
+     * current site because the ViewModels should be created through injection by ViewModelFactory. We need a different
+     * way to do one time setups. This method should be implemented by every ViewModel to streamline that process.
+     * It should first verify that the ViewModel has not been started yet by using the `isStarted()` method. An example
+     * use case might be to start a fetch or refresh of the data the ViewModel will be using. The activity should be
+     * calling this method in its `onCreate` and will not know if it's because of a configuration change or if it's
+     * re-created. So, this method ensures that we do one time calls only when we have to.
+     *
+     * This method should be called after `readFromBundle` in the activity!
+     */
     void onStart();
+
+    /**
+     * Although the ViewModel survives configuration changes, we'll often need some information to be able to re-create
+     * the ViewModel from scratch. This method gives us a consistent way to do that. The activity should be calling this
+     * method from its onCreate(Bundle savedInstanceState) method only if the `savedInstanceState` is not `null`.
+     *
+     * This method will be called when the activity is re-created AND after a configuration change. However, since we
+     * should not be saving actual data in the bundle, it should be safe to override the property even if we already
+     * have it set. If overriding a particular property feels wrong, it's most likely that the property doesn't belong
+     * in the Bundle and should be handled in a different way.
+     *
+     * This method should be called before `onStart` in the activity!
+     *
+     * @param savedInstanceState should be passed from onCreate(Bundle savedInstanceState) when it's not `null`.
+     */
     void readFromBundle(@NonNull Bundle savedInstanceState);
+
+    /**
+     * We need to save enough information to be able to re-create the ViewModel from scratch if the activity is
+     * re-created and the cached data is lost. We should NOT save the actual data in the bundle. The bundle only meant
+     * to hold small piece of information. A typical use case would be to save the `id` of an object or the `type` of
+     * a list and read that in the `readFromBundle` method and ask the FluxC for the actual data. Since we shouldn't be
+     * saving big amounts of data, it should be safe to write to the Bundle even during configuration changes since
+     * it'll be a quick process.
+     *
+     * @param outState should be passed from the onSaveInstanceState(Bundle outState) of the activity.
+     */
     void writeToBundle(@NonNull Bundle outState);
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/ViewModelInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/ViewModelInterface.java
@@ -1,0 +1,11 @@
+package org.wordpress.android.viewmodel;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+
+interface ViewModelInterface {
+    boolean isStarted();
+    void onStart();
+    void readFromBundle(@NonNull Bundle savedInstanceState);
+    void writeToBundle(@NonNull Bundle outState);
+}


### PR DESCRIPTION
**TL;DR:** This PR is about how we can solve common problems for ViewModels in a consistent way. It talks about a specific problem, activity re-creation, and proposes a solution for it. It's meant to be the first step of documenting the `ViewModel` pattern to make it easier for any developer to utilize in a consistent manner.

--------------------------------

We have only recently started using `ViewModel`s in the app with the introduction of `PluginBrowserViewModel`. That gives us a great opportunity to document everything properly from the start and introduce a good structure for all of us to follow. Although there will be a document in the repository to explain and showcase the patterns we use, I strongly believe that the code should be self-documenting as much as possible. By that I mean, instead of saying we should do `X` in a document and bring it up during reviews, the structure itself should enforce doing that and ideally explain why and how of it as a javadoc. Once we figure out a solution for a common problem and settle on it, we shouldn't have to re-solve it unless something has changed that makes the solution invalid (not-ideal).

This PR is only the first step for this. I'll try to contain each decision/improvement in a PR like this one, so we can make incremental decisions and document them along the way.

**The Problem**

> ViewModels only survive configuration change-related destruction; they do not survive the process being stopped. This makes ViewModels a replacement for using a fragment with setRetainInstance(true) (in fact ViewModels use a fragment with setRetainInstance set to true behind the scenes). [#](https://medium.com/google-developers/viewmodels-persistence-onsaveinstancestate-restoring-ui-state-and-loaders-fc7cc4a6c090)

What this means is that, we don't need to handle configuration changes in our ViewModel, the data you have cached in your ViewModel will survive these which is very important. However, if the process is stopped, we still need a way to re-create the Activity/Fragment. In practice, this means we still need to keep the `id`s of the objects we are interested in, so that if the ViewModel is re-created we can ask FluxC (or another data source) for the data.

_This is all good, but how do we do that and why is it not straightforward?_

The activity does not know about whether it was re-created due to configuration change or because the process has stopped, so it can't tell the `ViewModel` to do an `initial setup*`. The `ViewModel` can not do the initial setup in its constructor either, because in most, if not all, cases it'll need some kind of information from the Activity and since the Activity does not handle the construction of the ViewModel.

Although there are a lot of different ways to go about this, the only ones I am comfortable with that I've thought of so far are:
1. Use an interface for the common methods that each ViewModel will need to implement
2. Use an abstract class for the same reason

If there are alternatives, I'll always prefer NOT TO add a base class for pretty much anything. I think the **implementation inheritance** is an evil concept and should be avoided like a plague. However, my personal opinion of them is not important and all it matters is that we are **consistent** about it.

I am not going to document the implementation details of the `ViewModelInterface` here, because I think the documentation in the code should do that. If it's not good enough and if anything is not clear, we should just improve on that instead of explaining here.

**Initial Setup**
I don't know if this was clear from the context, but these are the things we want to do only once when the `ViewModel` is created but can't be done in the constructor. Let's say the `ViewModel` needs the `SiteModel` to be able to fetch/load plugins for that site. Since we don't know what that site is in the constructor, we can't do it there, so we need to do that in a different place. (`onStart` naming comes from a Google example or doc, I can't remember it exactly, but Google was using the `start` method)

**Expectation**

I really think every Android developer at a8c should at least check this PR out. I expect these to be the foundation of the app going forward. Here are my suggestion of steps everyone should consider (without skipping any):

1. Make sure to understand why `ViewModel`s might be re-created.
2. Check out the current approach of how the initial setup happens currently (`onStarted`, `writeToBundle`, `readFromBundle`). If you have a different idea of how we might do this, please make sure to share that.
3. **If you agree with the current approach for the initial setup** check out the current `Interface` approach and consider whether the `abstract class` approach would have been better and why. I only suggested 2 ways, but please share any other approach you think might work.
4. **If you agree with everything so far**, it'd be great if you can read the documentation in `ViewModelInterface` and give feedback on how it can be improved. (**Bonus**)

_P.S:_ If you give thumbs up to this PR, I'll consider that you completed the first 3 steps and you are in agreement with it. Also, please let me know if you have any feedback on how these proposals can be done in a better way.