### PR TITLE
Fixed issue where app was ignoring non-english device languages on in…

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/util/LocaleManager.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/LocaleManager.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Helper class for working with localized strings. Ensures updates to the users
@@ -29,6 +30,11 @@ public class LocaleManager {
      * Key used for saving the language selection to shared preferences.
      */
     private static final String LANGUAGE_KEY = "language-pref";
+
+    /**
+     * Pattern to split a language string (to parse the language and region values).
+     */
+    private static Pattern languageSplitter = Pattern.compile("_");
 
     /**
      * Activate the locale associated with the provided context.
@@ -143,23 +149,20 @@ public class LocaleManager {
 
     /**
      * Gets a locale for the given language code.
-     * @param languageCode The 2-letter language code (example "en"). If null or empty will return
+     * @param languageCode The language code (example "en" or "es-US"). If null or empty will return
      *                     the current default locale.
      */
     public static Locale languageLocale(@Nullable String languageCode) {
         if (TextUtils.isEmpty(languageCode)) {
             return Locale.getDefault();
         }
-        if (languageCode.contains("_")) {
-            // Attempt to parse language and region codes.
-            String[] opts = languageCode.split("_");
-            if (opts.length >= 2) {
-                return new Locale(opts[0], opts[1]);
-            } else {
-                return new Locale(opts[0]);
-            }
+        // Attempt to parse language and region codes.
+        String[] opts = languageSplitter.split(languageCode, 0);
+        if (opts.length > 1) {
+            return new Locale(opts[0], opts[1]);
+        } else {
+            return new Locale(opts[0]);
         }
-        return new Locale(languageCode);
     }
 
     /**


### PR DESCRIPTION
This PR fixes two issues:

## Fixes
***Issue 1***
App ignoring non-english device languages on install and defaulting to English. 

This was a parsing issue when dealing with language + region strings (Example: `es-US`). The previous logic for parsing the Locale object from this string would only work in the case of a language string that did NOT contain the region code. (Example: `en`). Since the logic did not split the language and region, the locale was not being parsed and was defaulting to the base language on every Android Device: English.

**The Fix:**
Properly break up strings by "_" separator to properly instantiate a Locale Object:
```
public static Locale languageLocale(@Nullable String languageCode) {
    if (TextUtils.isEmpty(languageCode)) {
        return Locale.getDefault();
    }
    if (languageCode.contains("_")) {
        // Attempt to parse language and region codes.
        String[] opts = languageCode.split("_");
        if (opts.length >= 2) {
            return new Locale(opts[0], opts[1]);
        } else {
            return new Locale(opts[0]);
        }
    }
    return new Locale(languageCode);
}
```
While I was in this block I also updated the logic to accept 2 and 3-letter language codes to be compliant with ISO 639. Removed the hardcoded string lengths. 

***Issue 2***
When changing language in App Settings, the region code was being stripped before saving to SharedPreferences. For example `es_CO` would be stripped and saved as `es`. This worked great for updating the interface, but would not be applying the region-value of the language. 

**The Fix:**
Save the full string to SharedPreferences. 

## To test:
Issue 1:
1. Set device to a non-english language. 
2. Do a fresh install WordPress. 
3. Language should match the system language settings.

Issue 2:
1. Open WordPress App and open App Settings
2. Change language to "Spanish (Colombia)"
3. Click Ok
4. Verify the language reflects "Espanol (Colombia)" on the App Settings screen. 
5. Change language to "Espanol (Chile)". 
6. Click ok
7. Verify the language reflects "Espanol (Chile)" on the App Settings Screen. 
