### PR TITLE
Convert PublicizeUpdateService from IntentService to JobIntentService

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -564,6 +564,7 @@
             android:label="Reader Comment Service" />
         <service
             android:name=".ui.publicize.services.PublicizeUpdateService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
             android:label="Publicize Update Service"
             android:exported="false" />
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/publicize/services/PublicizeUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/publicize/services/PublicizeUpdateService.java
@@ -1,9 +1,9 @@
 package org.wordpress.android.ui.publicize.services;
 
-import android.app.IntentService;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.NonNull;
+import android.support.v4.app.JobIntentService;
 
 import com.android.volley.VolleyError;
 import com.wordpress.rest.RestRequest;
@@ -25,7 +25,8 @@ import de.greenrobot.event.EventBus;
  * service which requests the user's available sharing services and publicize connections
  */
 
-public class PublicizeUpdateService extends IntentService {
+public class PublicizeUpdateService extends JobIntentService {
+    static final int PUBLICIZE_UPDATE_SERVICE_JOB_ID = 3000;
     private static boolean mHasUpdatedServices;
 
     /*
@@ -34,11 +35,11 @@ public class PublicizeUpdateService extends IntentService {
     public static void updateConnectionsForSite(Context context, @NonNull SiteModel site) {
         Intent intent = new Intent(context, PublicizeUpdateService.class);
         intent.putExtra(WordPress.SITE, site);
-        context.startService(intent);
+        enqueueWork(context, intent);
     }
 
-    public PublicizeUpdateService() {
-        super("PublicizeUpdateService");
+    public static void enqueueWork(Context context, Intent work) {
+        enqueueWork(context, PublicizeUpdateService.class, PUBLICIZE_UPDATE_SERVICE_JOB_ID, work);
     }
 
     @Override
@@ -54,7 +55,7 @@ public class PublicizeUpdateService extends IntentService {
     }
 
     @Override
-    protected void onHandleIntent(Intent intent) {
+    protected void onHandleWork(@NonNull Intent intent) {
         if (intent == null) {
             return;
         }
@@ -69,6 +70,14 @@ public class PublicizeUpdateService extends IntentService {
 
         SiteModel site = (SiteModel) intent.getSerializableExtra(WordPress.SITE);
         updateConnections(site.getSiteId());
+    }
+
+    @Override
+    public boolean onStopCurrentWork() {
+        // this Service was failing silently if it couldn't get to update its data, so
+        // that hints us that we shouldn't really care about rescheduling this job
+        // in the case something failed.
+        return false;
     }
 
     /*


### PR DESCRIPTION
Converts `PublicizeUpdateService` from being an `IntentService` to a `JobIntentService` for compatibility pre and post API 26.

This PR follows along then lines of the work done in #7598

To test:
1. go to the Sharing screen of your site
2. check that the available networks, etc get updated as usual.

cc @nbradbury 