### PR TITLE
Fix title TalkBack announcements in sign in/up and site creation

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -120,6 +120,7 @@
 
         <activity
             android:name=".ui.accounts.LoginEpilogueActivity"
+            android:label="@string/login_epilogue_screen_title"
             android:theme="@style/LoginTheme" />
 
         <activity
@@ -130,6 +131,7 @@
 
         <activity
             android:name=".ui.accounts.SignupEpilogueActivity"
+            android:label="@string/signup_epilogue_screen_title"
             android:theme="@style/LoginTheme" />
 
         <activity

--- a/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ShareIntentReceiverFragment.java
@@ -70,6 +70,12 @@ public class ShareIntentReceiverFragment extends Fragment {
         }
     }
 
+    @Override public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.share_intent_screen_title);
+    }
+
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
@@ -113,14 +119,14 @@ public class ShareIntentReceiverFragment extends Fragment {
     }
 
     private void initShareActionPostButton(final ViewGroup layout) {
-        mSharePostBtn = (Button) layout.findViewById(R.id.primary_button);
+        mSharePostBtn = layout.findViewById(R.id.primary_button);
         addShareActionListener(mSharePostBtn, ShareAction.SHARE_TO_POST);
         mSharePostBtn.setVisibility(View.VISIBLE);
         mSharePostBtn.setText(R.string.share_action_post);
     }
 
     private void initShareActionMediaButton(final ViewGroup layout, boolean sharingMediaFile) {
-        mShareMediaBtn = (Button) layout.findViewById(R.id.secondary_button);
+        mShareMediaBtn = layout.findViewById(R.id.secondary_button);
         addShareActionListener(mShareMediaBtn, ShareAction.SHARE_TO_MEDIA_LIBRARY);
         mShareMediaBtn.setVisibility(sharingMediaFile ? View.VISIBLE : View.GONE);
         mShareMediaBtn.setText(R.string.share_action_media);
@@ -136,7 +142,7 @@ public class ShareIntentReceiverFragment extends Fragment {
     }
 
     private void initRecyclerView(ViewGroup layout) {
-        mRecyclerView = (RecyclerView) layout.findViewById(R.id.recycler_view);
+        mRecyclerView = layout.findViewById(R.id.recycler_view);
         mRecyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
         mRecyclerView.setScrollBarStyle(View.SCROLLBARS_OUTSIDE_OVERLAY);
         mRecyclerView.setItemAnimator(null);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginPrologueFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginPrologueFragment.java
@@ -2,6 +2,7 @@ package org.wordpress.android.ui.accounts.login;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
 import android.support.design.widget.TabLayout;
 import android.support.v4.app.Fragment;
 import android.support.v4.view.ViewPager;
@@ -74,13 +75,13 @@ public class LoginPrologueFragment extends Fragment {
             }
         };
 
-        WPViewPager pager = (WPViewPager) view.findViewById(R.id.intros_pager);
+        WPViewPager pager = view.findViewById(R.id.intros_pager);
         LoginProloguePagerAdapter adapter = new LoginProloguePagerAdapter(getChildFragmentManager());
         pager.setAdapter(adapter);
         pager.addOnPageChangeListener(listener);
 
         // Using a TabLayout for simulating a page indicator strip
-        TabLayout tabLayout = (TabLayout) view.findViewById(R.id.tab_layout_indicator);
+        TabLayout tabLayout = view.findViewById(R.id.tab_layout_indicator);
         tabLayout.setupWithViewPager(pager, true);
 
         if (savedInstanceState == null) {
@@ -88,6 +89,12 @@ public class LoginPrologueFragment extends Fragment {
         }
 
         return view;
+    }
+
+    @Override public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.login_prologue_screen_title);
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEmailFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupEmailFragment.java
@@ -88,6 +88,8 @@ public class SignupEmailFragment extends LoginBaseFormFragment<LoginListener> im
 
     @Override
     protected void setupContent(ViewGroup rootView) {
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.signup_email_screen_title);
         mEmailInput = rootView.findViewById(R.id.login_email_row);
 
         if (BuildConfig.DEBUG) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupMagicLinkFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SignupMagicLinkFragment.java
@@ -105,6 +105,12 @@ public class SignupMagicLinkFragment extends Fragment {
         }
     }
 
+    @Override public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.signup_magic_link_title);
+    }
+
     @Override
     public void onAttach(Context context) {
         ((WordPress) getActivity().getApplication()).component().inject(this);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCategoryFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCategoryFragment.java
@@ -21,6 +21,8 @@ public class SiteCreationCategoryFragment extends SiteCreationBaseFormFragment<S
 
     @Override
     protected void setupContent(ViewGroup rootView) {
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.site_creation_category_title);
         rootView.findViewById(R.id.site_creation_card_blog).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationDomainFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationDomainFragment.java
@@ -65,6 +65,8 @@ public class SiteCreationDomainFragment extends SiteCreationBaseFormFragment<Sit
 
     @Override
     protected void setupContent(ViewGroup rootView) {
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.site_creation_domain_selection_title);
         RecyclerView recyclerView = rootView.findViewById(R.id.recycler_view);
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
         recyclerView.setAdapter(mSiteCreationDomainAdapter);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationSiteDetailsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationSiteDetailsFragment.java
@@ -32,6 +32,8 @@ public class SiteCreationSiteDetailsFragment extends SiteCreationBaseFormFragmen
 
     @Override
     protected void setupContent(ViewGroup rootView) {
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.site_creation_site_details_title);
         mScrollView = rootView.findViewById(R.id.scroll_view);
 
         mSiteTitleInput = rootView.findViewById(R.id.site_creation_site_title_row);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationThemeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationThemeFragment.java
@@ -47,6 +47,8 @@ public class SiteCreationThemeFragment extends SiteCreationBaseFormFragment<Site
 
     @Override
     protected void setupContent(ViewGroup rootView) {
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.site_creation_theme_selection_title);
         RecyclerView recyclerView = (RecyclerView) rootView.findViewById(R.id.recycler_view);
         recyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
         recyclerView.setAdapter(mSiteCreationThemeAdapter);

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -47,6 +47,12 @@
     <string name="publicize_buttons_screen_title">Sharing buttons</string>
     <string name="media_settings_screen_title">File details</string>
     <string name="person_detail_screen_title">Person detail</string>
+    <string name="login_epilogue_screen_title">Logged in as</string>
+    <string name="login_prologue_screen_title">Login</string>
+    <string name="signup_email_screen_title">Email signup</string>
+    <string name="signup_epilogue_screen_title">New account</string>
+    <string name="signup_magic_link_title">Magic link sent</string>
+
 
     <!-- general strings -->
     <string name="device">Device</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -52,6 +52,7 @@
     <string name="signup_email_screen_title">Email signup</string>
     <string name="signup_epilogue_screen_title">New account</string>
     <string name="signup_magic_link_title">Magic link sent</string>
+    <string name="share_intent_screen_title">Pick site</string>
 
 
     <!-- general strings -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2194,6 +2194,10 @@
 
     <!-- Site Creation -->
     <string name="site_creation_title">Create New Site</string>
+    <string name="site_creation_category_title">Create New Site Step 1</string>
+    <string name="site_creation_theme_selection_title">Create New Site Step 2</string>
+    <string name="site_creation_site_details_title">Create New Site Step 3</string>
+    <string name="site_creation_domain_selection_title">Create New Site Step 4</string>
     <string name="site_creation_label_category_title">Step 1 of 4</string>
     <string name="site_creation_label_category">What kind of site do you need?\nChoose an option below:</string>
     <string name="site_creation_title_blog">Start with a Blog</string>

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/Login2FaFragment.java
@@ -160,7 +160,9 @@ public class Login2FaFragment extends LoginBaseFormFragment<LoginListener> imple
 
     @Override
     protected void setupContent(ViewGroup rootView) {
-        m2FaInput = (WPLoginInputRow) rootView.findViewById(R.id.login_2fa_row);
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.verification_2fa_screen_title);
+        m2FaInput = rootView.findViewById(R.id.login_2fa_row);
         m2FaInput.addTextChangedListener(this);
         m2FaInput.setOnEditorCommitListener(this);
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -108,6 +108,8 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
 
     @Override
     protected void setupContent(ViewGroup rootView) {
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.email_address_login_title);
         mEmailInput = rootView.findViewById(R.id.login_email_row);
         if (BuildConfig.DEBUG) {
             mEmailInput.getEditText().setText(BuildConfig.DEBUG_WPCOM_LOGIN_EMAIL);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailPasswordFragment.java
@@ -141,6 +141,8 @@ public class LoginEmailPasswordFragment extends LoginBaseFormFragment<LoginListe
 
     @Override
     protected void setupContent(ViewGroup rootView) {
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.selfhosted_site_login_title);
         ((TextView) rootView.findViewById(R.id.login_email)).setText(mEmailAddress);
 
         mPasswordInput = rootView.findViewById(R.id.login_password_row);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkRequestFragment.java
@@ -99,7 +99,7 @@ public class LoginMagicLinkRequestFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.login_magic_link_request_screen, container, false);
-        mRequestMagicLinkButton = (Button) view.findViewById(R.id.login_request_magic_link);
+        mRequestMagicLinkButton = view.findViewById(R.id.login_request_magic_link);
         mRequestMagicLinkButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -123,7 +123,7 @@ public class LoginMagicLinkRequestFragment extends Fragment {
         });
 
         mAvatarProgressBar = view.findViewById(R.id.avatar_progress);
-        ImageView avatarView = (ImageView) view.findViewById(R.id.gravatar);
+        ImageView avatarView = view.findViewById(R.id.gravatar);
         Glide.with(this)
                 .load(GravatarUtils.gravatarFromEmail(mEmail,
                         getContext().getResources().getDimensionPixelSize(R.dimen.avatar_sz_login)))
@@ -153,7 +153,7 @@ public class LoginMagicLinkRequestFragment extends Fragment {
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        Toolbar toolbar = (Toolbar) view.findViewById(R.id.toolbar);
+        Toolbar toolbar = view.findViewById(R.id.toolbar);
         ((AppCompatActivity) getActivity()).setSupportActionBar(toolbar);
 
         ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
@@ -180,6 +180,8 @@ public class LoginMagicLinkRequestFragment extends Fragment {
             boolean gravatarInProgress = savedInstanceState.getBoolean(KEY_GRAVATAR_IN_PROGRESS);
             mAvatarProgressBar.setVisibility(gravatarInProgress ? View.VISIBLE : View.GONE);
         }
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.magic_link_login_title);
     }
 
     @Override

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkSentFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginMagicLinkSentFragment.java
@@ -76,7 +76,7 @@ public class LoginMagicLinkSentFragment extends Fragment {
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        Toolbar toolbar = (Toolbar) view.findViewById(R.id.toolbar);
+        Toolbar toolbar = view.findViewById(R.id.toolbar);
         ((AppCompatActivity) getActivity()).setSupportActionBar(toolbar);
 
         ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
@@ -88,6 +88,12 @@ public class LoginMagicLinkSentFragment extends Fragment {
         if (savedInstanceState == null) {
             mAnalyticsListener.trackMagicLinkOpenEmailClientViewed();
         }
+    }
+
+    @Override public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.magic_link_sent_login_title);
     }
 
     @Override

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginSiteAddressFragment.java
@@ -91,7 +91,9 @@ public class LoginSiteAddressFragment extends LoginBaseFormFragment<LoginListene
 
     @Override
     protected void setupContent(ViewGroup rootView) {
-        mSiteAddressInput = (WPLoginInputRow) rootView.findViewById(R.id.login_site_address_row);
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.site_address_login_title);
+        mSiteAddressInput = rootView.findViewById(R.id.login_site_address_row);
         mSiteAddressInput.addTextChangedListener(this);
         mSiteAddressInput.setOnEditorCommitListener(this);
     }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginUsernamePasswordFragment.java
@@ -119,7 +119,9 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
 
     @Override
     protected void setupContent(ViewGroup rootView) {
-        mScrollView = (ScrollView) rootView.findViewById(R.id.scroll_view);
+        // important for accessibility - talkback
+        getActivity().setTitle(R.string.selfhosted_site_login_title);
+        mScrollView = rootView.findViewById(R.id.scroll_view);
 
         rootView.findViewById(R.id.login_site_title_static).setVisibility(mIsWpcom ? View.GONE : View.VISIBLE);
         rootView.findViewById(R.id.login_blavatar_static).setVisibility(mIsWpcom ? View.GONE : View.VISIBLE);
@@ -133,17 +135,17 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
                 .into(((ImageView) rootView.findViewById(R.id.login_blavatar)));
         }
 
-        TextView siteNameView = ((TextView) rootView.findViewById(R.id.login_site_title));
+        TextView siteNameView = (rootView.findViewById(R.id.login_site_title));
         siteNameView.setText(mSiteName);
         siteNameView.setVisibility(mSiteName != null ? View.VISIBLE : View.GONE);
 
-        TextView siteAddressView = ((TextView) rootView.findViewById(R.id.login_site_address));
+        TextView siteAddressView = (rootView.findViewById(R.id.login_site_address));
         siteAddressView.setText(UrlUtils.removeScheme(UrlUtils.removeXmlrpcSuffix(mInputSiteAddress)));
         siteAddressView.setVisibility(mInputSiteAddress != null ? View.VISIBLE : View.GONE);
 
         mInputSiteAddressWithoutSuffix = UrlUtils.removeXmlrpcSuffix(mEndpointAddress);
 
-        mUsernameInput = (WPLoginInputRow) rootView.findViewById(R.id.login_username_row);
+        mUsernameInput = rootView.findViewById(R.id.login_username_row);
         mUsernameInput.setText(mInputUsername);
         if (BuildConfig.DEBUG) {
             mUsernameInput.getEditText().setText(BuildConfig.DEBUG_WPCOM_LOGIN_USERNAME);
@@ -157,7 +159,7 @@ public class LoginUsernamePasswordFragment extends LoginBaseFormFragment<LoginLi
             }
         });
 
-        mPasswordInput = (WPLoginInputRow) rootView.findViewById(R.id.login_password_row);
+        mPasswordInput = rootView.findViewById(R.id.login_password_row);
         mPasswordInput.setText(mInputPassword);
         if (BuildConfig.DEBUG) {
             mPasswordInput.getEditText().setText(BuildConfig.DEBUG_WPCOM_LOGIN_PASSWORD);

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -101,6 +101,17 @@
     <string name="notification_2fa_needed">Please provide an authentication code to continue.</string>
     <string name="notification_login_failed">An error has occurred.</string>
 
+    <!-- Screen titles -->
+    <string name="email_address_login_title">Email address login</string>
+    <string name="site_address_login_title">Site address login</string>
+    <string name="magic_link_login_title">Magic link login</string>
+    <string name="magic_link_sent_login_title">Magic link sent</string>
+    <string name="wpcom_login_title">Login password</string>
+    <string name="selfhosted_site_login_title">Login credentials</string>
+    <string name="email_signup_title">Sign up with email</string>
+    <string name="verification_2fa_screen_title">Code verification</string>
+
+
     <!-- HTTP Authentication -->
     <string name="http_authorization_required">Authorization required</string>
     <string name="httpuser">HTTP username</string>


### PR DESCRIPTION
Partially fixes #7370

Fixes screen titles in the sign in/up, site creation and sharing to WordPress sections.

To test:
1. turn on TalkBack
2. Enter each screen and make sure, that it's title is announced (the title should be announced also when you get back to the screen - either from a nested activity or from another app/system ui)

Not ready for Review -> The #7499 needs to be merged first.