### PR TITLE
Changed google api client ID so it's unique to that fragment

### DIFF
--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginEmailFragment.java
@@ -61,7 +61,7 @@ public class LoginEmailFragment extends LoginBaseFormFragment<LoginListener> imp
     private static final String KEY_OLD_SITES_IDS = "KEY_OLD_SITES_IDS";
     private static final String KEY_REQUESTED_EMAIL = "KEY_REQUESTED_EMAIL";
     private static final String LOG_TAG = LoginEmailFragment.class.getSimpleName();
-    private static final int GOOGLE_API_CLIENT_ID = 1001;
+    private static final int GOOGLE_API_CLIENT_ID = 1002;
     private static final int EMAIL_CREDENTIALS_REQUEST_CODE = 25100;
 
     public static final String TAG = "login_email_fragment_tag";


### PR DESCRIPTION
Fixes #7106 

There’s only 2 fragments that use the `autoManagement` functionality, namely `LoginEmailFragment` and `SignupEmailFragment`.
As per what I could test, I think these 2 fragments seem to briefly coexist when you try to signup with an email that is already registered on wp.com: tapping NEXT briefly connects to the server and ends up moving  from `SignupEmailFragment` and getting `LoginEmailFragment` to slide in, while showing the “Email already exists in wp.com - proceeding with login” snackbar.
At this point, the first fragment is only detached once the second one is fully visible. Thus, the exception occurs.

This PR tries to solve that by using a different Google API client ID for each fragment.


To test: N/A

