### PR TITLE
Api26/jobschedule reader search service

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -572,6 +572,12 @@
             android:exported="false"
             android:label="Reader Search Service" />
         <service
+            android:name=".ui.reader.services.search.ReaderSearchJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="false"
+            android:label="Reader Search Job Service" />
+
+        <service
             android:name=".ui.reader.services.ReaderCommentService"
             android:exported="false"
             android:label="Reader Comment Service" />

--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -568,7 +568,7 @@
             android:label="Reader Post JobService" />
 
         <service
-            android:name=".ui.reader.services.ReaderSearchService"
+            android:name=".ui.reader.services.search.ReaderSearchService"
             android:exported="false"
             android:label="Reader Search Service" />
         <service

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -53,7 +53,7 @@ import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderPostAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionAdapter;
 import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter;
-import org.wordpress.android.ui.reader.services.ReaderSearchService;
+import org.wordpress.android.ui.reader.services.search.ReaderSearchService;
 import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.UpdateAction;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -652,7 +652,7 @@ public class ReaderPostListFragment extends Fragment
 
         // remove cached results for this search - search results are ephemeral so each search
         // should be treated as a "fresh" one
-        ReaderTag searchTag = ReaderSearchService.getTagForSearchQuery(trimQuery);
+        ReaderTag searchTag = ReaderUtils.getTagForSearchQuery(trimQuery);
         ReaderPostTable.deletePostsWithTag(searchTag);
 
         mPostAdapter.setCurrentTag(searchTag);
@@ -1016,7 +1016,7 @@ public class ReaderPostListFragment extends Fragment
                             break;
 
                         case SEARCH_RESULTS:
-                            ReaderTag searchTag = ReaderSearchService.getTagForSearchQuery(mCurrentSearchQuery);
+                            ReaderTag searchTag = ReaderUtils.getTagForSearchQuery(mCurrentSearchQuery);
                             int offset = ReaderPostTable.getNumPostsWithTag(searchTag);
                             if (offset < ReaderConstants.READER_MAX_POSTS_TO_DISPLAY) {
                                 updatePostsInCurrentSearch(offset);
@@ -1044,7 +1044,7 @@ public class ReaderPostListFragment extends Fragment
             } else if (getPostListType() == ReaderPostListType.BLOG_PREVIEW) {
                 mPostAdapter.setCurrentBlogAndFeed(mCurrentBlogId, mCurrentFeedId);
             } else if (getPostListType() == ReaderPostListType.SEARCH_RESULTS) {
-                ReaderTag searchTag = ReaderSearchService.getTagForSearchQuery(mCurrentSearchQuery);
+                ReaderTag searchTag = ReaderUtils.getTagForSearchQuery(mCurrentSearchQuery);
                 mPostAdapter.setCurrentTag(searchTag);
             }
         }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -55,6 +55,7 @@ import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionAdapter;
 import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter;
 import org.wordpress.android.ui.reader.services.search.ReaderSearchService;
 import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.UpdateAction;
+import org.wordpress.android.ui.reader.services.search.ReaderSearchServiceStarter;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
@@ -634,7 +635,7 @@ public class ReaderPostListFragment extends Fragment
      * offset is used during infinite scroll, pass zero for initial search
      */
     private void updatePostsInCurrentSearch(int offset) {
-        ReaderSearchService.startService(getActivity(), mCurrentSearchQuery, offset);
+        ReaderSearchServiceStarter.startService(getActivity(), mCurrentSearchQuery, offset);
     }
 
     private void submitSearchQuery(@NonNull String query) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/ReaderPostListFragment.java
@@ -53,7 +53,6 @@ import org.wordpress.android.ui.reader.adapters.ReaderMenuAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderPostAdapter;
 import org.wordpress.android.ui.reader.adapters.ReaderSearchSuggestionAdapter;
 import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter;
-import org.wordpress.android.ui.reader.services.search.ReaderSearchService;
 import org.wordpress.android.ui.reader.services.post.ReaderPostServiceStarter.UpdateAction;
 import org.wordpress.android.ui.reader.services.search.ReaderSearchServiceStarter;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic.UpdateTask;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostServiceStarter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/post/ReaderPostServiceStarter.java
@@ -88,7 +88,7 @@ public class ReaderPostServiceStarter {
     @TargetApi(21)
     private static void doScheduleJobWithBundle(Context context, PersistableBundle extras, int jobId) {
         // schedule the JobService here for API >= 26. The JobScheduler is available since API 21, but
-        // it's preferrable to use it only since enforcement in API 26 to not break any old behavior
+        // it's preferable to use it only since enforcement in API 26 to not break any old behavior
         ComponentName componentName = new ComponentName(context, ReaderPostJobService.class);
 
         JobInfo jobInfo = new JobInfo.Builder(jobId, componentName)

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchJobService.java
@@ -1,0 +1,54 @@
+package org.wordpress.android.ui.reader.services.search;
+
+import android.annotation.TargetApi;
+import android.app.job.JobParameters;
+import android.app.job.JobService;
+
+import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
+import org.wordpress.android.util.AppLog;
+
+import static org.wordpress.android.ui.reader.services.search.ReaderSearchServiceStarter.ARG_OFFSET;
+import static org.wordpress.android.ui.reader.services.search.ReaderSearchServiceStarter.ARG_QUERY;
+
+/**
+ * service which searches for reader posts on wordpress.com
+ */
+
+@TargetApi(21)
+public class ReaderSearchJobService extends JobService implements ServiceCompletionListener {
+    private ReaderSearchLogic mReaderSearchLogic;
+
+    @Override public boolean onStartJob(JobParameters params) {
+        if (params.getExtras() != null && params.getExtras().containsKey(ARG_QUERY)) {
+            String query = params.getExtras().getString(ARG_QUERY);
+            int offset = params.getExtras().getInt(ARG_OFFSET, 0);
+            mReaderSearchLogic.startSearch(query, offset, params);
+        }
+
+        return true;
+    }
+
+    @Override public boolean onStopJob(JobParameters params) {
+        jobFinished(params, false);
+        return false;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        mReaderSearchLogic = new ReaderSearchLogic(this);
+        AppLog.i(AppLog.T.READER, "reader search job service > created");
+    }
+
+    @Override
+    public void onDestroy() {
+        AppLog.i(AppLog.T.READER, "reader search job service > destroyed");
+        super.onDestroy();
+    }
+
+    @Override
+    public void onCompleted(Object companion) {
+        AppLog.i(AppLog.T.READER, "reader search job service > all tasks completed");
+        jobFinished((JobParameters) companion, false);
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchLogic.java
@@ -1,0 +1,71 @@
+package org.wordpress.android.ui.reader.services.search;
+
+import com.android.volley.VolleyError;
+import com.wordpress.rest.RestRequest;
+
+import org.json.JSONObject;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.datasets.ReaderPostTable;
+import org.wordpress.android.models.ReaderPostList;
+import org.wordpress.android.ui.reader.ReaderConstants;
+import org.wordpress.android.ui.reader.ReaderEvents;
+import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
+import org.wordpress.android.util.AppLog;
+import org.wordpress.android.util.UrlUtils;
+
+import de.greenrobot.event.EventBus;
+
+import static org.wordpress.android.ui.reader.services.search.ReaderSearchService.getTagForSearchQuery;
+
+public class ReaderSearchLogic {
+    private ServiceCompletionListener mCompletionListener;
+    private Object mListenerCompanion;
+
+    public ReaderSearchLogic(ServiceCompletionListener listener) {
+        mCompletionListener = listener;
+    }
+
+    public void startSearch(final String query, final int offset, Object companion) {
+        mListenerCompanion = companion;
+        String path = "read/search?q="
+                      + UrlUtils.urlEncode(query)
+                      + "&number=" + ReaderConstants.READER_MAX_SEARCH_POSTS_TO_REQUEST
+                      + "&offset=" + offset
+                      + "&meta=site,likes";
+
+        RestRequest.Listener listener = new RestRequest.Listener() {
+            @Override
+            public void onResponse(JSONObject jsonObject) {
+                if (jsonObject != null) {
+                    handleSearchResponse(query, offset, jsonObject);
+                } else {
+                    EventBus.getDefault().post(new ReaderEvents.SearchPostsEnded(query, offset, false));
+                }
+            }
+        };
+        RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
+            @Override
+            public void onErrorResponse(VolleyError volleyError) {
+                AppLog.e(AppLog.T.READER, volleyError);
+                EventBus.getDefault().post(new ReaderEvents.SearchPostsEnded(query, offset, false));
+                mCompletionListener.onCompleted(mListenerCompanion);
+            }
+        };
+
+        AppLog.d(AppLog.T.READER, "reader search service > starting search for " + query);
+        EventBus.getDefault().post(new ReaderEvents.SearchPostsStarted(query, offset));
+        WordPress.getRestClientUtilsV1_2().get(path, null, null, listener, errorListener);
+    }
+
+    private void handleSearchResponse(final String query, final int offset, final JSONObject jsonObject) {
+        new Thread() {
+            @Override
+            public void run() {
+                ReaderPostList serverPosts = ReaderPostList.fromJson(jsonObject);
+                ReaderPostTable.addOrUpdatePosts(getTagForSearchQuery(query), serverPosts);
+                EventBus.getDefault().post(new ReaderEvents.SearchPostsEnded(query, offset, true));
+                mCompletionListener.onCompleted(mListenerCompanion);
+            }
+        }.start();
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchLogic.java
@@ -15,7 +15,7 @@ import org.wordpress.android.util.UrlUtils;
 
 import de.greenrobot.event.EventBus;
 
-import static org.wordpress.android.ui.reader.services.search.ReaderSearchService.getTagForSearchQuery;
+import static org.wordpress.android.ui.reader.utils.ReaderUtils.getTagForSearchQuery;
 
 public class ReaderSearchLogic {
     private ServiceCompletionListener mCompletionListener;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchService.java
@@ -1,4 +1,4 @@
-package org.wordpress.android.ui.reader.services;
+package org.wordpress.android.ui.reader.services.search;
 
 import android.app.Service;
 import android.content.Context;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchService.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.reader.services.search;
 
 import android.app.Service;
-import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
 import android.support.annotation.NonNull;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchService.java
@@ -6,31 +6,22 @@ import android.content.Intent;
 import android.os.IBinder;
 import android.support.annotation.NonNull;
 
-import com.android.volley.VolleyError;
-import com.wordpress.rest.RestRequest;
-
-import org.json.JSONObject;
-import org.wordpress.android.WordPress;
-import org.wordpress.android.datasets.ReaderPostTable;
-import org.wordpress.android.models.ReaderPostList;
 import org.wordpress.android.models.ReaderTag;
 import org.wordpress.android.models.ReaderTagType;
-import org.wordpress.android.ui.reader.ReaderConstants;
-import org.wordpress.android.ui.reader.ReaderEvents;
+import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
 import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
-import org.wordpress.android.util.UrlUtils;
-
-import de.greenrobot.event.EventBus;
 
 /**
  * service which searches for reader posts on wordpress.com
  */
 
-public class ReaderSearchService extends Service {
+public class ReaderSearchService extends Service implements ServiceCompletionListener {
     private static final String ARG_QUERY = "query";
     private static final String ARG_OFFSET = "offset";
+
+    private ReaderSearchLogic mReaderSearchLogic;
 
     public static void startService(Context context, @NonNull String query, int offset) {
         Intent intent = new Intent(context, ReaderSearchService.class);
@@ -56,6 +47,7 @@ public class ReaderSearchService extends Service {
     @Override
     public void onCreate() {
         super.onCreate();
+        mReaderSearchLogic = new ReaderSearchLogic(this);
         AppLog.i(AppLog.T.READER, "reader search service > created");
     }
 
@@ -73,50 +65,15 @@ public class ReaderSearchService extends Service {
 
         String query = StringUtils.notNullStr(intent.getStringExtra(ARG_QUERY));
         int offset = intent.getIntExtra(ARG_OFFSET, 0);
-        startSearch(query, offset);
+        mReaderSearchLogic.startSearch(query, offset, null);
 
         return START_NOT_STICKY;
     }
 
-    private void startSearch(final String query, final int offset) {
-        String path = "read/search?q="
-                      + UrlUtils.urlEncode(query)
-                      + "&number=" + ReaderConstants.READER_MAX_SEARCH_POSTS_TO_REQUEST
-                      + "&offset=" + offset
-                      + "&meta=site,likes";
-
-        RestRequest.Listener listener = new RestRequest.Listener() {
-            @Override
-            public void onResponse(JSONObject jsonObject) {
-                if (jsonObject != null) {
-                    handleSearchResponse(query, offset, jsonObject);
-                } else {
-                    EventBus.getDefault().post(new ReaderEvents.SearchPostsEnded(query, offset, false));
-                }
-            }
-        };
-        RestRequest.ErrorListener errorListener = new RestRequest.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError volleyError) {
-                AppLog.e(AppLog.T.READER, volleyError);
-                EventBus.getDefault().post(new ReaderEvents.SearchPostsEnded(query, offset, false));
-            }
-        };
-
-        AppLog.d(AppLog.T.READER, "reader search service > starting search for " + query);
-        EventBus.getDefault().post(new ReaderEvents.SearchPostsStarted(query, offset));
-        WordPress.getRestClientUtilsV1_2().get(path, null, null, listener, errorListener);
-    }
-
-    private static void handleSearchResponse(final String query, final int offset, final JSONObject jsonObject) {
-        new Thread() {
-            @Override
-            public void run() {
-                ReaderPostList serverPosts = ReaderPostList.fromJson(jsonObject);
-                ReaderPostTable.addOrUpdatePosts(getTagForSearchQuery(query), serverPosts);
-                EventBus.getDefault().post(new ReaderEvents.SearchPostsEnded(query, offset, true));
-            }
-        }.start();
+    @Override
+    public void onCompleted(Object companion) {
+        AppLog.i(AppLog.T.READER, "reader search service > all tasks completed");
+        stopSelf();
     }
 
     /*

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchService.java
@@ -58,13 +58,4 @@ public class ReaderSearchService extends Service implements ServiceCompletionLis
         AppLog.i(AppLog.T.READER, "reader search service > all tasks completed");
         stopSelf();
     }
-
-    /*
-     * used when storing search results in the reader post table
-     */
-    public static ReaderTag getTagForSearchQuery(@NonNull String query) {
-        String trimQuery = query != null ? query.trim() : "";
-        String slug = ReaderUtils.sanitizeWithDashes(trimQuery);
-        return new ReaderTag(slug, trimQuery, trimQuery, null, ReaderTagType.SEARCH);
-    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchService.java
@@ -23,22 +23,6 @@ public class ReaderSearchService extends Service implements ServiceCompletionLis
 
     private ReaderSearchLogic mReaderSearchLogic;
 
-    public static void startService(Context context, @NonNull String query, int offset) {
-        Intent intent = new Intent(context, ReaderSearchService.class);
-        intent.putExtra(ARG_QUERY, query);
-        intent.putExtra(ARG_OFFSET, offset);
-        context.startService(intent);
-    }
-
-    public static void stopService(Context context) {
-        if (context == null) {
-            return;
-        }
-
-        Intent intent = new Intent(context, ReaderSearchService.class);
-        context.stopService(intent);
-    }
-
     @Override
     public IBinder onBind(Intent intent) {
         return null;

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchService.java
@@ -3,12 +3,8 @@ package org.wordpress.android.ui.reader.services.search;
 import android.app.Service;
 import android.content.Intent;
 import android.os.IBinder;
-import android.support.annotation.NonNull;
 
-import org.wordpress.android.models.ReaderTag;
-import org.wordpress.android.models.ReaderTagType;
 import org.wordpress.android.ui.reader.services.ServiceCompletionListener;
-import org.wordpress.android.ui.reader.utils.ReaderUtils;
 import org.wordpress.android.util.AppLog;
 import org.wordpress.android.util.StringUtils;
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchServiceStarter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchServiceStarter.java
@@ -28,7 +28,7 @@ public class ReaderSearchServiceStarter {
             context.startService(intent);
         } else {
             // schedule the JobService here for API >= 26. The JobScheduler is available since API 21, but
-            // it's preferrable to use it only since enforcement in API 26 to not break any old behavior
+            // it's preferable to use it only since enforcement in API 26 to not break any old behavior
             ComponentName componentName = new ComponentName(context, ReaderSearchJobService.class);
 
             PersistableBundle extras = new PersistableBundle();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchServiceStarter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/search/ReaderSearchServiceStarter.java
@@ -1,0 +1,54 @@
+package org.wordpress.android.ui.reader.services.search;
+
+import android.app.job.JobInfo;
+import android.app.job.JobScheduler;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.os.PersistableBundle;
+import android.support.annotation.NonNull;
+
+import org.wordpress.android.util.AppLog;
+
+/**
+ * service which searches for reader posts on wordpress.com
+ */
+
+public class ReaderSearchServiceStarter {
+    private static final int JOB_READER_SEARCH_SERVICE_ID = 5000;
+    public static final String ARG_QUERY = "query";
+    public static final String ARG_OFFSET = "offset";
+
+    public static void startService(Context context, @NonNull String query, int offset) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            Intent intent = new Intent(context, ReaderSearchService.class);
+            intent.putExtra(ARG_QUERY, query);
+            intent.putExtra(ARG_OFFSET, offset);
+            context.startService(intent);
+        } else {
+            // schedule the JobService here for API >= 26. The JobScheduler is available since API 21, but
+            // it's preferrable to use it only since enforcement in API 26 to not break any old behavior
+            ComponentName componentName = new ComponentName(context, ReaderSearchJobService.class);
+
+            PersistableBundle extras = new PersistableBundle();
+            extras.putString(ARG_QUERY, query);
+            extras.putInt(ARG_OFFSET, offset);
+
+            JobInfo jobInfo = new JobInfo.Builder(JOB_READER_SEARCH_SERVICE_ID, componentName)
+                    .setRequiresCharging(false)
+                    .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+                    .setOverrideDeadline(0) // if possible, try to run right away
+                    .setExtras(extras)
+                    .build();
+
+            JobScheduler jobScheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+            int resultCode = jobScheduler.schedule(jobInfo);
+            if (resultCode == JobScheduler.RESULT_SUCCESS) {
+                AppLog.i(AppLog.T.READER, "reader search job service > job scheduled");
+            } else {
+                AppLog.e(AppLog.T.READER, "reader search job service > job could not be scheduled");
+            }
+        }
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateServiceStarter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/services/update/ReaderUpdateServiceStarter.java
@@ -29,7 +29,7 @@ public class ReaderUpdateServiceStarter {
             context.startService(intent);
         } else {
             // schedule the JobService here for API >= 26. The JobScheduler is available since API 21, but
-            // it's preferrable to use it only since enforcement in API 26 to not break any old behavior
+            // it's preferable to use it only since enforcement in API 26 to not break any old behavior
             ComponentName componentName = new ComponentName(context, ReaderUpdateJobService.class);
 
             PersistableBundle extras = new PersistableBundle();

--- a/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/reader/utils/ReaderUtils.java
@@ -4,6 +4,7 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Build;
+import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import android.view.View;
 
@@ -210,5 +211,14 @@ public class ReaderUtils {
      */
     public static ReaderTag getDefaultTag() {
         return getTagFromTagName(ReaderTag.TAG_TITLE_DEFAULT, ReaderTagType.DEFAULT);
+    }
+
+    /*
+  * used when storing search results in the reader post table
+  */
+    public static ReaderTag getTagForSearchQuery(@NonNull String query) {
+        String trimQuery = query != null ? query.trim() : "";
+        String slug = ReaderUtils.sanitizeWithDashes(trimQuery);
+        return new ReaderTag(slug, trimQuery, trimQuery, null, ReaderTagType.SEARCH);
     }
 }


### PR DESCRIPTION
*Note:* Builds on top of #7603 AND #7607 both of which should be merged first (in that order). Otherwise this looks like an even super mega big PR 😱 

Continues the API26 migration series. This time we bring `ReaderSearchService` in its two versions, a `Service` for API below level 26, and `JobService` for API 26 and beyond.

To test:
1. Start the app
2. Go to the reader
3. Search for a term
4. also, scroll down to get new queries / offset params

Use please both platform 26+ and below.

cc @nbradbury 