### PR TITLE
Issue/7515 update authentication analytics

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -26,6 +26,7 @@ import org.wordpress.android.ui.accounts.NewBlogFragment;
 import org.wordpress.android.ui.accounts.SignInDialogFragment;
 import org.wordpress.android.ui.accounts.SiteCreationActivity;
 import org.wordpress.android.ui.accounts.login.LoginEpilogueFragment;
+import org.wordpress.android.ui.accounts.login.MagicLinkRequestFragment;
 import org.wordpress.android.ui.accounts.signup.SignupEpilogueFragment;
 import org.wordpress.android.ui.accounts.signup.SiteCreationCategoryFragment;
 import org.wordpress.android.ui.accounts.signup.SiteCreationDomainAdapter;
@@ -169,6 +170,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(LoginEpilogueFragment object);
 
     void inject(LoginMagicLinkInterceptActivity object);
+
+    void inject(MagicLinkRequestFragment object);
 
     void inject(SignupEpilogueFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -21,6 +21,7 @@ import org.wordpress.android.ui.WPWebViewActivity;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.LoginActivity;
 import org.wordpress.android.ui.accounts.LoginEpilogueActivity;
+import org.wordpress.android.ui.accounts.LoginMagicLinkInterceptActivity;
 import org.wordpress.android.ui.accounts.NewBlogFragment;
 import org.wordpress.android.ui.accounts.SignInDialogFragment;
 import org.wordpress.android.ui.accounts.SiteCreationActivity;
@@ -166,6 +167,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(LoginEpilogueActivity object);
 
     void inject(LoginEpilogueFragment object);
+
+    void inject(LoginMagicLinkInterceptActivity object);
 
     void inject(SignupEpilogueFragment object);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -94,7 +94,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     private LoginMode mLoginMode;
 
     @Inject DispatchingAndroidInjector<Fragment> mFragmentInjector;
-    @Inject protected LoginAnalyticsListener mAnalyticsListener;
+    @Inject protected LoginAnalyticsListener mLoginAnalyticsListener;
 
     @Override
     protected void attachBaseContext(Context newBase) {
@@ -109,7 +109,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
         setContentView(R.layout.login_activity);
 
         if (savedInstanceState == null) {
-            mAnalyticsListener.trackLoginAccessed();
+            mLoginAnalyticsListener.trackLoginAccessed();
 
             switch (getLoginMode()) {
                 case FULL:
@@ -234,7 +234,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
                 break;
             case RequestCodes.SMART_LOCK_SAVE:
                 if (resultCode == RESULT_OK) {
-                    mAnalyticsListener.trackLoginAutofillCredentialsUpdated();
+                    mLoginAnalyticsListener.trackLoginAutofillCredentialsUpdated();
                     AppLog.d(AppLog.T.NUX, "Credentials saved");
                 } else {
                     AppLog.d(AppLog.T.NUX, "Credentials save cancelled");
@@ -396,7 +396,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
 
     @Override
     public void loggedInViaSocialAccount(ArrayList<Integer> oldSitesIds, boolean doLoginUpdate) {
-        mAnalyticsListener.trackLoginSocialSuccess();
+        mLoginAnalyticsListener.trackLoginSocialSuccess();
         loggedInAndFinish(oldSitesIds, doLoginUpdate);
     }
 
@@ -420,7 +420,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     @Override
     public void openEmailClient() {
         if (WPActivityUtils.isEmailClientAvailable(this)) {
-            mAnalyticsListener.trackLoginMagicLinkOpenEmailClientClicked();
+            mLoginAnalyticsListener.trackLoginMagicLinkOpenEmailClientClicked();
             WPActivityUtils.openEmailClient(this);
         } else {
             ToastUtils.showToast(this, R.string.login_email_client_not_found);
@@ -429,7 +429,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
 
     @Override
     public void usePasswordInstead(String email) {
-        mAnalyticsListener.trackLoginMagicLinkExited();
+        mLoginAnalyticsListener.trackLoginMagicLinkExited();
         LoginEmailPasswordFragment loginEmailPasswordFragment =
                 LoginEmailPasswordFragment.newInstance(email, null, null, null, false);
         slideInFragment(loginEmailPasswordFragment, true, LoginEmailPasswordFragment.TAG);
@@ -437,7 +437,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
 
     @Override
     public void forgotPassword(String url) {
-        mAnalyticsListener.trackLoginForgotPasswordClicked();
+        mLoginAnalyticsListener.trackLoginForgotPasswordClicked();
         ActivityLauncher.openUrlExternal(this, url + FORGOT_PASSWORD_URL_SUFFIX);
     }
 
@@ -451,7 +451,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     public void needs2faSocial(String email, String userId, String nonceAuthenticator, String nonceBackup,
                                String nonceSms) {
         dismissSignupSheet();
-        mAnalyticsListener.trackLoginSocial2faNeeded();
+        mLoginAnalyticsListener.trackLoginSocial2faNeeded();
         Login2FaFragment login2FaFragment = Login2FaFragment.newInstanceSocial(email, userId,
                                                                                nonceAuthenticator, nonceBackup,
                                                                                nonceSms);
@@ -460,7 +460,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
 
     @Override
     public void needs2faSocialConnect(String email, String password, String idToken, String service) {
-        mAnalyticsListener.trackLoginSocial2faNeeded();
+        mLoginAnalyticsListener.trackLoginSocial2faNeeded();
         Login2FaFragment login2FaFragment =
                 Login2FaFragment.newInstanceSocialConnect(email, password, idToken, service);
         slideInFragment(login2FaFragment, true, Login2FaFragment.TAG);
@@ -668,7 +668,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
 
     @Override
     public void onCredentialRetrieved(Credential credential) {
-        mAnalyticsListener.trackLoginAutofillCredentialsFilled();
+        mLoginAnalyticsListener.trackLoginAutofillCredentialsFilled();
 
         mSmartLockHelperState = SmartLockHelperState.FINISHED;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -451,7 +451,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     public void needs2faSocial(String email, String userId, String nonceAuthenticator, String nonceBackup,
                                String nonceSms) {
         dismissSignupSheet();
-        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_SOCIAL_2FA_NEEDED);
+        mAnalyticsListener.trackLoginSocial2faNeeded();
         Login2FaFragment login2FaFragment = Login2FaFragment.newInstanceSocial(email, userId,
                                                                                nonceAuthenticator, nonceBackup,
                                                                                nonceSms);
@@ -460,7 +460,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
 
     @Override
     public void needs2faSocialConnect(String email, String password, String idToken, String service) {
-        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_SOCIAL_2FA_NEEDED);
+        mAnalyticsListener.trackLoginSocial2faNeeded();
         Login2FaFragment login2FaFragment =
                 Login2FaFragment.newInstanceSocialConnect(email, password, idToken, service);
         slideInFragment(login2FaFragment, true, Login2FaFragment.TAG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -437,7 +437,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
 
     @Override
     public void forgotPassword(String url) {
-        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_FORGOT_PASSWORD_CLICKED);
+        mAnalyticsListener.trackLoginForgotPasswordClicked();
         ActivityLauncher.openUrlExternal(this, url + FORGOT_PASSWORD_URL_SUFFIX);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -396,7 +396,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
 
     @Override
     public void loggedInViaSocialAccount(ArrayList<Integer> oldSitesIds, boolean doLoginUpdate) {
-        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_SOCIAL_SUCCESS);
+        mAnalyticsListener.trackLoginSocialSuccess();
         loggedInAndFinish(oldSitesIds, doLoginUpdate);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -26,6 +26,7 @@ import org.wordpress.android.fluxc.network.MemorizingTrustManager;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.login.GoogleFragment.GoogleListener;
 import org.wordpress.android.login.Login2FaFragment;
+import org.wordpress.android.login.LoginAnalyticsListener;
 import org.wordpress.android.login.LoginEmailFragment;
 import org.wordpress.android.login.LoginEmailPasswordFragment;
 import org.wordpress.android.login.LoginGoogleFragment;
@@ -93,6 +94,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     private LoginMode mLoginMode;
 
     @Inject DispatchingAndroidInjector<Fragment> mFragmentInjector;
+    @Inject protected LoginAnalyticsListener mAnalyticsListener;
 
     @Override
     protected void attachBaseContext(Context newBase) {
@@ -107,7 +109,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
         setContentView(R.layout.login_activity);
 
         if (savedInstanceState == null) {
-            AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_ACCESSED);
+            mAnalyticsListener.trackLoginAccessed();
 
             switch (getLoginMode()) {
                 case FULL:

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -420,7 +420,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
     @Override
     public void openEmailClient() {
         if (WPActivityUtils.isEmailClientAvailable(this)) {
-            AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_OPEN_EMAIL_CLIENT_CLICKED);
+            mAnalyticsListener.trackLoginMagicLinkOpenEmailClientClicked();
             WPActivityUtils.openEmailClient(this);
         } else {
             ToastUtils.showToast(this, R.string.login_email_client_not_found);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -234,7 +234,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
                 break;
             case RequestCodes.SMART_LOCK_SAVE:
                 if (resultCode == RESULT_OK) {
-                    AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_AUTOFILL_CREDENTIALS_UPDATED);
+                    mAnalyticsListener.trackLoginAutofillCredentialsUpdated();
                     AppLog.d(AppLog.T.NUX, "Credentials saved");
                 } else {
                     AppLog.d(AppLog.T.NUX, "Credentials save cancelled");

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -429,7 +429,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
 
     @Override
     public void usePasswordInstead(String email) {
-        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_EXITED);
+        mAnalyticsListener.trackLoginMagicLinkExited();
         LoginEmailPasswordFragment loginEmailPasswordFragment =
                 LoginEmailPasswordFragment.newInstance(email, null, null, null, false);
         slideInFragment(loginEmailPasswordFragment, true, LoginEmailPasswordFragment.TAG);

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -668,7 +668,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
 
     @Override
     public void onCredentialRetrieved(Credential credential) {
-        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_AUTOFILL_CREDENTIALS_FILLED);
+        mAnalyticsListener.trackLoginAutofillCredentialsFilled();
 
         mSmartLockHelperState = SmartLockHelperState.FINISHED;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginMagicLinkInterceptActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginMagicLinkInterceptActivity.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 
+import org.wordpress.android.WordPress;
 import org.wordpress.android.login.LoginAnalyticsListener;
 import org.wordpress.android.ui.main.WPMainActivity;
 
@@ -18,9 +19,10 @@ public class LoginMagicLinkInterceptActivity extends Activity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        ((WordPress) getApplication()).component().inject(this);
         super.onCreate(savedInstanceState);
 
-         mAnalyticsListener.trackLoginMagicLinkOpened();
+        mAnalyticsListener.trackLoginMagicLinkOpened();
 
         Intent intent = new Intent(this, WPMainActivity.class);
         intent.setAction(getIntent().getAction());

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginMagicLinkInterceptActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginMagicLinkInterceptActivity.java
@@ -15,14 +15,14 @@ import javax.inject.Inject;
  * or signup based on deep link scheme, host, and parameters.
  */
 public class LoginMagicLinkInterceptActivity extends Activity {
-    @Inject protected LoginAnalyticsListener mAnalyticsListener;
+    @Inject protected LoginAnalyticsListener mLoginAnalyticsListener;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         ((WordPress) getApplication()).component().inject(this);
         super.onCreate(savedInstanceState);
 
-        mAnalyticsListener.trackLoginMagicLinkOpened();
+        mLoginAnalyticsListener.trackLoginMagicLinkOpened();
 
         Intent intent = new Intent(this, WPMainActivity.class);
         intent.setAction(getIntent().getAction());

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginMagicLinkInterceptActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginMagicLinkInterceptActivity.java
@@ -4,19 +4,23 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 
-import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.login.LoginAnalyticsListener;
 import org.wordpress.android.ui.main.WPMainActivity;
+
+import javax.inject.Inject;
 
 /**
  * Deep link receiver for magic links. Starts {@link WPMainActivity} where flow is routed to login
  * or signup based on deep link scheme, host, and parameters.
  */
 public class LoginMagicLinkInterceptActivity extends Activity {
+    @Inject protected LoginAnalyticsListener mAnalyticsListener;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_OPENED);
+         mAnalyticsListener.trackLoginMagicLinkOpened();
 
         Intent intent = new Intent(this, WPMainActivity.class);
         intent.setAction(getIntent().getAction());

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginMagicLinkInterceptActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginMagicLinkInterceptActivity.java
@@ -19,8 +19,8 @@ public class LoginMagicLinkInterceptActivity extends Activity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        ((WordPress) getApplication()).component().inject(this);
         super.onCreate(savedInstanceState);
+        ((WordPress) getApplication()).component().inject(this);
 
         mLoginAnalyticsListener.trackLoginMagicLinkOpened();
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -48,6 +48,11 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
+    public void trackLoginForgotPasswordClicked() {
+        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_FORGOT_PASSWORD_CLICKED);
+    }
+
+    @Override
     public void trackLoginMagicLinkExited() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_EXITED);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -33,6 +33,11 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
+    public void trackLoginAccessed() {
+        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_ACCESSED);
+    }
+
+    @Override
     public void trackLoginFailed(String errorContext, String errorType, String errorDescription) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_FAILED, errorContext, errorType, errorDescription);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -38,6 +38,11 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
+    public void trackLoginMagicLinkOpened() {
+        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_OPENED);
+    }
+
+    @Override
     public void trackMagicLinkFailed(Map<String, ?> properties) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_FAILED, properties);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -48,6 +48,11 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
+    public void trackLoginMagicLinkExited() {
+        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_EXITED);
+    }
+
+    @Override
     public void trackLoginMagicLinkOpened() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_OPENED);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -38,6 +38,11 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
+    public void trackLoginAutofillCredentialsFilled() {
+        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_AUTOFILL_CREDENTIALS_FILLED);
+    }
+
+    @Override
     public void trackLoginAutofillCredentialsUpdated() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_AUTOFILL_CREDENTIALS_UPDATED);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -58,6 +58,11 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
+    public void trackLoginSocialSuccess() {
+        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_SOCIAL_SUCCESS);
+    }
+
+    @Override
     public void trackMagicLinkFailed(Map<String, ?> properties) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_FAILED, properties);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -53,6 +53,11 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
+    public void trackLoginMagicLinkOpenEmailClientClicked() {
+        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_OPEN_EMAIL_CLIENT_CLICKED);
+    }
+
+    @Override
     public void trackLoginMagicLinkSucceeded() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_SUCCEEDED);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -43,6 +43,11 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
+    public void trackLoginMagicLinkSucceeded() {
+        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_SUCCEEDED);
+    }
+
+    @Override
     public void trackMagicLinkFailed(Map<String, ?> properties) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_FAILED, properties);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -38,6 +38,11 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
+    public void trackLoginAutofillCredentialsUpdated() {
+        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_AUTOFILL_CREDENTIALS_UPDATED);
+    }
+
+    @Override
     public void trackLoginFailed(String errorContext, String errorType, String errorDescription) {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_FAILED, errorContext, errorType, errorDescription);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -112,35 +112,43 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_PASSWORD_FORM_VIEWED);
     }
 
-    @Override public void trackSignupEmailToLogin() {
+    @Override
+    public void trackSignupEmailToLogin() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_EMAIL_TO_LOGIN);
     }
 
-    @Override public void trackSignupMagicLinkFailed() {
+    @Override
+    public void trackSignupMagicLinkFailed() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_MAGIC_LINK_FAILED);
     }
 
-    @Override public void trackSignupMagicLinkSent() {
+    @Override
+    public void trackSignupMagicLinkSent() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_MAGIC_LINK_SENT);
     }
 
-    @Override public void trackSignupMagicLinkSucceeded() {
+    @Override
+    public void trackSignupMagicLinkSucceeded() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_MAGIC_LINK_SUCCEEDED);
     }
 
-    @Override public void trackSignupSocial2faNeeded() {
+    @Override
+    public void trackSignupSocial2faNeeded() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_SOCIAL_2FA_NEEDED);
     }
 
-    @Override public void trackSignupSocialAccountsNeedConnecting() {
+    @Override
+    public void trackSignupSocialAccountsNeedConnecting() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_SOCIAL_ACCOUNTS_NEED_CONNECTING);
     }
 
-    @Override public void trackSignupSocialButtonFailure() {
+    @Override
+    public void trackSignupSocialButtonFailure() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_SOCIAL_BUTTON_FAILURE);
     }
 
-    @Override public void trackSignupSocialToLogin() {
+    @Override
+    public void trackSignupSocialToLogin() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_SOCIAL_TO_LOGIN);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/LoginAnalyticsTracker.java
@@ -73,6 +73,11 @@ public class LoginAnalyticsTracker implements LoginAnalyticsListener {
     }
 
     @Override
+    public void trackLoginSocial2faNeeded() {
+        AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_SOCIAL_2FA_NEEDED);
+    }
+
+    @Override
     public void trackLoginSocialSuccess() {
         AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_SOCIAL_SUCCESS);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
@@ -19,7 +19,6 @@ import org.json.JSONObject;
 import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
-import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.login.LoginAnalyticsListener;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.JetpackCallbacks;
@@ -150,7 +149,7 @@ public class MagicLinkRequestFragment extends Fragment {
             @Override
             public void onResponse(JSONObject response) {
                 mProgressDialog.cancel();
-                AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_REQUESTED);
+                mAnalyticsListener.trackMagicLinkRequested();
                 if (mListener != null) {
                     mListener.onMagicLinkSent();
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
@@ -67,14 +67,10 @@ public class MagicLinkRequestFragment extends Fragment {
     }
 
     @Override
-    public void onAttachFragment(Fragment childFragment) {
-        ((WordPress) getActivity().getApplication()).component().inject(this);
-        super.onAttachFragment(childFragment);
-    }
-
-    @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        ((WordPress) getActivity().getApplication()).component().inject(this);
+
         if (getArguments() != null) {
             mEmail = getArguments().getString(ARG_EMAIL_ADDRESS);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
@@ -67,6 +67,12 @@ public class MagicLinkRequestFragment extends Fragment {
     }
 
     @Override
+    public void onAttachFragment(Fragment childFragment) {
+        ((WordPress) getActivity().getApplication()).component().inject(this);
+        super.onAttachFragment(childFragment);
+    }
+
+    @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         if (getArguments() != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
@@ -38,7 +38,7 @@ public class MagicLinkRequestFragment extends Fragment {
     public static final String CLIENT_SECRET_KEY = "client_secret";
     public static final String ERROR_KEY = "error";
 
-    @Inject protected LoginAnalyticsListener mAnalyticsListener;
+    @Inject protected LoginAnalyticsListener mLoginAnalyticsListener;
 
     public interface OnMagicLinkFragmentInteraction {
         void onMagicLinkSent();
@@ -155,7 +155,7 @@ public class MagicLinkRequestFragment extends Fragment {
             @Override
             public void onResponse(JSONObject response) {
                 mProgressDialog.cancel();
-                mAnalyticsListener.trackMagicLinkRequested();
+                mLoginAnalyticsListener.trackMagicLinkRequested();
                 if (mListener != null) {
                     mListener.onMagicLinkSent();
                 }
@@ -165,7 +165,7 @@ public class MagicLinkRequestFragment extends Fragment {
             public void onErrorResponse(VolleyError error) {
                 HashMap<String, String> errorProperties = new HashMap<>();
                 errorProperties.put(ERROR_KEY, error.getMessage());
-                mAnalyticsListener.trackMagicLinkFailed(errorProperties);
+                mLoginAnalyticsListener.trackMagicLinkFailed(errorProperties);
                 mProgressDialog.cancel();
                 if (isAdded()) {
                     ToastUtils.showToast(getActivity(), R.string.magic_link_unavailable_error_message,

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/login/MagicLinkRequestFragment.java
@@ -20,6 +20,7 @@ import org.wordpress.android.BuildConfig;
 import org.wordpress.android.R;
 import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
+import org.wordpress.android.login.LoginAnalyticsListener;
 import org.wordpress.android.ui.accounts.HelpActivity;
 import org.wordpress.android.ui.accounts.JetpackCallbacks;
 import org.wordpress.android.util.HelpshiftHelper;
@@ -30,11 +31,15 @@ import org.wordpress.android.widgets.WPTextView;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.inject.Inject;
+
 public class MagicLinkRequestFragment extends Fragment {
     public static final String EMAIL_KEY = "email";
     public static final String CLIENT_ID_KEY = "client_id";
     public static final String CLIENT_SECRET_KEY = "client_secret";
     public static final String ERROR_KEY = "error";
+
+    @Inject protected LoginAnalyticsListener mAnalyticsListener;
 
     public interface OnMagicLinkFragmentInteraction {
         void onMagicLinkSent();
@@ -155,7 +160,7 @@ public class MagicLinkRequestFragment extends Fragment {
             public void onErrorResponse(VolleyError error) {
                 HashMap<String, String> errorProperties = new HashMap<>();
                 errorProperties.put(ERROR_KEY, error.getMessage());
-                AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_FAILED, errorProperties);
+                mAnalyticsListener.trackMagicLinkFailed(errorProperties);
                 mProgressDialog.cancel();
                 if (isAdded()) {
                     ToastUtils.showToast(getActivity(), R.string.magic_link_unavailable_error_message,

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -103,7 +103,7 @@ public class WPMainActivity extends AppCompatActivity {
     @Inject SiteStore mSiteStore;
     @Inject PostStore mPostStore;
     @Inject Dispatcher mDispatcher;
-    @Inject protected LoginAnalyticsListener mAnalyticsListener;
+    @Inject protected LoginAnalyticsListener mLoginAnalyticsListener;
 
     /*
      * tab fragments implement this if their contents can be scrolled, called when user
@@ -285,7 +285,7 @@ public class WPMainActivity extends AppCompatActivity {
             ActivityLauncher.showLoginEpilogue(this, getIntent().getBooleanExtra(ARG_DO_LOGIN_UPDATE, false),
                                                getIntent().getIntegerArrayListExtra(ARG_OLD_SITES_IDS));
         } else if (getIntent().getBooleanExtra(ARG_SHOW_SIGNUP_EPILOGUE, false) && savedInstanceState == null) {
-            mAnalyticsListener.trackCreatedAccount();
+            mLoginAnalyticsListener.trackCreatedAccount();
             ActivityLauncher.showSignupEpilogue(this,
                                                 getIntent().getStringExtra(
                                                         SignupEpilogueActivity.EXTRA_SIGNUP_DISPLAY_NAME),
@@ -523,7 +523,7 @@ public class WPMainActivity extends AppCompatActivity {
     private void checkMagicLinkSignIn() {
         if (getIntent() != null) {
             if (getIntent().getBooleanExtra(LoginActivity.MAGIC_LOGIN, false)) {
-                mAnalyticsListener.trackLoginMagicLinkSucceeded();
+                mLoginAnalyticsListener.trackLoginMagicLinkSucceeded();
                 startWithNewAccount();
             }
         }
@@ -742,12 +742,12 @@ public class WPMainActivity extends AppCompatActivity {
 
             if (hasMagicLinkLoginIntent()) {
                 if (hasMagicLinkSignupIntent()) {
-                    mAnalyticsListener.trackCreatedAccount();
-                    mAnalyticsListener.trackSignupMagicLinkSucceeded();
+                    mLoginAnalyticsListener.trackCreatedAccount();
+                    mLoginAnalyticsListener.trackSignupMagicLinkSucceeded();
                     Intent intent = getIntent();
                     ActivityLauncher.showSignupEpilogue(this, null, null, null, null, true);
                 } else {
-                    mAnalyticsListener.trackLoginMagicLinkSucceeded();
+                    mLoginAnalyticsListener.trackLoginMagicLinkSucceeded();
                     ActivityLauncher
                             .showLoginEpilogue(this, true, getIntent().getIntegerArrayListExtra(ARG_OLD_SITES_IDS));
                 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -37,6 +37,7 @@ import org.wordpress.android.fluxc.store.PostStore;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteChanged;
 import org.wordpress.android.fluxc.store.SiteStore.OnSiteRemoved;
+import org.wordpress.android.login.LoginAnalyticsListener;
 import org.wordpress.android.networking.ConnectionChangeReceiver;
 import org.wordpress.android.push.GCMMessageService;
 import org.wordpress.android.push.GCMRegistrationIntentService;
@@ -102,6 +103,7 @@ public class WPMainActivity extends AppCompatActivity {
     @Inject SiteStore mSiteStore;
     @Inject PostStore mPostStore;
     @Inject Dispatcher mDispatcher;
+    @Inject protected LoginAnalyticsListener mAnalyticsListener;
 
     /*
      * tab fragments implement this if their contents can be scrolled, called when user
@@ -283,7 +285,7 @@ public class WPMainActivity extends AppCompatActivity {
             ActivityLauncher.showLoginEpilogue(this, getIntent().getBooleanExtra(ARG_DO_LOGIN_UPDATE, false),
                                                getIntent().getIntegerArrayListExtra(ARG_OLD_SITES_IDS));
         } else if (getIntent().getBooleanExtra(ARG_SHOW_SIGNUP_EPILOGUE, false) && savedInstanceState == null) {
-            AnalyticsTracker.track(AnalyticsTracker.Stat.CREATED_ACCOUNT);
+            mAnalyticsListener.trackCreatedAccount();
             ActivityLauncher.showSignupEpilogue(this,
                                                 getIntent().getStringExtra(
                                                         SignupEpilogueActivity.EXTRA_SIGNUP_DISPLAY_NAME),
@@ -740,7 +742,7 @@ public class WPMainActivity extends AppCompatActivity {
 
             if (hasMagicLinkLoginIntent()) {
                 if (hasMagicLinkSignupIntent()) {
-                    AnalyticsTracker.track(AnalyticsTracker.Stat.CREATED_ACCOUNT);
+                    mAnalyticsListener.trackCreatedAccount();
                     AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_MAGIC_LINK_SUCCEEDED);
                     Intent intent = getIntent();
                     ActivityLauncher.showSignupEpilogue(this, null, null, null, null, true);

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -743,7 +743,7 @@ public class WPMainActivity extends AppCompatActivity {
             if (hasMagicLinkLoginIntent()) {
                 if (hasMagicLinkSignupIntent()) {
                     mAnalyticsListener.trackCreatedAccount();
-                    AnalyticsTracker.track(AnalyticsTracker.Stat.SIGNUP_MAGIC_LINK_SUCCEEDED);
+                    mAnalyticsListener.trackSignupMagicLinkSucceeded();
                     Intent intent = getIntent();
                     ActivityLauncher.showSignupEpilogue(this, null, null, null, null, true);
                 } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/main/WPMainActivity.java
@@ -523,7 +523,7 @@ public class WPMainActivity extends AppCompatActivity {
     private void checkMagicLinkSignIn() {
         if (getIntent() != null) {
             if (getIntent().getBooleanExtra(LoginActivity.MAGIC_LOGIN, false)) {
-                AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_SUCCEEDED);
+                mAnalyticsListener.trackLoginMagicLinkSucceeded();
                 startWithNewAccount();
             }
         }
@@ -747,7 +747,7 @@ public class WPMainActivity extends AppCompatActivity {
                     Intent intent = getIntent();
                     ActivityLauncher.showSignupEpilogue(this, null, null, null, null, true);
                 } else {
-                    AnalyticsTracker.track(AnalyticsTracker.Stat.LOGIN_MAGIC_LINK_SUCCEEDED);
+                    mAnalyticsListener.trackLoginMagicLinkSucceeded();
                     ActivityLauncher
                             .showLoginEpilogue(this, true, getIntent().getIntegerArrayListExtra(ARG_OLD_SITES_IDS));
                 }

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -10,6 +10,7 @@ public interface LoginAnalyticsListener {
     void trackCreatedAccount();
     void trackEmailFormViewed();
     void trackInsertedInvalidUrl();
+    void trackLoginAccessed();
     void trackLoginFailed(String errorContext, String errorType, String errorDescription);
     void trackLoginMagicLinkOpened();
     void trackLoginMagicLinkSucceeded();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -13,6 +13,7 @@ public interface LoginAnalyticsListener {
     void trackLoginAccessed();
     void trackLoginAutofillCredentialsUpdated();
     void trackLoginFailed(String errorContext, String errorType, String errorDescription);
+    void trackLoginMagicLinkExited();
     void trackLoginMagicLinkOpened();
     void trackLoginMagicLinkOpenEmailClientClicked();
     void trackLoginMagicLinkSucceeded();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -13,6 +13,7 @@ public interface LoginAnalyticsListener {
     void trackLoginAccessed();
     void trackLoginAutofillCredentialsUpdated();
     void trackLoginFailed(String errorContext, String errorType, String errorDescription);
+    void trackLoginForgotPasswordClicked();
     void trackLoginMagicLinkExited();
     void trackLoginMagicLinkOpened();
     void trackLoginMagicLinkOpenEmailClientClicked();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -11,6 +11,7 @@ public interface LoginAnalyticsListener {
     void trackEmailFormViewed();
     void trackInsertedInvalidUrl();
     void trackLoginAccessed();
+    void trackLoginAutofillCredentialsFilled();
     void trackLoginAutofillCredentialsUpdated();
     void trackLoginFailed(String errorContext, String errorType, String errorDescription);
     void trackLoginForgotPasswordClicked();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -14,6 +14,7 @@ public interface LoginAnalyticsListener {
     void trackLoginAutofillCredentialsUpdated();
     void trackLoginFailed(String errorContext, String errorType, String errorDescription);
     void trackLoginMagicLinkOpened();
+    void trackLoginMagicLinkOpenEmailClientClicked();
     void trackLoginMagicLinkSucceeded();
     void trackLoginSocialSuccess();
     void trackMagicLinkFailed(Map<String, ?> properties);

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -12,6 +12,7 @@ public interface LoginAnalyticsListener {
     void trackInsertedInvalidUrl();
     void trackLoginFailed(String errorContext, String errorType, String errorDescription);
     void trackLoginMagicLinkOpened();
+    void trackLoginMagicLinkSucceeded();
     void trackMagicLinkFailed(Map<String, ?> properties);
     void trackMagicLinkOpenEmailClientViewed();
     void trackMagicLinkRequested();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -15,6 +15,7 @@ public interface LoginAnalyticsListener {
     void trackLoginFailed(String errorContext, String errorType, String errorDescription);
     void trackLoginMagicLinkOpened();
     void trackLoginMagicLinkSucceeded();
+    void trackLoginSocialSuccess();
     void trackMagicLinkFailed(Map<String, ?> properties);
     void trackMagicLinkOpenEmailClientViewed();
     void trackMagicLinkRequested();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -11,6 +11,7 @@ public interface LoginAnalyticsListener {
     void trackEmailFormViewed();
     void trackInsertedInvalidUrl();
     void trackLoginAccessed();
+    void trackLoginAutofillCredentialsUpdated();
     void trackLoginFailed(String errorContext, String errorType, String errorDescription);
     void trackLoginMagicLinkOpened();
     void trackLoginMagicLinkSucceeded();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -11,6 +11,7 @@ public interface LoginAnalyticsListener {
     void trackEmailFormViewed();
     void trackInsertedInvalidUrl();
     void trackLoginFailed(String errorContext, String errorType, String errorDescription);
+    void trackLoginMagicLinkOpened();
     void trackMagicLinkFailed(Map<String, ?> properties);
     void trackMagicLinkOpenEmailClientViewed();
     void trackMagicLinkRequested();

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginAnalyticsListener.java
@@ -18,6 +18,7 @@ public interface LoginAnalyticsListener {
     void trackLoginMagicLinkOpened();
     void trackLoginMagicLinkOpenEmailClientClicked();
     void trackLoginMagicLinkSucceeded();
+    void trackLoginSocial2faNeeded();
     void trackLoginSocialSuccess();
     void trackMagicLinkFailed(Map<String, ?> properties);
     void trackMagicLinkOpenEmailClientViewed();


### PR DESCRIPTION
### Fix
Update the login/sign analytics to use `LoginAnalyticsListener` across the app as described in https://github.com/wordpress-mobile/WordPress-Android/issues/7515.

#### Note
The prologue and epilogue analytics were intentionally excluded since they are exclusive to the WordPress app.