### PR TITLE
fixed using getSpaceAllowed instead of getSpaceAvailable

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -1051,7 +1051,7 @@ public abstract class SiteSettingsInterface {
                     mContext.getString(R.string.file_size_in_megabytes),
                     mContext.getString(R.string.file_size_in_gigabytes),
                     mContext.getString(R.string.file_size_in_terabytes) };
-            String spaceAllowed = FormatUtils.formatFileSize(mSite.getSpaceAvailable(), units);
+            String spaceAllowed = FormatUtils.formatFileSize(mSite.getSpaceAllowed(), units);
             String quotaAvailableSentence = String.format(mContext.getString(R.string.site_settings_quota_space_value),
                     percentage, spaceAllowed);
             setQuotaDiskSpace(quotaAvailableSentence);


### PR DESCRIPTION

Fixes #7564 

To test:
1. Go to site settings
2. Observe the space allowed is now correct
<img width="232" alt="screen shot 2018-03-29 at 11 48 23 am" src="https://user-images.githubusercontent.com/6597771/38095626-4bb7e3be-3347-11e8-9540-0a3e324674c1.png">
