### PR TITLE
Issue/7594 reader image scanner

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
@@ -14,7 +14,7 @@ public class ReaderImageScanner {
     private final boolean mContentContainsImages;
 
     private static final Pattern IMG_TAG_PATTERN = Pattern.compile(
-            ".*(<img\\s+.*src\\s*=\\s*'([^']+)'.*>).*",
+            ".*(<img\\s+.*src\\s*=\\s*\"([^\"]+)\".*>).*",
             Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
     public ReaderImageScanner(String contentOfPost, boolean isPrivate) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.reader.utils;
 
 import android.support.annotation.NonNull;
-import android.text.TextUtils;
 
 import org.wordpress.android.ui.reader.models.ReaderImageList;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java
@@ -14,7 +14,7 @@ public class ReaderImageScanner {
     private final boolean mContentContainsImages;
 
     private static final Pattern IMG_TAG_PATTERN = Pattern.compile(
-            "<img(\\s+.*?) (?:src\\s*=\\s*(?:'|\") (.*?) (?:'|\")) (.*?)>",
+            ".*(<img\\s+.*src\\s*=\\s*'([^']+)'.*>).*",
             Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
     public ReaderImageScanner(String contentOfPost, boolean isPrivate) {
@@ -37,11 +37,9 @@ public class ReaderImageScanner {
 
         Matcher imgMatcher = IMG_TAG_PATTERN.matcher(mContent);
         while (imgMatcher.find()) {
-            String imageTag = mContent.substring(imgMatcher.start(), imgMatcher.end());
-            String imageUrl = ReaderHtmlUtils.getSrcAttrValue(imageTag);
-            if (!TextUtils.isEmpty(imageUrl)) {
-                listener.onTagFound(imageTag, imageUrl);
-            }
+            String imageTag = imgMatcher.group(1);
+            String imageUrl = imgMatcher.group(2);
+            listener.onTagFound(imageTag, imageUrl);
         }
     }
 
@@ -58,13 +56,13 @@ public class ReaderImageScanner {
 
         Matcher imgMatcher = IMG_TAG_PATTERN.matcher(mContent);
         while (imgMatcher.find()) {
-            String imgTag = mContent.substring(imgMatcher.start(), imgMatcher.end());
-            String imageUrl = ReaderHtmlUtils.getSrcAttrValue(imgTag);
+            String imageTag = imgMatcher.group(1);
+            String imageUrl = imgMatcher.group(2);
 
             if (minImageWidth == 0) {
                 imageList.addImageUrl(imageUrl);
             } else {
-                int width = Math.max(ReaderHtmlUtils.getWidthAttrValue(imgTag),
+                int width = Math.max(ReaderHtmlUtils.getWidthAttrValue(imageTag),
                                      ReaderHtmlUtils.getIntQueryParam(imageUrl, "w"));
                 if (width >= minImageWidth) {
                     imageList.addImageUrl(imageUrl);
@@ -100,15 +98,15 @@ public class ReaderImageScanner {
 
         Matcher imgMatcher = IMG_TAG_PATTERN.matcher(mContent);
         while (imgMatcher.find()) {
-            String imgTag = mContent.substring(imgMatcher.start(), imgMatcher.end());
-            String imageUrl = ReaderHtmlUtils.getSrcAttrValue(imgTag);
+            String imageTag = imgMatcher.group(1);
+            String imageUrl = imgMatcher.group(2);
 
-            int width = Math.max(ReaderHtmlUtils.getWidthAttrValue(imgTag),
+            int width = Math.max(ReaderHtmlUtils.getWidthAttrValue(imageTag),
                                  ReaderHtmlUtils.getIntQueryParam(imageUrl, "w"));
             if (width > currentMaxWidth) {
                 currentImageUrl = imageUrl;
                 currentMaxWidth = width;
-            } else if (currentImageUrl == null && hasSuitableClassForFeaturedImage(imgTag)) {
+            } else if (currentImageUrl == null && hasSuitableClassForFeaturedImage(imageTag)) {
                 currentImageUrl = imageUrl;
             }
         }

--- a/WordPress/src/main/res/layout/reader_activity_photo_viewer.xml
+++ b/WordPress/src/main/res/layout/reader_activity_photo_viewer.xml
@@ -5,7 +5,7 @@
                 xmlns:app="http://schemas.android.com/apk/res-auto"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:background="@color/grey_dark">
+                android:background="@color/black">
 
     <org.wordpress.android.widgets.WPViewPager
         android:id="@+id/viewpager"


### PR DESCRIPTION
Fixes #7594 - the regex used to match images in `ReaderImageScanner` stopped working at some point, and wasn't very efficient. This PR replaces the regex with a more efficient pattern that enables group matching.

To test: set a breakpoint [here](https://github.com/wordpress-mobile/WordPress-Android/blob/66e1845c2f9c0dad7583e13fc1d4cb00914c4312/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderImageScanner.java#L61), browse around the reader, and confirm that `imageUrl` is being parsed correctly.
