### PR TITLE
Fix/7562 publish now fix take 2

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1065,9 +1065,23 @@ public class EditPostActivity extends AppCompatActivity implements
             } else if (itemId == R.id.menu_save_as_draft_or_publish) {
                 // save as draft if it's a local post with UNKNOWN status, or PUBLISH if it's a DRAFT (as this
                 //  R.id.menu_save_as_draft button will be "Publish Now" in that case)
+
+                // we update the mPost object first, so we can pre-check Post publishability and inform the user
+                updatePostObject();
                 if (PostStatus.fromPost(mPost) == PostStatus.DRAFT) {
+                    if (isDiscardable()) {
+                        String message = getString(
+                                mIsPage ? R.string.error_publish_empty_page : R.string.error_publish_empty_post);
+                        ToastUtils.showToast(EditPostActivity.this, message, Duration.SHORT);
+                        return false;
+                    }
                     showPublishConfirmationDialog();
                 } else {
+                    if (isDiscardable()) {
+                        ToastUtils.showToast(EditPostActivity.this,
+                                getString(R.string.error_save_empty_draft), Duration.SHORT);
+                        return false;
+                    }
                     UploadUtils.showSnackbar(findViewById(R.id.editor_activity), R.string.editor_uploading_post);
                     if (isNewPost()) {
                         mPost.setStatus(PostStatus.DRAFT.toString());

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -3243,6 +3243,7 @@ public class EditPostActivity extends AppCompatActivity implements
             }
 
             mPost = post;
+            mIsNewPost = false;
             invalidateOptionsMenu();
             switch (PostStatus.fromPost(post)) {
                 case PUBLISHED:

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -713,6 +713,10 @@ public class EditPostActivity extends AppCompatActivity implements
             return getString(R.string.submit_for_review);
         }
 
+        if (isNewPost()) {
+            return getString(R.string.menu_save_as_draft);
+        }
+
         switch (PostStatus.fromPost(mPost)) {
             case DRAFT:
                 return getString(R.string.menu_publish_now);

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1064,7 +1064,11 @@ public class EditPostActivity extends AppCompatActivity implements
                 if (PostStatus.fromPost(mPost) == PostStatus.DRAFT) {
                     showPublishConfirmationDialog();
                 } else {
-                    showPublishConfirmationOrUpdateIfNotLocalDraft();
+                    UploadUtils.showSnackbar(findViewById(R.id.editor_activity), R.string.editor_uploading_post);
+                    if (isNewPost()) {
+                        mPost.setStatus(PostStatus.DRAFT.toString());
+                    }
+                    savePostAndOptionallyFinish(false);
                 }
             } else if (itemId == R.id.menu_html_mode) {
                 // toggle HTML mode

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1234,6 +1234,7 @@
     <string name="error_edit_comment">An error occurred while editing the comment</string>
     <string name="error_publish_empty_post">Can\'t publish an empty post</string>
     <string name="error_publish_empty_page">Can\'t publish an empty page</string>
+    <string name="error_save_empty_draft">Can\'t save an empty draft</string>
     <string name="error_publish_no_network">Device is offline. Changes saved locally.</string>
     <string name="error_upload_post_param">There was an error uploading this post: %s.</string>
     <string name="error_upload_page_param">There was an error uploading this page: %s.</string>


### PR DESCRIPTION
Coming from https://github.com/wordpress-mobile/WordPress-Android/pull/7568#issuecomment-377940373 and https://github.com/wordpress-mobile/WordPress-Android/pull/7568#issuecomment-377927499  (thanks for making the right questions @hypest!)

So, this PR should be reverted https://github.com/wordpress-mobile/WordPress-Android/pull/7568 (reverted in this PR in commit ef995ac) and THIS other thing was needed to be fixed: the actual labelling of options instead of _what they did_. What they did was right (so it really needed not be changed), but labelling was not.

My fault. Sorry @iamthomasbishop @hypest and @rachelmcr !

This PR now tackles this, effectively fixing #7562 and #7563 in the following way:
- This commit https://github.com/wordpress-mobile/WordPress-Android/commit/8e31dab6e236359cad75d8a7ae8b5bb727a62376 makes sure `Save as a Draft` is what is shown on the overflow menu for any brand new Post
- This commit https://github.com/wordpress-mobile/WordPress-Android/commit/5218e523e616d2dcd49a30d6fcc7eeb6188e13fa makes sure that once the Post is sent to the server, then `Save as Draft` is not shown anymore, and the labelling follows the pre-existing publishing logic (it either shows `Update` for posts having a `PUBLISHED` or `UNKNOWN` state, that we know are not local drafts, or shows `Save as a Draft` for any other case). Please note the switch with explicit state handling in `getSaveAsADraftButtonText()` is still kept as it was, to not complicate things and keep track that each case needs to be handled in a specific way on purpose.
- Finally, this commit https://github.com/wordpress-mobile/WordPress-Android/commit/6c82f610ab357e02b8dcc736b7bb90e1ed4893d5 tackles the Toast behavior and pre-checks for empty posts, to specifically address #7563 


To test:
*CASE A: attempt to save empty draft using the overflow menu*
1. Start a new post in the app but don't enter any content.
2. Open the overflow menu.
3. Select "Save as a Draft"
4. observe a toast is shown saying can't publish an empty draft.

*CASE B: attempt to publish empty draft using the action bar action*
1. Start a new post in the app but don't enter any content.
2. Tap on the action bar's PUBLISH action
3. observe the dialog appears and tap PUBLISH NOW
4. observe a toast is shown saying can't publish an empty post.

*CASE C: save a draft and observe menu option changes*
1. start a new post in the app
2. enter some title and optionally some content
3. observe the available options are `PUBLISH` as the main action in the action bar, and `Save as a Draft` in the overflow menu.
4. use the overflow menu and tap on `Save as a Draft`
5. Observe snackbars appear "uploading..."  first and then  "Draft saved online"
6. now observe the main action bar action has changed to `UPDATE`, and the overflow menu option has changed to `Publish Now`.
7. Tap on `UPDATE` to update the draft on the server
8. Observe the editor is exited and the draft gets uploaded (same behavior as usual)
9. tap on the same draft to edit it again
10. Observe the available actions are the same as in step 6 above.
11. Now, tap on `Publish Now` in the overflow menu.
12. Observe the publish confirmation dialog appears - tap on PUBLISH NOW
13. Observe the editor is exited, and the Post that used to be a draft is now published.


Here's a quick animation showing all of this:

![overflow_tests](https://user-images.githubusercontent.com/6597771/38208292-fde9252e-3686-11e8-911f-ea2e94b26d65.gif)

