### PR TITLE
Fixing accessibility issue in site creation flow

### DIFF
--- a/WordPress/src/main/res/layout/site_creation_category_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_category_screen.xml
@@ -6,53 +6,61 @@
     android:layout_height="match_parent">
 
     <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/margin_extra_large"
-        android:layout_width="match_parent"
-        android:orientation="vertical"
         android:clipChildren="false"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/margin_extra_large"
         android:paddingEnd="@dimen/margin_extra_large"
         android:paddingLeft="@dimen/margin_extra_large"
         android:paddingRight="@dimen/margin_extra_large"
         android:paddingStart="@dimen/margin_extra_large"
-        android:paddingTop="@dimen/margin_extra_large"
-        android:paddingBottom="@dimen/margin_extra_large" >
-
-        <TextView
-            android:id="@+id/label_title"
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent"
-            android:text="@string/site_creation_label_category_title"
-            style="@style/SiteCreation.Heading" />
-
-        <TextView
-            android:id="@+id/label"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_extra_large"
-            android:layout_width="match_parent"
-            android:text="@string/site_creation_label_category"
-            style="@style/LoginTheme.TextLabel" />
+        android:paddingTop="@dimen/margin_extra_large">
 
         <LinearLayout
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/margin_medium"
-            android:layout_marginBottom="@dimen/margin_medium"
             android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:focusable="true"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/label_title"
+                style="@style/SiteCreation.Heading"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/site_creation_label_category_title"/>
+
+            <TextView
+                android:id="@+id/label"
+                style="@style/LoginTheme.TextLabel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/margin_extra_large"
+                android:text="@string/site_creation_label_category"/>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_medium"
+            android:layout_marginTop="@dimen/margin_medium"
             android:clipChildren="false"
-            android:orientation="vertical" >
+            android:orientation="vertical">
 
             <android.support.v7.widget.CardView
                 android:id="@+id/site_creation_card_blog"
-                android:layout_gravity="center"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/card_elevation"
-                android:layout_marginStart="@dimen/card_elevation"
-                android:layout_marginRight="@dimen/card_elevation"
+                android:layout_gravity="center"
                 android:layout_marginEnd="@dimen/card_elevation"
-                android:foreground="?android:attr/selectableItemBackground"
+                android:layout_marginLeft="@dimen/card_elevation"
+                android:layout_marginRight="@dimen/card_elevation"
+                android:layout_marginStart="@dimen/card_elevation"
                 android:clickable="true"
                 android:focusable="true"
+                android:foreground="?android:attr/selectableItemBackground"
                 app:cardBackgroundColor="@color/white"
                 app:cardCornerRadius="@dimen/cardview_default_radius"
                 app:cardElevation="@dimen/card_elevation">
@@ -67,50 +75,50 @@
                         android:layout_width="@dimen/site_creation_category_illustration_sz"
                         android:layout_height="@dimen/site_creation_category_illustration_sz"
                         android:layout_centerVertical="true"
-                        android:scaleType="centerInside"
                         android:importantForAccessibility="no"
+                        android:scaleType="centerInside"
                         app:srcCompat="@drawable/img_site_creation_type_blog_80dp"/>
 
                     <RelativeLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_toRightOf="@id/image_blog"
-                        android:layout_toEndOf="@id/image_blog"
+                        android:layout_centerVertical="true"
                         android:layout_marginLeft="@dimen/margin_extra_large"
                         android:layout_marginStart="@dimen/margin_extra_large"
-                        android:layout_centerVertical="true">
+                        android:layout_toEndOf="@id/image_blog"
+                        android:layout_toRightOf="@id/image_blog">
 
                         <TextView
                             android:id="@+id/title_blog"
-                            android:layout_height="wrap_content"
+                            style="@style/SiteCreation.CardTitle"
                             android:layout_width="match_parent"
-                            android:text="@string/site_creation_title_blog"
-                            style="@style/SiteCreation.CardTitle" />
+                            android:layout_height="wrap_content"
+                            android:text="@string/site_creation_title_blog"/>
 
                         <TextView
-                            android:layout_height="wrap_content"
+                            style="@style/SiteCreation.Subhead"
                             android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
                             android:layout_below="@+id/title_blog"
                             android:layout_marginTop="@dimen/margin_small"
-                            android:text="@string/site_creation_subtitle_blog"
-                            style="@style/SiteCreation.Subhead" />
+                            android:text="@string/site_creation_subtitle_blog"/>
                     </RelativeLayout>
                 </RelativeLayout>
             </android.support.v7.widget.CardView>
 
             <android.support.v7.widget.CardView
                 android:id="@+id/site_creation_card_website"
-                android:layout_gravity="center"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_extra_large"
-                android:layout_marginLeft="@dimen/card_elevation"
-                android:layout_marginStart="@dimen/card_elevation"
-                android:layout_marginRight="@dimen/card_elevation"
+                android:layout_gravity="center"
                 android:layout_marginEnd="@dimen/card_elevation"
-                android:foreground="?android:attr/selectableItemBackground"
+                android:layout_marginLeft="@dimen/card_elevation"
+                android:layout_marginRight="@dimen/card_elevation"
+                android:layout_marginStart="@dimen/card_elevation"
+                android:layout_marginTop="@dimen/margin_extra_large"
                 android:clickable="true"
                 android:focusable="true"
+                android:foreground="?android:attr/selectableItemBackground"
                 app:cardBackgroundColor="@color/white"
                 app:cardCornerRadius="@dimen/cardview_default_radius"
                 app:cardElevation="@dimen/card_elevation">
@@ -125,50 +133,50 @@
                         android:layout_width="@dimen/site_creation_category_illustration_sz"
                         android:layout_height="@dimen/site_creation_category_illustration_sz"
                         android:layout_centerVertical="true"
-                        android:scaleType="centerInside"
                         android:importantForAccessibility="no"
+                        android:scaleType="centerInside"
                         app:srcCompat="@drawable/img_site_creation_type_website_80dp"/>
 
                     <RelativeLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_toRightOf="@id/image_website"
-                        android:layout_toEndOf="@id/image_website"
+                        android:layout_centerVertical="true"
                         android:layout_marginLeft="@dimen/margin_extra_large"
                         android:layout_marginStart="@dimen/margin_extra_large"
-                        android:layout_centerVertical="true">
+                        android:layout_toEndOf="@id/image_website"
+                        android:layout_toRightOf="@id/image_website">
 
                         <TextView
                             android:id="@+id/title_website"
-                            android:layout_height="wrap_content"
+                            style="@style/SiteCreation.CardTitle"
                             android:layout_width="match_parent"
-                            android:text="@string/site_creation_title_website"
-                            style="@style/SiteCreation.CardTitle" />
+                            android:layout_height="wrap_content"
+                            android:text="@string/site_creation_title_website"/>
 
                         <TextView
-                            android:layout_height="wrap_content"
+                            style="@style/SiteCreation.Subhead"
                             android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
                             android:layout_below="@+id/title_website"
                             android:layout_marginTop="@dimen/margin_small"
-                            android:text="@string/site_creation_subtitle_website"
-                            style="@style/SiteCreation.Subhead" />
+                            android:text="@string/site_creation_subtitle_website"/>
                     </RelativeLayout>
                 </RelativeLayout>
             </android.support.v7.widget.CardView>
 
             <android.support.v7.widget.CardView
                 android:id="@+id/site_creation_card_portfolio"
-                android:layout_gravity="center"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_extra_large"
-                android:layout_marginLeft="@dimen/card_elevation"
-                android:layout_marginStart="@dimen/card_elevation"
-                android:layout_marginRight="@dimen/card_elevation"
+                android:layout_gravity="center"
                 android:layout_marginEnd="@dimen/card_elevation"
-                android:foreground="?android:attr/selectableItemBackground"
+                android:layout_marginLeft="@dimen/card_elevation"
+                android:layout_marginRight="@dimen/card_elevation"
+                android:layout_marginStart="@dimen/card_elevation"
+                android:layout_marginTop="@dimen/margin_extra_large"
                 android:clickable="true"
                 android:focusable="true"
+                android:foreground="?android:attr/selectableItemBackground"
                 app:cardBackgroundColor="@color/white"
                 app:cardCornerRadius="@dimen/cardview_default_radius"
                 app:cardElevation="@dimen/card_elevation">
@@ -183,33 +191,33 @@
                         android:layout_width="@dimen/site_creation_category_illustration_sz"
                         android:layout_height="@dimen/site_creation_category_illustration_sz"
                         android:layout_centerVertical="true"
-                        android:scaleType="centerInside"
                         android:importantForAccessibility="no"
+                        android:scaleType="centerInside"
                         app:srcCompat="@drawable/img_site_creation_type_portfolio_80dp"/>
 
                     <RelativeLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_toRightOf="@id/image_portfolio"
-                        android:layout_toEndOf="@id/image_portfolio"
+                        android:layout_centerVertical="true"
                         android:layout_marginLeft="@dimen/margin_extra_large"
                         android:layout_marginStart="@dimen/margin_extra_large"
-                        android:layout_centerVertical="true">
+                        android:layout_toEndOf="@id/image_portfolio"
+                        android:layout_toRightOf="@id/image_portfolio">
 
                         <TextView
                             android:id="@+id/title_portfolio"
-                            android:layout_height="wrap_content"
+                            style="@style/SiteCreation.CardTitle"
                             android:layout_width="match_parent"
-                            android:text="@string/site_creation_title_portfolio"
-                            style="@style/SiteCreation.CardTitle" />
+                            android:layout_height="wrap_content"
+                            android:text="@string/site_creation_title_portfolio"/>
 
                         <TextView
-                            android:layout_height="wrap_content"
+                            style="@style/SiteCreation.Subhead"
                             android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
                             android:layout_below="@+id/title_portfolio"
                             android:layout_marginTop="@dimen/margin_small"
-                            android:text="@string/site_creation_subtitle_portfolio"
-                            style="@style/SiteCreation.Subhead" />
+                            android:text="@string/site_creation_subtitle_portfolio"/>
                     </RelativeLayout>
                 </RelativeLayout>
             </android.support.v7.widget.CardView>

--- a/WordPress/src/main/res/layout/site_creation_domain_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_domain_screen.xml
@@ -4,4 +4,5 @@
     android:id="@+id/recycler_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/white"/>
+    android:background="@color/white"
+    android:importantForAccessibility="no"/>

--- a/WordPress/src/main/res/layout/site_creation_site_details_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_site_details_screen.xml
@@ -7,40 +7,48 @@
     android:layout_height="match_parent">
 
     <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/margin_extra_large"
-        android:layout_width="match_parent"
-        android:orientation="vertical"
         android:clipChildren="false"
+        android:orientation="vertical"
+        android:paddingBottom="@dimen/margin_extra_large"
         android:paddingEnd="@dimen/margin_extra_large"
         android:paddingLeft="@dimen/margin_extra_large"
         android:paddingRight="@dimen/margin_extra_large"
         android:paddingStart="@dimen/margin_extra_large"
-        android:paddingTop="@dimen/margin_extra_large"
-        android:paddingBottom="@dimen/margin_extra_large" >
+        android:paddingTop="@dimen/margin_extra_large">
 
-        <TextView
-            android:id="@+id/label_title"
-            android:layout_height="wrap_content"
+        <LinearLayout
             android:layout_width="match_parent"
-            android:text="@string/site_creation_label_site_details_title"
-            style="@style/SiteCreation.Heading" />
+            android:layout_height="wrap_content"
+            android:focusable="true"
+            android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/label"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/margin_extra_large"
-            android:layout_width="match_parent"
-            android:text="@string/site_creation_label_site_details"
-            style="@style/LoginTheme.TextLabel" />
+            <TextView
+                android:id="@+id/label_title"
+                style="@style/SiteCreation.Heading"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/site_creation_label_site_details_title"/>
+
+            <TextView
+                android:id="@+id/label"
+                style="@style/LoginTheme.TextLabel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/margin_extra_large"
+                android:text="@string/site_creation_label_site_details"/>
+
+        </LinearLayout>
 
         <org.wordpress.android.login.widgets.WPLoginInputRow
             android:id="@+id/site_creation_site_title_row"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/site_creation_title_hint"
-            android:inputType="textNoSuggestions"
             android:imeOptions="actionNext"
+            android:inputType="textNoSuggestions"
             app:wpIconDrawable="@drawable/ic_globe_grey_24dp"/>
 
         <org.wordpress.android.login.widgets.WPLoginInputRow
@@ -53,11 +61,11 @@
             app:wpIconDrawable="@drawable/ic_aside_grey_24dp"/>
 
         <TextView
-            android:layout_height="wrap_content"
             android:layout_width="match_parent"
-            android:layout_marginTop="@dimen/margin_small"
-            android:layout_marginStart="@dimen/margin_tagline_left"
+            android:layout_height="wrap_content"
             android:layout_marginLeft="@dimen/margin_tagline_left"
+            android:layout_marginStart="@dimen/margin_tagline_left"
+            android:layout_marginTop="@dimen/margin_small"
             android:text="@string/site_creation_tagline_helper"/>
     </LinearLayout>
 </ScrollView>

--- a/WordPress/src/main/res/layout/site_creation_theme_header.xml
+++ b/WordPress/src/main/res/layout/site_creation_theme_header.xml
@@ -2,46 +2,55 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_height="wrap_content"
     android:layout_width="match_parent"
-    android:orientation="vertical"
-    android:clipChildren="false"
+    android:layout_height="wrap_content"
     android:animateLayoutChanges="true"
-    android:paddingTop="@dimen/margin_extra_large" >
+    android:clipChildren="false"
+    android:orientation="vertical"
+    android:paddingTop="@dimen/margin_extra_large">
 
-    <TextView
-        android:id="@+id/label_title"
-        android:layout_height="wrap_content"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:paddingEnd="@dimen/margin_extra_large"
-        android:paddingLeft="@dimen/margin_extra_large"
-        android:paddingRight="@dimen/margin_extra_large"
-        android:paddingStart="@dimen/margin_extra_large"
-        android:text="@string/site_creation_label_theme_selection_title"
-        style="@style/SiteCreation.Heading" />
+        android:layout_height="wrap_content"
+        android:focusable="true"
+        android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/label"
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
-        android:layout_marginBottom="@dimen/margin_extra_large"
-        android:paddingEnd="@dimen/margin_extra_large"
-        android:paddingLeft="@dimen/margin_extra_large"
-        android:paddingRight="@dimen/margin_extra_large"
-        android:paddingStart="@dimen/margin_extra_large"
-        android:text="@string/site_creation_label_theme_selection"
-        style="@style/LoginTheme.TextLabel" />
+        <TextView
+            android:id="@+id/label_title"
+            style="@style/SiteCreation.Heading"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingEnd="@dimen/margin_extra_large"
+            android:paddingLeft="@dimen/margin_extra_large"
+            android:paddingRight="@dimen/margin_extra_large"
+            android:paddingStart="@dimen/margin_extra_large"
+            android:text="@string/site_creation_label_theme_selection_title"/>
+
+        <TextView
+            android:id="@+id/label"
+            style="@style/LoginTheme.TextLabel"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_extra_large"
+            android:paddingEnd="@dimen/margin_extra_large"
+            android:paddingLeft="@dimen/margin_extra_large"
+            android:paddingRight="@dimen/margin_extra_large"
+            android:paddingStart="@dimen/margin_extra_large"
+            android:text="@string/site_creation_label_theme_selection"/>
+
+    </LinearLayout>
+
 
     <LinearLayout
         android:id="@+id/progress_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/margin_extra_large"
+        android:orientation="vertical"
         android:paddingEnd="@dimen/margin_extra_large"
         android:paddingLeft="@dimen/margin_extra_large"
         android:paddingRight="@dimen/margin_extra_large"
         android:paddingStart="@dimen/margin_extra_large"
-        android:layout_marginBottom="@dimen/margin_extra_large"
-        android:orientation="vertical"
         android:visibility="gone"
         tools:visibility="visible">
 
@@ -53,10 +62,10 @@
 
         <TextView
             android:id="@+id/progress_label"
-            android:layout_height="wrap_content"
+            style="@style/LoginTheme.TextLabel"
             android:layout_width="match_parent"
-            android:text="@string/site_creation_label_theme_loading"
+            android:layout_height="wrap_content"
             android:gravity="center_horizontal"
-            style="@style/LoginTheme.TextLabel" />
+            android:text="@string/site_creation_label_theme_loading"/>
     </LinearLayout>
 </LinearLayout>

--- a/WordPress/src/main/res/layout/site_creation_theme_screen.xml
+++ b/WordPress/src/main/res/layout/site_creation_theme_screen.xml
@@ -3,4 +3,5 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/recycler_view"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"/>
+    android:layout_height="match_parent"
+    android:importantForAccessibility="no"/>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1971,6 +1971,7 @@
     <string name="notification_site_creation_step_fetching">Step 2 of 4</string>
     <string name="notification_site_creation_step_tagline">Step 3 of 4</string>
     <string name="notification_site_creation_step_theme">Step 4 of 4</string>
+    <string name="notification_site_creation_title_in_progress">Creating site…</string>
     <string name="notification_site_creation_title_stopped">Site creation stopped</string>
     <string name="notification_site_creation_failed">An error has occurred.</string>
 


### PR DESCRIPTION
PR fixes couple of accessibility issues in site creation flow.

- Label for each step is combined in one notification like it was on step 4.
- Fixed issues with label getting focus when transitioning to the next step.

[![https://gyazo.com/40deaa0e0571c207e21695c3240deed4](https://i.gyazo.com/40deaa0e0571c207e21695c3240deed4.png)](https://gyazo.com/40deaa0e0571c207e21695c3240deed4)

Somehow we missed that `notification_site_creation_title_in_progress` only available in some locales and was not announced in English, and was silently throwing exceptions in the background:
[![https://gyazo.com/9c18ef644e81590066a3f9e0b21c94ea](https://i.gyazo.com/9c18ef644e81590066a3f9e0b21c94ea.png)](https://gyazo.com/9c18ef644e81590066a3f9e0b21c94ea)
