### PR TITLE
ListNetworkResource: Improvements, Documentation and Unit Tests

### DIFF
--- a/WordPress/src/main/java/org/wordpress/android/models/networkresource/ListNetworkResource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/networkresource/ListNetworkResource.kt
@@ -1,9 +1,7 @@
 package org.wordpress.android.models.networkresource
 
 /**
- * ListNetworkResource aims to give a highly structured and easy to use way to manage any list that's network bound. It
- * was specifically designed to be as simple as possible and in order to utilize it, you don't need to understand the
- * inner workings of the class, although it'd be straightforward to do so.
+ * ListNetworkResource aims to give a highly structured and easy to use way to manage any list that's network bound.
  *
  * There are 5 different states: [Init], [Ready], [Success], [Loading], [Error]. Check out their documentation to see
  * how each state behaves.
@@ -16,38 +14,40 @@ package org.wordpress.android.models.networkresource
  */
 sealed class ListNetworkResource<T>(val data: List<T>) {
     /**
-     * In some situations the data might change outside of a fetch for the list. Adding a new item, removing one,
-     * changing contents would be some typical examples. In these situations, the current data might need to be
-     * transformed.
+     * In some situations the underlying data might change outside of a fetch. Adding a new item, removing one,
+     * a single item getting updated would be some typical examples. Since the [data] property can not be altered
+     * directly, by design, we need a different way to update it.
      *
-     * This method can be used to handle any such transformation easily while preserving the current state. Any function
-     * that takes a [List] and returns a new one can be used.
+     * This method can be used to handle any transformation easily while preserving the current state. Any function
+     * that takes a [List] and returns a new one can be used as the transformation.
+     *
+     * @return a new ListNetworkResource instance that has the transformed data while preserving the state
      */
     abstract fun getTransformedListNetworkResource(transform: (List<T>) -> List<T>): ListNetworkResource<T>
 
     /**
-     * Helper function for [Ready].
+     * Helper function for initializing [Ready] state.
      *
      * @return a new [ListNetworkResource] instance.
      */
     fun ready(data: List<T>): ListNetworkResource<T> = Ready(data)
 
     /**
-     * Helper function for [Success].
+     * Helper function for initializing [Success] state.
      *
      * @return a new [ListNetworkResource] instance.
      */
     fun success(data: List<T>, canLoadMore: Boolean = false) = Success(data, canLoadMore)
 
     /**
-     * Helper function for [Loading] which passes `this` as the previous state.
+     * Helper function for initializing [Loading] state which passes `this` as the previous state.
      *
      * @return a new [ListNetworkResource] instance.
      */
     fun loading(loadingMore: Boolean) = Loading(this, loadingMore)
 
     /**
-     * Helper function for [Error] which passes `this` as the previous state.
+     * Helper function for initializing [Error] state which passes `this` as the previous state.
      *
      * @return a new [ListNetworkResource] instance.
      */
@@ -149,9 +149,6 @@ sealed class ListNetworkResource<T>(val data: List<T>) {
      * where the network is not available.
      *
      * @see error helper function for easier initialization.
-     *
-     * Some possible improvements to this state would be to add a helper function to get a flag for whether
-     * first page or more data was being loaded. Adding an error type `enum` could also prove useful.
      */
     class Error<T> private constructor(data: List<T>, val errorMessage: String?)
         : ListNetworkResource<T>(data) {

--- a/WordPress/src/main/java/org/wordpress/android/models/networkresource/ListNetworkResource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/networkresource/ListNetworkResource.kt
@@ -26,34 +26,6 @@ sealed class ListNetworkResource<T>(val data: List<T>) {
     abstract fun getTransformedListNetworkResource(transform: (List<T>) -> List<T>): ListNetworkResource<T>
 
     /**
-     * Helper function for initializing [Ready] state.
-     *
-     * @return a new [ListNetworkResource] instance.
-     */
-    fun ready(data: List<T>): ListNetworkResource<T> = Ready(data)
-
-    /**
-     * Helper function for initializing [Success] state.
-     *
-     * @return a new [ListNetworkResource] instance.
-     */
-    fun success(data: List<T>, canLoadMore: Boolean = false) = Success(data, canLoadMore)
-
-    /**
-     * Helper function for initializing [Loading] state which passes `this` as the previous state.
-     *
-     * @return a new [ListNetworkResource] instance.
-     */
-    fun loading(loadingMore: Boolean) = Loading(this, loadingMore)
-
-    /**
-     * Helper function for initializing [Error] state which passes `this` as the previous state.
-     *
-     * @return a new [ListNetworkResource] instance.
-     */
-    fun error(errorMessage: String?) = Error(this, errorMessage)
-
-    /**
      * Helper function for checking whether the first page is being loaded. It can be used to either show or hide a
      * [android.support.v4.widget.SwipeRefreshLayout].
      */
@@ -94,8 +66,6 @@ sealed class ListNetworkResource<T>(val data: List<T>) {
      *
      * @param data This is one of 2 places where the data can be directly passed in. In most cases, it will be set
      * using the cached version of the data, for example from its `Store`.
-     *
-     * @see ready helper function for alternative initialization.
      */
     class Ready<T>(data: List<T>) : ListNetworkResource<T>(data) {
         override fun getTransformedListNetworkResource(transform: (List<T>) -> List<T>) = Ready(transform(data))
@@ -110,8 +80,6 @@ sealed class ListNetworkResource<T>(val data: List<T>) {
      *
      * @param loadingMore flag is used to indicate whether the first page or more data is being fetched. It's default
      * value is `false` which should be useful in situations where pagination is not available.
-     *
-     * @see loading helper function for alternative initialization.
      */
     class Loading<T> private constructor(data: List<T>, val loadingMore: Boolean)
         : ListNetworkResource<T>(data) {
@@ -129,8 +97,6 @@ sealed class ListNetworkResource<T>(val data: List<T>) {
      * @param canLoadMore For resources where pagination is available, this flag can be used to indicate if more data
      * can be fetched. It's default value is `false` which should be useful in situations where pagination is not
      * available.
-     *
-     * @see success helper function for easier initialization.
      */
     class Success<T>(data: List<T>, val canLoadMore: Boolean = false)
         : ListNetworkResource<T>(data) {
@@ -147,8 +113,6 @@ sealed class ListNetworkResource<T>(val data: List<T>) {
      *
      * @param errorMessage will be the error string received from the API. It can also be used to show connection errors
      * where the network is not available.
-     *
-     * @see error helper function for easier initialization.
      */
     class Error<T> private constructor(data: List<T>, val errorMessage: String?)
         : ListNetworkResource<T>(data) {

--- a/WordPress/src/main/java/org/wordpress/android/models/networkresource/ListNetworkResource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/networkresource/ListNetworkResource.kt
@@ -1,20 +1,85 @@
 package org.wordpress.android.models.networkresource
 
+/**
+ * ListNetworkResource aims to give a highly structured and easy to use way to manage any list that's network bound. It
+ * was specifically designed to be as simple as possible. In order to utilize it you don't need to understand the inner
+ * workings of the class, although it'd be straightforward to do so.
+ *
+ * There are 5 different states: [Init], [Ready], [Success], [Loading], [Error]. Check out their documentation to see
+ * how each state behaves.
+ *
+ * @property previous is the previous state. There are several use cases for it one of which is calculating the
+ * difference in data in [org.wordpress.android.ui.ListDiffCallback]. Another example would be to check the previous
+ * [Loading] state to see if the first page or more data was being fetched to show the proper error to the user.
+ * In [Init] state this should be `null`, but for every other state a previous one will need to be passed in.
+ *
+ * @property data is initialized depending on each state and once initialized it can not be altered. In [Ready] and
+ * [Success] states, it'll be passed as a parameter. In [Loading] and [Error] states, it'll be initialized from the
+ * previous state to make sure the access to the data is not lost. In [Init], an empty list will be passed.
+ * In situations where the data needs to be changed outside of a fetch [getTransformedListNetworkResource] can be used
+ * to get a new instance by using a transform function.
+ */
 sealed class ListNetworkResource<T>(val previous: ListNetworkResource<T>?, val data: List<T>) {
+    /**
+     * In some situations the data might change outside of a fetch for the list. Adding a new item, removing one,
+     * changing contents would be some typical examples. In these situations, the current data might need to be
+     * transformed.
+     *
+     * This method can be used to handle any such transformation easily while preserving the current state. Any function
+     * that takes a [List] and returns a new one can be used. The only important thing to keep in mind is that, the new
+     * instance that'll be returned from this method will have the current resource as its [previous] state. That way
+     * there is a continuity to the states and the data difference can be calculated correctly in
+     * [org.wordpress.android.ui.ListDiffCallback].
+     */
     abstract fun getTransformedListNetworkResource(transform: (List<T>) -> List<T>): ListNetworkResource<T>
 
+    /**
+     * Helper function for [Ready] which passes `this` as the previous state.
+     *
+     * @return a new [ListNetworkResource] instance.
+     */
     fun ready(data: List<T>): ListNetworkResource<T> = Ready(this, data)
 
+    /**
+     * Helper function for [Success] which passes `this` as the previous state.
+     *
+     * @return a new [ListNetworkResource] instance.
+     */
     fun success(data: List<T>, canLoadMore: Boolean = false) = Success(this, data, canLoadMore)
 
+    /**
+     * Helper function for [Loading] which passes `this` as the previous state.
+     *
+     * @return a new [ListNetworkResource] instance.
+     */
     fun loading(loadingMore: Boolean) = Loading(this, loadingMore)
 
+    /**
+     * Helper function for [Error] which passes `this` as the previous state.
+     *
+     * @return a new [ListNetworkResource] instance.
+     */
     fun error(errorMessage: String?) = Error(this, errorMessage)
 
+    /**
+     * Helper function for checking whether the first page is being loaded. It can be used to either show or hide a
+     * [android.support.v4.widget.SwipeRefreshLayout].
+     */
     fun isFetchingFirstPage(): Boolean = if (this is Loading) !loadingMore else false
 
+    /**
+     * Helper function for checking whether more data is being loaded. It can be used to either show or hide a
+     * [android.widget.ProgressBar] such as at the bottom of a screen.
+     */
     fun isLoadingMore(): Boolean = (this as? Loading)?.loadingMore == true
 
+    /**
+     * Helper function to check whether a fetch should occur. If the state is [Loading] fetch is not allowed. Otherwise,
+     * the first page can be fetched at any time. Loading more data is only allowed if it's specifically flagged to be
+     * possible in [Success] state.
+     *
+     * @param loadMore should be passed to indicate what kind of fetch is intended: first page or load more
+     */
     fun shouldFetch(loadMore: Boolean): Boolean = when (this) {
         is Init -> false // Not ready yet
         is Loading -> false // Already fetching
@@ -22,20 +87,46 @@ sealed class ListNetworkResource<T>(val previous: ListNetworkResource<T>?, val d
         else -> !loadMore // First page can be fetched since we are not fetching anything else
     }
 
+    /**
+     * This is the state each object should be created in. In this state [data] would be empty and [shouldFetch] will
+     * return `false` with the assumption that the caller will need to get ready before fetch can happen. A typical
+     * example would be to initialize a resource as a property and then [ready] it after the necessary setup, such as
+     * getting the `SiteModel` from a `Store`.
+     */
     class Init<T> : ListNetworkResource<T>(null, ArrayList()) {
         override fun getTransformedListNetworkResource(transform: (List<T>) -> List<T>) = this
     }
 
+    /**
+     * Ready state signifies that this resource can start being used.
+     *
+     * @param previous The previous state. In most cases, [Init] state should be passed in for it, however in cases
+     * where a reset is necessary such as change to a search term (which invalidates the current data), another state
+     * might be passed in for it. See the property explanation in [ListNetworkResource] for more details.
+     *
+     * @param data This is one of 2 places where the data can be directly passed in. In most cases, it will be set
+     * using the cached version of the data, for example from its `Store`.
+     *
+     * @see ready helper function for easier initialization.
+     */
     class Ready<T>(previous: ListNetworkResource<T>, data: List<T>) : ListNetworkResource<T>(previous, data) {
         override fun getTransformedListNetworkResource(transform: (List<T>) -> List<T>) = Ready(this, transform(data))
     }
 
-    class Success<T>(previous: ListNetworkResource<T>, data: List<T>, val canLoadMore: Boolean = false)
-        : ListNetworkResource<T>(previous, data) {
-        override fun getTransformedListNetworkResource(transform: (List<T>) -> List<T>) =
-                Success(this, transform(data), canLoadMore)
-    }
-
+    /**
+     * This state means that a network request has been started to fetch either the first page or more data.
+     *
+     * @param previous The previous state. See the property explanation in [ListNetworkResource] for more details.
+     *
+     * @param data can not be passed directly to [Loading] state as it's prevented by a private constructor.
+     * The only time it's used is when the existing data needs to be transformed. See
+     * [ListNetworkResource.getTransformedListNetworkResource] for more details.
+     *
+     * @param loadingMore flag is used to indicate whether the first page or more data is being fetched. It's default
+     * value is `false` which should be useful in situations where pagination is not available.
+     *
+     * @see loading helper function for easier initialization.
+     */
     class Loading<T> private constructor(previous: ListNetworkResource<T>, data: List<T>, val loadingMore: Boolean)
         : ListNetworkResource<T>(previous, data) {
         constructor(previous: ListNetworkResource<T>, loadingMore: Boolean = false)
@@ -45,6 +136,44 @@ sealed class ListNetworkResource<T>(val previous: ListNetworkResource<T>?, val d
                 Loading(this, transform(data), loadingMore)
     }
 
+    /** This state means that at least one fetch has successfully completed.
+     *
+     * @param previous The previous state. The [Loading] state is expected to be passed in for it, but it's not forced.
+     * See the property explanation in [ListNetworkResource] for more details.
+     *
+     * @param data This is the second and final state where the data can be passed in directly.
+     *
+     * @param canLoadMore For resources where pagination is available, this flag can be used to indicate if more data
+     * can be fetched. It's default value is `false` which should be useful in situations where pagination is not
+     * available.
+     *
+     * @see success helper function for easier initialization.
+     */
+    class Success<T>(previous: ListNetworkResource<T>, data: List<T>, val canLoadMore: Boolean = false)
+        : ListNetworkResource<T>(previous, data) {
+        override fun getTransformedListNetworkResource(transform: (List<T>) -> List<T>) =
+                Success(this, transform(data), canLoadMore)
+    }
+
+    /**
+     * This state means that at least one fetch has resulted in error.
+     *
+     * @param previous The previous state. The [Loading] state is expected to be passed in for it, but it's not forced.
+     * [previous] property in this state can be used to check whether first page or more data was being loaded. See
+     * the property explanation in [ListNetworkResource] for more details.
+     *
+     * @param data can not be passed directly to [Error] state as it's prevented by a private constructor.
+     * The only time it's used is when the existing data needs to be transformed. See
+     * [ListNetworkResource.getTransformedListNetworkResource] for more details.
+     *
+     * @param errorMessage will be the error string received from the API. It can also be used to show connection errors
+     * where the network is not available.
+     *
+     * @see error helper function for easier initialization.
+     *
+     * Some possible improvements to this state would be to add a helper function to get a flag for whether
+     * first page or more data was being loaded. Adding an error type `enum` could also prove useful.
+     */
     class Error<T> private constructor(previous: ListNetworkResource<T>, data: List<T>, val errorMessage: String?)
         : ListNetworkResource<T>(previous, data) {
         constructor(previous: ListNetworkResource<T>, errorMessage: String?)

--- a/WordPress/src/main/java/org/wordpress/android/models/networkresource/ListNetworkResource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/networkresource/ListNetworkResource.kt
@@ -3,7 +3,7 @@ package org.wordpress.android.models.networkresource
 sealed class ListNetworkResource<T>(val previous: ListNetworkResource<T>?, val data: List<T>) {
     abstract fun getTransformedListNetworkResource(transform: (List<T>) -> List<T>): ListNetworkResource<T>
 
-    fun ready(data: List<T>): ListNetworkResource<T> =  Ready(this, data)
+    fun ready(data: List<T>): ListNetworkResource<T> = Ready(this, data)
 
     fun success(data: List<T>, canLoadMore: Boolean = false) = Success(this, data, canLoadMore)
 
@@ -15,16 +15,12 @@ sealed class ListNetworkResource<T>(val previous: ListNetworkResource<T>?, val d
 
     fun isLoadingMore(): Boolean = (this as? Loading)?.loadingMore == true
 
-    fun shouldFetch(loadMore: Boolean): Boolean {
-        return when (this) {
-            is Init -> false // Not ready yet
-            is Loading -> false // Already fetching
-            is Success -> if (loadMore) canLoadMore else true // Trying to load more or refreshing
-            else -> !loadMore // First page can be fetched since we are not fetching anything else
-        }
+    fun shouldFetch(loadMore: Boolean): Boolean = when (this) {
+        is Init -> false // Not ready yet
+        is Loading -> false // Already fetching
+        is Success -> if (loadMore) canLoadMore else true // Trying to load more or refreshing
+        else -> !loadMore // First page can be fetched since we are not fetching anything else
     }
-
-    // Classes
 
     class Init<T> : ListNetworkResource<T>(null, ArrayList()) {
         override fun getTransformedListNetworkResource(transform: (List<T>) -> List<T>) = this

--- a/WordPress/src/main/java/org/wordpress/android/models/networkresource/ListNetworkResource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/networkresource/ListNetworkResource.kt
@@ -1,9 +1,6 @@
 package org.wordpress.android.models.networkresource
 
-import org.wordpress.android.ui.ListDiffCallback
-import org.wordpress.android.util.AppLog
-
-sealed class ListNetworkResource<T>(private val previous: ListNetworkResource<T>?, val data: List<T>) {
+sealed class ListNetworkResource<T>(val previous: ListNetworkResource<T>?, val data: List<T>) {
     abstract fun getTransformedListNetworkResource(transform: (List<T>) -> List<T>): ListNetworkResource<T>
 
     fun ready(data: List<T>): ListNetworkResource<T> =  Ready(this, data)
@@ -20,20 +17,11 @@ sealed class ListNetworkResource<T>(private val previous: ListNetworkResource<T>
 
     fun shouldFetch(loadMore: Boolean): Boolean {
         return when (this) {
-            is Init -> { // Not ready yet
-                // TODO: Don't use T.MAIN for the log
-                AppLog.e(AppLog.T.MAIN, "ListNetworkResource should be ready before fetching")
-                false
-            }
+            is Init -> false // Not ready yet
             is Loading -> false // Already fetching
             is Success -> if (loadMore) canLoadMore else true // Trying to load more or refreshing
             else -> !loadMore // First page can be fetched since we are not fetching anything else
         }
-    }
-
-    fun getDiffCallback(areItemsTheSame: (T?, T?) -> Boolean,
-                        areContentsTheSame: (T?, T?) -> Boolean): ListDiffCallback<T> {
-        return ListDiffCallback(previous?.data, data, areItemsTheSame, areContentsTheSame)
     }
 
     // Classes

--- a/WordPress/src/main/java/org/wordpress/android/models/networkresource/ListNetworkResource.kt
+++ b/WordPress/src/main/java/org/wordpress/android/models/networkresource/ListNetworkResource.kt
@@ -2,16 +2,11 @@ package org.wordpress.android.models.networkresource
 
 /**
  * ListNetworkResource aims to give a highly structured and easy to use way to manage any list that's network bound. It
- * was specifically designed to be as simple as possible. In order to utilize it you don't need to understand the inner
- * workings of the class, although it'd be straightforward to do so.
+ * was specifically designed to be as simple as possible and in order to utilize it, you don't need to understand the
+ * inner workings of the class, although it'd be straightforward to do so.
  *
  * There are 5 different states: [Init], [Ready], [Success], [Loading], [Error]. Check out their documentation to see
  * how each state behaves.
- *
- * @property previous is the previous state. There are several use cases for it one of which is calculating the
- * difference in data in [org.wordpress.android.ui.ListDiffCallback]. Another example would be to check the previous
- * [Loading] state to see if the first page or more data was being fetched to show the proper error to the user.
- * In [Init] state this should be `null`, but for every other state a previous one will need to be passed in.
  *
  * @property data is initialized depending on each state and once initialized it can not be altered. In [Ready] and
  * [Success] states, it'll be passed as a parameter. In [Loading] and [Error] states, it'll be initialized from the
@@ -26,22 +21,19 @@ sealed class ListNetworkResource<T>(val data: List<T>) {
      * transformed.
      *
      * This method can be used to handle any such transformation easily while preserving the current state. Any function
-     * that takes a [List] and returns a new one can be used. The only important thing to keep in mind is that, the new
-     * instance that'll be returned from this method will have the current resource as its [previous] state. That way
-     * there is a continuity to the states and the data difference can be calculated correctly in
-     * [org.wordpress.android.ui.ListDiffCallback].
+     * that takes a [List] and returns a new one can be used.
      */
     abstract fun getTransformedListNetworkResource(transform: (List<T>) -> List<T>): ListNetworkResource<T>
 
     /**
-     * Helper function for [Ready] which passes `this` as the previous state.
+     * Helper function for [Ready].
      *
      * @return a new [ListNetworkResource] instance.
      */
     fun ready(data: List<T>): ListNetworkResource<T> = Ready(data)
 
     /**
-     * Helper function for [Success] which passes `this` as the previous state.
+     * Helper function for [Success].
      *
      * @return a new [ListNetworkResource] instance.
      */
@@ -69,7 +61,7 @@ sealed class ListNetworkResource<T>(val data: List<T>) {
 
     /**
      * Helper function for checking whether more data is being loaded. It can be used to either show or hide a
-     * [android.widget.ProgressBar] such as at the bottom of a screen.
+     * [android.widget.ProgressBar] for instance, at the bottom of a screen.
      */
     fun isLoadingMore(): Boolean = (this as? Loading)?.loadingMore == true
 
@@ -100,14 +92,10 @@ sealed class ListNetworkResource<T>(val data: List<T>) {
     /**
      * Ready state signifies that this resource can start being used.
      *
-     * @param previous The previous state. In most cases, [Init] state should be passed in for it, however in cases
-     * where a reset is necessary such as change to a search term (which invalidates the current data), another state
-     * might be passed in for it. See the property explanation in [ListNetworkResource] for more details.
-     *
      * @param data This is one of 2 places where the data can be directly passed in. In most cases, it will be set
      * using the cached version of the data, for example from its `Store`.
      *
-     * @see ready helper function for easier initialization.
+     * @see ready helper function for alternative initialization.
      */
     class Ready<T>(data: List<T>) : ListNetworkResource<T>(data) {
         override fun getTransformedListNetworkResource(transform: (List<T>) -> List<T>) = Ready(transform(data))
@@ -116,16 +104,14 @@ sealed class ListNetworkResource<T>(val data: List<T>) {
     /**
      * This state means that a network request has been started to fetch either the first page or more data.
      *
-     * @param previous The previous state. See the property explanation in [ListNetworkResource] for more details.
-     *
      * @param data can not be passed directly to [Loading] state as it's prevented by a private constructor.
-     * The only time it's used is when the existing data needs to be transformed. See
-     * [ListNetworkResource.getTransformedListNetworkResource] for more details.
+     * It's initialized either from the previous state or from the transformed data using
+     * [ListNetworkResource.getTransformedListNetworkResource].
      *
      * @param loadingMore flag is used to indicate whether the first page or more data is being fetched. It's default
      * value is `false` which should be useful in situations where pagination is not available.
      *
-     * @see loading helper function for easier initialization.
+     * @see loading helper function for alternative initialization.
      */
     class Loading<T> private constructor(data: List<T>, val loadingMore: Boolean)
         : ListNetworkResource<T>(data) {
@@ -137,9 +123,6 @@ sealed class ListNetworkResource<T>(val data: List<T>) {
     }
 
     /** This state means that at least one fetch has successfully completed.
-     *
-     * @param previous The previous state. The [Loading] state is expected to be passed in for it, but it's not forced.
-     * See the property explanation in [ListNetworkResource] for more details.
      *
      * @param data This is the second and final state where the data can be passed in directly.
      *
@@ -158,13 +141,9 @@ sealed class ListNetworkResource<T>(val data: List<T>) {
     /**
      * This state means that at least one fetch has resulted in error.
      *
-     * @param previous The previous state. The [Loading] state is expected to be passed in for it, but it's not forced.
-     * [previous] property in this state can be used to check whether first page or more data was being loaded. See
-     * the property explanation in [ListNetworkResource] for more details.
-     *
      * @param data can not be passed directly to [Error] state as it's prevented by a private constructor.
-     * The only time it's used is when the existing data needs to be transformed. See
-     * [ListNetworkResource.getTransformedListNetworkResource] for more details.
+     * It's initialized either from the previous state or from the transformed data using
+     * [ListNetworkResource.getTransformedListNetworkResource].
      *
      * @param errorMessage will be the error string received from the API. It can also be used to show connection errors
      * where the network is not available.

--- a/WordPress/src/main/java/org/wordpress/android/ui/ListDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ListDiffCallback.kt
@@ -1,7 +1,6 @@
 package org.wordpress.android.ui
 
 import android.support.v7.util.DiffUtil
-import org.wordpress.android.models.networkresource.ListNetworkResource
 
 class ListDiffCallback<T>(private val oldList: List<T>?,
                           private val newList: List<T>?,

--- a/WordPress/src/main/java/org/wordpress/android/ui/ListDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ListDiffCallback.kt
@@ -7,14 +7,6 @@ class ListDiffCallback<T>(private val oldList: List<T>?,
                           private val newList: List<T>?,
                           private val areItemsTheSame: (T?, T?) -> Boolean,
                           private val areContentsTheSame: (T?, T?) -> Boolean) : DiffUtil.Callback() {
-    companion object {
-        fun <T> fromListNetworkResource(listNetworkResource: ListNetworkResource<T>,
-                                        areItemsTheSame: (T?, T?) -> Boolean,
-                                        areContentsTheSame: (T?, T?) -> Boolean): ListDiffCallback<T> {
-            return ListDiffCallback(listNetworkResource.previous?.data, listNetworkResource.data,
-                    areItemsTheSame, areContentsTheSame)
-        }
-    }
 
     override fun getOldListSize(): Int = oldList?.size ?: 0
 

--- a/WordPress/src/main/java/org/wordpress/android/ui/ListDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ListDiffCallback.kt
@@ -1,0 +1,18 @@
+package org.wordpress.android.ui
+
+import android.support.v7.util.DiffUtil
+
+class ListDiffCallback<T>(private val oldList: List<T>?,
+                          private val newList: List<T>?,
+                          private val areItemsTheSame: (T?, T?) -> Boolean,
+                          private val areContentsTheSame: (T?, T?) -> Boolean) : DiffUtil.Callback() {
+    override fun getOldListSize(): Int = oldList?.size ?: 0
+
+    override fun getNewListSize(): Int = newList?.size ?: 0
+
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean
+            = areItemsTheSame(oldList?.get(oldItemPosition), newList?.get(newItemPosition))
+
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean
+            = areContentsTheSame(oldList?.get(oldItemPosition), newList?.get(newItemPosition))
+}

--- a/WordPress/src/main/java/org/wordpress/android/ui/ListDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ListDiffCallback.kt
@@ -20,9 +20,9 @@ class ListDiffCallback<T>(private val oldList: List<T>?,
 
     override fun getNewListSize(): Int = newList?.size ?: 0
 
-    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean
-            = areItemsTheSame(oldList?.get(oldItemPosition), newList?.get(newItemPosition))
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
+            areItemsTheSame(oldList?.get(oldItemPosition), newList?.get(newItemPosition))
 
-    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean
-            = areContentsTheSame(oldList?.get(oldItemPosition), newList?.get(newItemPosition))
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean =
+            areContentsTheSame(oldList?.get(oldItemPosition), newList?.get(newItemPosition))
 }

--- a/WordPress/src/main/java/org/wordpress/android/ui/ListDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ListDiffCallback.kt
@@ -7,7 +7,6 @@ class ListDiffCallback<T>(private val oldList: List<T>?,
                           private val newList: List<T>?,
                           private val areItemsTheSame: (T?, T?) -> Boolean,
                           private val areContentsTheSame: (T?, T?) -> Boolean) : DiffUtil.Callback() {
-
     override fun getOldListSize(): Int = oldList?.size ?: 0
 
     override fun getNewListSize(): Int = newList?.size ?: 0

--- a/WordPress/src/main/java/org/wordpress/android/ui/ListDiffCallback.kt
+++ b/WordPress/src/main/java/org/wordpress/android/ui/ListDiffCallback.kt
@@ -1,11 +1,21 @@
 package org.wordpress.android.ui
 
 import android.support.v7.util.DiffUtil
+import org.wordpress.android.models.networkresource.ListNetworkResource
 
 class ListDiffCallback<T>(private val oldList: List<T>?,
                           private val newList: List<T>?,
                           private val areItemsTheSame: (T?, T?) -> Boolean,
                           private val areContentsTheSame: (T?, T?) -> Boolean) : DiffUtil.Callback() {
+    companion object {
+        fun <T> fromListNetworkResource(listNetworkResource: ListNetworkResource<T>,
+                                        areItemsTheSame: (T?, T?) -> Boolean,
+                                        areContentsTheSame: (T?, T?) -> Boolean): ListDiffCallback<T> {
+            return ListDiffCallback(listNetworkResource.previous?.data, listNetworkResource.data,
+                    areItemsTheSame, areContentsTheSame)
+        }
+    }
+
     override fun getOldListSize(): Int = oldList?.size ?: 0
 
     override fun getNewListSize(): Int = newList?.size ?: 0

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -37,7 +37,6 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.plugin.ImmutablePluginModel;
 import org.wordpress.android.models.networkresource.ListNetworkResource;
 import org.wordpress.android.ui.ActivityLauncher;
-import org.wordpress.android.ui.ListDiffCallback;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -14,6 +14,7 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.util.DiffUtil;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.RecyclerView.ViewHolder;
@@ -36,6 +37,7 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.plugin.ImmutablePluginModel;
 import org.wordpress.android.models.networkresource.ListNetworkResource;
 import org.wordpress.android.ui.ActivityLauncher;
+import org.wordpress.android.ui.ListDiffCallback;
 import org.wordpress.android.util.ActivityUtils;
 import org.wordpress.android.util.AnalyticsUtils;
 import org.wordpress.android.util.AniUtils;
@@ -273,10 +275,7 @@ public class PluginBrowserActivity extends AppCompatActivity
     private void reloadPluginAdapterAndVisibility(@NonNull PluginListType pluginType,
                                                   @Nullable ListNetworkResource<ImmutablePluginModel>
                                                           listNetworkResource) {
-        // TODO: Find a better way to check for the status change and when to reload the data
-        // Don't reload for every status change, only do it when necessary
-        if (!(listNetworkResource instanceof ListNetworkResource.Ready
-              || listNetworkResource instanceof ListNetworkResource.Success)) {
+        if (listNetworkResource == null) {
             return;
         }
         PluginBrowserAdapter adapter = null;
@@ -305,7 +304,7 @@ public class PluginBrowserActivity extends AppCompatActivity
             return;
         }
         List<ImmutablePluginModel> plugins = listNetworkResource.getData();
-        adapter.setPlugins(plugins);
+        adapter.setPlugins(plugins, mViewModel.getDiffCallback(listNetworkResource));
 
         int newVisibility = plugins.size() > 0 ? View.VISIBLE : View.GONE;
         int oldVisibility = cardView.getVisibility();
@@ -376,10 +375,11 @@ public class PluginBrowserActivity extends AppCompatActivity
             setHasStableIds(true);
         }
 
-        void setPlugins(@Nullable List<ImmutablePluginModel> items) {
+        void setPlugins(@Nullable List<ImmutablePluginModel> items,
+                        ListDiffCallback<ImmutablePluginModel> diffCallback) {
             mItems.clear();
             mItems.addAll(items);
-            notifyDataSetChanged();
+            DiffUtil.calculateDiff(diffCallback).dispatchUpdatesTo(this);
         }
 
         private @Nullable Object getItem(int position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginBrowserActivity.java
@@ -304,7 +304,7 @@ public class PluginBrowserActivity extends AppCompatActivity
             return;
         }
         List<ImmutablePluginModel> plugins = listNetworkResource.getData();
-        adapter.setPlugins(plugins, mViewModel.getDiffCallback(listNetworkResource));
+        adapter.setPlugins(plugins);
 
         int newVisibility = plugins.size() > 0 ? View.VISIBLE : View.GONE;
         int oldVisibility = cardView.getVisibility();
@@ -375,11 +375,11 @@ public class PluginBrowserActivity extends AppCompatActivity
             setHasStableIds(true);
         }
 
-        void setPlugins(@Nullable List<ImmutablePluginModel> items,
-                        ListDiffCallback<ImmutablePluginModel> diffCallback) {
+        void setPlugins(@NonNull List<ImmutablePluginModel> items) {
+            DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(mViewModel.getDiffCallback(mItems, items));
             mItems.clear();
             mItems.addAll(items);
-            DiffUtil.calculateDiff(diffCallback).dispatchUpdatesTo(this);
+            diffResult.dispatchUpdatesTo(this);
         }
 
         private @Nullable Object getItem(int position) {

--- a/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
+++ b/WordPress/src/main/java/org/wordpress/android/ui/plugins/PluginListFragment.java
@@ -30,7 +30,6 @@ import org.wordpress.android.fluxc.model.SiteModel;
 import org.wordpress.android.fluxc.model.plugin.ImmutablePluginModel;
 import org.wordpress.android.models.networkresource.ListNetworkResource;
 import org.wordpress.android.ui.ActivityLauncher;
-import org.wordpress.android.ui.ListDiffCallback;
 import org.wordpress.android.util.NetworkUtils;
 import org.wordpress.android.util.ToastUtils;
 import org.wordpress.android.util.helpers.SwipeToRefreshHelper;
@@ -185,7 +184,7 @@ public class PluginListFragment extends Fragment {
         } else {
             adapter = (PluginListAdapter) mRecycler.getAdapter();
         }
-        adapter.setPlugins(listNetworkResource.getData(), mViewModel.getDiffCallback(listNetworkResource));
+        adapter.setPlugins(listNetworkResource.getData());
         refreshProgressBars(listNetworkResource);
     }
 
@@ -215,11 +214,11 @@ public class PluginListFragment extends Fragment {
             setHasStableIds(true);
         }
 
-        void setPlugins(@Nullable List<ImmutablePluginModel> items,
-                        ListDiffCallback<ImmutablePluginModel> diffCallback) {
+        void setPlugins(@NonNull List<ImmutablePluginModel> items) {
+            DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(mViewModel.getDiffCallback(mItems, items));
             mItems.clear();
             mItems.addAll(items);
-            DiffUtil.calculateDiff(diffCallback).dispatchUpdatesTo(this);
+            diffResult.dispatchUpdatesTo(this);
         }
 
         protected @Nullable Object getItem(int position) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.kt
@@ -168,7 +168,7 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
             }
             same
         }
-        return listNetworkResource.getDiffCallback(areItemsTheSame, areContentsTheSame)
+        return ListDiffCallback.fromListNetworkResource(listNetworkResource, areItemsTheSame, areContentsTheSame)
     }
 
     fun loadMore(listType: PluginListType) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.kt
@@ -144,7 +144,7 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
 
     // Actions
 
-    fun getDiffCallback(listNetworkResource: ListNetworkResource<ImmutablePluginModel>):
+    fun getDiffCallback(oldList: List<ImmutablePluginModel>, newList: List<ImmutablePluginModel>):
             ListDiffCallback<ImmutablePluginModel> {
         val areItemsTheSame: (ImmutablePluginModel?, ImmutablePluginModel?) -> Boolean = { old, new ->
             old?.slug == new?.slug
@@ -168,7 +168,7 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
             }
             same
         }
-        return ListDiffCallback.fromListNetworkResource(listNetworkResource, areItemsTheSame, areContentsTheSame)
+        return ListDiffCallback(oldList, newList, areItemsTheSame, areContentsTheSame)
     }
 
     fun loadMore(listType: PluginListType) {

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.kt
@@ -187,27 +187,27 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
         }
         when (listType) {
             PluginBrowserViewModel.PluginListType.SITE -> {
-                sitePlugins = sitePlugins.loading(loadMore)
+                sitePlugins = ListNetworkResource.Loading(sitePlugins, loadMore)
                 val payload = FetchPluginDirectoryPayload(PluginDirectoryType.SITE, site, loadMore)
                 mDispatcher.dispatch(PluginActionBuilder.newFetchPluginDirectoryAction(payload))
             }
             PluginBrowserViewModel.PluginListType.FEATURED -> {
-                featuredPlugins = featuredPlugins.loading(loadMore)
+                featuredPlugins = ListNetworkResource.Loading(featuredPlugins, loadMore)
                 val featuredPayload = FetchPluginDirectoryPayload(PluginDirectoryType.FEATURED, site, loadMore)
                 mDispatcher.dispatch(PluginActionBuilder.newFetchPluginDirectoryAction(featuredPayload))
             }
             PluginBrowserViewModel.PluginListType.POPULAR -> {
-                popularPlugins = popularPlugins.loading(loadMore)
+                popularPlugins = ListNetworkResource.Loading(popularPlugins, loadMore)
                 val popularPayload = FetchPluginDirectoryPayload(PluginDirectoryType.POPULAR, site, loadMore)
                 mDispatcher.dispatch(PluginActionBuilder.newFetchPluginDirectoryAction(popularPayload))
             }
             PluginBrowserViewModel.PluginListType.NEW -> {
-                newPlugins = newPlugins.loading(loadMore)
+                newPlugins = ListNetworkResource.Loading(newPlugins, loadMore)
                 val newPayload = FetchPluginDirectoryPayload(PluginDirectoryType.NEW, site, loadMore)
                 mDispatcher.dispatch(PluginActionBuilder.newFetchPluginDirectoryAction(newPayload))
             }
             PluginBrowserViewModel.PluginListType.SEARCH -> {
-                searchResults = searchResults.loading(loadMore)
+                searchResults = ListNetworkResource.Loading(searchResults, loadMore)
                 val searchPayload = PluginStore.SearchPluginDirectoryPayload(site, searchQuery, 1)
                 mDispatcher.dispatch(PluginActionBuilder.newSearchPluginDirectoryAction(searchPayload))
             }
@@ -259,10 +259,10 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
         }
         if (event.isError) {
             AppLog.e(T.PLUGINS, "An error occurred while searching the plugin directory")
-            searchResults = searchResults.error(event.error.message)
+            searchResults = ListNetworkResource.Error(searchResults, event.error.message)
             return
         }
-        searchResults = searchResults.success(event.plugins, false) // Disable pagination for search
+        searchResults = ListNetworkResource.Success(event.plugins, false) // Disable pagination for search
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
@@ -341,7 +341,7 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
                 }
             }, 250)
         } else {
-            searchResults = searchResults.ready(ArrayList())
+            searchResults = ListNetworkResource.Ready(ArrayList())
 
             if (shouldSearch) {
                 fetchPlugins(PluginListType.SEARCH, false)
@@ -370,10 +370,10 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
         site?.let {
             val pluginList = mPluginStore.getPluginDirectory(it, directoryType)
             when (directoryType) {
-                PluginDirectoryType.FEATURED -> featuredPlugins = featuredPlugins.ready(pluginList)
-                PluginDirectoryType.NEW -> newPlugins = newPlugins.ready(pluginList)
-                PluginDirectoryType.POPULAR -> popularPlugins = popularPlugins.ready(pluginList)
-                PluginDirectoryType.SITE -> sitePlugins = sitePlugins.ready(pluginList)
+                PluginDirectoryType.FEATURED -> featuredPlugins = ListNetworkResource.Ready(pluginList)
+                PluginDirectoryType.NEW -> newPlugins = ListNetworkResource.Ready(pluginList)
+                PluginDirectoryType.POPULAR -> popularPlugins = ListNetworkResource.Ready(pluginList)
+                PluginDirectoryType.SITE -> sitePlugins = ListNetworkResource.Ready(pluginList)
             }
         }
     }
@@ -382,20 +382,20 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
         site?.let {
             val pluginList = mPluginStore.getPluginDirectory(it, directoryType)
             when (directoryType) {
-                PluginDirectoryType.FEATURED -> featuredPlugins = featuredPlugins.success(pluginList, canLoadMore)
-                PluginDirectoryType.NEW -> newPlugins = newPlugins.success(pluginList, canLoadMore)
-                PluginDirectoryType.POPULAR -> popularPlugins = popularPlugins.success(pluginList, canLoadMore)
-                PluginDirectoryType.SITE -> sitePlugins = sitePlugins.success(pluginList, canLoadMore)
+                PluginDirectoryType.FEATURED -> featuredPlugins = ListNetworkResource.Success(pluginList, canLoadMore)
+                PluginDirectoryType.NEW -> newPlugins = ListNetworkResource.Success(pluginList, canLoadMore)
+                PluginDirectoryType.POPULAR -> popularPlugins = ListNetworkResource.Success(pluginList, canLoadMore)
+                PluginDirectoryType.SITE -> sitePlugins = ListNetworkResource.Success(pluginList, canLoadMore)
             }
         }
     }
 
     private fun errorListNetworkResource(directoryType: PluginDirectoryType, errorMessage: String?) {
         when (directoryType) {
-            PluginDirectoryType.FEATURED -> featuredPlugins = featuredPlugins.error(errorMessage)
-            PluginDirectoryType.NEW -> newPlugins = newPlugins.error(errorMessage)
-            PluginDirectoryType.POPULAR -> popularPlugins = popularPlugins.error(errorMessage)
-            PluginDirectoryType.SITE -> sitePlugins = sitePlugins.error(errorMessage)
+            PluginDirectoryType.FEATURED -> featuredPlugins = ListNetworkResource.Error(featuredPlugins, errorMessage)
+            PluginDirectoryType.NEW -> newPlugins = ListNetworkResource.Error(newPlugins, errorMessage)
+            PluginDirectoryType.POPULAR -> popularPlugins = ListNetworkResource.Error(popularPlugins, errorMessage)
+            PluginDirectoryType.SITE -> sitePlugins = ListNetworkResource.Error(sitePlugins, errorMessage)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.kt
@@ -155,27 +155,27 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
         }
         when (listType) {
             PluginBrowserViewModel.PluginListType.SITE -> {
-                sitePlugins = ListNetworkResource.Loading(sitePlugins, loadMore)
+                sitePlugins = sitePlugins.loading(loadMore)
                 val payload = FetchPluginDirectoryPayload(PluginDirectoryType.SITE, site, loadMore)
                 mDispatcher.dispatch(PluginActionBuilder.newFetchPluginDirectoryAction(payload))
             }
             PluginBrowserViewModel.PluginListType.FEATURED -> {
-                featuredPlugins = ListNetworkResource.Loading(featuredPlugins, loadMore)
+                featuredPlugins = featuredPlugins.loading(loadMore)
                 val featuredPayload = FetchPluginDirectoryPayload(PluginDirectoryType.FEATURED, site, loadMore)
                 mDispatcher.dispatch(PluginActionBuilder.newFetchPluginDirectoryAction(featuredPayload))
             }
             PluginBrowserViewModel.PluginListType.POPULAR -> {
-                popularPlugins = ListNetworkResource.Loading(popularPlugins, loadMore)
+                popularPlugins = popularPlugins.loading(loadMore)
                 val popularPayload = FetchPluginDirectoryPayload(PluginDirectoryType.POPULAR, site, loadMore)
                 mDispatcher.dispatch(PluginActionBuilder.newFetchPluginDirectoryAction(popularPayload))
             }
             PluginBrowserViewModel.PluginListType.NEW -> {
-                newPlugins = ListNetworkResource.Loading(newPlugins, loadMore)
+                newPlugins = newPlugins.loading(loadMore)
                 val newPayload = FetchPluginDirectoryPayload(PluginDirectoryType.NEW, site, loadMore)
                 mDispatcher.dispatch(PluginActionBuilder.newFetchPluginDirectoryAction(newPayload))
             }
             PluginBrowserViewModel.PluginListType.SEARCH -> {
-                searchResults = ListNetworkResource.Loading(searchResults, loadMore)
+                searchResults = searchResults.loading(loadMore)
                 val searchPayload = PluginStore.SearchPluginDirectoryPayload(site, searchQuery, 1)
                 mDispatcher.dispatch(PluginActionBuilder.newSearchPluginDirectoryAction(searchPayload))
             }
@@ -217,7 +217,7 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
         if (event.isError) {
             AppLog.e(T.PLUGINS, "An error occurred while fetching the plugin directory " + event.type + ": "
                     + event.error.type)
-            errorListNetworkResource(event.type, event.error.message, event.loadMore)
+            errorListNetworkResource(event.type, event.error.message)
         } else {
             successListNetworkResource(event.type, event.canLoadMore)
         }
@@ -231,10 +231,10 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
         }
         if (event.isError) {
             AppLog.e(T.PLUGINS, "An error occurred while searching the plugin directory")
-            searchResults = ListNetworkResource.Error(searchResults, event.error.message)
+            searchResults = searchResults.error(event.error.message)
             return
         }
-        searchResults = ListNetworkResource.Success(event.plugins, false) // Disable pagination for search
+        searchResults = searchResults.success(event.plugins, false) // Disable pagination for search
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
@@ -313,7 +313,7 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
                 }
             }, 250)
         } else {
-            searchResults = ListNetworkResource.Ready(ArrayList())
+            searchResults = searchResults.ready(ArrayList())
 
             if (shouldSearch) {
                 fetchPlugins(PluginListType.SEARCH, false)
@@ -342,10 +342,10 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
         site?.let {
             val pluginList = mPluginStore.getPluginDirectory(it, directoryType)
             when (directoryType) {
-                PluginDirectoryType.FEATURED -> featuredPlugins = ListNetworkResource.Ready(pluginList)
-                PluginDirectoryType.NEW -> newPlugins = ListNetworkResource.Ready(pluginList)
-                PluginDirectoryType.POPULAR -> popularPlugins = ListNetworkResource.Ready(pluginList)
-                PluginDirectoryType.SITE -> sitePlugins = ListNetworkResource.Ready(pluginList)
+                PluginDirectoryType.FEATURED -> featuredPlugins = featuredPlugins.ready(pluginList)
+                PluginDirectoryType.NEW -> newPlugins = newPlugins.ready(pluginList)
+                PluginDirectoryType.POPULAR -> popularPlugins = popularPlugins.ready(pluginList)
+                PluginDirectoryType.SITE -> sitePlugins = sitePlugins.ready(pluginList)
             }
         }
     }
@@ -354,24 +354,20 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
         site?.let {
             val pluginList = mPluginStore.getPluginDirectory(it, directoryType)
             when (directoryType) {
-                PluginDirectoryType.FEATURED -> featuredPlugins = ListNetworkResource.Success(pluginList, canLoadMore)
-                PluginDirectoryType.NEW -> newPlugins = ListNetworkResource.Success(pluginList, canLoadMore)
-                PluginDirectoryType.POPULAR -> popularPlugins = ListNetworkResource.Success(pluginList, canLoadMore)
-                PluginDirectoryType.SITE -> sitePlugins = ListNetworkResource.Success(pluginList, canLoadMore)
+                PluginDirectoryType.FEATURED -> featuredPlugins = featuredPlugins.success(pluginList, canLoadMore)
+                PluginDirectoryType.NEW -> newPlugins = newPlugins.success(pluginList, canLoadMore)
+                PluginDirectoryType.POPULAR -> popularPlugins = popularPlugins.success(pluginList, canLoadMore)
+                PluginDirectoryType.SITE -> sitePlugins = sitePlugins.success(pluginList, canLoadMore)
             }
         }
     }
 
-    private fun errorListNetworkResource(directoryType: PluginDirectoryType, errorMessage: String?, loadMore: Boolean) {
+    private fun errorListNetworkResource(directoryType: PluginDirectoryType, errorMessage: String?) {
         when (directoryType) {
-            PluginDirectoryType.FEATURED ->
-                featuredPlugins = ListNetworkResource.Error(featuredPlugins, errorMessage, loadMore)
-            PluginDirectoryType.NEW ->
-                newPlugins = ListNetworkResource.Error(newPlugins, errorMessage, loadMore)
-            PluginDirectoryType.POPULAR ->
-                popularPlugins = ListNetworkResource.Error(popularPlugins, errorMessage, loadMore)
-            PluginDirectoryType.SITE ->
-                sitePlugins = ListNetworkResource.Error(sitePlugins, errorMessage, loadMore)
+            PluginDirectoryType.FEATURED -> featuredPlugins = featuredPlugins.error(errorMessage)
+            PluginDirectoryType.NEW -> newPlugins = newPlugins.error(errorMessage)
+            PluginDirectoryType.POPULAR -> popularPlugins = popularPlugins.error(errorMessage)
+            PluginDirectoryType.SITE -> sitePlugins = sitePlugins.error(errorMessage)
         }
     }
 }

--- a/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.kt
+++ b/WordPress/src/main/java/org/wordpress/android/viewmodel/PluginBrowserViewModel.kt
@@ -144,8 +144,8 @@ constructor(private val mDispatcher: Dispatcher, private val mPluginStore: Plugi
 
     // Actions
 
-    fun getDiffCallback(listNetworkResource: ListNetworkResource<ImmutablePluginModel>)
-            : ListDiffCallback<ImmutablePluginModel> {
+    fun getDiffCallback(listNetworkResource: ListNetworkResource<ImmutablePluginModel>):
+            ListDiffCallback<ImmutablePluginModel> {
         val areItemsTheSame: (ImmutablePluginModel?, ImmutablePluginModel?) -> Boolean = { old, new ->
             old?.slug == new?.slug
         }

--- a/WordPress/src/test/java/org/wordpress/android/models/networkresource/ListNetworkResourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/models/networkresource/ListNetworkResourceTest.kt
@@ -1,0 +1,75 @@
+package org.wordpress.android.models.networkresource
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ListNetworkResourceTest {
+    @Test
+    fun testInitState() {
+        val initState = ListNetworkResource.Init<String>()
+
+        // Verify the state
+
+        assertNull(initState.previous)
+        assertTrue(initState.data.isEmpty())
+
+        // We are not loading anything
+        assertFalse(initState.isFetchingFirstPage())
+        assertFalse(initState.isLoadingMore())
+
+        // We shouldn't be able to fetch anything
+        assertFalse(initState.shouldFetch(true))
+        assertFalse(initState.shouldFetch(false))
+
+        // State transitions
+
+        val readyState = initState.ready(ArrayList())
+        assertEquals(initState, readyState.previous)
+
+        val successState = initState.success(ArrayList())
+        assertEquals(initState, successState.previous)
+
+        val loadingState = initState.loading(false)
+        assertEquals(initState, loadingState.previous)
+
+        val errorState = initState.error("error")
+        assertEquals(initState, errorState.previous)
+    }
+
+    @Test
+    fun testReadyState() {
+        val initState = ListNetworkResource.Init<String>()
+        val testData = listOf("item1", "item2")
+        val readyState = ListNetworkResource.Ready(initState, testData)
+
+        // Verify the state
+
+        assertEquals(testData, readyState.data)
+        assertEquals(initState, readyState.previous)
+
+        // We are not loading anything
+        assertFalse(readyState.isFetchingFirstPage())
+        assertFalse(readyState.isLoadingMore())
+
+        // We can refresh the first page but we can't load more
+        assertFalse(readyState.shouldFetch(true))
+        assertTrue(readyState.shouldFetch(false))
+
+        // State transitions
+
+        val successState = readyState.success(ArrayList())
+        assertEquals(readyState, successState.previous)
+        assertEquals(testData, successState.previous?.data)
+
+        val loadingState = readyState.loading(false)
+        assertEquals(readyState, loadingState.previous)
+        assertEquals(testData, loadingState.previous?.data)
+
+        val errorState = readyState.error("error")
+        assertEquals(readyState, errorState.previous)
+        assertEquals(testData, errorState.previous?.data)
+    }
+}

--- a/WordPress/src/test/java/org/wordpress/android/models/networkresource/ListNetworkResourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/models/networkresource/ListNetworkResourceTest.kt
@@ -79,7 +79,7 @@ class ListNetworkResourceTest {
         val loadingState: ListNetworkResource<String> = ListNetworkResource.Loading(readyState, true)
 
         val errorMessage = "Some error message"
-        val errorState = loadingState.error(errorMessage)
+        val errorState = ListNetworkResource.Error(loadingState, errorMessage)
         assertThat(errorState.errorMessage, `is`(equalTo(errorMessage)))
         assertThat(errorState.data, `is`(testDataReady))
     }
@@ -99,7 +99,7 @@ class ListNetworkResourceTest {
         val filterNotItem: (List<String>) -> List<String> = { list ->
             list.filter { it != "not-item".toUpperCase() }
         }
-        val loadingState: ListNetworkResource<String> = newReadyState.loading(true)
+        val loadingState: ListNetworkResource<String> = ListNetworkResource.Loading(newReadyState, true)
         val newLoadingState = loadingState.getTransformedListNetworkResource(filterNotItem)
         assertThat(newLoadingState.data, `is`(equalTo(filterNotItem(loadingState.data))))
         assertThat(newLoadingState.data.size, `is`(2))

--- a/WordPress/src/test/java/org/wordpress/android/models/networkresource/ListNetworkResourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/models/networkresource/ListNetworkResourceTest.kt
@@ -103,4 +103,29 @@ class ListNetworkResourceTest {
         assertThat(errorState.previous?.isLoadingMore(), `is`(true))
         assertThat(errorState.previous?.isFetchingFirstPage(), `is`(false))
     }
+
+    @Test
+    fun testGetTransformedListNetworkResource() {
+        val testDataReady = listOf("item10", "item11", "not-item")
+        val readyState: ListNetworkResource<String> = ListNetworkResource.Ready(ListNetworkResource.Init(),
+                testDataReady)
+        val toUpperCase: (List<String>) -> List<String> = { list ->
+            list.map { it.toUpperCase() }
+        }
+        val newReadyState = readyState.getTransformedListNetworkResource(toUpperCase)
+        assertThat(newReadyState.data, `is`(equalTo(toUpperCase(testDataReady))))
+        assertThat(newReadyState.data.size, `is`(3))
+        assertThat(newReadyState.previous, `is`(equalTo(readyState)))
+        assertThat(newReadyState is ListNetworkResource.Ready, `is`(true))
+
+        val filterNotItem: (List<String>) -> List<String> = { list ->
+            list.filter { it != "not-item".toUpperCase() }
+        }
+        val loadingState: ListNetworkResource<String> = newReadyState.loading(true)
+        val newLoadingState = loadingState.getTransformedListNetworkResource(filterNotItem)
+        assertThat(newLoadingState.data, `is`(equalTo(filterNotItem(loadingState.data))))
+        assertThat(newLoadingState.data.size, `is`(2))
+        assertThat(newLoadingState.previous, `is`(equalTo(loadingState)))
+        assertThat(newLoadingState is ListNetworkResource.Loading, `is`(true))
+    }
 }

--- a/WordPress/src/test/java/org/wordpress/android/models/networkresource/ListNetworkResourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/models/networkresource/ListNetworkResourceTest.kt
@@ -1,75 +1,116 @@
 package org.wordpress.android.models.networkresource
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
+import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.nullValue
+import org.junit.Assert.assertThat
 import org.junit.Test
 
 class ListNetworkResourceTest {
     @Test
     fun testInitState() {
-        val initState = ListNetworkResource.Init<String>()
+        val initState: ListNetworkResource<String> = ListNetworkResource.Init()
 
         // Verify the state
 
-        assertNull(initState.previous)
-        assertTrue(initState.data.isEmpty())
+        assertThat(initState.previous, `is`(nullValue()))
+        assertThat(initState.data, `is`(emptyList()))
 
         // We are not loading anything
-        assertFalse(initState.isFetchingFirstPage())
-        assertFalse(initState.isLoadingMore())
+        assertThat(initState.isFetchingFirstPage(), `is`(false))
+        assertThat(initState.isLoadingMore(), `is`(false))
 
         // We shouldn't be able to fetch anything
-        assertFalse(initState.shouldFetch(true))
-        assertFalse(initState.shouldFetch(false))
+        assertThat(initState.shouldFetch(true), `is`(false))
+        assertThat(initState.shouldFetch(false), `is`(false))
 
         // State transitions
 
         val readyState = initState.ready(ArrayList())
-        assertEquals(initState, readyState.previous)
+        assertThat(readyState.previous, `is`(equalTo(initState)))
 
         val successState = initState.success(ArrayList())
-        assertEquals(initState, successState.previous)
+        assertThat(successState.previous, `is`(equalTo(initState)))
 
         val loadingState = initState.loading(false)
-        assertEquals(initState, loadingState.previous)
+        assertThat(loadingState.previous, `is`(equalTo(initState)))
 
         val errorState = initState.error("error")
-        assertEquals(initState, errorState.previous)
+        assertThat(errorState.previous, `is`(equalTo(initState)))
     }
 
     @Test
     fun testReadyState() {
-        val initState = ListNetworkResource.Init<String>()
+        val initState: ListNetworkResource<String> = ListNetworkResource.Init()
         val testData = listOf("item1", "item2")
-        val readyState = ListNetworkResource.Ready(initState, testData)
+        val readyState: ListNetworkResource<String> = ListNetworkResource.Ready(initState, testData)
 
         // Verify the state
 
-        assertEquals(testData, readyState.data)
-        assertEquals(initState, readyState.previous)
+        assertThat(readyState.data, `is`(equalTo(testData)))
+        assertThat(readyState.previous, `is`(equalTo(initState)))
 
         // We are not loading anything
-        assertFalse(readyState.isFetchingFirstPage())
-        assertFalse(readyState.isLoadingMore())
+        assertThat(readyState.isFetchingFirstPage(), `is`(false))
+        assertThat(readyState.isLoadingMore(), `is`(false))
 
         // We can refresh the first page but we can't load more
-        assertFalse(readyState.shouldFetch(true))
-        assertTrue(readyState.shouldFetch(false))
+        assertThat(readyState.shouldFetch(true), `is`(false))
+        assertThat(readyState.shouldFetch(false), `is`(true))
 
         // State transitions
 
         val successState = readyState.success(ArrayList())
-        assertEquals(readyState, successState.previous)
-        assertEquals(testData, successState.previous?.data)
+        assertThat(successState.previous, `is`(equalTo(readyState)))
+        assertThat(successState.previous?.data, `is`(equalTo(testData)))
 
         val loadingState = readyState.loading(false)
-        assertEquals(readyState, loadingState.previous)
-        assertEquals(testData, loadingState.previous?.data)
+        assertThat(loadingState.previous, `is`(equalTo(readyState)))
+        assertThat(loadingState.previous?.data, `is`(equalTo(testData)))
 
         val errorState = readyState.error("error")
-        assertEquals(readyState, errorState.previous)
-        assertEquals(testData, errorState.previous?.data)
+        assertThat(errorState.previous, `is`(equalTo(readyState)))
+        assertThat(errorState.previous?.data, `is`(equalTo(testData)))
+    }
+
+    @Test
+    fun testLoadingFirstPageState() {
+        val testDataReady = listOf("item3", "item4")
+        val readyState: ListNetworkResource<String> = ListNetworkResource.Ready(ListNetworkResource.Init(),
+                testDataReady)
+        val loadingState: ListNetworkResource<String> = ListNetworkResource.Loading(readyState)
+
+        // Verify the state
+
+        assertThat(loadingState.data, `is`(equalTo(testDataReady)))
+        assertThat(loadingState.previous, `is`(equalTo(readyState)))
+
+        // We are not first page
+        assertThat(loadingState.isFetchingFirstPage(), `is`(true))
+        assertThat(loadingState.isLoadingMore(), `is`(false))
+
+        // We are already fetching
+        assertThat(loadingState.shouldFetch(true), `is`(false))
+        assertThat(loadingState.shouldFetch(false), `is`(false))
+
+        // State transitions
+
+        val testDataSuccess = listOf("item 5")
+
+        val successState = loadingState.success(testDataSuccess)
+        assertThat(successState.previous, `is`(equalTo(loadingState)))
+        assertThat(successState.previous?.data, `is`(equalTo(testDataReady)))
+        assertThat(successState.data, `is`(equalTo(testDataSuccess)))
+
+        assertThat(successState.previous?.isLoadingMore(), `is`(false))
+        assertThat(successState.previous?.isFetchingFirstPage(), `is`(true))
+
+        val errorState = loadingState.error("error")
+        assertThat(errorState.previous, `is`(equalTo(loadingState)))
+        assertThat(errorState.previous?.data, `is`(equalTo(testDataReady)))
+        assertThat(errorState.data, `is`(equalTo(testDataReady)))
+
+        assertThat(errorState.previous?.isLoadingMore(), `is`(false))
+        assertThat(errorState.previous?.isFetchingFirstPage(), `is`(true))
     }
 }

--- a/WordPress/src/test/java/org/wordpress/android/models/networkresource/ListNetworkResourceTest.kt
+++ b/WordPress/src/test/java/org/wordpress/android/models/networkresource/ListNetworkResourceTest.kt
@@ -33,11 +33,11 @@ class ListNetworkResourceTest {
 
     @Test
     fun testLoadingFirstPageState() {
-        val testDataReady = listOf("item3", "item4")
-        val readyState: ListNetworkResource<String> = ListNetworkResource.Ready(testDataReady)
+        val testData = listOf("item3", "item4")
+        val readyState: ListNetworkResource<String> = ListNetworkResource.Ready(testData)
         val loadingState: ListNetworkResource<String> = ListNetworkResource.Loading(readyState)
 
-        assertThat(loadingState.data, `is`(equalTo(testDataReady)))
+        assertThat(loadingState.data, `is`(equalTo(testData)))
 
         assertThat(loadingState.isFetchingFirstPage(), `is`(true))
         assertThat(loadingState.isLoadingMore(), `is`(false))
@@ -47,11 +47,11 @@ class ListNetworkResourceTest {
 
     @Test
     fun testLoadMoreState() {
-        val testDataReady = listOf("item5", "item6")
-        val readyState: ListNetworkResource<String> = ListNetworkResource.Ready(testDataReady)
+        val testData = listOf("item5", "item6")
+        val readyState: ListNetworkResource<String> = ListNetworkResource.Ready(testData)
         val loadingState: ListNetworkResource<String> = ListNetworkResource.Loading(readyState, true)
 
-        assertThat(loadingState.data, `is`(equalTo(testDataReady)))
+        assertThat(loadingState.data, `is`(equalTo(testData)))
 
         assertThat(loadingState.isFetchingFirstPage(), `is`(false))
         assertThat(loadingState.isLoadingMore(), `is`(true))
@@ -60,21 +60,26 @@ class ListNetworkResourceTest {
     }
 
     @Test
-    fun testSuccessState() {
-        val testDataSuccess = listOf("item 7")
+    fun testSuccessStateWhereAllDataIsLoaded() {
+        val testData = listOf("item7")
 
-        val successState = ListNetworkResource.Success(testDataSuccess)
-        assertThat(successState.data, `is`(equalTo(testDataSuccess)))
+        val successState = ListNetworkResource.Success(testData)
+        assertThat(successState.data, `is`(equalTo(testData)))
         assertThat(successState.canLoadMore, `is`(false))
+    }
 
-        val successState2 = ListNetworkResource.Success(testDataSuccess, true)
-        assertThat(successState2.data, `is`(equalTo(testDataSuccess)))
+    @Test
+    fun testSuccessStatesWhereMoreDataCanBeLoaded() {
+        val testData = listOf("item8")
+
+        val successState2 = ListNetworkResource.Success(testData, true)
+        assertThat(successState2.data, `is`(equalTo(testData)))
         assertThat(successState2.canLoadMore, `is`(true))
     }
 
     @Test
     fun testErrorState() {
-        val testDataReady = listOf("item8", "item9")
+        val testDataReady = listOf("item9", "item10")
         val readyState: ListNetworkResource<String> = ListNetworkResource.Ready(testDataReady)
         val loadingState: ListNetworkResource<String> = ListNetworkResource.Loading(readyState, true)
 
@@ -85,24 +90,29 @@ class ListNetworkResourceTest {
     }
 
     @Test
-    fun testGetTransformedListNetworkResource() {
-        val testDataReady = listOf("item10", "item11", "not-item")
-        val readyState: ListNetworkResource<String> = ListNetworkResource.Ready(testDataReady)
+    fun testGetTransformedByUpperCaseListNetworkResource() {
+        val testData = listOf("item11", "item12", "item13")
+        val readyState: ListNetworkResource<String> = ListNetworkResource.Ready(testData)
         val toUpperCase: (List<String>) -> List<String> = { list ->
             list.map { it.toUpperCase() }
         }
-        val newReadyState = readyState.getTransformedListNetworkResource(toUpperCase)
-        assertThat(newReadyState.data, `is`(equalTo(toUpperCase(testDataReady))))
-        assertThat(newReadyState.data.size, `is`(3))
-        assertThat(newReadyState is ListNetworkResource.Ready, `is`(true))
+        val transformedReadyState = readyState.getTransformedListNetworkResource(toUpperCase)
+        assertThat(transformedReadyState.data, `is`(equalTo(toUpperCase(testData))))
+        assertThat(transformedReadyState.data.size, `is`(3))
+        assertThat(transformedReadyState is ListNetworkResource.Ready, `is`(true))
+    }
 
+    @Test
+    fun testGetTransformedByFilterListNetworkResource() {
+        val testData = listOf("item14", "item15", "not-item")
+        val readyState: ListNetworkResource<String> = ListNetworkResource.Ready(testData)
+        val loadingState: ListNetworkResource<String> = ListNetworkResource.Loading(readyState, true)
         val filterNotItem: (List<String>) -> List<String> = { list ->
-            list.filter { it != "not-item".toUpperCase() }
+            list.filter { it != "not-item" }
         }
-        val loadingState: ListNetworkResource<String> = ListNetworkResource.Loading(newReadyState, true)
-        val newLoadingState = loadingState.getTransformedListNetworkResource(filterNotItem)
-        assertThat(newLoadingState.data, `is`(equalTo(filterNotItem(loadingState.data))))
-        assertThat(newLoadingState.data.size, `is`(2))
-        assertThat(newLoadingState is ListNetworkResource.Loading, `is`(true))
+        val transformedLoadingState = loadingState.getTransformedListNetworkResource(filterNotItem)
+        assertThat(transformedLoadingState.data, `is`(equalTo(filterNotItem(testData))))
+        assertThat(transformedLoadingState.data.size, `is`(2))
+        assertThat(transformedLoadingState is ListNetworkResource.Loading, `is`(true))
     }
 }


### PR DESCRIPTION
This PR combines the #7615 & #7616 as well as a few improvements to the documentation and some minor fixes/changes. I believe it'll make it much easier to follow the changes and review them as I ended up removing some things that were introduced in #7615.

This PR adds `ListDiffCallback` which makes it easy to only reload the changes in an adapter. Both the class itself and its usage is fairly simple. One possible improvement is to move the calculation to a background thread, but for now I'd prefer to keep it simple as I'd consider the optimization of that component to be out of scope for `ListNetworkResource` PRs.

It also adds documentation for the `ListNetworkResource` as well as unit tests. I believe this concludes the inital version of this component, but there is a lot more I have planned for it, assuming that it makes it to `develop`.

/cc @0nko 