### PR TITLE
Api26/jobschedule notifications update

### DIFF
--- a/WordPress/src/main/AndroidManifest.xml
+++ b/WordPress/src/main/AndroidManifest.xml
@@ -593,10 +593,17 @@
             android:name=".push.NotificationsProcessingService"
             android:exported="false"
             android:label="Notifications Quick Actions processing Service" />
+
         <service
             android:name=".ui.notifications.services.NotificationsUpdateService"
             android:exported="false"
             android:label="Notifications Update Service" />
+        <service
+            android:name=".ui.notifications.services.NotificationsUpdateJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="false"
+            android:label="Notifications Update Job Service" />
+
         <service
             android:name=".login.LoginWpcomService"
             android:exported="false"

--- a/WordPress/src/main/java/org/wordpress/android/WordPress.java
+++ b/WordPress/src/main/java/org/wordpress/android/WordPress.java
@@ -62,7 +62,7 @@ import org.wordpress.android.networking.RestClientUtils;
 import org.wordpress.android.push.GCMRegistrationIntentService;
 import org.wordpress.android.ui.ActivityId;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
-import org.wordpress.android.ui.notifications.services.NotificationsUpdateService;
+import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.prefs.AppPrefs;
 import org.wordpress.android.ui.stats.StatsWidgetProvider;
@@ -393,7 +393,7 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
         if (mAccountStore.hasAccessToken()) {
             mDispatcher.dispatch(AccountActionBuilder.newFetchAccountAction());
             mDispatcher.dispatch(AccountActionBuilder.newFetchSettingsAction());
-            NotificationsUpdateService.startService(getContext());
+            NotificationsUpdateServiceStarter.startService(getContext());
         }
     }
 
@@ -856,11 +856,11 @@ public class WordPress extends MultiDexApplication implements HasServiceInjector
                 if (mAccountStore.hasAccessToken()) {
                     Intent intent = activity.getIntent();
                     if (intent != null && intent.hasExtra(NotificationsListFragment.NOTE_ID_EXTRA)) {
-                        NotificationsUpdateService.startService(getContext(),
+                        NotificationsUpdateServiceStarter.startService(getContext(),
                                                                 getNoteIdFromNoteDetailActivityIntent(
                                                                         activity.getIntent()));
                     } else {
-                        NotificationsUpdateService.startService(getContext());
+                        NotificationsUpdateServiceStarter.startService(getContext());
                     }
                 }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/accounts/LoginActivity.java
@@ -46,7 +46,7 @@ import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.accounts.SmartLockHelper.Callback;
 import org.wordpress.android.ui.accounts.login.LoginPrologueFragment;
 import org.wordpress.android.ui.accounts.login.LoginPrologueListener;
-import org.wordpress.android.ui.notifications.services.NotificationsUpdateService;
+import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateLogic;
 import org.wordpress.android.ui.reader.services.update.ReaderUpdateServiceStarter;
 import org.wordpress.android.util.AppLog;
@@ -612,7 +612,7 @@ public class LoginActivity extends AppCompatActivity implements ConnectionCallba
         ReaderUpdateServiceStarter.startService(getApplicationContext(), EnumSet.of(ReaderUpdateLogic.UpdateTask.TAGS));
 
         // Start Notification service
-        NotificationsUpdateService.startService(getApplicationContext());
+        NotificationsUpdateServiceStarter.startService(getApplicationContext());
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsDetailActivity.java
@@ -33,7 +33,7 @@ import org.wordpress.android.ui.comments.CommentActions;
 import org.wordpress.android.ui.comments.CommentDetailFragment;
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter;
 import org.wordpress.android.ui.notifications.blocks.NoteBlockRangeType;
-import org.wordpress.android.ui.notifications.services.NotificationsUpdateService;
+import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter;
 import org.wordpress.android.ui.notifications.utils.NotificationsActions;
 import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.ui.prefs.AppPrefs;
@@ -132,7 +132,7 @@ public class NotificationsDetailActivity extends AppCompatActivity implements
         if (doRefresh) {
             setProgressVisible(true);
             // here start the service and wait for it
-            NotificationsUpdateService.startService(this, mNoteId);
+            NotificationsUpdateServiceStarter.startService(this, mNoteId);
             return;
         }
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/NotificationsListFragment.java
@@ -35,7 +35,7 @@ import org.wordpress.android.ui.JetpackConnectionWebViewActivity;
 import org.wordpress.android.ui.RequestCodes;
 import org.wordpress.android.ui.main.WPMainActivity;
 import org.wordpress.android.ui.notifications.adapters.NotesAdapter;
-import org.wordpress.android.ui.notifications.services.NotificationsUpdateService;
+import org.wordpress.android.ui.notifications.services.NotificationsUpdateServiceStarter;
 import org.wordpress.android.ui.notifications.utils.NotificationsActions;
 import org.wordpress.android.util.AniUtils;
 import org.wordpress.android.util.NetworkUtils;
@@ -393,7 +393,7 @@ public class NotificationsListFragment extends Fragment implements WPMainActivit
             return;
         }
 
-        NotificationsUpdateService.startService(getActivity());
+        NotificationsUpdateServiceStarter.startService(getActivity());
     }
 
     // Show different empty list message and action button based on the active filter

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateJobService.java
@@ -16,35 +16,18 @@ public class NotificationsUpdateJobService extends JobService
 
     private NotificationsUpdateLogic mNotificationsUpdateLogic;
 
-    public static void startService(Context context) {
-        if (context == null) {
-            return;
-        }
-        Intent intent = new Intent(context, NotificationsUpdateJobService.class);
-        context.startService(intent);
-    }
-
-    public static void startService(Context context, String noteId) {
-        if (context == null) {
-            return;
-        }
-        Intent intent = new Intent(context, NotificationsUpdateJobService.class);
-        intent.putExtra(NotificationsListFragment.NOTE_ID_EXTRA, noteId);
-        intent.putExtra(IS_TAPPED_ON_NOTIFICATION, true);
-        context.startService(intent);
-    }
-
     @TargetApi(22)
     @Override
     public boolean onStartJob(JobParameters params) {
+        String noteId = null;
+        boolean isStartedByTappingOnNotification = false;
         if (params.getExtras() != null && params.getExtras().containsKey(NotificationsListFragment.NOTE_ID_EXTRA)) {
-            String noteId = params.getExtras().getString(NotificationsListFragment.NOTE_ID_EXTRA);
-            boolean isStartedByTappingOnNotification = params.getExtras().getBoolean(
+            noteId = params.getExtras().getString(NotificationsListFragment.NOTE_ID_EXTRA);
+            isStartedByTappingOnNotification = params.getExtras().getBoolean(
                     IS_TAPPED_ON_NOTIFICATION, false);
-            mNotificationsUpdateLogic.performRefresh(noteId, isStartedByTappingOnNotification, params);
-            return true;
         }
-        return false;
+        mNotificationsUpdateLogic.performRefresh(noteId, isStartedByTappingOnNotification, params);
+        return true;
     }
 
     @Override

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateJobService.java
@@ -1,0 +1,74 @@
+package org.wordpress.android.ui.notifications.services;
+
+import android.annotation.TargetApi;
+import android.app.job.JobParameters;
+import android.app.job.JobService;
+import android.content.Context;
+import android.content.Intent;
+
+import org.wordpress.android.ui.notifications.NotificationsListFragment;
+import org.wordpress.android.util.AppLog;
+
+@TargetApi(21)
+public class NotificationsUpdateJobService extends JobService
+        implements NotificationsUpdateLogic.ServiceCompletionListener {
+    public static final String IS_TAPPED_ON_NOTIFICATION = "is-tapped-on-notification";
+
+    private NotificationsUpdateLogic mNotificationsUpdateLogic;
+
+    public static void startService(Context context) {
+        if (context == null) {
+            return;
+        }
+        Intent intent = new Intent(context, NotificationsUpdateJobService.class);
+        context.startService(intent);
+    }
+
+    public static void startService(Context context, String noteId) {
+        if (context == null) {
+            return;
+        }
+        Intent intent = new Intent(context, NotificationsUpdateJobService.class);
+        intent.putExtra(NotificationsListFragment.NOTE_ID_EXTRA, noteId);
+        intent.putExtra(IS_TAPPED_ON_NOTIFICATION, true);
+        context.startService(intent);
+    }
+
+    @TargetApi(22)
+    @Override
+    public boolean onStartJob(JobParameters params) {
+        if (params.getExtras() != null && params.getExtras().containsKey(NotificationsListFragment.NOTE_ID_EXTRA)) {
+            String noteId = params.getExtras().getString(NotificationsListFragment.NOTE_ID_EXTRA);
+            boolean isStartedByTappingOnNotification = params.getExtras().getBoolean(
+                    IS_TAPPED_ON_NOTIFICATION, false);
+            mNotificationsUpdateLogic.performRefresh(noteId, isStartedByTappingOnNotification, params);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean onStopJob(JobParameters params) {
+        jobFinished(params, false);
+        return false;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        AppLog.i(AppLog.T.NOTIFS, "notifications update job service > created");
+        mNotificationsUpdateLogic = new NotificationsUpdateLogic(this);
+    }
+
+    @Override
+    public void onDestroy() {
+        AppLog.i(AppLog.T.NOTIFS, "notifications update job service > destroyed");
+        super.onDestroy();
+    }
+
+    @Override
+    public void onCompleted(Object companion) {
+        AppLog.i(AppLog.T.READER, "notifications update job service > all tasks completed");
+        jobFinished((JobParameters) companion, false);
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateJobService.java
@@ -3,8 +3,6 @@ package org.wordpress.android.ui.notifications.services;
 import android.annotation.TargetApi;
 import android.app.job.JobParameters;
 import android.app.job.JobService;
-import android.content.Context;
-import android.content.Intent;
 
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
 import org.wordpress.android.util.AppLog;

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateJobService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateJobService.java
@@ -49,7 +49,7 @@ public class NotificationsUpdateJobService extends JobService
 
     @Override
     public void onCompleted(Object companion) {
-        AppLog.i(AppLog.T.READER, "notifications update job service > all tasks completed");
+        AppLog.i(AppLog.T.NOTIFS, "notifications update job service > all tasks completed");
         jobFinished((JobParameters) companion, false);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateLogic.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateLogic.java
@@ -1,0 +1,128 @@
+package org.wordpress.android.ui.notifications.services;
+
+import com.android.volley.NetworkResponse;
+import com.android.volley.VolleyError;
+import com.wordpress.rest.RestRequest;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.wordpress.android.WordPress;
+import org.wordpress.android.datasets.NotificationsTable;
+import org.wordpress.android.models.Note;
+import org.wordpress.android.networking.RestClientUtils;
+import org.wordpress.android.ui.notifications.NotificationEvents;
+import org.wordpress.android.ui.notifications.utils.NotificationsActions;
+import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
+import org.wordpress.android.util.AppLog;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import de.greenrobot.event.EventBus;
+
+public class NotificationsUpdateLogic {
+    private ServiceCompletionListener mCompletionListener;
+    private Object mListenerCompanion;
+
+    private boolean mRunning = false;
+    private String mNoteId;
+    private boolean mIsStartedByTappingOnNotification = false;
+
+    public NotificationsUpdateLogic(ServiceCompletionListener listener) {
+        mCompletionListener = listener;
+    }
+
+    public void performRefresh(String noteId, boolean isStartedByTappingOnNotification, Object companion) {
+        if (mRunning) {
+            return;
+        }
+        mListenerCompanion = companion;
+        mRunning = true;
+        mNoteId = noteId;
+        mIsStartedByTappingOnNotification = isStartedByTappingOnNotification;
+        Map<String, String> params = new HashMap<>();
+        params.put("number", "200");
+        params.put("num_note_items", "20");
+        params.put("fields", RestClientUtils.NOTIFICATION_FIELDS);
+        RestListener listener = new RestListener();
+        WordPress.getRestClientUtilsV1_1().getNotifications(params, listener, listener);
+    }
+
+    private class RestListener implements RestRequest.Listener, RestRequest.ErrorListener {
+        @Override
+        public void onResponse(final JSONObject response) {
+            List<Note> notes;
+            if (response == null) {
+                // Not sure this could ever happen, but make sure we're catching all response types
+                AppLog.w(AppLog.T.NOTIFS, "Success, but did not receive any notes");
+                EventBus.getDefault().post(
+                        new NotificationEvents.NotificationsRefreshCompleted(
+                                new ArrayList<Note>(0)
+                        )
+                                          );
+            } else {
+                try {
+                    notes = NotificationsActions.parseNotes(response);
+                    // if we have a note id, we were started from NotificationsDetailActivity.
+                    // That means we need to re-set the *read* flag on this note.
+                    if (mIsStartedByTappingOnNotification && mNoteId != null) {
+                        setNoteRead(mNoteId, notes);
+                    }
+                    NotificationsTable.saveNotes(notes, true);
+                    EventBus.getDefault().post(
+                            new NotificationEvents.NotificationsRefreshCompleted(notes)
+                                              );
+                } catch (JSONException e) {
+                    AppLog.e(AppLog.T.NOTIFS, "Success, but can't parse the response", e);
+                    EventBus.getDefault().post(
+                            new NotificationEvents.NotificationsRefreshError()
+                                              );
+                }
+            }
+            completed();
+        }
+
+        @Override
+        public void onErrorResponse(final VolleyError volleyError) {
+            logVolleyErrorDetails(volleyError);
+            EventBus.getDefault().post(
+                    new NotificationEvents.NotificationsRefreshError(volleyError)
+                                      );
+            completed();
+        }
+    }
+
+    private void setNoteRead(String noteId, List<Note> notes) {
+        int notePos = NotificationsUtils.findNoteInNoteArray(notes, noteId);
+        if (notePos != -1) {
+            notes.get(notePos).setRead();
+        }
+    }
+
+    private static void logVolleyErrorDetails(final VolleyError volleyError) {
+        if (volleyError == null) {
+            AppLog.e(AppLog.T.NOTIFS, "Tried to log a VolleyError, but the error obj was null!");
+            return;
+        }
+        if (volleyError.networkResponse != null) {
+            NetworkResponse networkResponse = volleyError.networkResponse;
+            AppLog.e(AppLog.T.NOTIFS, "Network status code: " + networkResponse.statusCode);
+            if (networkResponse.data != null) {
+                AppLog.e(AppLog.T.NOTIFS, "Network data: " + new String(networkResponse.data));
+            }
+        }
+        AppLog.e(AppLog.T.NOTIFS, "Volley Error Message: " + volleyError.getMessage(), volleyError);
+    }
+
+    private void completed() {
+        AppLog.i(AppLog.T.NOTIFS, "notifications update service > completed");
+        mRunning = false;
+        mCompletionListener.onCompleted(mListenerCompanion);
+    }
+
+    interface ServiceCompletionListener {
+        void onCompleted(Object companion);
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateService.java
@@ -5,36 +5,13 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
 
-import com.android.volley.NetworkResponse;
-import com.android.volley.VolleyError;
-import com.wordpress.rest.RestRequest;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.wordpress.android.WordPress;
-import org.wordpress.android.datasets.NotificationsTable;
-import org.wordpress.android.models.Note;
-import org.wordpress.android.networking.RestClientUtils;
-import org.wordpress.android.ui.notifications.NotificationEvents;
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
-import org.wordpress.android.ui.notifications.utils.NotificationsActions;
-import org.wordpress.android.ui.notifications.utils.NotificationsUtils;
 import org.wordpress.android.util.AppLog;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import de.greenrobot.event.EventBus;
-
-
-public class NotificationsUpdateService extends Service {
+public class NotificationsUpdateService extends Service implements NotificationsUpdateLogic.ServiceCompletionListener {
     public static final String IS_TAPPED_ON_NOTIFICATION = "is-tapped-on-notification";
 
-    private boolean mRunning = false;
-    private String mNoteId;
-    private boolean mIsStartedByTappingOnNotification = false;
+    private NotificationsUpdateLogic mNotificationsUpdateLogic;
 
     public static void startService(Context context) {
         if (context == null) {
@@ -63,6 +40,7 @@ public class NotificationsUpdateService extends Service {
     public void onCreate() {
         super.onCreate();
         AppLog.i(AppLog.T.NOTIFS, "notifications update service > created");
+        mNotificationsUpdateLogic = new NotificationsUpdateLogic(this);
     }
 
     @Override
@@ -74,95 +52,16 @@ public class NotificationsUpdateService extends Service {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         if (intent != null) {
-            mNoteId = intent.getStringExtra(NotificationsListFragment.NOTE_ID_EXTRA);
-            mIsStartedByTappingOnNotification = intent.getBooleanExtra(IS_TAPPED_ON_NOTIFICATION, false);
-            performRefresh();
+            String noteId = intent.getStringExtra(NotificationsListFragment.NOTE_ID_EXTRA);
+            boolean isStartedByTappingOnNotification = intent.getBooleanExtra(
+                    IS_TAPPED_ON_NOTIFICATION, false);
+            mNotificationsUpdateLogic.performRefresh(noteId, isStartedByTappingOnNotification, null);
         }
         return START_NOT_STICKY;
     }
 
-    private void performRefresh() {
-        if (mRunning) {
-            return;
-        }
-        mRunning = true;
-        Map<String, String> params = new HashMap<>();
-        params.put("number", "200");
-        params.put("num_note_items", "20");
-        params.put("fields", RestClientUtils.NOTIFICATION_FIELDS);
-        RestListener listener = new RestListener();
-        WordPress.getRestClientUtilsV1_1().getNotifications(params, listener, listener);
-    }
-
-    private class RestListener implements RestRequest.Listener, RestRequest.ErrorListener {
-        @Override
-        public void onResponse(final JSONObject response) {
-            List<Note> notes;
-            if (response == null) {
-                // Not sure this could ever happen, but make sure we're catching all response types
-                AppLog.w(AppLog.T.NOTIFS, "Success, but did not receive any notes");
-                EventBus.getDefault().post(
-                        new NotificationEvents.NotificationsRefreshCompleted(
-                                new ArrayList<Note>(0)
-                        )
-                                          );
-            } else {
-                try {
-                    notes = NotificationsActions.parseNotes(response);
-                    // if we have a note id, we were started from NotificationsDetailActivity.
-                    // That means we need to re-set the *read* flag on this note.
-                    if (mIsStartedByTappingOnNotification && mNoteId != null) {
-                        setNoteRead(mNoteId, notes);
-                    }
-                    NotificationsTable.saveNotes(notes, true);
-                    EventBus.getDefault().post(
-                            new NotificationEvents.NotificationsRefreshCompleted(notes)
-                                              );
-                } catch (JSONException e) {
-                    AppLog.e(AppLog.T.NOTIFS, "Success, but can't parse the response", e);
-                    EventBus.getDefault().post(
-                            new NotificationEvents.NotificationsRefreshError()
-                                              );
-                }
-            }
-            completed();
-        }
-
-        @Override
-        public void onErrorResponse(final VolleyError volleyError) {
-            logVolleyErrorDetails(volleyError);
-            EventBus.getDefault().post(
-                    new NotificationEvents.NotificationsRefreshError(volleyError)
-                                      );
-            completed();
-        }
-    }
-
-    private void setNoteRead(String noteId, List<Note> notes) {
-        int notePos = NotificationsUtils.findNoteInNoteArray(notes, noteId);
-        if (notePos != -1) {
-            notes.get(notePos).setRead();
-        }
-    }
-
-    private static void logVolleyErrorDetails(final VolleyError volleyError) {
-        if (volleyError == null) {
-            AppLog.e(AppLog.T.NOTIFS, "Tried to log a VolleyError, but the error obj was null!");
-            return;
-        }
-        if (volleyError.networkResponse != null) {
-            NetworkResponse networkResponse = volleyError.networkResponse;
-            AppLog.e(AppLog.T.NOTIFS, "Network status code: " + networkResponse.statusCode);
-            if (networkResponse.data != null) {
-                AppLog.e(AppLog.T.NOTIFS, "Network data: " + new String(networkResponse.data));
-            }
-        }
-        AppLog.e(AppLog.T.NOTIFS, "Volley Error Message: " + volleyError.getMessage(), volleyError);
-    }
-
-    private void completed() {
-        AppLog.i(AppLog.T.NOTIFS, "notifications update service > completed");
-        mRunning = false;
+    @Override public void onCompleted(Object companion) {
+        AppLog.i(AppLog.T.READER, "notifications update service > all tasks completed");
         stopSelf();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateService.java
@@ -42,7 +42,7 @@ public class NotificationsUpdateService extends Service implements Notifications
     }
 
     @Override public void onCompleted(Object companion) {
-        AppLog.i(AppLog.T.READER, "notifications update service > all tasks completed");
+        AppLog.i(AppLog.T.NOTIFS, "notifications update service > all tasks completed");
         stopSelf();
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateService.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateService.java
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui.notifications.services;
 
 import android.app.Service;
-import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
 
@@ -12,24 +11,6 @@ public class NotificationsUpdateService extends Service implements Notifications
     public static final String IS_TAPPED_ON_NOTIFICATION = "is-tapped-on-notification";
 
     private NotificationsUpdateLogic mNotificationsUpdateLogic;
-
-    public static void startService(Context context) {
-        if (context == null) {
-            return;
-        }
-        Intent intent = new Intent(context, NotificationsUpdateService.class);
-        context.startService(intent);
-    }
-
-    public static void startService(Context context, String noteId) {
-        if (context == null) {
-            return;
-        }
-        Intent intent = new Intent(context, NotificationsUpdateService.class);
-        intent.putExtra(NotificationsListFragment.NOTE_ID_EXTRA, noteId);
-        intent.putExtra(IS_TAPPED_ON_NOTIFICATION, true);
-        context.startService(intent);
-    }
 
     @Override
     public IBinder onBind(Intent intent) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateServiceStarter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateServiceStarter.java
@@ -35,7 +35,7 @@ public class NotificationsUpdateServiceStarter {
             context.startService(intent);
         } else {
             // schedule the JobService here for API >= 26. The JobScheduler is available since API 21, but
-            // it's preferrable to use it only since enforcement in API 26 to not break any old behavior
+            // it's preferable to use it only since enforcement in API 26 to not break any old behavior
             ComponentName componentName = new ComponentName(context, NotificationsUpdateJobService.class);
 
             PersistableBundle extras = new PersistableBundle();

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateServiceStarter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateServiceStarter.java
@@ -1,0 +1,29 @@
+package org.wordpress.android.ui.notifications.services;
+
+import android.content.Context;
+import android.content.Intent;
+
+import org.wordpress.android.ui.notifications.NotificationsListFragment;
+
+public class NotificationsUpdateServiceStarter {
+    public static final String IS_TAPPED_ON_NOTIFICATION = "is-tapped-on-notification";
+
+    public static void startService(Context context) {
+        if (context == null) {
+            return;
+        }
+        startService(context, null);
+    }
+
+    public static void startService(Context context, String noteId) {
+        if (context == null) {
+            return;
+        }
+        Intent intent = new Intent(context, NotificationsUpdateService.class);
+        if (noteId != null) {
+            intent.putExtra(NotificationsListFragment.NOTE_ID_EXTRA, noteId);
+            intent.putExtra(IS_TAPPED_ON_NOTIFICATION, true);
+        }
+        context.startService(intent);
+    }
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateServiceStarter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateServiceStarter.java
@@ -1,12 +1,19 @@
 package org.wordpress.android.ui.notifications.services;
 
+import android.app.job.JobInfo;
+import android.app.job.JobScheduler;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
+import android.os.PersistableBundle;
 
 import org.wordpress.android.ui.notifications.NotificationsListFragment;
+import org.wordpress.android.util.AppLog;
 
 public class NotificationsUpdateServiceStarter {
     public static final String IS_TAPPED_ON_NOTIFICATION = "is-tapped-on-notification";
+    private static final int JOB_NOTIFICATIONS_UPDATE_SERVICE_ID = 7000;
 
     public static void startService(Context context) {
         if (context == null) {
@@ -19,11 +26,36 @@ public class NotificationsUpdateServiceStarter {
         if (context == null) {
             return;
         }
-        Intent intent = new Intent(context, NotificationsUpdateService.class);
-        if (noteId != null) {
-            intent.putExtra(NotificationsListFragment.NOTE_ID_EXTRA, noteId);
-            intent.putExtra(IS_TAPPED_ON_NOTIFICATION, true);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            Intent intent = new Intent(context, NotificationsUpdateService.class);
+            if (noteId != null) {
+                intent.putExtra(NotificationsListFragment.NOTE_ID_EXTRA, noteId);
+                intent.putExtra(IS_TAPPED_ON_NOTIFICATION, true);
+            }
+            context.startService(intent);
+        } else {
+            // schedule the JobService here for API >= 26. The JobScheduler is available since API 21, but
+            // it's preferrable to use it only since enforcement in API 26 to not break any old behavior
+            ComponentName componentName = new ComponentName(context, NotificationsUpdateService.class);
+
+            PersistableBundle extras = new PersistableBundle();
+            extras.putString(NotificationsListFragment.NOTE_ID_EXTRA, noteId);
+            extras.putBoolean(IS_TAPPED_ON_NOTIFICATION, true);
+
+            JobInfo jobInfo = new JobInfo.Builder(JOB_NOTIFICATIONS_UPDATE_SERVICE_ID, componentName)
+                    .setRequiresCharging(false)
+                    .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+                    .setOverrideDeadline(0) // if possible, try to run right away
+                    .setExtras(extras)
+                    .build();
+
+            JobScheduler jobScheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+            int resultCode = jobScheduler.schedule(jobInfo);
+            if (resultCode == JobScheduler.RESULT_SUCCESS) {
+                AppLog.i(AppLog.T.READER, "notifications update job service > job scheduled");
+            } else {
+                AppLog.e(AppLog.T.READER, "notifications update job service > job could not be scheduled");
+            }
         }
-        context.startService(intent);
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateServiceStarter.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/notifications/services/NotificationsUpdateServiceStarter.java
@@ -36,11 +36,13 @@ public class NotificationsUpdateServiceStarter {
         } else {
             // schedule the JobService here for API >= 26. The JobScheduler is available since API 21, but
             // it's preferrable to use it only since enforcement in API 26 to not break any old behavior
-            ComponentName componentName = new ComponentName(context, NotificationsUpdateService.class);
+            ComponentName componentName = new ComponentName(context, NotificationsUpdateJobService.class);
 
             PersistableBundle extras = new PersistableBundle();
-            extras.putString(NotificationsListFragment.NOTE_ID_EXTRA, noteId);
-            extras.putBoolean(IS_TAPPED_ON_NOTIFICATION, true);
+            if (noteId != null) {
+                extras.putString(NotificationsListFragment.NOTE_ID_EXTRA, noteId);
+                extras.putBoolean(IS_TAPPED_ON_NOTIFICATION, true);
+            }
 
             JobInfo jobInfo = new JobInfo.Builder(JOB_NOTIFICATIONS_UPDATE_SERVICE_ID, componentName)
                     .setRequiresCharging(false)


### PR DESCRIPTION
Continues the API26 migration series. This time we bring `NotificationsUpdateService` in its two versions, a `Service` for API below level 26, and `JobService` for API 26 and beyond.

To test:
1. Start the app
2. Observe the service is run, as this is triggered every time the app is brought to the foreground
3. Go to the Notifications screen
4. pull the list down to refresh
5. Observe the service is triggered again.

Use please both platform 26+ and below, and observe the `NotificationsUpdateJobService` and the `NotificationsUpdateService` are executed respectively.

cc @nbradbury 