### PR TITLE
issue/7534-reader-empty-after-resume

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/datasets/ReaderTagTable.java
+++ b/WordPress/src/main/java/org/wordpress/android/datasets/ReaderTagTable.java
@@ -253,6 +253,18 @@ public class ReaderTagTable {
         }
     }
 
+    public static ReaderTag getFirstTag() {
+        Cursor c = ReaderDatabase.getReadableDb().rawQuery("SELECT * FROM tbl_tags ORDER BY tag_slug LIMIT 1", null);
+        try {
+            if (c.moveToFirst()) {
+                return getTagFromCursor(c);
+            }
+            return null;
+        } finally {
+            SqlUtils.closeCursor(c);
+        }
+    }
+
     public static void deleteTag(ReaderTag tag) {
         if (tag == null) {
             return;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -300,7 +300,13 @@ public class ReaderPostListFragment extends Fragment
         } else if (!ReaderTagTable.tagExists(getCurrentTag())) {
             // current tag no longer exists, revert to default
             AppLog.d(T.READER, "reader post list > current tag no longer valid");
-            setCurrentTag(ReaderUtils.getDefaultTag());
+            ReaderTag tag = ReaderUtils.getDefaultTag();
+            // it's possible the default tag won't exist if the user just changed the app's
+            // language, in which case default to the first tag in the table
+            if (!ReaderTagTable.tagExists(tag)) {
+                tag = ReaderTagTable.getFirstTag();
+            }
+            setCurrentTag(tag);
         } else {
             // otherwise, refresh posts to make sure any changes are reflected and auto-update
             // posts in the current tag if it's time


### PR DESCRIPTION
Fixes #7534 - When the reader fragment is resumed, default to the first tag in the table if the current tag no longer exists and the default tag is no longer valid due to a language change.

cc: @mzorz 
