### PR TITLE
Update Support Lib to v27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ android:
     - extra-android-support
     - platform-tools
     - tools
-    - build-tools-26.0.2
-    - android-26
+    - build-tools-27.0.3
+    - android-27
 
 env:
   global:

--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -33,8 +33,8 @@ android {
         dexInProcess = true
     }
 
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "org.wordpress.android"
@@ -105,18 +105,19 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.6.+'
     implementation 'org.ccil.cowan.tagsoup:tagsoup:1.2.1'
 
-    implementation 'com.android.support:support-compat:26.1.0'
-    implementation 'com.android.support:support-core-ui:26.1.0'
-    implementation 'com.android.support:support-fragment:26.1.0'
+    implementation 'com.android.support:support-compat:27.1.0'
+    implementation 'com.android.support:support-core-ui:27.1.0'
+    implementation 'com.android.support:support-fragment:27.1.0'
 
     implementation 'com.android.support:multidex:1.0.2'
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support:support-v13:26.1.0'
-    implementation 'com.android.support:cardview-v7:26.1.0'
-    implementation 'com.android.support:recyclerview-v7:26.1.0'
-    implementation 'com.android.support:design:26.1.0'
-    implementation 'com.android.support:percent:26.1.0'
-    implementation 'com.android.support:preference-v7:26.1.0'
+    implementation 'com.android.support:appcompat-v7:27.1.0'
+    implementation 'com.android.support:support-v13:27.1.0'
+    implementation 'com.android.support:cardview-v7:27.1.0'
+    implementation 'com.android.support:recyclerview-v7:27.1.0'
+    implementation 'com.android.support:design:27.1.0'
+    implementation 'com.android.support:percent:27.1.0'
+    implementation 'com.android.support:preference-v7:27.1.0'
+
     // ViewModel and LiveData
     implementation 'android.arch.lifecycle:extensions:1.1.0'
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/AddQuickPressShortcutActivity.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.content.pm.ShortcutInfoCompat;
 import android.support.v4.content.pm.ShortcutManagerCompat;
+import android.support.v4.graphics.drawable.IconCompat;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -150,7 +151,7 @@ public class AddQuickPressShortcutActivity extends ListActivity {
 
                     ShortcutInfoCompat pinShortcutInfo =
                             new ShortcutInfoCompat.Builder(getApplicationContext(), shortcutName)
-                                    .setIcon(R.mipmap.app_icon)
+                                    .setIcon(IconCompat.createWithResource(getApplicationContext(), R.mipmap.app_icon))
                                     .setShortLabel(shortcutName)
                                     .setIntent(shortcutIntent)
                                     .build();

--- a/WordPress/src/main/res/values/colors.xml
+++ b/WordPress/src/main/res/values/colors.xml
@@ -134,6 +134,7 @@
     <color name="reader_following">@color/alert_green</color>
     <color name="reader_hyperlink">@color/blue_medium</color>
     <color name="filtered_list_suggestions">#f8f8f8</color>
+    <color name="reader_accent_material_dark">@color/material_deep_teal_200</color>
 
     <!-- Comment Status -->
     <color name="comment_status_unapproved">@color/orange_jazzy</color>

--- a/WordPress/src/main/res/values/reader_styles.xml
+++ b/WordPress/src/main/res/values/reader_styles.xml
@@ -5,7 +5,7 @@
 -->
 <resources>
     <style name="ReaderMediaViewerTheme" parent="Theme.AppCompat.NoActionBar">
-        <item name="colorAccent">@color/accent_material_dark</item>
+        <item name="colorAccent">@color/reader_accent_material_dark</item>
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowFullscreen">true</item>
     </style>

--- a/libs/analytics/WordPressAnalytics/build.gradle
+++ b/libs/analytics/WordPressAnalytics/build.gradle
@@ -26,8 +26,8 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         versionName "1.3.0"

--- a/libs/editor/WordPressEditor/build.gradle
+++ b/libs/editor/WordPressEditor/build.gradle
@@ -19,8 +19,8 @@ repositories {
 }
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         versionCode 13
@@ -46,10 +46,10 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support:support-v13:26.1.0'
-    implementation 'com.android.support:support-v4:26.1.0'
-    implementation 'com.android.support:design:26.1.0'
+    implementation 'com.android.support:appcompat-v7:27.1.0'
+    implementation 'com.android.support:support-v13:27.1.0'
+    implementation 'com.android.support:support-v4:27.1.0'
+    implementation 'com.android.support:design:27.1.0'
     implementation 'org.apache.commons:commons-lang3:3.5'
     implementation 'org.wordpress:utils:1.18.1'
 

--- a/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
+++ b/libs/editor/WordPressEditor/src/main/java/org/wordpress/android/editor/EditorFragment.java
@@ -540,6 +540,7 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         }
     }
 
+    @SuppressLint("AddJavascriptInterface")
     protected void initJsEditor() {
         if (!isAdded()) {
             return;
@@ -564,7 +565,6 @@ public class EditorFragment extends EditorFragmentAbstract implements View.OnCli
         if (Build.VERSION.SDK_INT < 17) {
             mWebView.setJsCallbackReceiver(new JsCallbackReceiver(this));
         } else {
-            //noinspection AddJavascriptInterface
             mWebView.addJavascriptInterface(new JsCallbackReceiver(this), JS_CALLBACK_HANDLER);
         }
 

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -17,8 +17,8 @@ repositories {
 }
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 16
@@ -35,8 +35,8 @@ dependencies {
         exclude group: "com.mcxiaoke.volley"
     }
 
-    implementation 'com.android.support:appcompat-v7:26.1.0'
-    implementation 'com.android.support:design:26.1.0'
+    implementation 'com.android.support:appcompat-v7:27.1.0'
+    implementation 'com.android.support:design:27.1.0'
 
     implementation 'com.google.android.gms:play-services-auth:10.0.1'
 

--- a/libs/networking/WordPressNetworking/build.gradle
+++ b/libs/networking/WordPressNetworking/build.gradle
@@ -18,8 +18,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'maven'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         minSdkVersion 14

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -20,9 +20,9 @@ repositories {
 dependencies {
     implementation 'org.apache.commons:commons-text:1.1'
     implementation 'com.mcxiaoke.volley:library:1.0.18'
-    implementation 'com.android.support:support-v13:26.1.0'
-    implementation 'com.android.support:design:26.1.0'
-    implementation 'com.android.support:recyclerview-v7:26.1.0'
+    implementation 'com.android.support:support-v13:27.1.0'
+    implementation 'com.android.support:design:27.1.0'
+    implementation 'com.android.support:recyclerview-v7:27.1.0'
     implementation 'org.greenrobot:eventbus:3.0.0'
 
     lintChecks 'org.wordpress:lint:1.0.0'
@@ -31,8 +31,8 @@ dependencies {
 android {
     useLibrary 'org.apache.http.legacy'
 
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         versionName "1.20.0"


### PR DESCRIPTION
Updates the following:
- `compileSdkVersion` to 27
- `buildToolsVersion` to 27.0.3 
- support library modules to version 27.1.0. 

There was a minor change required to fix the build.