### PR TITLE
Issue/7398 incorrect behavior when search media

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -514,6 +514,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             onQueryTextChange(mQuery);
         }
 
+        reloadMediaGrid();
+
         return true;
     }
 
@@ -523,6 +525,8 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         invalidateOptionsMenu();
 
         enableTabs(true);
+
+        reloadMediaGrid();
 
         return true;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaBrowserActivity.java
@@ -514,8 +514,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
             onQueryTextChange(mQuery);
         }
 
-        reloadMediaGrid();
-
         return true;
     }
 
@@ -525,8 +523,6 @@ public class MediaBrowserActivity extends AppCompatActivity implements MediaGrid
         invalidateOptionsMenu();
 
         enableTabs(true);
-
-        reloadMediaGrid();
 
         return true;
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -506,8 +506,27 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
     }
 
     public void search(String searchTerm) {
+        List<MediaModel> mediaList;
         mSearchTerm = searchTerm;
-        List<MediaModel> mediaList = mMediaStore.searchSiteMedia(mSite, mSearchTerm);
+
+        switch (mFilter) {
+            case FILTER_IMAGES:
+                mediaList = mMediaStore.searchSiteImages(mSite, mSearchTerm);
+                break;
+            case FILTER_DOCUMENTS:
+                mediaList = mMediaStore.searchSiteDocuments(mSite, mSearchTerm);
+                break;
+            case FILTER_VIDEOS:
+                mediaList = mMediaStore.searchSiteVideos(mSite, mSearchTerm);
+                break;
+            case FILTER_AUDIO:
+                mediaList = mMediaStore.searchSiteAudio(mSite, mSearchTerm);
+                break;
+            default:
+                mediaList = mMediaStore.searchSiteMedia(mSite, mSearchTerm);
+                break;
+        }
+
         mGridAdapter.setMediaList(mediaList);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -350,7 +350,23 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
     List<MediaModel> getFilteredMedia() {
         List<MediaModel> mediaList;
         if (!TextUtils.isEmpty(mSearchTerm)) {
-            mediaList = mMediaStore.searchSiteMedia(mSite, mSearchTerm);
+            switch (mFilter) {
+                case FILTER_IMAGES:
+                    mediaList = mMediaStore.searchSiteImages(mSite, mSearchTerm);
+                    break;
+                case FILTER_DOCUMENTS:
+                    mediaList = mMediaStore.searchSiteDocuments(mSite, mSearchTerm);
+                    break;
+                case FILTER_VIDEOS:
+                    mediaList = mMediaStore.searchSiteVideos(mSite, mSearchTerm);
+                    break;
+                case FILTER_AUDIO:
+                    mediaList = mMediaStore.searchSiteAudio(mSite, mSearchTerm);
+                    break;
+                default:
+                    mediaList = mMediaStore.searchSiteMedia(mSite, mSearchTerm);
+                    break;
+            }
         } else if (mBrowserType.isSingleImagePicker()) {
             mediaList = mMediaStore.getSiteImages(mSite);
         } else if (mBrowserType.canFilter()) {
@@ -506,27 +522,8 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
     }
 
     public void search(String searchTerm) {
-        List<MediaModel> mediaList;
         mSearchTerm = searchTerm;
-
-        switch (mFilter) {
-            case FILTER_IMAGES:
-                mediaList = mMediaStore.searchSiteImages(mSite, mSearchTerm);
-                break;
-            case FILTER_DOCUMENTS:
-                mediaList = mMediaStore.searchSiteDocuments(mSite, mSearchTerm);
-                break;
-            case FILTER_VIDEOS:
-                mediaList = mMediaStore.searchSiteVideos(mSite, mSearchTerm);
-                break;
-            case FILTER_AUDIO:
-                mediaList = mMediaStore.searchSiteAudio(mSite, mSearchTerm);
-                break;
-            default:
-                mediaList = mMediaStore.searchSiteMedia(mSite, mSearchTerm);
-                break;
-        }
-
+        List<MediaModel> mediaList = getFilteredMedia();
         mGridAdapter.setMediaList(mediaList);
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '1b2dee4e9edaf46e404c44dc0011af790d55c31d'
+    fluxCVersion = '80c252666e397f638b1228261f276b702d95d9e7'
 }


### PR DESCRIPTION
Fixes #7398 Media browser: Incorrect behavior when displaying search results

To test:

1. Go to **Sites** tab.
2. Tap **Media** item.
3. Add one or more **images, documents, videos or audio**.
4. Tap **Images** tab.
5. Tap **Search** action.
6. Only **images** should be shown.
7. Enter **search text** to filter out images.
8. Only images with the 'term' searched should be shown.

The same way should work if you choose "Documents", "Videos" or "Audio" and If you choose "All" tab, it should search in any type of media. 

cc: @theck13 