### PR TITLE
offering different notification settings for pre and post API26

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceCategory;
@@ -83,8 +84,16 @@ public class NotificationsSettingsFragment extends PreferenceFragment
         super.onCreate(savedInstanceState);
         ((WordPress) getActivity().getApplication()).component().inject(this);
 
-        addPreferencesFromResource(R.xml.notifications_settings);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // on API26 we removed the Sight & Sounds category altogether, as it can always be
+            // overriden by the user in the Device settings, and the settings here
+            // wouldn't either reflect nor have any effect anyway.
+            addPreferencesFromResource(R.xml.notifications_settings_api26);
+        } else {
+            addPreferencesFromResource(R.xml.notifications_settings);
+        }
         setHasOptionsMenu(true);
+
 
         // Bump Analytics
         if (savedInstanceState == null) {

--- a/WordPress/src/main/res/xml/notifications_settings_api26.xml
+++ b/WordPress/src/main/res/xml/notifications_settings_api26.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:key="@string/wp_pref_notifications_root" >
+
+    <PreferenceCategory
+        android:key="@string/pref_notification_blogs"
+        android:title="@string/notification_settings_category_your_sites" />
+
+    <PreferenceCategory
+        android:key="@string/pref_notification_other_category"
+        android:title="@string/notification_settings_category_other" >
+
+        <PreferenceScreen
+            android:key="@string/pref_notification_other_blogs"
+            android:title="@string/notification_settings_item_other_comments_other_blogs" />
+
+        <SwitchPreference
+            android:key="@string/pref_key_notification_pending_drafts"
+            android:defaultValue="true"
+            android:title="@string/notification_settings_item_other_pending_drafts" />
+
+    </PreferenceCategory>
+
+</PreferenceScreen>


### PR DESCRIPTION
Notifications settings such as sounds, vibration and light on API 26 are only taken seriously from the device Settings, as anything the user does on the app can be overriden by what the device settings say. I think we should hide that section from the app on Android O altogether, as the user can override the settings from outside the app, and the app would never know, thus not reflecting the actual setting, and confusing the user.

This is what you can do on the device:
![screenshot_20180404-194952](https://user-images.githubusercontent.com/6597771/38338916-fc88cf10-3841-11e8-91c8-5aa3f46f1c8b.png)

And this is what you can do on the app:
![screenshot_20180404-194959](https://user-images.githubusercontent.com/6597771/38338928-0815bee2-3842-11e8-8aeb-4df362173e2f.png)


This is how it ends up looking like with this PR on API26: 

![screenshot_20180404-211437](https://user-images.githubusercontent.com/6597771/38341135-71d934c0-384d-11e8-9800-c9621412aaf9.png)
 

**To test:**
_CASE A: Pre-Android Oreo_
1. go to app settings
2. observe the Sights & sounds section is there and can be manipulated

_CASE B: Post-Android Oreo_
1. go to app settings
2. observe the Sights & sounds section is not there

cc @nbradbury 