### PR TITLE
Add a back button when you tap an image in the reader on fullscreen

### DIFF
--- a/WordPress/src/main/res/layout/reader_activity_photo_viewer.xml
+++ b/WordPress/src/main/res/layout/reader_activity_photo_viewer.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="@color/grey_dark">
+                xmlns:tools="http://schemas.android.com/tools"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <org.wordpress.android.widgets.WPViewPager
         android:id="@+id/viewpager"
@@ -29,5 +29,18 @@
         android:paddingEnd="@dimen/margin_large"
         android:paddingStart="@dimen/margin_large"
         android:layout_marginStart="@dimen/margin_small"/>
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:elevation="@dimen/appbar_elevation"
+        app:contentInsetEnd="@dimen/toolbar_content_offset_end"
+        app:contentInsetLeft="@dimen/toolbar_content_offset"
+        app:contentInsetRight="@dimen/toolbar_content_offset_end"
+        app:contentInsetStart="@dimen/toolbar_content_offset"
+        app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+        app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+        tools:targetApi="LOLLIPOP" />
 
 </RelativeLayout>

--- a/WordPress/src/main/res/layout/reader_activity_photo_viewer.xml
+++ b/WordPress/src/main/res/layout/reader_activity_photo_viewer.xml
@@ -2,9 +2,10 @@
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
                 xmlns:tools="http://schemas.android.com/tools"
+                xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                xmlns:app="http://schemas.android.com/apk/res-auto">
+                android:background="@color/grey_dark">
 
     <org.wordpress.android.widgets.WPViewPager
         android:id="@+id/viewpager"


### PR DESCRIPTION
Fixes #7578 - Reader: no back button on fullscreen image

To test:

1. Go to **reader** and choose any article
2. Tap an **image** in the reader 
3. It shows the image on fullscreen with the toolbar for some seconds  
4. If you tap again the image it shows a back button again

![screenshot_1522709007](https://user-images.githubusercontent.com/2581647/38219883-ce3d4e4e-36a5-11e8-9ae2-3162d5295d02.png)

cc @nbradbury @theck13 
