### PR TITLE
Issue/7527 - Cancel edit dialog on rotation

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/comments/EditCommentActivity.java
@@ -49,11 +49,14 @@ public class EditCommentActivity extends AppCompatActivity {
     static final String KEY_NOTE_ID = "KEY_NOTE_ID";
 
     private static final int ID_DIALOG_SAVING = 0;
+    private static final String ARG_CANCEL_EDITING_COMMENT_DIALOG_VISIBLE = "cancel_editing_comment_dialog_visible";
 
     private SiteModel mSite;
     private CommentModel mComment;
     private Note mNote;
     private boolean mFetchingComment;
+
+    private AlertDialog mCancelEditCommentDialog;
 
     @Inject Dispatcher mDispatcher;
     @Inject SiteStore mSiteStore;
@@ -79,6 +82,12 @@ public class EditCommentActivity extends AppCompatActivity {
 
         loadComment(getIntent());
 
+        if (icicle != null) {
+            if (icicle.getBoolean(ARG_CANCEL_EDITING_COMMENT_DIALOG_VISIBLE, false)) {
+                cancelEditCommentConfirmation();
+            }
+        }
+
         ActivityId.trackLastActivity(ActivityId.COMMENT_EDITOR);
     }
 
@@ -86,6 +95,15 @@ public class EditCommentActivity extends AppCompatActivity {
     public void onStart() {
         super.onStart();
         mDispatcher.register(this);
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        if (mCancelEditCommentDialog != null) {
+            outState.putBoolean(ARG_CANCEL_EDITING_COMMENT_DIALOG_VISIBLE, mCancelEditCommentDialog.isShowing());
+        }
     }
 
     @Override
@@ -278,28 +296,39 @@ public class EditCommentActivity extends AppCompatActivity {
     @Override
     public void onBackPressed() {
         if (isCommentEdited()) {
-            AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(
-                    new ContextThemeWrapper(this, R.style.Calypso_Dialog));
-            dialogBuilder.setTitle(getResources().getText(R.string.cancel_edit));
-            dialogBuilder.setMessage(getResources().getText(R.string.sure_to_cancel_edit_comment));
-            dialogBuilder.setPositiveButton(getResources().getText(R.string.yes),
-                                            new DialogInterface.OnClickListener() {
-                                                public void onClick(DialogInterface dialog, int whichButton) {
-                                                    finish();
-                                                }
-                                            });
-            dialogBuilder.setNegativeButton(
-                    getResources().getText(R.string.no),
-                    new DialogInterface.OnClickListener() {
-                        public void onClick(DialogInterface dialog, int whichButton) {
-                            // just close the dialog
-                        }
-                    });
-            dialogBuilder.setCancelable(true);
-            dialogBuilder.create().show();
+            cancelEditCommentConfirmation();
         } else {
             super.onBackPressed();
         }
+    }
+
+    private void cancelEditCommentConfirmation() {
+        if (mCancelEditCommentDialog != null) {
+            mCancelEditCommentDialog.show();
+            return;
+        }
+
+        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(
+                new ContextThemeWrapper(this, R.style.Calypso_Dialog));
+        dialogBuilder.setTitle(getResources().getText(R.string.cancel_edit));
+        dialogBuilder.setMessage(getResources().getText(R.string.sure_to_cancel_edit_comment));
+        dialogBuilder.setPositiveButton(getResources().getText(R.string.yes),
+                new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int whichButton) {
+                        finish();
+                    }
+                });
+        dialogBuilder.setNegativeButton(
+                getResources().getText(R.string.no),
+                new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int whichButton) {
+                        // just close the dialog
+                    }
+                });
+        dialogBuilder.setCancelable(true);
+
+        mCancelEditCommentDialog = dialogBuilder.create();
+        mCancelEditCommentDialog.show();
     }
 
     private void onCommentPushed(OnCommentChanged event) {


### PR DESCRIPTION
Fixes #7527 - Edit Comment: Cancel edit dialog leaks on rotation 

**To test:**

1. Go to edit comment screen
2. Edit the comment
3. Press the back button
4. The Cancel dialog is shown
5. Rotate device and notice the Cancel dialog is showing again

cc @theck13 