### PR TITLE
Fixing TalkBack issues around site creation process

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
@@ -352,8 +352,7 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
                 mutateToCompleted(mWebViewLoadedInTime);
                 break;
         }
-
+        
         getView().announceForAccessibility(statusAnnouncement);
     }
-
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
@@ -303,18 +303,22 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
                 configureImage(false);
                 break;
             case NEW_SITE:
+                getView().announceForAccessibility(getText(R.string.site_creation_creating_laying_foundation));
                 disableUntil(R.id.site_creation_creating_laying_foundation);
                 configureImage(false);
                 break;
             case FETCHING_NEW_SITE:
+                getView().announceForAccessibility(getText(R.string.site_creation_creating_fetching_info));
                 disableUntil(R.id.site_creation_creating_fetching_info);
                 configureImage(false);
                 break;
             case SET_TAGLINE:
+                getView().announceForAccessibility(getText(R.string.site_creation_creating_configuring_content));
                 disableUntil(R.id.site_creation_creating_configuring_content);
                 configureImage(false);
                 break;
             case SET_THEME:
+                getView().announceForAccessibility(getText(R.string.site_creation_creating_configuring_theme));
                 disableUntil(R.id.site_creation_creating_configuring_theme);
                 configureImage(false);
                 break;
@@ -327,6 +331,7 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
                 NetworkUtils.checkConnection(getContext());
                 break;
             case PRELOAD:
+                getView().announceForAccessibility(getText(R.string.site_creation_creating_preparing_frontend));
                 disableUntil(R.id.site_creation_creating_preparing_frontend);
                 configureImage(false);
                 mPreviewWebViewClient = loadWebview();

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
@@ -352,7 +352,6 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
                 mutateToCompleted(mWebViewLoadedInTime);
                 break;
         }
-        
         getView().announceForAccessibility(statusAnnouncement);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationCreatingFragment.java
@@ -262,7 +262,7 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
 
     private void configureImage(boolean hasFailure) {
         mImageView.setImageResource(hasFailure ? R.drawable.img_site_error_camera_pencils_226dp
-                                            : R.drawable.img_site_wordpress_camera_pencils_226dp);
+                : R.drawable.img_site_wordpress_camera_pencils_226dp);
     }
 
     private void handleFailure(final SiteCreationState failedState) {
@@ -278,7 +278,7 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
                 AppLog.d(T.NUX, "User retries failed site creation on step: " + failedState.getStepName());
                 if (failedState.isTerminal()) {
                     throw new RuntimeException("Internal inconsistency: Cannot resume site creation from "
-                            + failedState.getStepName());
+                                               + failedState.getStepName());
                 } else {
                     createSite(failedState);
                 }
@@ -296,34 +296,36 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
 
         configureBackButton();
 
+        CharSequence statusAnnouncement = "";
+
         switch (event.getStep()) {
             case IDLE:
-                getView().announceForAccessibility(getText(R.string.notification_site_creation_title_in_progress));
+                statusAnnouncement = getText(R.string.notification_site_creation_title_in_progress);
                 disableUntil(0);
                 configureImage(false);
                 break;
             case NEW_SITE:
-                getView().announceForAccessibility(getText(R.string.site_creation_creating_laying_foundation));
+                statusAnnouncement = getText(R.string.site_creation_creating_laying_foundation);
                 disableUntil(R.id.site_creation_creating_laying_foundation);
                 configureImage(false);
                 break;
             case FETCHING_NEW_SITE:
-                getView().announceForAccessibility(getText(R.string.site_creation_creating_fetching_info));
+                statusAnnouncement = getText(R.string.site_creation_creating_fetching_info);
                 disableUntil(R.id.site_creation_creating_fetching_info);
                 configureImage(false);
                 break;
             case SET_TAGLINE:
-                getView().announceForAccessibility(getText(R.string.site_creation_creating_configuring_content));
+                statusAnnouncement = getText(R.string.site_creation_creating_configuring_content);
                 disableUntil(R.id.site_creation_creating_configuring_content);
                 configureImage(false);
                 break;
             case SET_THEME:
-                getView().announceForAccessibility(getText(R.string.site_creation_creating_configuring_theme));
+                statusAnnouncement = getText(R.string.site_creation_creating_configuring_theme);
                 disableUntil(R.id.site_creation_creating_configuring_theme);
                 configureImage(false);
                 break;
             case FAILURE:
-                getView().announceForAccessibility(getText(R.string.notification_site_creation_failed));
+                statusAnnouncement = getText(R.string.notification_site_creation_failed);
                 configureImage(true);
                 mProgressContainer.setVisibility(View.GONE);
                 mErrorContainer.setVisibility(View.VISIBLE);
@@ -331,13 +333,13 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
                 NetworkUtils.checkConnection(getContext());
                 break;
             case PRELOAD:
-                getView().announceForAccessibility(getText(R.string.site_creation_creating_preparing_frontend));
+                statusAnnouncement = getText(R.string.site_creation_creating_preparing_frontend);
                 disableUntil(R.id.site_creation_creating_preparing_frontend);
                 configureImage(false);
                 mPreviewWebViewClient = loadWebview();
                 break;
             case SUCCESS:
-                getView().announceForAccessibility(getText(R.string.notification_site_creation_title_success));
+                statusAnnouncement = getText(R.string.notification_site_creation_title_success);
                 mNewSiteLocalId = (Integer) event.getPayload();
 
                 if (mPreviewWebViewClient == null) {
@@ -350,5 +352,8 @@ public class SiteCreationCreatingFragment extends SiteCreationBaseFormFragment<S
                 mutateToCompleted(mWebViewLoadedInTime);
                 break;
         }
+
+        getView().announceForAccessibility(statusAnnouncement);
     }
+
 }

--- a/WordPress/src/main/res/layout/my_site_fragment.xml
+++ b/WordPress/src/main/res/layout/my_site_fragment.xml
@@ -482,6 +482,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/empty_list_button_top_margin"
             android:text="@string/my_site_add_new_site"
+            android:contentDescription="@string/my_site_add_new_site"
             android:theme="@style/WordPress.Button.Primary"/>
 
     </LinearLayout>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1980,7 +1980,7 @@
     <string name="notification_site_creation_step_fetching">Step 2 of 4</string>
     <string name="notification_site_creation_step_tagline">Step 3 of 4</string>
     <string name="notification_site_creation_step_theme">Step 4 of 4</string>
-    <string name="notification_site_creation_title_in_progress">Creating site…</string>
+    <string name="notification_site_creation_title_in_progress">Creating site… This might take a couple of minutes.</string>
     <string name="notification_site_creation_title_stopped">Site creation stopped</string>
     <string name="notification_site_creation_failed">An error has occurred.</string>
 


### PR DESCRIPTION
Fixes #7573 and adds announcing for site creation steps.

To test (1): 
Turn on Talk Back.
During sign up flow, reach the "ADD SITE" step (empty My Site fragment).
Select "ADD SITE" button, and make sure it's announced properly (ADD is not abbreviated).

To test (2):
During site creation flow, reach the last step:
![screenshot_1522674657](https://user-images.githubusercontent.com/728822/38197382-c5703e44-36c2-11e8-9c10-b05fa4de1600.png)
Make sure each step is announced.

I changed the first announcement, to make it more clear that the process might take some time, and decided to announce each step after that. I realize that majority of steps are announced towards the end, but it's still an accurate description of what is going on, and I think it's worth announcing.



