### PR TITLE
Automated Transfers v1

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -1288,7 +1288,7 @@ public class PluginDetailActivity extends AppCompatActivity {
                         // Let's wait a second before checking the status again
                         mDispatcher.dispatch(SiteActionBuilder.newCheckAutomatedTransferStatusAction(mSite));
                     }
-                }, 1000);
+                }, 3000); // Wait 3 seconds before checking the status again
             }
         }
     }

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -40,6 +40,7 @@ import org.wordpress.android.WordPress;
 import org.wordpress.android.analytics.AnalyticsTracker;
 import org.wordpress.android.fluxc.Dispatcher;
 import org.wordpress.android.fluxc.generated.PluginActionBuilder;
+import org.wordpress.android.fluxc.generated.SiteActionBuilder;
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.plugin.ImmutablePluginModel;
 import org.wordpress.android.fluxc.store.PluginStore;
@@ -51,6 +52,8 @@ import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginDeleted;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginInstalled;
 import org.wordpress.android.fluxc.store.PluginStore.OnSitePluginUpdated;
 import org.wordpress.android.fluxc.store.PluginStore.UpdateSitePluginPayload;
+import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.fluxc.store.SiteStore.OnAutomatedTransferEligibilityChecked;
 import org.wordpress.android.ui.ActivityLauncher;
 import org.wordpress.android.util.AccessibilityUtils;
 import org.wordpress.android.util.AnalyticsUtils;
@@ -112,6 +115,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     private Switch mSwitchActive;
     private Switch mSwitchAutoupdates;
     private ProgressDialog mRemovePluginProgressDialog;
+    private ProgressDialog mAutomatedTransferProgressDialog;
 
     private CardView mWPOrgPluginDetailsContainer;
     private RelativeLayout mRatingsSectionContainer;
@@ -741,6 +745,7 @@ public class PluginDetailActivity extends AppCompatActivity {
     }
 
     private void showRemovePluginProgressDialog() {
+        // TODO: check if mRemovePluginProgressDialog is not null
         mRemovePluginProgressDialog = new ProgressDialog(this);
         mRemovePluginProgressDialog.setCancelable(false);
         mRemovePluginProgressDialog.setIndeterminate(true);
@@ -781,6 +786,16 @@ public class PluginDetailActivity extends AppCompatActivity {
         mIsShowingInstallFirstPluginConfirmationDialog = true;
         builder.show();
 
+    }
+
+    private void showAutomatedTransferDialog() {
+        // TODO: check if mAutomatedTransferProgressDialog is not null
+        mAutomatedTransferProgressDialog = new ProgressDialog(this);
+        mAutomatedTransferProgressDialog.setCancelable(false);
+        mAutomatedTransferProgressDialog.setIndeterminate(false);
+        String message = getString(R.string.plugin_install_first_plugin_progress_dialog_title);
+        mAutomatedTransferProgressDialog.setMessage(message);
+        mAutomatedTransferProgressDialog.show();
     }
 
     // Network Helpers
@@ -841,7 +856,9 @@ public class PluginDetailActivity extends AppCompatActivity {
     }
 
     private void startAutomatedTransfer() {
-        // TODO
+        showAutomatedTransferDialog();
+
+        mDispatcher.dispatch(SiteActionBuilder.newCheckAutomatedTransferEligibilityAction(mSite));
     }
 
     protected void disableAndRemovePlugin() {
@@ -1053,6 +1070,16 @@ public class PluginDetailActivity extends AppCompatActivity {
             invalidateOptionsMenu();
         }
         showSuccessfulPluginRemovedSnackbar();
+    }
+
+    @SuppressWarnings("unused")
+    @Subscribe(threadMode = ThreadMode.MAIN)
+    public void onAutomatedTransferEligibilityChecked(OnAutomatedTransferEligibilityChecked event) {
+        if (event.isError()) {
+            // TODO
+            return;
+        }
+        // TODO
     }
 
     // This check should only handle events for already installed plugins - onSitePluginConfigured,

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -1064,12 +1064,6 @@ public class PluginDetailActivity extends AppCompatActivity {
                && mPlugin.getName().equals(eventPluginName); // event is for the plugin we are showing
     }
 
-    private void handleAutomatedTransferFailed(String errorMessage) {
-        // TODO: Better handle specific errors
-        cancelAutomatedTransferDialog();
-        ToastUtils.showToast(this, errorMessage, Duration.LONG);
-    }
-
     // Utils
 
     private void refreshPluginFromStore() {
@@ -1175,6 +1169,11 @@ public class PluginDetailActivity extends AppCompatActivity {
         invalidateOptionsMenu();
     }
 
+    private void handleAutomatedTransferFailed(String errorMessage) {
+        cancelAutomatedTransferDialog();
+        ToastUtils.showToast(this, errorMessage, Duration.LONG);
+    }
+
     @SuppressWarnings("unused")
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onAutomatedTransferEligibilityChecked(OnAutomatedTransferEligibilityChecked event) {
@@ -1182,7 +1181,10 @@ public class PluginDetailActivity extends AppCompatActivity {
             return;
         }
         if (!event.isEligible) {
-            handleAutomatedTransferFailed(getString(R.string.plugin_install_error_site_ineligible));
+            String message =
+                    event.eligibilityErrors.isEmpty() ? getString(R.string.plugin_install_error_site_ineligible)
+                            : event.eligibilityErrors.get(0);
+            handleAutomatedTransferFailed(message);
         } else {
             mDispatcher.dispatch(SiteActionBuilder
                     .newInitiateAutomatedTransferAction(new InitiateAutomatedTransferPayload(mSite, mSlug)));

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -765,17 +765,20 @@ public class PluginDetailActivity extends AppCompatActivity {
     }
 
     private void showRemovePluginProgressDialog() {
-        // TODO: check if mRemovePluginProgressDialog is not null
-        mRemovePluginProgressDialog = new ProgressDialog(this);
-        mRemovePluginProgressDialog.setCancelable(false);
-        mRemovePluginProgressDialog.setIndeterminate(true);
-        // Even though we are deactivating the plugin to make sure it's disabled on the server side, since the user
-        // sees that the plugin is disabled, it'd be confusing to say we are disabling the plugin
-        String message = mIsActive
-                ? getString(R.string.plugin_disable_progress_dialog_message, mPlugin.getDisplayName())
-                : getRemovingPluginMessage();
-        mRemovePluginProgressDialog.setMessage(message);
-        mRemovePluginProgressDialog.show();
+        if (mRemovePluginProgressDialog == null) {
+            mRemovePluginProgressDialog = new ProgressDialog(this);
+            mRemovePluginProgressDialog.setCancelable(false);
+            mRemovePluginProgressDialog.setIndeterminate(true);
+            // Even though we are deactivating the plugin to make sure it's disabled on the server side, since the user
+            // sees that the plugin is disabled, it'd be confusing to say we are disabling the plugin
+            String message = mIsActive
+                    ? getString(R.string.plugin_disable_progress_dialog_message, mPlugin.getDisplayName())
+                    : getRemovingPluginMessage();
+            mRemovePluginProgressDialog.setMessage(message);
+        }
+        if (!mRemovePluginProgressDialog.isShowing()) {
+            mRemovePluginProgressDialog.show();
+        }
     }
 
     private void cancelRemovePluginProgressDialog() {
@@ -827,7 +830,7 @@ public class PluginDetailActivity extends AppCompatActivity {
             mIsInstallingPlugin = true;
             refreshUpdateVersionViews();
 
-            PluginStore.InstallSitePluginPayload payload = new InstallSitePluginPayload(mSite, mSlug);
+            InstallSitePluginPayload payload = new InstallSitePluginPayload(mSite, mSlug);
             mDispatcher.dispatch(PluginActionBuilder.newInstallSitePluginAction(payload));
         }
     }
@@ -1143,15 +1146,18 @@ public class PluginDetailActivity extends AppCompatActivity {
     }
 
     private void showAutomatedTransferProgressDialog() {
-        // TODO: check if mAutomatedTransferProgressDialog is not null
-        mAutomatedTransferProgressDialog = new ProgressDialog(this);
-        mAutomatedTransferProgressDialog.setCancelable(false);
-        mAutomatedTransferProgressDialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
-        mAutomatedTransferProgressDialog.setIndeterminate(false);
-        String message = getString(R.string.plugin_install_first_plugin_progress_dialog_title);
-        mAutomatedTransferProgressDialog.setMessage(message);
-        mIsShowingAutomatedTransferProgress = true;
-        mAutomatedTransferProgressDialog.show();
+        if (mAutomatedTransferProgressDialog == null) {
+            mAutomatedTransferProgressDialog = new ProgressDialog(this);
+            mAutomatedTransferProgressDialog.setCancelable(false);
+            mAutomatedTransferProgressDialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
+            mAutomatedTransferProgressDialog.setIndeterminate(false);
+            String message = getString(R.string.plugin_install_first_plugin_progress_dialog_title);
+            mAutomatedTransferProgressDialog.setMessage(message);
+        }
+        if (!mAutomatedTransferProgressDialog.isShowing()) {
+            mIsShowingAutomatedTransferProgress = true;
+            mAutomatedTransferProgressDialog.show();
+        }
     }
 
     private void cancelAutomatedTransferDialog() {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginDetailActivity.java
@@ -1097,7 +1097,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         if (isFinishing()) {
             return;
         }
-        if (!event.isError()) {
+        if (event.isError()) {
             handleAutomatedTransferFailed(event.error.message);
         } else{
             mDispatcher.dispatch(SiteActionBuilder.newCheckAutomatedTransferStatusAction(mSite));
@@ -1110,7 +1110,7 @@ public class PluginDetailActivity extends AppCompatActivity {
         if (isFinishing()) {
             return;
         }
-        if (!event.isError()) {
+        if (event.isError()) {
             handleAutomatedTransferFailed(event.error.message);
         } else{
             if (event.isCompleted) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
@@ -16,7 +16,7 @@ public class PluginUtils {
             return SiteUtils.checkMinimalJetpackVersion(site, "5.6");
         }
         // If the site has business plan we can do an automated transfer
-        return SiteUtils.hasBusinessPlan(site);
+        return SiteUtils.hasNonJetpackBusinessPlan(site);
     }
 
     static boolean isUpdateAvailable(@Nullable ImmutablePluginModel immutablePlugin) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
@@ -12,7 +12,11 @@ import org.wordpress.android.util.helpers.Version;
 
 public class PluginUtils {
     public static boolean isPluginFeatureAvailable(SiteModel site) {
-        return SiteUtils.checkMinimalJetpackVersion(site, "5.6");
+        if (site.isUsingWpComRestApi() && site.isJetpackConnected()) {
+            return SiteUtils.checkMinimalJetpackVersion(site, "5.6");
+        }
+        // If the site has business plan we can do an automated transfer
+        return SiteUtils.hasBusinessPlan(site);
     }
 
     static boolean isUpdateAvailable(@Nullable ImmutablePluginModel immutablePlugin) {
@@ -26,7 +30,7 @@ public class PluginUtils {
         try {
             Version currentVersion = new Version(installedVersionStr);
             Version availableVersion = new Version(availableVersionStr);
-            return currentVersion.compareTo(availableVersion) == -1;
+            return currentVersion.compareTo(availableVersion) < 0;
         } catch (IllegalArgumentException e) {
             String errorStr =
                     String.format("An IllegalArgumentException occurred while trying to compare site plugin version: %s"

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginUtils.java
@@ -15,8 +15,11 @@ public class PluginUtils {
         if (site.isUsingWpComRestApi() && site.isJetpackConnected()) {
             return SiteUtils.checkMinimalJetpackVersion(site, "5.6");
         }
-        // If the site has business plan we can do an automated transfer
-        return SiteUtils.hasNonJetpackBusinessPlan(site);
+        // If the site has business plan we can do an Automated Transfer
+        return site.isWPCom()
+               && SiteUtils.hasNonJetpackBusinessPlan(site)
+               && !site.getUrl().contains(".wordpress.com") // Automated Transfers require custom domains
+               && !site.isPrivate(); // Private sites are not eligible for Automated Transfer
     }
 
     static boolean isUpdateAvailable(@Nullable ImmutablePluginModel immutablePlugin) {

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -5,6 +5,7 @@ import android.text.TextUtils;
 
 import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.store.SiteStore;
+import org.wordpress.android.ui.plans.PlansConstants;
 import org.wordpress.android.util.helpers.Version;
 
 import java.util.ArrayList;
@@ -90,10 +91,10 @@ public class SiteUtils {
     }
 
     public static boolean isNonAtomicBusinessPlanSite(@Nullable SiteModel site) {
-        return site != null && !site.isAutomatedTransfer() && SiteUtils.hasBusinessPlan(site);
+        return site != null && !site.isAutomatedTransfer() && SiteUtils.hasNonJetpackBusinessPlan(site);
     }
 
-    public static boolean hasBusinessPlan(SiteModel site) {
-        return site.getPlanShortName() != null && site.getPlanShortName().equalsIgnoreCase("business");
+    public static boolean hasNonJetpackBusinessPlan(SiteModel site) {
+        return site.getPlanId() == PlansConstants.BUSINESS_PLAN_ID;
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -87,4 +87,8 @@ public class SiteUtils {
         }
         return false;
     }
+
+    public static boolean hasBusinessPlan(SiteModel site) {
+        return site.getPlanShortName() != null && site.getPlanShortName().equalsIgnoreCase("business");
+    }
 }

--- a/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
+++ b/WordPress/src/main/java/org/wordpress/android/util/SiteUtils.java
@@ -1,5 +1,6 @@
 package org.wordpress.android.util;
 
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import org.wordpress.android.fluxc.model.SiteModel;
@@ -86,6 +87,10 @@ public class SiteUtils {
             }
         }
         return false;
+    }
+
+    public static boolean isNonAtomicBusinessPlanSite(@Nullable SiteModel site) {
+        return site != null && !site.isAutomatedTransfer() && SiteUtils.hasBusinessPlan(site);
     }
 
     public static boolean hasBusinessPlan(SiteModel site) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.kt
@@ -211,7 +211,7 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
     }
 
     private fun shouldFetchPlugins(listType: PluginListType, loadMore: Boolean): Boolean {
-        if (listType == PluginListType.SITE || SiteUtils.isNonAtomicBusinessPlanSite(site)) {
+        if (listType == PluginListType.SITE && SiteUtils.isNonAtomicBusinessPlanSite(site)) {
             return false
         }
         val currentStatus = when (listType) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.kt
@@ -19,6 +19,7 @@ import org.wordpress.android.fluxc.store.PluginStore
 import org.wordpress.android.fluxc.store.PluginStore.FetchPluginDirectoryPayload
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
+import org.wordpress.android.util.SiteUtils
 import java.util.ArrayList
 import java.util.HashMap
 import java.util.HashSet
@@ -210,6 +211,9 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
     }
 
     private fun shouldFetchPlugins(listType: PluginListType, loadMore: Boolean): Boolean {
+        if (listType == PluginListType.SITE || SiteUtils.isNonAtomicBusinessPlanSite(site)) {
+            return false
+        }
         val currentStatus = when (listType) {
             PluginBrowserViewModel.PluginListType.SITE -> sitePluginsListStatus.value
             PluginBrowserViewModel.PluginListType.FEATURED -> featuredPluginsListStatus.value

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.kt
@@ -17,6 +17,7 @@ import org.wordpress.android.fluxc.model.plugin.ImmutablePluginModel
 import org.wordpress.android.fluxc.model.plugin.PluginDirectoryType
 import org.wordpress.android.fluxc.store.PluginStore
 import org.wordpress.android.fluxc.store.PluginStore.FetchPluginDirectoryPayload
+import org.wordpress.android.fluxc.store.SiteStore
 import org.wordpress.android.util.AppLog
 import org.wordpress.android.util.AppLog.T
 import org.wordpress.android.util.SiteUtils
@@ -30,8 +31,9 @@ private const val KEY_SEARCH_QUERY = "KEY_SEARCH_QUERY"
 private const val KEY_TITLE = "KEY_TITLE"
 
 @WorkerThread
-class PluginBrowserViewModel @Inject
-constructor(private val mDispatcher: Dispatcher, private val mPluginStore: PluginStore) : ViewModel() {
+class PluginBrowserViewModel @Inject constructor(private val mDispatcher: Dispatcher,
+                                                 private val mPluginStore: PluginStore,
+                                                 private val mSiteStore: SiteStore) : ViewModel() {
     enum class PluginListType {
         SITE,
         FEATURED,
@@ -342,6 +344,21 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
         // if the slug is not in the set
         if (!TextUtils.isEmpty(event.slug) && updatedPluginSlugSet.add(event.slug)) {
             updateAllPluginListsIfNecessary()
+        }
+    }
+
+    @Subscribe(threadMode = ThreadMode.BACKGROUND)
+    @SuppressWarnings("unused")
+    fun onSiteChanged(event: SiteStore.OnSiteChanged) {
+        if (event.isError) {
+            // The error should be safe to ignore since we are not triggering the action and there is nothing we need
+            // to do about it
+            return
+        }
+
+        val siteId = site?.siteId
+        siteId?.let {
+            site = mSiteStore.getSiteBySiteId(siteId)
         }
     }
 

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1693,6 +1693,7 @@
     <string name="plugin_remove_progress_dialog_message">Removing %s&#8230;</string>
     <string name="plugin_remove_dialog_title">Remove Plugin</string>
     <string name="plugin_remove_dialog_message">Are you sure you want to remove %1$s from %2$s?\n\nThis will deactivate the plugin and delete all associated files and data.</string>
+    <string name="plugin_install_first_plugin_confirmation_dialog_message">Installing the first plugin on your site can take up to 1 minute and until it\'s complete you won\'t be able to use your site or make any changes to it. Would you like to proceed?</string>
     <string name="plugin_fetch_error">Unable to load plugins</string>
     <string name="plugin_search_error">Unable to search plugins</string>
     <string name="plugin_manage">Manage</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1700,6 +1700,7 @@
     <string name="plugin_see_all">See All</string>
     <string name="plugins_empty_search_list">No matches</string>
     <string name="plugin_install_first_plugin_progress_dialog_title">Install Plugin</string>
+    <string name="plugin_install_error_site_ineligible">Plugins feature is not available on this site.</string>
 
     <string name="plugin_caption_installed" translatable="false">@string/plugin_installed</string>
     <string name="plugin_caption_featured">Featured</string>

--- a/WordPress/src/main/res/values/strings.xml
+++ b/WordPress/src/main/res/values/strings.xml
@@ -1699,6 +1699,7 @@
     <string name="plugin_manage">Manage</string>
     <string name="plugin_see_all">See All</string>
     <string name="plugins_empty_search_list">No matches</string>
+    <string name="plugin_install_first_plugin_progress_dialog_title">Install Plugin</string>
 
     <string name="plugin_caption_installed" translatable="false">@string/plugin_installed</string>
     <string name="plugin_caption_featured">Featured</string>

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '0c6f055ea067138142930651143cdbda882aae7f'
+    fluxCVersion = '3ed81a6d0d1b819692547e187217e69ab7ec4b81'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,5 +69,5 @@ subprojects {
 }
 
 ext {
-    fluxCVersion = '5147680838494249110f9a07b16f4217e5f0a2dc'
+    fluxCVersion = '0c6f055ea067138142930651143cdbda882aae7f'
 }


### PR DESCRIPTION
This PR adds the ability to install plugins for wp.com (non-atomic) business plan sites. Trying to install a plugin will start an Automated Transfer. Its steps are explained as comments in `PluginDetailActivity`. The changes to FluxC are added in https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/775. Although it'd be good to check out the description of that PR, it's not necessary to review this one or to merge it since it's targeting a WIP branch.

To test:
1. Create a new business plan site on WordPress.com
2. Go into the plugins page for that site
3. Tap on any plugin and try to install it
4. Verify that you get an error
5. Add a custom domain to your site
6. Try to install the plugin again, make sure the progress bar is updated and the view refreshes after it's complete (the install button should say `Installed` for example)
7. Go back to the plugin directory page and make sure the site plugins showed up