### PR TITLE
Fix Edit Photo title announcement with TalkBack

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -526,6 +526,7 @@
         <!-- Lib activities-->
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"
+            android:label="@string/edit_photo_screen_title"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
 
         <!-- Services -->

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="login_prologue_screen_title">Login</string>
     <string name="signup_epilogue_screen_title">New account</string>
     <string name="share_intent_screen_title">Pick site</string>
+    <string name="edit_photo_screen_title">Edit Photo</string>
 
 
     <!-- general strings -->
@@ -1629,6 +1630,7 @@
     <string name="follower_remove_confirmation_message">If removed, this follower will stop receiving notifications about this site, unless they re-follow.\n\nWould you still like to remove this follower?</string>
     <string name="viewer_remove_confirmation_message">If you remove this viewer, he or she will not be able to visit this site.\n\nWould you still like to remove this viewer?</string>
     <string name="person_removed">Successfully removed %1$s</string>
+    <string name="invite_people">Invite People</string>
     <string name="invite_names_title">Usernames or Emails</string>
     <string name="invite">Invite</string>
     <string name="button_invite" translatable="false">@string/invite</string>


### PR DESCRIPTION
Fixes TalkBack announcement on the edit photo screen.
Fixes missing `invite_people` resource.

To test:
1. Enable TalkBack
2. Go to Me section
3. Edit photo
4. `Edit photo` title should be announced

1. Go to My Site
2. People
3. Add people
4. Observe that the app doesn't crash on a missing resource exception 
