### PR TITLE
Hide keyboard before calling the site creation action

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationDomainFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationDomainFragment.java
@@ -21,6 +21,7 @@ import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.network.rest.wpcom.site.DomainSuggestionResponse;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.ui.accounts.signup.SiteCreationDomainLoaderFragment.DomainSuggestionEvent;
+import org.wordpress.android.util.ActivityUtils;
 
 import java.util.ArrayList;
 
@@ -81,6 +82,11 @@ public class SiteCreationDomainFragment extends SiteCreationBaseFormFragment<Sit
         mFinishButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                // hide keyboard before calling the site creation action
+                if (getActivity() != null) {
+                    ActivityUtils.hideKeyboardForced(getActivity().getCurrentFocus());
+                }
+
                 mSiteCreationListener.withDomain(mSelectedDomain);
             }
         });


### PR DESCRIPTION
Fixes #7511 Site-creation: virtual keyboard stays visible in "Creating" screen

_To test:_

1. With the app logged in, head over to **MySite**, tap on the "**Switch Site**" button, the "**+**" action on the toolbar and select "**Creation WordPress.com site**" option from the popup

2. Tap on any of the category cards, then on any of the themes, then input a site title in the first input box, hit "NEXT"

3. Pick an available domain from the list and **_make sure the virtual keyboard is showing on the screen_**  then hit "**CREATE SITE**"

<img src="https://user-images.githubusercontent.com/2581647/37796776-d22668cc-2df6-11e8-8426-af89c8510771.jpg" width="200"/>

4. The "**Creating**" screen will appear  and notice that the virtual keyboard has disappears 

<img src="https://user-images.githubusercontent.com/2581647/37796775-d20174ae-2df6-11e8-9ca7-db543fee8f32.jpg" width="200"/>​
