### PR TITLE
Issue/7518 - Media Library Empty State Message Shows Incorrect Category

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -526,7 +526,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         List<MediaModel> mediaList = getFilteredMedia();
         mGridAdapter.setMediaList(mediaList);
 
-        if(isEmpty()){
+        if(isEmpty()) {
             updateEmptyView(EmptyViewMessageType.NO_CONTENT);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -526,7 +526,7 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         List<MediaModel> mediaList = getFilteredMedia();
         mGridAdapter.setMediaList(mediaList);
 
-        if(isEmpty()) {
+        if (isEmpty()) {
             updateEmptyView(EmptyViewMessageType.NO_CONTENT);
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/media/MediaGridFragment.java
@@ -525,6 +525,10 @@ public class MediaGridFragment extends Fragment implements MediaGridAdapterCallb
         mSearchTerm = searchTerm;
         List<MediaModel> mediaList = getFilteredMedia();
         mGridAdapter.setMediaList(mediaList);
+
+        if(isEmpty()){
+            updateEmptyView(EmptyViewMessageType.NO_CONTENT);
+        }
     }
 
     public void clearSelection() {


### PR DESCRIPTION
Fixes #7518 Media Library Empty State Message Shows Incorrect Category

To test:

1. Go to **Sites** tab.
2. Tap **Media** item from Publish section.
3. Select tab with no items (e.g. **Documents**).
4. Select tab with some items (i.e. **Images**).
5. Tap **Search** action.
6. Enter characters until empty state is shown.
6. Notice the empty state message shown on the media library screen shows the currently selected tab value (e.g. "You don't have any images)

cc @theck13 