### PR TITLE
Issue/7508 google signup progress

### DIFF
--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1926,6 +1926,7 @@
     <string name="signup_user_exists">Email already exists on WordPress.com.\nProceeding with login.</string>
     <string name="signup_with_email_button">Sign Up with Email</string>
     <string name="signup_with_google_button">Sign Up with Google</string>
+    <string name="signup_with_google_progress">Signing up with Google&#8230;</string>
     <string name="content_description_add_avatar">Add avatar</string>
 
     <string name="username_changer_action">Save</string>

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/SignupGoogleFragment.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.login;
 
+import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 
@@ -28,13 +29,17 @@ import static android.app.Activity.RESULT_OK;
 
 public class SignupGoogleFragment extends GoogleFragment {
     private ArrayList<Integer> mOldSitesIds;
+    private ProgressDialog mProgressDialog;
 
     private static final int REQUEST_SIGNUP = 1002;
 
     public static final String TAG = "signup_google_fragment_tag";
 
-    @Override public void onAttach(Context context) {
+    @Override
+    public void onAttach(Context context) {
         AndroidSupportInjection.inject(this);
+        mProgressDialog = ProgressDialog.show(
+                getActivity(), null, getString(R.string.signup_with_google_progress), true, false, null);
         super.onAttach(context);
     }
 
@@ -115,13 +120,21 @@ public class SignupGoogleFragment extends GoogleFragment {
                 } else if (result == RESULT_CANCELED) {
                     mAnalyticsListener.trackSignupSocialButtonFailure();
                     AppLog.e(T.NUX, "Google Signup Failed: result was CANCELED.");
+                    cancelProgressDialog();
                 } else {
                     mAnalyticsListener.trackSignupSocialButtonFailure();
                     AppLog.e(T.NUX, "Google Signup Failed: result was not OK or CANCELED.");
                     showErrorDialog(getString(R.string.login_error_generic));
+                    cancelProgressDialog();
                 }
 
                 break;
+        }
+    }
+
+    private void cancelProgressDialog() {
+        if (mProgressDialog.isShowing()) {
+            mProgressDialog.dismiss();
         }
     }
 

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     <string name="signup_terms_of_service_text">By signing up, you agree to our %1$sTerms of Service%2$s.</string>
     <string name="signup_with_email_button">Sign Up with Email</string>
     <string name="signup_with_google_button">Sign Up with Google</string>
+    <string name="signup_with_google_progress">Signing up with Google&#8230;</string>
 
     <string name="google_error_timeout">Google took too long to respond. You may need to wait until you have a stronger internet connection.</string>
 


### PR DESCRIPTION
### Fix
Add a progress dialog in the background of the Google signup interface to indicate the process is still ongoing to solve the issue described in https://github.com/wordpress-mobile/WordPress-Android/issues/7508.

### Test
0. Clear app data.
1. Tap ***Sign Up for WordPress.com*** button.
2. Tap ***Sign Up with Google*** button.
3. Notice ***Signing up with Google...*** progress dialog is shown.
4. Tap back arrow.
5. Notice ***Signing up with Google...*** progress dialog is dismissed.
6. Tap ***Sign Up with Google*** button.
7. Notice ***Signing up with Google...*** progress dialog is shown.
8. Tap Google account from chooser dialog.
9. Notice ***Signing up with Google...*** progress dialog is still shown.