### PR TITLE
Make overflow menu Publish Now option behave the same as PUBLISH action

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1064,11 +1064,7 @@ public class EditPostActivity extends AppCompatActivity implements
                 if (PostStatus.fromPost(mPost) == PostStatus.DRAFT) {
                     showPublishConfirmationDialog();
                 } else {
-                    UploadUtils.showSnackbar(findViewById(R.id.editor_activity), R.string.editor_uploading_post);
-                    if (isNewPost()) {
-                        mPost.setStatus(PostStatus.DRAFT.toString());
-                    }
-                    savePostAndOptionallyFinish(false);
+                    showPublishConfirmationOrUpdateIfNotLocalDraft();
                 }
             } else if (itemId == R.id.menu_html_mode) {
                 // toggle HTML mode


### PR DESCRIPTION
Fixes #7562 and #7563 

This PR makes the handling of `itemId == R.id.menu_save_as_draft_or_publish` in the overflow menu behave the same as in the main action bar item `itemId == R.id.menu_save_post`
https://github.com/wordpress-mobile/WordPress-Android/blob/release/9.7/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java#L1040

To test:
*CASE A: using the overflow menu*
1. Start a new post in the app but don't enter any content.
2. Open the overflow menu.
3. Select "Publish Now."
4. observe the dialog appears and tap PUBLISH NOW
5. observe a toast is shown saying can't publish an empty post.

*CASE B: using the action bar action*
1. Start a new post in the app but don't enter any content.
2. Tap on the action bar's PUBLISH action
3. observe the dialog appears and tap PUBLISH NOW
4. observe a toast is shown saying can't publish an empty post.
