### PR TITLE
Issue/7463 post list settings gone on rotate

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -171,7 +171,8 @@ public class EditPostActivity extends AppCompatActivity implements
         OnRequestPermissionsResultCallback,
         PhotoPickerFragment.PhotoPickerListener,
         EditPostSettingsFragment.EditPostActivityHook,
-        BaseYesNoFragmentDialog.BasicYesNoDialogClickInterface {
+        BaseYesNoFragmentDialog.BasicYesNoDialogClickInterface,
+        PostSettingsDialogFragment.OnPostSettingsDialogFragmentListener {
     public static final String EXTRA_POST_LOCAL_ID = "postModelLocalId";
     public static final String EXTRA_IS_PAGE = "isPage";
     public static final String EXTRA_IS_PROMO = "isPromo";
@@ -1335,6 +1336,14 @@ public class EditPostActivity extends AppCompatActivity implements
     @Override public void onNegativeClicked(String instanceTag) {
         if (instanceTag != null && instanceTag == TAG_PUBLISH_CONFIRMATION_DIALOG) {
             // no op
+        }
+    }
+
+    @Override
+    public void onPostSettingsFragmentPositiveButtonClicked(@NonNull PostSettingsDialogFragment fragment) {
+        // pass it along to the settings fragment
+        if (mEditPostSettingsFragment != null) {
+            mEditPostSettingsFragment.onPostSettingsFragmentPositiveButtonClicked(fragment);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -172,7 +172,7 @@ public class EditPostActivity extends AppCompatActivity implements
         PhotoPickerFragment.PhotoPickerListener,
         EditPostSettingsFragment.EditPostActivityHook,
         BaseYesNoFragmentDialog.BasicYesNoDialogClickInterface,
-        PostSettingsDialogFragment.OnPostSettingsDialogFragmentListener {
+        PostSettingsListDialogFragment.OnPostSettingsDialogFragmentListener {
     public static final String EXTRA_POST_LOCAL_ID = "postModelLocalId";
     public static final String EXTRA_IS_PAGE = "isPage";
     public static final String EXTRA_IS_PROMO = "isPromo";
@@ -1344,7 +1344,7 @@ public class EditPostActivity extends AppCompatActivity implements
      * along to the settings fragment
      */
     @Override
-    public void onPostSettingsFragmentPositiveButtonClicked(@NonNull PostSettingsDialogFragment fragment) {
+    public void onPostSettingsFragmentPositiveButtonClicked(@NonNull PostSettingsListDialogFragment fragment) {
         if (mEditPostSettingsFragment != null) {
             mEditPostSettingsFragment.onPostSettingsFragmentPositiveButtonClicked(fragment);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1339,9 +1339,12 @@ public class EditPostActivity extends AppCompatActivity implements
         }
     }
 
+    /*
+     * user clicked OK on a settings dialog displayed from the settings fragment - pass the event
+     * along to the settings fragment
+     */
     @Override
     public void onPostSettingsFragmentPositiveButtonClicked(@NonNull PostSettingsDialogFragment fragment) {
-        // pass it along to the settings fragment
         if (mEditPostSettingsFragment != null) {
             mEditPostSettingsFragment.onPostSettingsFragmentPositiveButtonClicked(fragment);
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -489,19 +489,15 @@ public class EditPostSettingsFragment extends Fragment {
      * this will be called by the activity when the user taps OK on a PostSettingsDialogFragment
      */
     public void onPostSettingsFragmentPositiveButtonClicked(@NonNull PostSettingsListDialogFragment fragment) {
-        DialogType dialogType = fragment.getDialogType();
-        String selectedItem = fragment.getSelectedItem();
-
-        switch (dialogType) {
+        switch (fragment.getDialogType()) {
             case POST_STATUS:
-                if (!StringUtils.isEmpty(selectedItem)) {
-                    updatePostStatus(selectedItem);
-                }
+                int index = fragment.getCheckedIndex();
+                String status = getPostStatusAtIndex(index).toString();
+                updatePostStatus(status);
                 break;
             case POST_FORMAT:
-                if (!StringUtils.isEmpty(selectedItem)) {
-                    updatePostFormat(getPostFormatKeyFromName(selectedItem));
-                }
+                String formatName = fragment.getSelectedItem();
+                updatePostFormat(getPostFormatKeyFromName(formatName));
                 break;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -63,7 +63,7 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaBrowserType;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
-import org.wordpress.android.ui.posts.PostSettingsDialogFragment.DialogType;
+import org.wordpress.android.ui.posts.PostSettingsListDialogFragment.DialogType;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface.SiteSettingsListener;
@@ -488,8 +488,8 @@ public class EditPostSettingsFragment extends Fragment {
     /*
      * this will be called by the activity when the user taps OK on a PostSettingsDialogFragment
      */
-    public void onPostSettingsFragmentPositiveButtonClicked(@NonNull PostSettingsDialogFragment fragment) {
-        DialogType dialogType = fragment.getDialogTyoe();
+    public void onPostSettingsFragmentPositiveButtonClicked(@NonNull PostSettingsListDialogFragment fragment) {
+        DialogType dialogType = fragment.getDialogType();
         String selectedItem = fragment.getSelectedItem();
 
         switch (dialogType) {
@@ -513,9 +513,9 @@ public class EditPostSettingsFragment extends Fragment {
 
         int index = getCurrentPostStatusIndex();
         FragmentManager fm = ((AppCompatActivity) getActivity()).getSupportFragmentManager();
-        PostSettingsDialogFragment fragment =
-                PostSettingsDialogFragment.newInstance(DialogType.POST_STATUS, index);
-        fragment.show(fm, PostSettingsDialogFragment.TAG);
+        PostSettingsListDialogFragment fragment =
+                PostSettingsListDialogFragment.newInstance(DialogType.POST_STATUS, index);
+        fragment.show(fm, PostSettingsListDialogFragment.TAG);
     }
 
     private void showPostFormatDialog() {
@@ -535,9 +535,9 @@ public class EditPostSettingsFragment extends Fragment {
         }
 
         FragmentManager fm = ((AppCompatActivity) getActivity()).getSupportFragmentManager();
-        PostSettingsDialogFragment fragment =
-                PostSettingsDialogFragment.newInstance(DialogType.POST_FORMAT, checkedIndex);
-        fragment.show(fm, PostSettingsDialogFragment.TAG);
+        PostSettingsListDialogFragment fragment =
+                PostSettingsListDialogFragment.newInstance(DialogType.POST_FORMAT, checkedIndex);
+        fragment.show(fm, PostSettingsListDialogFragment.TAG);
     }
 
     private void showPostPasswordDialog() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -13,7 +13,6 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentManager;
-import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.view.menu.MenuPopupHelper;
 import android.support.v7.widget.CardView;
@@ -29,7 +28,6 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.DatePicker;
 import android.widget.LinearLayout;
-import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.TimePicker;
 
@@ -66,7 +64,6 @@ import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaBrowserType;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
 import org.wordpress.android.ui.posts.PostSettingsDialogFragment.DialogType;
-import org.wordpress.android.ui.posts.PostSettingsDialogFragment.OnPostSettingsDialogFragmentListener;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface.SiteSettingsListener;
@@ -493,11 +490,18 @@ public class EditPostSettingsFragment extends Fragment {
      */
     public void onPostSettingsFragmentPositiveButtonClicked(@NonNull PostSettingsDialogFragment fragment) {
         DialogType dialogType = fragment.getDialogTyoe();
-        int index = fragment.getChoiceIndex();
+        String selectedItem = fragment.getSelectedItem();
 
         switch (dialogType) {
             case PUBLISH_DATE:
-                updatePostStatus(getPostStatusAtIndex(index).toString());
+                if (!StringUtils.isEmpty(selectedItem)) {
+                    updatePostStatus(selectedItem);
+                }
+                break;
+            case POST_FORMAT:
+                if (!StringUtils.isEmpty(selectedItem)) {
+                    updatePostFormat(getPostFormatKeyFromName(selectedItem));
+                }
                 break;
         }
     }
@@ -512,48 +516,28 @@ public class EditPostSettingsFragment extends Fragment {
         PostSettingsDialogFragment fragment =
                 PostSettingsDialogFragment.newInstance(DialogType.PUBLISH_DATE, index);
         fragment.show(fm, PostSettingsDialogFragment.TAG);
-
-        /*AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(), R.style.Calypso_AlertDialog);
-        builder.setTitle(R.string.post_settings_status);
-        builder.setSingleChoiceItems(R.array.post_settings_statuses, getCurrentPostStatusIndex(), null);
-        builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int which) {
-                ListView listView = ((AlertDialog) dialog).getListView();
-                int index = listView.getCheckedItemPosition();
-                updatePostStatus(getPostStatusAtIndex(index).toString());
-            }
-        });
-        builder.setNegativeButton(R.string.cancel, null);
-        builder.show();*/
     }
 
     private void showPostFormatDialog() {
         if (!isAdded()) {
             return;
         }
-        int checkedItem = 0;
+
+        int checkedIndex = 0;
         String postFormat = getPost().getPostFormat();
         if (!TextUtils.isEmpty(postFormat)) {
             for (int i = 0; i < mPostFormatKeys.size(); i++) {
                 if (postFormat.equals(mPostFormatKeys.get(i))) {
-                    checkedItem = i;
+                    checkedIndex = i;
                     break;
                 }
             }
         }
 
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(), R.style.Calypso_AlertDialog);
-        builder.setTitle(R.string.post_settings_post_format);
-        builder.setSingleChoiceItems(mPostFormatNames.toArray(new CharSequence[0]), checkedItem, null);
-        builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface dialog, int which) {
-                ListView listView = ((AlertDialog) dialog).getListView();
-                String formatName = (String) listView.getAdapter().getItem(listView.getCheckedItemPosition());
-                updatePostFormat(getPostFormatKeyFromName(formatName));
-            }
-        });
-        builder.setNegativeButton(R.string.cancel, null);
-        builder.show();
+        FragmentManager fm = ((AppCompatActivity) getActivity()).getSupportFragmentManager();
+        PostSettingsDialogFragment fragment =
+                PostSettingsDialogFragment.newInstance(DialogType.POST_FORMAT, checkedIndex);
+        fragment.show(fm, PostSettingsDialogFragment.TAG);
     }
 
     private void showPostPasswordDialog() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -12,7 +12,9 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AlertDialog;
+import android.support.v7.app.AppCompatActivity;
 import android.support.v7.view.menu.MenuPopupHelper;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.PopupMenu;
@@ -63,6 +65,8 @@ import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaBrowserType;
 import org.wordpress.android.ui.photopicker.PhotoPickerActivity;
+import org.wordpress.android.ui.posts.PostSettingsDialogFragment.DialogType;
+import org.wordpress.android.ui.posts.PostSettingsDialogFragment.OnPostSettingsDialogFragmentListener;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface.SiteSettingsListener;
@@ -129,6 +133,7 @@ public class EditPostSettingsFragment extends Fragment {
     @Inject MediaStore mMediaStore;
     @Inject TaxonomyStore mTaxonomyStore;
     @Inject Dispatcher mDispatcher;
+
 
     interface EditPostActivityHook {
         PostModel getPost();
@@ -483,11 +488,32 @@ public class EditPostSettingsFragment extends Fragment {
         startActivityForResult(tagsIntent, ACTIVITY_REQUEST_CODE_SELECT_TAGS);
     }
 
+    /*
+     * this will be called by the activity when the user taps OK on a PostSettingsDialogFragment
+     */
+    public void onPostSettingsFragmentPositiveButtonClicked(@NonNull PostSettingsDialogFragment fragment) {
+        DialogType dialogType = fragment.getDialogTyoe();
+        int index = fragment.getChoiceIndex();
+
+        switch (dialogType) {
+            case PUBLISH_DATE:
+                updatePostStatus(getPostStatusAtIndex(index).toString());
+                break;
+        }
+    }
+
     private void showStatusDialog() {
         if (!isAdded()) {
             return;
         }
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(), R.style.Calypso_AlertDialog);
+
+        int index = getCurrentPostStatusIndex();
+        FragmentManager fm = ((AppCompatActivity) getActivity()).getSupportFragmentManager();
+        PostSettingsDialogFragment fragment =
+                PostSettingsDialogFragment.newInstance(DialogType.PUBLISH_DATE, index);
+        fragment.show(fm, PostSettingsDialogFragment.TAG);
+
+        /*AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(), R.style.Calypso_AlertDialog);
         builder.setTitle(R.string.post_settings_status);
         builder.setSingleChoiceItems(R.array.post_settings_statuses, getCurrentPostStatusIndex(), null);
         builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
@@ -498,7 +524,7 @@ public class EditPostSettingsFragment extends Fragment {
             }
         });
         builder.setNegativeButton(R.string.cancel, null);
-        builder.show();
+        builder.show();*/
     }
 
     private void showPostFormatDialog() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostSettingsFragment.java
@@ -493,7 +493,7 @@ public class EditPostSettingsFragment extends Fragment {
         String selectedItem = fragment.getSelectedItem();
 
         switch (dialogType) {
-            case PUBLISH_DATE:
+            case POST_STATUS:
                 if (!StringUtils.isEmpty(selectedItem)) {
                     updatePostStatus(selectedItem);
                 }
@@ -514,7 +514,7 @@ public class EditPostSettingsFragment extends Fragment {
         int index = getCurrentPostStatusIndex();
         FragmentManager fm = ((AppCompatActivity) getActivity()).getSupportFragmentManager();
         PostSettingsDialogFragment fragment =
-                PostSettingsDialogFragment.newInstance(DialogType.PUBLISH_DATE, index);
+                PostSettingsDialogFragment.newInstance(DialogType.POST_STATUS, index);
         fragment.show(fm, PostSettingsDialogFragment.TAG);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsDialogFragment.java
@@ -5,19 +5,22 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
 import android.support.v7.app.AlertDialog;
 import android.widget.ListView;
 
 import org.wordpress.android.R;
+import org.wordpress.android.util.AppLog;
 
 public class PostSettingsDialogFragment extends DialogFragment {
     private static final String ARG_DIALOG_TYPE = "dialog_type";
-    private static final String ARG_CHOICE_INDEX = "choice_index";
+    private static final String ARG_CHECKED_INDEX = "checked_index";
     public static final String TAG = "post_settings_dialog_fragment";
 
     enum DialogType {
-        PUBLISH_DATE
+        PUBLISH_DATE,
+        POST_FORMAT
     }
 
     interface OnPostSettingsDialogFragmentListener {
@@ -25,7 +28,7 @@ public class PostSettingsDialogFragment extends DialogFragment {
     }
 
     private DialogType mDialogTyoe;
-    private int mChoiceIndex;
+    private int mCheckedIndex;
     private OnPostSettingsDialogFragmentListener mListener;
 
     public static PostSettingsDialogFragment newInstance(@NonNull DialogType dialogType) {
@@ -36,7 +39,7 @@ public class PostSettingsDialogFragment extends DialogFragment {
         PostSettingsDialogFragment fragment = new PostSettingsDialogFragment();
         Bundle args = new Bundle();
         args.putSerializable(ARG_DIALOG_TYPE, dialogType);
-        args.putInt(ARG_CHOICE_INDEX, index);
+        args.putInt(ARG_CHECKED_INDEX, index);
         fragment.setArguments(args);
         return fragment;
     }
@@ -53,7 +56,7 @@ public class PostSettingsDialogFragment extends DialogFragment {
     public void setArguments(Bundle args) {
         super.setArguments(args);
         mDialogTyoe = (DialogType) args.getSerializable(ARG_DIALOG_TYPE);
-        mChoiceIndex = args.getInt(ARG_CHOICE_INDEX);
+        mCheckedIndex = args.getInt(ARG_CHECKED_INDEX);
     }
 
     @Override
@@ -70,24 +73,39 @@ public class PostSettingsDialogFragment extends DialogFragment {
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        DialogInterface.OnClickListener clickListener = new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                mCheckedIndex = which;
+                getArguments().putInt(ARG_CHECKED_INDEX, mCheckedIndex);
+            }
+        };
 
         switch (mDialogTyoe) {
             case PUBLISH_DATE:
                 builder.setTitle(R.string.post_settings_status);
-                builder.setSingleChoiceItems(R.array.post_settings_statuses, mChoiceIndex, null);
-                builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int which) {
-                        ListView listView = ((AlertDialog) dialog).getListView();
-                        mChoiceIndex = listView.getCheckedItemPosition();
-                        getArguments().putInt(ARG_CHOICE_INDEX, mChoiceIndex);
-                        mListener.onPostSettingsFragmentPositiveButtonClicked(PostSettingsDialogFragment.this);
-                    }
-                });
-                builder.setNegativeButton(R.string.cancel, null);
+                builder.setSingleChoiceItems(
+                        R.array.post_settings_statuses,
+                        mCheckedIndex,
+                        clickListener);
+                break;
+            case POST_FORMAT:
+                builder.setTitle(R.string.post_settings_post_format);
+                builder.setSingleChoiceItems(
+                        R.array.post_format_display_names,
+                        mCheckedIndex,
+                        clickListener);
                 break;
             default:
                 return null;
         }
+
+        builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+            public void onClick(DialogInterface dialog, int which) {
+                mListener.onPostSettingsFragmentPositiveButtonClicked(PostSettingsDialogFragment.this);
+            }
+        });
+        builder.setNegativeButton(R.string.cancel, null);
 
         return builder.create();
     }
@@ -96,8 +114,16 @@ public class PostSettingsDialogFragment extends DialogFragment {
         return mDialogTyoe;
     }
 
-    public int getChoiceIndex() {
-        return mChoiceIndex;
+    public @Nullable String getSelectedItem() {
+        ListView listView = ((AlertDialog) getDialog()).getListView();
+        if (listView != null) {
+            try {
+                return (String) listView.getItemAtPosition(mCheckedIndex);
+            } catch (IndexOutOfBoundsException e) {
+                AppLog.e(AppLog.T.POSTS, e);
+            }
+        }
+        return null;
     }
 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsDialogFragment.java
@@ -1,0 +1,103 @@
+package org.wordpress.android.ui.posts;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.support.v7.app.AlertDialog;
+import android.widget.ListView;
+
+import org.wordpress.android.R;
+
+public class PostSettingsDialogFragment extends DialogFragment {
+    private static final String ARG_DIALOG_TYPE = "dialog_type";
+    private static final String ARG_CHOICE_INDEX = "choice_index";
+    public static final String TAG = "post_settings_dialog_fragment";
+
+    enum DialogType {
+        PUBLISH_DATE
+    }
+
+    interface OnPostSettingsDialogFragmentListener {
+        void onPostSettingsFragmentPositiveButtonClicked(@NonNull PostSettingsDialogFragment fragment);
+    }
+
+    private DialogType mDialogTyoe;
+    private int mChoiceIndex;
+    private OnPostSettingsDialogFragmentListener mListener;
+
+    public static PostSettingsDialogFragment newInstance(@NonNull DialogType dialogType) {
+        return newInstance(dialogType, 0);
+    }
+
+    public static PostSettingsDialogFragment newInstance(@NonNull DialogType dialogType, int index) {
+        PostSettingsDialogFragment fragment = new PostSettingsDialogFragment();
+        Bundle args = new Bundle();
+        args.putSerializable(ARG_DIALOG_TYPE, dialogType);
+        args.putInt(ARG_CHOICE_INDEX, index);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setCancelable(true);
+        int style = DialogFragment.STYLE_NORMAL, theme = 0;
+        setStyle(style, theme);
+    }
+
+    @Override
+    public void setArguments(Bundle args) {
+        super.setArguments(args);
+        mDialogTyoe = (DialogType) args.getSerializable(ARG_DIALOG_TYPE);
+        mChoiceIndex = args.getInt(ARG_CHOICE_INDEX);
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+
+        try {
+            mListener = (OnPostSettingsDialogFragmentListener) activity;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(activity.toString() + " must implement OnPostSettingsDialogFragmentListener");
+        }
+    }
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+
+        switch (mDialogTyoe) {
+            case PUBLISH_DATE:
+                builder.setTitle(R.string.post_settings_status);
+                builder.setSingleChoiceItems(R.array.post_settings_statuses, mChoiceIndex, null);
+                builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int which) {
+                        ListView listView = ((AlertDialog) dialog).getListView();
+                        mChoiceIndex = listView.getCheckedItemPosition();
+                        getArguments().putInt(ARG_CHOICE_INDEX, mChoiceIndex);
+                        mListener.onPostSettingsFragmentPositiveButtonClicked(PostSettingsDialogFragment.this);
+                    }
+                });
+                builder.setNegativeButton(R.string.cancel, null);
+                break;
+            default:
+                return null;
+        }
+
+        return builder.create();
+    }
+
+    public DialogType getDialogTyoe() {
+        return mDialogTyoe;
+    }
+
+    public int getChoiceIndex() {
+        return mChoiceIndex;
+    }
+}
+

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsDialogFragment.java
@@ -19,7 +19,7 @@ public class PostSettingsDialogFragment extends DialogFragment {
     public static final String TAG = "post_settings_dialog_fragment";
 
     enum DialogType {
-        PUBLISH_DATE,
+        POST_STATUS,
         POST_FORMAT
     }
 
@@ -82,7 +82,7 @@ public class PostSettingsDialogFragment extends DialogFragment {
         };
 
         switch (mDialogTyoe) {
-            case PUBLISH_DATE:
+            case POST_STATUS:
                 builder.setTitle(R.string.post_settings_status);
                 builder.setSingleChoiceItems(
                         R.array.post_settings_statuses,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsListDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsListDialogFragment.java
@@ -45,8 +45,6 @@ public class PostSettingsListDialogFragment extends DialogFragment {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setCancelable(true);
-        int style = DialogFragment.STYLE_NORMAL, theme = 0;
-        setStyle(style, theme);
     }
 
     @Override
@@ -60,7 +58,6 @@ public class PostSettingsListDialogFragment extends DialogFragment {
     @Override
     public void onAttach(Activity activity) {
         super.onAttach(activity);
-
         try {
             mListener = (OnPostSettingsDialogFragmentListener) activity;
         } catch (ClassCastException e) {
@@ -71,7 +68,8 @@ public class PostSettingsListDialogFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity(), R.style.Calypso_AlertDialog);
+
         DialogInterface.OnClickListener clickListener = new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsListDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsListDialogFragment.java
@@ -109,6 +109,10 @@ public class PostSettingsListDialogFragment extends DialogFragment {
         return mDialogType;
     }
 
+    public int getCheckedIndex() {
+        return mCheckedIndex;
+    }
+
     public @Nullable String getSelectedItem() {
         ListView listView = ((AlertDialog) getDialog()).getListView();
         if (listView != null) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsListDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsListDialogFragment.java
@@ -17,7 +17,7 @@ public class PostSettingsListDialogFragment extends DialogFragment {
     private static final String ARG_DIALOG_TYPE = "dialog_type";
     private static final String ARG_CHECKED_INDEX = "checked_index";
 
-    public static final String TAG = "post_settings_dialog_fragment";
+    public static final String TAG = "post_list_settings_dialog_fragment";
 
     enum DialogType {
         POST_STATUS,

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsListDialogFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/PostSettingsListDialogFragment.java
@@ -13,9 +13,10 @@ import android.widget.ListView;
 import org.wordpress.android.R;
 import org.wordpress.android.util.AppLog;
 
-public class PostSettingsDialogFragment extends DialogFragment {
+public class PostSettingsListDialogFragment extends DialogFragment {
     private static final String ARG_DIALOG_TYPE = "dialog_type";
     private static final String ARG_CHECKED_INDEX = "checked_index";
+
     public static final String TAG = "post_settings_dialog_fragment";
 
     enum DialogType {
@@ -24,19 +25,15 @@ public class PostSettingsDialogFragment extends DialogFragment {
     }
 
     interface OnPostSettingsDialogFragmentListener {
-        void onPostSettingsFragmentPositiveButtonClicked(@NonNull PostSettingsDialogFragment fragment);
+        void onPostSettingsFragmentPositiveButtonClicked(@NonNull PostSettingsListDialogFragment fragment);
     }
 
-    private DialogType mDialogTyoe;
+    private DialogType mDialogType;
     private int mCheckedIndex;
     private OnPostSettingsDialogFragmentListener mListener;
 
-    public static PostSettingsDialogFragment newInstance(@NonNull DialogType dialogType) {
-        return newInstance(dialogType, 0);
-    }
-
-    public static PostSettingsDialogFragment newInstance(@NonNull DialogType dialogType, int index) {
-        PostSettingsDialogFragment fragment = new PostSettingsDialogFragment();
+    public static PostSettingsListDialogFragment newInstance(@NonNull DialogType dialogType, int index) {
+        PostSettingsListDialogFragment fragment = new PostSettingsListDialogFragment();
         Bundle args = new Bundle();
         args.putSerializable(ARG_DIALOG_TYPE, dialogType);
         args.putInt(ARG_CHECKED_INDEX, index);
@@ -55,10 +52,11 @@ public class PostSettingsDialogFragment extends DialogFragment {
     @Override
     public void setArguments(Bundle args) {
         super.setArguments(args);
-        mDialogTyoe = (DialogType) args.getSerializable(ARG_DIALOG_TYPE);
+        mDialogType = (DialogType) args.getSerializable(ARG_DIALOG_TYPE);
         mCheckedIndex = args.getInt(ARG_CHECKED_INDEX);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void onAttach(Activity activity) {
         super.onAttach(activity);
@@ -70,6 +68,7 @@ public class PostSettingsDialogFragment extends DialogFragment {
         }
     }
 
+    @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
@@ -81,7 +80,7 @@ public class PostSettingsDialogFragment extends DialogFragment {
             }
         };
 
-        switch (mDialogTyoe) {
+        switch (mDialogType) {
             case POST_STATUS:
                 builder.setTitle(R.string.post_settings_status);
                 builder.setSingleChoiceItems(
@@ -96,13 +95,11 @@ public class PostSettingsDialogFragment extends DialogFragment {
                         mCheckedIndex,
                         clickListener);
                 break;
-            default:
-                return null;
         }
 
         builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
             public void onClick(DialogInterface dialog, int which) {
-                mListener.onPostSettingsFragmentPositiveButtonClicked(PostSettingsDialogFragment.this);
+                mListener.onPostSettingsFragmentPositiveButtonClicked(PostSettingsListDialogFragment.this);
             }
         });
         builder.setNegativeButton(R.string.cancel, null);
@@ -110,8 +107,8 @@ public class PostSettingsDialogFragment extends DialogFragment {
         return builder.create();
     }
 
-    public DialogType getDialogTyoe() {
-        return mDialogTyoe;
+    public DialogType getDialogType() {
+        return mDialogType;
     }
 
     public @Nullable String getSelectedItem() {


### PR DESCRIPTION
Partially fixes #7463 - this resolves the problem with the Post Status and Post Format dialogs disappearing upon rotation, a separate PR (#7542) tackles the Publish Date dialog disappearing.

To test:

- Open post settings
- Tap Status or Format
- Rotate the device
- Notice that the dialogs continue showing, and retain their current selection