### PR TITLE
now showing unlimited storage space for business plans

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/SiteSettingsInterface.java
@@ -24,6 +24,7 @@ import org.wordpress.android.fluxc.store.SiteStore.OnPostFormatsChanged;
 import org.wordpress.android.models.CategoryModel;
 import org.wordpress.android.models.JetpackSettingsModel;
 import org.wordpress.android.models.SiteSettingsModel;
+import org.wordpress.android.ui.plans.PlansConstants;
 import org.wordpress.android.util.FormatUtils;
 import org.wordpress.android.util.LanguageUtils;
 import org.wordpress.android.util.LocaleManager;
@@ -1051,9 +1052,17 @@ public abstract class SiteSettingsInterface {
                     mContext.getString(R.string.file_size_in_megabytes),
                     mContext.getString(R.string.file_size_in_gigabytes),
                     mContext.getString(R.string.file_size_in_terabytes) };
-            String spaceAllowed = FormatUtils.formatFileSize(mSite.getSpaceAllowed(), units);
-            String quotaAvailableSentence = String.format(mContext.getString(R.string.site_settings_quota_space_value),
-                    percentage, spaceAllowed);
+
+            String quotaAvailableSentence;
+            if (mSite.getPlanId() == PlansConstants.BUSINESS_PLAN_ID) {
+                String usedSpace = FormatUtils.formatFileSize(mSite.getSpaceUsed(), units);
+                quotaAvailableSentence = String.format(mContext.getString(R.string.site_settings_quota_space_unlimited),
+                        usedSpace);
+            } else {
+                String spaceAllowed = FormatUtils.formatFileSize(mSite.getSpaceAllowed(), units);
+                quotaAvailableSentence = String.format(mContext.getString(R.string.site_settings_quota_space_value),
+                        percentage, spaceAllowed);
+            }
             setQuotaDiskSpace(quotaAvailableSentence);
         }
         // Self hosted always read account data from the main table

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -532,6 +532,7 @@
     <string name="site_settings_quota_space_title">Space Used</string>
     <string name="site_settings_quota_space_hint">If you need more space consider upgrading your WordPress plan.</string>
     <string name="site_settings_quota_space_value">%1$s of %2$s</string>
+    <string name="site_settings_quota_space_unlimited">%1$s of unlimited</string>
 
     <!-- these represent a formatted amount along with a measuring unit, i.e. 10 B, or 132 kB, or 10.2 MB, 1,037.76 kB etc. -->
     <string name="file_size_in_bytes">%s B</string>


### PR DESCRIPTION
Fixes #7571 

To test:
1. select a site with a Business Plan
2. on the main screen, go to Settings
3. scroll down to the Media section and observe the "Space Used" section under "Media" shows the amount of space used, "of unlimited", i.e. `2.8 GB of unlimited`, as shown in the screenshot below

![untitled 4](https://user-images.githubusercontent.com/6597771/38198709-48311ad8-3664-11e8-90f3-5c4f43136ae9.png)

cc @nbradbury as you mentioned this particular case in #7569 🙇 
