### PR TITLE
Api26/jobschedule reader post service

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -546,6 +546,7 @@
             android:name=".ui.stats.service.StatsService"
             android:exported="false"
             android:label="Stats Update Service" />
+
         <service
             android:name=".ui.reader.services.update.ReaderUpdateService"
             android:exported="false"
@@ -555,10 +556,17 @@
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="false"
             android:label="Reader Update JobService" />
+
         <service
             android:name=".ui.reader.services.post.ReaderPostService"
             android:exported="false"
             android:label="Reader Post Service" />
+        <service
+            android:name=".ui.reader.services.post.ReaderPostJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="false"
+            android:label="Reader Post JobService" />
+
         <service
             android:name=".ui.reader.services.ReaderSearchService"
             android:exported="false"

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -556,7 +556,7 @@
             android:exported="false"
             android:label="Reader Update JobService" />
         <service
-            android:name=".ui.reader.services.ReaderPostService"
+            android:name=".ui.reader.services.post.ReaderPostService"
             android:exported="false"
             android:label="Reader Post Service" />
         <service

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
@@ -6,7 +6,7 @@ import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.models.ReaderSimplePostList;
-import org.wordpress.android.ui.reader.services.post.ReaderPostService;
+import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter;
 import org.wordpress.android.util.StringUtils;
 
 /**
@@ -45,13 +45,13 @@ public class ReaderEvents {
     }
 
     public static class UpdatePostsStarted {
-        private final ReaderPostService.UpdateAction mAction;
+        private final ReaderPostServiceStarter.UpdateAction mAction;
 
-        public UpdatePostsStarted(ReaderPostService.UpdateAction action) {
+        public UpdatePostsStarted(ReaderPostServiceStarter.UpdateAction action) {
             mAction = action;
         }
 
-        public ReaderPostService.UpdateAction getAction() {
+        public ReaderPostServiceStarter.UpdateAction getAction() {
             return mAction;
         }
     }
@@ -59,10 +59,10 @@ public class ReaderEvents {
     public static class UpdatePostsEnded {
         private final ReaderTag mReaderTag;
         private final ReaderActions.UpdateResult mResult;
-        private final ReaderPostService.UpdateAction mAction;
+        private final ReaderPostServiceStarter.UpdateAction mAction;
 
         public UpdatePostsEnded(ReaderActions.UpdateResult result,
-                                ReaderPostService.UpdateAction action) {
+                                ReaderPostServiceStarter.UpdateAction action) {
             mResult = result;
             mAction = action;
             mReaderTag = null;
@@ -70,7 +70,7 @@ public class ReaderEvents {
 
         public UpdatePostsEnded(ReaderTag readerTag,
                                 ReaderActions.UpdateResult result,
-                                ReaderPostService.UpdateAction action) {
+                                ReaderPostServiceStarter.UpdateAction action) {
             mReaderTag = readerTag;
             mResult = result;
             mAction = action;
@@ -84,7 +84,7 @@ public class ReaderEvents {
             return mResult;
         }
 
-        public ReaderPostService.UpdateAction getAction() {
+        public ReaderPostServiceStarter.UpdateAction getAction() {
             return mAction;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderEvents.java
@@ -6,7 +6,7 @@ import org.wordpress.android.models.ReaderPost;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.models.ReaderSimplePostList;
-import org.wordpress.android.ui.reader.services.ReaderPostService;
+import org.wordpress.android.ui.reader.services.post.ReaderPostService;
 import org.wordpress.android.util.StringUtils;
 
 /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -52,8 +52,8 @@ import org.wordpress.android.ui.reader.actions.ReaderBlogActions.BlockedBlogResu
 import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderPostAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionAdapter;
-import org.wordpress.android.ui.reader.services.ReaderPostService;
-import org.wordpress.android.ui.reader.services.ReaderPostService.UpdateAction;
+import org.wordpress.android.ui.reader.services.post.ReaderPostService;
+import org.wordpress.android.ui.reader.services.post.ReaderPostService.UpdateAction;
 import org.wordpress.android.ui.reader.services.ReaderSearchService;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -52,9 +52,9 @@ import org.wordpress.android.ui.reader.actions.ReaderBlogActions.BlockedBlogResu
 import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderPostAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionAdapter;
-import org.wordpress.android.ui.reader.services.post.ReaderPostService;
-import org.wordpress.android.ui.reader.services.post.ReaderPostService.UpdateAction;
+import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter;
 import org.wordpress.android.ui.reader.services.ReaderSearchService;
+import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.UpdateAction;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
@@ -349,7 +349,7 @@ public class ReaderPostListFragment extends Fragment
                 if (getPostListType().isTagType()) {
                     updateCurrentTagIfTime();
                 } else if (getPostListType() == ReaderPostListType.BLOG_PREVIEW) {
-                    updatePostsInCurrentBlogOrFeed(UpdateAction.REQUEST_NEWER);
+                    updatePostsInCurrentBlogOrFeed(ReaderPostServiceStarter.UpdateAction.REQUEST_NEWER);
                 }
             }
         }
@@ -1190,9 +1190,9 @@ public class ReaderPostListFragment extends Fragment
             return;
         }
         if (mCurrentFeedId != 0) {
-            ReaderPostService.startServiceForFeed(getActivity(), mCurrentFeedId, updateAction);
+            ReaderPostServiceStarter.startServiceForFeed(getActivity(), mCurrentFeedId, updateAction);
         } else {
-            ReaderPostService.startServiceForBlog(getActivity(), mCurrentBlogId, updateAction);
+            ReaderPostServiceStarter.startServiceForBlog(getActivity(), mCurrentBlogId, updateAction);
         }
     }
 
@@ -1266,7 +1266,7 @@ public class ReaderPostListFragment extends Fragment
         }
         AppLog.d(T.READER,
                  "reader post list > updating tag " + tag.getTagNameForLog() + ", updateAction=" + updateAction.name());
-        ReaderPostService.startServiceForTag(getActivity(), tag, updateAction);
+        ReaderPostServiceStarter.startServiceForTag(getActivity(), tag, updateAction);
     }
 
     private void updateCurrentTag() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -37,7 +37,7 @@ import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderPostActions;
 import org.wordpress.android.ui.reader.models.ReaderBlogIdPostId;
 import org.wordpress.android.ui.reader.models.ReaderBlogIdPostIdList;
-import org.wordpress.android.ui.reader.services.ReaderPostService;
+import org.wordpress.android.ui.reader.services.post.ReaderPostService;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -37,7 +37,6 @@ import org.wordpress.android.ui.reader.actions.ReaderActions;
 import org.wordpress.android.ui.reader.actions.ReaderPostActions;
 import org.wordpress.android.ui.reader.models.ReaderBlogIdPostId;
 import org.wordpress.android.ui.reader.models.ReaderBlogIdPostIdList;
-import org.wordpress.android.ui.reader.services.post.ReaderPostService;
 import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostPagerActivity.java
@@ -38,6 +38,7 @@ import org.wordpress.android.ui.reader.actions.ReaderPostActions;
 import org.wordpress.android.ui.reader.models.ReaderBlogIdPostId;
 import org.wordpress.android.ui.reader.models.ReaderBlogIdPostIdList;
 import org.wordpress.android.ui.reader.services.post.ReaderPostService;
+import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.AppLog;
@@ -772,17 +773,17 @@ public class ReaderPostPagerActivity extends AppCompatActivity
         switch (getPostListType()) {
             case TAG_PREVIEW:
             case TAG_FOLLOWED:
-                ReaderPostService.startServiceForTag(
+                ReaderPostServiceStarter.startServiceForTag(
                         this,
                         getCurrentTag(),
-                        ReaderPostService.UpdateAction.REQUEST_OLDER);
+                        ReaderPostServiceStarter.UpdateAction.REQUEST_OLDER);
                 break;
 
             case BLOG_PREVIEW:
-                ReaderPostService.startServiceForBlog(
+                ReaderPostServiceStarter.startServiceForBlog(
                         this,
                         mBlogId,
-                        ReaderPostService.UpdateAction.REQUEST_OLDER);
+                        ReaderPostServiceStarter.UpdateAction.REQUEST_OLDER);
                 break;
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ServiceCompletionListener.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/ServiceCompletionListener.java
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.reader.services.update;
+package org.wordpress.android.ui.reader.services;
 
 public interface ServiceCompletionListener {
     void onCompleted(Object companion);

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostJobService.java
@@ -33,7 +33,7 @@ public class ReaderPostJobService extends JobService implements ServiceCompletio
     private ReaderPostLogic mReaderPostLogic;
 
     @Override public boolean onStartJob(JobParameters params) {
-        AppLog.i(AppLog.T.READER, "reader post service > started");
+        AppLog.i(AppLog.T.READER, "reader post job service > started");
         UpdateAction action;
         if (params.getExtras() != null) {
             if (params.getExtras().containsKey(ARG_ACTION)) {
@@ -59,7 +59,7 @@ public class ReaderPostJobService extends JobService implements ServiceCompletio
     }
 
     @Override public boolean onStopJob(JobParameters params) {
-        AppLog.i(AppLog.T.READER, "reader post service > stopped");
+        AppLog.i(AppLog.T.READER, "reader post job service > stopped");
         jobFinished(params, false);
         return false;
     }
@@ -68,18 +68,18 @@ public class ReaderPostJobService extends JobService implements ServiceCompletio
     public void onCreate() {
         super.onCreate();
         mReaderPostLogic = new ReaderPostLogic(this);
-        AppLog.i(AppLog.T.READER, "reader post service > created");
+        AppLog.i(AppLog.T.READER, "reader post job service > created");
     }
 
     @Override
     public void onDestroy() {
-        AppLog.i(AppLog.T.READER, "reader post service > destroyed");
+        AppLog.i(AppLog.T.READER, "reader post job service > destroyed");
         super.onDestroy();
     }
 
     @Override
     public void onCompleted(Object companion) {
-        AppLog.i(AppLog.T.READER, "reader post service > all tasks completed");
+        AppLog.i(AppLog.T.READER, "reader post job service > all tasks completed");
         jobFinished((JobParameters) companion, false);
     }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostJobService.java
@@ -89,7 +89,7 @@ public class ReaderPostJobService extends JobService implements ServiceCompletio
         String title = bundle.getString(ARG_TAG_PARAM_TITLE);
         String endpoint = bundle.getString(ARG_TAG_PARAM_ENDPOINT);
         int tagType = bundle.getInt(ARG_TAG_PARAM_TAGTYPE);
-        ReaderTag tag = new ReaderTag(slug, displayName, title, endpoint, ReaderTagType.values()[tagType]);
+        ReaderTag tag = new ReaderTag(slug, displayName, title, endpoint, ReaderTagType.fromInt(tagType));
         return tag;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostJobService.java
@@ -1,0 +1,95 @@
+package org.wordpress.android.ui.reader.services.post;
+
+import android.annotation.TargetApi;
+import android.app.job.JobParameters;
+import android.app.job.JobService;
+import android.os.PersistableBundle;
+
+import org.wordpress.android.models.ReaderTag;
+import org.wordpress.android.models.ReaderTagType;
+import org.wordpress.android.ui.reader.ReaderEvents;
+import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
+import org.wordpress.android.util.AppLog;
+
+import de.greenrobot.event.EventBus;
+
+import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_ACTION;
+import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_BLOG_ID;
+import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_FEED_ID;
+import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_TAG_PARAM_DISPLAY_NAME;
+import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_TAG_PARAM_ENDPOINT;
+import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_TAG_PARAM_SLUG;
+import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_TAG_PARAM_TAGTYPE;
+import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_TAG_PARAM_TITLE;
+import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.UpdateAction;
+
+/**
+ * service which updates posts with specific tags or in specific blogs/feeds - relies on
+ * EventBus to alert of update status
+ */
+
+@TargetApi(21)
+public class ReaderPostJobService extends JobService implements ServiceCompletionListener {
+    private ReaderPostLogic mReaderPostLogic;
+
+    @Override public boolean onStartJob(JobParameters params) {
+        AppLog.i(AppLog.T.READER, "reader post service > started");
+        UpdateAction action;
+        if (params.getExtras() != null) {
+            if (params.getExtras().containsKey(ARG_ACTION)) {
+                action = UpdateAction.values()[(Integer) params.getExtras().get(ARG_ACTION)];
+            } else {
+                action = UpdateAction.REQUEST_NEWER;
+            }
+
+            EventBus.getDefault().post(new ReaderEvents.UpdatePostsStarted(action));
+
+            if (params.getExtras().containsKey(ARG_TAG_PARAM_SLUG)) {
+                ReaderTag tag = getReaderTagFromBundleParams(params.getExtras());
+                mReaderPostLogic.performTask(params, action, tag, -1, -1);
+            } else if (params.getExtras().containsKey(ARG_BLOG_ID)) {
+                long blogId = params.getExtras().getLong(ARG_BLOG_ID, 0);
+                mReaderPostLogic.performTask(params, action, null, blogId, -1);
+            } else if (params.getExtras().containsKey(ARG_FEED_ID)) {
+                long feedId = params.getExtras().getLong(ARG_FEED_ID, 0);
+                mReaderPostLogic.performTask(params, action, null, -1, feedId);
+            }
+        }
+        return true;
+    }
+
+    @Override public boolean onStopJob(JobParameters params) {
+        AppLog.i(AppLog.T.READER, "reader post service > stopped");
+        jobFinished(params, false);
+        return false;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        mReaderPostLogic = new ReaderPostLogic(this);
+        AppLog.i(AppLog.T.READER, "reader post service > created");
+    }
+
+    @Override
+    public void onDestroy() {
+        AppLog.i(AppLog.T.READER, "reader post service > destroyed");
+        super.onDestroy();
+    }
+
+    @Override
+    public void onCompleted(Object companion) {
+        AppLog.i(AppLog.T.READER, "reader post service > all tasks completed");
+        jobFinished((JobParameters) companion, false);
+    }
+
+    private ReaderTag getReaderTagFromBundleParams(PersistableBundle bundle) {
+        String slug = bundle.getString(ARG_TAG_PARAM_SLUG);
+        String displayName = bundle.getString(ARG_TAG_PARAM_DISPLAY_NAME);
+        String title = bundle.getString(ARG_TAG_PARAM_TITLE);
+        String endpoint = bundle.getString(ARG_TAG_PARAM_ENDPOINT);
+        int tagType = bundle.getInt(ARG_TAG_PARAM_TAGTYPE);
+        ReaderTag tag = new ReaderTag(slug, displayName, title, endpoint, ReaderTagType.values()[tagType]);
+        return tag;
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostService.java
@@ -1,0 +1,116 @@
+package org.wordpress.android.ui.reader.services.post;
+
+import android.app.Service;
+import android.content.Context;
+import android.content.Intent;
+import android.os.IBinder;
+
+import org.wordpress.android.models.ReaderTag;
+import org.wordpress.android.ui.reader.ReaderEvents;
+import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
+import org.wordpress.android.util.AppLog;
+
+import de.greenrobot.event.EventBus;
+
+/**
+ * service which updates posts with specific tags or in specific blogs/feeds - relies on
+ * EventBus to alert of update status
+ */
+
+public class ReaderPostService extends Service implements ServiceCompletionListener {
+    private static final String ARG_TAG = "tag";
+    private static final String ARG_ACTION = "action";
+    private static final String ARG_BLOG_ID = "blog_id";
+    private static final String ARG_FEED_ID = "feed_id";
+
+    private ReaderPostLogic mReaderPostLogic;
+
+    public enum UpdateAction {
+        REQUEST_NEWER, // request the newest posts for this tag/blog/feed
+        REQUEST_OLDER, // request posts older than the oldest existing one for this tag/blog/feed
+        REQUEST_OLDER_THAN_GAP // request posts older than the one with the gap marker for this tag
+                               // (not supported for blog/feed)
+    }
+
+    /*
+     * update posts with the passed tag
+     */
+    public static void startServiceForTag(Context context, ReaderTag tag, UpdateAction action) {
+        Intent intent = new Intent(context, ReaderPostService.class);
+        intent.putExtra(ARG_TAG, tag);
+        intent.putExtra(ARG_ACTION, action);
+        context.startService(intent);
+    }
+
+    /*
+     * update posts in the passed blog
+     */
+    public static void startServiceForBlog(Context context, long blogId, UpdateAction action) {
+        Intent intent = new Intent(context, ReaderPostService.class);
+        intent.putExtra(ARG_BLOG_ID, blogId);
+        intent.putExtra(ARG_ACTION, action);
+        context.startService(intent);
+    }
+
+    /*
+     * update posts in the passed feed
+     */
+    public static void startServiceForFeed(Context context, long feedId, UpdateAction action) {
+        Intent intent = new Intent(context, ReaderPostService.class);
+        intent.putExtra(ARG_FEED_ID, feedId);
+        intent.putExtra(ARG_ACTION, action);
+        context.startService(intent);
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        mReaderPostLogic = new ReaderPostLogic(this);
+        AppLog.i(AppLog.T.READER, "reader post service > created");
+    }
+
+    @Override
+    public void onDestroy() {
+        AppLog.i(AppLog.T.READER, "reader post service > destroyed");
+        super.onDestroy();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent == null) {
+            return START_NOT_STICKY;
+        }
+
+        UpdateAction action;
+        if (intent.hasExtra(ARG_ACTION)) {
+            action = (UpdateAction) intent.getSerializableExtra(ARG_ACTION);
+        } else {
+            action = UpdateAction.REQUEST_NEWER;
+        }
+
+        EventBus.getDefault().post(new ReaderEvents.UpdatePostsStarted(action));
+
+        if (intent.hasExtra(ARG_TAG)) {
+            ReaderTag tag = (ReaderTag) intent.getSerializableExtra(ARG_TAG);
+            mReaderPostLogic.performTask(null, action, tag, -1, -1);
+        } else if (intent.hasExtra(ARG_BLOG_ID)) {
+            long blogId = intent.getLongExtra(ARG_BLOG_ID, 0);
+            mReaderPostLogic.performTask(null, action, null, blogId, -1);
+        } else if (intent.hasExtra(ARG_FEED_ID)) {
+            long feedId = intent.getLongExtra(ARG_FEED_ID, 0);
+            mReaderPostLogic.performTask(null, action, null, -1, feedId);
+        }
+
+        return START_NOT_STICKY;
+    }
+
+    @Override
+    public void onCompleted(Object companion) {
+        stopSelf();
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostService.java
@@ -10,6 +10,12 @@ import org.wordpress.android.ui.reader.ReaderEvents;
 import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
 import org.wordpress.android.util.AppLog;
 
+import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_ACTION;
+import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_BLOG_ID;
+import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_FEED_ID;
+import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.ARG_TAG;
+import static org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.UpdateAction;
+
 import de.greenrobot.event.EventBus;
 
 /**
@@ -18,49 +24,7 @@ import de.greenrobot.event.EventBus;
  */
 
 public class ReaderPostService extends Service implements ServiceCompletionListener {
-    private static final String ARG_TAG = "tag";
-    private static final String ARG_ACTION = "action";
-    private static final String ARG_BLOG_ID = "blog_id";
-    private static final String ARG_FEED_ID = "feed_id";
-
     private ReaderPostLogic mReaderPostLogic;
-
-    public enum UpdateAction {
-        REQUEST_NEWER, // request the newest posts for this tag/blog/feed
-        REQUEST_OLDER, // request posts older than the oldest existing one for this tag/blog/feed
-        REQUEST_OLDER_THAN_GAP // request posts older than the one with the gap marker for this tag
-                               // (not supported for blog/feed)
-    }
-
-    /*
-     * update posts with the passed tag
-     */
-    public static void startServiceForTag(Context context, ReaderTag tag, UpdateAction action) {
-        Intent intent = new Intent(context, ReaderPostService.class);
-        intent.putExtra(ARG_TAG, tag);
-        intent.putExtra(ARG_ACTION, action);
-        context.startService(intent);
-    }
-
-    /*
-     * update posts in the passed blog
-     */
-    public static void startServiceForBlog(Context context, long blogId, UpdateAction action) {
-        Intent intent = new Intent(context, ReaderPostService.class);
-        intent.putExtra(ARG_BLOG_ID, blogId);
-        intent.putExtra(ARG_ACTION, action);
-        context.startService(intent);
-    }
-
-    /*
-     * update posts in the passed feed
-     */
-    public static void startServiceForFeed(Context context, long feedId, UpdateAction action) {
-        Intent intent = new Intent(context, ReaderPostService.class);
-        intent.putExtra(ARG_FEED_ID, feedId);
-        intent.putExtra(ARG_ACTION, action);
-        context.startService(intent);
-    }
 
     @Override
     public IBinder onBind(Intent intent) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostService.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.reader.services.post;
 
 import android.app.Service;
-import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostServiceStarter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostServiceStarter.java
@@ -1,16 +1,29 @@
 package org.wordpress.android.ui.reader.services.post;
 
+import android.annotation.TargetApi;
+import android.app.job.JobInfo;
+import android.app.job.JobScheduler;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
+import android.os.PersistableBundle;
 
 import org.wordpress.android.models.ReaderTag;
+import org.wordpress.android.util.AppLog;
 
 public class ReaderPostServiceStarter {
+    private static final int JOB_READER_POST_SERVICE_ID = 4000;
     public static final String ARG_TAG = "tag";
     public static final String ARG_ACTION = "action";
     public static final String ARG_BLOG_ID = "blog_id";
     public static final String ARG_FEED_ID = "feed_id";
+
+    public static final String ARG_TAG_PARAM_SLUG = "tag-slug";
+    public static final String ARG_TAG_PARAM_DISPLAY_NAME = "tag-display-name";
+    public static final String ARG_TAG_PARAM_TITLE = "tag-title";
+    public static final String ARG_TAG_PARAM_ENDPOINT = "tag-endpoint";
+    public static final String ARG_TAG_PARAM_TAGTYPE = "tag-type";
 
     public enum UpdateAction {
         REQUEST_NEWER, // request the newest posts for this tag/blog/feed
@@ -29,7 +42,10 @@ public class ReaderPostServiceStarter {
             intent.putExtra(ARG_ACTION, action);
             context.startService(intent);
         } else {
-            // TODO implement API26 JobScheduler
+            PersistableBundle extras = new PersistableBundle();
+            extras.putInt(ARG_ACTION, action.ordinal());
+            putReaderTagExtras(extras, tag);
+            doScheduleJobWithBundle(context, extras);
         }
     }
 
@@ -43,7 +59,10 @@ public class ReaderPostServiceStarter {
             intent.putExtra(ARG_ACTION, action);
             context.startService(intent);
         } else {
-            // TODO implement API26 JobScheduler
+            PersistableBundle extras = new PersistableBundle();
+            extras.putLong(ARG_BLOG_ID, blogId);
+            extras.putInt(ARG_ACTION, action.ordinal());
+            doScheduleJobWithBundle(context, extras);
         }
     }
 
@@ -57,7 +76,41 @@ public class ReaderPostServiceStarter {
             intent.putExtra(ARG_ACTION, action);
             context.startService(intent);
         } else {
-            // TODO implement API26 JobScheduler
+            PersistableBundle extras = new PersistableBundle();
+            extras.putLong(ARG_FEED_ID, feedId);
+            extras.putInt(ARG_ACTION, action.ordinal());
+            doScheduleJobWithBundle(context, extras);
         }
+    }
+
+    @TargetApi(21)
+    private static void doScheduleJobWithBundle(Context context, PersistableBundle extras) {
+        // schedule the JobService here for API >= 26. The JobScheduler is available since API 21, but
+        // it's preferrable to use it only since enforcement in API 26 to not break any old behavior
+        ComponentName componentName = new ComponentName(context, ReaderPostJobService.class);
+
+        JobInfo jobInfo = new JobInfo.Builder(JOB_READER_POST_SERVICE_ID, componentName)
+                .setRequiresCharging(false)
+                .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+                .setOverrideDeadline(0) // if possible, try to run right away
+                .setExtras(extras)
+                .build();
+
+        JobScheduler jobScheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+        int resultCode = jobScheduler.schedule(jobInfo);
+        if (resultCode == JobScheduler.RESULT_SUCCESS) {
+            AppLog.i(AppLog.T.READER, "reader post service > job scheduled");
+        } else {
+            AppLog.e(AppLog.T.READER, "reader post service > job could not be scheduled");
+        }
+    }
+
+    @TargetApi(21)
+    private static void putReaderTagExtras(PersistableBundle extras, ReaderTag tag) {
+        extras.putString(ARG_TAG_PARAM_SLUG, tag.getTagSlug());
+        extras.putString(ARG_TAG_PARAM_DISPLAY_NAME, tag.getTagDisplayName());
+        extras.putString(ARG_TAG_PARAM_TITLE, tag.getTagTitle());
+        extras.putString(ARG_TAG_PARAM_ENDPOINT, tag.getEndpoint());
+        extras.putInt(ARG_TAG_PARAM_TAGTYPE, tag.tagType.toInt());
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostServiceStarter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostServiceStarter.java
@@ -1,0 +1,63 @@
+package org.wordpress.android.ui.reader.services.post;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+
+import org.wordpress.android.models.ReaderTag;
+
+public class ReaderPostServiceStarter {
+    public static final String ARG_TAG = "tag";
+    public static final String ARG_ACTION = "action";
+    public static final String ARG_BLOG_ID = "blog_id";
+    public static final String ARG_FEED_ID = "feed_id";
+
+    public enum UpdateAction {
+        REQUEST_NEWER, // request the newest posts for this tag/blog/feed
+        REQUEST_OLDER, // request posts older than the oldest existing one for this tag/blog/feed
+        REQUEST_OLDER_THAN_GAP // request posts older than the one with the gap marker for this tag
+                               // (not supported for blog/feed)
+    }
+
+    /*
+     * update posts with the passed tag
+     */
+    public static void startServiceForTag(Context context, ReaderTag tag, UpdateAction action) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            Intent intent = new Intent(context, ReaderPostService.class);
+            intent.putExtra(ARG_TAG, tag);
+            intent.putExtra(ARG_ACTION, action);
+            context.startService(intent);
+        } else {
+            // TODO implement API26 JobScheduler
+        }
+    }
+
+    /*
+     * update posts in the passed blog
+     */
+    public static void startServiceForBlog(Context context, long blogId, UpdateAction action) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            Intent intent = new Intent(context, ReaderPostService.class);
+            intent.putExtra(ARG_BLOG_ID, blogId);
+            intent.putExtra(ARG_ACTION, action);
+            context.startService(intent);
+        } else {
+            // TODO implement API26 JobScheduler
+        }
+    }
+
+    /*
+     * update posts in the passed feed
+     */
+    public static void startServiceForFeed(Context context, long feedId, UpdateAction action) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            Intent intent = new Intent(context, ReaderPostService.class);
+            intent.putExtra(ARG_FEED_ID, feedId);
+            intent.putExtra(ARG_ACTION, action);
+            context.startService(intent);
+        } else {
+            // TODO implement API26 JobScheduler
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostServiceStarter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostServiceStarter.java
@@ -13,7 +13,9 @@ import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.util.AppLog;
 
 public class ReaderPostServiceStarter {
-    private static final int JOB_READER_POST_SERVICE_ID = 4000;
+    private static final int JOB_READER_POST_SERVICE_ID_TAG = 4001;
+    private static final int JOB_READER_POST_SERVICE_ID_BLOG = 4002;
+    private static final int JOB_READER_POST_SERVICE_ID_FEED = 4003;
     public static final String ARG_TAG = "tag";
     public static final String ARG_ACTION = "action";
     public static final String ARG_BLOG_ID = "blog_id";
@@ -45,7 +47,7 @@ public class ReaderPostServiceStarter {
             PersistableBundle extras = new PersistableBundle();
             extras.putInt(ARG_ACTION, action.ordinal());
             putReaderTagExtras(extras, tag);
-            doScheduleJobWithBundle(context, extras);
+            doScheduleJobWithBundle(context, extras, JOB_READER_POST_SERVICE_ID_TAG);
         }
     }
 
@@ -62,7 +64,7 @@ public class ReaderPostServiceStarter {
             PersistableBundle extras = new PersistableBundle();
             extras.putLong(ARG_BLOG_ID, blogId);
             extras.putInt(ARG_ACTION, action.ordinal());
-            doScheduleJobWithBundle(context, extras);
+            doScheduleJobWithBundle(context, extras, JOB_READER_POST_SERVICE_ID_BLOG);
         }
     }
 
@@ -79,17 +81,17 @@ public class ReaderPostServiceStarter {
             PersistableBundle extras = new PersistableBundle();
             extras.putLong(ARG_FEED_ID, feedId);
             extras.putInt(ARG_ACTION, action.ordinal());
-            doScheduleJobWithBundle(context, extras);
+            doScheduleJobWithBundle(context, extras, JOB_READER_POST_SERVICE_ID_FEED);
         }
     }
 
     @TargetApi(21)
-    private static void doScheduleJobWithBundle(Context context, PersistableBundle extras) {
+    private static void doScheduleJobWithBundle(Context context, PersistableBundle extras, int jobId) {
         // schedule the JobService here for API >= 26. The JobScheduler is available since API 21, but
         // it's preferrable to use it only since enforcement in API 26 to not break any old behavior
         ComponentName componentName = new ComponentName(context, ReaderPostJobService.class);
 
-        JobInfo jobInfo = new JobInfo.Builder(JOB_READER_POST_SERVICE_ID, componentName)
+        JobInfo jobInfo = new JobInfo.Builder(jobId, componentName)
                 .setRequiresCharging(false)
                 .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
                 .setOverrideDeadline(0) // if possible, try to run right away

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateJobService.java
@@ -5,6 +5,7 @@ import android.app.job.JobParameters;
 import android.app.job.JobService;
 
 import org.wordpress.android.WordPress;
+import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
 import org.wordpress.android.util.AppLog;
 
 import java.util.EnumSet;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateLogic.java
@@ -19,6 +19,7 @@ import org.wordpress.android.models.ReaderTagList;
 import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.reader.ReaderConstants;
 import org.wordpress.android.ui.reader.ReaderEvents;
+import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.JSONUtils;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateService.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.IBinder;
 
 import org.wordpress.android.WordPress;
+import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
 import org.wordpress.android.util.AppLog;
 
 import java.util.EnumSet;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderGapMarkerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderGapMarkerView.java
@@ -9,8 +9,8 @@ import android.widget.TextView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.models.ReaderTag;
-import org.wordpress.android.ui.reader.services.ReaderPostService;
-import org.wordpress.android.ui.reader.services.ReaderPostService.UpdateAction;
+import org.wordpress.android.ui.reader.services.post.ReaderPostService;
+import org.wordpress.android.ui.reader.services.post.ReaderPostService.UpdateAction;
 import org.wordpress.android.util.NetworkUtils;
 
 /**

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderGapMarkerView.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/views/ReaderGapMarkerView.java
@@ -9,8 +9,8 @@ import android.widget.TextView;
 
 import org.wordpress.android.R;
 import org.wordpress.android.models.ReaderTag;
-import org.wordpress.android.ui.reader.services.post.ReaderPostService;
-import org.wordpress.android.ui.reader.services.post.ReaderPostService.UpdateAction;
+import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.UpdateAction;
+import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter;
 import org.wordpress.android.util.NetworkUtils;
 
 /**
@@ -63,7 +63,7 @@ public class ReaderGapMarkerView extends RelativeLayout {
 
         // start service to fill the gap - EventBus will notify the owning fragment of new posts,
         // and will take care of hiding this view
-        ReaderPostService.startServiceForTag(getContext(), mCurrentTag, UpdateAction.REQUEST_OLDER_THAN_GAP);
+        ReaderPostServiceStarter.startServiceForTag(getContext(), mCurrentTag, UpdateAction.REQUEST_OLDER_THAN_GAP);
         showProgress();
     }
 


### PR DESCRIPTION
*Note:* Builds on top of #7603 which should be merged first. Otherwise this looks like a super big PR 😱 

Continues the API26 migration series. This time we bring `ReaderPostService` in its two versions, a `Service` for API below level 26, and `JobService` for API 26 and beyond.

To test:
1. Start the app
2. Go to the reader
3. Change tags filters, refresh, etc. and see that it works.

Use please both platform 26+ and below.

cc @nbradbury 