### PR TITLE
Issue/5530 basic notification channels android o

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -330,7 +330,8 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         // create Notification channels introduced in Android Oreo
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             // Create the NORMAL channel (used for likes, comments, replies, etc.)
-            NotificationChannel normalChannel = new NotificationChannel(NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID,
+            NotificationChannel normalChannel = new NotificationChannel(
+                    getString(R.string.notification_channel_normal_id),
                     getString(R.string.notification_channel_general_title), NotificationManager.IMPORTANCE_DEFAULT);
             // Register the channel with the system; you can't change the importance
             // or other notification behaviors after this
@@ -341,7 +342,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
 
             // Create the IMPORTANT channel (used for 2fa auth, for example)
             NotificationChannel importantChannel = new NotificationChannel(
-                    NotificationsUtils.GENERAL_IMPORTANT_CHANNEL_ID,
+                    getString(R.string.notification_channel_important_id),
                     getString(R.string.notification_channel_important_title), NotificationManager.IMPORTANCE_HIGH);
             // Register the channel with the system; you can't change the importance
             // or other notification behaviors after this

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -3,6 +3,8 @@ package org.wordpress.android;
 import android.app.Activity;
 import android.app.Application;
 import android.app.Dialog;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.app.Service;
 import android.content.ComponentCallbacks2;
 import android.content.Context;
@@ -277,6 +279,8 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
 
         initAnalytics(SystemClock.elapsedRealtime() - startDate);
 
+        createNotificationChannelsOnSdk26();
+
         disableRtlLayoutDirectionOnSdk17();
 
         // Allows vector drawable from resources (in selectors for instance) on Android < 21 (can cause issues
@@ -319,6 +323,28 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
                     UploadService.sanitizeMediaUploadStateForSite(mMediaStore, mDispatcher, selectedSite);
                 }
             }).start();
+        }
+    }
+
+    private void createNotificationChannelsOnSdk26() {
+        // create Notification channels introduced in Android Oreo
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // Create the NORMAL channel (used for likes, comments, replies, etc.)
+            NotificationChannel normalChannel = new NotificationChannel(NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID,
+                    getString(R.string.notification_channel_general_title), NotificationManager.IMPORTANCE_DEFAULT);
+            // Register the channel with the system; you can't change the importance
+            // or other notification behaviors after this
+            NotificationManager notificationManager = (NotificationManager) getSystemService(
+                    NOTIFICATION_SERVICE);
+            notificationManager.createNotificationChannel(normalChannel);
+
+
+            // Create the IMPORTANT channel (used for 2fa auth, for example)
+            NotificationChannel importantChannel = new NotificationChannel(NotificationsUtils.GENERAL_IMPORTANT_CHANNEL_ID,
+                    getString(R.string.notification_channel_important_title), NotificationManager.IMPORTANCE_HIGH);
+            // Register the channel with the system; you can't change the importance
+            // or other notification behaviors after this
+            notificationManager.createNotificationChannel(importantChannel);
         }
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -340,7 +340,8 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
 
 
             // Create the IMPORTANT channel (used for 2fa auth, for example)
-            NotificationChannel importantChannel = new NotificationChannel(NotificationsUtils.GENERAL_IMPORTANT_CHANNEL_ID,
+            NotificationChannel importantChannel = new NotificationChannel(
+                    NotificationsUtils.GENERAL_IMPORTANT_CHANNEL_ID,
                     getString(R.string.notification_channel_important_title), NotificationManager.IMPORTANCE_HIGH);
             // Register the channel with the system; you can't change the importance
             // or other notification behaviors after this

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -600,7 +600,8 @@ public class GCMMessageService extends GcmListenerService {
 
         private NotificationCompat.Builder getNotificationBuilder(Context context, String title, String message) {
             // Build the new notification, add group to support wearable stacking
-            return new NotificationCompat.Builder(context, NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID)
+            return new NotificationCompat.Builder(context,
+                    context.getString(R.string.notification_channel_normal_id))
                     .setSmallIcon(R.drawable.ic_my_sites_24dp)
                     .setColor(context.getResources().getColor(R.color.blue_wordpress))
                     .setContentTitle(title)
@@ -651,7 +652,7 @@ public class GCMMessageService extends GcmListenerService {
                 String subject =
                         String.format(context.getString(R.string.new_notifications), ACTIVE_NOTIFICATIONS_MAP.size());
                 NotificationCompat.Builder groupBuilder = new NotificationCompat.Builder(context,
-                        NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID)
+                        context.getString(R.string.notification_channel_normal_id))
                         .setSmallIcon(R.drawable.ic_my_sites_24dp)
                         .setColor(context.getResources().getColor(R.color.blue_wordpress))
                         .setGroup(NOTIFICATION_GROUP_KEY)
@@ -932,7 +933,7 @@ public class GCMMessageService extends GcmListenerService {
             pushAuthIntent.addCategory("android.intent.category.LAUNCHER");
 
             NotificationCompat.Builder builder = new NotificationCompat.Builder(context,
-                    NotificationsUtils.GENERAL_IMPORTANT_CHANNEL_ID)
+                    context.getString(R.string.notification_channel_important_id))
                     .setSmallIcon(R.drawable.ic_my_sites_24dp)
                     .setColor(context.getResources().getColor(R.color.blue_wordpress))
                     .setContentTitle(title)

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -607,6 +607,7 @@ public class GCMMessageService extends GcmListenerService {
                     .setContentTitle(title)
                     .setContentText(message)
                     .setTicker(message)
+                    .setOnlyAlertOnce(true)
                     .setAutoCancel(true)
                     .setStyle(new NotificationCompat.BigTextStyle().bigText(message))
                     .setGroup(NOTIFICATION_GROUP_KEY);
@@ -940,6 +941,7 @@ public class GCMMessageService extends GcmListenerService {
                     .setContentText(message)
                     .setAutoCancel(true)
                     .setStyle(new NotificationCompat.BigTextStyle().bigText(message))
+                    .setOnlyAlertOnce(true)
                     .setPriority(NotificationCompat.PRIORITY_MAX);
 
             PendingIntent pendingIntent =

--- a/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/GCMMessageService.java
@@ -600,7 +600,7 @@ public class GCMMessageService extends GcmListenerService {
 
         private NotificationCompat.Builder getNotificationBuilder(Context context, String title, String message) {
             // Build the new notification, add group to support wearable stacking
-            return new NotificationCompat.Builder(context)
+            return new NotificationCompat.Builder(context, NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID)
                     .setSmallIcon(R.drawable.ic_my_sites_24dp)
                     .setColor(context.getResources().getColor(R.color.blue_wordpress))
                     .setContentTitle(title)
@@ -650,7 +650,8 @@ public class GCMMessageService extends GcmListenerService {
 
                 String subject =
                         String.format(context.getString(R.string.new_notifications), ACTIVE_NOTIFICATIONS_MAP.size());
-                NotificationCompat.Builder groupBuilder = new NotificationCompat.Builder(context)
+                NotificationCompat.Builder groupBuilder = new NotificationCompat.Builder(context,
+                        NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID)
                         .setSmallIcon(R.drawable.ic_my_sites_24dp)
                         .setColor(context.getResources().getColor(R.color.blue_wordpress))
                         .setGroup(NOTIFICATION_GROUP_KEY)
@@ -930,7 +931,8 @@ public class GCMMessageService extends GcmListenerService {
             pushAuthIntent.setAction("android.intent.action.MAIN");
             pushAuthIntent.addCategory("android.intent.category.LAUNCHER");
 
-            NotificationCompat.Builder builder = new NotificationCompat.Builder(context)
+            NotificationCompat.Builder builder = new NotificationCompat.Builder(context,
+                    NotificationsUtils.GENERAL_IMPORTANT_CHANNEL_ID)
                     .setSmallIcon(R.drawable.ic_my_sites_24dp)
                     .setColor(context.getResources().getColor(R.color.blue_wordpress))
                     .setContentTitle(title)

--- a/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
@@ -21,7 +21,8 @@ public class NativeNotificationsUtils {
     public static void showMessageToUser(String message, boolean intermediateMessage, int pushId, Context context) {
         NotificationCompat.Builder builder = getBuilder(context,
                 context.getString(R.string.notification_channel_normal_id))
-                .setContentText(message).setTicker(message);
+                .setContentText(message).setTicker(message)
+                .setOnlyAlertOnce(true);
         showMessageToUserWithBuilder(builder, message, intermediateMessage, pushId, context);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
@@ -6,6 +6,7 @@ import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 
 import org.wordpress.android.R;
+import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 
 import static org.wordpress.android.push.GCMMessageService.ACTIONS_PROGRESS_NOTIFICATION_ID;
 
@@ -19,7 +20,8 @@ public class NativeNotificationsUtils {
     }
 
     public static void showMessageToUser(String message, boolean intermediateMessage, int pushId, Context context) {
-        NotificationCompat.Builder builder = getBuilder(context).setContentText(message).setTicker(message);
+        NotificationCompat.Builder builder = getBuilder(context, NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID)
+                .setContentText(message).setTicker(message);
         showMessageToUserWithBuilder(builder, message, intermediateMessage, pushId, context);
     }
 
@@ -34,8 +36,8 @@ public class NativeNotificationsUtils {
         notificationManager.notify(pushId, builder.build());
     }
 
-    public static NotificationCompat.Builder getBuilder(Context context) {
-        return new NotificationCompat.Builder(context)
+    public static NotificationCompat.Builder getBuilder(Context context, String channelId) {
+        return new NotificationCompat.Builder(context, channelId)
                 .setSmallIcon(R.drawable.ic_my_sites_24dp)
                 .setColor(context.getResources().getColor(R.color.blue_wordpress))
                 .setContentTitle(context.getString(R.string.app_name))

--- a/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
@@ -6,7 +6,6 @@ import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 
 import org.wordpress.android.R;
-import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 
 import static org.wordpress.android.push.GCMMessageService.ACTIONS_PROGRESS_NOTIFICATION_ID;
 

--- a/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/push/NativeNotificationsUtils.java
@@ -20,7 +20,8 @@ public class NativeNotificationsUtils {
     }
 
     public static void showMessageToUser(String message, boolean intermediateMessage, int pushId, Context context) {
-        NotificationCompat.Builder builder = getBuilder(context, NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID)
+        NotificationCompat.Builder builder = getBuilder(context,
+                context.getString(R.string.notification_channel_normal_id))
                 .setContentText(message).setTicker(message);
         showMessageToUserWithBuilder(builder, message, intermediateMessage, pushId, context);
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
@@ -25,6 +25,7 @@ import org.wordpress.android.fluxc.model.ThemeModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.ThemeStore;
 import org.wordpress.android.ui.accounts.signup.SiteCreationService.SiteCreationState;
+import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;
@@ -119,7 +120,9 @@ public class SiteCreationService extends AutoForeground<SiteCreationState> {
     private static class SiteCreationNotification {
         static Notification progress(Context context, int progress, @StringRes int titleString,
                                      @StringRes int stepString) {
-            return AutoForegroundNotification.progress(context, progress,
+            return AutoForegroundNotification.progress(context,
+                                                       NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID,
+                                                       progress,
                                                        titleString,
                                                        stepString,
                                                        R.drawable.ic_my_sites_24dp,
@@ -128,6 +131,7 @@ public class SiteCreationService extends AutoForeground<SiteCreationState> {
 
         static Notification success(Context context) {
             return AutoForegroundNotification.success(context,
+                                                      NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID,
                                                       R.string.notification_site_creation_title_success,
                                                       R.string.notification_site_creation_created,
                                                       R.drawable.ic_my_sites_24dp,
@@ -136,6 +140,7 @@ public class SiteCreationService extends AutoForeground<SiteCreationState> {
 
         static Notification failure(Context context, @StringRes int content) {
             return AutoForegroundNotification.failure(context,
+                                                      NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID,
                                                       R.string.notification_site_creation_title_stopped,
                                                       content,
                                                       R.drawable.ic_my_sites_24dp,

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
@@ -25,7 +25,6 @@ import org.wordpress.android.fluxc.model.ThemeModel;
 import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.fluxc.store.ThemeStore;
 import org.wordpress.android.ui.accounts.signup.SiteCreationService.SiteCreationState;
-import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.prefs.SiteSettingsInterface;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.AppLog.T;

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/signup/SiteCreationService.java
@@ -121,7 +121,7 @@ public class SiteCreationService extends AutoForeground<SiteCreationState> {
         static Notification progress(Context context, int progress, @StringRes int titleString,
                                      @StringRes int stepString) {
             return AutoForegroundNotification.progress(context,
-                                                       NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID,
+                                                       context.getString(R.string.notification_channel_normal_id),
                                                        progress,
                                                        titleString,
                                                        stepString,
@@ -131,7 +131,7 @@ public class SiteCreationService extends AutoForeground<SiteCreationState> {
 
         static Notification success(Context context) {
             return AutoForegroundNotification.success(context,
-                                                      NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID,
+                                                      context.getString(R.string.notification_channel_normal_id),
                                                       R.string.notification_site_creation_title_success,
                                                       R.string.notification_site_creation_created,
                                                       R.drawable.ic_my_sites_24dp,
@@ -140,7 +140,7 @@ public class SiteCreationService extends AutoForeground<SiteCreationState> {
 
         static Notification failure(Context context, @StringRes int content) {
             return AutoForegroundNotification.failure(context,
-                                                      NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID,
+                                                      context.getString(R.string.notification_channel_normal_id),
                                                       R.string.notification_site_creation_title_stopped,
                                                       content,
                                                       R.drawable.ic_my_sites_24dp,

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/receivers/NotificationsPendingDraftsReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/receivers/NotificationsPendingDraftsReceiver.java
@@ -16,6 +16,7 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.push.NativeNotificationsUtils;
 import org.wordpress.android.push.NotificationsProcessingService;
 import org.wordpress.android.ui.main.WPMainActivity;
+import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.notifications.utils.PendingDraftsNotificationsUtils;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;
@@ -157,7 +158,8 @@ public class NotificationsPendingDraftsReceiver extends BroadcastReceiver {
 
     private void buildNotificationWithIntent(Context context, PendingIntent intent, String message, int postId,
                                              boolean isPage) {
-        NotificationCompat.Builder builder = NativeNotificationsUtils.getBuilder(context);
+        NotificationCompat.Builder builder = NativeNotificationsUtils.getBuilder(context,
+                NotificationsUtils.GENERAL_IMPORTANT_CHANNEL_ID);
         builder.setContentText(message)
                .setPriority(NotificationCompat.PRIORITY_MAX);
         builder.setContentIntent(intent);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/receivers/NotificationsPendingDraftsReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/receivers/NotificationsPendingDraftsReceiver.java
@@ -16,7 +16,6 @@ import org.wordpress.android.fluxc.store.SiteStore;
 import org.wordpress.android.push.NativeNotificationsUtils;
 import org.wordpress.android.push.NotificationsProcessingService;
 import org.wordpress.android.ui.main.WPMainActivity;
-import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.notifications.utils.PendingDraftsNotificationsUtils;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.util.AppLog;

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/receivers/NotificationsPendingDraftsReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/receivers/NotificationsPendingDraftsReceiver.java
@@ -160,7 +160,8 @@ public class NotificationsPendingDraftsReceiver extends BroadcastReceiver {
         NotificationCompat.Builder builder = NativeNotificationsUtils.getBuilder(context,
                 context.getString(R.string.notification_channel_important_id));
         builder.setContentText(message)
-               .setPriority(NotificationCompat.PRIORITY_MAX);
+               .setPriority(NotificationCompat.PRIORITY_MAX)
+               .setOnlyAlertOnce(true);
         builder.setContentIntent(intent);
 
         if (postId != 0) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/receivers/NotificationsPendingDraftsReceiver.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/receivers/NotificationsPendingDraftsReceiver.java
@@ -159,7 +159,7 @@ public class NotificationsPendingDraftsReceiver extends BroadcastReceiver {
     private void buildNotificationWithIntent(Context context, PendingIntent intent, String message, int postId,
                                              boolean isPage) {
         NotificationCompat.Builder builder = NativeNotificationsUtils.getBuilder(context,
-                NotificationsUtils.GENERAL_IMPORTANT_CHANNEL_ID);
+                context.getString(R.string.notification_channel_important_id));
         builder.setContentText(message)
                .setPriority(NotificationCompat.PRIORITY_MAX);
         builder.setContentIntent(intent);

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -53,6 +53,9 @@ import java.util.List;
 import java.util.Map;
 
 public class NotificationsUtils {
+    public static final String GENERAL_IMPORTANT_CHANNEL_ID = "wpandroid_notification_important_channel_id";
+    public static final String GENERAL_NORMAL_CHANNEL_ID = "wpandroid_notification_normal_channel_id";
+
     public static final String ARG_PUSH_AUTH_TOKEN = "arg_push_auth_token";
     public static final String ARG_PUSH_AUTH_TITLE = "arg_push_auth_title";
     public static final String ARG_PUSH_AUTH_MESSAGE = "arg_push_auth_message";

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/utils/NotificationsUtils.java
@@ -53,9 +53,6 @@ import java.util.List;
 import java.util.Map;
 
 public class NotificationsUtils {
-    public static final String GENERAL_IMPORTANT_CHANNEL_ID = "wpandroid_notification_important_channel_id";
-    public static final String GENERAL_NORMAL_CHANNEL_ID = "wpandroid_notification_normal_channel_id";
-
     public static final String ARG_PUSH_AUTH_TOKEN = "arg_push_auth_token";
     public static final String ARG_PUSH_AUTH_TITLE = "arg_push_auth_title";
     public static final String ARG_PUSH_AUTH_MESSAGE = "arg_push_auth_message";

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -77,7 +77,8 @@ class PostUploadNotifier {
         mNotificationBuilder = new NotificationCompat.Builder(mContext.getApplicationContext(),
                 context.getString(R.string.notification_channel_normal_id));
         mNotificationBuilder.setSmallIcon(android.R.drawable.stat_sys_upload)
-                            .setColor(context.getResources().getColor(R.color.blue_wordpress));
+                            .setColor(context.getResources().getColor(R.color.blue_wordpress))
+                            .setOnlyAlertOnce(true);
     }
 
     private void updateForegroundNotification(@Nullable PostModel post) {
@@ -311,6 +312,7 @@ class PostUploadNotifier {
         notificationBuilder.setContentTitle(notificationTitle);
         notificationBuilder.setContentText(notificationMessage);
         notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(notificationMessage));
+        notificationBuilder.setOnlyAlertOnce(true);
         notificationBuilder.setAutoCancel(true);
 
         long notificationId = getNotificationIdForPost(post);
@@ -390,6 +392,7 @@ class PostUploadNotifier {
         notificationBuilder.setContentText(notificationMessage);
         // notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(newSuccessMessage));
         notificationBuilder.setContentIntent(pendingIntent);
+        notificationBuilder.setOnlyAlertOnce(true);
         notificationBuilder.setAutoCancel(true);
 
         // Add WRITE POST action - only if there is media we can insert in the Post
@@ -472,6 +475,7 @@ class PostUploadNotifier {
         notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(newErrorMessage));
         notificationBuilder.setContentIntent(pendingIntent);
         notificationBuilder.setAutoCancel(true);
+        notificationBuilder.setOnlyAlertOnce(true);
 
         // Add RETRY action - only available on Aztec
         if (AppPrefs.isAztecEditorEnabled()) {
@@ -523,6 +527,7 @@ class PostUploadNotifier {
         notificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(newErrorMessage));
         notificationBuilder.setContentIntent(pendingIntent);
         notificationBuilder.setAutoCancel(true);
+        notificationBuilder.setOnlyAlertOnce(true);
 
         // Add RETRY action - only if there is media to retry
         if (mediaList != null && !mediaList.isEmpty()) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -20,7 +20,6 @@ import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.notifications.ShareAndDismissNotificationReceiver;
-import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.posts.PostsListActivity;

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -20,6 +20,7 @@ import org.wordpress.android.fluxc.model.post.PostStatus;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.media.MediaBrowserActivity;
 import org.wordpress.android.ui.notifications.ShareAndDismissNotificationReceiver;
+import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.posts.EditPostActivity;
 import org.wordpress.android.ui.posts.PostUtils;
 import org.wordpress.android.ui.posts.PostsListActivity;
@@ -74,7 +75,8 @@ class PostUploadNotifier {
         sNotificationData = new NotificationData();
         mNotificationManager = (NotificationManager) SystemServiceFactory.get(mContext,
                                                                               Context.NOTIFICATION_SERVICE);
-        mNotificationBuilder = new NotificationCompat.Builder(mContext.getApplicationContext());
+        mNotificationBuilder = new NotificationCompat.Builder(mContext.getApplicationContext(),
+                NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID);
         mNotificationBuilder.setSmallIcon(android.R.drawable.stat_sys_upload)
                             .setColor(context.getResources().getColor(R.color.blue_wordpress));
     }
@@ -281,7 +283,8 @@ class PostUploadNotifier {
 
         // Notification builder
         NotificationCompat.Builder notificationBuilder =
-                new NotificationCompat.Builder(mContext.getApplicationContext());
+                new NotificationCompat.Builder(mContext.getApplicationContext(),
+                        NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID);
         String notificationTitle;
         String notificationMessage;
 
@@ -362,7 +365,8 @@ class PostUploadNotifier {
         AppLog.d(AppLog.T.MEDIA, "updateNotificationSuccessForMedia");
 
         NotificationCompat.Builder notificationBuilder =
-                new NotificationCompat.Builder(mContext.getApplicationContext());
+                new NotificationCompat.Builder(mContext.getApplicationContext(),
+                        NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID);
 
         long notificationId = getNotificationIdForMedia(site);
         // Tap notification intent (open the media browser)
@@ -439,7 +443,8 @@ class PostUploadNotifier {
         AppLog.d(AppLog.T.POSTS, "updateNotificationErrorForPost: " + errorMessage);
 
         NotificationCompat.Builder notificationBuilder =
-                new NotificationCompat.Builder(mContext.getApplicationContext());
+                new NotificationCompat.Builder(mContext.getApplicationContext(),
+                        NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID);
 
         long notificationId = getNotificationIdForPost(post);
         // Tap notification intent (open the post list)
@@ -491,7 +496,8 @@ class PostUploadNotifier {
         AppLog.d(AppLog.T.MEDIA, "updateNotificationErrorForMedia: " + errorMessage);
 
         NotificationCompat.Builder notificationBuilder =
-                new NotificationCompat.Builder(mContext.getApplicationContext());
+                new NotificationCompat.Builder(mContext.getApplicationContext(),
+                        NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID);
 
         long notificationId = getNotificationIdForMedia(site);
         // Tap notification intent (open the media browser)

--- a/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/uploads/PostUploadNotifier.java
@@ -76,7 +76,7 @@ class PostUploadNotifier {
         mNotificationManager = (NotificationManager) SystemServiceFactory.get(mContext,
                                                                               Context.NOTIFICATION_SERVICE);
         mNotificationBuilder = new NotificationCompat.Builder(mContext.getApplicationContext(),
-                NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID);
+                context.getString(R.string.notification_channel_normal_id));
         mNotificationBuilder.setSmallIcon(android.R.drawable.stat_sys_upload)
                             .setColor(context.getResources().getColor(R.color.blue_wordpress));
     }
@@ -284,7 +284,7 @@ class PostUploadNotifier {
         // Notification builder
         NotificationCompat.Builder notificationBuilder =
                 new NotificationCompat.Builder(mContext.getApplicationContext(),
-                        NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID);
+                        mContext.getString(R.string.notification_channel_normal_id));
         String notificationTitle;
         String notificationMessage;
 
@@ -366,7 +366,7 @@ class PostUploadNotifier {
 
         NotificationCompat.Builder notificationBuilder =
                 new NotificationCompat.Builder(mContext.getApplicationContext(),
-                        NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID);
+                        mContext.getString(R.string.notification_channel_normal_id));
 
         long notificationId = getNotificationIdForMedia(site);
         // Tap notification intent (open the media browser)
@@ -444,7 +444,7 @@ class PostUploadNotifier {
 
         NotificationCompat.Builder notificationBuilder =
                 new NotificationCompat.Builder(mContext.getApplicationContext(),
-                        NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID);
+                        mContext.getString(R.string.notification_channel_normal_id));
 
         long notificationId = getNotificationIdForPost(post);
         // Tap notification intent (open the post list)
@@ -497,7 +497,7 @@ class PostUploadNotifier {
 
         NotificationCompat.Builder notificationBuilder =
                 new NotificationCompat.Builder(mContext.getApplicationContext(),
-                        NotificationsUtils.GENERAL_NORMAL_CHANNEL_ID);
+                        mContext.getString(R.string.notification_channel_normal_id));
 
         long notificationId = getNotificationIdForMedia(site);
         // Tap notification intent (open the media browser)

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1939,6 +1939,10 @@
 
     <string name="google_error_timeout">Google took too long to respond. You may need to wait until you have a stronger internet connection.</string>
 
+    <!-- Android O notification channels, these show in the Android app settings -->
+    <string name="notification_channel_general_title">General</string>
+    <string name="notification_channel_important_title">Important</string>
+
     <!-- Site Creation notifications -->
     <string name="notification_site_creation_title_success">Site created!</string>
     <string name="notification_site_creation_created">Tap to continue.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1943,6 +1943,9 @@
     <string name="notification_channel_general_title">General</string>
     <string name="notification_channel_important_title">Important</string>
 
+    <string name="notification_channel_normal_id">wpandroid_notification_normal_channel_id</string>
+    <string name="notification_channel_important_id">wpandroid_notification_important_channel_id</string>
+
     <!-- Site Creation notifications -->
     <string name="notification_site_creation_title_success">Site created!</string>
     <string name="notification_site_creation_created">Tap to continue.</string>

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -31,7 +31,7 @@ android {
 }
 
 dependencies {
-    implementation ('org.wordpress:utils:1.20.0') {
+    implementation ('org.wordpress:utils:1.20.2-beta1') {
         exclude group: "com.mcxiaoke.volley"
     }
 

--- a/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginWpcomService.java
+++ b/libs/login/WordPressLoginFlow/src/main/java/org/wordpress/android/login/LoginWpcomService.java
@@ -113,7 +113,9 @@ public class LoginWpcomService extends AutoForeground<LoginState> {
 
     private static class LoginNotification {
         static Notification progress(Context context, int progress) {
-            return AutoForegroundNotification.progress(context, progress,
+            return AutoForegroundNotification.progress(context,
+                    context.getString(R.string.notification_channel_normal_id),
+                    progress,
                     R.string.notification_login_title_in_progress,
                     R.string.notification_logging_in,
                     R.drawable.ic_my_sites_24dp,
@@ -122,6 +124,7 @@ public class LoginWpcomService extends AutoForeground<LoginState> {
 
         static Notification success(Context context) {
             return AutoForegroundNotification.success(context,
+                    context.getString(R.string.notification_channel_normal_id),
                     R.string.notification_login_title_success,
                     R.string.notification_logged_in,
                     R.drawable.ic_my_sites_24dp,
@@ -130,6 +133,7 @@ public class LoginWpcomService extends AutoForeground<LoginState> {
 
         static Notification failure(Context context, @StringRes int content) {
             return AutoForegroundNotification.failure(context,
+                    context.getString(R.string.notification_channel_normal_id),
                     R.string.notification_login_title_stopped,
                     content,
                     R.drawable.ic_my_sites_24dp,

--- a/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
+++ b/libs/login/WordPressLoginFlow/src/main/res/values/strings.xml
@@ -121,6 +121,11 @@
     This resource will be automatically overwritten in the host project with the real value from google-services.json. -->
     <string name="default_web_client_id">placeholder</string>
 
+    <!-- same as above, we need to have these same-named string resources to be used as channel IDs in a similar way in the
+    host application -->
+    <string name="notification_channel_normal_id">placeholder</string>
+    <string name="notification_channel_important_id">placeholder</string>
+
     <!-- Image Descriptions for Accessibility -->
     <string name="login_site_address_help_image">The site address can be found in the navigation bar of your web browser</string>
 </resources>

--- a/libs/utils/WordPressUtils/build.gradle
+++ b/libs/utils/WordPressUtils/build.gradle
@@ -35,7 +35,7 @@ android {
     buildToolsVersion '26.0.2'
 
     defaultConfig {
-        versionName "1.20.0"
+        versionName "1.20.2-beta1"
         minSdkVersion 15
         targetSdkVersion 26
     }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AutoForegroundNotification.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AutoForegroundNotification.java
@@ -40,6 +40,7 @@ public class AutoForegroundNotification {
                 .setSmallIcon(icon)
                 .setColor(context.getResources().getColor(accentColor))
                 .setAutoCancel(true)
+                .setOnlyAlertOnce(true)
                 .setContentIntent(PendingIntent.getActivity(
                         context,
                         requestCode,

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AutoForegroundNotification.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AutoForegroundNotification.java
@@ -26,14 +26,14 @@ public class AutoForegroundNotification {
         return resumeIntent;
     }
 
-    private static NotificationCompat.Builder getNotificationBuilder(Context context, int requestCode,
+    private static NotificationCompat.Builder getNotificationBuilder(Context context, String channelId, int requestCode,
                                                                      @StringRes int title, @StringRes int content,
                                                                      @DrawableRes int icon, @ColorRes int accentColor) {
         NotificationCompat.BigTextStyle bigTextStyle = new NotificationCompat.BigTextStyle();
         bigTextStyle.setBigContentTitle(context.getString(title));
         bigTextStyle.bigText(context.getString(content));
 
-        return new NotificationCompat.Builder(context)
+        return new NotificationCompat.Builder(context, channelId)
                 .setStyle(bigTextStyle)
                 .setContentTitle(context.getString(title))
                 .setContentText(context.getString(content))
@@ -47,20 +47,20 @@ public class AutoForegroundNotification {
                         PendingIntent.FLAG_ONE_SHOT));
     }
 
-    public static Notification progress(Context context, int progress, @StringRes int title, @StringRes int content,
+    public static Notification progress(Context context, String channelId, int progress, @StringRes int title, @StringRes int content,
                                         @DrawableRes int icon, @ColorRes int accentColor) {
-        return getNotificationBuilder(context, NOTIFICATION_ID_PROGRESS, title, content, icon, accentColor)
+        return getNotificationBuilder(context, channelId, NOTIFICATION_ID_PROGRESS, title, content, icon, accentColor)
                 .setProgress(100, progress, false)
                 .build();
     }
 
-    public static Notification success(Context context, @StringRes int title, @StringRes int content,
+    public static Notification success(Context context, String channelId, @StringRes int title, @StringRes int content,
                                        @DrawableRes int icon, @ColorRes int accentColor) {
-        return getNotificationBuilder(context, NOTIFICATION_ID_SUCCESS, title, content, icon, accentColor).build();
+        return getNotificationBuilder(context, channelId, NOTIFICATION_ID_SUCCESS, title, content, icon, accentColor).build();
     }
 
-    public static Notification failure(Context context, @StringRes int title, @StringRes int content,
+    public static Notification failure(Context context, String channelId, @StringRes int title, @StringRes int content,
                                        @DrawableRes int icon, @ColorRes int accentColor) {
-        return getNotificationBuilder(context, NOTIFICATION_ID_FAILURE, title, content, icon, accentColor).build();
+        return getNotificationBuilder(context, channelId, NOTIFICATION_ID_FAILURE, title, content, icon, accentColor).build();
     }
 }

--- a/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AutoForegroundNotification.java
+++ b/libs/utils/WordPressUtils/src/main/java/org/wordpress/android/util/AutoForegroundNotification.java
@@ -47,7 +47,8 @@ public class AutoForegroundNotification {
                         PendingIntent.FLAG_ONE_SHOT));
     }
 
-    public static Notification progress(Context context, String channelId, int progress, @StringRes int title, @StringRes int content,
+    public static Notification progress(Context context, String channelId, int progress, @StringRes int title,
+                                        @StringRes int content,
                                         @DrawableRes int icon, @ColorRes int accentColor) {
         return getNotificationBuilder(context, channelId, NOTIFICATION_ID_PROGRESS, title, content, icon, accentColor)
                 .setProgress(100, progress, false)
@@ -56,11 +57,13 @@ public class AutoForegroundNotification {
 
     public static Notification success(Context context, String channelId, @StringRes int title, @StringRes int content,
                                        @DrawableRes int icon, @ColorRes int accentColor) {
-        return getNotificationBuilder(context, channelId, NOTIFICATION_ID_SUCCESS, title, content, icon, accentColor).build();
+        return getNotificationBuilder(context, channelId, NOTIFICATION_ID_SUCCESS, title, content, icon, accentColor)
+                .build();
     }
 
     public static Notification failure(Context context, String channelId, @StringRes int title, @StringRes int content,
                                        @DrawableRes int icon, @ColorRes int accentColor) {
-        return getNotificationBuilder(context, channelId, NOTIFICATION_ID_FAILURE, title, content, icon, accentColor).build();
+        return getNotificationBuilder(context, channelId, NOTIFICATION_ID_FAILURE, title, content, icon, accentColor)
+                .build();
     }
 }


### PR DESCRIPTION
Fixes #5530

**Note:** Please note this PR only creates the needed Notification Channels for Android O, but does not care for the other new restrictions on the platform.([#](https://developer.android.com/about/versions/oreo/android-8.0-migration.html) and [#](https://developer.android.com/about/versions/oreo/background.html)) These will be addressed in other PRs.

This PR creates the Notification Channels as required in Android Oreo, and updates all of the instances of `NotificationCompat.Builder` constructor calls to pass the channel ID.

This PR creates 2 notification channels (named "Important" and "General"), because the 2fa auth notification should have a maximum priority and now the priorities cannot be set on the Notifications themselves but rather belong to the Channels these notifications belong to on Android O+ devices.

To test:
On Android 8+
1. Run the app
2. Now go to the device's Settings screen -> Apps & notifications -> WordPress
3. Tap on "App Notifications"
4. You should see the 2 new channels created under the section labelled "Categories":
a. Important
b. General

![screenshot_20180404-141901](https://user-images.githubusercontent.com/6597771/38323383-79ffed5e-3813-11e8-80ea-93d70b413b32.png)

On Android N and lower:
- Nothing should change.

cc @nbradbury 
