### PR TITLE
Prevent Save as Draft if media is uploading

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1066,6 +1066,12 @@ public class EditPostActivity extends AppCompatActivity implements
                 // save as draft if it's a local post with UNKNOWN status, or PUBLISH if it's a DRAFT (as this
                 //  R.id.menu_save_as_draft button will be "Publish Now" in that case)
 
+                if (UploadService.hasInProgressMediaUploadsForPost(mPost)) {
+                    ToastUtils.showToast(EditPostActivity.this,
+                            getString(R.string.error_save_draft_while_media_uploading), Duration.SHORT);
+                    return false;
+                }
+
                 // we update the mPost object first, so we can pre-check Post publishability and inform the user
                 updatePostObject();
                 if (PostStatus.fromPost(mPost) == PostStatus.DRAFT) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/posts/EditPostActivity.java
@@ -1068,7 +1068,7 @@ public class EditPostActivity extends AppCompatActivity implements
 
                 if (UploadService.hasInProgressMediaUploadsForPost(mPost)) {
                     ToastUtils.showToast(EditPostActivity.this,
-                            getString(R.string.error_save_draft_while_media_uploading), Duration.SHORT);
+                            getString(R.string.editor_toast_uploading_please_wait), Duration.SHORT);
                     return false;
                 }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1236,7 +1236,6 @@
     <string name="error_publish_empty_post">Can\'t publish an empty post</string>
     <string name="error_publish_empty_page">Can\'t publish an empty page</string>
     <string name="error_save_empty_draft">Can\'t save an empty draft</string>
-    <string name="error_save_draft_while_media_uploading">Can\'t save as draft while media is uploading. Please wait.</string>
     <string name="error_publish_no_network">Device is offline. Changes saved locally.</string>
     <string name="error_upload_post_param">There was an error uploading this post: %s.</string>
     <string name="error_upload_page_param">There was an error uploading this page: %s.</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1236,6 +1236,7 @@
     <string name="error_publish_empty_post">Can\'t publish an empty post</string>
     <string name="error_publish_empty_page">Can\'t publish an empty page</string>
     <string name="error_save_empty_draft">Can\'t save an empty draft</string>
+    <string name="error_save_draft_while_media_uploading">Can\'t save as draft while media is uploading. Please wait.</string>
     <string name="error_publish_no_network">Device is offline. Changes saved locally.</string>
     <string name="error_upload_post_param">There was an error uploading this post: %s.</string>
     <string name="error_upload_page_param">There was an error uploading this page: %s.</string>


### PR DESCRIPTION
h/t @frosty for making me realize this was lacking 🙇 

Drafts that have media uploading cannot be saved to the server as they have a local reference to the media file. This PR prevents the draft from being saved, unless all media items have been uploaded already.

To test:
1. start a new draft
2. include some media
3. try to tape `Save as Draft` in the options menu
4. observe a new toast is shown.

Repeat the process while no media is being uploaded, and observe the draft gets uploaded and snackbar is shown.




