### PR TITLE
Fixing wrong content description in Stats

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsCommentsFragment.java
@@ -139,7 +139,7 @@ public class StatsCommentsFragment extends StatsAbstractListFragment {
         if (mTopPagerSelectedButtonIndex == 0 && hasAuthors()) {
             adapter = new AuthorsAdapter(getActivity(), getAuthors());
         } else if (mTopPagerSelectedButtonIndex == 1 && hasPosts()) {
-            adapter = new PostsAndPagesAdapter(getActivity(), getPosts());
+            adapter = new PostsAndPagesAdapter(getActivity(), getPosts(), true);
         }
 
         if (adapter != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsTopPostsAndPagesFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/StatsTopPostsAndPagesFragment.java
@@ -68,7 +68,7 @@ public class StatsTopPostsAndPagesFragment extends StatsAbstractListFragment {
 
         if (hasTopPostsAndPages()) {
             List<StatsPostModel> postViews = mTopPostsAndPagesModel.getTopPostsAndPages();
-            ArrayAdapter adapter = new PostsAndPagesAdapter(getActivity(), postViews);
+            ArrayAdapter adapter = new PostsAndPagesAdapter(getActivity(), postViews, false);
             StatsUIHelper.reloadLinearLayout(getActivity(), adapter, mList, getMaxNumberOfItemsToShowInList());
             showHideNoResultsUI(false);
         } else {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/adapters/PostsAndPagesAdapter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/adapters/PostsAndPagesAdapter.java
@@ -19,11 +19,13 @@ import java.util.List;
 public class PostsAndPagesAdapter extends ArrayAdapter<StatsPostModel> {
     private final List<StatsPostModel> mList;
     private final LayoutInflater mInflater;
+    private final boolean mAnnounceValueAsComments;
 
-    public PostsAndPagesAdapter(Context context, List<StatsPostModel> list) {
+    public PostsAndPagesAdapter(Context context, List<StatsPostModel> list, boolean announceValueAsComments) {
         super(context, R.layout.stats_list_cell, list);
         mList = list;
         mInflater = LayoutInflater.from(context);
+        mAnnounceValueAsComments = announceValueAsComments;
     }
 
     @Override
@@ -49,13 +51,23 @@ public class PostsAndPagesAdapter extends ArrayAdapter<StatsPostModel> {
 
         // totals
         holder.totalsTextView.setText(FormatUtils.formatDecimal(currentRowData.getTotals()));
-        holder.totalsTextView.setContentDescription(
-                StringUtils.getQuantityString(
-                        holder.totalsTextView.getContext(),
-                        R.string.stats_comments_zero_desc,
-                        R.string.stats_comments_one_desc,
-                        R.string.stats_comments_many_desc,
-                        currentRowData.getTotals()));
+        if (mAnnounceValueAsComments) {
+            holder.totalsTextView.setContentDescription(
+                    StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_comments_zero_desc,
+                            R.string.stats_comments_one_desc,
+                            R.string.stats_comments_many_desc,
+                            currentRowData.getTotals()));
+        } else {
+            holder.totalsTextView.setContentDescription(
+                    StringUtils.getQuantityString(
+                            holder.totalsTextView.getContext(),
+                            R.string.stats_views_zero_desc,
+                            R.string.stats_views_one_desc,
+                            R.string.stats_views_many_desc,
+                            currentRowData.getTotals()));
+        }
 
         // no icon
         holder.networkImageView.setVisibility(View.GONE);


### PR DESCRIPTION
I noticed that `PostsAndPagesAdapter` is used twice for stats with different content type. Thi PR adds support for both comments and views stats accessibility announcements.

To test:

Enable talk back.
Navigate to Stats, select Insight from the dropdown list.
Scroll down to:
[![https://gyazo.com/4afc970198bf86e2bb7f692e9b595860](https://i.gyazo.com/4afc970198bf86e2bb7f692e9b595860.png)](https://gyazo.com/4afc970198bf86e2bb7f692e9b595860)

Select `By Posts & Pages`.
Select any row below it, and make sure the word "comments" is following the total value (ex. 100 comments).

Select "Days" from the dropdown list.
Direct your attention to:
[![https://gyazo.com/d1ca69f1ebccc0982db431de2a20734d](https://i.gyazo.com/d1ca69f1ebccc0982db431de2a20734d.png)](https://gyazo.com/d1ca69f1ebccc0982db431de2a20734d)
Select any row below it, and make sure that the word "views" is following the total value (ex. 100 views).


