### PR TITLE
Feature/awesome accesible stats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAuthorsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsAuthorsFragment.java
@@ -173,6 +173,13 @@ public class StatsAuthorsFragment extends StatsAbstractListFragment {
             // totals
             int total = children.getTotals();
             holder.totalsTextView.setText(FormatUtils.formatDecimal(total));
+            holder.totalsTextView.setContentDescription(
+                    org.wordpress.android.util.StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_views_zero_desc,
+                            R.string.stats_views_one_desc,
+                            R.string.stats_views_many_desc,
+                            total));
 
             // no icon
             holder.networkImageView.setVisibility(View.GONE);
@@ -233,6 +240,13 @@ public class StatsAuthorsFragment extends StatsAbstractListFragment {
 
             // totals
             holder.totalsTextView.setText(FormatUtils.formatDecimal(total));
+            holder.totalsTextView.setContentDescription(
+                    org.wordpress.android.util.StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_views_zero_desc,
+                            R.string.stats_views_one_desc,
+                            R.string.stats_views_many_desc,
+                            total));
 
             // icon
             //holder.showNetworkImage(icon);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsBarGraph.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsBarGraph.java
@@ -24,6 +24,7 @@ import com.jjoe64.graphview.GraphViewStyle;
 import com.jjoe64.graphview.IndexDependentColor;
 
 import org.wordpress.android.R;
+import org.wordpress.android.util.AppLog;
 
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -315,6 +316,7 @@ class StatsBarGraph extends GraphView {
         if (mAccessibleVirtualLabels != null && index < mAccessibleVirtualLabels.length) {
             return mAccessibleVirtualLabels[index];
         }
+        AppLog.w(AppLog.T.STATS, "Missing StatsBarGraph accessible label at index " + index);
         return "";
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsBarGraph.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsBarGraph.java
@@ -232,7 +232,7 @@ class StatsBarGraph extends GraphView {
             }
 
             if(mVirtualBars.size() < values.length){
-                mVirtualBars.add(new BarChartRect(left - pad, 10f, right - pad, bottom));
+                mVirtualBars.add(new BarChartRect(left - pad, 10f, right + pad, bottom));
             }
 
             if ((top - bottom) == 1) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsBarGraph.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsBarGraph.java
@@ -115,17 +115,7 @@ class StatsBarGraph extends GraphView {
     }
 
     private void highlightBarAndBroadcastDate() {
-        int tappedBar = getTappedBar();
-        //AppLog.d(AppLog.T.STATS, this.getClass().getName() + " Tapped bar " + tappedBar);
-        if (tappedBar >= 0) {
-            highlightBar(tappedBar);
-            if (mGestureListener != null) {
-                mGestureListener.onBarTapped(tappedBar);
-            }
-            if (mStatsBarGraphAccessibilityHelper != null) {
-                mStatsBarGraphAccessibilityHelper.invalidateVirtualView(tappedBar);
-            }
-        }
+        highlightBarAndBroadcastDateAt(getTappedBar());
     }
 
     private void highlightBarAndBroadcastDateAt(int barIndex) {
@@ -140,6 +130,7 @@ class StatsBarGraph extends GraphView {
         }
     }
 
+    // accessibility is emplemented with StatsBarGraphAccessibilityHelper
     @SuppressLint("ClickableViewAccessibility")
     @Override
     public boolean onTouchEvent(MotionEvent event) {
@@ -249,9 +240,7 @@ class StatsBarGraph extends GraphView {
                 if (mBarPositionToHighlight != i) {
                     paint.setColor(style.color);
                     paint.setAlpha(25);
-                    Shader shader =
-                            new LinearGradient(left + pad, bottom - 50, left + pad, bottom, Color.WHITE, Color.BLACK,
-                                    Shader.TileMode.CLAMP);
+                    Shader shader = new LinearGradient(left + pad, bottom - 50, left + pad, bottom, Color.WHITE, Color.BLACK, Shader.TileMode.CLAMP);
                     paint.setShader(shader);
                     canvas.drawRect(left + pad, bottom - 50, right - pad, bottom, paint);
                     paint.setShader(null);
@@ -317,7 +306,6 @@ class StatsBarGraph extends GraphView {
     protected double getMinY() {
         return 0;
     }
-
 
     public void setAccessibleHorizontalLabels(String[] virtualLabels) {
         mAccessibleVirtualLabels = virtualLabels;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsBarGraph.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsBarGraph.java
@@ -143,11 +143,10 @@ class StatsBarGraph extends GraphView {
     @SuppressLint("ClickableViewAccessibility")
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        boolean handled = super.onTouchEvent(event);
-        if (mDetector != null && handled) {
+        if (mDetector != null) {
             this.mDetector.onTouchEvent(event);
         }
-        return handled;
+        return super.onTouchEvent(event);
     }
 
     private class HorizontalLabelsColor implements IndexDependentColor {
@@ -405,7 +404,7 @@ class StatsBarGraph extends GraphView {
 
             node.setSelected(getHighlightedBar() == virtualViewId);
 
-            node.setClickable(true);
+            node.setClickable(mGestureListener != null);
             node.setFocusable(true);
 
             node.addAction(AccessibilityNodeInfoCompat.ACTION_CLICK);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsBarGraph.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsBarGraph.java
@@ -232,7 +232,7 @@ class StatsBarGraph extends GraphView {
             }
 
             if(mVirtualBars.size() < values.length){
-                mVirtualBars.add(new BarChartRect(left, 10f, right, bottom));
+                mVirtualBars.add(new BarChartRect(left - pad, 10f, right - pad, bottom));
             }
 
             if ((top - bottom) == 1) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsBarGraph.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsBarGraph.java
@@ -43,7 +43,7 @@ class StatsBarGraph extends GraphView {
     private int mBarPositionToHighlight = -1;
     private boolean[] mWeekendDays;
 
-    private final StatsBarGraphAccessHelper mStatsBarGraphAccessHelper;
+    private final StatsBarGraphAccessibilityHelper mStatsBarGraphAccessibilityHelper;
     private final List<BarChartRect> mVirtualBars = new ArrayList<>();
     private String[] mAccessibleVirtualLabels;
 
@@ -64,17 +64,17 @@ class StatsBarGraph extends GraphView {
 
         if (isInEditMode()) {
             // Special considerations for edit mode.
-            mStatsBarGraphAccessHelper = null;
+            mStatsBarGraphAccessibilityHelper = null;
         } else {
             // Set up accessibility helper class.
-            mStatsBarGraphAccessHelper = new StatsBarGraphAccessHelper(this);
-            ViewCompat.setAccessibilityDelegate(this, mStatsBarGraphAccessHelper);
+            mStatsBarGraphAccessibilityHelper = new StatsBarGraphAccessibilityHelper(this);
+            ViewCompat.setAccessibilityDelegate(this, mStatsBarGraphAccessibilityHelper);
         }
     }
 
     @Override
     public boolean dispatchHoverEvent(MotionEvent event) {
-        if (mStatsBarGraphAccessHelper != null && mStatsBarGraphAccessHelper.dispatchHoverEvent(event)) {
+        if (mStatsBarGraphAccessibilityHelper != null && mStatsBarGraphAccessibilityHelper.dispatchHoverEvent(event)) {
             return true;
         }
 
@@ -122,8 +122,8 @@ class StatsBarGraph extends GraphView {
             if (mGestureListener != null) {
                 mGestureListener.onBarTapped(tappedBar);
             }
-            if (mStatsBarGraphAccessHelper != null) {
-                mStatsBarGraphAccessHelper.invalidateVirtualView(tappedBar);
+            if (mStatsBarGraphAccessibilityHelper != null) {
+                mStatsBarGraphAccessibilityHelper.invalidateVirtualView(tappedBar);
             }
         }
     }
@@ -134,8 +134,8 @@ class StatsBarGraph extends GraphView {
             if (mGestureListener != null) {
                 mGestureListener.onBarTapped(barIndex);
             }
-            if (mStatsBarGraphAccessHelper != null) {
-                mStatsBarGraphAccessHelper.invalidateVirtualView(barIndex);
+            if (mStatsBarGraphAccessibilityHelper != null) {
+                mStatsBarGraphAccessibilityHelper.invalidateVirtualView(barIndex);
             }
         }
     }
@@ -240,7 +240,9 @@ class StatsBarGraph extends GraphView {
                 canvas.drawRect(left, 10f, right, bottom, paint);
             }
 
-            mVirtualBars.add(new BarChartRect(left, 10f, right, bottom));
+            if(mVirtualBars.size() < values.length){
+                mVirtualBars.add(new BarChartRect(left, 10f, right, bottom));
+            }
 
             if ((top - bottom) == 1) {
                 // draw a placeholder
@@ -317,7 +319,7 @@ class StatsBarGraph extends GraphView {
     }
 
 
-     public void setAccessibleHorizontalLabels(String[] virtualLabels) {
+    public void setAccessibleHorizontalLabels(String[] virtualLabels) {
         mAccessibleVirtualLabels = virtualLabels;
     }
 
@@ -377,9 +379,9 @@ class StatsBarGraph extends GraphView {
         void onBarTapped(int tappedBar);
     }
 
-    private class StatsBarGraphAccessHelper extends ExploreByTouchHelper {
+    private class StatsBarGraphAccessibilityHelper extends ExploreByTouchHelper {
 
-        StatsBarGraphAccessHelper(View parentView) {
+        StatsBarGraphAccessibilityHelper(View parentView) {
             super(parentView);
         }
 
@@ -393,9 +395,9 @@ class StatsBarGraph extends GraphView {
         }
 
         @Override protected void getVisibleVirtualViews(List<Integer> virtualViewIds) {
-            final int count = mVirtualBars.size();
-            for (int index = 0; index < count; index++) {
-                virtualViewIds.add(index);
+                final int count = mVirtualBars.size();
+                for (int index = 0; index < count; index++) {
+                    virtualViewIds.add(index);
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsClicksFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsClicksFragment.java
@@ -165,6 +165,13 @@ public class StatsClicksFragment extends StatsAbstractListFragment {
             holder.totalsTextView.setText(FormatUtils.formatDecimal(
                     children.getTotals()
             ));
+            holder.totalsTextView.setContentDescription(
+                    org.wordpress.android.util.StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_clicks_zero_desc,
+                            R.string.stats_clicks_one_desc,
+                            R.string.stats_clicks_many_desc,
+                            children.getTotals()));
 
             // no icon
             holder.networkImageView.setVisibility(View.GONE);
@@ -228,6 +235,13 @@ public class StatsClicksFragment extends StatsAbstractListFragment {
 
             // totals
             holder.totalsTextView.setText(FormatUtils.formatDecimal(total));
+            holder.totalsTextView.setContentDescription(
+                    org.wordpress.android.util.StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_clicks_zero_desc,
+                            R.string.stats_clicks_one_desc,
+                            R.string.stats_clicks_many_desc,
+                            total));
 
             // Site icon
             holder.networkImageView.setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
@@ -18,6 +18,7 @@ import org.wordpress.android.ui.stats.models.StatsPostModel;
 import org.wordpress.android.ui.stats.service.StatsService;
 import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.GravatarUtils;
+import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.util.ArrayList;
@@ -218,6 +219,13 @@ public class StatsCommentsFragment extends StatsAbstractListFragment {
 
             // totals
             holder.totalsTextView.setText(FormatUtils.formatDecimal(currentRowData.getViews()));
+            holder.totalsTextView.setContentDescription(
+                    StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_comments_zero_desc,
+                            R.string.stats_comments_one_desc,
+                            R.string.stats_comments_many_desc,
+                            currentRowData.getViews()));
 
             // avatar
             holder.networkImageView.setImageUrl(GravatarUtils.fixGravatarUrl(currentRowData.getAvatar(), mResourceVars.headerAvatarSizePx), WPNetworkImageView.ImageType.AVATAR);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConstants.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsConstants.java
@@ -7,6 +7,7 @@ public class StatsConstants {
     public static final String STATS_OUTPUT_DATE_MONTH_SHORT_DAY_SHORT_FORMAT = "MMM d";
     public static final String STATS_OUTPUT_DATE_MONTH_LONG_DAY_SHORT_FORMAT = "MMMM d";
     public static final String STATS_OUTPUT_DATE_MONTH_LONG_DAY_LONG_FORMAT = "MMMM dd";
+    public static final String STATS_OUTPUT_DATE_MONTH_SHORT_FORMAT = "MMM";
     public static final String STATS_OUTPUT_DATE_MONTH_LONG_FORMAT = "MMMM";
     public static final String STATS_OUTPUT_DATE_YEAR_FORMAT = "yyyy";
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsFollowersFragment.java
@@ -374,6 +374,10 @@ public class StatsFollowersFragment extends StatsAbstractListFragment {
                             currentRowData.getDateSubscribed()
                     )
             );
+            holder.totalsTextView.setContentDescription(
+                    holder.totalsTextView.getContext().getString(
+                            R.string.stats_follower_since_desc,
+                            holder.totalsTextView.getText()));
 
             // Avatar
             holder.networkImageView.setImageUrl(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsGeoviewsFragment.java
@@ -24,6 +24,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.GravatarUtils;
+import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.util.List;
@@ -265,6 +266,13 @@ public class StatsGeoviewsFragment extends StatsAbstractListFragment {
             String entry = currentRowData.getCountryFullName();
             String imageUrl = currentRowData.getFlatFlagIconURL();
             holder.totalsTextView.setText(FormatUtils.formatDecimal(currentRowData.getViews()));
+            holder.totalsTextView.setContentDescription(
+                    StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_views_zero_desc,
+                            R.string.stats_views_one_desc,
+                            R.string.stats_views_many_desc,
+                            currentRowData.getViews()));
 
             holder.setEntryText(entry);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsPublicizeFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsPublicizeFragment.java
@@ -135,6 +135,13 @@ public class StatsPublicizeFragment extends StatsAbstractListFragment {
 
             // totals
             holder.totalsTextView.setText(FormatUtils.formatDecimal(currentRowData.getTotals()));
+            holder.totalsTextView.setContentDescription(
+                    org.wordpress.android.util.StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_followers_zero_desc,
+                            R.string.stats_followers_one_desc,
+                            R.string.stats_followers_many_desc,
+                            currentRowData.getTotals()));
 
             // image
             holder.networkImageView.setImageUrl(

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsReferrersFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsReferrersFragment.java
@@ -16,6 +16,7 @@ import org.wordpress.android.ui.stats.models.SingleItemModel;
 import org.wordpress.android.ui.stats.service.StatsService;
 import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.GravatarUtils;
+import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.widgets.WPNetworkImageView;
 
 import java.util.ArrayList;
@@ -217,6 +218,13 @@ public class StatsReferrersFragment extends StatsAbstractListFragment {
 
             // totals
             holder.totalsTextView.setText(FormatUtils.formatDecimal(views));
+            holder.totalsTextView.setContentDescription(
+                    StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_views_zero_desc,
+                            R.string.stats_views_one_desc,
+                            R.string.stats_views_many_desc,
+                            views));
 
             // site icon
             holder.networkImageView.setVisibility(View.GONE);
@@ -287,6 +295,13 @@ public class StatsReferrersFragment extends StatsAbstractListFragment {
 
             // totals
             holder.totalsTextView.setText(FormatUtils.formatDecimal(total));
+            holder.totalsTextView.setContentDescription(
+                    org.wordpress.android.util.StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_views_zero_desc,
+                            R.string.stats_views_one_desc,
+                            R.string.stats_views_many_desc,
+                            total));
 
             // Site icon
             holder.networkImageView.setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSearchTermsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSearchTermsFragment.java
@@ -12,6 +12,7 @@ import org.wordpress.android.ui.stats.models.SearchTermModel;
 import org.wordpress.android.ui.stats.models.SearchTermsModel;
 import org.wordpress.android.ui.stats.service.StatsService;
 import org.wordpress.android.util.FormatUtils;
+import org.wordpress.android.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -196,6 +197,13 @@ public class StatsSearchTermsFragment extends StatsAbstractListFragment {
 
             // totals
             holder.totalsTextView.setText(FormatUtils.formatDecimal(currentRowData.getTotals()));
+            holder.totalsTextView.setContentDescription(
+                    StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_views_zero_desc,
+                            R.string.stats_views_one_desc,
+                            R.string.stats_views_many_desc,
+                            currentRowData.getTotals()));
 
             // image
             holder.networkImageView.setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -458,6 +458,7 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
                 DisplayUtils.dpToPx(this, StatsConstants.STATS_GRAPH_BAR_MAX_COLUMN_WIDTH_DP)
         );
         mGraphView.setHorizontalLabels(horLabels);
+        mGraphView.setAccessibleHorizontalLabels(horLabels);
         mGraphView.setGestureListener(this);
 
         // Reset the bar selected upon rotation of the device when the no. of bars can change with orientation.
@@ -497,7 +498,6 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
         RecentWeeksListAdapter recentWeeksListAdapter = new RecentWeeksListAdapter(this, recentWeeks, mRestResponseParsed.getHighestWeekAverage());
         StatsUIHelper.reloadGroupViews(this, recentWeeksListAdapter, mRecentWeeksIdToExpandedMap, mRecentWeeksList);
      }
-
 
     private void setMainViewsLabel(String dateFormatted, int totals) {
         mStatsViewsLabel.setText(getString(R.string.stats_views) + ": "
@@ -902,6 +902,7 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
                 StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_DAY_SHORT_FORMAT
         );
         setMainViewsLabel(currentItemStatsDate, dataToShowOnGraph[mSelectedBarGraphIndex].getViews());
+        mGraphContainer.announceForAccessibility(getString(R.string.stats_single_item_bad_desc, dataToShowOnGraph[mSelectedBarGraphIndex].getViews()));
     }
 
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -572,6 +572,8 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
                 holder.imgMore.setVisibility(View.GONE);
             }
 
+            holder.imgMore.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
+
             holder.networkImageView.setVisibility(View.GONE);
             return convertView;
         }
@@ -651,6 +653,8 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
             } else {
                 holder.imgMore.setVisibility(View.GONE);
             }
+
+            holder.imgMore.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
 
             // expand/collapse chevron
             holder.chevronImageView.setVisibility(numberOfChilds > 0 ? View.VISIBLE : View.GONE);
@@ -734,6 +738,8 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
             } else {
                 holder.imgMore.setVisibility(View.GONE);
             }
+
+            holder.imgMore.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
 
             holder.networkImageView.setVisibility(View.GONE);
             return convertView;

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -38,6 +38,7 @@ import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DisplayUtils;
 import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.NetworkUtils;
+import org.wordpress.android.util.StringUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
 import org.wordpress.android.util.widgets.CustomSwipeRefreshLayout;
@@ -562,6 +563,14 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
 
             // totals
             holder.totalsTextView.setText(FormatUtils.formatDecimal(currentDay.getCount()));
+            holder.totalsTextView.setContentDescription(
+                    StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_views_zero_desc,
+                            R.string.stats_views_one_desc,
+                            R.string.stats_views_many_desc,
+                            currentDay.getCount()));
+
 
             // show the trophy indicator if the value is the maximum reached
             if (currentDay.getCount() == maxReachedValue && maxReachedValue > 0) {
@@ -646,6 +655,13 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
 
             // totals
             holder.totalsTextView.setText(FormatUtils.formatDecimal(total));
+            holder.totalsTextView.setContentDescription(
+                    StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_views_zero_desc,
+                            R.string.stats_views_one_desc,
+                            R.string.stats_views_many_desc,
+                            total));
             if (shouldShowTheTrophyIcon) {
                 holder.imgMore.setVisibility(View.VISIBLE);
                 holder.imgMore.setImageDrawable(getResources().getDrawable(R.drawable.ic_trophy_alert_yellow_32dp));
@@ -729,6 +745,13 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
 
             // totals
             holder.totalsTextView.setText(FormatUtils.formatDecimal(currentMonth.getCount()));
+            holder.totalsTextView.setContentDescription(
+                    StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_views_zero_desc,
+                            R.string.stats_views_one_desc,
+                            R.string.stats_views_many_desc,
+                            currentMonth.getCount()));
 
             // show the trophy indicator if the value is the maximum reached
             if (currentMonth.getCount() == maxReachedValue && maxReachedValue > 0) {
@@ -810,6 +833,13 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
 
             // totals
             holder.totalsTextView.setText(FormatUtils.formatDecimal(total));
+            holder.totalsTextView.setContentDescription(
+                    StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_views_zero_desc,
+                            R.string.stats_views_one_desc,
+                            R.string.stats_views_many_desc,
+                            total));
 
             holder.networkImageView.setVisibility(View.GONE);
 
@@ -916,7 +946,12 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
                 StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_DAY_SHORT_FORMAT
         );
         setMainViewsLabel(currentItemStatsDate, dataToShowOnGraph[mSelectedBarGraphIndex].getViews());
-        mGraphContainer.announceForAccessibility(getString(R.string.stats_single_item_bad_desc, dataToShowOnGraph[mSelectedBarGraphIndex].getViews()));
+        mGraphContainer.announceForAccessibility(
+                StringUtils.getQuantityString(this,
+                        R.string.stats_views_zero_desc,
+                        R.string.stats_views_one_desc,
+                        R.string.stats_views_many_desc,
+                        dataToShowOnGraph[mSelectedBarGraphIndex].getViews()));
     }
 
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -32,6 +32,7 @@ import org.wordpress.android.networking.RestClientUtils;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.stats.models.PostViewsModel;
 import org.wordpress.android.ui.stats.models.VisitModel;
+import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.DisplayUtils;
@@ -546,14 +547,17 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
 
             holder.setEntryText(StatsUtils.parseDate(currentDay.getDay(), StatsConstants.STATS_INPUT_DATE_FORMAT, "EEE, MMM dd"));
 
-            // Intercept clicks at row level and eat the event. We don't want to show the ripple here.
-            holder.rowContent.setOnClickListener(
-                    new View.OnClickListener() {
-                        @Override
-                        public void onClick(View view) {
-
-                        }
-                    });
+            if(AccessibilityUtils.isAccessibilityEnabled(holder.rowContent.getContext())){
+                holder.rowContent.setClickable(false);
+            }else{
+                // Intercept clicks at row level and eat the event. We don't want to show the ripple here.
+                holder.rowContent.setOnClickListener(
+                        new View.OnClickListener() {
+                            @Override
+                            public void onClick(View view) {
+                            }
+                        });
+            }
             holder.rowContent.setBackgroundColor(Color.TRANSPARENT);
 
             // totals
@@ -705,14 +709,18 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
 
             holder.setEntryText(StatsUtils.parseDate(currentMonth.getMonth(), "MM", StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_FORMAT));
 
-            // Intercept clicks at row level and eat the event. We don't want to show the ripple here.
-            holder.rowContent.setOnClickListener(
-                    new View.OnClickListener() {
-                        @Override
-                        public void onClick(View view) {
+            if(AccessibilityUtils.isAccessibilityEnabled(holder.rowContent.getContext())){
+                holder.rowContent.setClickable(false);
+            }else{
+                // Intercept clicks at row level and eat the event. We don't want to show the ripple here.
+                holder.rowContent.setOnClickListener(
+                        new View.OnClickListener() {
+                            @Override
+                            public void onClick(View view) {
+                            }
+                        });
+            }
 
-                        }
-                    });
             holder.rowContent.setBackgroundColor(Color.TRANSPARENT);
 
             // totals

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsTagsAndCategoriesFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsTagsAndCategoriesFragment.java
@@ -247,6 +247,13 @@ public class StatsTagsAndCategoriesFragment extends StatsAbstractListFragment {
 
             // totals
             holder.totalsTextView.setText(FormatUtils.formatDecimal(total));
+            holder.totalsTextView.setContentDescription(
+                    org.wordpress.android.util.StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_views_zero_desc,
+                            R.string.stats_views_one_desc,
+                            R.string.stats_views_many_desc,
+                            total));
 
             // expand/collapse chevron
             holder.chevronImageView.setVisibility(children > 0 ? View.VISIBLE : View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVideoplaysFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVideoplaysFragment.java
@@ -12,6 +12,7 @@ import org.wordpress.android.ui.stats.models.SingleItemModel;
 import org.wordpress.android.ui.stats.models.VideoPlaysModel;
 import org.wordpress.android.ui.stats.service.StatsService;
 import org.wordpress.android.util.FormatUtils;
+import org.wordpress.android.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -128,6 +129,13 @@ public class StatsVideoplaysFragment extends StatsAbstractListFragment {
 
             // totals
             holder.totalsTextView.setText(FormatUtils.formatDecimal(currentRowData.getTotals()));
+            holder.totalsTextView.setContentDescription(
+                    StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_plays_zero_desc,
+                            R.string.stats_plays_one_desc,
+                            R.string.stats_plays_many_desc,
+                            currentRowData.getTotals()));
 
             // no icon
             holder.networkImageView.setVisibility(View.GONE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
@@ -485,6 +485,8 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         mGraphView.setHorizontalLabels(horLabels);
         mGraphView.setAccessibleHorizontalLabels(makeAccessibleHorizontalLabels(horLabels));
         mGraphView.setGestureListener(this);
+        mGraphView.setImportantForAccessibility(atLeastOneResultIsAvailable
+                ? View.IMPORTANT_FOR_ACCESSIBILITY_YES : View.IMPORTANT_FOR_ACCESSIBILITY_NO);
 
         // If zero results in the current section disable clicks on the graph and show the dialog.
         mNoActivtyThisPeriodContainer.setVisibility(atLeastOneResultIsAvailable ? View.GONE : View.VISIBLE);

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
@@ -216,7 +216,8 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
 
         public void setChecked(boolean checked) {
             if (checked){
-                tab.announceForAccessibility("Showing " + labelItem.getLabel());
+                tab.announceForAccessibility(
+                        tab.getContext().getString(R.string.stats_tab_tap_content_description, labelItem.getLabel()));
             }
             this.isChecked = checked;
         }
@@ -643,23 +644,19 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
                     c.setTime(parsedDate);
                     // first day of this week
                     c.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
-                    String startDateLabel = StatsUtils.msToString(c.getTimeInMillis(),
-                            StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_DAY_LONG_FORMAT);
+                    String startDateLabel = StatsUtils.msToString(c.getTimeInMillis(), StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_DAY_LONG_FORMAT);
                     // last day of this week
                     c.add(Calendar.DAY_OF_WEEK, +6);
-                    String endDateLabel = StatsUtils.msToString(c.getTimeInMillis(),
-                            StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_DAY_LONG_FORMAT);
+                    String endDateLabel = StatsUtils.msToString(c.getTimeInMillis(), StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_DAY_LONG_FORMAT);
                     return String.format(prefix, startDateLabel + " - " + endDateLabel);
                 } catch (ParseException e) {
                     AppLog.e(AppLog.T.UTILS, e);
                     return "";
                 }
             case MONTH:
-                return String.format(prefix, StatsUtils.parseDate(date, StatsConstants.STATS_INPUT_DATE_FORMAT,
-                        StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_FORMAT));
+                return String.format(prefix, StatsUtils.parseDate(date, StatsConstants.STATS_INPUT_DATE_FORMAT, StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_FORMAT));
             case YEAR:
-                return String.format(prefix, StatsUtils.parseDate(date, StatsConstants.STATS_INPUT_DATE_FORMAT,
-                        StatsConstants.STATS_OUTPUT_DATE_YEAR_FORMAT));
+                return String.format(prefix, StatsUtils.parseDate(date, StatsConstants.STATS_INPUT_DATE_FORMAT, StatsConstants.STATS_OUTPUT_DATE_YEAR_FORMAT));
         }
         return "";
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
@@ -6,6 +6,7 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.view.ViewCompat;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -129,7 +130,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         // Fix an issue on devices with 4.1 or lower, where the Checkbox already uses padding by default internally and overriding it with paddingLeft
         // causes the issue report here https://github.com/wordpress-mobile/WordPress-Android/pull/2377#issuecomment-77067993
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            ViewCompat.setPaddingRelative(mVisitorsCheckbox,getResources().getDimensionPixelSize(R.dimen.margin_medium), 0, 0, 0);
+            ViewCompat.setPaddingRelative(mVisitorsCheckbox, getResources().getDimensionPixelSize(R.dimen.margin_medium), 0, 0, 0);
         }
 
         // Make sure we've all the info to build the tab correctly. This is ALWAYS true
@@ -246,14 +247,14 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
                 }
             }
 
-            if (checkedId == -1)
+            if (checkedId == -1) {
                 return;
+            }
 
             mSelectedOverviewItemIndex = checkedId;
             if (mOverviewItemChangeListener != null) {
                 mOverviewItemChangeListener.onOverviewItemChanged(
-                        overviewItems[mSelectedOverviewItemIndex]
-                );
+                        overviewItems[mSelectedOverviewItemIndex]);
             }
             updateUI();
         }
@@ -274,6 +275,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
     protected boolean hasDataAvailable() {
         return mVisitsData != null;
     }
+
     @Override
     protected void saveStatsData(Bundle outState) {
         if (hasDataAvailable()) {
@@ -284,6 +286,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         outState.putInt(ARG_SELECTED_OVERVIEW_ITEM, mSelectedOverviewItemIndex);
         outState.putBoolean(ARG_CHECKBOX_SELECTED, mVisitorsCheckbox.isChecked());
     }
+
     @Override
     protected void restoreStatsData(Bundle savedInstanceState) {
         if (savedInstanceState != null) {
@@ -320,7 +323,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         int currentPointIndex = numPoints - 1;
         VisitModel[] visitModelsToShow = new VisitModel[numPoints];
 
-        for (int i = visitModels.size() -1; i >= 0 && currentPointIndex >= 0; i--) {
+        for (int i = visitModels.size() - 1; i >= 0 && currentPointIndex >= 0; i--) {
             VisitModel currentVisitModel = visitModels.get(i);
             visitModelsToShow[currentPointIndex] = currentVisitModel;
             currentPointIndex--;
@@ -356,7 +359,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         // Update the Legend and enable/disable the visitors checkboxes
         mLegendContainer.setVisibility(View.VISIBLE);
         mLegendLabel.setText(StringUtils.capitalize(selectedStatsType.getLabel().toLowerCase()));
-        switch(selectedStatsType) {
+        switch (selectedStatsType) {
             case VIEWS:
                 mVisitorsCheckboxContainer.setVisibility(View.VISIBLE);
                 mVisitorsCheckbox.setEnabled(true);
@@ -391,7 +394,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         // Fill series variables with data
         for (int i = 0; i < dataToShowOnGraph.length; i++) {
             int currentItemValue = 0;
-            switch(selectedStatsType) {
+            switch (selectedStatsType) {
                 case VIEWS:
                     currentItemValue = dataToShowOnGraph[i].getViews();
                     break;
@@ -464,7 +467,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         // Setup the Y-axis on Visitors and Views Tabs.
         // Views and Visitors tabs have the exact same Y-axis as shifting from one Y-axis to another defeats
         // the purpose of making these bars visually easily to compare.
-        switch(selectedStatsType) {
+        switch (selectedStatsType) {
             case VISITORS:
                 double maxYValue = getMaxYValueForVisitorsAndView(dataToShowOnGraph);
                 mGraphView.setManualYAxisBounds(maxYValue, 0d);
@@ -478,9 +481,9 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         mGraphView.getGraphViewStyle().setNumHorizontalLabels(dataToShowOnGraph.length);
         // Set the maximum size a column can get on the screen in PX
         mGraphView.getGraphViewStyle().setMaxColumnWidth(
-                DisplayUtils.dpToPx(getActivity(), StatsConstants.STATS_GRAPH_BAR_MAX_COLUMN_WIDTH_DP)
-        );
+                DisplayUtils.dpToPx(getActivity(), StatsConstants.STATS_GRAPH_BAR_MAX_COLUMN_WIDTH_DP));
         mGraphView.setHorizontalLabels(horLabels);
+        mGraphView.setAccessibleHorizontalLabels(makeAccessibleHorizontalLabels(horLabels));
         mGraphView.setGestureListener(this);
 
         // If zero results in the current section disable clicks on the graph and show the dialog.
@@ -517,7 +520,23 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         mGraphView.highlightBar(barSelectedOnGraph);
     }
 
-    private int getDefaultBarIndex(final VisitModel[] dataToShowOnGraph){
+    private String[] makeAccessibleHorizontalLabels(String[] horizontalLabels) {
+        String[] accessibleLabels = new String[horizontalLabels.length];
+
+        for (int i = 0; i < horizontalLabels.length; i++) {
+            if (getTimeframe() == StatsTimeframe.MONTH) {
+                accessibleLabels[i] = StatsUtils.parseDate(horizontalLabels[i], "MMM", "MMMM");
+            } else if (getTimeframe() == StatsTimeframe.WEEK) {
+                accessibleLabels[i] = getString(R.string.stats_bar_week_desc, horizontalLabels[i]);
+            } else {
+                accessibleLabels[i] = horizontalLabels[i];
+            }
+        }
+
+        return accessibleLabels;
+    }
+
+    private int getDefaultBarIndex(final VisitModel[] dataToShowOnGraph) {
         return RtlUtils.isRtl(getActivity()) && dataToShowOnGraph.length > 0 ? 0 : dataToShowOnGraph.length - 1;
     }
 
@@ -559,10 +578,10 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         // This check should never be true, since we put a check on the index in the calling function updateUI()
         if (dataToShowOnGraph.length <= itemPosition || itemPosition == -1) {
             // Make sure we're not highlighting
-            itemPosition = dataToShowOnGraph.length -1;
+            itemPosition = dataToShowOnGraph.length - 1;
         }
 
-        String date =  mStatsDate[itemPosition];
+        String date = mStatsDate[itemPosition];
         if (date == null) {
             AppLog.w(AppLog.T.STATS, "Cannot update the area below the graph if a null date is passed!!");
             return;
@@ -571,10 +590,10 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         mDateTextView.setText(getDateForDisplayInLabels(date, getTimeframe()));
 
         VisitModel modelTapped = dataToShowOnGraph[itemPosition];
-        for (int i=0 ; i < mModuleButtonsContainer.getChildCount(); i++) {
+        for (int i = 0; i < mModuleButtonsContainer.getChildCount(); i++) {
             View o = mModuleButtonsContainer.getChildAt(i);
-            if (o instanceof LinearLayout && o.getTag() instanceof  TabViewHolder) {
-                TabViewHolder tabViewHolder = (TabViewHolder)o.getTag();
+            if (o instanceof LinearLayout && o.getTag() instanceof TabViewHolder) {
+                TabViewHolder tabViewHolder = (TabViewHolder) o.getTag();
                 int currentValue = 0;
                 switch (tabViewHolder.labelItem) {
                     case VIEWS:
@@ -618,20 +637,24 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
                     c.setFirstDayOfWeek(Calendar.MONDAY);
                     c.setTime(parsedDate);
                     // first day of this week
-                    c.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY );
-                    String startDateLabel = StatsUtils.msToString(c.getTimeInMillis(), StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_DAY_LONG_FORMAT);
+                    c.set(Calendar.DAY_OF_WEEK, Calendar.MONDAY);
+                    String startDateLabel = StatsUtils.msToString(c.getTimeInMillis(),
+                            StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_DAY_LONG_FORMAT);
                     // last day of this week
-                    c.add(Calendar.DAY_OF_WEEK, + 6);
-                    String endDateLabel = StatsUtils.msToString(c.getTimeInMillis(), StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_DAY_LONG_FORMAT);
+                    c.add(Calendar.DAY_OF_WEEK, +6);
+                    String endDateLabel = StatsUtils.msToString(c.getTimeInMillis(),
+                            StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_DAY_LONG_FORMAT);
                     return String.format(prefix, startDateLabel + " - " + endDateLabel);
                 } catch (ParseException e) {
                     AppLog.e(AppLog.T.UTILS, e);
                     return "";
                 }
             case MONTH:
-                return String.format(prefix, StatsUtils.parseDate(date, StatsConstants.STATS_INPUT_DATE_FORMAT, StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_FORMAT));
+                return String.format(prefix, StatsUtils.parseDate(date, StatsConstants.STATS_INPUT_DATE_FORMAT,
+                        StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_FORMAT));
             case YEAR:
-                return String.format(prefix, StatsUtils.parseDate(date, StatsConstants.STATS_INPUT_DATE_FORMAT, StatsConstants.STATS_OUTPUT_DATE_YEAR_FORMAT));
+                return String.format(prefix, StatsUtils.parseDate(date, StatsConstants.STATS_INPUT_DATE_FORMAT,
+                        StatsConstants.STATS_OUTPUT_DATE_YEAR_FORMAT));
         }
         return "";
     }
@@ -646,7 +669,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
                         dateToFormat,
                         StatsConstants.STATS_INPUT_DATE_FORMAT,
                         StatsConstants.STATS_OUTPUT_DATE_MONTH_SHORT_DAY_SHORT_FORMAT
-                );
+                                           );
             case WEEK:
                 // first four digits are the year
                 // followed by Wxx where xx is the month
@@ -690,12 +713,12 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         }
         mDateTextView.setText("");
 
-        for (int i=0 ; i < mModuleButtonsContainer.getChildCount(); i++) {
+        for (int i = 0; i < mModuleButtonsContainer.getChildCount(); i++) {
             View o = mModuleButtonsContainer.getChildAt(i);
             if (o instanceof CheckedTextView) {
-                CheckedTextView currentBtm = (CheckedTextView)o;
-                OverviewLabel overviewItem = (OverviewLabel)currentBtm.getTag();
-                String labelPrefix = overviewItem.getLabel() + "\n 0" ;
+                CheckedTextView currentBtm = (CheckedTextView) o;
+                OverviewLabel overviewItem = (OverviewLabel) currentBtm.getTag();
+                String labelPrefix = overviewItem.getLabel() + "\n 0";
                 currentBtm.setText(labelPrefix);
             }
         }
@@ -754,7 +777,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         }
 
         // Update Stats here
-        String date =  mStatsDate[tappedBar];
+        String date = mStatsDate[tappedBar];
         if (date == null) {
             AppLog.w(AppLog.T.STATS, "A bar was tapped but a null date is received!!");
             return;
@@ -816,12 +839,19 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         }
 
         // Update the data below the graph
-        if (mListener!= null) {
+        if (mListener != null) {
             // Should never be null
             SiteModel site = mSiteStore.getSiteByLocalId(getLocalTableBlogID());
             if (site != null && SiteUtils.isAccessedViaWPComRest(site)) {
                 mListener.onDateChanged(site.getSiteId(), getTimeframe(), calculatedDate);
             }
+        }
+
+        String selectedDate = mStatsDate[tappedBar];
+
+        if (!TextUtils.isEmpty(selectedDate)) {
+            mGraphView.announceForAccessibility(getString(R.string.stats_bar_desc,
+                    getDateForDisplayInLabels(selectedDate, getTimeframe())));
         }
 
         AnalyticsUtils.trackWithSiteDetails(AnalyticsTracker.Stat.STATS_TAPPED_BAR_CHART,
@@ -832,8 +862,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         VIEWS(R.string.stats_views),
         VISITORS(R.string.stats_visitors),
         LIKES(R.string.stats_likes),
-        COMMENTS(R.string.stats_comments),
-        ;
+        COMMENTS(R.string.stats_comments);
 
         private final int mLabelResId;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
@@ -531,7 +531,10 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
 
         for (int i = 0; i < horizontalLabels.length; i++) {
             if (getTimeframe() == StatsTimeframe.MONTH) {
-                accessibleLabels[i] = StatsUtils.parseDate(horizontalLabels[i], "MMM", "MMMM");
+                accessibleLabels[i] = StatsUtils.parseDate(
+                        horizontalLabels[i],
+                        StatsConstants.STATS_OUTPUT_DATE_MONTH_SHORT_FORMAT,
+                        StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_FORMAT);
             } else if (getTimeframe() == StatsTimeframe.WEEK) {
                 accessibleLabels[i] = getString(R.string.stats_bar_week_desc, StatsUtils.parseDate(
                         horizontalLabels[i],
@@ -682,7 +685,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
                 // ex: 2013W07W22 = July 22, 2013
                 return StatsUtils.parseDate(dateToFormat, "yyyy'W'MM'W'dd", StatsConstants.STATS_OUTPUT_DATE_MONTH_SHORT_DAY_SHORT_FORMAT);
             case MONTH:
-                return StatsUtils.parseDate(dateToFormat, "yyyy-MM", "MMM");
+                return StatsUtils.parseDate(dateToFormat, "yyyy-MM", StatsConstants.STATS_OUTPUT_DATE_MONTH_SHORT_FORMAT);
             case YEAR:
                 return StatsUtils.parseDate(dateToFormat, StatsConstants.STATS_INPUT_DATE_FORMAT, StatsConstants.STATS_OUTPUT_DATE_YEAR_FORMAT);
             default:

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
@@ -215,6 +215,9 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         }
 
         public void setChecked(boolean checked) {
+            if (checked){
+                tab.announceForAccessibility("Showing " + labelItem.getLabel());
+            }
             this.isChecked = checked;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
@@ -533,7 +533,10 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
             if (getTimeframe() == StatsTimeframe.MONTH) {
                 accessibleLabels[i] = StatsUtils.parseDate(horizontalLabels[i], "MMM", "MMMM");
             } else if (getTimeframe() == StatsTimeframe.WEEK) {
-                accessibleLabels[i] = getString(R.string.stats_bar_week_desc, horizontalLabels[i]);
+                accessibleLabels[i] = getString(R.string.stats_bar_week_desc, StatsUtils.parseDate(
+                        horizontalLabels[i],
+                        StatsConstants.STATS_OUTPUT_DATE_MONTH_SHORT_DAY_SHORT_FORMAT,
+                        StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_DAY_SHORT_FORMAT));
             } else {
                 accessibleLabels[i] = horizontalLabels[i];
             }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/adapters/PostsAndPagesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/adapters/PostsAndPagesAdapter.java
@@ -11,6 +11,7 @@ import org.wordpress.android.R;
 import org.wordpress.android.ui.stats.StatsViewHolder;
 import org.wordpress.android.ui.stats.models.StatsPostModel;
 import org.wordpress.android.util.FormatUtils;
+import org.wordpress.android.util.StringUtils;
 
 import java.util.List;
 
@@ -47,6 +48,13 @@ public class PostsAndPagesAdapter extends ArrayAdapter<StatsPostModel> {
 
         // totals
         holder.totalsTextView.setText(FormatUtils.formatDecimal(currentRowData.getTotals()));
+        holder.totalsTextView.setContentDescription(
+                StringUtils.getQuantityString(
+                        holder.totalsTextView.getContext(),
+                        R.string.stats_comments_zero_desc,
+                        R.string.stats_comments_one_desc,
+                        R.string.stats_comments_many_desc,
+                        currentRowData.getTotals()));
 
         // no icon
         holder.networkImageView.setVisibility(View.GONE);

--- a/WordPress/src/main/res/layout-sw720dp/stats_insights_all_time_item.xml
+++ b/WordPress/src/main/res/layout-sw720dp/stats_insights_all_time_item.xml
@@ -10,6 +10,7 @@
 
     <!-- Posts item -->
     <LinearLayout
+        android:focusable="true"
         android:orientation="vertical"
         android:layout_width="0dp"
         android:layout_weight="1"
@@ -57,6 +58,7 @@
 
     <!-- Views Item -->
     <LinearLayout
+        android:focusable="true"
         android:orientation="vertical"
         android:layout_width="0dp"
         android:layout_weight="1"
@@ -103,6 +105,7 @@
 
     <!-- Visitors Item -->
     <LinearLayout
+        android:focusable="true"
         android:orientation="vertical"
         android:layout_width="0dp"
         android:layout_weight="1"
@@ -149,6 +152,7 @@
 
     <!-- Best Ever Item -->
     <LinearLayout
+        android:focusable="true"
         android:orientation="vertical"
         android:layout_width="0dp"
         android:layout_weight="1"

--- a/WordPress/src/main/res/layout/stats_activity_single_post_details.xml
+++ b/WordPress/src/main/res/layout/stats_activity_single_post_details.xml
@@ -54,7 +54,6 @@
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
                     android:minHeight="@dimen/stats_barchart_height"
-                    android:importantForAccessibility="noHideDescendants"
                     android:orientation="vertical" />
 
                 <RelativeLayout

--- a/WordPress/src/main/res/layout/stats_insights_all_time_item.xml
+++ b/WordPress/src/main/res/layout/stats_insights_all_time_item.xml
@@ -16,6 +16,7 @@
 
         <!-- Posts item -->
         <LinearLayout
+            android:focusable="true"
             android:orientation="vertical"
             android:layout_width="0dp"
             android:layout_weight="1"
@@ -63,6 +64,7 @@
 
         <!-- Views Item -->
         <LinearLayout
+            android:focusable="true"
             android:orientation="vertical"
             android:layout_width="0dp"
             android:layout_weight="1"
@@ -116,6 +118,7 @@
 
         <!-- Visitors Item -->
         <LinearLayout
+            android:focusable="true"
             android:orientation="vertical"
             android:layout_width="0dp"
             android:layout_weight="1"
@@ -162,6 +165,7 @@
 
         <!-- Best Ever Item -->
         <LinearLayout
+            android:focusable="true"
             android:orientation="vertical"
             android:layout_width="0dp"
             android:layout_weight="1"

--- a/WordPress/src/main/res/layout/stats_insights_most_popular_item.xml
+++ b/WordPress/src/main/res/layout/stats_insights_most_popular_item.xml
@@ -1,99 +1,96 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:orientation="vertical">
 
-    <include layout="@layout/stats_insights_header_line" />
+    <include layout="@layout/stats_insights_header_line"/>
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:baselineAligned="false"
-        android:padding="@dimen/margin_extra_large"
         android:gravity="center_vertical|center_horizontal"
-        android:orientation="vertical">
+        android:orientation="horizontal"
+        android:padding="@dimen/margin_extra_large">
 
         <LinearLayout
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:paddingBottom="@dimen/margin_medium"
-            android:gravity="center_vertical|center_horizontal" >
+            android:layout_weight="1"
+            android:focusable="true"
+            android:orientation="vertical">
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
                 style="@style/StatsInsightsLabel"
-                android:gravity="center_vertical|center_horizontal"
-                android:layout_width="0dp"
-                android:layout_weight="1"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:gravity="center_vertical|center_horizontal"
+                android:paddingBottom="@dimen/margin_medium"
                 android:text="@string/stats_insights_most_popular_day"
-                android:textAllCaps="true" />
+                android:textAllCaps="true"/>
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
-                style="@style/StatsInsightsLabel"
-                android:gravity="center_vertical|center_horizontal"
-                android:layout_height="wrap_content"
-                android:layout_width="0dp"
-                android:layout_weight="1"
-                android:text="@string/stats_insights_most_popular_hour"
-                android:textAllCaps="true" />
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:gravity="center_vertical|center_horizontal">
-
-            <org.wordpress.android.util.widgets.AutoResizeTextView
-                android:gravity="center_vertical|center_horizontal"
-                android:layout_gravity="center_vertical|center_horizontal"
                 android:id="@+id/stats_most_popular_day"
                 style="@style/StatsInsightsValues"
-                android:layout_width="0dp"
-                android:layout_weight="1"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical|center_horizontal"
+                android:gravity="center_vertical|center_horizontal"
                 android:text="@string/stats_default_number_zero"
-                android:textColor="@color/grey_darken_30" />
+                android:textColor="@color/grey_darken_30"/>
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
-                android:gravity="center_vertical|center_horizontal"
-                android:layout_gravity="center_vertical|center_horizontal"
-                android:id="@+id/stats_most_popular_hour"
-                style="@style/StatsInsightsValues"
-                android:layout_width="0dp"
-                android:layout_weight="1"
+                android:id="@+id/stats_most_popular_day_percent"
+                style="@style/StatsInsightsLabel"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/stats_default_number_zero"
-                android:textColor="@color/grey_darken_30" />
+                android:gravity="center_vertical|center_horizontal"
+                android:paddingTop="@dimen/margin_medium"
+                android:text="@string/stats_insights_most_popular_percent_views"
+                android:textColor="@color/grey_darken_10"/>
+
         </LinearLayout>
 
+
         <LinearLayout
-            android:layout_width="match_parent"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:paddingTop="@dimen/margin_medium"
-            android:gravity="center_vertical|center_horizontal" >
+            android:layout_weight="1"
+            android:focusable="true"
+            android:orientation="vertical">
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
                 style="@style/StatsInsightsLabel"
-                android:id="@+id/stats_most_popular_day_percent"
-                android:gravity="center_vertical|center_horizontal"
-                android:layout_width="0dp"
-                android:layout_weight="1"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/stats_insights_most_popular_percent_views"
-                android:textColor="@color/grey_darken_10" />
+                android:gravity="center_vertical|center_horizontal"
+                android:paddingBottom="@dimen/margin_medium"
+                android:text="@string/stats_insights_most_popular_hour"
+                android:textAllCaps="true"/>
+
 
             <org.wordpress.android.util.widgets.AutoResizeTextView
-                style="@style/StatsInsightsLabel"
+                android:id="@+id/stats_most_popular_hour"
+                style="@style/StatsInsightsValues"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical|center_horizontal"
+                android:gravity="center_vertical|center_horizontal"
+                android:text="@string/stats_default_number_zero"
+                android:textColor="@color/grey_darken_30"/>
+
+            <org.wordpress.android.util.widgets.AutoResizeTextView
                 android:id="@+id/stats_most_popular_hour_percent"
-                android:gravity="center_vertical|center_horizontal"
+                style="@style/StatsInsightsLabel"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_width="0dp"
-                android:layout_weight="1"
+                android:gravity="center_vertical|center_horizontal"
+                android:paddingTop="@dimen/margin_medium"
                 android:text="@string/stats_insights_most_popular_percent_views"
-                android:textColor="@color/grey_darken_10" />
+                android:textColor="@color/grey_darken_10"/>
+
         </LinearLayout>
 
     </LinearLayout>

--- a/WordPress/src/main/res/layout/stats_visitors_and_views_fragment.xml
+++ b/WordPress/src/main/res/layout/stats_visitors_and_views_fragment.xml
@@ -59,6 +59,7 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content">
             <LinearLayout
+                android:focusable="false"
                 android:id="@+id/stats_bar_chart_fragment_container"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
@@ -67,7 +68,6 @@
                 android:paddingRight="@dimen/margin_extra_small"
                 android:paddingBottom="@dimen/margin_large"
                 android:minHeight="@dimen/stats_barchart_height"
-                android:importantForAccessibility="noHideDescendants"
                 android:orientation="vertical"
                 android:paddingEnd="@dimen/margin_extra_small"
                 android:paddingStart="@dimen/margin_medium"/>

--- a/WordPress/src/main/res/layout/stats_visitors_and_views_fragment.xml
+++ b/WordPress/src/main/res/layout/stats_visitors_and_views_fragment.xml
@@ -72,6 +72,8 @@
                 android:paddingEnd="@dimen/margin_extra_small"
                 android:paddingStart="@dimen/margin_medium"/>
             <LinearLayout
+                android:contentDescription="@string/stats_no_activity_this_period"
+                android:importantForAccessibility="yes"
                 android:id="@+id/stats_bar_chart_no_activity"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -104,14 +106,15 @@
 
         <!-- Bottom Legend -->
         <LinearLayout
+            android:contentDescription="@string/stats_legend"
             android:id="@+id/stats_legend_container"
             android:orientation="horizontal"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:gravity="center_vertical"
-            android:importantForAccessibility="noHideDescendants"
             android:layout_marginBottom="@dimen/margin_medium">
             <LinearLayout
+                android:focusable="false"
                 android:orientation="horizontal"
                 android:layout_width="0dp"
                 android:layout_weight="1"
@@ -136,6 +139,7 @@
                     android:textColor="@color/grey_darken_30"/>
             </LinearLayout>
             <LinearLayout
+                android:focusable="false"
                 android:id="@+id/stats_checkbox_visitors_container"
                 android:orientation="horizontal"
                 android:layout_width="0dp"
@@ -144,6 +148,7 @@
                 android:gravity="center"
                 android:visibility="gone">
                 <CheckBox
+                    android:focusable="false"
                     android:id="@+id/stats_checkbox_visitors"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2179,6 +2179,8 @@
     <string name="notification_settings_switch_desc">Notifications</string>
     <string name="navigate_up_desc">navigate up</string>
     <string name="stats_list_cell_chevron_collapse_desc">collapse</string>
+    <string name="stats_bar_desc">Showing %s</string>
+    <string name="stats_bar_week_desc">Week of %s</string>
     <string name="fab_add_tag_desc">create tag</string>
     <string name="fab_create_post_desc">create post</string>
     <string name="fab_create_desc">create</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2184,6 +2184,7 @@
     <string name="fab_add_tag_desc">create tag</string>
     <string name="fab_create_post_desc">create post</string>
     <string name="fab_create_desc">create</string>
+    <string name="stats_legend">stats graph legend</string>
 
     <!-- Site Creation -->
     <string name="site_creation_title">Create New Site</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2185,7 +2185,22 @@
     <string name="fab_create_post_desc">create post</string>
     <string name="fab_create_desc">create</string>
     <string name="stats_legend">stats graph legend</string>
-    <string name="stats_single_item_bad_desc">%d views</string>
+    <string name="stats_follower_since_desc">since %s ago</string>
+    <string name="stats_views_zero_desc">zero views</string>
+    <string name="stats_views_one_desc">%d view</string>
+    <string name="stats_views_many_desc">%d views</string>
+    <string name="stats_clicks_zero_desc">zero clicks</string>
+    <string name="stats_clicks_one_desc">%d click</string>
+    <string name="stats_clicks_many_desc">%d clicks</string>
+    <string name="stats_plays_zero_desc">zero plays</string>
+    <string name="stats_plays_one_desc">%d play</string>
+    <string name="stats_plays_many_desc">%d plays</string>
+    <string name="stats_comments_zero_desc">zero comments</string>
+    <string name="stats_comments_one_desc">%d comment</string>
+    <string name="stats_comments_many_desc">%d comments</string>
+    <string name="stats_followers_zero_desc">zero followers</string>
+    <string name="stats_followers_one_desc">%d followers</string>
+    <string name="stats_followers_many_desc">%d followers</string>
 
     <!-- Site Creation -->
     <string name="site_creation_title">Create New Site</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2185,6 +2185,7 @@
     <string name="fab_create_post_desc">create post</string>
     <string name="fab_create_desc">create</string>
     <string name="stats_legend">stats graph legend</string>
+    <string name="stats_single_item_bad_desc">%d views</string>
 
     <!-- Site Creation -->
     <string name="site_creation_title">Create New Site</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2188,19 +2188,19 @@
     <string name="stats_tab_tap_content_description">showing %s</string>
     <string name="stats_follower_since_desc">since %s ago</string>
     <string name="stats_views_zero_desc">zero views</string>
-    <string name="stats_views_one_desc">%d view</string>
+    <string name="stats_views_one_desc">one view</string>
     <string name="stats_views_many_desc">%d views</string>
     <string name="stats_clicks_zero_desc">zero clicks</string>
-    <string name="stats_clicks_one_desc">%d click</string>
+    <string name="stats_clicks_one_desc">one click</string>
     <string name="stats_clicks_many_desc">%d clicks</string>
     <string name="stats_plays_zero_desc">zero plays</string>
-    <string name="stats_plays_one_desc">%d play</string>
+    <string name="stats_plays_one_desc">one play</string>
     <string name="stats_plays_many_desc">%d plays</string>
     <string name="stats_comments_zero_desc">zero comments</string>
-    <string name="stats_comments_one_desc">%d comment</string>
+    <string name="stats_comments_one_desc">one comment</string>
     <string name="stats_comments_many_desc">%d comments</string>
     <string name="stats_followers_zero_desc">zero followers</string>
-    <string name="stats_followers_one_desc">%d followers</string>
+    <string name="stats_followers_one_desc">one follower</string>
     <string name="stats_followers_many_desc">%d followers</string>
 
     <!-- Site Creation -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2185,6 +2185,7 @@
     <string name="fab_create_post_desc">create post</string>
     <string name="fab_create_desc">create</string>
     <string name="stats_legend">stats graph legend</string>
+    <string name="stats_tab_tap_content_description">showing %s</string>
     <string name="stats_follower_since_desc">since %s ago</string>
     <string name="stats_views_zero_desc">zero views</string>
     <string name="stats_views_one_desc">%d view</string>


### PR DESCRIPTION
Fixes #7287 

Adds accessibility to Stats and Stats GraphView. Making custom views accessible with `ExploreByTouchHelper` was surprisingly straightforward, but discovering the helper was not so easy. Documentation on Accessibility is unsurprisingly lacking. I stumbled upon `ExploreByTouchHelper` totally by chance in some comment about Google I/O 2013...

Hope I haven't missed anything.

One this I wasn't able to do is prevent Stats graph container from getting Switch Access selection:
[![https://gyazo.com/dab99a3682a8a2d430270fa970c75882](https://i.gyazo.com/dab99a3682a8a2d430270fa970c75882.png)](https://gyazo.com/dab99a3682a8a2d430270fa970c75882)