### PR TITLE
Issue/7483 post preview blank after rotate

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
+++ b/WordPress/src/main/java/org/wordpress/android/modules/AppComponent.java
@@ -72,6 +72,7 @@ import org.wordpress.android.ui.plugins.PluginDetailActivity;
 import org.wordpress.android.ui.plugins.PluginListFragment;
 import org.wordpress.android.ui.posts.AddCategoryFragment;
 import org.wordpress.android.ui.posts.EditPostActivity;
+import org.wordpress.android.ui.posts.EditPostPreviewFragment;
 import org.wordpress.android.ui.posts.EditPostSettingsFragment;
 import org.wordpress.android.ui.posts.PostPreviewActivity;
 import org.wordpress.android.ui.posts.PostPreviewFragment;
@@ -304,6 +305,8 @@ public interface AppComponent extends AndroidInjector<WordPress> {
     void inject(EditPostActivity object);
 
     void inject(EditPostSettingsFragment object);
+
+    void inject(EditPostPreviewFragment object);
 
     void inject(PostSettingsTagsActivity object);
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -442,7 +442,7 @@ public class EditPostActivity extends AppCompatActivity implements
                                     @Override
                                     public void run() {
                                         if (mEditPostPreviewFragment != null) {
-                                            mEditPostPreviewFragment.loadPost(mPost);
+                                            mEditPostPreviewFragment.loadPost();
                                         }
                                     }
                                 });
@@ -1733,7 +1733,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 case 1:
                     return EditPostSettingsFragment.newInstance();
                 default:
-                    return EditPostPreviewFragment.newInstance(mSite);
+                    return EditPostPreviewFragment.newInstance(mSite, mPost);
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1733,7 +1733,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 case 1:
                     return EditPostSettingsFragment.newInstance();
                 default:
-                    return EditPostPreviewFragment.newInstance(mSite, mPost);
+                    return EditPostPreviewFragment.newInstance(mPost);
             }
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPreviewFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostPreviewFragment.java
@@ -24,20 +24,18 @@ import org.wordpress.android.util.WPHtml;
 import javax.inject.Inject;
 
 public class EditPostPreviewFragment extends Fragment {
-    private static final String ARG_POST_ID = "post_id";
+    private static final String ARG_LOCAL_POST_ID = "local_post_id";
     private WebView mWebView;
     private TextView mTextView;
-
+    private int mLocalPostId;
     private LoadPostPreviewTask mLoadTask;
-
-    private int mPostId;
 
     @Inject PostStore mPostStore;
 
     public static EditPostPreviewFragment newInstance(@NonNull PostModel post) {
         EditPostPreviewFragment fragment = new EditPostPreviewFragment();
         Bundle bundle = new Bundle();
-        bundle.putInt(ARG_POST_ID, post.getId());
+        bundle.putInt(ARG_LOCAL_POST_ID, post.getId());
         fragment.setArguments(bundle);
         return fragment;
     }
@@ -45,7 +43,7 @@ public class EditPostPreviewFragment extends Fragment {
     @Override
     public void setArguments(Bundle args) {
         super.setArguments(args);
-        mPostId = args.getInt(ARG_POST_ID);
+        mLocalPostId = args.getInt(ARG_LOCAL_POST_ID);
     }
 
     @Override
@@ -114,7 +112,7 @@ public class EditPostPreviewFragment extends Fragment {
                 return null;
             }
 
-            mPost = mPostStore.getPostByLocalPostId(mPostId);
+            mPost = mPostStore.getPostByLocalPostId(mLocalPostId);
             if (mPost == null) {
                 return null;
             }


### PR DESCRIPTION
Fixes #7483 - rotating the device while previewing a post now correctly shows the post.

To test:

- Open a post in the editor
- Preview the post
- Rotate the device

Previously this would result in an empty preview.