### PR TITLE
Fix NestedScrollView in Switch Control mode

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/NestedScrollViewExt.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/NestedScrollViewExt.java
@@ -3,6 +3,8 @@ package org.wordpress.android.ui.stats;
 import android.content.Context;
 import android.util.AttributeSet;
 
+import org.wordpress.android.widgets.WPNestedScrollView;
+
 public class NestedScrollViewExt extends WPNestedScrollView {
     private ScrollViewListener mScrollViewListener = null;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/NestedScrollViewExt.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/NestedScrollViewExt.java
@@ -1,10 +1,9 @@
 package org.wordpress.android.ui.stats;
 
 import android.content.Context;
-import android.support.v4.widget.NestedScrollView;
 import android.util.AttributeSet;
 
-public class NestedScrollViewExt extends NestedScrollView {
+public class NestedScrollViewExt extends WPNestedScrollView {
     private ScrollViewListener mScrollViewListener = null;
 
     public NestedScrollViewExt(Context context) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/WPNestedScrollView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/WPNestedScrollView.java
@@ -26,8 +26,6 @@ import android.widget.ScrollView;
  * https://issuetracker.google.com/issues/68366782
  * https://issuetracker.google.com/issues/70310373
  */
-@SuppressWarnings("CheckStyle")  // we want to keep the code as similar to the original as possible
-//CHECKSTYLE:OFF
 public class WPNestedScrollView extends NestedScrollView {
     private static final AccessibilityDelegate ACCESSIBILITY_DELEGATE = new AccessibilityDelegate();
 
@@ -65,30 +63,32 @@ public class WPNestedScrollView extends NestedScrollView {
             if (!nsvHost.isEnabled()) {
                 return false;
             }
+            int viewportHeight;
+            int targetScrollY;
             switch (action) {
-                case AccessibilityNodeInfoCompat.ACTION_SCROLL_FORWARD: {
+                case AccessibilityNodeInfoCompat.ACTION_SCROLL_FORWARD:
                     nsvHost.fling(0);
-                    final int viewportHeight = nsvHost.getHeight() - nsvHost.getPaddingBottom()
+                    viewportHeight = nsvHost.getHeight() - nsvHost.getPaddingBottom()
                                                - nsvHost.getPaddingTop();
-                    final int targetScrollY = Math.min(nsvHost.getScrollY() + viewportHeight,
+                    targetScrollY = Math.min(nsvHost.getScrollY() + viewportHeight,
                             nsvHost.getScrollRange());
                     if (targetScrollY != nsvHost.getScrollY()) {
                         nsvHost.smoothScrollTo(0, targetScrollY);
                         return true;
                     }
-                }
-                return false;
-                case AccessibilityNodeInfoCompat.ACTION_SCROLL_BACKWARD: {
+
+                    return false;
+                case AccessibilityNodeInfoCompat.ACTION_SCROLL_BACKWARD:
                     nsvHost.fling(0);
-                    final int viewportHeight = nsvHost.getHeight() - nsvHost.getPaddingBottom()
+                    viewportHeight = nsvHost.getHeight() - nsvHost.getPaddingBottom()
                                                - nsvHost.getPaddingTop();
-                    final int targetScrollY = Math.max(nsvHost.getScrollY() - viewportHeight, 0);
+                    targetScrollY = Math.max(nsvHost.getScrollY() - viewportHeight, 0);
                     if (targetScrollY != nsvHost.getScrollY()) {
                         nsvHost.smoothScrollTo(0, targetScrollY);
                         return true;
                     }
-                }
-                return false;
+
+                    return false;
             }
             return false;
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/WPNestedScrollView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/WPNestedScrollView.java
@@ -1,0 +1,127 @@
+package org.wordpress.android.ui.stats;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.v4.view.AccessibilityDelegateCompat;
+import android.support.v4.view.ViewCompat;
+import android.support.v4.view.accessibility.AccessibilityNodeInfoCompat;
+import android.support.v4.view.accessibility.AccessibilityRecordCompat;
+import android.support.v4.widget.NestedScrollView;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.accessibility.AccessibilityEvent;
+import android.widget.ScrollView;
+
+
+/**
+ * Code copied from android.support.v4.widget.NestedScrollView with one modification in the AccessibilityDelegate
+ * .performAccessibilityAction(..) method. There is a bug in the Support Library which breaks scroll in the
+ * Accessibility Switch Control mode.
+ * Steps to reproduce the bug
+ * 1. Go to Stats
+ * 2. Scroll to the bottom using the Switch Control
+ * 3. Try to scroll to the top -> clicking on the scrollView doesn't do anything.
+ * <p>
+ * WARNING - Do not modify this file, so we can remove it, when the bug in the support library is fixed.
+ * https://issuetracker.google.com/issues/68366782
+ * https://issuetracker.google.com/issues/70310373
+ */
+@SuppressWarnings("CheckStyle")  // we want to keep the code as similar to the original as possible
+public class WPNestedScrollView extends NestedScrollView {
+    private static final AccessibilityDelegate ACCESSIBILITY_DELEGATE = new AccessibilityDelegate();
+
+    public WPNestedScrollView(Context context) {
+        this(context, null);
+    }
+
+    public WPNestedScrollView(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public WPNestedScrollView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        ViewCompat.setAccessibilityDelegate(this, ACCESSIBILITY_DELEGATE);
+    }
+
+
+    int getScrollRange() {
+        int scrollRange = 0;
+        if (getChildCount() > 0) {
+            View child = getChildAt(0);
+            scrollRange = Math.max(0,
+                    child.getHeight() - (getHeight() - getPaddingBottom() - getPaddingTop()));
+        }
+        return scrollRange;
+    }
+
+    static class AccessibilityDelegate extends AccessibilityDelegateCompat {
+        @Override
+        public boolean performAccessibilityAction(View host, int action, Bundle arguments) {
+            if (super.performAccessibilityAction(host, action, arguments)) {
+                return true;
+            }
+            final WPNestedScrollView nsvHost = (WPNestedScrollView) host;
+            if (!nsvHost.isEnabled()) {
+                return false;
+            }
+            switch (action) {
+                case AccessibilityNodeInfoCompat.ACTION_SCROLL_FORWARD: {
+                    nsvHost.fling(0);
+                    final int viewportHeight = nsvHost.getHeight() - nsvHost.getPaddingBottom()
+                                               - nsvHost.getPaddingTop();
+                    final int targetScrollY = Math.min(nsvHost.getScrollY() + viewportHeight,
+                            nsvHost.getScrollRange());
+                    if (targetScrollY != nsvHost.getScrollY()) {
+                        nsvHost.smoothScrollTo(0, targetScrollY);
+                        return true;
+                    }
+                }
+                return false;
+                case AccessibilityNodeInfoCompat.ACTION_SCROLL_BACKWARD: {
+                    nsvHost.fling(0);
+                    final int viewportHeight = nsvHost.getHeight() - nsvHost.getPaddingBottom()
+                                               - nsvHost.getPaddingTop();
+                    final int targetScrollY = Math.max(nsvHost.getScrollY() - viewportHeight, 0);
+                    if (targetScrollY != nsvHost.getScrollY()) {
+                        nsvHost.smoothScrollTo(0, targetScrollY);
+                        return true;
+                    }
+                }
+                return false;
+            }
+            return false;
+        }
+
+        @Override
+        public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {
+            super.onInitializeAccessibilityNodeInfo(host, info);
+            final WPNestedScrollView nsvHost = (WPNestedScrollView) host;
+            info.setClassName(ScrollView.class.getName());
+            if (nsvHost.isEnabled()) {
+                final int scrollRange = nsvHost.getScrollRange();
+                if (scrollRange > 0) {
+                    info.setScrollable(true);
+                    if (nsvHost.getScrollY() > 0) {
+                        info.addAction(AccessibilityNodeInfoCompat.ACTION_SCROLL_BACKWARD);
+                    }
+                    if (nsvHost.getScrollY() < scrollRange) {
+                        info.addAction(AccessibilityNodeInfoCompat.ACTION_SCROLL_FORWARD);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void onInitializeAccessibilityEvent(View host, AccessibilityEvent event) {
+            super.onInitializeAccessibilityEvent(host, event);
+            final WPNestedScrollView nsvHost = (WPNestedScrollView) host;
+            event.setClassName(ScrollView.class.getName());
+            final boolean scrollable = nsvHost.getScrollRange() > 0;
+            event.setScrollable(scrollable);
+            event.setScrollX(nsvHost.getScrollX());
+            event.setScrollY(nsvHost.getScrollY());
+            AccessibilityRecordCompat.setMaxScrollX(event, nsvHost.getScrollX());
+            AccessibilityRecordCompat.setMaxScrollY(event, nsvHost.getScrollRange());
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/stats/WPNestedScrollView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/stats/WPNestedScrollView.java
@@ -27,6 +27,7 @@ import android.widget.ScrollView;
  * https://issuetracker.google.com/issues/70310373
  */
 @SuppressWarnings("CheckStyle")  // we want to keep the code as similar to the original as possible
+//CHECKSTYLE:OFF
 public class WPNestedScrollView extends NestedScrollView {
     private static final AccessibilityDelegate ACCESSIBILITY_DELEGATE = new AccessibilityDelegate();
 

--- a/WordPress/src/main/java/org/wordpress/android/widgets/WPNestedScrollView.java
+++ b/WordPress/src/main/java/org/wordpress/android/widgets/WPNestedScrollView.java
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.stats;
+package org.wordpress.android.widgets;
 
 import android.content.Context;
 import android.os.Bundle;

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -72,7 +72,7 @@
 
     </android.support.design.widget.AppBarLayout>
 
-    <android.support.v4.widget.NestedScrollView
+    <org.wordpress.android.ui.stats.WPNestedScrollView
         android:id="@+id/scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -549,7 +549,7 @@
 
         </RelativeLayout>
 
-    </android.support.v4.widget.NestedScrollView>
+    </org.wordpress.android.ui.stats.WPNestedScrollView>
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/fab_button"

--- a/WordPress/src/main/res/layout/media_settings_activity.xml
+++ b/WordPress/src/main/res/layout/media_settings_activity.xml
@@ -72,7 +72,7 @@
 
     </android.support.design.widget.AppBarLayout>
 
-    <org.wordpress.android.ui.stats.WPNestedScrollView
+    <org.wordpress.android.widgets.WPNestedScrollView
         android:id="@+id/scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -549,7 +549,7 @@
 
         </RelativeLayout>
 
-    </org.wordpress.android.ui.stats.WPNestedScrollView>
+    </org.wordpress.android.widgets.WPNestedScrollView>
 
     <android.support.design.widget.FloatingActionButton
         android:id="@+id/fab_button"

--- a/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
+++ b/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
@@ -206,7 +206,7 @@
     </LinearLayout>
 
 
-    <org.wordpress.android.ui.stats.WPNestedScrollView
+    <org.wordpress.android.widgets.WPNestedScrollView
         android:id="@+id/connect_jetpack"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -241,5 +241,5 @@
                 android:text="@string/stats_jetpack_connection_setup"
                 android:theme="@style/JetpackConnectionButton"/>
         </LinearLayout>
-    </org.wordpress.android.ui.stats.WPNestedScrollView>
+    </org.wordpress.android.widgets.WPNestedScrollView>
 </android.support.design.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
+++ b/WordPress/src/main/res/layout/notifications_fragment_notes_list.xml
@@ -206,7 +206,7 @@
     </LinearLayout>
 
 
-    <android.support.v4.widget.NestedScrollView
+    <org.wordpress.android.ui.stats.WPNestedScrollView
         android:id="@+id/connect_jetpack"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -222,6 +222,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_extra_large"
+                android:contentDescription="@null"
                 app:srcCompat="@drawable/jetpack_connection_notifications"/>
 
             <TextView
@@ -240,5 +241,5 @@
                 android:text="@string/stats_jetpack_connection_setup"
                 android:theme="@style/JetpackConnectionButton"/>
         </LinearLayout>
-    </android.support.v4.widget.NestedScrollView>
+    </org.wordpress.android.ui.stats.WPNestedScrollView>
 </android.support.design.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -59,7 +59,7 @@
 
     </android.support.design.widget.AppBarLayout>
 
-    <org.wordpress.android.ui.stats.WPNestedScrollView
+    <org.wordpress.android.widgets.WPNestedScrollView
         android:id="@+id/scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -448,5 +448,5 @@
 
             <include layout="@layout/plugin_ratings_cardview" />
         </LinearLayout>
-    </org.wordpress.android.ui.stats.WPNestedScrollView>
+    </org.wordpress.android.widgets.WPNestedScrollView>
 </android.support.design.widget.CoordinatorLayout>

--- a/WordPress/src/main/res/layout/plugin_detail_activity.xml
+++ b/WordPress/src/main/res/layout/plugin_detail_activity.xml
@@ -59,7 +59,7 @@
 
     </android.support.design.widget.AppBarLayout>
 
-    <android.support.v4.widget.NestedScrollView
+    <org.wordpress.android.ui.stats.WPNestedScrollView
         android:id="@+id/scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -448,5 +448,5 @@
 
             <include layout="@layout/plugin_ratings_cardview" />
         </LinearLayout>
-    </android.support.v4.widget.NestedScrollView>
+    </org.wordpress.android.ui.stats.WPNestedScrollView>
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
Fixes #7471

Fixes broken NestedScrollView scroll in the Switch Control mode.

To test:
1. Go to Stats, Media Settings, and Jetpack Plugin Details.
2. Scroll to the bottom.
3. Scroll to the top.