### PR TITLE
removes the Sight And Sounds category on API26+

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -102,7 +102,8 @@ public class NotificationsSettingsFragment extends PreferenceFragment
             PreferenceScreen preferenceScreen =
                     (PreferenceScreen) findPreference(getActivity().getString(R.string.wp_pref_notifications_root));
 
-            PreferenceCategory categorySightsAndSounds = (PreferenceCategory) preferenceScreen.findPreference(getActivity()
+            PreferenceCategory categorySightsAndSounds =
+                    (PreferenceCategory) preferenceScreen.findPreference(getActivity()
                     .getString(
                             R.string.pref_notification_sights_sounds));
             preferenceScreen.removePreference(categorySightsAndSounds);

--- a/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/prefs/notifications/NotificationsSettingsFragment.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceCategory;
@@ -85,12 +86,29 @@ public class NotificationsSettingsFragment extends PreferenceFragment
 
         addPreferencesFromResource(R.xml.notifications_settings);
         setHasOptionsMenu(true);
+        removeSightAndSoundsForAPI26();
 
         // Bump Analytics
         if (savedInstanceState == null) {
             AnalyticsTracker.track(AnalyticsTracker.Stat.NOTIFICATION_SETTINGS_LIST_OPENED);
         }
     }
+
+    private void removeSightAndSoundsForAPI26() {
+        // on API26 we removed the Sight & Sounds category altogether, as it can always be
+        // overriden by the user in the Device settings, and the settings here
+        // wouldn't either reflect nor have any effect anyway.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            PreferenceScreen preferenceScreen =
+                    (PreferenceScreen) findPreference(getActivity().getString(R.string.wp_pref_notifications_root));
+
+            PreferenceCategory categorySightsAndSounds = (PreferenceCategory) preferenceScreen.findPreference(getActivity()
+                    .getString(
+                            R.string.pref_notification_sights_sounds));
+            preferenceScreen.removePreference(categorySightsAndSounds);
+        }
+    }
+
 
     @Override
     public void onActivityCreated(Bundle savedInstanceState) {


### PR DESCRIPTION
This PR replaces #7597 with a better approach. Copying the description for better tracking here:

Notifications settings such as sounds, vibration and light on API 26 are only taken seriously from the device Settings, as anything the user does on the app can be overriden by what the device settings say. I think we should hide that section from the app on Android O altogether, as the user can override the settings from outside the app, and the app would never know, thus not reflecting the actual setting, and confusing the user.

This is what you can do on the device:
![screenshot_20180404-194952](https://user-images.githubusercontent.com/6597771/38338916-fc88cf10-3841-11e8-91c8-5aa3f46f1c8b.png)

And this is what you can do on the app:
![screenshot_20180404-194959](https://user-images.githubusercontent.com/6597771/38338928-0815bee2-3842-11e8-8aeb-4df362173e2f.png)


This is how it ends up looking like with this PR on API26: 

![screenshot_20180404-211437](https://user-images.githubusercontent.com/6597771/38341135-71d934c0-384d-11e8-9800-c9621412aaf9.png)
 

**To test:**
_CASE A: Pre-Android Oreo_
1. go to app settings
2. observe the Sights & sounds section is there and can be manipulated

_CASE B: Post-Android Oreo_
1. go to app settings
2. observe the Sights & sounds section is not there

cc @nbradbury 