### PR TITLE
Feature/improving stats bar announcements

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsSingleItemDetailsActivity.java
@@ -465,7 +465,7 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
         mGraphView.getGraphViewStyle().setMaxColumnWidth(
                 DisplayUtils.dpToPx(this, StatsConstants.STATS_GRAPH_BAR_MAX_COLUMN_WIDTH_DP));
         mGraphView.setHorizontalLabels(horLabels);
-        mGraphView.setAccessibleHorizontalLabels(horLabels);
+        mGraphView.setAccessibleHorizontalLabels(makeAccessibleHorizontalViewLabels(horLabels, dataToShowOnGraph));
         mGraphView.setGestureListener(this);
 
         // Reset the bar selected upon rotation of the device when the no. of bars can change with orientation.
@@ -504,6 +504,17 @@ public class StatsSingleItemDetailsActivity extends AppCompatActivity
         RecentWeeksListAdapter recentWeeksListAdapter =
                 new RecentWeeksListAdapter(this, recentWeeks, mRestResponseParsed.getHighestWeekAverage());
         StatsUIHelper.reloadGroupViews(this, recentWeeksListAdapter, mRecentWeeksIdToExpandedMap, mRecentWeeksList);
+    }
+
+    private String[] makeAccessibleHorizontalViewLabels(String[] horizontalLabels, VisitModel[] dataToShowOnGraph) {
+        String[] accessibleLabels = new String[horizontalLabels.length];
+
+        for (int i = 0; i < horizontalLabels.length; i++) {
+            accessibleLabels[i] = getString(R.string.stats_bar_date_value_desc, horizontalLabels[i],
+                    dataToShowOnGraph[i].getViews());
+        }
+
+        return accessibleLabels;
     }
 
     private void setMainViewsLabel(String dateFormatted, int totals) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsVisitorsAndViewsFragment.java
@@ -262,8 +262,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
             mSelectedOverviewItemIndex = checkedId;
             if (mOverviewItemChangeListener != null) {
                 mOverviewItemChangeListener.onOverviewItemChanged(
-                        mOverviewItems[mSelectedOverviewItemIndex]
-                );
+                        mOverviewItems[mSelectedOverviewItemIndex]);
             }
             updateUI();
         }
@@ -493,10 +492,10 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         mGraphView.getGraphViewStyle().setNumHorizontalLabels(dataToShowOnGraph.length);
         // Set the maximum size a column can get on the screen in PX
         mGraphView.getGraphViewStyle().setMaxColumnWidth(
-                DisplayUtils.dpToPx(getActivity(), StatsConstants.STATS_GRAPH_BAR_MAX_COLUMN_WIDTH_DP)
-        );
+                DisplayUtils.dpToPx(getActivity(), StatsConstants.STATS_GRAPH_BAR_MAX_COLUMN_WIDTH_DP));
         mGraphView.setHorizontalLabels(horLabels);
-        mGraphView.setAccessibleHorizontalLabels(makeAccessibleHorizontalLabels(horLabels));
+        mGraphView.setAccessibleHorizontalLabels(makeAccessibleHorizontalLabels(horLabels,
+                mainSeriesItems, selectedStatsType));
         mGraphView.setGestureListener(this);
         mGraphView.setImportantForAccessibility(atLeastOneResultIsAvailable
                 ? View.IMPORTANT_FOR_ACCESSIBILITY_YES : View.IMPORTANT_FOR_ACCESSIBILITY_NO);
@@ -535,23 +534,30 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
         mGraphView.highlightBar(barSelectedOnGraph);
     }
 
-    private String[] makeAccessibleHorizontalLabels(String[] horizontalLabels) {
+    private String[] makeAccessibleHorizontalLabels(String[] horizontalLabels,
+                                                    GraphView.GraphViewData[] dataToShowOnGraph,
+                                                    OverviewLabel typeOfStats) {
         String[] accessibleLabels = new String[horizontalLabels.length];
 
         for (int i = 0; i < horizontalLabels.length; i++) {
+            String barDate;
+
             if (getTimeframe() == StatsTimeframe.MONTH) {
-                accessibleLabels[i] = StatsUtils.parseDateToLocalizedFormat(
+                barDate = StatsUtils.parseDateToLocalizedFormat(
                         horizontalLabels[i],
                         StatsConstants.STATS_OUTPUT_DATE_MONTH_SHORT_FORMAT,
                         StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_FORMAT);
             } else if (getTimeframe() == StatsTimeframe.WEEK) {
-                accessibleLabels[i] = getString(R.string.stats_bar_week_desc, StatsUtils.parseDateToLocalizedFormat(
+                barDate = getString(R.string.stats_bar_week_desc, StatsUtils.parseDateToLocalizedFormat(
                         horizontalLabels[i],
                         StatsConstants.STATS_OUTPUT_DATE_MONTH_SHORT_DAY_SHORT_FORMAT,
                         StatsConstants.STATS_OUTPUT_DATE_MONTH_LONG_DAY_SHORT_FORMAT));
             } else {
-                accessibleLabels[i] = horizontalLabels[i];
+                barDate = horizontalLabels[i];
             }
+
+            accessibleLabels[i] = getString(R.string.stats_bar_date_value_type_desc, barDate,
+                    (int) dataToShowOnGraph[i].getY(), typeOfStats.getLabel());
         }
 
         return accessibleLabels;
@@ -694,8 +700,7 @@ public class StatsVisitorsAndViewsFragment extends StatsAbstractFragment
                 return StatsUtils.parseDateToLocalizedFormat(
                         dateToFormat,
                         StatsConstants.STATS_INPUT_DATE_FORMAT,
-                        StatsConstants.STATS_OUTPUT_DATE_MONTH_SHORT_DAY_SHORT_FORMAT
-                );
+                        StatsConstants.STATS_OUTPUT_DATE_MONTH_SHORT_DAY_SHORT_FORMAT);
             case WEEK:
                 // first four digits are the year
                 // followed by Wxx where xx is the month

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -2015,6 +2015,8 @@
     <string name="navigate_up_desc">navigate up</string>
     <string name="stats_list_cell_chevron_collapse_desc">collapse</string>
     <string name="stats_bar_desc">Showing %s</string>
+    <string name="stats_bar_date_value_type_desc">%s, %d %s</string>
+    <string name="stats_bar_date_value_desc">%s, %d views</string>
     <string name="stats_bar_week_desc">Week of %s</string>
     <string name="fab_add_tag_desc">create tag</string>
     <string name="fab_create_post_desc">create post</string>


### PR DESCRIPTION
This PR adds the accessibility announcement of value and type to Stats graph Bars when exploring them by touch.

At the single item stats graph, the number of views is also announced when you select the bar. This redundancy is for compatibility with Switch Access.
