### PR TITLE
bumped play services lib version

### DIFF
--- a/WordPress/build.gradle
+++ b/WordPress/build.gradle
@@ -120,9 +120,9 @@ dependencies {
     // ViewModel and LiveData
     implementation 'android.arch.lifecycle:extensions:1.1.0'
 
-    implementation 'com.google.android.gms:play-services-gcm:10.0.1'
-    implementation 'com.google.android.gms:play-services-auth:10.0.1'
-    implementation 'com.google.android.gms:play-services-places:10.0.1'
+    implementation 'com.google.android.gms:play-services-gcm:12.0.1'
+    implementation 'com.google.android.gms:play-services-auth:12.0.1'
+    implementation 'com.google.android.gms:play-services-places:12.0.1'
     implementation 'com.github.chrisbanes.photoview:library:1.2.4'
     implementation 'com.helpshift:android-helpshift-aar:6.4.1'
     implementation 'de.greenrobot:eventbus:2.4.0'

--- a/libs/login/WordPressLoginFlow/build.gradle
+++ b/libs/login/WordPressLoginFlow/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:26.1.0'
     implementation 'com.android.support:design:26.1.0'
 
-    implementation 'com.google.android.gms:play-services-auth:10.0.1'
+    implementation 'com.google.android.gms:play-services-auth:12.0.1'
 
     // Share FluxC version from host project if defined, otherwise fallback to default
     if (project.hasProperty("fluxCVersion")) {


### PR DESCRIPTION
As part of the migraton to Android O, we need to update the Google Play Services libraries.

Migration from GCM to Firebase (FCM) ([#](https://github.com/wordpress-mobile/WordPress-Android/issues/4670)) is still not strictly needed, but we need to update the Google Play Services libraries from `10.0.1` to at least [`10.2.1`](https://developers.google.com/android/guides/releases#march_2017_-_version_1021), deciding here to bump it all the way to latest library.

```This release includes updates to provide compatibility with Android O Developer Preview 1. The most significant updates are internal changes to the Google Cloud Messaging (GCM) and Firebase Cloud Messaging (FCM) libraries and a change in the guaranteed lifecycle of GCM and FCM callbacks to 10 seconds, after which Android O considers such callbacks eligible for termination. For more information on handling GCM and FCM messages on Android O, see The Firebase Blog.```

A follow up PR will make use of JobIntentService for processing `onTokenRefresh()` calls as per avised here https://firebase.googleblog.com/2017/03/using-firebase-cloud-messaging-with.html

To test:
N/A

cc @nbradbury 